### PR TITLE
Refactor the service detail task view

### DIFF
--- a/src/js/components/ServiceDetail.js
+++ b/src/js/components/ServiceDetail.js
@@ -1,18 +1,13 @@
 import mixin from 'reactjs-mixin';
 import React from 'react';
-import {StoreMixin} from 'mesosphere-shared-reactjs';
 
 import InternalStorageMixin from '../mixins/InternalStorageMixin';
-import MesosStateStore from '../stores/MesosStateStore';
 import Service from '../structs/Service';
+import ServiceDetailTaskTab from './ServiceDetailTaskTab';
 import ServiceInfo from './ServiceInfo';
 import TabsMixin from '../mixins/TabsMixin';
-import TaskView from './TaskView';
 
-const METHODS_TO_BIND = [];
-
-class ServiceDetail
-  extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
+class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
 
   constructor() {
     super(...arguments);
@@ -27,14 +22,6 @@ class ServiceDetail
     this.state = {
       currentTab: Object.keys(this.tabs_tabs).shift()
     };
-
-    this.store_listeners = [
-      {name: 'state', events: ['success']}
-    ];
-
-    METHODS_TO_BIND.forEach((method) => {
-      this[method] = this[method].bind(this);
-    });
   }
 
   renderConfigurationTabView() {
@@ -50,11 +37,8 @@ class ServiceDetail
   }
 
   renderTasksTabView() {
-    let tasks = MesosStateStore.getTasksByServiceId(this.props.service.getId());
-
     return (
-      <TaskView tasks={tasks} inverseStyle={true}
-        parentRouter={this.context.router} />
+      <ServiceDetailTaskTab service={this.props.service}/>
     );
   }
 

--- a/src/js/components/ServiceDetailTaskTab.js
+++ b/src/js/components/ServiceDetailTaskTab.js
@@ -1,0 +1,37 @@
+import mixin from 'reactjs-mixin';
+import React from 'react';
+import {StoreMixin} from 'mesosphere-shared-reactjs';
+
+import MesosStateStore from '../stores/MesosStateStore';
+import Service from '../structs/Service';
+import TaskView from './TaskView';
+
+class ServiceDetailTaskTab extends mixin(StoreMixin) {
+
+  constructor() {
+    super(...arguments);
+
+    this.store_listeners = [
+      {name: 'state', events: ['success']}
+    ];
+  }
+
+  render() {
+    let tasks = MesosStateStore.getTasksByServiceId(this.props.service.getId());
+
+    return (
+      <TaskView tasks={tasks} inverseStyle={true}
+        parentRouter={this.context.router} />
+    );
+  }
+}
+
+ServiceDetailTaskTab.contextTypes = {
+  router: React.PropTypes.func
+};
+
+ServiceDetailTaskTab.propTypes = {
+  service: React.PropTypes.instanceOf(Service)
+};
+
+module.exports = ServiceDetailTaskTab;

--- a/src/js/components/__tests__/ServiceDetail-test.js
+++ b/src/js/components/__tests__/ServiceDetail-test.js
@@ -1,8 +1,6 @@
 jest.dontMock('../ServiceDetail');
+jest.dontMock('../ServiceDetailTaskTab');
 jest.dontMock('../ServiceInfo');
-jest.dontMock('../TaskView');
-jest.dontMock('../../mixins/GetSetMixin');
-jest.dontMock('../../stores/MesosStateStore');
 
 /* eslint-disable no-unused-vars */
 var React = require('react');
@@ -13,7 +11,7 @@ var JestUtil = require('../../utils/JestUtil');
 
 var Service = require('../../structs/Service');
 var ServiceDetail = require('../ServiceDetail');
-var TaskView = require('../TaskView');
+var ServiceDetailTaskTab = require('../ServiceDetailTaskTab');
 
 describe('ServiceDetail', function () {
 
@@ -31,7 +29,7 @@ describe('ServiceDetail', function () {
 
   beforeEach(function () {
     this.container = document.createElement('div');
-    this.wrapper  = ReactDOM.render(
+    this.wrapper = ReactDOM.render(
       JestUtil.stubRouterContext(ServiceDetail, {service}),
       this.container
     );
@@ -93,15 +91,15 @@ describe('ServiceDetail', function () {
 
   describe('#renderTasksTabView', function () {
 
-    it('renders task view', function () {
+    it('renders task tab', function () {
       var tasksTabView = ReactDOM.render(
         this.instance.renderTasksTabView(),
         this.container
       );
+      var serviceDetailTaskTab = TestUtils
+        .findRenderedComponentWithType(tasksTabView, ServiceDetailTaskTab);
 
-      expect(
-        TestUtils.findRenderedComponentWithType(tasksTabView, TaskView)
-      ).toBeDefined();
+      expect(serviceDetailTaskTab).toBeDefined();
 
     });
 

--- a/src/js/components/__tests__/ServiceDetailTaskTab-test.js
+++ b/src/js/components/__tests__/ServiceDetailTaskTab-test.js
@@ -47,7 +47,6 @@ describe('ServiceDetailTaskTab', function () {
         .findRenderedComponentWithType(this.instance, TaskView);
 
       expect(taskView).toBeDefined();
-
     });
 
   });

--- a/src/js/components/__tests__/ServiceDetailTaskTab-test.js
+++ b/src/js/components/__tests__/ServiceDetailTaskTab-test.js
@@ -1,0 +1,55 @@
+jest.dontMock('../../mixins/GetSetMixin');
+jest.dontMock('../../stores/MesosStateStore');
+jest.dontMock('../ServiceDetailTaskTab');
+jest.dontMock('../TaskView');
+
+/* eslint-disable no-unused-vars */
+var React = require('react');
+/* eslint-enable no-unused-vars */
+var ReactDOM = require('react-dom');
+var TestUtils = require('react-addons-test-utils');
+var JestUtil = require('../../utils/JestUtil');
+
+var Service = require('../../structs/Service');
+var ServiceDetailTaskTab = require('../ServiceDetailTaskTab');
+var TaskView = require('../TaskView');
+
+describe('ServiceDetailTaskTab', function () {
+
+  const service = new Service({
+    id: '/group/test',
+    healthChecks: [{path: '', protocol: 'HTTP'}],
+    cpus: 1,
+    mem: 2048,
+    disk: 0,
+    tasksStaged: 0,
+    tasksRunning: 2,
+    tasksHealthy: 2,
+    tasksUnhealthy: 0
+  });
+
+  beforeEach(function () {
+    this.container = document.createElement('div');
+    this.instance = ReactDOM.render(
+      JestUtil.stubRouterContext(ServiceDetailTaskTab, {service}),
+      this.container
+    );
+  });
+
+  afterEach(function () {
+    ReactDOM.unmountComponentAtNode(this.container);
+  });
+
+  describe('#render', function () {
+
+    it('renders task view', function () {
+      var taskView =  TestUtils
+        .findRenderedComponentWithType(this.instance, TaskView);
+
+      expect(taskView).toBeDefined();
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
![task-tab-mesos-polling](https://cloud.githubusercontent.com/assets/647035/14886318/7c882efa-0d50-11e6-9c28-36a76afce56f.gif)
Refactor the service detail and move the tasks view into it's own component - this enables us to only poll the Mesos state, while a user is looking at the tasks list.