### PR TITLE
Preserve serviceID format when dispatching actions

### DIFF
--- a/src/js/events/ServicePlanActions.js
+++ b/src/js/events/ServicePlanActions.js
@@ -12,9 +12,9 @@ import RequestUtil from '../utils/RequestUtil';
 const ServicePlanActions = {
 
   fetchPlan: function (serviceID) {
-    serviceID = encodeURIComponent(serviceID);
+    let uriServiceID = encodeURIComponent(serviceID);
     RequestUtil.json({
-      url: `${Config.rootUrl}/service/${serviceID}${Config.servicePlanAPIPath}`,
+      url: `${Config.rootUrl}/service/${uriServiceID}${Config.servicePlanAPIPath}`,
       success: function (response) {
         AppDispatcher.handleServerAction({
           type: REQUEST_PLAN_FETCH_SUCCESS,
@@ -33,10 +33,10 @@ const ServicePlanActions = {
   },
 
   sendDecisionCommand: function (cmd, serviceID) {
-    serviceID = encodeURIComponent(serviceID);
+    let uriServiceID = encodeURIComponent(serviceID);
     RequestUtil.json({
       method: 'PUT',
-      url: `${Config.rootUrl}/service/${serviceID}${Config.servicePlanAPIPath}?cmd=${cmd}`,
+      url: `${Config.rootUrl}/service/${uriServiceID}${Config.servicePlanAPIPath}?cmd=${cmd}`,
       success: function (response) {
         AppDispatcher.handleServerAction({
           type: REQUEST_PLAN_DECISION_SUCCESS,


### PR DESCRIPTION
@MatApple Let me know if you'd prefer to do this in some other way, but `ServicePlanStore` expects the dispatched `serviceID` to not be URI encoded.