### PR TITLE
Bug - Give PageHeader correct padding when it has no tabs

### DIFF
--- a/src/js/components/PageHeader.js
+++ b/src/js/components/PageHeader.js
@@ -84,9 +84,10 @@ class PageHeader extends React.Component {
     );
 
     let dividerClasses = classNames(
-      'container-pod container-pod-short flush-top flush-bottom',
+      'container-pod container-pod-short flush-top',
       'container-pod-divider-bottom container-pod-divider-bottom-align-right',
       'container-pod-divider-inverse',
+      {'flush-bottom': !!navigationTabs},
       dividerClassName
     );
 


### PR DESCRIPTION
This class was added to `PageHeader`, and needs to be removed in these special cases when there are no tabs. 

For example, 

before:
![](http://cl.ly/440A26423e41/Image%202016-05-19%20at%201.37.38%20PM.png)

after:
![](http://cl.ly/301t2A2j1x0m/Image%202016-05-19%20at%201.36.56%20PM.png)