### PR TITLE
Always show full url in table, ref. DCOS-6085

### DIFF
--- a/src/js/components/RepositoriesTable.js
+++ b/src/js/components/RepositoriesTable.js
@@ -124,8 +124,8 @@ class RepositoriesTable extends mixin(StoreMixin) {
   getColGroup() {
     return (
       <colgroup>
+        <col style={{width: '30%'}} />
         <col />
-        <col style={{width: '320px'}} />
         <col style={{width: '120px'}} />
       </colgroup>
     );

--- a/src/js/components/RepositoriesTable.js
+++ b/src/js/components/RepositoriesTable.js
@@ -126,7 +126,7 @@ class RepositoriesTable extends mixin(StoreMixin) {
       <colgroup>
         <col style={{width: '30%'}} />
         <col />
-        <col style={{width: '120px'}} />
+        <col style={{width: '85px'}} />
       </colgroup>
     );
   }

--- a/src/js/components/RepositoriesTable.js
+++ b/src/js/components/RepositoriesTable.js
@@ -134,7 +134,7 @@ class RepositoriesTable extends mixin(StoreMixin) {
   getUri(prop, repository) {
     return (
       <div className="flex-box table-cell-flex-box">
-        <span className="text-overflow" title={repository.get('uri')}>
+        <span className="text-overflow-break-word" title={repository.get('uri')}>
           {repository.get('uri')}
         </span>
       </div>

--- a/src/styles/components/typography.less
+++ b/src/styles/components/typography.less
@@ -71,7 +71,7 @@ components/typography.less
   .text-super-muted {
 
     &.inverse {
-      color: color-lighten(@neutral, 10);  
+      color: color-lighten(@neutral, 10);
     }
   }
 
@@ -196,6 +196,14 @@ components/typography.less
 
   }
 
+  .text-overflow-break-word {
+
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
+    hyphens: auto;
+
+  }
 
 
   & when (@heading-h1-large-text-enabled) {


### PR DESCRIPTION
In collaboration with the designers we came to the conclusion to always show the full URL and break it into multiple lines in the table, if there is not enough space. An added benefit with this is that people now can copy the whole URL if needed.

Also, the URL field will now take up 'the rest of the space' in the table, if there is any left.

Small screen:
<img src="http://cl.ly/0R011d1z0t3K/Image%202016-04-19%20at%2015.34.27.png" width="50%" />
Bigger screen:
<img src="http://cl.ly/201H1g0O3E12/Image%202016-04-19%20at%2015.38.36.png" width="75%" />