### PR TITLE
[1/6] Deployments Table - Deployment struct updates

### DIFF
--- a/src/js/stores/DCOSStore.js
+++ b/src/js/stores/DCOSStore.js
@@ -8,10 +8,10 @@ import {
   MARATHON_SERVICE_VERSION_CHANGE,
   MARATHON_SERVICE_VERSIONS_CHANGE
 } from '../constants/EventTypes';
+import DeploymentsList from '../structs/DeploymentsList';
 import Framework from '../structs/Framework';
 import MarathonStore from './MarathonStore';
 import MesosSummaryStore from './MesosSummaryStore';
-import DeploymentsList from '../structs/DeploymentsList';
 import ServicesList from '../structs/ServicesList';
 import ServiceTree from '../structs/ServiceTree';
 import SummaryList from '../structs/SummaryList';
@@ -93,13 +93,11 @@ class DCOSStore extends EventEmitter {
     let deploymentsList = MarathonStore.get('deployments');
     let serviceTree = MarathonStore.get('groups');
 
-    // Populate deployments wth affected services
+    // Populate deployments with affected services
     this.data.marathon.deploymentsList = deploymentsList
       .mapItems(function (deployment) {
         let ids = deployment.getAffectedServiceIds();
-        let services = ids.map(function (id) {
-          return serviceTree.findItemById(id);
-        });
+        let services = ids.map(serviceTree.findItemById.bind(serviceTree));
 
         return Object.assign({
           affectedServices: new ServicesList({items: services})

--- a/src/js/structs/Deployment.js
+++ b/src/js/structs/Deployment.js
@@ -1,4 +1,5 @@
 import Item from './Item';
+import ServicesList from './ServicesList';
 
 /**
  * An application deployment.
@@ -22,6 +23,21 @@ module.exports = class Deployment extends Item {
    */
   getAffectedServiceIds() {
     return this.get('affectedApps');
+  }
+
+  /**
+   * @return {ServiceList} list of services affected by this deployment.
+   */
+  getAffectedServices() {
+    let ids = this.getAffectedServiceIds();
+    let services = this.get('affectedServices');
+    if (ids == null || ids.length === 0) {
+      return new ServicesList();
+    }
+    if (services == null) {
+      throw Error('Affected services list is stale.');
+    }
+    return services;
   }
 
   /**

--- a/src/js/structs/__tests__/Deployment-test.js
+++ b/src/js/structs/__tests__/Deployment-test.js
@@ -1,4 +1,5 @@
-let Deployment = require('../Deployment');
+import Deployment from '../Deployment';
+import ServicesList from '../ServicesList';
 
 describe('Deployment', function () {
 
@@ -25,6 +26,33 @@ describe('Deployment', function () {
       let deployment = new Deployment({version});
       expect(deployment.getStartTime()).toEqual(jasmine.any(Date));
       expect(deployment.getStartTime().toISOString()).toEqual(version);
+    });
+  });
+
+  describe('#getAffectedServices', function () {
+
+    it('returns an empty ServiceList by default', function () {
+      let deployment = new Deployment();
+      let affectedServices = deployment.getAffectedServices();
+      expect(affectedServices).toEqual(jasmine.any(ServicesList));
+      expect(affectedServices.getItems()).toEqual([]);
+    });
+
+    it('throws an error if service IDs are set but services are not', function () {
+      let deployment = new Deployment({affectedApps: ['app1', 'app2']});
+      expect(deployment.getAffectedServices.bind(deployment)).toThrow();
+    });
+
+    it('returns the populated ServiceList if it is up-to-date', function () {
+      let deployment = new Deployment({
+        affectedApps: ['app1', 'app2'],
+        affectedServices: new ServicesList({items: [
+          {id: 'app1'}, {id: 'app2'}
+        ]})
+      });
+      let affectedServices = deployment.getAffectedServices();
+      expect(affectedServices).toEqual(jasmine.any(ServicesList));
+      expect(affectedServices.getItems().length).toEqual(2);
     });
   });
 


### PR DESCRIPTION
Note that this work is based off a feature branch (`deployments-table`).

This PR adds the `affectedServices` field to `Deployment`. This field is populated by `DCOSStore` when it receives deployments data from `MarathonStore`. If it is not populated and something attempts to access it, it will error rather than show bad data. 

Once this is merged, the whole services table can be populated using only the output from `DCOSStore.deploymentsList`. 