### PR TITLE
Make npm honor environment variables

### DIFF
--- a/jest/gen-config.js
+++ b/jest/gen-config.js
@@ -5,8 +5,8 @@ var fs = require('fs');
 var path = require('path');
 var testPaths = ['src', 'plugins'];
 
-if (process.env.npm_package_config_external_plugins) {
-  testPaths.push(process.env.npm_package_config_external_plugins);
+if (process.env.npm_config_externalplugins) {
+  testPaths.push(process.env.npm_config_externalplugins);
 }
 
 var config = {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "config": {
     "port": 4200,
-    "external_plugins": ""
+    "externalplugins": ""
   },
   "dependencies": {
     "babel-polyfill": "6.7.2",
@@ -99,7 +99,7 @@
     "build": "npm run clean && npm run lint && npm test && npm run build-assets",
     "build-with-external-plugins": "npm run clean && npm run lint && npm run lint-plugins && npm test && npm run build-assets",
     "lint": "./node_modules/.bin/eslint '**/*.js' --quiet",
-    "lint-plugins": "PLUGINS=$npm_package_config_external_plugins; ./node_modules/.bin/eslint \"$PLUGINS/**/*.js\" --quiet",
+    "lint-plugins": "PLUGINS=$npm_config_externalplugins; ./node_modules/.bin/eslint \"$PLUGINS/**/*.js\" --quiet",
     "prebuild": "./scripts/validate-tests",
     "serve": "NODE_ENV='development' npm run build-assets && ./node_modules/.bin/gulp serve",
     "serve-notify": "export NOTIFY=true && npm run serve",

--- a/src/js/plugin-bridge/__mocks__/Loader.js
+++ b/src/js/plugin-bridge/__mocks__/Loader.js
@@ -10,7 +10,7 @@ let pluginsList;
 let externalPluginsList;
 let pluginsDir = 'plugins';
 let externalPluginsDir = path.resolve(
-  process.env.npm_package_config_external_plugins
+  process.env.npm_config_externalplugins
 );
 
 try {

--- a/webpack/webpack.config.babel.js
+++ b/webpack/webpack.config.babel.js
@@ -10,7 +10,7 @@ function absPath() {
 }
 
 // Can override this with npm config set dcos-ui:external_plugins ../some/relative/path/to/repo
-let externalPluginsDir = absPath(process.env.npm_package_config_external_plugins || 'plugins');
+let externalPluginsDir = absPath(process.env.npm_config_externalplugins || 'plugins');
 
 module.exports = {
   lessLoader: {


### PR DESCRIPTION
`npm config set` doesn't work in CI where we have protected user directories `/Users/[username]/..`.

To honor setting npm config via environment variables, we cannot have underscores in our keys because they get converted to hyphens and therefore do not override the npm config.