### PR TITLE
Quickfix for RWD in Services tab

### DIFF
--- a/src/js/components/SidebarFilter.js
+++ b/src/js/components/SidebarFilter.js
@@ -199,7 +199,7 @@ class SidebarFilter extends mixin(QueryParamsMixin) {
     let {props} = this;
 
     return (
-      <div className="side-list sidebar-filters">
+      <div className="side-list sidebar-filters hidden-medium hidden-small hidden-mini">
         <div className="flex-box flex-align-right flush">
           {this.getTitle()}
           {this.getClearLinkForFilter(props.filterType)}


### PR DESCRIPTION
Just a quick hotfix to have a somewhat usable Services page when on smaller screens. 

![rwd](https://cloud.githubusercontent.com/assets/1078545/15393849/c14a6e74-1dcf-11e6-95e5-1d9760f64d08.gif)

A proper RWD implementation will follow later (captured in MARATHON-1060).