### PR TITLE
[ES6 class] Introduce base store

### DIFF
--- a/jest/gen-config.js
+++ b/jest/gen-config.js
@@ -57,6 +57,7 @@ var config = {
     'src/js/plugin-bridge/middleware',
     'src/js/plugin-bridge/PluginSDK',
     'src/js/plugin-bridge/PluginTestUtils',
+    'src/js/stores/BaseStore',
     'src/js/structs',
     'src/js/utils',
     'plugins',

--- a/src/js/stores/BaseStore.js
+++ b/src/js/stores/BaseStore.js
@@ -10,10 +10,6 @@ if (global.__DEV__) {
 import {APP_STORE_CHANGE} from '../constants/EventTypes';
 
 class BaseStore extends EventEmitter {
-  constructor() {
-    super(...arguments);
-  }
-
   get(key) {
     if (typeof this.getSet_data === 'undefined') {
       return null;

--- a/src/js/stores/BaseStore.js
+++ b/src/js/stores/BaseStore.js
@@ -1,0 +1,52 @@
+import {EventEmitter} from 'events';
+
+let PluginSDK;
+
+// Hack until we fix circular dependency - DCOS-5040
+if (global.__DEV__) {
+  PluginSDK = require('PluginSDK');
+}
+
+import {APP_STORE_CHANGE} from '../constants/EventTypes';
+
+class BaseStore extends EventEmitter {
+  constructor() {
+    super(...arguments);
+  }
+
+  get(key) {
+    if (typeof this.getSet_data === 'undefined') {
+      return null;
+    }
+
+    return this.getSet_data[key];
+  }
+
+  set(data) {
+    // Throw error if data is an array or is not an object
+    if (!(typeof data === 'object' && !Array.isArray(data))) {
+      throw new Error('Can only update getSet_data with data of type Object.');
+    }
+
+    // Allows overriding `getSet_data` wherever this is implemented
+    if (typeof this.getSet_data === 'undefined') {
+      this.getSet_data = {};
+    }
+
+    Object.assign(this.getSet_data, data);
+
+    if (!global.__DEV__) {
+      PluginSDK = require('PluginSDK');
+    }
+
+    // Dispatch new Store data
+    PluginSDK.dispatch({
+      type: APP_STORE_CHANGE,
+      storeID: this.storeID,
+      data: this.getSet_data
+    });
+  }
+
+}
+
+module.exports = BaseStore;

--- a/src/js/stores/__tests__/BaseStore-test.js
+++ b/src/js/stores/__tests__/BaseStore-test.js
@@ -1,0 +1,65 @@
+jest.dontMock('../BaseStore');
+
+var BaseStore = require('../BaseStore');
+
+describe('BaseStore', function () {
+
+  beforeEach(function () {
+    this.instance = new BaseStore();
+  });
+
+  describe('#get', function () {
+
+    it('should return undefined if no key is given', function () {
+      expect(this.instance.get()).toEqual(null);
+    });
+
+    it('should return undefined if given an object', function () {
+      expect(this.instance.get({})).toEqual(null);
+    });
+
+    it('returns null if property hasn\'t been defined', function () {
+      expect(this.instance.get('foo')).toEqual(null);
+    });
+
+    it('should return the correct value given a key', function () {
+      var instance = this.instance;
+      instance.set({someProperty: 'someValue'});
+      expect(this.instance.get('someProperty')).toEqual('someValue');
+    });
+
+    it('should allow for default state values', function () {
+      var instance = new BaseStore();
+      instance.getSet_data = {
+        foo: 'bar'
+      };
+
+      expect(instance.get('foo')).toEqual('bar');
+    });
+
+  });
+
+  describe('#set', function () {
+
+    it('throws an error when called with a non-object', function () {
+      var fn = this.instance.set.bind(this.instance, 'string');
+      expect(fn).toThrow();
+    });
+
+    it('throws an error when called with an array-like object', function () {
+      var fn = this.instance.set.bind(this.instance, []);
+      expect(fn).toThrow();
+    });
+
+    it('overrides previously set values', function () {
+      this.instance.set({foo: 1, bar: 2, baz: 3});
+      this.instance.set({foo: 'foo', bar: 'bar'});
+
+      expect(this.instance.get('foo')).toEqual('foo');
+      expect(this.instance.get('bar')).toEqual('bar');
+      expect(this.instance.get('baz')).toEqual(3);
+    });
+
+  });
+
+});


### PR DESCRIPTION
This base store will be extended by all other stores and it's intended to replace the `Store.create` util as well as the GetSet mixin.