### PR TITLE
Introduce struct for deployments

### DIFF
--- a/src/js/structs/Deployment.js
+++ b/src/js/structs/Deployment.js
@@ -1,0 +1,50 @@
+import Item from './Item';
+
+/**
+ * An application deployment.
+ *
+ * @struct
+ * @see the
+ *   {@link http://mesosphere.github.io/marathon/docs/deployments.html|Marathon
+ *   application deployment documentation}
+ */
+module.exports = class Deployment extends Item {
+
+  /**
+   * @return {string} the id of this deployment
+   */
+  getId() {
+    return this.get('id');
+  }
+
+  /**
+   * @return {Array.<string>} an array of app IDs affected by this deployment.
+   */
+  getAffectedServiceIds() {
+    return this.get('affectedApps');
+  }
+
+  /**
+   * @return {Date} the date and time at which the deployment was started.
+   */
+  getStartTime() {
+    return new Date(this.get('version'));
+  }
+
+  /**
+   * @return {number} the index of the deployment step currently underway.
+   * @see {@link getTotalSteps}
+   */
+  getCurrentStep() {
+    return this.get('currentStep');
+  }
+
+  /**
+   * @return {number} the number of steps in this deployment.
+   * @see {@link getCurrentStep}
+   */
+  getTotalSteps() {
+    return this.get('totalSteps');
+  }
+
+}

--- a/src/js/structs/DeploymentsList.js
+++ b/src/js/structs/DeploymentsList.js
@@ -1,0 +1,12 @@
+import List from './List';
+import Deployment from './Deployment';
+
+/**
+ * A typed {@link List} of {@link Deployment}s.
+ *
+ * @struct
+ */
+class DeploymentsList extends List {}
+DeploymentsList.type = Deployment;
+
+module.exports = DeploymentsList;

--- a/src/js/structs/__tests__/Deployment-test.js
+++ b/src/js/structs/__tests__/Deployment-test.js
@@ -1,0 +1,32 @@
+let Deployment = require('../Deployment');
+
+describe('Deployment', function () {
+
+  describe('#get...', function () {
+    it('calls through to `Item.get`', function () {
+      let deployment = new Deployment({
+        id: 'deployment-id',
+        version: '2001-01-01T01:01:01.001Z',
+        affectedApps: ['app1', 'app2'],
+        currentStep: 2,
+        totalSteps: 3
+      });
+      expect(deployment.getId()).toEqual('deployment-id');
+      expect(deployment.getAffectedServiceIds())
+        .toEqual(['app1', 'app2']);
+      expect(deployment.getCurrentStep()).toEqual(2);
+      expect(deployment.getTotalSteps()).toEqual(3);
+    });
+  });
+
+  describe('#getStartTime', function () {
+    it('returns a Date object derived from the version property', function () {
+      let version = '2001-01-01T01:01:01.001Z';
+      let deployment = new Deployment({version});
+      expect(deployment.getStartTime()).toEqual(jasmine.any(Date));
+      expect(deployment.getStartTime().toISOString()).toEqual(version);
+    });
+  });
+
+});
+


### PR DESCRIPTION
This PR introduces a 'struct' for the `Deployment` type, in preparation for a second PR which will introduce the `Deployment` to the `MarathonStore`

This PR must be merged before #136. 