### PR TITLE
Fix DCOSStore/StoreMixin behaviour

### DIFF
--- a/src/js/stores/DCOSStore.js
+++ b/src/js/stores/DCOSStore.js
@@ -216,7 +216,7 @@ class DCOSStore extends EventEmitter {
     return this.data.dataProcessed;
   }
 
-  static get storeID() {
+  get storeID() {
     return 'dcos';
   }
 }

--- a/src/js/stores/__tests__/DCOSStore-test.js
+++ b/src/js/stores/__tests__/DCOSStore-test.js
@@ -251,4 +251,10 @@ describe('DCOSStore', function () {
 
   });
 
+  describe('#get storeID', function () {
+    it('should return \'dcos\'', function () {
+      expect(DCOSStore.storeID).toEqual('dcos');
+    });
+  });
+
 });


### PR DESCRIPTION
`DCOSStore` is a singleton. The `storeID` property was defined statically. `StoreMixin` accesses its store's `storeID` property naively - in this case from an instantiated `DCOSStore` rather than from its constructor. 

This meant that the `StoreMixin`'s inflection methods weren't able to assemble the correct method name, and components which used the mixin and implemented `onDcosStoreChange` never had their listener methods called. 

![I love debugging mixin code, it's the best](https://s3.amazonaws.com/f.cl.ly/items/2z2n0R1F2P3e2u292q3R/Screen%20Shot%202016-05-24%20at%2015.55.50.png?v=12cdd923)

This PR resolves that issue by moving `storeId` to the instance. 