### PR TITLE
Introduce job tree struct

### DIFF
--- a/src/js/structs/JobTree.js
+++ b/src/js/structs/JobTree.js
@@ -19,6 +19,12 @@ module.exports = class JobTree extends Tree {
     this.id = '/';
 
     if (typeof id == 'string') {
+      if (id !== '/' && (!id.startsWith('/') || id.endsWith('/'))) {
+        throw new Error(`Id (${id}) must start with a leading slash ("/") ` +
+          'and should not end with a slash, except for root id which is only ' +
+          'a slash.');
+      }
+
       this.id = id;
     }
 

--- a/src/js/structs/JobTree.js
+++ b/src/js/structs/JobTree.js
@@ -30,7 +30,7 @@ module.exports = class JobTree extends Tree {
 
     // Parse and add items to the current tree
     if (Array.isArray(items)) {
-      items.forEach((item)=> {
+      items.forEach((item) => {
         // Create instances of JobTree for tree like items and add them
         if ((item.items != null && Array.isArray(item.items))
           && !(item instanceof JobTree)) {
@@ -63,11 +63,12 @@ module.exports = class JobTree extends Tree {
       throw new TypeError('item is neither an instance of Job nor JobTree');
     }
 
+    const id = this.getId();
     const itemId = item.getId();
 
-    if (!itemId.startsWith(this.getId())) {
+    if (!itemId.startsWith(id)) {
       throw new Error(
-        `item id (${itemId}) doesn't match tree id (${this.getId()})`
+        `item id (${itemId}) doesn't match tree id (${id})`
       );
     }
 
@@ -82,7 +83,7 @@ module.exports = class JobTree extends Tree {
     const [parentId] = itemId.match(/\/.*?(?=\/?[^/]+\/?$)/);
 
     // Add item to the current tree if it's the actual parent tree
-    if (this.getId() === parentId) {
+    if (id === parentId) {
       super.add(item);
       return;
     }

--- a/src/js/structs/JobTree.js
+++ b/src/js/structs/JobTree.js
@@ -1,0 +1,112 @@
+import Job from './Job';
+import Tree from './Tree';
+
+module.exports = class JobTree extends Tree {
+  /**
+   * (Chronos) JobTree
+   * @param {{
+   *          id:string,
+   *          items:array<({id:string, items:array}|*)>,
+   *          filterProperties:{propertyName:(null|string|function)}
+   *        }} options
+   * TODO: DCOS-7369 - Add remove item method
+   * @constructor
+   * @struct
+   */
+  constructor({id, items, filterProperties} = {}) {
+    super({filterProperties});
+
+    this.id = '/';
+
+    if (typeof id == 'string') {
+      this.id = id;
+    }
+
+    // Parse and add items to the current tree
+    if (Array.isArray(items)) {
+      items.forEach((item)=> {
+        // Create instances of JobTree for tree like items and add them
+        if ((item.items != null && Array.isArray(item.items))
+          && !(item instanceof JobTree)) {
+          this.add(new this.constructor(
+            Object.assign({filterProperties: this.getFilterProperties()}, item)
+          ));
+
+          return;
+        }
+
+        // Convert items into instance of Job and add them to the current tree
+        if (!(item instanceof Job) && !(item instanceof JobTree)) {
+          this.add(new Job(item));
+
+          return;
+        }
+
+        this.add(item);
+      })
+    }
+  }
+
+  /**
+   * Add item - This method will create sub trees if needed to insert the item
+   * at the correct location (based on id/path matching).
+   * @param {JobTree|Job} item
+   */
+  add(item) {
+    if (!(item instanceof Job || item instanceof JobTree)) {
+      throw new TypeError('item is neither an instance of Job nor JobTree');
+    }
+
+    const itemId = item.getId();
+
+    if (!itemId.startsWith(this.getId())) {
+      throw new Error(
+        `item id (${itemId}) doesn't match tree id (${this.getId()})`
+      );
+    }
+
+    // Check if the item is already present in the tree (including sub trees)
+    if (this.findItemById(itemId)) {
+      // TODO: DCOS-7370 - Update item (type Job) data
+      return;
+    }
+
+    // Get the parent id (e.g. /group) by matching every thing but the item
+    // name including the preceding slash "/" (e.g. /id).
+    const [parentId] = itemId.match(/\/.*?(?=\/?[^/]+\/?$)/);
+
+    // Add item to the current tree if it's the actual parent tree
+    if (this.getId() === parentId) {
+      super.add(item);
+      return;
+    }
+
+    // Find or create corresponding parent tree and add it to the tree
+    let parent = this.findItemById(parentId);
+    if (!parent) {
+      parent = new this.constructor({id: parentId});
+      this.add(parent);
+    }
+
+    // Add item to parent tree
+    parent.add(item);
+  }
+
+  getId() {
+    return this.id;
+  }
+
+  /**
+   * @param {string} id
+   * @return {Job|JobTree} matching item
+   */
+  findItemById(id) {
+    return this.findItem(function (item) {
+      return item.getId() === id;
+    });
+  }
+
+  getName() {
+    return this.getId().split('/').pop();
+  }
+};

--- a/src/js/structs/__tests__/JobTree-test.js
+++ b/src/js/structs/__tests__/JobTree-test.js
@@ -18,12 +18,12 @@ describe('JobTree', function () {
       });
     });
 
-    it('defaults id to root tree (groups) id', function () {
+    it('defaults id to slash (root group id)', function () {
       let tree = new JobTree({items: []});
       expect(tree.getId()).toEqual('/');
     });
 
-    it('sets correct tree (groups) id', function () {
+    it('sets correct tree id', function () {
       expect(this.instance.getId()).toEqual('/group');
     });
 

--- a/src/js/structs/__tests__/JobTree-test.js
+++ b/src/js/structs/__tests__/JobTree-test.js
@@ -1,0 +1,115 @@
+let Job = require('../Job');
+let JobTree = require('../JobTree');
+
+describe('JobTree', function () {
+
+  describe('#constructor', function () {
+
+    beforeEach(function () {
+      this.instance = new JobTree({
+        id: '/group',
+        items: [
+          new JobTree({id: '/group/foo', items: []}),
+          {id: '/group/bar', items: []},
+          {id: '/group/alpha'},
+          new Job({id: '/group/beta'}),
+          {id: '/group/wibble/wobble'}
+        ],
+      });
+    });
+
+    it('defaults id to root tree (groups) id', function () {
+      let tree = new JobTree({items: []});
+      expect(tree.getId()).toEqual('/');
+    });
+
+    it('sets correct tree (groups) id', function () {
+      expect(this.instance.getId()).toEqual('/group');
+    });
+
+    it('accepts nested trees (groups)', function () {
+      expect(this.instance.getItems()[0] instanceof JobTree).toEqual(true);
+    });
+
+    it('converts tree like items into instances of JobTree', function () {
+      expect(this.instance.getItems()[1] instanceof JobTree).toEqual(true);
+    });
+
+    it('converts items into instances of Job', function () {
+      expect(this.instance.getItems()[2] instanceof Job).toEqual(true);
+    });
+
+  });
+
+  describe('#add', function () {
+
+    beforeEach(function () {
+      this.instance = new JobTree();
+    });
+
+    it('adds a job to the tree', function () {
+      this.instance.add(new Job({id: '/alpha'}));
+
+      expect(this.instance.getItems()[0].getId()).toEqual('/alpha');
+    });
+
+    it('adds nested items at the correct location based on id/path matching',
+      function () {
+        this.instance.add(new Job({id: '/group/foo/bar'}));
+
+        expect(this.instance.getItems()[0].getId()).toEqual('/group');
+        expect(this.instance.getItems()[0].getItems()[0].getId())
+          .toEqual('/group/foo');
+        expect(this.instance.getItems()[0].getItems()[0].getItems()[0].getId())
+          .toEqual('/group/foo/bar');
+      }
+    );
+
+    it('should throw error if item is neither an instance of Job nor JobTree',
+      function () {
+        expect(function () {
+          this.instance.add({})
+        }).toThrow();
+        expect(function () {
+          this.instance.add([])
+        }).toThrow();
+        expect(function () {
+          this.instance.add(NaN)
+        }).toThrow();
+        expect(function () {
+          this.instance.add()
+        }).toThrow();
+      }
+    );
+
+  });
+
+  describe('#findItemById', function () {
+
+    beforeEach(function () {
+      this.instance = new JobTree({
+        id: '/',
+        items: [
+          {id: '/foo', items: []},
+          {id: '/alpha'},
+          {id: '/wibble/wobble'}
+        ],
+      });
+    });
+
+    it('should find matching item', function () {
+      expect(this.instance.findItemById('/alpha').getId()).toEqual('/alpha');
+    });
+
+    it('should find matching subtree item', function () {
+      expect(this.instance.findItemById('/wibble/wobble').getId())
+        .toEqual('/wibble/wobble');
+    });
+
+    it('should find matching subtree', function () {
+      expect(this.instance.findItemById('/foo').getId()).toEqual('/foo');
+    });
+
+  });
+
+});

--- a/src/js/structs/__tests__/JobTree-test.js
+++ b/src/js/structs/__tests__/JobTree-test.js
@@ -27,6 +27,30 @@ describe('JobTree', function () {
       expect(this.instance.getId()).toEqual('/group');
     });
 
+    it('should throw error if the provided id doesn\'t start with a slash',
+      function () {
+        expect(function () {
+          new JobTree({id: 'malformed/id'});
+        }).toThrow();
+      }
+    );
+
+    it('should throw error if the provided id ends with a slash',
+      function () {
+        expect(function () {
+          new JobTree({id: '/malformed/id/'});
+        }).toThrow();
+      }
+    );
+
+    it('should not throw error if the provided id is only a slash (root id)',
+      function () {
+        expect(function () {
+          new JobTree({id: '/'});
+        }).not.toThrow();
+      }
+    );
+
     it('accepts nested trees (groups)', function () {
       expect(this.instance.getItems()[0] instanceof JobTree).toEqual(true);
     });


### PR DESCRIPTION
---
ℹ️   _This branch depends on changes that will be introduced with #250, thus it will fail until the respective branch is merged._

---

Introduce basic job tree struct – this struct will be used to type and abstract the Chronos API response. It provide the needed functionality to parse and create sub trees (if needed), to insert jobs in the correct location based on id/path matching.