### PR TITLE
[4/8] Deployments Table - Use DCOSStore instead of MarathonStore

### DIFF
--- a/src/js/pages/__tests__/DeploymentsTab-test.js
+++ b/src/js/pages/__tests__/DeploymentsTab-test.js
@@ -3,16 +3,15 @@ jest.unmock('../services/DeploymentsTab');
 jest.unmock('../../structs/DeploymentsList');
 jest.unmock('../../structs/Deployment');
 jest.unmock('../../mixins/GetSetMixin');
-jest.mock('../../stores/MarathonStore');
 
 /* eslint-disable no-unused-vars */
 import React from 'react';
 /* eslint-enable no-unused-vars */
 import ReactDOM from 'react-dom';
 
+import DCOSStore from '../../stores/DCOSStore';
 import DeploymentsTab from '../services/DeploymentsTab';
 import DeploymentsList from '../../structs/DeploymentsList';
-import MarathonStore from '../../stores/MarathonStore';
 
 describe('DeploymentsTab', function () {
 
@@ -28,7 +27,7 @@ describe('DeploymentsTab', function () {
         }
       ]
     });
-    MarathonStore.__setKeyResponse('deployments', deployments);
+    DCOSStore.deploymentsList = deployments;
     this.container = document.createElement('div');
     this.instance = ReactDOM.render(
       <DeploymentsTab />,

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -1,10 +1,13 @@
 import moment from 'moment';
+import mixin from 'reactjs-mixin';
+/* eslint-disable no-unused-vars */
 import React from 'react';
+/* eslint-enable no-unused-vars */
+import {StoreMixin} from 'mesosphere-shared-reactjs';
 import {Table} from 'reactjs-components';
 
 import AlertPanel from '../../components/AlertPanel';
-import EventTypes from '../../constants/EventTypes';
-import MarathonStore from '../../stores/MarathonStore';
+import DCOSStore from '../../stores/DCOSStore';
 import ResourceTableUtil from '../../utils/ResourceTableUtil';
 import StringUtil from '../../utils/StringUtil'
 
@@ -41,33 +44,19 @@ const columns = [
   }
 ];
 
-class DeploymentsTab extends React.Component {
+class DeploymentsTab extends mixin(StoreMixin) {
 
   constructor() {
     super(...arguments);
-    this.onDeploymentsChange = this.onDeploymentsChange.bind(this);
 
-    this.state = {
-      deployments: MarathonStore.get('deployments')
-    };
+    this.state = {deployments: DCOSStore.deploymentsList};
+    this.store_listeners = [
+      {name: 'dcos', events: ['change'], suppressUpdate: true}
+    ];
   }
 
-  componentDidMount() {
-    MarathonStore.addChangeListener(
-      EventTypes.MARATHON_DEPLOYMENTS_CHANGE,
-      this.onDeploymentsChange
-    );
-  }
-
-  componentWillUnmount() {
-    MarathonStore.removeChangeListener(
-      EventTypes.MARATHON_DEPLOYMENTS_CHANGE,
-      this.onDeploymentsChange
-    );
-  }
-
-  onDeploymentsChange(deployments) {
-    this.setState({deployments});
+  onDcosStoreChange() {
+    this.setState({deployments: DCOSStore.deploymentsList});
   }
 
   renderEmpty() {

--- a/src/js/stores/DCOSStore.js
+++ b/src/js/stores/DCOSStore.js
@@ -107,6 +107,8 @@ class DCOSStore extends EventEmitter {
 
         return Object.assign({affectedServices: services}, deployment);
       });
+
+    this.emit(DCOS_CHANGE);
   }
 
   onMarathonGroupsChange() {


### PR DESCRIPTION
Note that this work is based off a feature branch (`deployments-table`).

This PR relies on ~~#241~~ and ~~#248~~ (it may be merged before #248 without issue)

The intention of the PR is to keep the behaviour of the deployments table exactly the same, but making use of the `DCOSStore` instead of the `MarathonStore`. 

Testing:
```bash
git checkout feature/deployment-dcos-store
curl "https://patch-diff.githubusercontent.com/raw/dcos/dcos-ui/pull/248.patch" | git apply
```

Note: the above is no longer necessary since the merge of #248