### PR TITLE
Adding filter bar offset, to remove extra padding if necessary

### DIFF
--- a/src/styles/components/filter-bar.less
+++ b/src/styles/components/filter-bar.less
@@ -4,6 +4,10 @@
   flex-wrap: wrap-reverse;
   width: 100%;
 
+  &.filter-bar-offset {
+    margin-bottom: -@base-spacing-unit * 1/4;
+  }
+
 }
 
 .filter-bar-right {
@@ -66,6 +70,14 @@
 
   @media (min-width: @screen-mini) {
 
+    .filter-bar {
+
+      &.filter-bar-offset {
+        margin-bottom: -@base-spacing-unit-screen-mini * 1/4;
+      }
+
+    }
+
     .flex-no-wrap-mini {
 
       flex-wrap: nowrap;
@@ -88,6 +100,14 @@
 
   @media (min-width: @screen-small) {
 
+    .filter-bar {
+
+      &.filter-bar-offset {
+        margin-bottom: -@base-spacing-unit-screen-small * 1/4;
+      }
+
+    }
+
     .filter-bar-item {
 
       padding-bottom: @base-spacing-unit-screen-small * 1/4;
@@ -104,6 +124,14 @@
 
   @media (min-width: @screen-medium) {
 
+    .filter-bar {
+
+      &.filter-bar-offset {
+        margin-bottom: -@base-spacing-unit-screen-medium * 1/4;
+      }
+
+    }
+
     .filter-bar-item {
 
       padding-bottom: @base-spacing-unit-screen-medium * 1/4;
@@ -119,6 +147,14 @@
 & when (@media-object-enabled) and (@screen-large-enabled) {
 
   @media (min-width: @screen-large) {
+
+    .filter-bar {
+
+      &.filter-bar-offset {
+        margin-bottom: -@base-spacing-unit-screen-large * 1/4;
+      }
+
+    }
 
     .filter-bar-item {
 


### PR DESCRIPTION
Adding filter bar offset, to remove extra padding for filter bar if not needed.

Example use in the modal header:
Before:
![](http://cl.ly/3q1B0k2A333e/Image%202016-05-17%20at%2019.48.10.png)

After:
![](http://cl.ly/0r360u3l0937/Image%202016-05-17%20at%2019.47.03.png)