### PR TITLE
Adjust local DC/OS URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Node 4.x (and above) is **required**. We suggest using [nvm](https://github.com/
 6. Save and quit vi
 7. Restart adminrouter with `sudo service dcos-adminrouter restart`. Your cluster is now prepped for local development.
 8. [Start](#user-content-dcos-ui-1) your local development server for DC/OS.
-9. Navigate to http://dcos.local.
+9. Navigate to http://m1.dcos.
 
-**NOTE:** http://dcos.local will only resolve if both your DC/OS UI Server and DC/OS Cluster are operational and running.
+**NOTE:** http://m1.dcos will only resolve if both your DC/OS UI Server and DC/OS Cluster are operational and running.
 
 ## DC/OS UI
 


### PR DESCRIPTION
Adjust the load DC/OS URL, as it will not resolve to 192.168.65.90 (http://m1.dcos) without an extra undocumented configuration step. 