### PR TITLE
[DONT MERGE!] Request for comments: button-bar in detail page

### DIFF
--- a/src/js/components/ServiceDetail.js
+++ b/src/js/components/ServiceDetail.js
@@ -57,7 +57,23 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
           service-detail-header media-object-spacing-wrapper
           media-object-spacing-narrow">
           <ServicesBreadcrumb serviceTreeItem={service} />
-          <ServiceInfo service={service} tabs={this.tabs_getUnroutedTabs()} />
+          <div className="flex-box control-group flex-grow">
+            <ServiceInfo service={service} tabs={this.tabs_getUnroutedTabs()} />
+            <div className="flex-grow flex-align-right">
+              <div className="filter-bar-item">
+                <button className="button button-stroke button-inverse">Scale</button>
+              </div>
+              <div className="filter-bar-item">
+                <button className="button button-stroke button-inverse">Edit</button>
+              </div>
+              <div className="filter-bar-item">
+                <button className="button button-stroke button-inverse">Suspend</button>
+              </div>
+              <div className="filter-bar-item">
+                <button className="button button-stroke button-inverse">Destroy</button>
+              </div>
+            </div>
+          </div>
           {this.tabs_getTabView()}
         </div>
       </div>


### PR DESCRIPTION
Opening this PR just to gather insights from others - not meant to be merged!

What is the best way to introduce the button bar in the Service detail page?
The approach outlined in this PR (for illustration purposes only), which relies on the Canvas `flex-*` classes, has the limitation of not allowing the `ServiceInfo` tabs to draw their border-bottom to the full-width of the viewport.

![image](https://cloud.githubusercontent.com/assets/1078545/15474556/9ab7f84c-2105-11e6-9d94-c1a94da13f7f.png)


- Is there already an ongoing effort to introduce a similar component somewhere else? 
- Is this the right approach or should i consider absolute positioning?
- should we consider extracting the tabs outside of `ServiceInfo` (which seems kinda wrong to begin with)?

I'd love to hear some thoughts and feel free to close this PR if there's a simplistic answer I may have missed!

