### PR TITLE
Fix services tab query param persistence

### DIFF
--- a/src/js/mixins/__mocks__/QueryParamsMixin.js
+++ b/src/js/mixins/__mocks__/QueryParamsMixin.js
@@ -1,0 +1,28 @@
+var QueryParamsMixin = jest.genMockFromModule('../QueryParamsMixin');
+
+var _data = {};
+
+/**
+ * Sets mock data for QueryParamsMixin.
+ * @param {Object} data the whole query params object
+ * @memberOf __mocks__/QueryParamsMixin
+ */
+function __setData(data) {
+  _data = data;
+}
+
+/**
+ * Mocks QueryParamsMixin.getQueryParamObject.
+ * @returns {Object} mock data
+ */
+function getQueryParamObject() {
+  return _data;
+}
+
+// This has to be done in a mock in order to be available at mixin time
+QueryParamsMixin.setQueryParam = jasmine.createSpy('setQueryParam');
+
+QueryParamsMixin.__setData = __setData;
+QueryParamsMixin.getQueryParamObject = getQueryParamObject;
+
+module.exports = QueryParamsMixin;

--- a/src/js/pages/__tests__/ServicesTab-test.js
+++ b/src/js/pages/__tests__/ServicesTab-test.js
@@ -1,5 +1,6 @@
 jest.dontMock('../services/ServicesTab');
 jest.dontMock('../../mixins/InternalStorageMixin');
+jest.dontMock('../../mixins/SaveStateMixin');
 
 /* eslint-disable no-unused-vars */
 var React = require('react');
@@ -10,10 +11,16 @@ var JestUtil = require('../../utils/JestUtil');
 
 var AlertPanel = require('../../components/AlertPanel');
 var DCOSStore = require('../../stores/DCOSStore');
+var QueryParamsMixin = require('../../mixins/QueryParamsMixin');
+QueryParamsMixin.getQueryParamObject = function () {
+  return {};
+};
+QueryParamsMixin.setQueryParam = jasmine.createSpy();
 var ServicesTab = require('../services/ServicesTab');
 var ServiceTree = require('../../structs/ServiceTree');
 var ServiceDetail = require('../../components/ServiceDetail');
 var ServicesTable = require('../../components/ServicesTable');
+var UserSettingsStore = require('../../stores/UserSettingsStore');
 
 describe('ServicesTab', function () {
 
@@ -30,6 +37,22 @@ describe('ServicesTab', function () {
 
   afterEach(function () {
     ReactDOM.unmountComponentAtNode(this.container);
+  });
+
+  it('reinstates the stored query parameters', function () {
+    UserSettingsStore.getKey = function () {
+      return {servicesPage: {filterHealth: ['0'], searchString: 'foo'}};
+    };
+    ReactDOM.render(
+      JestUtil.stubRouterContext(ServicesTab, {params: {id: '/'}}),
+      this.container
+    );
+    expect(QueryParamsMixin.setQueryParam).toHaveBeenCalledWith(
+      'filterHealth', ['0']
+    );
+    expect(QueryParamsMixin.setQueryParam).toHaveBeenCalledWith(
+      'searchString', 'foo'
+    );
   });
 
   describe('#render', function () {

--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -60,10 +60,9 @@ var ServicesTab = React.createClass({
     let {state} = this;
     Object.keys(DEFAULT_FILTER_OPTIONS).forEach((saveStateKey) => {
       const queryParams = this.getQueryParamObject();
-      if (queryParams != null &&
-        queryParams[saveStateKey] &&
-        state[saveStateKey] !== queryParams[saveStateKey]) {
-        this.setQueryParam(saveStateKey, state[saveStateKey]);
+      let saveStateValue = state[saveStateKey];
+      if (saveStateValue !== queryParams[saveStateKey]) {
+        this.setQueryParam(saveStateKey, saveStateValue);
       }
     });
   },

--- a/src/js/stores/__mocks__/UserSettingsStore.js
+++ b/src/js/stores/__mocks__/UserSettingsStore.js
@@ -1,0 +1,40 @@
+var UserSettingsStore = jest.genMockFromModule('../UserSettingsStore');
+
+var _data = {};
+
+/**
+ * Sets mock data for UserSettingsStore.getKey to return.
+ * @param {String} key the retrieval key
+ * @param {Object} response the data to return for the given key
+ * @memberOf __mocks__/UserSettingsStore
+ */
+function __setKeyResponse(key, response) {
+  _data[key] = response;
+}
+
+/**
+ * Clears all mock data from the UserSettingsStore.
+ * @memberOf __mocks__/UserSettingsStore
+ */
+function __reset() {
+  _data = {};
+}
+
+/**
+ * Mocks UserSettingsStore.getKey
+ * @param {String} key the retrieval key
+ * @returns {Object} mock data if present, otherwise an empty object.
+ * @memberOf __mocks__/UserSettingsStore
+ */
+function getKey(key) {
+  if (_data[key] == null) {
+    return {};
+  }
+  return _data[key];
+}
+
+UserSettingsStore.__setKeyResponse = __setKeyResponse;
+UserSettingsStore.__reset = __reset;
+UserSettingsStore.getKey = getKey;
+
+module.exports = UserSettingsStore;


### PR DESCRIPTION
This PR fixes the bug highlighted in this comment: https://github.com/dcos/dcos-ui/pull/92#discussion_r61952582

Previously, query parameters were not shown in the URL even though they persisted over navigation. 