### PR TITLE
Feature: Add Dialog component

### DIFF
--- a/src/js/components/Dialog.js
+++ b/src/js/components/Dialog.js
@@ -1,0 +1,93 @@
+import classNames from 'classnames';
+import React from 'react';
+
+import DialogSeverity from '../constants/DialogSeverity';
+import {Modal} from 'reactjs-components';
+
+class Dialog extends React.Component {
+  getButtons() {
+    return this.props.buttons.map(function (button, index) {
+      let classSet = classNames('button', button.className);
+      return (
+        <div key={index}
+          className={classSet}
+          onClick={button.onClick}>
+          {button.text}
+        </div>
+      )
+    });
+  }
+
+  getCloseByBackdropClick() {
+    return this.props.buttons.length === 1;
+  }
+
+  getFooter(buttons) {
+    if (buttons.length === 0) {
+      return null;
+    }
+
+    return (
+      <div className="button-collection text-align-center">
+        {buttons}
+      </div>
+    );
+  }
+
+  getModalClassSet() {
+    let {severity} = this.props;
+
+    return classNames('modal dialog', {
+      'dialog-info': severity === DialogSeverity.INFO,
+      'dialog-danger': severity === DialogSeverity.DANGER,
+      'dialog-warning': severity === DialogSeverity.WARNING
+    });
+  }
+
+  getOnClose() {
+    if (this.buttons === 1) {
+      return this.buttons[0].onClick;
+    }
+    return null;
+  }
+
+  render() {
+    let {title, children} = this.props;
+
+    let buttons = this.getButtons();
+
+    return (
+      <Modal
+        open={true}
+        modalClass={this.getModalClassSet()}
+        footer={this.getFooter(buttons)}
+        closeByBackdropClick={this.getCloseByBackdropClick()}
+        showHeader={title != null}
+        showFooter={buttons != null}
+        onClose={this.getOnClose()}
+        titleText={title}>
+        {children}
+      </Modal>
+    );
+  }
+}
+
+Dialog.defaultProps = {
+  buttons: [],
+  severity: DialogSeverity.INFO,
+  title: null
+};
+
+Dialog.PropTypes = {
+  buttons: React.PropTypes.arrayOf(
+    React.PropTypes.shape({
+      className: React.PropTypes.string,
+      onClick: React.PropTypes.func,
+      text: React.PropTypes.string
+    })
+  ),
+  severity: React.PropTypes.string,
+  title: React.PropTypes.string
+};
+
+module.exports = Dialog;

--- a/src/js/components/__tests__/Dialog-test.js
+++ b/src/js/components/__tests__/Dialog-test.js
@@ -1,0 +1,261 @@
+jest.dontMock('../Dialog');
+
+/* eslint-disable no-unused-vars */
+var React = require('react');
+/* eslint-enable no-unused-vars */
+let ReactDOM = require('react-dom');
+
+let Dialog = require('../Dialog');
+
+describe('#Dialog', function () {
+  beforeEach(function () {
+    this.container = document.createElement('div');
+    this.instance = ReactDOM.render(
+      <Dialog
+        title="Info Dialog"
+        buttons={[
+          {
+            text: 'Okay',
+            button: 'button-success',
+            onClick: function () {
+              alert('test');
+            }
+          },
+          {
+            text: 'No',
+            className: 'button-danger button-stroke',
+            onClick: function () {
+              alert('No');
+            }
+          }
+        ]}>
+        Some content
+      </Dialog>,
+      this.container
+    );
+  });
+
+  afterEach(function () {
+    ReactDOM.unmountComponentAtNode(this.container);
+  });
+
+  describe('getButtons', function () {
+    it('Should return an empty array', function () {
+      let instance = ReactDOM.render(
+        <Dialog
+          title="Info Dialog"
+          >
+          Some content
+        </Dialog>,
+        this.container
+      );
+      expect(instance.getButtons().length).toEqual(0);
+    });
+
+    it('Should return an array with one item', function () {
+      let arrayWithOneButton = [
+        {
+          text: 'Okay',
+          className: 'button-success',
+          onClick: function () {
+            alert('test');
+          }
+        }];
+
+      let instance = ReactDOM.render(
+        <Dialog
+          title="Info Dialog"
+          buttons={arrayWithOneButton}>
+          Some content
+        </Dialog>,
+        this.container
+      );
+
+      expect(instance.getButtons().length).toEqual(1);
+    });
+
+    it('Should set the right css class', function () {
+      let arrayWithOneButton = [
+        {
+          text: 'Okay',
+          className: 'button-success',
+          onClick: function () {
+            alert('test');
+          }
+        }];
+
+      let instance = ReactDOM.render(
+        <Dialog
+          title="Info Dialog"
+          buttons={arrayWithOneButton}>
+          Some content
+        </Dialog>,
+        this.container
+      );
+
+      let button = instance.getButtons()[0];
+
+      expect(button.props.className).toEqual('button button-success');
+    });
+
+    it('Should set the right css class if no className is provided',
+      function () {
+        let arrayWithOneButton = [
+          {
+            text: 'Okay',
+            onClick: function () {
+              alert('test');
+            }
+          }];
+
+        let instance = ReactDOM.render(
+          <Dialog
+            title="Info Dialog"
+            buttons={arrayWithOneButton}>
+            Some content
+          </Dialog>,
+          this.container
+        );
+
+        let button = instance.getButtons()[0];
+
+        expect(button.props.className).toEqual('button');
+      });
+
+    it('Should set the right text', function () {
+      let arrayWithOneButton = [
+        {
+          text: 'Okay',
+          className: 'button-success',
+          onClick: function () {
+            alert('test');
+          }
+        }];
+
+      let instance = ReactDOM.render(
+        <Dialog
+          title="Info Dialog"
+          buttons={arrayWithOneButton}>
+          Some content
+        </Dialog>,
+        this.container
+      );
+
+      let button = instance.getButtons()[0];
+
+      expect(button.props.children).toEqual('Okay');
+    });
+
+    it('Should return an array with two items', function () {
+      let arrayWithOneButton = [
+        {
+          text: 'Okay',
+          className: 'button-success',
+          onClick: function () {
+            alert('test');
+          }
+        },
+        {
+          text: 'Nay',
+          className: 'button-danger button-stroke',
+          onClick: function () {
+            alert('nay');
+          }
+        }];
+
+      let instance = ReactDOM.render(
+        <Dialog
+          title="Info Dialog"
+          buttons={arrayWithOneButton}>
+          Some content
+        </Dialog>,
+        this.container
+      );
+
+      expect(instance.getButtons().length).toEqual(2);
+    });
+  });
+
+  describe('getCloseByBackdropClick', function () {
+    it('Should return false', function () {
+      let instance = ReactDOM.render(
+        <Dialog
+          title="Info Dialog">
+          Some content
+        </Dialog>,
+        this.container
+      );
+      expect(instance.getCloseByBackdropClick()).toBeFalsy();
+    });
+
+    it('Should return true if only one button is present', function () {
+      let arrayWithOneButton = [
+        {
+          text: 'Okay',
+          className: 'button-success',
+          onClick: function () {
+            alert('test');
+          }
+        }];
+
+      let instance = ReactDOM.render(
+        <Dialog
+          title="Info Dialog"
+          buttons={arrayWithOneButton}>
+          Some content
+        </Dialog>,
+        this.container
+      );
+
+      expect(instance.getCloseByBackdropClick()).toBeTruthy();
+    });
+
+    it('Should return false if more then one button is present', function () {
+      let arrayWithOneButton = [
+        {
+          text: 'Okay',
+          className: 'button-success',
+          onClick: function () {
+            alert('test');
+          },
+        },
+        {
+          text: 'Nay',
+          className: 'button-danger button-stroke',
+          onClick: function () {
+            alert('nay');
+          }
+        }];
+
+      let instance = ReactDOM.render(
+        <Dialog
+          title="Info Dialog"
+          buttons={arrayWithOneButton}>
+          Some content
+        </Dialog>,
+        this.container
+      );
+
+      expect(instance.getCloseByBackdropClick()).toBeFalsy();
+    });
+  });
+
+  describe('getFooter', function () {
+    it('Should return null', function () {
+      expect(this.instance.getFooter([])).toEqual(null);
+    });
+
+    it('Should return an element containing one child', function () {
+      let arrayWithOneButton = [
+        (<div key={0}
+             className="button"
+             onClick={Function.prototype}>
+          Button
+        </div>)
+      ];
+      expect(this.instance.getFooter(arrayWithOneButton).props.children.length)
+        .toEqual(1);
+    });
+  });
+
+});

--- a/src/js/constants/DialogSeverity.js
+++ b/src/js/constants/DialogSeverity.js
@@ -1,0 +1,7 @@
+const DialogSeverity = {
+  DANGER: 'danger',
+  INFO: 'info',
+  WARNING: 'warning'
+};
+
+module.export = DialogSeverity;

--- a/src/styles/components/dialog.less
+++ b/src/styles/components/dialog.less
@@ -1,0 +1,15 @@
+.dialog {
+
+  .modal-footer {
+
+    background-color: @white;
+
+  }
+
+  .modal-header {
+
+    background-color: @white;
+
+  }
+
+}

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -131,6 +131,7 @@ Components
 @import "components/caret.less";
 @import "components/charts/index.less";
 @import "components/charts/dialchart.less";
+@import "components/dialog.less";
 @import "components/dropdown-menus.less";
 @import "components/filter-bar.less";
 @import "components/icons.less";


### PR DESCRIPTION
This adds a Dialog component which wraps the Modal component,

You may add buttons with css `classNames` and `onClick` handler and `text` Also a `title` can be set with a prop and the `severity` which is based on the Constants, `info`, `warning` and `danger`.

This PR does only contain the component and only a basic styling (removing grey footer and header). 

Sorry for the Size of this PR, but 🎆 260 lines are tests 🎉 

![image](https://cloud.githubusercontent.com/assets/156010/14930877/82e80bf4-0e67-11e6-892b-fef2c6cf15c5.png)
