### PR TITLE
Fix sidebar toggle button display problems

### DIFF
--- a/src/styles/components/user-dropdown-menu.less
+++ b/src/styles/components/user-dropdown-menu.less
@@ -37,7 +37,6 @@
 .user-dropdown {
   display: none;
 
-  .sidebar.is-expanded &,
   .canvas-sidebar-open & {
     display: flex;
   }
@@ -130,17 +129,13 @@
 }
 
 .sidebar-footer-user-dropdown {
+  display: none;
   position: relative;
   z-index: @z-index-sidebar-footer-user-dropdown;
 
   .dropdown-menu {
     left: 8px;
     margin-bottom: 8px;
-  }
-
-  .sidebar.is-expanded &,
-  .canvas-sidebar-open & {
-    display: none;
   }
 }
 
@@ -196,6 +191,20 @@
 
 & when (@screen-medium-enabled) {
   @media (min-width: @screen-medium) {
+
+    .sidebar {
+
+      &.is-expanded {
+
+        .sidebar-footer-user-dropdown {
+          display: none;
+        }
+
+        .user-dropdown {
+          display: flex;
+        }
+      }
+    }
 
     .user-dropdown-menu.dropdown {
       display: block;


### PR DESCRIPTION
Previously I had naively toggled the user `dropup` menus for all breakpoints. With this PR, the `sidebar-footer-user-dropdown` will be hidden from a viewport width of `0` up to `screen-small`, displayed from `screen-small` to `screen-medium`, and from there the toggle class `is-expanded` will determine its visibility.