### PR TITLE
[3/8] Deployments Table - Add badge to deployments tab

### DIFF
--- a/src/js/stores/DCOSStore.js
+++ b/src/js/stores/DCOSStore.js
@@ -12,6 +12,7 @@ import DeploymentsList from '../structs/DeploymentsList';
 import Framework from '../structs/Framework';
 import MarathonStore from './MarathonStore';
 import MesosSummaryStore from './MesosSummaryStore';
+import NotificationStore from './NotificationStore';
 import ServicesList from '../structs/ServicesList';
 import ServiceTree from '../structs/ServiceTree';
 import SummaryList from '../structs/SummaryList';
@@ -92,6 +93,12 @@ class DCOSStore extends EventEmitter {
   onMarathonDeploymentsChange() {
     let deploymentsList = MarathonStore.get('deployments');
     let serviceTree = MarathonStore.get('groups');
+
+    NotificationStore.addNotification(
+      'services-deployments',
+      'deployment-count',
+      deploymentsList.getItems().length
+    );
 
     // Populate deployments with affected services
     this.data.marathon.deploymentsList = deploymentsList

--- a/src/js/stores/__tests__/DCOSStore-test.js
+++ b/src/js/stores/__tests__/DCOSStore-test.js
@@ -11,6 +11,7 @@ jest.dontMock('../../structs/StateSummary');
 var DCOSStore = require('../DCOSStore');
 var MarathonStore = require('../MarathonStore');
 var MesosSummaryStore = require('../MesosSummaryStore');
+var NotificationStore = require('../NotificationStore');
 var DeploymentsList = require('../../structs/DeploymentsList');
 var ServicesList = require('../../structs/ServicesList');
 var ServiceTree = require('../../structs/ServiceTree');
@@ -57,6 +58,7 @@ describe('DCOSStore', function () {
           totalSteps: 3
         }
       ]}));
+      spyOn(NotificationStore, 'addNotification');
       DCOSStore.onMarathonGroupsChange();
       DCOSStore.onMarathonDeploymentsChange();
     });
@@ -71,6 +73,11 @@ describe('DCOSStore', function () {
       let services = deployment.getAffectedServices();
       expect(services).toEqual(jasmine.any(ServicesList));
       expect(services.getItems().length).toEqual(2);
+    });
+
+    it('should update the notification store', function () {
+      expect(NotificationStore.addNotification)
+        .toHaveBeenCalledWith('services-deployments', 'deployment-count', 1);
     });
 
   });


### PR DESCRIPTION
Note that this work is based off a feature branch (`deployments-table`).

This PR relies on ~~#241~~ and ~~#215~~ (but may be merged before ~~#215~~ without issue). 

This PR adds a notification badge to the Deployment tab. 

![moving pictures](https://s3.amazonaws.com/f.cl.ly/items/1a1j3f0R0J1E2e282N1m/Screen%20Recording%202016-05-24%20at%2012.36%20PM.gif?v=75eeb96e)

Testing:
```bash
git checkout feature/deployment-tab-badge
curl "https://patch-diff.githubusercontent.com/raw/dcos/dcos-ui/pull/215.patch" | git apply
```

(Note - no longer necessary following rebase)