### PR TITLE
Feature add health bar to service detail

### DIFF
--- a/src/js/components/ServiceInfo.js
+++ b/src/js/components/ServiceInfo.js
@@ -10,8 +10,8 @@ class ServiceInfo extends React.Component {
 
   getSubHeader(service) {
     let serviceHealth = service.getHealth();
-    let tasks = service.getTasksSummary();
-    let runningTasksCount = tasks.tasksRunning;
+    let tasksSummary = service.getTasksSummary();
+    let runningTasksCount = tasksSummary.tasksRunning;
     let instancesCount = service.getInstancesCount();
     let runningTasksSubHeader = StringUtil.pluralize('Task', runningTasksCount);
     let subHeaderItems = [
@@ -28,7 +28,7 @@ class ServiceInfo extends React.Component {
       {
         label: (
           <HealthBar
-            tasks={tasks}
+            tasksSummary={tasksSummary}
             instancesCount={instancesCount} />
         ),
         shouldShow: true

--- a/src/js/components/ServiceInfo.js
+++ b/src/js/components/ServiceInfo.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import HealthBar from './HealthBar';
 import HealthStatus from '../constants/HealthStatus';
 import HealthLabels from '../constants/HealthLabels';
 import Service from '../structs/Service';
@@ -9,7 +10,9 @@ class ServiceInfo extends React.Component {
 
   getSubHeader(service) {
     let serviceHealth = service.getHealth();
-    let runningTasksCount = service.getTasksSummary().tasksRunning;
+    let tasks = service.getTasksSummary();
+    let runningTasksCount = tasks.tasksRunning;
+    let instancesCount = service.getInstancesCount();
     let runningTasksSubHeader = StringUtil.pluralize('Task', runningTasksCount);
     let subHeaderItems = [
       {
@@ -21,6 +24,14 @@ class ServiceInfo extends React.Component {
         classes: 'media-object-item',
         label: `${runningTasksCount} Running ${runningTasksSubHeader}`,
         shouldShow: runningTasksCount != null && runningTasksSubHeader != null
+      },
+      {
+        label: (
+          <HealthBar
+            tasks={tasks}
+            instancesCount={instancesCount} />
+        ),
+        shouldShow: true
       }
     ];
 


### PR DESCRIPTION
⚡ Dependent on #61⚡ 

This adds the HealthBar to the Service Detail sub header.

![image](https://cloud.githubusercontent.com/assets/156010/14819551/ef17a322-0bc2-11e6-9e2e-cc8b1525f19a.png)