### PR TITLE
Fix/use page header consistently

### DIFF
--- a/src/js/components/ServiceDetail.js
+++ b/src/js/components/ServiceDetail.js
@@ -48,21 +48,13 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
 
     return (
       <div className="flex-container-col">
-        <div className="container-pod container-pod-divider-bottom
+        <div className="container-pod
           container-pod-divider-bottom-align-right
           container-pod-short-top flush-bottom flush-top
           service-detail-header media-object-spacing-wrapper
-          media-object-spacing-narrow container-pod-divider-inverse">
+          media-object-spacing-narrow">
           <ServicesBreadcrumb serviceTreeItem={service} />
-          <ServiceInfo service={service} />
-          <ul className="tabs list-inline flush-bottom container-pod
-            container-pod-short-top inverse">
-            {this.tabs_getUnroutedTabs()}
-          </ul>
-        </div>
-        <div className="side-panel-tab-content side-panel-section container
-          container-pod container-pod-short container-fluid
-          container-fluid-flush flex-container-col flex-grow">
+          <ServiceInfo service={service} tabs={this.tabs_getUnroutedTabs()} />
           {this.tabs_getTabView()}
         </div>
       </div>

--- a/src/js/components/ServiceInfo.js
+++ b/src/js/components/ServiceInfo.js
@@ -3,6 +3,7 @@ import React from 'react';
 import HealthBar from './HealthBar';
 import HealthStatus from '../constants/HealthStatus';
 import HealthLabels from '../constants/HealthLabels';
+import PageHeader from './PageHeader';
 import Service from '../structs/Service';
 import StringUtil from '../utils/StringUtil';
 
@@ -50,32 +51,33 @@ class ServiceInfo extends React.Component {
 
   render() {
     let service = this.props.service;
-    let imageTag = null;
+    let serviceIcon = null;
     let serviceImages = service.getImages();
     if (serviceImages && serviceImages['icon-large']) {
-      imageTag = (
-        <div
-          className="icon icon-large icon-image-container icon-app-container">
-          <img src={serviceImages['icon-large']} />
-        </div>
+      serviceIcon = (
+        <img src={serviceImages['icon-large']} />
       );
     }
 
+    const mediaWrapperClassNames = {
+      'media-object-spacing-narrow': false,
+      'media-object-offset': false
+    };
+
+    const tabs = (
+      <ul className="tabs list-inline flush-bottom container-pod
+        container-pod-short-top inverse">
+        {this.props.tabs}
+      </ul>
+    );
+
     return (
-      <div className="media-object flex-box
-        flex-box-align-vertical-center">
-        <div className="media-object-item">
-          {imageTag}
-        </div>
-        <div className="media-object-item">
-          <h1 className="flush inverse">
-            {service.getName()}
-          </h1>
-          <div>
-            {this.getSubHeader(service)}
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        icon={serviceIcon}
+        subTitle={this.getSubHeader(service)}
+        navigationTabs={tabs}
+        mediaWrapperClassName={mediaWrapperClassNames}
+        title={service.getName()} />
     );
   }
 }

--- a/src/js/components/TaskDetail.js
+++ b/src/js/components/TaskDetail.js
@@ -161,7 +161,8 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
     );
 
     let tabs = (
-      <ul className="tabs list-inline flush-bottom inverse">
+      <ul className="tabs list-inline flush-bottom container-pod
+        container-pod-short-top inverse">
         {this.tabs_getUnroutedTabs()}
       </ul>
     );
@@ -423,9 +424,15 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
 
     return (
       <div className="flex-container-col">
-        {this.getServicesBreadcrumb()}
-        {this.getBasicInfo(task, node)}
-        {this.tabs_getTabView()}
+        <div className="container-pod
+          container-pod-divider-bottom-align-right
+          container-pod-short-top flush-bottom flush-top
+          service-detail-header media-object-spacing-wrapper
+          media-object-spacing-narrow">
+          {this.getServicesBreadcrumb()}
+          {this.getBasicInfo(task, node)}
+          {this.tabs_getTabView()}
+        </div>
       </div>
     );
   }

--- a/src/js/components/__tests__/ServiceDetail-test.js
+++ b/src/js/components/__tests__/ServiceDetail-test.js
@@ -1,3 +1,4 @@
+jest.dontMock('../PageHeader');
 jest.dontMock('../ServiceDetail');
 jest.dontMock('../ServiceDetailTaskTab');
 jest.dontMock('../ServiceInfo');

--- a/src/js/components/__tests__/ServiceInfo-test.js
+++ b/src/js/components/__tests__/ServiceInfo-test.js
@@ -1,3 +1,4 @@
+jest.dontMock('../PageHeader');
 jest.dontMock('../ServiceInfo');
 
 /* eslint-disable no-unused-vars */


### PR DESCRIPTION
This makes sure we have the same markup and same behaviour across Task and Service detail pages.

From:
![from](https://cloud.githubusercontent.com/assets/1078545/15354663/f884051c-1cee-11e6-9852-4cc225bf2c34.gif)

To:
![to](https://cloud.githubusercontent.com/assets/1078545/15354658/f3fb4d0c-1cee-11e6-92b4-7f5b6d2c9b82.gif)
