### PR TITLE
[MERGE or PURGE] Show active tasks as initial state

### DIFF
--- a/src/js/components/TaskView.js
+++ b/src/js/components/TaskView.js
@@ -30,7 +30,7 @@ class TaskView extends mixin(SaveStateMixin) {
     this.state = {
       mesosStateErrorCount: 0,
       searchString: '',
-      filterByStatus: 'all'
+      filterByStatus: 'active'
     };
     this.saveState_properties = ['filterByStatus'];
 


### PR DESCRIPTION
I am not interested in completed tasks at the first point, so I've set the initial filter state to 'active'.

![active-default](https://cloud.githubusercontent.com/assets/859154/15575426/2553a862-2353-11e6-8233-e50fa8bd24e2.png)