### PR TITLE
[WIP] [Feedback Requested] Introduce ExpandingTable component

### DIFF
--- a/src/js/components/ExpandingTable.js
+++ b/src/js/components/ExpandingTable.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import {Table} from 'reactjs-components';
+
+class ExpandingTable extends React.Component {
+  constructor() {
+    super(...arguments);
+
+    this.state = {
+      expandedRows: []
+    };
+  }
+
+  defaultRenderer(prop, row) {
+    return row[prop];
+  }
+
+  expandRow(row) {
+    let {expandedRows} = this.state;
+    let rowID = this.getRowID(row);
+    let selectedRowIndex = expandedRows.indexOf(rowID);
+
+    // If the selected row is already expanded, then we want to collapse it.
+    if (selectedRowIndex > -1) {
+      expandedRows.splice(selectedRowIndex, 1);
+    } else {
+      expandedRows.push(rowID);
+    }
+
+    this.setState({expandedRows});
+  }
+
+  getColumns(columns) {
+    // Replace the #render method on each column.
+    return columns.map((column) => {
+      return Object.assign({}, column, {render: this.getRenderer(column)});
+    });
+  }
+
+  getRenderer(column) {
+    // Get the column's #render method if it exists. Otherwise use our default.
+    let renderFn = column.render || this.defaultRenderer;
+
+    return (prop, row) => {
+      let hasChildren = !!row.children;
+      let isExpanded = this.state.expandedRows.indexOf(this.getRowID(row)) > -1;
+
+      // Render the column's top-level item.
+      let cellContent = [
+        <div key={-1}>
+          {renderFn(prop, row, {hasChildren, isExpanded, isParent: true})}
+        </div>
+      ];
+
+      // If there are children, and the expanded row ID matches this row, then
+      // render all children. We need to render a whitespace character if the
+      // property is undefined to retain proper spacing.
+      if (hasChildren && isExpanded) {
+        const whitespace = '\u00A0';
+
+        cellContent = cellContent.concat(
+          row.children.map((child, childIndex) => {
+            return (
+              <div className={this.props.childRowClassName} key={childIndex}>
+                {renderFn(prop, child, {isParent: false}) || whitespace}
+              </div>
+            );
+          }
+        ));
+      }
+
+      return cellContent;
+    };
+  }
+
+  getRowID(row) {
+    return row.id;
+  }
+
+  render() {
+    let {props} = this;
+
+    return <Table {...props} columns={this.getColumns(props.columns)} />;
+  }
+}
+
+ExpandingTable.defaultProps = {
+  childRowClassName: 'text-overflow'
+};
+
+ExpandingTable.propTypes = {
+  childRowClassName: React.PropTypes.string
+};
+
+module.exports = ExpandingTable;


### PR DESCRIPTION
I'm introducing a component that allows table rows to be expanded & collapsed. I have a couple of concerns about the best approach for some things and wanted to get everyone's feedback before fully committing. Here's where it will be implemented: ![](http://cl.ly/1O3D3E3f1R3B/Screen%20Shot%202016-06-01%20at%2011.06.28%20AM.png)

Here's the component with a very simple toggle button: ![](https://s3.amazonaws.com/f.cl.ly/items/2G0D2X3B2p1v38172r0i/Screen%20Recording%202016-06-01%20at%2010.41%20AM.gif?v=64e4386c)

Here's a component you can copy/paste to test it: https://gist.github.com/jfurrow/30934b2d553f94d5009c61a58c56bdc8

Limitations:
* It doesn't generate new `<tr>` elements as you might expect. It simply renders additional elements inside each `<td>`. This is a decision @rcorral and I made to keep it simple. The downside to this is that when a row is expanded, all child nodes must be the exact same height, or the horizontal alignment will be off. It also means that text in the child nodes cannot wrap.
* The toggle button for expanding the row is implemented by the component that implements the table (via the `#render` method that is passed in with the `columns` — example in the above gist).
* It requires each row in the `data` to have a unique `id` attribute. In the `Table` component itself, we construct table cell IDs, so we could do something like that here too, but I thought explicit IDs would be safer.

Let me know what you guys think of this. If it looks good, I'll write tests and create a proper PR.