### PR TITLE
Adjust the List and Tree filterItemsByText method

### DIFF
--- a/src/js/structs/List.js
+++ b/src/js/structs/List.js
@@ -7,7 +7,7 @@ module.exports = class List {
    * List
    * @param {{
    *          items:array,
-   *          filterProperties:{propertyName:(null|string|function)}
+   *          filterProperties:{propertyName:(null|function)}
    *        }} options
    * @constructor
    * @struct

--- a/src/js/structs/List.js
+++ b/src/js/structs/List.js
@@ -58,11 +58,12 @@ module.exports = class List {
   /**
    * Filters items in list and returns a new instance of the list used.
    * @param  {string} filterText string to search in properties of the list
+   * @param  {{propertyName:(null|function)}} [filterProperties] object
+   *     to configure filter properties as well as their getters
    * @return {List} List (or child class) containing filtered items
    */
-  filterItemsByText(filterText) {
+  filterItemsByText(filterText, filterProperties = this.getFilterProperties()) {
     let items = this.getItems();
-    let filterProperties = this.getFilterProperties();
 
     if (filterText) {
       items = StringUtil.filterByString(items, function (item) {

--- a/src/js/structs/Tree.js
+++ b/src/js/structs/Tree.js
@@ -8,7 +8,7 @@ module.exports = class Tree extends List {
    * Tree
    * @param {{
    *          items:array<({items:array}|*)>,
-   *          filterProperties:{propertyName:(null|string|function)}
+   *          filterProperties:{propertyName:(null|function)}
    *        }} options
    * @constructor
    * @struct

--- a/src/js/structs/Tree.js
+++ b/src/js/structs/Tree.js
@@ -75,11 +75,11 @@ module.exports = class Tree extends List {
   /**
    * Filters items in tree and returns a new instance of the tree used.
    * @param  {string} filterText string to search in properties of the list
+   * @param  {{propertyName:(null|function)}} [filterProperties] object to
+   *     configure filter properties as well as their getters
    * @return {Tree} Tree (or child class) containing filtered items
    */
-  filterItemsByText(filterText) {
-    let filterProperties = this.getFilterProperties();
-
+  filterItemsByText(filterText, filterProperties = this.getFilterProperties()) {
     if (filterText) {
       let regex = StringUtil.escapeForRegExp(filterText);
       let searchPattern = new RegExp(regex, 'i');

--- a/src/js/structs/__tests__/List-test.js
+++ b/src/js/structs/__tests__/List-test.js
@@ -113,8 +113,16 @@ describe('List', function () {
 
     beforeEach(function () {
       var items = [
-        {name: 'foo', description: {value: 'qux'}, subItems: ['one', 'two']},
-        {name: 'bar', description: {value: 'quux'}, subItems: ['two', 'three']}
+        {
+          name: 'foo',
+          description: {value: 'qux', label: 'corge'},
+          subItems: ['one', 'two']
+        },
+        {
+          name: 'bar',
+          description: {value: 'quux', label: 'grault'},
+          subItems: ['two', 'three']
+        }
       ];
       var filterProperties = {
         name: null,
@@ -144,8 +152,8 @@ describe('List', function () {
         new Item({
           name: 'bar',
           description: {value: 'quux'},
-          subItems: ['two', 'three']}
-        )
+          subItems: ['two', 'three']
+        })
       ];
       var filterProperties = {
         name: null,
@@ -198,6 +206,18 @@ describe('List', function () {
       };
       var list = new List({items, filterProperties});
       expect(list.filterItemsByText.bind(list, 'foo')).not.toThrow();
+    });
+
+    it('should use provided filter properties', function () {
+      var filterProperties = {
+        description: function (item, prop) {
+          return item[prop] && item[prop].label;
+        }
+      };
+      var filteredItems = this.instance
+        .filterItemsByText('corge', filterProperties)
+        .getItems();
+      expect(filteredItems[0].name).toEqual('foo');
     });
 
   });

--- a/src/js/structs/__tests__/Tree-test.js
+++ b/src/js/structs/__tests__/Tree-test.js
@@ -164,18 +164,18 @@ describe('Tree', function () {
 
     beforeEach(function () {
       var items = [
-        {name: 'foo', description: {value: 'qux'}, tags: ['one', 'two']},
-        {name: 'bar', description: {value: 'quux'}, tags: ['two', 'three']},
+        {name: 'foo', description: {value: 'qux', label: 'corge' }, tags: ['one', 'two']},
+        {name: 'bar', description: {value: 'quux', label: 'grault'}, tags: ['two', 'three']},
         {
           items: [
             {
               name: 'alpha',
-              description: {value: 'gamma'},
+              description: {value: 'gamma', label: 'epsilon'},
               tags: ['one', 'two']
             },
             {
               name: 'beta',
-              description: {value: 'delta'},
+              description: {value: 'delta', label: 'zeta'},
               tags: ['one', 'two']
             }
           ]
@@ -269,6 +269,17 @@ describe('Tree', function () {
       };
       var list = new Tree({items, filterProperties});
       expect(list.filterItemsByText.bind(list, 'foo')).not.toThrow();
+    });
+
+    it('should use provided filter properties', function () {
+      var filterProperties = {
+        description: function (item, prop) {
+          return item[prop] && item[prop].label;
+        }
+      };
+      var filteredItems =
+        this.instance.filterItemsByText('zeta', filterProperties).getItems();
+      expect(filteredItems[0].getItems()[0].name).toEqual('beta');
     });
 
   });


### PR DESCRIPTION
Add optional `filterProperties` parameter to the list and tree struct `filterItemsByText` method. This allows the flexible definition of filter properties whenever you want to filter.

/cc @aldipower 