### PR TITLE
Add HeaderText to AdvancedConfig

### DIFF
--- a/src/js/components/AdvancedConfig.js
+++ b/src/js/components/AdvancedConfig.js
@@ -31,6 +31,7 @@ class AdvancedConfig extends React.Component {
   render() {
     let {
       className,
+      headerText,
       model,
       onChange,
       packageIcon,
@@ -43,6 +44,7 @@ class AdvancedConfig extends React.Component {
       <div className={className}>
         <SchemaForm
           getTriggerSubmit={this.getTriggerSubmit}
+          headerText={headerText}
           model={model}
           onChange={onChange}
           schema={schema}
@@ -62,6 +64,7 @@ AdvancedConfig.defaultProps = {
 
 AdvancedConfig.propTypes = {
   getTriggerSubmit: React.PropTypes.func,
+  headerText: React.PropTypes.string,
   model: React.PropTypes.object,
   onChange: React.PropTypes.func,
   schema: React.PropTypes.object,

--- a/src/js/components/SchemaForm.js
+++ b/src/js/components/SchemaForm.js
@@ -207,6 +207,28 @@ class SchemaForm extends React.Component {
     );
   }
 
+  getFormHeader() {
+    if (this.props.headerText != null) {
+      return this.getTitleHeader();
+    }
+
+    return this.getServiceHeader();
+  }
+
+  getTitleHeader() {
+    let {headerText}= this.props;
+
+    return (
+      <div className="modal-header modal-header-padding-narrow modal-header-bottom-border modal-header-white flex-no-shrink">
+        <div className="media-object-spacing-wrapper media-object-spacing-narrow media-object-offset">
+          <div className="media-object media-object-align-middle">
+            {headerText}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   getHeader(title, description) {
     return (
       <div key={title} className="form-row-element">
@@ -280,7 +302,7 @@ class SchemaForm extends React.Component {
   render() {
     return (
       <div>
-        {this.getServiceHeader()}
+        {this.getFormHeader()}
         <div className={this.props.className}>
           {this.getSideContent(this.multipleDefinition)}
           {this.getFormPanels()}
@@ -298,6 +320,7 @@ SchemaForm.defaultProps = {
 
 SchemaForm.propTypes = {
   getTriggerSubmit: React.PropTypes.func,
+  headerText: React.PropTypes.string,
   schema: React.PropTypes.object,
   packageIcon: React.PropTypes.string,
   packageName: React.PropTypes.string,


### PR DESCRIPTION
This introduces the capability of adding a header to the `advancedConfig` component. This is needed to show a generic title instead of the package name and version.

This is a dependency for #212