### PR TITLE
Updates to Breadcrumb

### DIFF
--- a/src/js/components/Breadcrumb.js
+++ b/src/js/components/Breadcrumb.js
@@ -126,7 +126,6 @@ class Breadcrumb extends React.Component {
   }
 
   getCrumb(crumb, key) {
-    let content = crumb;
     let label = null;
     let route = null;
 
@@ -139,7 +138,7 @@ class Breadcrumb extends React.Component {
     }
 
     if (route) {
-      content = (
+      crumb = (
         <Link to={route.to}
             params={route.params}
             title={label}>
@@ -150,7 +149,7 @@ class Breadcrumb extends React.Component {
 
     return (
       <li key={key}>
-        {content}
+        {crumb}
       </li>
     );
   }
@@ -175,7 +174,8 @@ class Breadcrumb extends React.Component {
   }
 
   buildCrumbs(routeName) {
-    let {namedRoutes} = this.context.router;
+    let {router} = this.context;
+    let {namedRoutes} = router;
     let route = namedRoutes[routeName];
 
     if (!route || !route.buildBreadCrumb) {
@@ -183,7 +183,7 @@ class Breadcrumb extends React.Component {
     }
 
     let crumbConfiguration = route.buildBreadCrumb();
-    let crumbs = crumbConfiguration.getCrumbs(this.context.router);
+    let crumbs = crumbConfiguration.getCrumbs(router);
 
     if (crumbConfiguration.parentCrumb) {
       crumbs = this.buildCrumbs(crumbConfiguration.parentCrumb).concat(crumbs);

--- a/src/js/components/Breadcrumb.js
+++ b/src/js/components/Breadcrumb.js
@@ -18,18 +18,20 @@ const PADDED_ICON_WIDTH = 38; // Width of icon + padding
  * @param {Object} routeParams Router routeParams Object
  * @param {Bool}   labelIsParam Boolean indicating if the label represents a
  * route parameter.
+ * @param {Object} customParams Additional params that force the breadcrumb to
+ * update when changed.
  * @return {Array} Array of crumbs containing the label and route.
  * The returned label is the text shown for the crumb. The route is
  * the route name which will be set on the Link-to attribute.
  * Each returned crumb will be spliced into the resulting breadcrumb.
  */
-const buildCrumb = function (label, route, routeParams, labelIsParam) {
-  // Extract param value as label e.g. (:userID -> Foo)
-  if (labelIsParam) {
-    // Decode value
+const buildCrumb = function (label, route, routeParams, labelIsParam, customParams) {
+  if (customParams[label]) {
+    label = customParams[label];
+  } else if (labelIsParam) {
     label = decodeURIComponent(routeParams[label]);
   } else {
-    // Split Label on space and - then capitalize each word and join.
+    // Split Label on `-`, then capitalize each word and join.
     // /foo-bar/ --> Foo Bar
     label = StringUtil.idToTitle([label], ['-']);
   }
@@ -283,6 +285,7 @@ Breadcrumb.contextTypes = {
 Breadcrumb.defaultProps = {
   breadcrumbClasses: 'inverse',
   buildCrumb: buildCrumb,
+  buildCrumbCustomParams: {},
   // Remove root '/' by default
   shift: 1
 }

--- a/tests/pages/services/ServiceSearchFilter-cy.js
+++ b/tests/pages/services/ServiceSearchFilter-cy.js
@@ -28,6 +28,7 @@ describe('Service Search Filters', function () {
     it('will clear filters by clear all link click', function () {
       cy.get('.filter-input-text').as('filterInputText');
       cy.get('@filterInputText').type('cassandra-healthy');
+      cy.wait(200);
       cy.get('.h4.clickable .small').click();
       cy.location().its('href').should(function (href) {
         var queries = href.split('?')[1];


### PR DESCRIPTION
A number of updates to `Breadcrumb` based on my attempt to use `Breadcrumb`

- trimmed down `buildCrumb` default function to keep parsing minutia external to that function so overriding this function with a prop requires less repeated code
- explicitly set the `buildCrumb` default function in `defaultProps`
- added `buildCrumbCustomParams` prop to supply custom parameters to `buildCrumb` function for custom labels. This prop also helps trigger `shouldComponentUpdate` when custom params are updated