### PR TITLE
Extract parent group id from input field

### DIFF
--- a/src/js/components/modals/ServiceGroupFormModal.js
+++ b/src/js/components/modals/ServiceGroupFormModal.js
@@ -56,8 +56,12 @@ class ServiceGroupFormModal extends mixin(StoreMixin) {
   }
 
   handleNewGroupSubmit(model) {
+    let {parentGroupId} = this.props;
+
     this.setState({disableNewGroup: true});
-    MarathonStore.createGroup(model);
+    MarathonStore.createGroup(Object.assign({}, model,
+      {id: `${parentGroupId}/${model.id}`})
+    );
   }
 
   getErrorMessage() {
@@ -71,11 +75,6 @@ class ServiceGroupFormModal extends mixin(StoreMixin) {
   }
 
   getNewGroupFormDefinition() {
-    let {parentGroupId} = this.props;
-    if (!parentGroupId.endsWith('/')) {
-      parentGroupId = `${parentGroupId}/`;
-    }
-
     return [
       {
         fieldType: 'text',
@@ -92,25 +91,30 @@ class ServiceGroupFormModal extends mixin(StoreMixin) {
         validationErrorText: 'Group name must be at least 1 character and ' +
           'may only contain digits (0-9), dashes (-), dots (.), ' +
           'and lowercase letters (a-z). The name may not begin or end ' +
-          'with a dash.',
-        value: parentGroupId
+          'with a dash.'
       }
     ];
   }
 
   render() {
+    let {props, state} = this;
+
     return (
       <FormModal
         ref="form"
-        disabled={this.state.disableNewGroup}
-        onClose={this.props.onClose}
+        disabled={state.disableNewGroup}
+        onClose={props.onClose}
         onSubmit={this.handleNewGroupSubmit}
         onChange={this.resetState}
-        open={this.props.open}
+        open={props.open}
         definition={this.getNewGroupFormDefinition()}>
         <h2 className="modal-header-title text-align-center flush-top">
-          Create New Group
+          Create Group
         </h2>
+        <p className="text-align-center flush-top">
+          Enter a path for the new group under&nbsp;
+          <span className="emphasize">{props.parentGroupId}</span>
+        </p>
         {this.getErrorMessage()}
       </FormModal>
     );

--- a/src/js/components/modals/ServiceGroupFormModal.js
+++ b/src/js/components/modals/ServiceGroupFormModal.js
@@ -15,6 +15,19 @@ const METHODS_TO_BIND = [
   'resetState'
 ];
 
+const buttonDefinition = [
+  {
+    text: 'Cancel',
+    className: 'button button-medium',
+    isClose: true
+  },
+  {
+    text: 'Create Group',
+    className: 'button button-success button-medium',
+    isSubmit: true
+  }
+];
+
 class ServiceGroupFormModal extends mixin(StoreMixin) {
   constructor() {
     super();
@@ -102,6 +115,7 @@ class ServiceGroupFormModal extends mixin(StoreMixin) {
     return (
       <FormModal
         ref="form"
+        buttonDefinition={buttonDefinition}
         disabled={state.disableNewGroup}
         onClose={props.onClose}
         onSubmit={this.handleNewGroupSubmit}
@@ -112,7 +126,7 @@ class ServiceGroupFormModal extends mixin(StoreMixin) {
           Create Group
         </h2>
         <p className="text-align-center flush-top">
-          Enter a path for the new group under&nbsp;
+          {'Enter a path for the new group under '}
           <span className="emphasize">{props.parentGroupId}</span>
         </p>
         {this.getErrorMessage()}


### PR DESCRIPTION
Fix the Create Group modal form to reproduce existing behaviour in Marathon UI.

Extract the parent group ID from the input field itself and show indication of target group in the modal header itself.

Example:

![screen shot 2016-05-23 at 14 05 10](https://cloud.githubusercontent.com/assets/1078545/15470248/cf51622a-20ef-11e6-85db-50811b7ce8c7.png)
![screen shot 2016-05-23 at 14 04 36](https://cloud.githubusercontent.com/assets/1078545/15470247/cf3fad8c-20ef-11e6-90c1-ef07298c46df.png)


cc @MatApple and @leemunroe 