### PR TITLE
Bug - StatusBar value not showing

### DIFF
--- a/src/js/components/StatusBar.js
+++ b/src/js/components/StatusBar.js
@@ -25,11 +25,10 @@ class StatusBar extends React.Component {
         return null;
       }
 
-      let width = value / max * 100;
+      let scale = value / max;
 
       let style = {
-        width: `${width}%`,
-        height: '100%'
+        transform: `scaleX(${scale})`
       };
 
       return (

--- a/src/js/components/__tests__/StatusBar-test.js
+++ b/src/js/components/__tests__/StatusBar-test.js
@@ -144,11 +144,11 @@ describe('#StatusBar', function () {
           ).toBeTruthy();
         });
 
-      it('should have a width of 40', function () {
+      it('should have a transform of scaleX(0.4)', function () {
         expect(
           this.container.querySelector('.bar:first-child')
-            .style.width
-        ).toEqual('40%');
+            .style.transform
+        ).toEqual('scaleX(0.4)');
       });
     });
 
@@ -161,11 +161,11 @@ describe('#StatusBar', function () {
         ).toBeTruthy();
       });
 
-      it('should have a width of 60', function () {
+      it('should have a transform of scaleX(0.6)', function () {
         expect(
           this.container.querySelector('.bar:nth-child(2)')
-            .style.width
-        ).toEqual('60%');
+            .style.transform
+        ).toEqual('scaleX(0.6)');
       });
     });
   });


### PR DESCRIPTION
In ServicesPage, the `StatusBar` component was not showing value because of previously changed styles that animated `transform` rather than `width`. This PR updates `StatusBar` accordingly.