### PR TITLE
Only cast list items if type is set

### DIFF
--- a/src/js/structs/List.js
+++ b/src/js/structs/List.js
@@ -39,7 +39,12 @@ module.exports = class List {
       if (!Util.isArray(options.items)) {
         throw new Error('Expected an array.');
       }
-      this.list = options.items.map(cast.bind(this));
+      if (this.constructor.type != null) {
+        this.list = options.items.map(cast.bind(this));
+      } else {
+        this.list = options.items;
+      }
+
     }
 
     this.filterProperties = options.filterProperties || {};


### PR DESCRIPTION
This PR addresses concerns over performance problems with untyped list initiation. I ran a couple of benchmarks - initiating a `NodesList` (untyped, inherits from `List`) of 1,000 items

 - Before: `1,653 ops/sec`
 - After: `3,395 ops/sec`
