### PR TITLE
Fix broken testing task

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "lint": "./node_modules/.bin/eslint '**/*.js' --quiet",
     "livereload": "NODE_ENV='development' ./node_modules/.bin/gulp livereload",
     "livereload-notify": "export NOTIFY=true && npm run livereload",
-    "test": "./node_modules/.bin/gulp copy:external-plugins && npm run lint && jest"
+    "test": "./node_modules/.bin/gulp copy:external-plugins && npm run lint && jest --no-cache"
   },
   "jest-webpack-alias": {
     "configFile": ".webpack.config.js"


### PR DESCRIPTION
Plugin testing is broken since upgrading `babel-jest`. This should fix.