### PR TITLE
Feature - Service page text search

### DIFF
--- a/src/js/components/ServiceSearchFilter.js
+++ b/src/js/components/ServiceSearchFilter.js
@@ -1,0 +1,61 @@
+import mixin from 'reactjs-mixin';
+import React from 'react';
+
+import FilterInputText from './FilterInputText';
+import QueryParamsMixin from '../mixins/QueryParamsMixin';
+import ServiceFilterTypes from '../constants/ServiceFilterTypes';
+
+const METHODS_TO_BIND = ['setSearchString'];
+
+class ServiceSearchFilter extends mixin(QueryParamsMixin) {
+  static get defaultProps() {
+    return {
+    };
+  }
+
+  constructor() {
+    super();
+
+    this.state = {
+      searchString: ''
+    };
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  componentDidMount() {
+    this.updateFilterStatus();
+  }
+
+  componentWillReceiveProps() {
+    this.updateFilterStatus();
+  }
+
+  setSearchString(filterValue) {
+    this.setQueryParam(ServiceFilterTypes.TEXT, filterValue);
+    this.props.handleFilterChange(filterValue, ServiceFilterTypes.TEXT);
+  }
+
+  updateFilterStatus() {
+    let {state} = this;
+    let searchString =
+      this.getQueryParamObject()[ServiceFilterTypes.TEXT] || '';
+
+    if (searchString !== state.searchString) {
+      this.setState({searchString},
+        this.props.handleFilterChange.bind(null, searchString, ServiceFilterTypes.TEXT));
+    }
+  }
+
+  render() {
+    return (
+      <FilterInputText
+        searchString={this.state.searchString}
+        handleFilterChange={this.setSearchString} />
+    );
+  }
+};
+
+module.exports = ServiceSearchFilter;

--- a/src/js/components/ServiceSearchFilter.js
+++ b/src/js/components/ServiceSearchFilter.js
@@ -52,8 +52,10 @@ class ServiceSearchFilter extends mixin(QueryParamsMixin) {
   render() {
     return (
       <FilterInputText
-        searchString={this.state.searchString}
-        handleFilterChange={this.setSearchString} />
+        handleFilterChange={this.setSearchString}
+        inverseStyle={true}
+        placeholder="Search"
+        searchString={this.state.searchString} />
     );
   }
 };

--- a/src/js/components/ServiceSearchFilter.js
+++ b/src/js/components/ServiceSearchFilter.js
@@ -1,5 +1,7 @@
 import mixin from 'reactjs-mixin';
+/* eslint-disable no-unused-vars */
 import React from 'react';
+/* eslint-enable no-unused-vars */
 
 import FilterInputText from './FilterInputText';
 import QueryParamsMixin from '../mixins/QueryParamsMixin';

--- a/src/js/components/ServiceSearchFilter.js
+++ b/src/js/components/ServiceSearchFilter.js
@@ -10,11 +10,6 @@ import ServiceFilterTypes from '../constants/ServiceFilterTypes';
 const METHODS_TO_BIND = ['setSearchString'];
 
 class ServiceSearchFilter extends mixin(QueryParamsMixin) {
-  static get defaultProps() {
-    return {
-    };
-  }
-
   constructor() {
     super();
 
@@ -22,7 +17,7 @@ class ServiceSearchFilter extends mixin(QueryParamsMixin) {
       searchString: ''
     };
 
-    METHODS_TO_BIND.forEach((method) => {
+    METHODS_TO_BIND.forEach(method => {
       this[method] = this[method].bind(this);
     });
   }

--- a/src/js/components/ServiceSearchFilter.js
+++ b/src/js/components/ServiceSearchFilter.js
@@ -17,7 +17,7 @@ class ServiceSearchFilter extends mixin(QueryParamsMixin) {
       searchString: ''
     };
 
-    METHODS_TO_BIND.forEach(method => {
+    METHODS_TO_BIND.forEach((method) => {
       this[method] = this[method].bind(this);
     });
   }

--- a/src/js/pages/ServicesPage.js
+++ b/src/js/pages/ServicesPage.js
@@ -11,6 +11,7 @@ import SaveStateMixin from '../mixins/SaveStateMixin';
 import Service from '../structs/Service';
 import ServiceDetail from '../components/ServiceDetail';
 import ServiceFilterTypes from '../constants/ServiceFilterTypes';
+import ServiceSearchFilter from '../components/ServiceSearchFilter';
 import ServiceSidebarFilters from '../components/ServiceSidebarFilters';
 import ServicesTable from '../components/ServicesTable';
 import ServiceTree from '../structs/ServiceTree';
@@ -124,6 +125,8 @@ var ServicesPage = React.createClass({
               name="Services"
               currentLength={filteredServices.length}
               totalLength={services.length} />
+            <ServiceSearchFilter
+              handleFilterChange={this.handleFilterChange} />
             <ServicesTable
               services={filteredServices} />
           </div>

--- a/src/js/pages/ServicesPage.js
+++ b/src/js/pages/ServicesPage.js
@@ -64,7 +64,7 @@ var ServicesPage = React.createClass({
   },
 
   handleFilterChange: function (filterValues, filterType) {
-    var stateChanges = Object.assign({}, DEFAULT_FILTER_OPTIONS);
+    var stateChanges = Object.assign({}, this.state);
     stateChanges[filterType] = filterValues;
 
     this.setState(stateChanges);

--- a/src/js/stores/DCOSStore.js
+++ b/src/js/stores/DCOSStore.js
@@ -24,8 +24,16 @@ class DCOSStore extends EventEmitter {
       this[method] = this[method].bind(this);
     });
 
+    this.serviceTreeOptions = {
+      filterProperties: {
+        name: function (item) {
+          return item.id;
+        }
+      }
+    };
+
     this.data = {
-      marathon: new ServiceTree(),
+      marathon: new ServiceTree(this.serviceTreeOptions),
       mesos: {
         frameworks: []
       },

--- a/src/js/stores/DCOSStore.js
+++ b/src/js/stores/DCOSStore.js
@@ -24,16 +24,8 @@ class DCOSStore extends EventEmitter {
       this[method] = this[method].bind(this);
     });
 
-    this.serviceTreeOptions = {
-      filterProperties: {
-        name: function (item) {
-          return item.id;
-        }
-      }
-    };
-
     this.data = {
-      marathon: new ServiceTree(this.serviceTreeOptions),
+      marathon: new ServiceTree(),
       mesos: {
         frameworks: []
       },

--- a/src/js/stores/MarathonStore.js
+++ b/src/js/stores/MarathonStore.js
@@ -160,7 +160,11 @@ var MarathonStore = Store.createStore({
   },
 
   processMarathonGroups: function (data) {
-    let groups = new ServiceTree(data);
+    let groups = new ServiceTree({items: data.apps, filterProperties: {
+      name: function (item) {
+        return item.id;
+      }
+    }});
 
     let apps = groups.reduceItems(function (map, item) {
       if (item instanceof Service) {

--- a/src/js/stores/MarathonStore.js
+++ b/src/js/stores/MarathonStore.js
@@ -160,11 +160,13 @@ var MarathonStore = Store.createStore({
   },
 
   processMarathonGroups: function (data) {
-    let groups = new ServiceTree({items: data.apps, filterProperties: {
+    data.filterProperties = {
       name: function (item) {
         return item.id;
       }
-    }});
+    };
+
+    let groups = new ServiceTree(data);
 
     let apps = groups.reduceItems(function (map, item) {
       if (item instanceof Service) {

--- a/src/js/structs/List.js
+++ b/src/js/structs/List.js
@@ -22,7 +22,7 @@ module.exports = class List {
       this.list = options.items;
     }
 
-    this.filterProperties = options.filterProperties || [];
+    this.filterProperties = options.filterProperties || {};
   }
 
   add(item) {

--- a/src/js/structs/Tree.js
+++ b/src/js/structs/Tree.js
@@ -130,8 +130,8 @@ module.exports = class Tree extends List {
       if (filter.name) {
         let tree =
           new this.constructor(Object.assign({},
-            this, {items: services, filterProperties: 'name'}));
-        services = tree.filterItems(filter.name).getItems();
+            this, {items: services, filterProperties: this.getFilterProperties()}));
+        services = tree.filterItemsByText(filter.name).getItems();
       }
 
       if (filter.health != null && filter.health.length !== 0) {

--- a/src/js/structs/__tests__/CompositeState-test.js
+++ b/src/js/structs/__tests__/CompositeState-test.js
@@ -378,7 +378,7 @@ describe('CompositeState', function () {
             _itemData: { id: 'qq-id', hostname: 'qq' }
           }
         ],
-        filterProperties: []
+        filterProperties: {}
       };
 
       var nodesList = CompositeState.getNodesList();

--- a/src/js/structs/__tests__/ServiceTree-test.js
+++ b/src/js/structs/__tests__/ServiceTree-test.js
@@ -14,20 +14,39 @@ describe('ServiceTree', function () {
       this.instance = new ServiceTree({
         id: '/group/id',
         apps: [
-          {id: 'alpha', cmd: 'cmd'},
+          {
+            id: 'alpha',
+            cmd: 'cmd'
+          },
           {
             id: 'beta',
             cmd: 'cmd',
-            labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'}
+            labels: {
+              DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'
+            }
           },
-          {id: 'gamma', cmd: 'cmd', labels: {RANDOM_LABEL: 'random'}}
+          {
+            id: 'gamma',
+            cmd: 'cmd',
+            labels: {
+              RANDOM_LABEL: 'random'
+            }
+          }
         ],
         groups: [
           {
-            id: '/test', apps: [
-              {id: 'foo', cmd: 'cmd'},
-              {id: 'bar', cmd: 'cmd'}
-            ], groups: []
+            id: '/test',
+            apps: [
+              {
+                id: 'foo',
+                cmd: 'cmd'
+              },
+              {
+                id: 'bar',
+                cmd: 'cmd'
+              }
+            ],
+            groups: []
           }
         ],
         filterProperties: {
@@ -103,20 +122,39 @@ describe('ServiceTree', function () {
       this.instance = new ServiceTree({
         id: '/group/id',
         apps: [
-          {id: 'alpha', cmd: 'cmd'},
+          {
+            id: 'alpha',
+            cmd: 'cmd'
+          },
           {
             id: 'beta',
             cmd: 'cmd',
-            labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'}
+            labels: {
+              DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'
+            }
           },
-          {id: 'gamma', cmd: 'cmd', labels: {RANDOM_LABEL: 'random'}}
+          {
+            id: 'gamma',
+            cmd: 'cmd',
+            labels: {
+              RANDOM_LABEL: 'random'
+            }
+          }
         ],
         groups: [
           {
-            id: '/test', apps: [
-              {id: 'foo', cmd: 'cmd'},
-              {id: 'bar', cmd: 'cmd'}
-            ], groups: []
+            id: '/test',
+            apps: [
+              {
+                id: 'foo',
+                cmd: 'cmd'
+              },
+              {
+                id: 'bar',
+                cmd: 'cmd'
+              }
+            ],
+            groups: []
           }
         ],
         filterProperties: {
@@ -161,18 +199,35 @@ describe('ServiceTree', function () {
           {
             id: 'beta',
             cmd: 'cmd',
-            labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'},
+            labels: {
+              DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'
+            },
             tasksHealthy: 1,
             tasksRunning: 1
           },
-          {id: 'gamma', cmd: 'cmd', labels: {RANDOM_LABEL: 'random'}}
+          {
+            id: 'gamma',
+            cmd: 'cmd',
+            labels:
+            {
+              RANDOM_LABEL: 'random'
+            }
+          }
         ],
         groups: [
           {
-            id: '/test', apps: [
-              {id: 'foo', cmd: 'cmd'},
-              {id: 'bar', cmd: 'cmd'}
-            ], groups: []
+            id: '/test',
+            apps: [
+              {
+                id: 'foo',
+                cmd: 'cmd'
+              },
+              {
+                id: 'bar',
+                cmd: 'cmd'
+              }
+            ],
+            groups: []
           }
         ],
         filterProperties: {
@@ -210,7 +265,7 @@ describe('ServiceTree', function () {
       expect(filteredServices[0].id).toEqual('beta');
     });
 
-    it('should filter AND-connected', function () {
+    it('should perform a logical AND with multiple filters', function () {
       let filteredServices = this.instance.filterItemsByFilter({
         health: [HealthTypes.NA],
         name: 'alpha'
@@ -227,20 +282,39 @@ describe('ServiceTree', function () {
       this.instance = new ServiceTree({
         id: '/group/id',
         apps: [
-          {id: 'alpha', cmd: 'cmd'},
+          {
+            id: 'alpha',
+            cmd: 'cmd'
+          },
           {
             id: 'beta',
             cmd: 'cmd',
-            labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'}
+            labels: {
+              DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'
+            }
           },
-          {id: 'gamma', cmd: 'cmd', labels: {RANDOM_LABEL: 'random'}}
+          {
+            id: 'gamma',
+            cmd: 'cmd',
+            labels: {
+              RANDOM_LABEL: 'random'
+            }
+          }
         ],
         groups: [
           {
-            id: '/test', apps: [
-              {id: 'foo', cmd: 'cmd'},
-              {id: 'bar', cmd: 'cmd'}
-            ], groups: []
+            id: '/test',
+            apps: [
+              {
+                id: 'foo',
+                cmd: 'cmd'
+              },
+              {
+                id: 'bar',
+                cmd: 'cmd'
+              }
+            ],
+            groups: []
           }
         ],
         filterProperties: {
@@ -265,20 +339,39 @@ describe('ServiceTree', function () {
       this.instance = new ServiceTree({
         id: '/group/id',
         apps: [
-          {id: '/alpha', cmd: 'cmd'},
+          {
+            id: '/alpha',
+            cmd: 'cmd'
+          },
           {
             id: '/beta',
             cmd: 'cmd',
-            labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'}
+            labels: {
+              DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'
+            }
           },
-          {id: '/gamma', cmd: 'cmd', labels: {RANDOM_LABEL: 'random'}}
+          {
+            id: '/gamma',
+            cmd: 'cmd',
+            labels: {
+              RANDOM_LABEL: 'random'
+            }
+          }
         ],
         groups: [
           {
-            id: '/test', apps: [
-              {id: '/foo', cmd: 'cmd'},
-              {id: '/bar', cmd: 'cmd'}
-            ], groups: []
+            id: '/test',
+            apps: [
+              {
+                id: '/foo',
+                cmd: 'cmd'
+              },
+              {
+                id: '/bar',
+                cmd: 'cmd'
+              }
+            ],
+            groups: []
           }
         ]
       });
@@ -303,21 +396,42 @@ describe('ServiceTree', function () {
       let serviceTree = new ServiceTree({
         id: '/group/id',
         apps: [
-          {id: '/alpha', cmd: 'cmd', deployments: []},
+          {
+            id: '/alpha',
+            cmd: 'cmd',
+            deployments: []
+          },
           {
             id: '/beta',
             cmd: 'cmd',
             deployments: [],
-            labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'}
+            labels: {
+              DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'
+            }
           },
-          {id: '/gamma', cmd: 'cmd', labels: {RANDOM_LABEL: 'random'}}
+          {
+            id: '/gamma',
+            cmd: 'cmd',
+            labels: {
+              RANDOM_LABEL: 'random'
+            }
+          }
         ],
         groups: [
           {
-            id: '/test', apps: [
-              {id: '/foo', cmd: 'cmd', deployments: []},
-              {id: '/bar', cmd: 'cmd'}
-            ], groups: []
+            id: '/test',
+            apps: [
+              {
+                id: '/foo',
+                cmd: 'cmd',
+                deployments: []
+              },
+              {
+                id: '/bar',
+                cmd: 'cmd'
+              }
+            ],
+            groups: []
           }
         ]
       });
@@ -332,26 +446,51 @@ describe('ServiceTree', function () {
           {
             id: '/alpha',
             cmd: 'cmd',
-            deployments: [{id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f2'}]
+            deployments: [
+              {
+                id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f2'
+              }
+            ]
           },
           {
             id: '/beta',
             cmd: 'cmd',
-            deployments: [{id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f3'}],
-            labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'}
+            deployments: [
+              {
+                id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f3'
+              }
+            ],
+            labels: {
+              DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'
+            }
           },
-          {id: '/gamma', cmd: 'cmd', labels: {RANDOM_LABEL: 'random'}}
+          {
+            id: '/gamma',
+            cmd: 'cmd',
+            labels: {
+              RANDOM_LABEL: 'random'
+            }
+          }
         ],
         groups: [
           {
-            id: '/test', apps: [
+            id: '/test',
+            apps: [
               {
                 id: '/foo',
                 cmd: 'cmd',
-                deployments: [{id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f1'}]
+                deployments: [
+                  {
+                    id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f1'
+                  }
+                ]
               },
-              {id: '/bar', cmd: 'cmd'}
-            ], groups: []
+              {
+                id: '/bar',
+                cmd: 'cmd'
+              }
+            ],
+            groups: []
           }
         ]
       });

--- a/tests/servicesPage/ServiceSearchFilter-cy.js
+++ b/tests/servicesPage/ServiceSearchFilter-cy.js
@@ -1,0 +1,39 @@
+describe('Service Search Filters', function () {
+  context('Filters services table', function () {
+    beforeEach(function () {
+      cy.configureCluster({
+        mesos: '1-for-each-health',
+        nodeHealth: true
+      });
+      cy.visitUrl({url: '/services'});
+    });
+
+    it('filters correctly on search string', function () {
+      cy.get('tbody tr').should('to.have.length', 6);
+      cy.get('.filter-input-text').as('filterInputText');
+      cy.get('@filterInputText').type('unhealthy');
+      cy.get('tbody tr').should('to.have.length', 3);
+    });
+
+    it('sets the correct search string filter query params', function () {
+      cy.get('.filter-input-text').as('filterInputText');
+      cy.get('@filterInputText').type('cassandra-healthy');
+      cy.location().its('href').should(function (href) {
+        var queries = href.split('?')[1];
+        expect(decodeURIComponent(queries))
+          .to.equal('searchString=cassandra-healthy');
+      });
+    });
+
+    it('will clear filters by clear all link click', function () {
+      cy.get('.filter-input-text').as('filterInputText');
+      cy.get('@filterInputText').type('cassandra-healthy');
+      cy.get('.h4.clickable .small').click();
+      cy.location().its('href').should(function (href) {
+        var queries = href.split('?')[1];
+        expect(queries).to.equal(undefined);
+      });
+      cy.get('tbody tr').should('to.have.length', 6);
+    });
+  });
+});

--- a/tests/servicesPage/SidebarFilter-cy.js
+++ b/tests/servicesPage/SidebarFilter-cy.js
@@ -10,7 +10,7 @@ describe('Sidebar Filter', function () {
 
     it('filters correctly on Idle', function () {
       cy.get('.sidebar-filters .label').contains('Idle').click();
-      cy.get('tbody tr').should('to.have.length', 3);
+      cy.get('tbody tr').should('to.have.length', 1);
     });
 
     it('filters correctly on Unhealthy', function () {
@@ -20,7 +20,7 @@ describe('Sidebar Filter', function () {
 
     it('filters correctly on N/A', function () {
       cy.get('.sidebar-filters .label').contains('N/A').click();
-      cy.get('tbody tr').should('to.have.length', 3);
+      cy.get('tbody tr').should('to.have.length', 4);
     });
 
     it('filters correctly on Healthy', function () {
@@ -32,13 +32,6 @@ describe('Sidebar Filter', function () {
       cy.get('.sidebar-filters .label').contains('Healthy').click();
       cy.get('.sidebar-filters .label').contains('Unhealthy').click();
       cy.get('tbody tr').should('to.have.length', 4);
-    });
-
-    it('resets search input on filter change', function () {
-      cy.get('.filter-input-text').as('filterInputText');
-      cy.get('@filterInputText').type('cassandra-healthy');
-      cy.get('.sidebar-filters .label').contains('Healthy').click();
-      cy.get('@filterInputText').should('have.value', '');
     });
 
     it('sets the correct filter query params', function () {


### PR DESCRIPTION
This reintroduces the service page text search, which enables a search of the complete Marathon Services (Groups, Apps).
The search is stored as a query param and AND-connected to the sidebar filters.

The search field could be placed anywhere in the application, so it's basically a global search placed locally.

Thx @kennyt for the help and preliminary work.

![search1](https://cloud.githubusercontent.com/assets/859154/14868554/702154f2-0cce-11e6-8966-955188636a3b.png)
 
![search2](https://cloud.githubusercontent.com/assets/859154/14868557/756be86e-0cce-11e6-98ca-0dce64f1fa01.png)
