### PR TITLE
[EASY REVIEW] Update secrets fixtures

### DIFF
--- a/tests/_fixtures/secrets/policies.json
+++ b/tests/_fixtures/secrets/policies.json
@@ -1,3 +1,0 @@
-{
-  "array": ["a list", "of", "policies"]
-}

--- a/tests/_fixtures/secrets/policy.json
+++ b/tests/_fixtures/secrets/policy.json
@@ -1,4 +1,0 @@
-{
-  "name": "randomPolicyName",
-  "rules": ["alist", "of", "policyrules"]
-}

--- a/tests/_fixtures/secrets/secret.json
+++ b/tests/_fixtures/secrets/secret.json
@@ -1,3 +1,5 @@
 {
-  "value": "thisisasecretvalue2016"
+  "author": "KennyTran",
+  "value": "thisisasecretvalue2016",
+  "created": "June 12 2015, 15:23:22"
 }

--- a/tests/_fixtures/secrets/secrets.json
+++ b/tests/_fixtures/secrets/secrets.json
@@ -1,3 +1,3 @@
 {
-  "array": ["a list", "of", "secret values"]
+  "array": ["a/list", "of/secret/paths", "even/deeper/paths"]
 }


### PR DESCRIPTION
No more policies.

According to [this spec](https://github.com/mesosphere/dcos-security/blob/master/secrets/docs/apispec-swagger.yaml)