### PR TITLE
Reduce amount of webpack console output

### DIFF
--- a/webpack/webpack.dev.babel.js
+++ b/webpack/webpack.dev.babel.js
@@ -28,7 +28,16 @@ module.exports = Object.assign({}, webpackConfig, {
     filename: 'index.js'
   },
   devServer: {
-    proxy: proxy
+    proxy: proxy,
+    stats: {
+      assets: false,
+      colors: true,
+      version: false,
+      hash: false,
+      timings: true,
+      chunks: true,
+      chunkModules: false
+    }
   },
   plugins: [
     new StringReplacePlugin(),


### PR DESCRIPTION
The new Webpack setup is awesome but a tad verbose ;) This PR reduces the amount of output for easier reading.

From:
<img width="1005" alt="screen shot 2016-05-06 at 11 11 39" src="https://cloud.githubusercontent.com/assets/1078545/15069069/939bb4b4-137b-11e6-9c55-e298ec236820.png">

To:
<img width="690" alt="screen shot 2016-05-06 at 11 12 03" src="https://cloud.githubusercontent.com/assets/1078545/15069074/9c5bb680-137b-11e6-81f2-55df12926e90.png">


Example with errors:

<img width="787" alt="screen shot 2016-05-06 at 11 12 25" src="https://cloud.githubusercontent.com/assets/1078545/15069079/a1e4c0e2-137b-11e6-8e37-14f26286efa3.png">

Cheers!