### PR TITLE
De-dupe PageHeader classnames attributes

### DIFF
--- a/src/js/components/PageHeader.js
+++ b/src/js/components/PageHeader.js
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import classNames from 'classnames/dedupe';
 import React from 'react';
 
 class PageHeader extends React.Component {

--- a/src/js/components/__tests__/PageHeader-test.js
+++ b/src/js/components/__tests__/PageHeader-test.js
@@ -1,0 +1,44 @@
+jest.dontMock('../PageHeader');
+/* eslint-disable no-unused-vars */
+var React = require('react');
+/* eslint-enable no-unused-vars */
+var ReactDOM = require('react-dom');
+
+var PageHeader = require('../PageHeader');
+
+describe('PageHeader', function () {
+  beforeEach(function () {
+    this.container = document.createElement('div');
+  });
+
+  afterEach(function () {
+    ReactDOM.unmountComponentAtNode(this.container);
+  });
+
+  describe('#render', function () {
+
+    it('allows classes to be added', function () {
+      let className = 'foo';
+      let instance = ReactDOM.render(
+        <PageHeader className={className} />,
+        this.container
+      );
+      let node = ReactDOM.findDOMNode(instance);
+      expect(node.classList).toContain('foo');
+    });
+
+    it('allows classes to be removed', function () {
+      var className = {
+        'container': false
+      };
+      let instance = ReactDOM.render(
+        <PageHeader className={className} />,
+        this.container
+      );
+      let node = ReactDOM.findDOMNode(instance);
+      expect(node.classList).not.toContain('container');
+    });
+
+  });
+
+});


### PR DESCRIPTION
PageHeader was using the `classnames` API correctly, but classes were not actually being removed because we weren't using the `dedupe` version.

```
// Without dedupe:
classnames('class-1 class 2', {'class-1': false})
> 'class-1 class 2'
// With dedupe:
classnames('class-1 class 2', {'class-1': false})
> 'class-1'
```