### PR TITLE
Feature add status to service and service tree structs 

### DIFF
--- a/src/js/constants/ServiceStatus.js
+++ b/src/js/constants/ServiceStatus.js
@@ -1,0 +1,16 @@
+var SERVICE_STATUS = {
+  RUNNING: {
+    key: 0,
+    displayName: 'Running'
+  },
+  DEPLOYING: {
+    key: 1,
+    displayName: 'Deploying'
+  },
+  SUSPENDED: {
+    key: 2,
+    displayName: 'Suspended'
+  }
+};
+
+module.exports = SERVICE_STATUS;

--- a/src/js/constants/StatusLabels.js
+++ b/src/js/constants/StatusLabels.js
@@ -1,7 +1,0 @@
-var STATUS_LABELS = {
-  RUNNING: 'Running',
-  DEPLOYING: 'Deploying',
-  SUSPENDED: 'Suspended'
-};
-
-module.exports = STATUS_LABELS;

--- a/src/js/constants/StatusLabels.js
+++ b/src/js/constants/StatusLabels.js
@@ -1,0 +1,7 @@
+var STATUS_LABELS = {
+  RUNNING: 'Running',
+  DEPLOYING: 'Deploying',
+  SUSPENDED: 'Suspended'
+};
+
+module.exports = STATUS_LABELS;

--- a/src/js/structs/Service.js
+++ b/src/js/structs/Service.js
@@ -1,6 +1,7 @@
 import HealthStatus from '../constants/HealthStatus';
 import Item from './Item';
 import ServiceImages from '../constants/ServiceImages';
+import StatusLabels from '../constants/StatusLabels';
 
 module.exports = class Service extends Item {
   getArguments() {
@@ -83,6 +84,24 @@ module.exports = class Service extends Item {
       mem: this.get('mem'),
       disk: this.get('disk')
     };
+  }
+
+  getStatus() {
+    let {tasksRunning} = this.getTasksSummary();
+    let deployments = this.getDeployments();
+
+    if (deployments.length > 0) {
+      return StatusLabels.DEPLOYING;
+    }
+
+    if (tasksRunning > 0) {
+      return StatusLabels.RUNNING;
+    }
+
+    let instances = this.getInstances();
+    if (instances === 0) {
+      return StatusLabels.SUSPENDED;
+    }
   }
 
   getTasksSummary() {

--- a/src/js/structs/Service.js
+++ b/src/js/structs/Service.js
@@ -15,6 +15,10 @@ module.exports = class Service extends Item {
     return this.get('container');
   }
 
+  getDeployments() {
+    return this.get('deployments');
+  }
+
   getExecutor() {
     return this.get('executor');
   }

--- a/src/js/structs/Service.js
+++ b/src/js/structs/Service.js
@@ -1,7 +1,7 @@
 import HealthStatus from '../constants/HealthStatus';
 import Item from './Item';
 import ServiceImages from '../constants/ServiceImages';
-import StatusLabels from '../constants/StatusLabels';
+import ServiceStatus from '../constants/ServiceStatus';
 
 module.exports = class Service extends Item {
   getArguments() {
@@ -91,16 +91,16 @@ module.exports = class Service extends Item {
     let deployments = this.getDeployments();
 
     if (deployments.length > 0) {
-      return StatusLabels.DEPLOYING;
+      return ServiceStatus.DEPLOYING.displayName;
     }
 
     if (tasksRunning > 0) {
-      return StatusLabels.RUNNING;
+      return ServiceStatus.RUNNING.displayName;
     }
 
     let instances = this.getInstances();
     if (instances === 0) {
-      return StatusLabels.SUSPENDED;
+      return ServiceStatus.SUSPENDED.displayName;
     }
   }
 

--- a/src/js/structs/Service.js
+++ b/src/js/structs/Service.js
@@ -90,7 +90,9 @@ module.exports = class Service extends Item {
       tasksHealthy: this.get('tasksHealthy'),
       tasksRunning: this.get('tasksRunning'),
       tasksStaged: this.get('tasksStaged'),
-      tasksUnhealthy: this.get('tasksUnhealthy')
+      tasksUnhealthy: this.get('tasksUnhealthy'),
+      tasksUnknown: this.get('tasksRunning') -
+        this.get('tasksHealthy') - this.get('tasksUnhealthy'),
     };
   }
 

--- a/src/js/structs/ServiceTree.js
+++ b/src/js/structs/ServiceTree.js
@@ -3,6 +3,7 @@ import Framework from './Framework';
 import HealthSorting from '../constants/HealthSorting';
 import HealthStatus from '../constants/HealthStatus';
 import Service from './Service';
+import StatusLabels from '../constants/StatusLabels';
 import Tree from './Tree';
 import Util from '../utils/Util';
 
@@ -102,7 +103,7 @@ module.exports = class ServiceTree extends Tree {
   }
 
   getInstances() {
-    return this.reduceItems(function(instances, item) {
+    return this.reduceItems(function (instances, item) {
       if (item instanceof Service) {
         instances += item.getInstances();
       }
@@ -127,6 +128,25 @@ module.exports = class ServiceTree extends Tree {
 
       return resources;
     }, {cpus: 0, mem: 0, disk: 0});
+  }
+
+  getStatus() {
+    let {tasksRunning} = this.getTasksSummary();
+    let deployments = this.getDeployments();
+
+    if (deployments.length > 0) {
+      return StatusLabels.DEPLOYING;
+    }
+
+    if (tasksRunning > 0) {
+      return StatusLabels.RUNNING;
+    }
+
+    let instances = this.getInstances();
+    if (instances === 0) {
+      return StatusLabels.SUSPENDED;
+    }
+
   }
 
   getTasksSummary() {

--- a/src/js/structs/ServiceTree.js
+++ b/src/js/structs/ServiceTree.js
@@ -64,6 +64,16 @@ module.exports = class ServiceTree extends Tree {
     });
   }
 
+  getDeployments() {
+    return this.reduceItems(function (deployments, item) {
+      if (item instanceof Service && item.getDeployments() != null) {
+        deployments = deployments.concat(item.getDeployments());
+      }
+
+      return deployments;
+    }, []);
+  }
+
   getHealth() {
     return this.reduceItems(function (aggregatedHealth, item) {
       if (item instanceof Service) {

--- a/src/js/structs/ServiceTree.js
+++ b/src/js/structs/ServiceTree.js
@@ -3,7 +3,7 @@ import Framework from './Framework';
 import HealthSorting from '../constants/HealthSorting';
 import HealthStatus from '../constants/HealthStatus';
 import Service from './Service';
-import StatusLabels from '../constants/StatusLabels';
+import ServiceStatus from '../constants/ServiceStatus';
 import Tree from './Tree';
 import Util from '../utils/Util';
 
@@ -135,16 +135,16 @@ module.exports = class ServiceTree extends Tree {
     let deployments = this.getDeployments();
 
     if (deployments.length > 0) {
-      return StatusLabels.DEPLOYING;
+      return ServiceStatus.DEPLOYING.displayName;
     }
 
     if (tasksRunning > 0) {
-      return StatusLabels.RUNNING;
+      return ServiceStatus.RUNNING.displayName;
     }
 
     let instances = this.getInstances();
     if (instances === 0) {
-      return StatusLabels.SUSPENDED;
+      return ServiceStatus.SUSPENDED.displayName;
     }
 
   }

--- a/src/js/structs/ServiceTree.js
+++ b/src/js/structs/ServiceTree.js
@@ -133,9 +133,12 @@ module.exports = class ServiceTree extends Tree {
         taskSummary.tasksRunning += tasksRunning;
         taskSummary.tasksStaged += tasksStaged;
         taskSummary.tasksUnhealthy += tasksUnhealthy;
+        taskSummary.tasksUnknown += tasksRunning -
+          tasksHealthy - tasksUnhealthy;
       }
 
       return taskSummary;
-    }, {tasksHealthy: 0, tasksRunning: 0, tasksStaged: 0, tasksUnhealthy: 0});
+    }, {tasksHealthy: 0, tasksRunning: 0, tasksStaged: 0, tasksUnhealthy: 0,
+      tasksUnknown: 0});
   }
 };

--- a/src/js/structs/ServiceTree.js
+++ b/src/js/structs/ServiceTree.js
@@ -101,6 +101,16 @@ module.exports = class ServiceTree extends Tree {
     });
   }
 
+  getInstances() {
+    return this.reduceItems(function(instances, item) {
+      if (item instanceof Service) {
+        instances += item.getInstances();
+      }
+
+      return instances;
+    }, 0);
+  }
+
   getName() {
     return this.getId().split('/').pop();
   }

--- a/src/js/structs/__tests__/Service-test.js
+++ b/src/js/structs/__tests__/Service-test.js
@@ -1,6 +1,7 @@
 let HealthStatus = require('../../constants/HealthStatus');
 let Service = require('../Service');
 let ServiceImages = require('../../constants/ServiceImages');
+let StatusLabels = require('../../constants/StatusLabels');
 
 describe('Service', function () {
 
@@ -325,6 +326,49 @@ describe('Service', function () {
         mem: 2048,
         disk: 0
       });
+    });
+
+  });
+
+  describe('#getStatus', function () {
+
+    it('returns correct status for running app', function () {
+      let service = new Service({
+        tasksStaged: 0,
+        tasksRunning: 1,
+        tasksHealthy: 0,
+        tasksUnhealthy: 0,
+        instances: 1,
+        deployments: []
+      });
+
+      expect(service.getStatus()).toEqual(StatusLabels.RUNNING);
+    });
+
+    it('returns correct status for suspended app', function () {
+      let service = new Service({
+        tasksStaged: 0,
+        tasksRunning: 0,
+        tasksHealthy: 0,
+        tasksUnhealthy: 0,
+        instances: 0,
+        deployments: []
+      });
+
+      expect(service.getStatus()).toEqual(StatusLabels.SUSPENDED);
+    });
+
+    it('returns correct status for deploying app', function () {
+      let service = new Service({
+        tasksStaged: 0,
+        tasksRunning: 15,
+        tasksHealthy: 0,
+        tasksUnhealthy: 0,
+        instances: 0,
+        deployments: [{id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f1"}]
+      });
+
+      expect(service.getStatus()).toEqual(StatusLabels.DEPLOYING);
     });
 
   });

--- a/src/js/structs/__tests__/Service-test.js
+++ b/src/js/structs/__tests__/Service-test.js
@@ -1,7 +1,7 @@
 let HealthStatus = require('../../constants/HealthStatus');
 let Service = require('../Service');
 let ServiceImages = require('../../constants/ServiceImages');
-let StatusLabels = require('../../constants/StatusLabels');
+let ServiceStatus = require('../../constants/ServiceStatus');
 
 describe('Service', function () {
 
@@ -342,7 +342,7 @@ describe('Service', function () {
         deployments: []
       });
 
-      expect(service.getStatus()).toEqual(StatusLabels.RUNNING);
+      expect(service.getStatus()).toEqual(ServiceStatus.RUNNING.displayName);
     });
 
     it('returns correct status for suspended app', function () {
@@ -355,7 +355,7 @@ describe('Service', function () {
         deployments: []
       });
 
-      expect(service.getStatus()).toEqual(StatusLabels.SUSPENDED);
+      expect(service.getStatus()).toEqual(ServiceStatus.SUSPENDED.displayName);
     });
 
     it('returns correct status for deploying app', function () {
@@ -368,7 +368,7 @@ describe('Service', function () {
         deployments: [{id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f1"}]
       });
 
-      expect(service.getStatus()).toEqual(StatusLabels.DEPLOYING);
+      expect(service.getStatus()).toEqual(ServiceStatus.DEPLOYING.displayName);
     });
 
   });

--- a/src/js/structs/__tests__/Service-test.js
+++ b/src/js/structs/__tests__/Service-test.js
@@ -343,7 +343,8 @@ describe('Service', function () {
         tasksStaged: 0,
         tasksRunning: 1,
         tasksHealthy: 1,
-        tasksUnhealthy: 0
+        tasksUnhealthy: 0,
+        tasksUnknown: 0
       });
     });
 

--- a/src/js/structs/__tests__/Service-test.js
+++ b/src/js/structs/__tests__/Service-test.js
@@ -74,6 +74,29 @@ describe('Service', function () {
 
   });
 
+  describe('#getDeployments', function () {
+    it('should return an empty array', function () {
+      let service = new Service({
+        deployments: []
+      });
+
+      expect(service.getDeployments()).toEqual([]);
+    });
+
+    it('should return an array with one deployment', function () {
+      let service = new Service({
+        deployments: [
+          {id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f7"}
+        ]
+      });
+
+      expect(service.getDeployments()).toEqual([
+        {id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f7"}
+      ]);
+    });
+  });
+
+
   describe('#getExecuter', function () {
 
     it('returns correct command', function () {

--- a/src/js/structs/__tests__/Service-test.js
+++ b/src/js/structs/__tests__/Service-test.js
@@ -87,12 +87,12 @@ describe('Service', function () {
     it('should return an array with one deployment', function () {
       let service = new Service({
         deployments: [
-          {id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f7"}
+          {id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f7'}
         ]
       });
 
       expect(service.getDeployments()).toEqual([
-        {id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f7"}
+        {id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f7'}
       ]);
     });
   });
@@ -365,7 +365,7 @@ describe('Service', function () {
         tasksHealthy: 0,
         tasksUnhealthy: 0,
         instances: 0,
-        deployments: [{id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f1"}]
+        deployments: [{id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f1'}]
       });
 
       expect(service.getStatus()).toEqual(ServiceStatus.DEPLOYING.displayName);

--- a/src/js/structs/__tests__/ServiceTree-test.js
+++ b/src/js/structs/__tests__/ServiceTree-test.js
@@ -224,6 +224,67 @@ describe('ServiceTree', function () {
 
   });
 
+  describe('#getDeployments', function () {
+    it('should return an empty array', function () {
+      let serviceTree = new ServiceTree({
+        id: '/group/id',
+        apps: [
+          {id: '/alpha', cmd: 'cmd', deployments: []},
+          {
+            id: '/beta',
+            cmd: 'cmd',
+            deployments: [],
+            labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'}
+          },
+          {id: '/gamma', cmd: 'cmd', labels: {RANDOM_LABEL: 'random'}}
+        ],
+        groups: [
+          {
+            id: '/test', apps: [
+            {id: '/foo', cmd: 'cmd', deployments: []},
+            {id: '/bar', cmd: 'cmd'}
+          ], groups: []
+          }
+        ]
+
+      });
+
+      expect(serviceTree.getDeployments()).toEqual([]);
+    });
+
+    it('should return an array with three deployments', function () {
+      let serviceTree = new ServiceTree(
+        {
+          id: '/group/id',
+          apps: [
+            {id: '/alpha', cmd: 'cmd', deployments: [{id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f2"}]},
+            {
+              id: '/beta',
+              cmd: 'cmd',
+              deployments: [{id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f3"}],
+              labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'}
+            },
+            {id: '/gamma', cmd: 'cmd', labels: {RANDOM_LABEL: 'random'}}
+          ],
+          groups: [
+            {
+              id: '/test', apps: [
+              {id: '/foo', cmd: 'cmd', deployments: [{id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f1"}]},
+              {id: '/bar', cmd: 'cmd'}
+            ], groups: []
+            }
+          ]
+
+        });
+
+      expect(serviceTree.getDeployments()).toEqual([
+        {id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f1"},
+        {id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f2"},
+        {id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f3"}
+      ]);
+    });
+  });
+
   describe('#getHealth', function () {
 
     const healthyService = new Service({

--- a/src/js/structs/__tests__/ServiceTree-test.js
+++ b/src/js/structs/__tests__/ServiceTree-test.js
@@ -24,9 +24,9 @@ describe('ServiceTree', function () {
         groups: [
           {
             id: '/test', apps: [
-            {id: 'foo', cmd: 'cmd'},
-            {id: 'bar', cmd: 'cmd'}
-          ], groups: []
+              {id: 'foo', cmd: 'cmd'},
+              {id: 'bar', cmd: 'cmd'}
+            ], groups: []
           }
         ],
         filterProperties: {
@@ -113,9 +113,9 @@ describe('ServiceTree', function () {
         groups: [
           {
             id: '/test', apps: [
-            {id: 'foo', cmd: 'cmd'},
-            {id: 'bar', cmd: 'cmd'}
-          ], groups: []
+              {id: 'foo', cmd: 'cmd'},
+              {id: 'bar', cmd: 'cmd'}
+            ], groups: []
           }
         ],
         filterProperties: {
@@ -164,9 +164,9 @@ describe('ServiceTree', function () {
         groups: [
           {
             id: '/test', apps: [
-            {id: 'foo', cmd: 'cmd'},
-            {id: 'bar', cmd: 'cmd'}
-          ], groups: []
+              {id: 'foo', cmd: 'cmd'},
+              {id: 'bar', cmd: 'cmd'}
+            ], groups: []
           }
         ],
         filterProperties: {
@@ -202,9 +202,9 @@ describe('ServiceTree', function () {
         groups: [
           {
             id: '/test', apps: [
-            {id: '/foo', cmd: 'cmd'},
-            {id: '/bar', cmd: 'cmd'}
-          ], groups: []
+              {id: '/foo', cmd: 'cmd'},
+              {id: '/bar', cmd: 'cmd'}
+            ], groups: []
           }
         ]
       });
@@ -241,9 +241,9 @@ describe('ServiceTree', function () {
         groups: [
           {
             id: '/test', apps: [
-            {id: '/foo', cmd: 'cmd', deployments: []},
-            {id: '/bar', cmd: 'cmd'}
-          ], groups: []
+              {id: '/foo', cmd: 'cmd', deployments: []},
+              {id: '/bar', cmd: 'cmd'}
+            ], groups: []
           }
         ]
       });
@@ -271,13 +271,13 @@ describe('ServiceTree', function () {
         groups: [
           {
             id: '/test', apps: [
-            {
-              id: '/foo',
-              cmd: 'cmd',
-              deployments: [{id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f1'}]
-            },
-            {id: '/bar', cmd: 'cmd'}
-          ], groups: []
+              {
+                id: '/foo',
+                cmd: 'cmd',
+                deployments: [{id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f1'}]
+              },
+              {id: '/bar', cmd: 'cmd'}
+            ], groups: []
           }
         ]
       });
@@ -516,7 +516,7 @@ describe('ServiceTree', function () {
         tasksHealthy: 0,
         tasksUnhealthy: 0,
         instances: 0,
-        deployments: [{id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f1"}]
+        deployments: [{id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f1'}]
       }));
 
       expect(this.instance.getStatus())

--- a/src/js/structs/__tests__/ServiceTree-test.js
+++ b/src/js/structs/__tests__/ServiceTree-test.js
@@ -3,6 +3,7 @@ let Framework = require('../Framework');
 let HealthStatus = require('../../constants/HealthStatus');
 let Service = require('../Service');
 let ServiceTree = require('../ServiceTree');
+let StatusLabels = require('../../constants/StatusLabels');
 
 describe('ServiceTree', function () {
 
@@ -462,10 +463,57 @@ describe('ServiceTree', function () {
       }));
 
       this.instance.add(new Service({
-        instances: 5
+        instances: 2
       }));
 
       expect(this.instance.getInstances()).toEqual(5);
+    });
+
+  });
+
+  describe('#getStatus', function () {
+
+    beforeEach(function () {
+      this.instance = new ServiceTree();
+    });
+
+    it('returns correct status for running tree', function () {
+      this.instance.add(new Service({
+        tasksStaged: 0,
+        tasksRunning: 1,
+        tasksHealthy: 0,
+        tasksUnhealthy: 0,
+        instances: 1,
+        deployments: []
+      }));
+
+      expect(this.instance.getStatus()).toEqual(StatusLabels.RUNNING);
+    });
+
+    it('returns correct status for suspended tree', function () {
+      this.instance.add(new Service({
+        tasksStaged: 0,
+        tasksRunning: 0,
+        tasksHealthy: 0,
+        tasksUnhealthy: 0,
+        instances: 0,
+        deployments: []
+      }));
+
+      expect(this.instance.getStatus()).toEqual(StatusLabels.SUSPENDED);
+    });
+
+    it('returns correct status for deploying tree', function () {
+      this.instance.add(new Service({
+        tasksStaged: 0,
+        tasksRunning: 15,
+        tasksHealthy: 0,
+        tasksUnhealthy: 0,
+        instances: 0,
+        deployments: [{id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f1"}]
+      }));
+
+      expect(this.instance.getStatus()).toEqual(StatusLabels.DEPLOYING);
     });
 
   });

--- a/src/js/structs/__tests__/ServiceTree-test.js
+++ b/src/js/structs/__tests__/ServiceTree-test.js
@@ -434,6 +434,42 @@ describe('ServiceTree', function () {
 
   });
 
+  describe('#getInstances', function () {
+
+    beforeEach(function () {
+      this.instance = new ServiceTree();
+    });
+
+    it('returns correct number for instances for 0 instances', function () {
+      this.instance.add(new Service({
+        instances: 0
+      }));
+
+      expect(this.instance.getInstances()).toEqual(0);
+    });
+
+    it('returns correct number for instances for 1 instance', function () {
+      this.instance.add(new Service({
+        instances: 1
+      }));
+
+      expect(this.instance.getInstances()).toEqual(1);
+    });
+
+    it('returns correct number for instances for 5 instances', function () {
+      this.instance.add(new Service({
+        instances: 3
+      }));
+
+      this.instance.add(new Service({
+        instances: 5
+      }));
+
+      expect(this.instance.getInstances()).toEqual(5);
+    });
+
+  });
+
   describe('#getTasksSummary', function () {
 
     beforeEach(function () {

--- a/src/js/structs/__tests__/ServiceTree-test.js
+++ b/src/js/structs/__tests__/ServiceTree-test.js
@@ -210,7 +210,6 @@ describe('ServiceTree', function () {
       });
     });
 
-
     it('should find matching item', function () {
       expect(this.instance.findItemById('/beta').getId()).toEqual('/beta');
     });
@@ -247,41 +246,46 @@ describe('ServiceTree', function () {
           ], groups: []
           }
         ]
-
       });
 
       expect(serviceTree.getDeployments()).toEqual([]);
     });
 
     it('should return an array with three deployments', function () {
-      let serviceTree = new ServiceTree(
-        {
-          id: '/group/id',
-          apps: [
-            {id: '/alpha', cmd: 'cmd', deployments: [{id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f2"}]},
+      let serviceTree = new ServiceTree({
+        id: '/group/id',
+        apps: [
+          {
+            id: '/alpha',
+            cmd: 'cmd',
+            deployments: [{id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f2'}]
+          },
+          {
+            id: '/beta',
+            cmd: 'cmd',
+            deployments: [{id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f3'}],
+            labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'}
+          },
+          {id: '/gamma', cmd: 'cmd', labels: {RANDOM_LABEL: 'random'}}
+        ],
+        groups: [
+          {
+            id: '/test', apps: [
             {
-              id: '/beta',
+              id: '/foo',
               cmd: 'cmd',
-              deployments: [{id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f3"}],
-              labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'}
+              deployments: [{id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f1'}]
             },
-            {id: '/gamma', cmd: 'cmd', labels: {RANDOM_LABEL: 'random'}}
-          ],
-          groups: [
-            {
-              id: '/test', apps: [
-              {id: '/foo', cmd: 'cmd', deployments: [{id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f1"}]},
-              {id: '/bar', cmd: 'cmd'}
-            ], groups: []
-            }
-          ]
-
-        });
+            {id: '/bar', cmd: 'cmd'}
+          ], groups: []
+          }
+        ]
+      });
 
       expect(serviceTree.getDeployments()).toEqual([
-        {id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f1"},
-        {id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f2"},
-        {id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f3"}
+        {id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f1'},
+        {id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f2'},
+        {id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f3'}
       ]);
     });
   });

--- a/src/js/structs/__tests__/ServiceTree-test.js
+++ b/src/js/structs/__tests__/ServiceTree-test.js
@@ -458,7 +458,8 @@ describe('ServiceTree', function () {
         tasksStaged: 1,
         tasksRunning: 4,
         tasksHealthy: 16,
-        tasksUnhealthy: 1
+        tasksUnhealthy: 1,
+        tasksUnknown: -13
       });
     });
 

--- a/src/js/structs/__tests__/ServiceTree-test.js
+++ b/src/js/structs/__tests__/ServiceTree-test.js
@@ -540,17 +540,17 @@ describe('ServiceTree', function () {
       }));
       this.instance.add(new Service({
         tasksStaged: 1,
-        tasksRunning: 3,
+        tasksRunning: 18,
         tasksHealthy: 15,
         tasksUnhealthy: 1
       }));
 
       expect(this.instance.getTasksSummary()).toEqual({
         tasksStaged: 1,
-        tasksRunning: 4,
+        tasksRunning: 19,
         tasksHealthy: 16,
         tasksUnhealthy: 1,
-        tasksUnknown: -13
+        tasksUnknown: 2
       });
     });
 

--- a/src/js/structs/__tests__/ServiceTree-test.js
+++ b/src/js/structs/__tests__/ServiceTree-test.js
@@ -3,7 +3,7 @@ let Framework = require('../Framework');
 let HealthStatus = require('../../constants/HealthStatus');
 let Service = require('../Service');
 let ServiceTree = require('../ServiceTree');
-let StatusLabels = require('../../constants/StatusLabels');
+let ServiceStatus = require('../../constants/ServiceStatus');
 
 describe('ServiceTree', function () {
 
@@ -487,7 +487,8 @@ describe('ServiceTree', function () {
         deployments: []
       }));
 
-      expect(this.instance.getStatus()).toEqual(StatusLabels.RUNNING);
+      expect(this.instance.getStatus())
+        .toEqual(ServiceStatus.RUNNING.displayName);
     });
 
     it('returns correct status for suspended tree', function () {
@@ -500,7 +501,8 @@ describe('ServiceTree', function () {
         deployments: []
       }));
 
-      expect(this.instance.getStatus()).toEqual(StatusLabels.SUSPENDED);
+      expect(this.instance.getStatus())
+        .toEqual(ServiceStatus.SUSPENDED.displayName);
     });
 
     it('returns correct status for deploying tree', function () {
@@ -513,7 +515,8 @@ describe('ServiceTree', function () {
         deployments: [{id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f1"}]
       }));
 
-      expect(this.instance.getStatus()).toEqual(StatusLabels.DEPLOYING);
+      expect(this.instance.getStatus())
+        .toEqual(ServiceStatus.DEPLOYING.displayName);
     });
 
   });


### PR DESCRIPTION
This adds getStatus to the service and the serviceTree structs as this is mandatory for the status bars on the service table. It does only support a small set of statuses to keep this PR small and the rest will be issued in another PR later.