### PR TITLE
Make the FilterButtons filterByKey prop optional

### DIFF
--- a/src/js/components/FilterButtons.js
+++ b/src/js/components/FilterButtons.js
@@ -3,12 +3,10 @@ import React from 'react';
 
 class FilterButtons extends React.Component {
 
-  getCountByKey(items, key) {
+  getCount(items) {
     let counts = {};
-    key = key.toLowerCase();
 
-    items.forEach(function (item) {
-      let value = item[key];
+    items.forEach(function (value) {
       if (typeof value === 'string') {
         value = value.toLowerCase();
       }
@@ -28,7 +26,14 @@ class FilterButtons extends React.Component {
 
   getFilterButtons() {
     let {filterByKey, filters, itemList, selectedFilter} = this.props;
-    let filterCount = this.getCountByKey(itemList, filterByKey);
+
+    if (filterByKey) {
+      itemList = itemList.map(function (item) {
+        return item[filterByKey];
+      });
+    }
+
+    let filterCount = this.getCount(itemList);
 
     return filters.map((filter) => {
       let classSet = classNames({
@@ -66,7 +71,7 @@ FilterButtons.propTypes = {
   renderButtonContent: React.PropTypes.func,
   filters: React.PropTypes.array,
   // The key in itemList that is being filtered
-  filterByKey: React.PropTypes.string.isRequired,
+  filterByKey: React.PropTypes.string,
   // A function that returns the onClick for a filter button given the filter.
   onFilterChange: React.PropTypes.func,
   itemList: React.PropTypes.array.isRequired,

--- a/src/js/components/__tests__/FilterButtons-test.js
+++ b/src/js/components/__tests__/FilterButtons-test.js
@@ -46,19 +46,29 @@ describe('FilterButtons', function () {
     });
   });
 
-  describe('#getCountByKey', function () {
+  describe('#getCount', function () {
+
+    beforeEach(function () {
+      this.itemList = [
+        'f0',
+        'f0',
+        'f1'
+      ];
+
+    });
+
     it('adds an "all" key with total item count as value', function () {
-      var counts = this.instance.getCountByKey(this.itemList, this.key);
-      expect(counts.all !== undefined).toEqual(true);
+      var counts = this.instance.getCount(this.itemList);
+      expect(counts.all).toEqual(3);
     });
 
     it('returns a hash map with only key "all" if no items given', function () {
-      var counts = this.instance.getCountByKey([], this.key);
+      var counts = this.instance.getCount([]);
       expect(counts).toEqual({all: 0});
     });
 
     it('creates a hash map of filter counts', function () {
-      var counts = this.instance.getCountByKey(this.itemList, this.key);
+      var counts = this.instance.getCount(this.itemList);
       var expectedCounts = {
         f0: 2,
         f1: 1,


### PR DESCRIPTION
Refactor the `FilterButtons` component, to make the `filterByKey` prop optional, as the item list could also be a plain list of values. 