### PR TITLE
Add task killing state

### DIFF
--- a/src/js/constants/TaskStates.js
+++ b/src/js/constants/TaskStates.js
@@ -14,14 +14,24 @@ const TaskStates = {
     displayName: 'Running'
   },
 
-  TASK_FAILED: {
-    stateTypes: ['completed', 'failure'],
-    displayName: 'Failed'
+  TASK_KILLING: {
+    stateTypes: ['active', 'failure'],
+    displayName: 'Killing'
+  },
+
+  TASK_FINISHED: {
+    stateTypes: ['completed', 'success'],
+    displayName: 'Finished'
   },
 
   TASK_KILLED: {
     stateTypes: ['completed', 'failure'],
     displayName: 'Killed'
+  },
+
+  TASK_FAILED: {
+    stateTypes: ['completed', 'failure'],
+    displayName: 'Failed'
   },
 
   TASK_LOST: {
@@ -32,11 +42,6 @@ const TaskStates = {
   TASK_ERROR: {
     stateTypes: ['completed', 'failure'],
     displayName: 'Error'
-  },
-
-  TASK_FINISHED: {
-    stateTypes: ['completed', 'success'],
-    displayName: 'Finished'
   }
 };
 

--- a/src/styles/components/icons.less
+++ b/src/styles/components/icons.less
@@ -394,7 +394,7 @@ Icon (huge)
 
       /* Icon: Killed */
 
-      &.icon-killed {
+      &.icon-killed,  &.icon-killing {
 
         background-position: floor(-@icon-sprite-mini-variant-black-offset-horizontal) -(floor(@icon-mini-height) * 9);
 

--- a/src/styles/components/typography.less
+++ b/src/styles/components/typography.less
@@ -71,7 +71,7 @@ components/typography.less
   .text-super-muted {
 
     &.inverse {
-      color: color-lighten(@neutral, 10);  
+      color: color-lighten(@neutral, 10);
     }
   }
 
@@ -150,6 +150,7 @@ components/typography.less
   .task-status-error,
   .task-status-failed,
   .task-status-killed,
+  .task-status-killing,
   .task-status-lost,
   .text-error-state {
     color: @text-danger-color;


### PR DESCRIPTION
![task-killing](https://cloud.githubusercontent.com/assets/647035/14853779/34f6498c-0c8d-11e6-8be2-e45f27757d7c.gif)
Introduce task killing state (`TASK_KILLING`) which was added in Mesos 0.28.0. This should fix issues with undefined task `stateTypes`.  I'm using the task killed icon for now, but I'm happy to replace it if you guys have a better one for me.



**Mesos Changelog**
https://github.com/apache/mesos/blob/4d2b1b793e07a9c90b984ca330a3d7bc9e1404cc/site/source/blog/2016-03-17-mesos-0-28-0-released.md

/closes DCOS-6528
/cc @silverem2 @leemunroe 