### PR TITLE
[ES6 class] Update plugin store es6

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4016,9 +4016,9 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz"
     },
     "mesosphere-shared-reactjs": {
-      "version": "0.0.14",
-      "from": "mesosphere-shared-reactjs@0.0.14",
-      "resolved": "https://registry.npmjs.org/mesosphere-shared-reactjs/-/mesosphere-shared-reactjs-0.0.14.tgz"
+      "version": "0.0.15",
+      "from": "mesosphere-shared-reactjs@0.0.15",
+      "resolved": "https://registry.npmjs.org/mesosphere-shared-reactjs/-/mesosphere-shared-reactjs-0.0.15.tgz"
     },
     "method-override": {
       "version": "2.3.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4016,9 +4016,9 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz"
     },
     "mesosphere-shared-reactjs": {
-      "version": "0.0.15",
-      "from": "mesosphere-shared-reactjs@0.0.15",
-      "resolved": "https://registry.npmjs.org/mesosphere-shared-reactjs/-/mesosphere-shared-reactjs-0.0.15.tgz"
+      "version": "0.0.16",
+      "from": "mesosphere-shared-reactjs@0.0.16",
+      "resolved": "https://registry.npmjs.org/mesosphere-shared-reactjs/-/mesosphere-shared-reactjs-0.0.16.tgz"
     },
     "method-override": {
       "version": "2.3.5",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "flux": "2.1.1",
     "less-color-lighten": "0.0.1",
     "md5": "2.1.0",
-    "mesosphere-shared-reactjs": "0.0.15",
+    "mesosphere-shared-reactjs": "0.0.16",
     "moment": "2.13.0",
     "query-string": "4.1.0",
     "react": "0.14.7",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "flux": "2.1.1",
     "less-color-lighten": "0.0.1",
     "md5": "2.1.0",
-    "mesosphere-shared-reactjs": "0.0.14",
+    "mesosphere-shared-reactjs": "0.0.15",
     "moment": "2.13.0",
     "query-string": "4.1.0",
     "react": "0.14.7",

--- a/src/js/plugin-bridge/PluginModules.js
+++ b/src/js/plugin-bridge/PluginModules.js
@@ -1,6 +1,7 @@
 // Modules to paths
 module.exports = {
   constants: {
+    EventTypes: 'EventTypes',
     FrameworkConstants: 'FrameworkConstants',
     HTTPStatusCodes: 'HTTPStatusCodes'
   },

--- a/src/js/plugin-bridge/PluginSDK.js
+++ b/src/js/plugin-bridge/PluginSDK.js
@@ -1,5 +1,4 @@
 import {createStore, combineReducers, applyMiddleware, compose} from 'redux';
-import {Store as fluxStore} from 'mesosphere-shared-reactjs';
 
 import {APPLICATION} from '../constants/PluginConstants';
 import {APP_STORE_CHANGE} from '../constants/EventTypes';
@@ -206,9 +205,7 @@ const addStoreConfig = function (definition) {
     // Register events with StoreMixinConfig. Only import this as needed
     // because its presence will degrade test performance.
     getApplicationModuleAPI().get('StoreMixinConfig')
-      .add(definition.storeID,
-        Object.assign({}, definition, {store: definition})
-      );
+      .add(definition.storeID, definition);
   }
 
   return definition;

--- a/src/js/plugin-bridge/PluginSDK.js
+++ b/src/js/plugin-bridge/PluginSDK.js
@@ -194,18 +194,8 @@ const getActionsAPI = function (SDK) {
  * @param  {Object} definition - Store definition
  * @return {Object}            - Created store
  */
-const createPluginStore = function (definition) {
-  // Extend with event handling to reduce boilerplate.
-  definition = Object.assign({}, {
-    addChangeListener: function (eventName, callback) {
-      this.on(eventName, callback);
-    },
-    removeChangeListener: function (eventName, callback) {
-      this.removeListener(eventName, callback);
-    }
-  }, definition);
-
-  if (definition.mixinEvents) {
+const addStoreConfig = function (definition) {
+  if (definition) {
     if (!definition.storeID) {
       throw new Error('Must define a valid storeID to expose events');
     }
@@ -213,13 +203,11 @@ const createPluginStore = function (definition) {
       throw new Error(`Store with ID ${definition.storeID} already exists.`);
     }
     EXISTING_FLUX_STORES[definition.storeID] = true;
-    // Create Store (same as used in core application)
-    definition = fluxStore.createStore(definition);
     // Register events with StoreMixinConfig. Only import this as needed
     // because its presence will degrade test performance.
     getApplicationModuleAPI().get('StoreMixinConfig')
       .add(definition.storeID,
-        Object.assign({}, definition.mixinEvents, {store: definition})
+        Object.assign({}, definition, {store: definition})
       );
   }
 
@@ -274,7 +262,7 @@ const getSDK = function (pluginID, config) {
 
   let SDK = new PluginSDKStruct({
     config: config || {},
-    createStore: createPluginStore,
+    addStoreConfig,
     dispatch: createDispatcher(pluginID),
     Store: StoreAPI,
     Hooks,


### PR DESCRIPTION
---
~~⚠️ This PR will fail until @orlandohohmeier's PR has merged~~
~~⚠️ Is dependent on this PR https://github.com/dcos/mesosphere-shared-reactjs/pull/4~~
⚠️ All plugins that depends on this needs to update their stores to use `addStoreConfig` in stead of `createPluginStore`

---

This PR is removing the concept of `createPluginStore` and replacing it with `addStoreConfig` to be used in the plugin stores.

To test this out `git checkout mlunoe/plugin-store-es6-update-test`