### PR TITLE
Add textarea to SchemaUtil

### DIFF
--- a/src/js/utils/SchemaUtil.js
+++ b/src/js/utils/SchemaUtil.js
@@ -57,6 +57,10 @@ function schemaToFieldDefinition(fieldName, fieldProps, formParent, isRequired, 
     definition.checked = fieldProps.default || false;
   }
 
+  if (fieldProps.multiLine === true) {
+    definition.fieldType = 'textarea';
+  }
+
   return definition;
 }
 


### PR DESCRIPTION
This adds the possibility to add a text area with a schema to the advanced config, this is needed for the command field in the `deploy a service` modal. With that minor change it is possible to configure a multiline field which embraces the form field for textareas from the reactjs components.

There is also a PR on the reactjs components to remove the keydown listener which blurs on enter.(mesosphere/reactjs-components/pull/255)

This is a dependency for #212