### PR TITLE
Bug: Node Table resource bar animation

### DIFF
--- a/src/js/components/charts/ProgressBar.js
+++ b/src/js/components/charts/ProgressBar.js
@@ -45,7 +45,7 @@ var ProgressBar = React.createClass({
       <div className="progress-bar">
         <div key="bar" ref="bar"
           className={'bar color-' + props.colorIndex}
-          style={{width: data.value + '%'}} />
+          style={{transform: `scaleX(${data.value / 100})`}} />
       </div>
     );
   }

--- a/src/js/components/charts/__tests__/ProgressBar-test.js
+++ b/src/js/components/charts/__tests__/ProgressBar-test.js
@@ -22,12 +22,12 @@ describe('ProgressBar', function () {
     ReactDOM.unmountComponentAtNode(this.container);
   });
 
-  it('has same style width as given percentage value', function () {
+  it('has the correct precentage transform', function () {
     var bar = TestUtils.findRenderedDOMComponentWithClass(
       this.progressbar, 'bar'
     );
 
-    expect(ReactDOM.findDOMNode(bar).style.width).toEqual('66%');
+    expect(ReactDOM.findDOMNode(bar).style.transform).toEqual('scaleX(0.66)');
   });
 
   it('will recieve new property for percentage value', function () {
@@ -39,7 +39,7 @@ describe('ProgressBar', function () {
       this.progressbar, 'bar'
     );
 
-    expect(ReactDOM.findDOMNode(bar).style.width).toEqual('88%');
+    expect(ReactDOM.findDOMNode(bar).style.transform).toEqual('scaleX(0.88)');
   });
 
   it('has correct color index', function () {

--- a/src/styles/components/progressbar.less
+++ b/src/styles/components/progressbar.less
@@ -20,7 +20,10 @@
   .bar {
     box-shadow: 1px 0px 0px 0px @body-background-color;
     height: 100%;
-    transition: width 600ms;
+    width: 100%;
+    transform: scaleX(0);
+    transform-origin: 0;
+    transition: transform 600ms;
 
     &.color-1 {
       background-color: @purple;

--- a/src/styles/components/progressbar.less
+++ b/src/styles/components/progressbar.less
@@ -20,10 +20,10 @@
   .bar {
     box-shadow: 1px 0px 0px 0px @body-background-color;
     height: 100%;
-    width: 100%;
     transform: scaleX(0);
     transform-origin: 0;
     transition: transform 600ms;
+    width: 100%;
 
     &.color-1 {
       background-color: @purple;


### PR DESCRIPTION
The resource bars on the Node Table were not always animating and displaying values properly (for example, when loading the UI in a different page and navigating to the Node page). This fix animates transform rather than width which will render properly on page changes. 