### PR TITLE
Fix packages search field

### DIFF
--- a/src/js/pages/universe/PackagesTab.js
+++ b/src/js/pages/universe/PackagesTab.js
@@ -211,7 +211,7 @@ class PackagesTab extends mixin(StoreMixin) {
     let gridPackages = splitPackages.selectedPackages;
 
     if (state.searchString) {
-      tablePackages = packages.filterItems(state.searchString);
+      tablePackages = packages.filterItemsByText(state.searchString);
     }
 
     return (


### PR DESCRIPTION
The packages tab search field was calling `filterItems` instead of `filterItemsByText`, with the result that the search field was broken:

![](https://s3.amazonaws.com/f.cl.ly/items/2w1i1H3E1C3A212N0m0t/Screen%20Recording%202016-04-28%20at%2003.51%20PM.gif?v=00a6482b)