### PR TITLE
Fix missing classnames import from rebase error

### DIFF
--- a/src/js/components/TaskView.js
+++ b/src/js/components/TaskView.js
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import mixin from 'reactjs-mixin';
 import React from 'react';
 


### PR DESCRIPTION
This crashed the task table view