### PR TITLE
Extend service struct

### DIFF
--- a/src/js/structs/Service.js
+++ b/src/js/structs/Service.js
@@ -12,6 +12,10 @@ module.exports = class Service extends Item {
     return this.get('cmd');
   }
 
+  getCpus() {
+    return this.get('cpus');
+  }
+
   getContainer() {
     return this.get('container');
   }

--- a/src/js/structs/Service.js
+++ b/src/js/structs/Service.js
@@ -24,6 +24,10 @@ module.exports = class Service extends Item {
     return this.get('deployments');
   }
 
+  getDisk() {
+    return this.get('disk');
+  }
+
   getExecutor() {
     return this.get('executor');
   }

--- a/src/js/structs/Service.js
+++ b/src/js/structs/Service.js
@@ -78,6 +78,10 @@ module.exports = class Service extends Item {
     return this.getVersionInfo().lastScalingAt;
   }
 
+  getMem() {
+    return this.get('mem');
+  }
+
   getName() {
     return this.getId().split('/').pop();
   }

--- a/src/js/structs/__tests__/Service-test.js
+++ b/src/js/structs/__tests__/Service-test.js
@@ -451,4 +451,14 @@ describe('Service', function () {
 
   });
 
+  describe('#getCpus', function () {
+    it('returns the correct cpus', function() {
+      let service = new Service({
+        cpus: 0.5
+      });
+
+      expect(service.getCpus()).toEqual(0.5);
+    })
+  });
+
 });

--- a/src/js/structs/__tests__/Service-test.js
+++ b/src/js/structs/__tests__/Service-test.js
@@ -461,4 +461,15 @@ describe('Service', function () {
     })
   });
 
+  describe('#getDisk', function () {
+    it('returns the correct disk', function () {
+      let service = new Service({
+        disk: 125
+      });
+
+      expect(service.getDisk()).toEqual(125);
+    });
+  });
+
+
 });

--- a/src/js/structs/__tests__/Service-test.js
+++ b/src/js/structs/__tests__/Service-test.js
@@ -471,5 +471,13 @@ describe('Service', function () {
     });
   });
 
+  describe('#getMem', function() {
+    it('returns the correct mem', function () {
+      let service = new Service({
+        mem: 49
+      });
 
+      expect(service.getMem()).toEqual(49);
+    })
+  });
 });

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -1,33 +1,35 @@
 import Service from '../structs/Service';
 
-const getFindPropertiesRecursive = function (service) {
-  let findPropertiesRecursive = function (item) {
-    return Object.keys(item).reduce(function (memo, subItem) {
-      if (item[subItem].type === 'object') {
-        memo[subItem] = findPropertiesRecursive(item[subItem].properties);
-        return memo;
-      }
+const getFindPropertiesRecursive = function (service, item) {
 
-      memo[subItem] = service.get(subItem) || item[subItem].default;
+  return Object.keys(item).reduce(function (memo, subItem) {
+    if (item[subItem].type === 'object') {
+      memo[subItem] = getFindPropertiesRecursive(service, item[subItem].properties);
+
       return memo;
-    }, {});
-  };
-  return findPropertiesRecursive;
+    }
+    memo[subItem] = service.get(subItem) || item[subItem].default;
+
+    return memo;
+  }, {});
 };
 
 const ServiceUtil = {
-  convertFormModelToService: function (formModel) {
-    formModel = Object.keys(formModel).reduce(function (memory, section) {
+  createServiceFromFormModel: function (formModel) {
+    let values = Object.keys(formModel).reduce(function (memo, section) {
       Object.keys(formModel[section]).forEach(function (attribute) {
-        memory[attribute] = formModel[section][attribute];
+        memo[attribute] = formModel[section][attribute];
       });
-      return memory;
+
+      return memo;
     }, {});
-    return new Service(formModel);
+
+    return new Service(values);
   },
 
   createFormModelFromSchema: function (service, schema) {
-    return getFindPropertiesRecursive(service)(schema.properties);
+
+    return getFindPropertiesRecursive(service, schema.properties);
   },
 
   getAppDefinitionFromService: function (service) {

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -1,0 +1,53 @@
+import Service from '../structs/Service';
+
+const getFindPropertiesRecursive = function (service) {
+  let findPropertiesRecursive = function (item) {
+    return Object.keys(item).reduce(function (memo, subItem) {
+      if (item[subItem].type === 'object') {
+        memo[subItem] = findPropertiesRecursive(item[subItem].properties);
+        return memo;
+      }
+
+      memo[subItem] = service.get(subItem) || item[subItem].default;
+      return memo;
+    }, {});
+  };
+  return findPropertiesRecursive;
+};
+
+const ServiceUtil = {
+  convertFormModelToService: function (formModel) {
+    formModel = Object.keys(formModel).reduce(function (memory, section) {
+      Object.keys(formModel[section]).forEach(function (attribute) {
+        memory[attribute] = formModel[section][attribute];
+      });
+      return memory;
+    }, {});
+    return new Service(formModel);
+  },
+
+  createFormModelFromSchema: function (service, schema) {
+    return getFindPropertiesRecursive(service)(schema.properties);
+  },
+
+  getAppDefinitionFromService: function (service) {
+    let appDefinition = {};
+
+    appDefinition.id = service.getId();
+    appDefinition.cpus = service.getCpus();
+    appDefinition.mem = service.getMem();
+    appDefinition.disk = service.getDisk();
+    appDefinition.instances = service.getInstancesCount();
+    appDefinition.cmd = service.getCommand();
+
+    Object.keys(appDefinition).forEach(function (key) {
+      if (appDefinition[key] == null) {
+        delete appDefinition[key];
+      }
+    });
+
+    return appDefinition;
+  }
+};
+
+module.exports = ServiceUtil;

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -1,0 +1,83 @@
+jest.dontMock('../ServiceUtil');
+jest.dontMock('../../structs/Service');
+
+var Service = require('../../structs/Service');
+var ServiceUtil = require('../ServiceUtil');
+
+describe('ServiceUtil', function () {
+  describe('#converModelToService', function () {
+    it('should convert to the correct Service', function () {
+      let model = {
+        General: {
+          id: '/test',
+          cmd: 'sleep 1000;'
+        }
+      };
+
+      let expectedService = new Service({
+        id: '/test',
+        cmd: 'sleep 1000;'
+      });
+
+      expect(ServiceUtil.convertFormModelToService(model)).toEqual(expectedService);
+    });
+  });
+
+  describe('#createFormModelFromSchema', function () {
+    it('should create the correct model', function () {
+      let schema = {
+        type: 'object',
+        properties: {
+          General: {
+            description: 'Configure your container',
+            type: 'object',
+            properties: {
+              id: {
+                default: '/service',
+                title: 'ID',
+                description: 'The id for the service',
+                type: 'string'
+              },
+              cmd: {
+                title: 'Command',
+                default: 'sleep 1000;',
+                description: 'The command which is executed by the service',
+                type: 'string',
+                multiLine: true
+              }
+            }
+          }
+        },
+        required: [
+          'General'
+        ]
+      };
+
+      let service = new Service({
+        id: '/test',
+        cmd: 'sleep 1000;'
+      });
+
+      expect(ServiceUtil.createFormModelFromSchema(service, schema)).toEqual({
+        General: {
+          id: '/test',
+          cmd: 'sleep 1000;'
+        }
+      });
+    });
+  });
+
+  describe('#getAppDefinitionFromService', function () {
+    it('should create the correct appDefinition', function () {
+      let service = new Service({
+        id: '/test',
+        cmd: 'sleep 1000;'
+      });
+
+      expect(ServiceUtil.getAppDefinitionFromService(service)).toEqual({
+        id: '/test',
+        cmd: 'sleep 1000;'
+      });
+    });
+  });
+});

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -19,7 +19,8 @@ describe('ServiceUtil', function () {
         cmd: 'sleep 1000;'
       });
 
-      expect(ServiceUtil.createServiceFromFormModel(model)).toEqual(expectedService);
+      expect(ServiceUtil.createServiceFromFormModel(model))
+        .toEqual(expectedService);
     });
   });
 

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -19,7 +19,7 @@ describe('ServiceUtil', function () {
         cmd: 'sleep 1000;'
       });
 
-      expect(ServiceUtil.convertFormModelToService(model)).toEqual(expectedService);
+      expect(ServiceUtil.createServiceFromFormModel(model)).toEqual(expectedService);
     });
   });
 


### PR DESCRIPTION
Extend the service struct with a couple of get functions, those are needed for the deploy a service modal.

Also introducing a `ServiceUtil.js` this contains for now 3 functions:
- `convertFormModelToService` - This function is creating a `Service` object from the a `formModel` which is provided by the `AdvancedConfig` component.
- `createFormModelFromSchema` - This is creating a `formModel` with a given `Schema` and `Service`.
- `getAppDefinitionFromService` - This is creating a marathon `appDefinition` from a `Service` Object. 

This is a dependency for #212 