### PR TITLE
Establish Jobs page and routes

### DIFF
--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -16,7 +16,14 @@ var MetadataStore = require('../stores/MetadataStore');
 import PluginSDK from 'PluginSDK';
 var SidebarActions = require('../events/SidebarActions');
 
-let defaultMenuItems = ['dashboard', 'services-page', 'nodes-list', 'universe', 'system'];
+let defaultMenuItems = [
+  'dashboard',
+  'services-page',
+  'jobs-page',
+  'nodes-list',
+  'universe',
+  'system'
+];
 
 let {Hooks} = PluginSDK;
 

--- a/src/js/pages/JobsPage.js
+++ b/src/js/pages/JobsPage.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import {RouteHandler} from 'react-router';
+
+import Page from '../components/Page';
+import TabsMixin from '../mixins/TabsMixin';
+
+var JobsPage = React.createClass({
+
+  contextTypes: {
+    router: React.PropTypes.func
+  },
+
+  mixins: [TabsMixin],
+
+  displayName: 'JobsPage',
+
+  statics: {
+    routeConfig: {
+      label: 'Jobs',
+      icon: 'jobs',
+      matches: /^\/jobs/
+    }
+  },
+
+  getInitialState: function () {
+    return {
+      currentTab: 'jobs-page'
+    };
+  },
+
+  componentWillMount: function () {
+    this.tabs_tabs = {
+      'jobs-page': 'Jobs'
+    };
+    this.updateCurrentTab();
+  },
+
+  updateCurrentTab: function () {
+    let routes = this.context.router.getCurrentRoutes();
+    let currentTab = routes[routes.length - 1].name;
+    if (currentTab != null) {
+      this.setState({currentTab});
+    }
+  },
+
+  getNavigation: function () {
+    return (
+      <ul className="tabs list-inline flush-bottom inverse">
+        {this.tabs_getRoutedTabs()}
+      </ul>
+    );
+  },
+
+  render: function () {
+    return (
+      <Page
+        navigation={this.getNavigation()}
+        title="Jobs">
+        <RouteHandler />
+      </Page>
+    );
+  }
+
+});
+
+module.exports = JobsPage;

--- a/src/js/pages/JobsPage.js
+++ b/src/js/pages/JobsPage.js
@@ -1,57 +1,44 @@
+import mixin from 'reactjs-mixin';
 import React from 'react';
 import {RouteHandler} from 'react-router';
 
 import Page from '../components/Page';
+import SidebarActions from '../events/SidebarActions';
 import TabsMixin from '../mixins/TabsMixin';
 
-var JobsPage = React.createClass({
+class JobsPage extends mixin(TabsMixin) {
+  constructor() {
+    super();
 
-  contextTypes: {
-    router: React.PropTypes.func
-  },
+    this.tabs_tabs = { 'jobs-page': 'Jobs'};
+    this.state = {currentTab: 'jobs-page'};
+  }
 
-  mixins: [TabsMixin],
-
-  displayName: 'JobsPage',
-
-  statics: {
-    routeConfig: {
-      label: 'Jobs',
-      icon: 'jobs',
-      matches: /^\/jobs/
-    }
-  },
-
-  getInitialState: function () {
-    return {
-      currentTab: 'jobs-page'
-    };
-  },
-
-  componentWillMount: function () {
-    this.tabs_tabs = {
-      'jobs-page': 'Jobs'
-    };
+  componentWillMount() {
     this.updateCurrentTab();
-  },
+  }
 
-  updateCurrentTab: function () {
+  componentWillReceiveProps() {
+    this.updateCurrentTab();
+  }
+
+  updateCurrentTab() {
     let routes = this.context.router.getCurrentRoutes();
     let currentTab = routes[routes.length - 1].name;
     if (currentTab != null) {
       this.setState({currentTab});
     }
-  },
+  }
 
-  getNavigation: function () {
+  getNavigation() {
     return (
       <ul className="tabs list-inline flush-bottom inverse">
         {this.tabs_getRoutedTabs()}
       </ul>
     );
-  },
+  }
 
-  render: function () {
+  render() {
     return (
       <Page
         navigation={this.getNavigation()}
@@ -60,7 +47,20 @@ var JobsPage = React.createClass({
       </Page>
     );
   }
+}
 
-});
+JobsPage.contextTypes = {
+  router: React.PropTypes.func
+};
+
+JobsPage.routeConfig = {
+  label: 'Jobs',
+  icon: 'jobs',
+  matches: /^\/jobs/
+};
+
+JobsPage.willTransitionTo = function () {
+  SidebarActions.close();
+};
 
 module.exports = JobsPage;

--- a/src/js/pages/JobsPage.js
+++ b/src/js/pages/JobsPage.js
@@ -8,9 +8,9 @@ import TabsMixin from '../mixins/TabsMixin';
 
 class JobsPage extends mixin(TabsMixin) {
   constructor() {
-    super();
+    super(...arguments);
 
-    this.tabs_tabs = { 'jobs-page': 'Jobs'};
+    this.tabs_tabs = {'jobs-page': 'Jobs'};
     this.state = {currentTab: 'jobs-page'};
   }
 
@@ -19,6 +19,7 @@ class JobsPage extends mixin(TabsMixin) {
   }
 
   componentWillReceiveProps() {
+    super.componentWillReceiveProps(...arguments);
     this.updateCurrentTab();
   }
 

--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import {RouteHandler} from 'react-router';
+import {StoreMixin} from 'mesosphere-shared-reactjs';
+
+import AlertPanel from '../../components/AlertPanel';
+import DCOSStore from '../../stores/DCOSStore';
+import QueryParamsMixin from '../../mixins/QueryParamsMixin';
+import SidebarActions from '../../events/SidebarActions';
+
+var JobsTab = React.createClass({
+
+  displayName: 'JobsTab',
+
+  mixins: [StoreMixin, QueryParamsMixin],
+
+  statics: {
+    // Static life cycle method from react router, that will be called
+    // 'when a handler is about to render', i.e. on route change:
+    // https://github.com/rackt/react-router/
+    // blob/master/docs/api/components/RouteHandler.md
+    willTransitionTo: function () {
+      SidebarActions.close();
+    }
+  },
+
+  contextTypes: {
+    router: React.PropTypes.func
+  },
+
+  componentWillMount: function () {
+    this.store_listeners = [{name: 'dcos', events: ['change']}];
+  },
+
+  getContents: function () {
+    // Render loading screen
+    if (!DCOSStore.dataProcessed) {
+      return (
+        <div className="container container-fluid container-pod text-align-center
+            vertical-center inverse">
+          <div className="row">
+            <div className="ball-scale">
+              <div />
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    if (this.props.params.taskID) {
+      return (
+        <RouteHandler />
+      );
+    }
+
+    // Render empty panel
+    return (
+      <AlertPanel
+        title="No Jobs Found"
+        iconClassName="icon icon-sprite icon-sprite-jumbo
+          icon-sprite-jumbo-white icon-jobs flush-top">
+        <p className="flush-bottom">
+         Jobs aren't available yet.
+        </p>
+      </AlertPanel>
+    );
+  },
+
+  render: function () {
+    let {id} = this.props.params;
+
+    return this.getContents(decodeURIComponent(id));
+  }
+
+});
+
+module.exports = JobsTab;

--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -9,16 +9,14 @@ import DCOSStore from '../../stores/DCOSStore';
 class JobsTab extends mixin(StoreMixin) {
 
   constructor() {
-    super();
+    super(...arguments);
 
     this.store_listeners = [
       {name: 'dcos', events: ['change']}
     ];
   }
 
-  /* eslint-disable no-unused-vars */
-  getContents(id) {
-  /* eslint-enable-no-unused-vars */
+  getContents() {
     // Render loading screen
     if (!DCOSStore.dataProcessed) {
       return (

--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -1,37 +1,24 @@
+import mixin from 'reactjs-mixin';
 import React from 'react';
 import {RouteHandler} from 'react-router';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
 import AlertPanel from '../../components/AlertPanel';
 import DCOSStore from '../../stores/DCOSStore';
-import QueryParamsMixin from '../../mixins/QueryParamsMixin';
-import SidebarActions from '../../events/SidebarActions';
 
-var JobsTab = React.createClass({
+class JobsTab extends mixin(StoreMixin) {
 
-  displayName: 'JobsTab',
+  constructor() {
+    super();
 
-  mixins: [StoreMixin, QueryParamsMixin],
+    this.store_listeners = [
+      {name: 'dcos', events: ['change']}
+    ];
+  }
 
-  statics: {
-    // Static life cycle method from react router, that will be called
-    // 'when a handler is about to render', i.e. on route change:
-    // https://github.com/rackt/react-router/
-    // blob/master/docs/api/components/RouteHandler.md
-    willTransitionTo: function () {
-      SidebarActions.close();
-    }
-  },
-
-  contextTypes: {
-    router: React.PropTypes.func
-  },
-
-  componentWillMount: function () {
-    this.store_listeners = [{name: 'dcos', events: ['change']}];
-  },
-
-  getContents: function () {
+  /* eslint-disable no-unused-vars */
+  getContents(id) {
+  /* eslint-enable-no-unused-vars */
     // Render loading screen
     if (!DCOSStore.dataProcessed) {
       return (
@@ -63,14 +50,16 @@ var JobsTab = React.createClass({
         </p>
       </AlertPanel>
     );
-  },
-
-  render: function () {
-    let {id} = this.props.params;
-
-    return this.getContents(decodeURIComponent(id));
   }
 
-});
+  render() {
+    let {id} = this.props.params;
+    return this.getContents(decodeURIComponent(id));
+  }
+}
+
+JobsTab.contextTypes = {
+  router: React.PropTypes.func
+};
 
 module.exports = JobsTab;

--- a/src/js/routes/index.js
+++ b/src/js/routes/index.js
@@ -7,12 +7,14 @@ import nodes from './nodes';
 import NotFoundPage from '../pages/NotFoundPage';
 import System from './factories/system';
 import services from './services';
+import jobs from './jobs';
 import universe from './universe';
 
 // Statically defined routes
 let applicationRoutes = [
   dashboard,
   services,
+  jobs,
   nodes,
 
   universe,

--- a/src/js/routes/jobs.js
+++ b/src/js/routes/jobs.js
@@ -1,0 +1,26 @@
+import {Route} from 'react-router';
+
+import JobsPage from '../pages/JobsPage';
+import JobsTab from '../pages/jobs/JobsTab';
+
+let jobsRoutes = {
+  type: Route,
+  name: 'jobs-page',
+  handler: JobsPage,
+  path: '/jobs/?',
+  children: [
+    {
+      type: Route,
+      handler: JobsTab,
+      children: [
+        {
+          type: Route,
+          name: 'jobs-detail',
+          path: ':id/?'
+        }
+      ]
+    }
+  ]
+};
+
+module.exports = jobsRoutes;

--- a/tests/pages/jobs/JobsOverview-cy.js
+++ b/tests/pages/jobs/JobsOverview-cy.js
@@ -1,0 +1,21 @@
+describe('Jobs Overview', function () {
+  context('Jobs page loads correctly', function () {
+    beforeEach(function () {
+      cy.configureCluster({
+        mesos: '1-for-each-health',
+        nodeHealth: true
+      });
+      cy.visitUrl({url: '/jobs'});
+    });
+
+    it('has the right active navigation entry', function () {
+      cy.get('.page-header-navigation .tab-item.active')
+        .should('to.have.text', 'Jobs');
+    });
+
+    it('displays empty jobs overview page', function () {
+      cy.get('.page-content .panel-content h3')
+        .should('to.have.text', 'No Jobs Found');
+    });
+  });
+});


### PR DESCRIPTION
All this PR accomplishes is to establish the Jobs overview page and routes. Consider it as the first step towards having the various Jobs views.

![screen shot 2016-05-18 at 14 04 25](https://cloud.githubusercontent.com/assets/1078545/15357828/8343e0ca-1d01-11e6-817d-8f3bf3606417.png)
