### PR TITLE
[Feature] System Health sidepanels upgrade to full page

### DIFF
--- a/src/js/components/SidePanels.js
+++ b/src/js/components/SidePanels.js
@@ -8,8 +8,6 @@ import MesosSummaryStore from '../stores/MesosSummaryStore';
 import ServiceSidePanelContents from './ServiceSidePanelContents';
 import StringUtil from '../utils/StringUtil';
 import TaskSidePanelContents from './TaskSidePanelContents';
-import UnitHealthSidePanelContents from './UnitHealthSidePanelContents';
-import UnitNodeSidePanelContents from './UnitNodeSidePanelContents';
 import Util from '../utils/Util';
 
 const METHODS_TO_BIND = [
@@ -58,13 +56,11 @@ class SidePanels extends mixin(StoreMixin) {
   }
 
   isOpen(itemIDs) {
-    let {unitID, unitNodeID, serviceName, taskID} = itemIDs;
+    let {serviceName, taskID} = itemIDs;
 
     return (
-      (unitNodeID != null && unitID != null) ||
       serviceName != null ||
-      taskID != null ||
-      unitID != null
+      taskID != null
     ) && MesosSummaryStore.get('statesProcessed');
   }
 
@@ -105,16 +101,7 @@ class SidePanels extends mixin(StoreMixin) {
       return null;
     }
 
-    let {unitID, unitNodeID, serviceName, taskID} = itemIDs;
-
-    if (unitID != null && unitNodeID != null) {
-      return (
-        <UnitNodeSidePanelContents
-          itemID={unitID}
-          params={this.props.params}
-          parentRouter={this.context.router} />
-      );
-    }
+    let {serviceName, taskID} = itemIDs;
 
     if (taskID != null) {
       return (
@@ -129,14 +116,6 @@ class SidePanels extends mixin(StoreMixin) {
       return (
         <ServiceSidePanelContents
           itemID={serviceName}
-          parentRouter={this.context.router} />
-      );
-    }
-
-    if (unitID != null) {
-      return (
-        <UnitHealthSidePanelContents
-          itemID={unitID}
           parentRouter={this.context.router} />
       );
     }

--- a/src/js/components/UnitHealthNodesTable.js
+++ b/src/js/components/UnitHealthNodesTable.js
@@ -1,3 +1,4 @@
+import {Link} from 'react-router';
 import React from 'react';
 import {Table} from 'reactjs-components';
 
@@ -82,23 +83,13 @@ class UnitHealthNodesTable extends React.Component {
   }
 
   getNodeLink(node, linkText) {
-    let parentPaths = this.props.parentRouter.getCurrentRoutes();
-    let parentPath = parentPaths[parentPaths.length - 2].name;
-    let path = 'system-overview-units-unit-nodes-node-panel';
-    // Route is available under dashboard root
-    if (parentPath === 'dashboard') {
-      path = 'dashboard-units-unit-nodes-node-panel';
-    }
-
-    let params = {unitID: this.props.itemID, unitNodeID: node.get('host_ip')};
+    let params = Object.assign({}, this.props.params, {unitNodeID: node.get('host_ip')});
 
     return (
-      <a
-        className="emphasize clickable text-overflow"
-        onClick={() => { this.props.parentRouter.transitionTo(path, params); }}
-        title={linkText}>
+      <Link className="emphasize clickable text-overflow" params={params}
+        to="system-overview-units-unit-nodes-node-detail">
         {linkText}
-      </a>
+      </Link>
     );
   }
 
@@ -126,20 +117,20 @@ class UnitHealthNodesTable extends React.Component {
     return (
       <Table
         className="table table-borderless-outer
-          table-borderless-inner-columns flush-bottom"
+          table-borderless-inner-columns flush-bottom inverse"
         columns={this.getColumns()}
         colGroup={this.getColGroup()}
         containerSelector=".gm-scroll-view"
         data={this.props.nodes}
         itemHeight={TableUtil.getRowHeight()}
-        sortBy={{prop: 'health', order: 'asc'}}
-        />
+        sortBy={{prop: 'health', order: 'asc'}} />
     );
   }
 }
 
 UnitHealthNodesTable.propTypes = {
-  nodes: React.PropTypes.array.isRequired
+  nodes: React.PropTypes.array.isRequired,
+  params: React.PropTypes.object
 };
 
 module.exports = UnitHealthNodesTable;

--- a/src/js/components/__tests__/SidePanels-test.js
+++ b/src/js/components/__tests__/SidePanels-test.js
@@ -10,8 +10,6 @@ jest.dontMock('../../events/MarathonActions');
 jest.dontMock('../ServiceSidePanelContents');
 jest.dontMock('../SidePanelContents');
 jest.dontMock('../TaskSidePanelContents');
-jest.dontMock('../UnitHealthSidePanelContents');
-jest.dontMock('../UnitNodeSidePanelContents');
 jest.dontMock('../../utils/Util');
 jest.dontMock('../../utils/RequestUtil');
 jest.dontMock('../../structs/SummaryList');
@@ -25,8 +23,6 @@ var MesosSummaryStore = require('../../stores/MesosSummaryStore');
 var ServiceSidePanelContents = require('../ServiceSidePanelContents');
 var SidePanels = require('../SidePanels');
 var TaskSidePanelContents = require('../TaskSidePanelContents');
-var UnitHealthSidePanelContents = require('../UnitHealthSidePanelContents');
-var UnitNodeSidePanelContents = require('../UnitNodeSidePanelContents');
 
 describe('SidePanels', function () {
   beforeEach(function () {
@@ -89,9 +85,7 @@ describe('SidePanels', function () {
       this.params = {
         nodeID: null,
         serviceName: null,
-        taskID: null,
-        unitID: null,
-        unitNodeID: null
+        taskID: null
       };
       this.container = document.createElement('div');
       this.instance = ReactDOM.render(
@@ -125,26 +119,7 @@ describe('SidePanels', function () {
 
         expect(contents.type === ServiceSidePanelContents).toEqual(true);
         this.params.serviceName = null;
-      });
-
-    it('should return UnitHealthSidePanelContents if unitID is set',
-      function () {
-        this.params.unitID = 'set';
-        var contents = this.instance.getContents(this.params);
-
-        expect(contents.type === UnitHealthSidePanelContents).toEqual(true);
-        this.params.serviceName = null;
-      });
-
-    it('should return UnitNodeSidePanelContents if unitID and unitNodeID are set',
-      function () {
-        this.params.unitID = 'set';
-        this.params.unitNodeID = 'set';
-        var contents = this.instance.getContents(this.params);
-
-        expect(contents.type === UnitNodeSidePanelContents).toEqual(true);
-        this.params.serviceName = null;
-      });
-
+      }
+    );
   });
 });

--- a/src/js/pages/system/UnitsHealthDetail.js
+++ b/src/js/pages/system/UnitsHealthDetail.js
@@ -1,0 +1,144 @@
+import mixin from 'reactjs-mixin';
+/* eslint-disable no-unused-vars */
+import React from 'react';
+/* eslint-enable no-unused-vars */
+import {StoreMixin} from 'mesosphere-shared-reactjs';
+
+import FilterBar from '../../components/FilterBar';
+import FilterHeadline from '../../components/FilterHeadline';
+import FilterInputText from '../../components/FilterInputText';
+import PageHeader from '../../components/PageHeader';
+import RequestErrorMsg from '../../components/RequestErrorMsg';
+import UnitHealthDropdown from '../../components/UnitHealthDropdown';
+import UnitHealthNodesTable from '../../components/UnitHealthNodesTable';
+import UnitHealthStore from '../../stores/UnitHealthStore';
+
+const METHODS_TO_BIND = [
+  'handleHealthSelection',
+  'handleSearchStringChange',
+  'resetFilter'
+];
+
+class UnitsHealthDetail extends mixin(StoreMixin) {
+  constructor() {
+    super(...arguments);
+
+    this.store_listeners = [
+      {
+        name: 'unitHealth',
+        events: ['unitSuccess', 'unitError', 'nodesSuccess', 'nodesError']
+      }
+    ];
+
+    this.state = {
+      healthFilter: 'all',
+      searchString: ''
+    };
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  componentDidMount() {
+    super.componentDidMount();
+
+    UnitHealthStore.fetchUnit(this.props.params.unitID);
+    UnitHealthStore.fetchUnitNodes(this.props.params.unitID);
+  }
+
+  handleHealthSelection(selectedHealth) {
+    this.setState({healthFilter: selectedHealth.id});
+  }
+
+  handleSearchStringChange(searchString) {
+    this.setState({searchString});
+  }
+
+  getErrorNotice() {
+    return (
+      <div className="container container-pod">
+        <RequestErrorMsg />
+      </div>
+    );
+  }
+
+  getNodesTable(unit, visibleData) {
+    return (
+      <UnitHealthNodesTable
+        nodes={visibleData}
+        params={this.props.params} />
+    );
+  }
+
+  getSubTitle(unit) {
+    let healthStatus = unit.getHealth();
+
+    return (
+      <ul className="list-inline flush-bottom">
+        <li>
+          <span className={healthStatus.classNames}>
+            {healthStatus.title}
+          </span>
+        </li>
+      </ul>
+    );
+  }
+
+  getUnit() {
+    return UnitHealthStore.getUnit(this.props.params.unitID);
+  }
+
+  getVisibleData(data, searchString, healthFilter) {
+    return data.filter({ip: searchString, health: healthFilter}).getItems();
+  }
+
+  resetFilter() {
+    this.setState({
+      searchString: '',
+      healthFilter: 'all'
+    });
+  }
+
+  render() {
+    let {healthFilter, searchString} = this.state;
+
+    let unit = this.getUnit();
+    let nodes = UnitHealthStore.getNodes(this.props.params.unitID);
+    let visibleData = this.getVisibleData(nodes, searchString, healthFilter);
+
+    return (
+      <div className="flex-container-col">
+        <PageHeader
+          icon={<img src="./img/services/icon-service-default-medium@2x.png" />}
+          subTitle={this.getSubTitle(unit)}
+          title={unit.getTitle()} />
+        <FilterHeadline
+          currentLength={visibleData.length}
+          inverseStyle={true}
+          name={"Health Checks"}
+          onReset={this.resetFilter}
+          totalLength={nodes.getItems().length} />
+        <FilterBar>
+          <div className="form-group flush-bottom">
+            <FilterInputText
+              className="flush-bottom"
+              searchString={searchString}
+              handleFilterChange={this.handleSearchStringChange}
+              inverseStyle={true} />
+          </div>
+          <UnitHealthDropdown
+            className="button dropdown-toggle text-align-left button-inverse"
+            dropdownMenuClassName="dropdown-menu inverse"
+            initialID="all"
+            onHealthSelection={this.handleHealthSelection} />
+        </FilterBar>
+        <div className="flex-container-col flex-grow no-overflow">
+          {this.getNodesTable(unit, visibleData)}
+        </div>
+      </div>
+    );
+  }
+};
+
+module.exports = UnitsHealthDetail;

--- a/src/js/pages/system/UnitsHealthNodeDetail.js
+++ b/src/js/pages/system/UnitsHealthNodeDetail.js
@@ -7,7 +7,7 @@ import {StoreMixin} from 'mesosphere-shared-reactjs';
 import {documentationURI} from '../../config/Config';
 import PageHeader from '../../components/PageHeader';
 import RequestErrorMsg from '../../components/RequestErrorMsg';
-import serviceDefaultURI from '../../img/services/icon-service-default-medium@2x.png';
+import serviceDefaultURI from '../../../img/services/icon-service-default-medium@2x.png';
 import UnitHealthStore from '../../stores/UnitHealthStore';
 import UnitSummaries from '../../constants/UnitSummaries';
 

--- a/src/js/pages/system/UnitsHealthNodeDetail.js
+++ b/src/js/pages/system/UnitsHealthNodeDetail.js
@@ -1,15 +1,17 @@
+import mixin from 'reactjs-mixin';
 /* eslint-disable no-unused-vars */
 import React from 'react';
 /* eslint-enable no-unused-vars */
+import {StoreMixin} from 'mesosphere-shared-reactjs';
 
-import {documentationURI} from '../config/Config';
+import {documentationURI} from '../../config/Config';
+import PageHeader from '../../components/PageHeader';
+import RequestErrorMsg from '../../components/RequestErrorMsg';
 import serviceDefaultURI from '../../img/services/icon-service-default-medium@2x.png';
-import RequestErrorMsg from './RequestErrorMsg';
-import SidePanelContents from './SidePanelContents';
-import UnitHealthStore from '../stores/UnitHealthStore';
-import UnitSummaries from '../constants/UnitSummaries';
+import UnitHealthStore from '../../stores/UnitHealthStore';
+import UnitSummaries from '../../constants/UnitSummaries';
 
-module.exports = class UnitNodeSidePanelContents extends SidePanelContents {
+class UnitsHealthNodeDetail extends mixin(StoreMixin) {
 
   constructor() {
     super(...arguments);
@@ -31,30 +33,6 @@ module.exports = class UnitNodeSidePanelContents extends SidePanelContents {
     UnitHealthStore.fetchUnitNode(unitID, unitNodeID);
   }
 
-  getHeader(unit, node) {
-    let imageTag = (
-      <div className="side-panel-icon icon icon-large icon-image-container
-        icon-app-container">
-        <img src={serviceDefaultURI} />
-      </div>
-    );
-
-    return (
-      <div className="side-panel-content-header-details flex-box
-        flex-box-align-vertical-center">
-        {imageTag}
-        <div>
-          <h1 className="side-panel-content-header-label flush">
-            {`${unit.getTitle()} Health Check`}
-          </h1>
-          <div>
-            {this.getSubHeader(unit, node)}
-          </div>
-        </div>
-      </div>
-    );
-  }
-
   getErrorNotice() {
     return (
       <div className="container container-pod">
@@ -63,7 +41,7 @@ module.exports = class UnitNodeSidePanelContents extends SidePanelContents {
     );
   }
 
-  getSubHeader(unit, node) {
+  getSubTitle(unit, node) {
     let healthStatus = node.getHealth();
 
     return (
@@ -90,16 +68,16 @@ module.exports = class UnitNodeSidePanelContents extends SidePanelContents {
 
     return (
       <div className="flex-container-col flex-grow">
-        <span className="h4">Summary</span>
-        <p>
+        <span className="h4 inverse flush-top">Summary</span>
+        <p className="inverse">
           {unitSummary.summary}
         </p>
-        <p>
+        <p className="inverse">
           <a href={unitDocsURL} target="_blank">
             View Documentation
           </a>
         </p>
-        <span className="h4">Output</span>
+        <span className="h4 inverse">Output</span>
         <pre className="flex-grow flush-bottom">
           {node.getOutput()}
         </pre>
@@ -111,20 +89,20 @@ module.exports = class UnitNodeSidePanelContents extends SidePanelContents {
     let {unitID, unitNodeID} = this.props.params;
     let node = UnitHealthStore.getNode(unitNodeID);
     let unit = UnitHealthStore.getUnit(unitID);
+    let serviceIcon = <img src={serviceDefaultURI} />;
 
     return (
       <div className="flex-container-col">
-        <div className="side-panel-section side-panel-content-header container container-pod container-fluid container-pod-divider-bottom container-pod-divider-bottom-align-right flush-bottom">
-          <div className="container-pod container-pod-short flush-top">
-            {this.getHeader(unit, node)}
-          </div>
-        </div>
-        <div className="side-panel-tab-content side-panel-section container
-          container-fluid container-pod container-pod-short container-fluid
-          flex-container-col flex-grow">
+        <PageHeader
+          icon={serviceIcon}
+          subTitle={this.getSubTitle(unit, node)}
+          title={`${unit.getTitle()} Health Check`} />
+        <div className="flex-container-col flex-grow no-overflow">
           {this.getNodeInfo(node, unit)}
         </div>
       </div>
     );
   }
 };
+
+module.exports = UnitsHealthNodeDetail;

--- a/src/js/pages/system/UnitsHealthTab.js
+++ b/src/js/pages/system/UnitsHealthTab.js
@@ -12,7 +12,6 @@ import FilterHeadline from '../../components/FilterHeadline';
 import FilterButtons from '../../components/FilterButtons';
 import FilterInputText from '../../components/FilterInputText';
 import ResourceTableUtil from '../../utils/ResourceTableUtil';
-import SidePanels from '../../components/SidePanels';
 import StringUtil from '../../utils/StringUtil';
 import TableUtil from '../../utils/TableUtil';
 import UnitHealthStore from '../../stores/UnitHealthStore';
@@ -60,7 +59,7 @@ class UnitsHealthTab extends mixin(StoreMixin) {
   renderUnit(prop, unit) {
     return (
       <div className="text-overflow">
-        <Link to="system-overview-units-unit-nodes-panel"
+        <Link to="system-overview-units-unit-nodes-detail"
           params={{unitID: unit.get('id')}}
           className="headline">
           {unit.getTitle()}
@@ -197,9 +196,6 @@ class UnitsHealthTab extends mixin(StoreMixin) {
             sortBy={{prop: 'health', order: 'asc'}}
             />
         </div>
-        <SidePanels
-          params={this.props.params}
-          openedPage="system-overview-units" />
       </div>
     );
   }

--- a/src/js/routes/factories/system.js
+++ b/src/js/routes/factories/system.js
@@ -3,6 +3,8 @@ import {Route, Redirect} from 'react-router';
 import {Hooks} from 'PluginSDK';
 import RepositoriesTab from '../../pages/system/RepositoriesTab';
 import SystemPage from '../../pages/SystemPage';
+import UnitsHealthDetail from '../../pages/system/UnitsHealthDetail';
+import UnitsHealthNodeDetail from '../../pages/system/UnitsHealthNodeDetail';
 import UnitsHealthTab from '../../pages/system/UnitsHealthTab';
 import UsersTab from '../../pages/system/UsersTab';
 
@@ -17,26 +19,19 @@ let RouteFactory = {
             type: Route,
             name: 'system-overview-units',
             path: 'components/?',
-            handler: UnitsHealthTab,
-            children: [
-              {
-                type: Route,
-                name: 'system-overview-units-unit-nodes-panel',
-                path: ':unitID/?',
-                children: [
-                  {
-                    type: Route,
-                    name: 'system-overview-units-unit-nodes-node-panel',
-                    path: 'nodes/:unitNodeID/?'
-                  }
-                ]
-              },
-              {
-                type: Redirect,
-                from: ':unitID/?',
-                to: 'system-overview-units-unit-nodes-panel'
-              }
-            ]
+            handler: UnitsHealthTab
+          },
+          {
+            type: Route,
+            name: 'system-overview-units-unit-nodes-detail',
+            path: 'components/:unitID/?',
+            handler: UnitsHealthDetail,
+          },
+          {
+            type: Route,
+            name: 'system-overview-units-unit-nodes-node-detail',
+            path: 'components/:unitID/nodes/:unitNodeID/?',
+            handler: UnitsHealthNodeDetail
           },
           {
             type: Route,


### PR DESCRIPTION
System Health side panels get an upgrade to full page ✨

depends on: 
- https://github.com/dcos/dcos-ui/commit/45908c02b13614f82ca5d3032b1f741bd85f9747 for correctly inverse styled dropdown
- https://github.com/dcos/dcos-ui/pull/82 for headers

notes:
- The top tabs are to be removed in detail views in the future, when the breadcrumbs are introduced.

`/system/overview/components`
![](http://f.cl.ly/items/270N2Z3M3H0H0j3d2A2r/Image%202016-04-29%20at%2012.23.48%20PM.png)

`/system/overview/components/<component>`
![](http://cl.ly/3U3E0s1O3z1Q/Image%202016-04-29%20at%201.50.48%20PM.png)

`/system/overview/components/<component>/nodes/<node>`
![](http://cl.ly/3z173w0V1L3W/Image%202016-04-29%20at%201.51.41%20PM.png)