### PR TITLE
Only highlight tab on prefix match

### DIFF
--- a/src/js/mixins/TabsMixin.js
+++ b/src/js/mixins/TabsMixin.js
@@ -6,6 +6,49 @@ import React from 'react';
 
 import TabsUtil from '../utils/TabsUtil';
 
+/**
+ * Adds tabs-specific methods onto a class.
+ *
+ * Note that routes may be cascaded where multiple tab hierarchies are in place
+ * by prefixing one route with another, eg the route 'universe-packages-detail'
+ * will result in the tab 'universe-packages' being highlighted as active.
+ *
+ * @mixin
+ * @see {@link TabsUtil}
+ * @example
+ * class PageWithRoutableTabs extends mixin(TabsMixin) {
+ *   constructor() {
+ *     super(...args);
+ *     // The default selected tab may be defined so:
+ *     this.state = {
+ *       currentTab: 'defined-route-1'
+ *     }
+ *   }
+ *   componentWillMount() {
+ *     // The keys to this object must be defined routes
+ *     this.tabs_tabs = {
+ *      'defined-route-1': 'Tab Title 1',
+ *      'defined-route-2': 'Tab Title 2'
+ *     }
+ *     this.updateCurrentTab();
+ *   }
+ *   getNavigation() {
+ *     return (
+ *       <ul>
+ *         {this.tabs_getRoutedTabs()}
+ *       </ul>
+ *     );
+ *   }
+ *   render() {
+ *     return (
+ *       <Page
+ *         navigation={this.getNavigation()}>
+ *         <RouteHandler />
+ *       </Page>
+ *     );
+ *   }
+ * }
+ */
 const TabsMixin = {
   /**
    * Returns a tab that has a callback when clicked.

--- a/src/js/utils/TabsUtil.js
+++ b/src/js/utils/TabsUtil.js
@@ -21,7 +21,7 @@ const TabsUtil = {
     return tabSet.map(function (tab, index) {
       let tabClass = classNames({
         'tab-item': true,
-        'active': currentTab.indexOf(tab) > -1
+        'active': currentTab.startsWith(tab)
       });
 
       return (

--- a/src/js/utils/__tests__/TabsUtil-test.js
+++ b/src/js/utils/__tests__/TabsUtil-test.js
@@ -6,6 +6,7 @@ describe('TabsUtil', function () {
   describe('#getTabs', function () {
     beforeEach(function () {
       this.tabs = {foo: 'bar', baz: 'qux', corge: 'grault'};
+      this.hierarchicalTabs = {foo: 'bar', foobar: 'foobar', '-foo': 'baz'};
       this.getElement = function () {};
       spyOn(this, 'getElement');
     });
@@ -24,7 +25,7 @@ describe('TabsUtil', function () {
       expect(result.length).toEqual(3);
     });
 
-    it('should return li\'s', function () {
+    it('should return LIs', function () {
       var result = TabsUtil.getTabs(this.tabs, 'baz', this.getElement);
 
       expect(result[0].type).toEqual('li');
@@ -32,13 +33,33 @@ describe('TabsUtil', function () {
       expect(result[2].type).toEqual('li');
     });
 
-    it('should return element\'s with one active class', function () {
+    it('should return elements with one active class', function () {
       var result = TabsUtil.getTabs(this.tabs, 'baz', this.getElement);
 
       expect(result[0].props.className).toEqual('tab-item');
       expect(result[1].props.className).toEqual('tab-item active');
       expect(result[2].props.className).toEqual('tab-item');
     });
+
+    it('should not highlight routes contained within the class name',
+        function () {
+          var tabs = TabsUtil.getTabs(this.hierarchicalTabs, '-foo',
+              this.getElement);
+
+          expect(tabs[0].props.className).toEqual('tab-item');
+          expect(tabs[1].props.className).toEqual('tab-item');
+          expect(tabs[2].props.className).toEqual('tab-item active');
+        });
+
+    it('should highlight all routes which prefix the current tab name',
+        function () {
+          var tabs = TabsUtil.getTabs(this.hierarchicalTabs, 'foobar',
+              this.getElement);
+
+          expect(tabs[0].props.className).toEqual('tab-item active');
+          expect(tabs[1].props.className).toEqual('tab-item active');
+          expect(tabs[2].props.className).toEqual('tab-item');
+        });
 
     it('should call getElement with appropriate arguments', function () {
       TabsUtil.getTabs(this.tabs, 'baz', this.getElement);


### PR DESCRIPTION
This PR updates the tab utility so that instead of making a tab active when its name exists anywhere in the route, it only makes the tab active when its name exists at the start of the route. 

- The tab named `universe-packages` will be active with either of the routes `universe-packages` or `universe-packages-detail`.
- The tab named `services` will be active with `services` and `services-detail` but not with `-services-deployment`. 

This PR provides the basis for the fix in #166