### PR TITLE
Move chronos jobs data to a reducer-like function

### DIFF
--- a/src/js/events/ChronosActions.js
+++ b/src/js/events/ChronosActions.js
@@ -21,6 +21,11 @@ const ChronosActions = {
             let data;
             try {
               data = ChronosUtil.parseJobs(response);
+              AppDispatcher.handleServerAction({
+                type: REQUEST_CHRONOS_JOBS_SUCCESS,
+                data
+              });
+              resolve();
             } catch (error) {
               AppDispatcher.handleServerAction({
                 type: REQUEST_CHRONOS_JOBS_ERROR,
@@ -28,12 +33,6 @@ const ChronosActions = {
               });
               reject();
             }
-
-            AppDispatcher.handleServerAction({
-              type: REQUEST_CHRONOS_JOBS_SUCCESS,
-              data
-            });
-            resolve();
           },
           error: function (e) {
             AppDispatcher.handleServerAction({

--- a/src/js/events/ChronosActions.js
+++ b/src/js/events/ChronosActions.js
@@ -31,7 +31,6 @@ const ChronosActions = {
             }
           },
           error: function (e) {
-            console.log(e.message);
             AppDispatcher.handleServerAction({
               type: REQUEST_CHRONOS_JOBS_ERROR,
               data: e.message

--- a/src/js/events/ChronosActions.js
+++ b/src/js/events/ChronosActions.js
@@ -17,9 +17,11 @@ const ChronosActions = {
           url: `${Config.rootUrl}/chronos/jobs`,
           data: [{name: 'embed', value: 'activeJobs'}],
           success: function (response) {
+            let data = ChronosUtil.parseJobs(response);
+
             AppDispatcher.handleServerAction({
               type: REQUEST_CHRONOS_JOBS_SUCCESS,
-              data: response
+              data
             });
             resolve();
           },

--- a/src/js/events/ChronosActions.js
+++ b/src/js/events/ChronosActions.js
@@ -27,14 +27,11 @@ const ChronosActions = {
               });
               resolve();
             } catch (error) {
-              AppDispatcher.handleServerAction({
-                type: REQUEST_CHRONOS_JOBS_ERROR,
-                data: error
-              });
-              reject();
+              this.error(error);
             }
           },
           error: function (e) {
+            console.log(e.message);
             AppDispatcher.handleServerAction({
               type: REQUEST_CHRONOS_JOBS_ERROR,
               data: e.message

--- a/src/js/events/ChronosActions.js
+++ b/src/js/events/ChronosActions.js
@@ -18,9 +18,8 @@ const ChronosActions = {
           url: `${Config.rootUrl}/chronos/jobs`,
           data: [{name: 'embed', value: 'activeJobs'}],
           success: function (response) {
-            let data;
             try {
-              data = ChronosUtil.parseJobs(response);
+              let data = ChronosUtil.parseJobs(response);
               AppDispatcher.handleServerAction({
                 type: REQUEST_CHRONOS_JOBS_SUCCESS,
                 data

--- a/src/js/events/ChronosActions.js
+++ b/src/js/events/ChronosActions.js
@@ -6,6 +6,7 @@ import {
   REQUEST_CHRONOS_JOBS_SUCCESS
 } from '../constants/ActionTypes';
 import AppDispatcher from './AppDispatcher';
+import ChronosUtil from '../utils/ChronosUtil';
 import Config from '../config/Config';
 
 const ChronosActions = {

--- a/src/js/events/ChronosActions.js
+++ b/src/js/events/ChronosActions.js
@@ -17,7 +17,16 @@ const ChronosActions = {
           url: `${Config.rootUrl}/chronos/jobs`,
           data: [{name: 'embed', value: 'activeJobs'}],
           success: function (response) {
-            let data = ChronosUtil.parseJobs(response);
+            let data;
+            try {
+              data = ChronosUtil.parseJobs(response);
+            } catch (error) {
+              AppDispatcher.handleServerAction({
+                type: REQUEST_CHRONOS_JOBS_ERROR,
+                data: error
+              });
+              reject();
+            }
 
             AppDispatcher.handleServerAction({
               type: REQUEST_CHRONOS_JOBS_SUCCESS,

--- a/src/js/structs/Job.js
+++ b/src/js/structs/Job.js
@@ -1,17 +1,8 @@
 import Item from './Item';
 
 module.exports = class Job extends Item {
-  constructor() {
-    super(...arguments);
-
-    const id = this.getId();
-    if (id !== '/' && (!id.startsWith('/') || id.endsWith('/'))) {
-      throw new Error(`Id (${id}) must start with a leading slash ("/") and should not end with a slash, except for root id which is only a slash`);
-    }
-  }
-
   getId() {
-    return this.get('id') || '/';
+    return this.get('id');
   }
 
   getName() {

--- a/src/js/structs/__tests__/Job-test.js
+++ b/src/js/structs/__tests__/Job-test.js
@@ -2,30 +2,6 @@ let Job = require('../Job');
 
 describe('Job', function () {
 
-  describe('#constructor', function () {
-
-    it('throws when id doesn\'t start with a slash', function () {
-      expect(function () { new Job({id: 'test/job'}); }).toThrow();
-    });
-
-    it('throws when id ends with a slash', function () {
-      expect(function () { new Job({id: '/test/job/'}); }).toThrow();
-    });
-
-    it('doesn\'t throw when no id is provided', function () {
-      expect(function () { new Job({}); }).not.toThrow();
-    });
-
-    it('doesn\'t throw when no options are provided', function () {
-      expect(function () { new Job(); }).not.toThrow();
-    });
-
-    it('doesn\'t throw when id is slash (\'/\')', function () {
-      expect(function () { new Job({id: '/'}); }).not.toThrow();
-    });
-
-  });
-
   describe('#getId', function () {
 
     it('returns correct id', function () {

--- a/src/js/structs/__tests__/JobTree-test.js
+++ b/src/js/structs/__tests__/JobTree-test.js
@@ -9,12 +9,11 @@ describe('JobTree', function () {
       this.instance = new JobTree({
         id: '/group',
         items: [
-          new JobTree({id: '/group/foo', items: []}),
+          {id: '/group/foo', items: []},
           {id: '/group/bar', items: []},
           {id: '/group/alpha'},
-          new Job({id: '/group/beta'}),
-          {id: '/group/wibble/wobble'}
-        ],
+          {id: '/group/beta'}
+        ]
       });
     });
 
@@ -26,30 +25,6 @@ describe('JobTree', function () {
     it('sets correct tree id', function () {
       expect(this.instance.getId()).toEqual('/group');
     });
-
-    it('should throw error if the provided id doesn\'t start with a slash',
-      function () {
-        expect(function () {
-          new JobTree({id: 'malformed/id'});
-        }).toThrow();
-      }
-    );
-
-    it('should throw error if the provided id ends with a slash',
-      function () {
-        expect(function () {
-          new JobTree({id: '/malformed/id/'});
-        }).toThrow();
-      }
-    );
-
-    it('should not throw error if the provided id is only a slash (root id)',
-      function () {
-        expect(function () {
-          new JobTree({id: '/'});
-        }).not.toThrow();
-      }
-    );
 
     it('accepts nested trees (groups)', function () {
       expect(this.instance.getItems()[0] instanceof JobTree).toEqual(true);
@@ -64,50 +39,6 @@ describe('JobTree', function () {
     });
 
   });
-
-  describe('#add', function () {
-
-    beforeEach(function () {
-      this.instance = new JobTree();
-    });
-
-    it('adds a job to the tree', function () {
-      this.instance.add(new Job({id: '/alpha'}));
-
-      expect(this.instance.getItems()[0].getId()).toEqual('/alpha');
-    });
-
-    it('adds nested items at the correct location based on id/path matching',
-      function () {
-        this.instance.add(new Job({id: '/group/foo/bar'}));
-
-        expect(this.instance.getItems()[0].getId()).toEqual('/group');
-        expect(this.instance.getItems()[0].getItems()[0].getId())
-          .toEqual('/group/foo');
-        expect(this.instance.getItems()[0].getItems()[0].getItems()[0].getId())
-          .toEqual('/group/foo/bar');
-      }
-    );
-
-    it('should throw error if item is neither an instance of Job nor JobTree',
-      function () {
-        expect(function () {
-          this.instance.add({})
-        }).toThrow();
-        expect(function () {
-          this.instance.add([])
-        }).toThrow();
-        expect(function () {
-          this.instance.add(NaN)
-        }).toThrow();
-        expect(function () {
-          this.instance.add()
-        }).toThrow();
-      }
-    );
-
-  });
-
   describe('#findItemById', function () {
 
     beforeEach(function () {
@@ -115,19 +46,13 @@ describe('JobTree', function () {
         id: '/',
         items: [
           {id: '/foo', items: []},
-          {id: '/alpha'},
-          {id: '/wibble/wobble'}
+          {id: '/alpha'}
         ],
       });
     });
 
     it('should find matching item', function () {
       expect(this.instance.findItemById('/alpha').getId()).toEqual('/alpha');
-    });
-
-    it('should find matching subtree item', function () {
-      expect(this.instance.findItemById('/wibble/wobble').getId())
-        .toEqual('/wibble/wobble');
     });
 
     it('should find matching subtree', function () {

--- a/src/js/utils/ChronosUtil.js
+++ b/src/js/utils/ChronosUtil.js
@@ -30,6 +30,7 @@ module.exports = {
     if (jobsAlreadyAdded[itemId]) {
       // handle merge data for job, not for group
       item = Object.assign(jobsAlreadyAdded[itemId], item);
+
       return;
     }
 
@@ -41,9 +42,18 @@ module.exports = {
       return;
     }
 
+
     // Add item to the current tree if it's the actual parent tree
     if (id === parentId) {
+      // Initialize items, if they don't already exist, before push
+      if (!parent.items) {
+        parent.items = [];
+      }
+
+      // Store child as added
+      jobsAlreadyAdded[item.id] = item;
       parent.items.push(item);
+
       return;
     }
 
@@ -68,7 +78,7 @@ module.exports = {
    * }} jobs and groups in a tree structure
    */
   parseJobs(jobs) {
-    let rootTree = {id: '/', items: []};
+    let rootTree = {id: '/'};
     let jobsAlreadyAdded = {
       [rootTree.id]: rootTree
     };

--- a/src/js/utils/ChronosUtil.js
+++ b/src/js/utils/ChronosUtil.js
@@ -78,13 +78,7 @@ module.exports = {
     }
 
     jobs.forEach((job) => {
-      try {
-        this.addJob(rootTree, job, jobsAlreadyAdded);
-      } catch (error) {
-        // Job, is invalid, do nothing
-        console.warn(`Job with id ${job.id} was left out of the jobs, because` +
-          'it contains malformed data.')
-      }
+      this.addJob(rootTree, job, jobsAlreadyAdded);
     });
 
     return rootTree;

--- a/src/js/utils/ChronosUtil.js
+++ b/src/js/utils/ChronosUtil.js
@@ -1,71 +1,72 @@
+/**
+ * Parse an item into a Job or JobTree - This method will create sub trees if
+ * needed to insert the item at the correct location
+ * (based on id/path matching).
+ * @param {{
+ *          id:string,
+ *          items:array<({id:string, items:array}|*)>,
+ * }} parent tree to add item to
+ * @param {{id:string}} item job to add to parent
+ * @param {[type]} jobsAlreadyAdded hash of id and jobs of jobs that
+ * have already been added to the parent
+ */
+function addJob(parent, item, jobsAlreadyAdded) {
+  const {id} = parent;
+
+  const itemId = item.id;
+
+  if (itemId !== '/' && (!itemId.startsWith('/') || itemId.endsWith('/'))) {
+    throw new Error(`Id (${itemId}) must start with a leading slash ("/") ` +
+      'and should not end with a slash, except for root id which is only ' +
+      'a slash.');
+  }
+
+  if (!itemId.startsWith(id)) {
+    throw new Error(`item id (${itemId}) doesn't match tree id (${id})`);
+  }
+
+  // Check if the item (group or job) has already been added
+  if (jobsAlreadyAdded[itemId]) {
+    // handle merge data for job, not for group
+    item = Object.assign(jobsAlreadyAdded[itemId], item);
+
+    return;
+  }
+
+  // Get the parent id (e.g. /group) by matching every thing but the item
+  // name including the preceding slash "/" (e.g. /id).
+  const [parentId] = itemId.match(/\/.*?(?=\/?[^/]+\/?$)/) || [null];
+
+  if (!parentId) {
+    return;
+  }
+
+  // Add item to the current tree if it's the actual parent tree
+  if (id === parentId) {
+    // Initialize items, if they don't already exist, before push
+    if (!parent.items) {
+      parent.items = [];
+    }
+
+    // Store child as added
+    jobsAlreadyAdded[item.id] = item;
+    parent.items.push(item);
+
+    return;
+  }
+
+  // Find or create corresponding parent tree and add it to the tree
+  let subParent = jobsAlreadyAdded[parentId];
+  if (!subParent) {
+    subParent = {id: parentId, items: []};
+    addJob(parent, subParent, jobsAlreadyAdded);
+  }
+
+  // Add item to parent tree
+  addJob(subParent, item, jobsAlreadyAdded);
+}
+
 module.exports = {
-  /**
-   * Parse an item into a Job or JobTree - This method will create sub trees if
-   * needed to insert the item at the correct location
-   * (based on id/path matching).
-   * @param {{
-   *          id:string,
-   *          items:array<({id:string, items:array}|*)>,
-   * }} parent tree to add item to
-   * @param {{id:string}} item job to add to parent
-   * @param {[type]} jobsAlreadyAdded hash of id and jobs of jobs that
-   * have already been added to the parent
-   */
-  addJob(parent, item, jobsAlreadyAdded) {
-    const {id} = parent;
-
-    const itemId = item.id;
-
-    if (itemId !== '/' && (!itemId.startsWith('/') || itemId.endsWith('/'))) {
-      throw new Error(`Id (${itemId}) must start with a leading slash ("/") ` +
-        'and should not end with a slash, except for root id which is only ' +
-        'a slash.');
-    }
-
-    if (!itemId.startsWith(id)) {
-      throw new Error(`item id (${itemId}) doesn't match tree id (${id})`);
-    }
-
-    // Check if the item (group or job) has already been added
-    if (jobsAlreadyAdded[itemId]) {
-      // handle merge data for job, not for group
-      item = Object.assign(jobsAlreadyAdded[itemId], item);
-
-      return;
-    }
-
-    // Get the parent id (e.g. /group) by matching every thing but the item
-    // name including the preceding slash "/" (e.g. /id).
-    const [parentId] = itemId.match(/\/.*?(?=\/?[^/]+\/?$)/) || [null];
-
-    if (!parentId) {
-      return;
-    }
-
-    // Add item to the current tree if it's the actual parent tree
-    if (id === parentId) {
-      // Initialize items, if they don't already exist, before push
-      if (!parent.items) {
-        parent.items = [];
-      }
-
-      // Store child as added
-      jobsAlreadyAdded[item.id] = item;
-      parent.items.push(item);
-
-      return;
-    }
-
-    // Find or create corresponding parent tree and add it to the tree
-    let subParent = jobsAlreadyAdded[parentId];
-    if (!subParent) {
-      subParent = {id: parentId, items: []};
-      this.addJob(parent, subParent, jobsAlreadyAdded);
-    }
-
-    // Add item to parent tree
-    this.addJob(subParent, item, jobsAlreadyAdded);
-  },
 
   /**
    * [parseJobs description]
@@ -86,8 +87,8 @@ module.exports = {
       jobs = [jobs];
     }
 
-    jobs.forEach((job) => {
-      this.addJob(rootTree, job, jobsAlreadyAdded);
+    jobs.forEach(function (job) {
+      addJob(rootTree, job, jobsAlreadyAdded);
     });
 
     return rootTree;

--- a/src/js/utils/ChronosUtil.js
+++ b/src/js/utils/ChronosUtil.js
@@ -1,0 +1,92 @@
+module.exports = {
+  /**
+   * Parse an item into a Job or JobTree - This method will create sub trees if
+   * needed to insert the item at the correct location
+   * (based on id/path matching).
+   * @param {{
+   *          id:string,
+   *          items:array<({id:string, items:array}|*)>,
+   * }} parent tree to add item to
+   * @param {{id:string}} item job to add to parent
+   * @param {[type]} jobsAlreadyAdded hash of id and jobs of jobs that
+   * have already been added to the parent
+   */
+  addJob(parent, item, jobsAlreadyAdded) {
+    const {id} = parent;
+
+    const itemId = item.id;
+
+    if (itemId !== '/' && (!itemId.startsWith('/') || itemId.endsWith('/'))) {
+      throw new Error(`Id (${itemId}) must start with a leading slash ("/") ` +
+        'and should not end with a slash, except for root id which is only ' +
+        'a slash.');
+    }
+
+    if (!itemId.startsWith(id)) {
+      throw new Error(`item id (${itemId}) doesn't match tree id (${id})`);
+    }
+
+    // Check if the item (group or job) has already been added
+    if (jobsAlreadyAdded[itemId]) {
+      // handle merge data for job, not for group
+      item = Object.assign(jobsAlreadyAdded[itemId], item);
+      return;
+    }
+
+    // Get the parent id (e.g. /group) by matching every thing but the item
+    // name including the preceding slash "/" (e.g. /id).
+    const [parentId] = itemId.match(/\/.*?(?=\/?[^/]+\/?$)/) || [null];
+
+    if (!parentId) {
+      return;
+    }
+
+    // Add item to the current tree if it's the actual parent tree
+    if (id === parentId) {
+      parent.items.push(item);
+      return;
+    }
+
+    // Find or create corresponding parent tree and add it to the tree
+    let subParent = jobsAlreadyAdded[parentId];
+    if (!subParent) {
+      subParent = {id: parentId, items: []};
+      this.addJob(parent, subParent, jobsAlreadyAdded);
+    }
+
+    // Add item to parent tree
+    this.addJob(subParent, item, jobsAlreadyAdded);
+  },
+
+  /**
+   * [parseJobs description]
+   * @param  {array} jobs to be turned into an acceptable structure
+   * for Job or JobTree
+   * @return {{
+   *          id:string,
+   *          items:array<({id:string, items:array}|*)>,
+   * }} jobs and groups in a tree structure
+   */
+  parseJobs(jobs) {
+    let rootTree = {id: '/', items: []};
+    let jobsAlreadyAdded = {
+      [rootTree.id]: rootTree
+    };
+
+    if (!Array.isArray(jobs)) {
+      jobs = [jobs];
+    }
+
+    jobs.forEach((job) => {
+      try {
+        this.addJob(rootTree, job, jobsAlreadyAdded);
+      } catch (error) {
+        // Job, is invalid, do nothing
+        console.warn(`Job with id ${job.id} was left out of the jobs, because` +
+          'it contains malformed data.')
+      }
+    });
+
+    return rootTree;
+  }
+};

--- a/src/js/utils/ChronosUtil.js
+++ b/src/js/utils/ChronosUtil.js
@@ -42,7 +42,6 @@ module.exports = {
       return;
     }
 
-
     // Add item to the current tree if it's the actual parent tree
     if (id === parentId) {
       // Initialize items, if they don't already exist, before push

--- a/src/js/utils/__tests__/ChronosUtil-test.js
+++ b/src/js/utils/__tests__/ChronosUtil-test.js
@@ -118,6 +118,16 @@ describe('ChronosUtil', function () {
       expect(instance.items[0].items[0].id).toEqual('/group/job');
     });
 
+    it('merges data of items that are defined multiple times', function () {
+      let result = this.instance.items[0].items[3];
+      expect(result).toEqual({
+        id: '/group/beta',
+        cmd: '>beta',
+        label: 'Beta',
+        description: 'Second beta'
+      });
+    });
+
   });
 
 });

--- a/src/js/utils/__tests__/ChronosUtil-test.js
+++ b/src/js/utils/__tests__/ChronosUtil-test.js
@@ -4,14 +4,10 @@ describe('ChronosUtil', function () {
 
   describe('#addJob', function () {
 
-    beforeEach(function () {
-      this.instance = {id: '/', items: []};
-    });
-
     it('should throw error if the provided id doesn\'t start with a slash',
       function () {
         expect(function () {
-          ChronosUtil.addJob(this.instance, {id: 'malformed/id'}, {});
+          ChronosUtil.parseJobs({id: 'malformed/id'});
         }.bind(this)).toThrow();
       }
     );
@@ -19,7 +15,7 @@ describe('ChronosUtil', function () {
     it('should throw error if the provided id ends with a slash',
       function () {
         expect(function () {
-          ChronosUtil.addJob(this.instance, {id: '/malformed/id/'}, {});
+          ChronosUtil.parseJobs({id: '/malformed/id/'});
         }.bind(this)).toThrow();
       }
     );
@@ -27,46 +23,47 @@ describe('ChronosUtil', function () {
     it('should not throw error if the provided id is only a slash (root id)',
       function () {
         expect(function () {
-          ChronosUtil.addJob(this.instance, {id: '/'}, {});
+          ChronosUtil.parseJobs({id: '/'});
         }.bind(this)).not.toThrow();
       }
     );
 
     it('adds a job to the tree', function () {
-      ChronosUtil.addJob(this.instance, {id: '/alpha'}, {});
+      var instance = ChronosUtil.parseJobs({id: '/alpha'});
 
-      expect(this.instance.items[0].id).toEqual('/alpha');
+      expect(instance.items[0].id).toEqual('/alpha');
     });
 
     it('adds nested items at the correct location based on id/path matching',
       function () {
 
-        ChronosUtil.addJob(this.instance, {id: '/group/foo/bar'}, {});
+        var instance = ChronosUtil.parseJobs({id: '/group/foo/bar'});
 
-        expect(this.instance.items[0].id).toEqual('/group');
-        expect(this.instance.items[0].items[0].id)
+        expect(instance.items[0].id).toEqual('/group');
+        expect(instance.items[0].items[0].id)
           .toEqual('/group/foo');
-        expect(this.instance.items[0].items[0].items[0].id)
+        expect(instance.items[0].items[0].items[0].id)
           .toEqual('/group/foo/bar');
       }
     );
 
-    it('should throw error if item is neither an instance of Job nor JobTree',
-      function () {
-        expect(function () {
-          ChronosUtil.addJob({})
-        }).toThrow();
-        expect(function () {
-          ChronosUtil.addJob([])
-        }).toThrow();
-        expect(function () {
-          ChronosUtil.addJob(NaN)
-        }).toThrow();
-        expect(function () {
-          ChronosUtil.addJob()
-        }).toThrow();
-      }
-    );
+    it('should throw error if item is not an object with id', function () {
+      expect(function () {
+        ChronosUtil.parseJobs({});
+      }).toThrow();
+      expect(function () {
+        ChronosUtil.parseJobs(NaN);
+      }).toThrow();
+      expect(function () {
+        ChronosUtil.parseJobs();
+      }).toThrow();
+    });
+
+    it('should return root group if empty array is passed', function () {
+      var instance = ChronosUtil.parseJobs([]);
+      expect(instance.id).toEqual('/');
+      expect(instance.items).toEqual(undefined);
+    });
 
   });
 

--- a/src/js/utils/__tests__/ChronosUtil-test.js
+++ b/src/js/utils/__tests__/ChronosUtil-test.js
@@ -88,6 +88,11 @@ describe('ChronosUtil', function () {
       expect(this.instance.id).toEqual('/');
     });
 
+    it('consolidates jobs into common parent', function () {
+      expect(this.instance.items.length).toEqual(1);
+      expect(this.instance.items[0].id).toEqual('/group');
+    });
+
     it('defaults id to slash (root group id)', function () {
       let tree = ChronosUtil.parseJobs([]);
       expect(tree.id).toEqual('/');

--- a/src/js/utils/__tests__/ChronosUtil-test.js
+++ b/src/js/utils/__tests__/ChronosUtil-test.js
@@ -73,16 +73,19 @@ describe('ChronosUtil', function () {
   describe('#parseJobs', function () {
 
     beforeEach(function () {
-      this.instance = ChronosUtil.parseJobs([{
-        id: '/group',
-        items: [
-          {id: '/group/foo', items: []},
-          {id: '/group/bar', items: []},
-          {id: '/group/alpha'},
-          {id: '/group/beta'},
-          {id: '/group/wibble/wobble'}
-        ],
-      }]);
+      this.instance = ChronosUtil.parseJobs([
+        {id: '/group'},
+        {id: '/group/foo'},
+        {id: '/group/bar'},
+        {id: '/group/alpha'},
+        {id: '/group/beta', cmd: '>beta', description: 'First beta'},
+        {id: '/group/beta', label: 'Beta', description: 'Second beta'},
+        {id: '/group/wibble/wobble'}
+      ]);
+    });
+
+    it('nests everything under root', function () {
+      expect(this.instance.id).toEqual('/');
     });
 
     it('defaults id to slash (root group id)', function () {
@@ -95,7 +98,7 @@ describe('ChronosUtil', function () {
     });
 
     it('accepts nested trees (groups)', function () {
-      expect(this.instance.items[0].items[0].items.length).toEqual(0);
+      expect(this.instance.items[0].items[4].items.length).toEqual(1);
     });
 
     it('doesn\'t add items to jobs with no nested items', function () {

--- a/src/js/utils/__tests__/ChronosUtil-test.js
+++ b/src/js/utils/__tests__/ChronosUtil-test.js
@@ -1,0 +1,115 @@
+let ChronosUtil = require('../ChronosUtil');
+
+describe('ChronosUtil', function () {
+
+  describe('#addJob', function () {
+
+    beforeEach(function () {
+      this.instance = {id: '/', items: []};
+    });
+
+    it('should throw error if the provided id doesn\'t start with a slash',
+      function () {
+        expect(function () {
+          ChronosUtil.addJob(this.instance, {id: 'malformed/id'}, {});
+        }.bind(this)).toThrow();
+      }
+    );
+
+    it('should throw error if the provided id ends with a slash',
+      function () {
+        expect(function () {
+          ChronosUtil.addJob(this.instance, {id: '/malformed/id/'}, {});
+        }.bind(this)).toThrow();
+      }
+    );
+
+    it('should not throw error if the provided id is only a slash (root id)',
+      function () {
+        expect(function () {
+          ChronosUtil.addJob(this.instance, {id: '/'}, {});
+        }.bind(this)).not.toThrow();
+      }
+    );
+
+    it('adds a job to the tree', function () {
+      ChronosUtil.addJob(this.instance, {id: '/alpha'}, {});
+
+      expect(this.instance.items[0].id).toEqual('/alpha');
+    });
+
+    it('adds nested items at the correct location based on id/path matching',
+      function () {
+
+        ChronosUtil.addJob(this.instance, {id: '/group/foo/bar'}, {});
+
+        expect(this.instance.items[0].id).toEqual('/group');
+        expect(this.instance.items[0].items[0].id)
+          .toEqual('/group/foo');
+        expect(this.instance.items[0].items[0].items[0].id)
+          .toEqual('/group/foo/bar');
+      }
+    );
+
+    it('should throw error if item is neither an instance of Job nor JobTree',
+      function () {
+        expect(function () {
+          ChronosUtil.addJob({})
+        }).toThrow();
+        expect(function () {
+          ChronosUtil.addJob([])
+        }).toThrow();
+        expect(function () {
+          ChronosUtil.addJob(NaN)
+        }).toThrow();
+        expect(function () {
+          ChronosUtil.addJob()
+        }).toThrow();
+      }
+    );
+
+  });
+
+  describe('#parseJobs', function () {
+
+    beforeEach(function () {
+      this.instance = ChronosUtil.parseJobs([{
+        id: '/group',
+        items: [
+          {id: '/group/foo', items: []},
+          {id: '/group/bar', items: []},
+          {id: '/group/alpha'},
+          {id: '/group/beta'},
+          {id: '/group/wibble/wobble'}
+        ],
+      }]);
+    });
+
+    it('defaults id to slash (root group id)', function () {
+      let tree = ChronosUtil.parseJobs([]);
+      expect(tree.id).toEqual('/');
+    });
+
+    it('sets correct tree id', function () {
+      expect(this.instance.items[0].id).toEqual('/group');
+    });
+
+    it('accepts nested trees (groups)', function () {
+      expect(this.instance.items[0].items[0].items.length).toEqual(0);
+    });
+
+    it('doesn\'t add items to jobs with no nested items', function () {
+      expect(this.instance.items[0].items[2].items).toEqual(undefined);
+    });
+
+    it('converts a single item into a subitem of root', function () {
+      let instance = ChronosUtil.parseJobs({id: '/group/job'});
+
+      expect(instance.id).toEqual('/');
+      expect(instance.items[0].id).toEqual('/group');
+      expect(instance.items[0].items[0].id).toEqual('/group/job');
+    });
+
+  });
+
+});


### PR DESCRIPTION
This moves chronos jobs data to a reducer-like function that will restructure before passing it to the application

This comment spawned a larger conversation about what we should and should not do in the structs. We decided to move the whole building of the tree to a 'reducer'-like function that is being used in the actions before the struct is being created. That way we can handle any malformed data gracefully before handing it off to the struct:
https://github.com/dcos/dcos-ui/pull/250#discussion_r64840695

Ping team: @MatApple @daiyiwhale @kennyt @rcorral @jfurrow @orlandohohmeier @philipnrmn @pierlo-upitup @Poltergeist @aldipower