### PR TITLE
Optionally enforce types on List.

### DIFF
--- a/src/js/structs/List.js
+++ b/src/js/structs/List.js
@@ -2,6 +2,25 @@ import Item from './Item';
 import StringUtil from '../utils/StringUtil';
 import Util from '../utils/Util';
 
+/**
+ * Cast an item to the List's type, if specified.
+ *
+ * Note that cast must be bound to the List's context in order to access
+ * its `type` property.
+ *
+ * @param {Object} item
+ * @access private
+ * @memberOf List
+ * @return {Object} item, cast if list is typed.
+ */
+function cast(item) {
+  let Type = this.constructor.type;
+  if (Type != null && !(item instanceof Type)) {
+    return new Type(item);
+  }
+  return item;
+}
+
 module.exports = class List {
   /**
    * List
@@ -9,6 +28,7 @@ module.exports = class List {
    *          items:array,
    *          filterProperties:{propertyName:(null|function)}
    *        }} options
+   * @property {Class} type - the type of list items
    * @constructor
    * @struct
    */
@@ -19,14 +39,14 @@ module.exports = class List {
       if (!Util.isArray(options.items)) {
         throw new Error('Expected an array.');
       }
-      this.list = options.items;
+      this.list = options.items.map(cast.bind(this));
     }
 
     this.filterProperties = options.filterProperties || {};
   }
 
   add(item) {
-    this.list.push(item);
+    this.list.push(cast.call(this, item));
   }
 
   getItems() {

--- a/src/js/structs/__tests__/List-test.js
+++ b/src/js/structs/__tests__/List-test.js
@@ -3,6 +3,18 @@ let List = require('../List');
 
 describe('List', function () {
 
+  beforeEach(function () {
+    this.Thing = class Thing {
+      constructor(value) {
+        if (value instanceof Thing) {
+          throw Error('Tried to re-instantiate a ThingList item');
+        }
+      }
+    };
+    this.ThingList = class ThingList extends List {};
+    this.ThingList.type = this.Thing;
+  });
+
   describe('#constructor', function () {
 
     it('defaults the list to an empty array', function () {
@@ -21,6 +33,18 @@ describe('List', function () {
       };
 
       expect(fn).toThrow();
+    });
+
+    it('enforces type, if specified', function () {
+      let {Thing, ThingList} = this;
+      let thingList = new ThingList({items: [{}]});
+      expect(thingList.last()).toEqual(jasmine.any(Thing));
+    });
+
+    it('does not re-cast items of the correct type', function () {
+      let {Thing, ThingList} = this;
+      // If re-cast, an error will be thrown
+      new ThingList({items: [new Thing({})]});
     });
 
   });
@@ -45,6 +69,20 @@ describe('List', function () {
       list.add(1);
       list.add(2);
       expect(list.getItems()).toEqual([0, 1, 2]);
+    });
+
+    it('enforces type, if specified', function () {
+      let {Thing, ThingList} = this;
+      let thingList = new ThingList();
+      thingList.add({});
+      expect(thingList.last()).toEqual(jasmine.any(Thing));
+    });
+
+    it('does not re-cast items of the correct type', function () {
+      let {Thing, ThingList} = this;
+      let thingList = new ThingList();
+      // If re-cast, an error will be thrown
+      thingList.add(new Thing());
     });
 
   });


### PR DESCRIPTION
This PR adds an optional `type` property to `List`, in order to avoid having to enforce typing in each subclass of `List` (eg [here](https://github.com/dcos/dcos-ui/blob/master/src/js/structs/NodesList.js#L11-L18) in `NodeList`). 

If the `type` property is present, `List` will enforce typing on instantiation and when an item is added. 