### PR TITLE
[2/8] Deployments Table - Don't use ServicesList to list services

### DIFF
--- a/src/js/stores/DCOSStore.js
+++ b/src/js/stores/DCOSStore.js
@@ -13,7 +13,6 @@ import Framework from '../structs/Framework';
 import MarathonStore from './MarathonStore';
 import MesosSummaryStore from './MesosSummaryStore';
 import NotificationStore from './NotificationStore';
-import ServicesList from '../structs/ServicesList';
 import ServiceTree from '../structs/ServiceTree';
 import SummaryList from '../structs/SummaryList';
 
@@ -106,9 +105,7 @@ class DCOSStore extends EventEmitter {
         let ids = deployment.getAffectedServiceIds();
         let services = ids.map(serviceTree.findItemById.bind(serviceTree));
 
-        return Object.assign({
-          affectedServices: new ServicesList({items: services})
-        }, deployment);
+        return Object.assign({affectedServices: services}, deployment);
       });
   }
 

--- a/src/js/stores/__tests__/DCOSStore-test.js
+++ b/src/js/stores/__tests__/DCOSStore-test.js
@@ -3,7 +3,6 @@ jest.mock('../MesosSummaryStore');
 jest.dontMock('../DCOSStore');
 jest.dontMock('../../mixins/GetSetMixin');
 jest.dontMock('../../structs/DeploymentsList');
-jest.dontMock('../../structs/ServicesList');
 jest.dontMock('../../structs/ServiceTree');
 jest.dontMock('../../structs/SummaryList');
 jest.dontMock('../../structs/StateSummary');
@@ -13,7 +12,6 @@ var MarathonStore = require('../MarathonStore');
 var MesosSummaryStore = require('../MesosSummaryStore');
 var NotificationStore = require('../NotificationStore');
 var DeploymentsList = require('../../structs/DeploymentsList');
-var ServicesList = require('../../structs/ServicesList');
 var ServiceTree = require('../../structs/ServiceTree');
 var SummaryList = require('../../structs/SummaryList');
 var StateSummary = require('../../structs/StateSummary');
@@ -71,8 +69,7 @@ describe('DCOSStore', function () {
     it('should populate the deployments with relevant services', function () {
       let deployment = DCOSStore.deploymentsList.last();
       let services = deployment.getAffectedServices();
-      expect(services).toEqual(jasmine.any(ServicesList));
-      expect(services.getItems().length).toEqual(2);
+      expect(services.length).toEqual(2);
     });
 
     it('should update the notification store', function () {

--- a/src/js/structs/Deployment.js
+++ b/src/js/structs/Deployment.js
@@ -1,5 +1,4 @@
 import Item from './Item';
-import ServicesList from './ServicesList';
 
 /**
  * An application deployment.
@@ -32,7 +31,7 @@ module.exports = class Deployment extends Item {
     let ids = this.getAffectedServiceIds();
     let services = this.get('affectedServices');
     if (ids == null || ids.length === 0) {
-      return new ServicesList();
+      return [];
     }
     if (services == null) {
       throw Error('Affected services list is stale.');

--- a/src/js/structs/__tests__/Deployment-test.js
+++ b/src/js/structs/__tests__/Deployment-test.js
@@ -1,5 +1,4 @@
 import Deployment from '../Deployment';
-import ServicesList from '../ServicesList';
 
 describe('Deployment', function () {
 
@@ -31,11 +30,10 @@ describe('Deployment', function () {
 
   describe('#getAffectedServices', function () {
 
-    it('returns an empty ServiceList by default', function () {
+    it('returns an empty array by default', function () {
       let deployment = new Deployment();
       let affectedServices = deployment.getAffectedServices();
-      expect(affectedServices).toEqual(jasmine.any(ServicesList));
-      expect(affectedServices.getItems()).toEqual([]);
+      expect(affectedServices).toEqual([]);
     });
 
     it('throws an error if service IDs are set but services are not', function () {
@@ -43,16 +41,15 @@ describe('Deployment', function () {
       expect(deployment.getAffectedServices.bind(deployment)).toThrow();
     });
 
-    it('returns the populated ServiceList if it is up-to-date', function () {
+    it('returns the populated list of services if it is up-to-date', function () {
       let deployment = new Deployment({
         affectedApps: ['app1', 'app2'],
-        affectedServices: new ServicesList({items: [
+        affectedServices: [
           {id: 'app1'}, {id: 'app2'}
-        ]})
+        ]
       });
       let affectedServices = deployment.getAffectedServices();
-      expect(affectedServices).toEqual(jasmine.any(ServicesList));
-      expect(affectedServices.getItems().length).toEqual(2);
+      expect(affectedServices.length).toEqual(2);
     });
   });
 


### PR DESCRIPTION
`ServicesList` is actually a list used for instances of `Framework`, not `Service`. In order to avoid casting our non-framework services to frameworks, let's use an array to hold services on deployments instead of a `List`. 