### PR TITLE
Make dropdown menu fix only work for direct children

### DIFF
--- a/src/styles/layout/media-object.less
+++ b/src/styles/layout/media-object.less
@@ -138,7 +138,7 @@ components/media-objects.less
     padding-bottom: @base-spacing-unit * 1/2;
     padding-right: @base-spacing-unit * 1/2;
 
-    .dropdown-menu.down {
+    > .dropdown-menu.down {
 
       top: calc(~"100% - "@base-spacing-unit * 1/2);
 
@@ -153,7 +153,7 @@ components/media-objects.less
       padding-bottom: @base-spacing-unit * 1/4;
       padding-right: @base-spacing-unit * 1/4;
 
-      .dropdown-menu.down {
+      > .dropdown-menu.down {
 
         top: calc(~"100% - "@base-spacing-unit * 1/4);
 
@@ -173,7 +173,7 @@ components/media-objects.less
       padding-bottom: @base-spacing-unit * 1/8;
       padding-right: @base-spacing-unit * 1/8;
 
-      .dropdown-menu.down {
+      > .dropdown-menu.down {
 
         top: calc(~"100% - "@base-spacing-unit * 1/8);
 
@@ -190,7 +190,7 @@ components/media-objects.less
       padding-bottom: @base-spacing-unit * 3/4;
       padding-right: @base-spacing-unit * 3/4;
 
-      .dropdown-menu.down {
+      > .dropdown-menu.down {
 
         top: calc(~"100% - "@base-spacing-unit * 3/4);
 
@@ -291,7 +291,7 @@ components/media-objects.less
         padding-bottom: @base-spacing-unit-screen-mini * 1/2;
         padding-right: @base-spacing-unit-screen-mini * 1/2;
 
-        .dropdown-menu.down {
+        > .dropdown-menu.down {
 
           top: calc(~"100% - "@base-spacing-unit-screen-mini * 1/2);
 
@@ -306,7 +306,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-mini * 1/4;
           padding-right: @base-spacing-unit-screen-mini * 1/4;
 
-          .dropdown-menu.down {
+          > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-mini * 1/4);
 
@@ -326,7 +326,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-mini * 1/8;
           padding-right: @base-spacing-unit-screen-mini * 1/8;
 
-          .dropdown-menu.down {
+          > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-mini * 1/8);
 
@@ -343,7 +343,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-mini * 3/4;
           padding-right: @base-spacing-unit-screen-mini * 3/4;
 
-          .dropdown-menu.down {
+          > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-mini * 3/4);
 
@@ -453,7 +453,7 @@ components/media-objects.less
         padding-bottom: @base-spacing-unit-screen-small * 1/2;
         padding-right: @base-spacing-unit-screen-small * 1/2;
 
-        .dropdown-menu.down {
+        > .dropdown-menu.down {
 
           top: calc(~"100% - "@base-spacing-unit-screen-small * 1/2);
 
@@ -468,7 +468,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-small * 1/4;
           padding-right: @base-spacing-unit-screen-small * 1/4;
 
-          .dropdown-menu.down {
+          > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-small * 1/4);
 
@@ -488,7 +488,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-small * 1/8;
           padding-right: @base-spacing-unit-screen-small * 1/8;
 
-          .dropdown-menu.down {
+          > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-small * 1/8);
 
@@ -505,7 +505,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-small * 3/4;
           padding-right: @base-spacing-unit-screen-small * 3/4;
 
-          .dropdown-menu.down {
+          > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-small * 3/4);
 
@@ -615,7 +615,7 @@ components/media-objects.less
         padding-bottom: @base-spacing-unit-screen-medium * 1/2;
         padding-right: @base-spacing-unit-screen-medium * 1/2;
 
-        .dropdown-menu.down {
+        > .dropdown-menu.down {
 
           top: calc(~"100% - "@base-spacing-unit-screen-medium * 1/2);
 
@@ -630,7 +630,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-medium * 1/4;
           padding-right: @base-spacing-unit-screen-medium * 1/4;
 
-          .dropdown-menu.down {
+          > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-medium * 1/4);
 
@@ -650,7 +650,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-medium * 1/8;
           padding-right: @base-spacing-unit-screen-medium * 1/8;
 
-          .dropdown-menu.down {
+          > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-medium * 1/8);
 
@@ -667,7 +667,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-medium * 3/4;
           padding-right: @base-spacing-unit-screen-medium * 3/4;
 
-          .dropdown-menu.down {
+          > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-medium * 3/4);
 
@@ -777,7 +777,7 @@ components/media-objects.less
         padding-bottom: @base-spacing-unit-screen-large * 1/2;
         padding-right: @base-spacing-unit-screen-large * 1/2;
 
-        .dropdown-menu.down {
+        > .dropdown-menu.down {
 
           top: calc(~"100% - "@base-spacing-unit-screen-large * 1/2);
 
@@ -792,7 +792,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-large * 1/4;
           padding-right: @base-spacing-unit-screen-large * 1/4;
 
-          .dropdown-menu.down {
+          > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-large * 1/4);
 
@@ -812,7 +812,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-large * 1/8;
           padding-right: @base-spacing-unit-screen-large * 1/8;
 
-          .dropdown-menu.down {
+          > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-large * 1/8);
 
@@ -829,7 +829,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-large * 3/4;
           padding-right: @base-spacing-unit-screen-large * 3/4;
 
-          .dropdown-menu.down {
+          > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-large * 3/4);
 

--- a/src/styles/layout/media-object.less
+++ b/src/styles/layout/media-object.less
@@ -138,7 +138,7 @@ components/media-objects.less
     padding-bottom: @base-spacing-unit * 1/2;
     padding-right: @base-spacing-unit * 1/2;
 
-    > .dropdown-menu.down {
+    & > .dropdown-menu.down {
 
       top: calc(~"100% - "@base-spacing-unit * 1/2);
 
@@ -153,7 +153,7 @@ components/media-objects.less
       padding-bottom: @base-spacing-unit * 1/4;
       padding-right: @base-spacing-unit * 1/4;
 
-      > .dropdown-menu.down {
+      & > .dropdown-menu.down {
 
         top: calc(~"100% - "@base-spacing-unit * 1/4);
 
@@ -173,7 +173,7 @@ components/media-objects.less
       padding-bottom: @base-spacing-unit * 1/8;
       padding-right: @base-spacing-unit * 1/8;
 
-      > .dropdown-menu.down {
+      & > .dropdown-menu.down {
 
         top: calc(~"100% - "@base-spacing-unit * 1/8);
 
@@ -190,7 +190,7 @@ components/media-objects.less
       padding-bottom: @base-spacing-unit * 3/4;
       padding-right: @base-spacing-unit * 3/4;
 
-      > .dropdown-menu.down {
+      & > .dropdown-menu.down {
 
         top: calc(~"100% - "@base-spacing-unit * 3/4);
 
@@ -291,7 +291,7 @@ components/media-objects.less
         padding-bottom: @base-spacing-unit-screen-mini * 1/2;
         padding-right: @base-spacing-unit-screen-mini * 1/2;
 
-        > .dropdown-menu.down {
+        & > .dropdown-menu.down {
 
           top: calc(~"100% - "@base-spacing-unit-screen-mini * 1/2);
 
@@ -306,7 +306,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-mini * 1/4;
           padding-right: @base-spacing-unit-screen-mini * 1/4;
 
-          > .dropdown-menu.down {
+          & > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-mini * 1/4);
 
@@ -326,7 +326,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-mini * 1/8;
           padding-right: @base-spacing-unit-screen-mini * 1/8;
 
-          > .dropdown-menu.down {
+          & > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-mini * 1/8);
 
@@ -343,7 +343,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-mini * 3/4;
           padding-right: @base-spacing-unit-screen-mini * 3/4;
 
-          > .dropdown-menu.down {
+          & > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-mini * 3/4);
 
@@ -453,7 +453,7 @@ components/media-objects.less
         padding-bottom: @base-spacing-unit-screen-small * 1/2;
         padding-right: @base-spacing-unit-screen-small * 1/2;
 
-        > .dropdown-menu.down {
+        & > .dropdown-menu.down {
 
           top: calc(~"100% - "@base-spacing-unit-screen-small * 1/2);
 
@@ -468,7 +468,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-small * 1/4;
           padding-right: @base-spacing-unit-screen-small * 1/4;
 
-          > .dropdown-menu.down {
+          & > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-small * 1/4);
 
@@ -488,7 +488,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-small * 1/8;
           padding-right: @base-spacing-unit-screen-small * 1/8;
 
-          > .dropdown-menu.down {
+          & > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-small * 1/8);
 
@@ -505,7 +505,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-small * 3/4;
           padding-right: @base-spacing-unit-screen-small * 3/4;
 
-          > .dropdown-menu.down {
+          & > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-small * 3/4);
 
@@ -615,7 +615,7 @@ components/media-objects.less
         padding-bottom: @base-spacing-unit-screen-medium * 1/2;
         padding-right: @base-spacing-unit-screen-medium * 1/2;
 
-        > .dropdown-menu.down {
+        & > .dropdown-menu.down {
 
           top: calc(~"100% - "@base-spacing-unit-screen-medium * 1/2);
 
@@ -630,7 +630,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-medium * 1/4;
           padding-right: @base-spacing-unit-screen-medium * 1/4;
 
-          > .dropdown-menu.down {
+          & > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-medium * 1/4);
 
@@ -650,7 +650,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-medium * 1/8;
           padding-right: @base-spacing-unit-screen-medium * 1/8;
 
-          > .dropdown-menu.down {
+          & > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-medium * 1/8);
 
@@ -667,7 +667,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-medium * 3/4;
           padding-right: @base-spacing-unit-screen-medium * 3/4;
 
-          > .dropdown-menu.down {
+          & > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-medium * 3/4);
 
@@ -777,7 +777,7 @@ components/media-objects.less
         padding-bottom: @base-spacing-unit-screen-large * 1/2;
         padding-right: @base-spacing-unit-screen-large * 1/2;
 
-        > .dropdown-menu.down {
+        & > .dropdown-menu.down {
 
           top: calc(~"100% - "@base-spacing-unit-screen-large * 1/2);
 
@@ -792,7 +792,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-large * 1/4;
           padding-right: @base-spacing-unit-screen-large * 1/4;
 
-          > .dropdown-menu.down {
+          & > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-large * 1/4);
 
@@ -812,7 +812,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-large * 1/8;
           padding-right: @base-spacing-unit-screen-large * 1/8;
 
-          > .dropdown-menu.down {
+          & > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-large * 1/8);
 
@@ -829,7 +829,7 @@ components/media-objects.less
           padding-bottom: @base-spacing-unit-screen-large * 3/4;
           padding-right: @base-spacing-unit-screen-large * 3/4;
 
-          > .dropdown-menu.down {
+          & > .dropdown-menu.down {
 
             top: calc(~"100% - "@base-spacing-unit-screen-large * 3/4);
 


### PR DESCRIPTION
When dropdowns are not direct children, but still children these introduced styles will still take effect, but they shouldn't.

Before:
![](http://cl.ly/2g0v1l1T1X38/Image%202016-05-16%20at%2017.05.56.png)

After:
![](http://cl.ly/2m2F1h1w2I1Q/Image%202016-05-16%20at%2017.05.18.png)