### PR TITLE
Add tab for deployments

### DIFF
--- a/src/js/pages/ServicesPage.js
+++ b/src/js/pages/ServicesPage.js
@@ -20,13 +20,13 @@ var ServicesPage = React.createClass({
 
   getInitialState: function () {
     return {
-      currentTab: 'services-all'
+      currentTab: 'services'
     };
   },
 
   componentWillMount: function () {
     this.tabs_tabs = {
-      'services-all': 'Services',
+      'services': 'Services',
       'services-deployments': 'Deployments'
     };
     this.updateCurrentTab();

--- a/src/js/pages/ServicesPage.js
+++ b/src/js/pages/ServicesPage.js
@@ -2,8 +2,11 @@ import React from 'react';
 import {RouteHandler} from 'react-router';
 
 import Page from '../components/Page';
+import TabsMixin from '../mixins/TabsMixin';
 
 var ServicesPage = React.createClass({
+
+  mixins: [TabsMixin],
 
   displayName: 'ServicesPage',
 
@@ -15,13 +18,45 @@ var ServicesPage = React.createClass({
     }
   },
 
+  getInitialState: function () {
+    return {
+      currentTab: 'services-all'
+    };
+  },
+
+  componentWillMount: function () {
+    this.tabs_tabs = {
+      'services-all': 'Services',
+      'services-deployments': 'Deployments'
+    };
+    this.updateCurrentTab();
+  },
+
+  updateCurrentTab: function () {
+    let routes = this.context.router.getCurrentRoutes();
+    let currentTab = routes[routes.length - 1].name;
+    if (currentTab != null) {
+      this.setState({currentTab});
+    }
+  },
+
+  getNavigation: function () {
+    return (
+      <ul className="tabs list-inline flush-bottom inverse">
+        {this.tabs_getRoutedTabs()}
+      </ul>
+    );
+  },
+
   contextTypes: {
     router: React.PropTypes.func
   },
 
   render: function () {
     return (
-      <Page title="Services">
+      <Page
+        navigation={this.getNavigation()}
+        title="Services">
         <RouteHandler />
       </Page>
     );

--- a/src/js/pages/ServicesPage.js
+++ b/src/js/pages/ServicesPage.js
@@ -1,53 +1,17 @@
 import React from 'react';
 import {RouteHandler} from 'react-router';
-import {StoreMixin} from 'mesosphere-shared-reactjs';
 
-import AlertPanel from '../components/AlertPanel';
-import Config from '../config/Config';
-import DCOSStore from '../stores/DCOSStore';
-import FilterHeadline from '../components/FilterHeadline';
 import Page from '../components/Page';
-import SaveStateMixin from '../mixins/SaveStateMixin';
-import Service from '../structs/Service';
-import ServiceDetail from '../components/ServiceDetail';
-import ServiceFilterTypes from '../constants/ServiceFilterTypes';
-import ServiceSearchFilter from '../components/ServiceSearchFilter';
-import ServiceSidebarFilters from '../components/ServiceSidebarFilters';
-import ServicesTable from '../components/ServicesTable';
-import ServiceTree from '../structs/ServiceTree';
-import SidebarActions from '../events/SidebarActions';
-import SidePanels from '../components/SidePanels';
-
-var DEFAULT_FILTER_OPTIONS = {
-  filterHealth: null,
-  searchString: ''
-};
-
-let saveState_properties = Object.keys(DEFAULT_FILTER_OPTIONS);
 
 var ServicesPage = React.createClass({
 
   displayName: 'ServicesPage',
-
-  saveState_key: 'servicesPage',
-
-  saveState_properties,
-
-  mixins: [SaveStateMixin, StoreMixin],
 
   statics: {
     routeConfig: {
       label: 'Services',
       icon: 'services',
       matches: /^\/services/
-    },
-
-    // Static life cycle method from react router, that will be called
-    // 'when a handler is about to render', i.e. on route change:
-    // https://github.com/rackt/react-router/
-    // blob/master/docs/api/components/RouteHandler.md
-    willTransitionTo: function () {
-      SidebarActions.close();
     }
   },
 
@@ -55,113 +19,9 @@ var ServicesPage = React.createClass({
     router: React.PropTypes.func
   },
 
-  getInitialState: function () {
-    return Object.assign({}, DEFAULT_FILTER_OPTIONS);
-  },
-
-  componentWillMount: function () {
-    this.store_listeners = [{name: 'dcos', events: ['change']}];
-  },
-
-  handleFilterChange: function (filterValues, filterType) {
-    var stateChanges = Object.assign({}, this.state);
-    stateChanges[filterType] = filterValues;
-
-    this.setState(stateChanges);
-  },
-
-  resetFilterQueryParams: function () {
-    let router = this.context.router;
-    let queryParams = router.getCurrentQuery();
-
-    Object.values(ServiceFilterTypes).forEach(function (filterKey) {
-      delete queryParams[filterKey];
-    });
-
-    router.transitionTo(router.getCurrentPathname(), {}, queryParams);
-  },
-
-  resetFilter: function () {
-    var state = Object.assign({}, this.state, DEFAULT_FILTER_OPTIONS);
-    this.setState(state, this.resetFilterQueryParams);
-  },
-
-  getContents: function (id) {
-    // Render loading screen
-    if (!DCOSStore.dataProcessed) {
-      return (
-        <div className="container container-fluid container-pod text-align-center
-            vertical-center inverse">
-          <div className="row">
-            <div className="ball-scale">
-              <div />
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    // Find item in root tree and default to root tree if there is no match
-    let item = DCOSStore.serviceTree.findItemById(id) || DCOSStore.serviceTree;
-
-    // Render service table
-    if (item instanceof ServiceTree && item.getItems().length > 0) {
-      let {state} = this;
-      let services = item.getItems();
-      let filteredServices = item.filterItemsByFilter({
-        health: state.filterHealth,
-        name: state.searchString
-      }).getItems();
-
-      return (
-        <div className="flex-box flush flex-mobile-column">
-          <ServiceSidebarFilters
-            handleFilterChange={this.handleFilterChange}
-            services={services} />
-          <div className="flex-grow">
-            <FilterHeadline
-              inverseStyle={true}
-              onReset={this.resetFilter}
-              name="Services"
-              currentLength={filteredServices.length}
-              totalLength={services.length} />
-            <ServiceSearchFilter
-              handleFilterChange={this.handleFilterChange} />
-            <ServicesTable
-              services={filteredServices} />
-          </div>
-          <SidePanels
-            params={this.props.params}
-            openedPage="services" />
-        </div>
-      );
-    }
-
-    // Render service detail
-    if (item instanceof Service) {
-      return (<ServiceDetail service={item} />);
-    }
-
-    // Render empty panel
-    return (
-      <AlertPanel
-        title="No Services Installed"
-        iconClassName="icon icon-sprite icon-sprite-jumbo
-          icon-sprite-jumbo-white icon-services flush-top">
-        <p className="flush-bottom">
-          Use the {Config.productName} command line tools to find and install
-          services.
-        </p>
-      </AlertPanel>
-    );
-  },
-
   render: function () {
-    let {id} = this.props.params;
-
     return (
       <Page title="Services">
-        {this.getContents(decodeURIComponent(id))}
         <RouteHandler />
       </Page>
     );

--- a/src/js/pages/__tests__/ServicesTab-test.js
+++ b/src/js/pages/__tests__/ServicesTab-test.js
@@ -1,5 +1,4 @@
-jest.dontMock('../ServicesPage');
-jest.dontMock('../../components/Page');
+jest.dontMock('../services/ServicesTab');
 jest.dontMock('../../mixins/InternalStorageMixin');
 
 /* eslint-disable no-unused-vars */
@@ -11,12 +10,12 @@ var JestUtil = require('../../utils/JestUtil');
 
 var AlertPanel = require('../../components/AlertPanel');
 var DCOSStore = require('../../stores/DCOSStore');
-var ServicesPage = require('../ServicesPage');
+var ServicesTab = require('../services/ServicesTab');
 var ServiceTree = require('../../structs/ServiceTree');
 var ServiceDetail = require('../../components/ServiceDetail');
 var ServicesTable = require('../../components/ServicesTable');
 
-describe('ServicesPage', function () {
+describe('ServicesTab', function () {
 
   beforeEach(function () {
     DCOSStore.serviceTree = new ServiceTree({
@@ -37,7 +36,7 @@ describe('ServicesPage', function () {
 
     it('renders the service table', function () {
       var instance = ReactDOM.render(
-        JestUtil.stubRouterContext(ServicesPage, {params: {id: '/'}}),
+        JestUtil.stubRouterContext(ServicesTab, {params: {id: '/'}}),
         this.container
       );
 
@@ -48,7 +47,7 @@ describe('ServicesPage', function () {
 
     it('renders the service detail', function () {
       var instance = ReactDOM.render(
-        JestUtil.stubRouterContext(ServicesPage, {params: {id: '/alpha'}}),
+        JestUtil.stubRouterContext(ServicesTab, {params: {id: '/alpha'}}),
         this.container
       );
 
@@ -60,7 +59,7 @@ describe('ServicesPage', function () {
     it('renders loading screen', function () {
       DCOSStore.dataProcessed = false;
       var instance = ReactDOM.render(
-        JestUtil.stubRouterContext(ServicesPage, {params: {id: '/'}}),
+        JestUtil.stubRouterContext(ServicesTab, {params: {id: '/'}}),
         this.container
       );
 
@@ -73,7 +72,7 @@ describe('ServicesPage', function () {
     it('renders correct empty panel', function () {
       DCOSStore.serviceTree = new ServiceTree({id: '/'});
       var instance = ReactDOM.render(
-        JestUtil.stubRouterContext(ServicesPage, {params: {id: '/'}}),
+        JestUtil.stubRouterContext(ServicesTab, {params: {id: '/'}}),
         this.container
       );
 

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import AlertPanel from '../../components/AlertPanel';
+
+var DeploymentsTab = React.createClass({
+
+  displayName: 'DeploymentsTab',
+
+  renderEmpty: function () {
+    return (
+      <AlertPanel
+        title="No Deployments"
+        iconClassName="icon icon-sprite icon-sprite-jumbo
+            icon-sprite-jumbo-white icon-services flush-top">
+        <p className="flush">Active deployments will be shown here.</p>
+      </AlertPanel>
+    );
+  },
+
+  render: function () {
+    return this.renderEmpty();
+  }
+
+});
+
+module.exports = DeploymentsTab;
+

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -2,11 +2,13 @@ import React from 'react';
 
 import AlertPanel from '../../components/AlertPanel';
 
-var DeploymentsTab = React.createClass({
+class DeploymentsTab extends React.Component {
 
-  displayName: 'DeploymentsTab',
+  constructor() {
+    super(...arguments);
+  }
 
-  renderEmpty: function () {
+  renderEmpty() {
     return (
       <AlertPanel
         title="No Deployments"
@@ -15,13 +17,13 @@ var DeploymentsTab = React.createClass({
         <p className="flush">Active deployments will be shown here.</p>
       </AlertPanel>
     );
-  },
+  }
 
-  render: function () {
+  render() {
     return this.renderEmpty();
   }
 
-});
+}
 
 module.exports = DeploymentsTab;
 

--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -1,0 +1,158 @@
+import React from 'react';
+import {StoreMixin} from 'mesosphere-shared-reactjs';
+
+import AlertPanel from '../../components/AlertPanel';
+import Config from '../../config/Config';
+import DCOSStore from '../../stores/DCOSStore';
+import FilterHeadline from '../../components/FilterHeadline';
+import SaveStateMixin from '../../mixins/SaveStateMixin';
+import Service from '../../structs/Service';
+import ServiceDetail from '../../components/ServiceDetail';
+import ServiceFilterTypes from '../../constants/ServiceFilterTypes';
+import ServiceSidebarFilters from '../../components/ServiceSidebarFilters';
+import ServicesTable from '../../components/ServicesTable';
+import ServiceTree from '../../structs/ServiceTree';
+import SidebarActions from '../../events/SidebarActions';
+import SidePanels from '../../components/SidePanels';
+
+var DEFAULT_FILTER_OPTIONS = {
+  filterHealth: null,
+  searchString: ''
+};
+
+let saveState_properties = Object.keys(DEFAULT_FILTER_OPTIONS);
+
+var ServicesTab = React.createClass({
+
+  displayName: 'ServicesTab',
+
+  saveState_key: 'servicesPage',
+
+  saveState_properties,
+
+  mixins: [SaveStateMixin, StoreMixin],
+
+  statics: {
+    // Static life cycle method from react router, that will be called
+    // 'when a handler is about to render', i.e. on route change:
+    // https://github.com/rackt/react-router/
+    // blob/master/docs/api/components/RouteHandler.md
+    willTransitionTo: function () {
+      SidebarActions.close();
+    }
+  },
+
+  contextTypes: {
+    router: React.PropTypes.func
+  },
+
+  getInitialState: function () {
+    return Object.assign({}, DEFAULT_FILTER_OPTIONS);
+  },
+
+  componentWillMount: function () {
+    this.store_listeners = [{name: 'dcos', events: ['change']}];
+  },
+
+  handleFilterChange: function (filterValues, filterType) {
+    var stateChanges = Object.assign({}, this.state);
+    stateChanges[filterType] = filterValues;
+
+    this.setState(stateChanges);
+  },
+
+  resetFilterQueryParams: function () {
+    let router = this.context.router;
+    let queryParams = router.getCurrentQuery();
+
+    Object.values(ServiceFilterTypes).forEach(function (filterKey) {
+      delete queryParams[filterKey];
+    });
+
+    router.transitionTo(router.getCurrentPathname(), {}, queryParams);
+  },
+
+  resetFilter: function () {
+    var state = Object.assign({}, this.state, DEFAULT_FILTER_OPTIONS);
+    this.setState(state, this.resetFilterQueryParams);
+  },
+
+  getContents: function (id) {
+    // Render loading screen
+    if (!DCOSStore.dataProcessed) {
+      return (
+        <div className="container container-fluid container-pod text-align-center
+            vertical-center inverse">
+          <div className="row">
+            <div className="ball-scale">
+              <div />
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // Find item in root tree and default to root tree if there is no match
+    let item = DCOSStore.serviceTree.findItemById(id) || DCOSStore.serviceTree;
+
+    // Render service table
+    if (item instanceof ServiceTree && item.getItems().length > 0) {
+      let {state} = this;
+      let services = item.getItems();
+      let filteredServices = item.filterItemsByFilter({
+        health: state.filterHealth,
+        name: state.searchString
+      }).getItems();
+
+      return (
+        <div className="flex-box flush flex-mobile-column">
+          <ServiceSidebarFilters
+            handleFilterChange={this.handleFilterChange}
+            services={services} />
+          <div className="flex-grow">
+            <FilterHeadline
+              inverseStyle={true}
+              onReset={this.resetFilter}
+              name="Services"
+              currentLength={filteredServices.length}
+              totalLength={services.length} />
+            <ServiceSearchFilter
+              handleFilterChange={this.handleFilterChange} />
+            <ServicesTable
+              services={filteredServices} />
+          </div>
+          <SidePanels
+            params={this.props.params}
+            openedPage="services"/>
+        </div>
+      );
+    }
+
+    // Render service detail
+    if (item instanceof Service) {
+      return (<ServiceDetail service={item} />);
+    }
+
+    // Render empty panel
+    return (
+      <AlertPanel
+        title="No Services Installed"
+        iconClassName="icon icon-sprite icon-sprite-jumbo
+          icon-sprite-jumbo-white icon-services flush-top">
+        <p className="flush-bottom">
+          Use the {Config.productName} command line tools to find and install
+          services.
+        </p>
+      </AlertPanel>
+    );
+  },
+
+  render: function () {
+    let {id} = this.props.params;
+
+    return this.getContents(decodeURIComponent(id));
+  }
+
+});
+
+module.exports = ServicesTab;

--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -9,6 +9,7 @@ import SaveStateMixin from '../../mixins/SaveStateMixin';
 import Service from '../../structs/Service';
 import ServiceDetail from '../../components/ServiceDetail';
 import ServiceFilterTypes from '../../constants/ServiceFilterTypes';
+import ServiceSearchFilter from '../../components/ServiceSearchFilter';
 import ServiceSidebarFilters from '../../components/ServiceSidebarFilters';
 import ServicesTable from '../../components/ServicesTable';
 import ServiceTree from '../../structs/ServiceTree';

--- a/src/js/routes/services.js
+++ b/src/js/routes/services.js
@@ -1,4 +1,4 @@
-import {Route, Redirect} from 'react-router';
+import {Route} from 'react-router';
 
 import DeploymentsTab from '../pages/services/DeploymentsTab';
 import ServiceOverlay from '../components/ServiceOverlay';
@@ -13,8 +13,12 @@ let serviceRoutes = {
   children: [
     {
       type: Route,
-      name: 'services-all',
-      path: 'all/',
+      name: 'services-deployments',
+      path: 'deployments/',
+      handler: DeploymentsTab
+    },
+    {
+      type: Route,
       handler: ServicesTab,
       children: [
         {
@@ -39,17 +43,6 @@ let serviceRoutes = {
           path: 'task-detail/:taskID/?'
         }
       ]
-    },
-    {
-      type: Route,
-      name: 'services-deployments',
-      path: 'deployments/',
-      handler: DeploymentsTab
-    },
-    {
-      type: Redirect,
-      from: '/services/?',
-      to: 'services-all'
     }
   ]
 };

--- a/src/js/routes/services.js
+++ b/src/js/routes/services.js
@@ -3,6 +3,7 @@ let Route = Router.Route;
 
 import ServiceOverlay from '../components/ServiceOverlay';
 import ServicesPage from '../pages/ServicesPage';
+import ServicesTab from '../pages/services/ServicesTab';
 
 let servicesRoutes = {
   type: Route,
@@ -10,6 +11,11 @@ let servicesRoutes = {
   path: 'services/?',
   handler: ServicesPage,
   children: [
+    // Undocumented RR 0.13.5 behaviour: unnamed routes are treated as default
+    {
+      type: Route,
+      handler: ServicesTab
+    },
     {
       type: Route,
       name: 'services-detail',

--- a/src/js/routes/services.js
+++ b/src/js/routes/services.js
@@ -1,43 +1,57 @@
-import Router from 'react-router';
-let Route = Router.Route;
+import {Route, Redirect} from 'react-router';
 
+import DeploymentsTab from '../pages/services/DeploymentsTab';
 import ServiceOverlay from '../components/ServiceOverlay';
 import ServicesPage from '../pages/ServicesPage';
 import ServicesTab from '../pages/services/ServicesTab';
 
-let servicesRoutes = {
+let serviceRoutes = {
   type: Route,
   name: 'services',
-  path: 'services/?',
   handler: ServicesPage,
+  path: '/services/?',
   children: [
-    // Undocumented RR 0.13.5 behaviour: unnamed routes are treated as default
     {
       type: Route,
-      handler: ServicesTab
+      name: 'services-all',
+      path: 'all/',
+      handler: ServicesTab,
+      children: [
+        {
+          type: Route,
+          name: 'services-detail',
+          path: ':id/?'
+        },
+        {
+          type: Route,
+          name: 'service-ui',
+          path: 'ui/:serviceName/?',
+          handler: ServiceOverlay
+        },
+        {
+          type: Route,
+          name: 'services-panel',
+          path: 'service-detail/:serviceName/?'
+        },
+        {
+          type: Route,
+          name: 'services-task-panel',
+          path: 'task-detail/:taskID/?'
+        }
+      ]
     },
     {
       type: Route,
-      name: 'services-detail',
-      path: ':id/?'
+      name: 'services-deployments',
+      path: 'deployments/',
+      handler: DeploymentsTab
     },
     {
-      type: Route,
-      name: 'service-ui',
-      path: 'ui/:serviceName/?',
-      handler: ServiceOverlay
-    },
-    {
-      type: Route,
-      name: 'services-panel',
-      path: 'service-detail/:serviceName/?'
-    },
-    {
-      type: Route,
-      name: 'services-task-panel',
-      path: 'task-detail/:taskID/?'
+      type: Redirect,
+      from: '/services/?',
+      to: 'services-all'
     }
   ]
 };
 
-module.exports = servicesRoutes;
+module.exports = serviceRoutes;


### PR DESCRIPTION
This PR introduces a tabbed navigation to the services page, and splits the functionality previously in `ServicesPage` out to `ServicesTab`. The `DeploymentsTab` currently only shows an empty state. 

Note that in order to avoid conflicts (eg with a service named `deployments`) the service detail routes have been updated to use the `service` prefix, eg `/services/web-server` is now accessible at `/service/web-server`. 