### PR TITLE
Bug - Disappearing padding from pages

### DIFF
--- a/src/js/components/Page.js
+++ b/src/js/components/Page.js
@@ -105,7 +105,7 @@ var Page = React.createClass({
         {this.getPageHeader(title, navigation)}
         <GeminiScrollbar autoshow={true} className="page-content
           container-scrollable inverse" ref="pageRef">
-          <div className="flex-container-col flex-grow container container-fluid container-pod container-pod-short-top">
+          <div className="flex-container-col container container-fluid container-pod container-pod-short-top">
             {this.getChildren()}
           </div>
         </GeminiScrollbar>

--- a/src/js/components/Page.js
+++ b/src/js/components/Page.js
@@ -105,7 +105,7 @@ var Page = React.createClass({
         {this.getPageHeader(title, navigation)}
         <GeminiScrollbar autoshow={true} className="page-content
           container-scrollable inverse" ref="pageRef">
-          <div className="flex-container-col flex-shrink flex-grow container container-fluid container-pod container-pod-short-top">
+          <div className="flex-container-col flex-grow container container-fluid container-pod container-pod-short-top">
             {this.getChildren()}
           </div>
         </GeminiScrollbar>


### PR DESCRIPTION
This bug happened when scrolling is set to `always` on Mac and the content flowed off the page (note the lack of margin under the secondary tabs):

![picture of bug](http://cl.ly/1i0d3Y16211s/Image%202016-05-19%20at%202.49.31%20PM.png)

To fix I removed `flex-shrink` so the page doesn't force all the children to shrink. 

I have checked the pages but I'd love a second glance! <3

Shoutout to @jfurrow for his champion css debug insight as always ✨ 