### PR TITLE
Introduce & Use ClickToSelect Component

### DIFF
--- a/src/js/components/ClickToSelect.js
+++ b/src/js/components/ClickToSelect.js
@@ -1,0 +1,39 @@
+import React from 'react';
+
+const METHODS_TO_BIND = [
+  'selectAll'
+];
+
+class ClickToSelect extends React.Component {
+  constructor() {
+    super();
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  selectAll(event) {
+    event.preventDefault;
+    let selection = document.getSelection();
+    let node = this.target;
+
+    selection.selectAllChildren(node);
+  }
+
+  render() {
+    return (
+      <span
+        onClick={this.selectAll}
+        ref={(node) => this.target = node}>
+        {this.props.children}
+      </span>
+    );
+  }
+}
+
+ClickToSelect.propTypes = {
+  children: React.PropTypes.any
+}
+
+module.exports = ClickToSelect;

--- a/src/js/components/ClickToSelect.js
+++ b/src/js/components/ClickToSelect.js
@@ -1,31 +1,20 @@
 import React from 'react';
 
-const METHODS_TO_BIND = [
-  'selectAll'
-];
-
 class ClickToSelect extends React.Component {
   constructor() {
     super();
-
-    METHODS_TO_BIND.forEach((method) => {
-      this[method] = this[method].bind(this);
-    });
+    this.selectAll = this.selectAll.bind(this);
   }
 
-  selectAll(event) {
-    event.preventDefault;
-    let selection = document.getSelection();
-    let node = this.target;
-
-    selection.selectAllChildren(node);
+  selectAll() {
+    document.getSelection().selectAllChildren(this.refs.node);
   }
 
   render() {
     return (
       <span
         onClick={this.selectAll}
-        ref={(node) => this.target = node}>
+        ref="node">
         {this.props.children}
       </span>
     );

--- a/src/js/components/__tests__/ClickToSelect-test.js
+++ b/src/js/components/__tests__/ClickToSelect-test.js
@@ -1,0 +1,45 @@
+jest.dontMock('../ClickToSelect');
+
+/* eslint-disable no-unused-vars */
+let React = require('react');
+/* eslint-enable no-unused-vars */
+let ReactDOM = require('react-dom');
+let TestUtils = require('react-addons-test-utils');
+
+let ClickToSelect = require('../ClickToSelect');
+
+describe('ClickToSelect', function () {
+
+  beforeEach(function () {
+    this.spy = {selectAllChildren: jasmine.createSpy()};
+    this.getSelection = document.getSelection;
+
+    // Mock this document function, which is unsupported by jest.
+    document.getSelection = function () {
+      return this.spy;
+    }.bind(this);
+
+    this.container = document.createElement('div');
+    this.instance = ReactDOM.render(
+      <ClickToSelect>
+        <span>hello text</span>
+      </ClickToSelect>,
+      this.container
+    );
+  });
+
+  afterEach(function () {
+    ReactDOM.unmountComponentAtNode(this.container);
+    document.getSelection = this.getSelection;
+  });
+
+  it('sets selection when node is clicked', function () {
+    var node = ReactDOM.findDOMNode(this.instance);
+    var element = node.querySelector('span');
+
+    TestUtils.Simulate.click(element);
+
+    expect(this.spy.selectAllChildren).toHaveBeenCalled();
+  });
+
+});

--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -1,10 +1,10 @@
 var browserInfo = require('browser-info');
 var classNames = require('classnames');
+import {Hooks} from 'PluginSDK';
 import {Modal} from 'reactjs-components';
 var React = require('react');
 
-import {Hooks} from 'PluginSDK';
-
+import ClickToSelect from '../ClickToSelect';
 import Config from '../../config/Config';
 
 var CliInstructionsModal = React.createClass({
@@ -82,7 +82,9 @@ var CliInstructionsModal = React.createClass({
         <div>
           <h4 className="snippet-description">To install the CLI, copy and paste into your terminal:</h4>
           <div className="flush-top snippet-wrapper">
-            <pre className="mute prettyprint flush-bottom prettyprinted">{cliSnippet}</pre>
+            <ClickToSelect>
+              <pre className="mute prettyprint flush-bottom prettyprinted">{cliSnippet}</pre>
+            </ClickToSelect>
           </div>
         </div>
       );

--- a/src/js/components/modals/VersionsModal.js
+++ b/src/js/components/modals/VersionsModal.js
@@ -1,7 +1,7 @@
-var React = require('react');
-
 import {Modal} from 'reactjs-components';
+import React from 'react';
 
+import ClickToSelect from '../ClickToSelect';
 import Config from '../../config/Config';
 
 var VersionsModal = React.createClass({
@@ -39,7 +39,9 @@ var VersionsModal = React.createClass({
         titleClass="modal-header-title text-align-center flush-top
           flush-bottom"
         titleText={`${Config.productName} Info`}>
-        {this.getContent()}
+        <ClickToSelect>
+          {this.getContent()}
+        </ClickToSelect>
       </Modal>
     );
   }


### PR DESCRIPTION
This PR introduces the `ClickToSelect` Component. 

Usage: wrap a component with `ClickToSelect` to cause browser highlights of the components contents when clicked. 

![](http://cl.ly/0i1i1N3s1H0a/Screen%20Recording%202016-04-26%20at%2003.24%20PM.gif)