### PR TITLE
Introduce Marathon parse groups util

### DIFF
--- a/src/js/events/MarathonActions.js
+++ b/src/js/events/MarathonActions.js
@@ -18,6 +18,7 @@ import {
 } from '../constants/ActionTypes';
 var AppDispatcher = require('./AppDispatcher');
 var Config = require('../config/Config');
+import MarathonUtil from '../utils/MarathonUtil';
 
 module.exports = {
 

--- a/src/js/events/MarathonActions.js
+++ b/src/js/events/MarathonActions.js
@@ -80,7 +80,7 @@ module.exports = {
           success: function (response) {
             AppDispatcher.handleServerAction({
               type: REQUEST_MARATHON_GROUPS_SUCCESS,
-              data: response
+              data: MarathonUtil.parseGroups(response)
             });
             resolve();
           },

--- a/src/js/pages/__tests__/ServicesTab-test.js
+++ b/src/js/pages/__tests__/ServicesTab-test.js
@@ -25,7 +25,7 @@ describe('ServicesTab', function () {
   beforeEach(function () {
     DCOSStore.serviceTree = new ServiceTree({
       id: '/',
-      apps: [{
+      items: [{
         id: '/alpha'
       }]
     });

--- a/src/js/pages/__tests__/fixtures/MockMarathonResponse.json
+++ b/src/js/pages/__tests__/fixtures/MockMarathonResponse.json
@@ -1,5 +1,5 @@
 {
-  "apps": [
+  "items": [
     {
       "healthChecks": [
         {

--- a/src/js/stores/MarathonStore.js
+++ b/src/js/stores/MarathonStore.js
@@ -284,6 +284,7 @@ class MarathonStore extends GetSetBaseStore {
       return map;
     }, {});
 
+    let numberOfApps = Object.keys(apps).length;
     // Specific health check for Marathon
     // We are setting the 'marathon' key here, since we can safely assume,
     // it to be 'marathon' (we control it).
@@ -293,8 +294,8 @@ class MarathonStore extends GetSetBaseStore {
         // Make sure health check has a result
         healthChecks: [{}],
         // Marathon is healthy if this request returned apps
-        tasksHealthy: data.apps.length,
-        tasksRunning: data.apps.length
+        tasksHealthy: numberOfApps,
+        tasksRunning: numberOfApps
       }),
       images: ServiceImages.MARATHON_IMAGES
     };

--- a/src/js/stores/__tests__/DCOSStore-test.js
+++ b/src/js/stores/__tests__/DCOSStore-test.js
@@ -50,7 +50,7 @@ describe('DCOSStore', function () {
       expect(DCOSStore.serviceTree.getItems().length).toEqual(0);
 
       MarathonStore.__setKeyResponse('groups', new ServiceTree({
-        apps: [{
+        items: [{
           id: '/alpha',
           labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'alpha'}
         }]
@@ -62,14 +62,14 @@ describe('DCOSStore', function () {
 
     it('should replace old Marathon data', function () {
       MarathonStore.__setKeyResponse('groups', new ServiceTree({
-        apps: [{
+        items: [{
           id: '/alpha',
           labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'alpha'}
         }]
       }));
       DCOSStore.onMarathonGroupsChange();
       MarathonStore.__setKeyResponse('groups', new ServiceTree({
-        apps: [{
+        items: [{
           id: '/beta',
           labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'}
         }]
@@ -80,7 +80,7 @@ describe('DCOSStore', function () {
 
     it('should merge (matching by id) summary data', function () {
       MarathonStore.__setKeyResponse('groups', new ServiceTree({
-        apps: [{
+        items: [{
           id: '/alpha', labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'alpha'}
         }]
       }));
@@ -93,7 +93,7 @@ describe('DCOSStore', function () {
     it('should not merge summary data if it doesn\'t find a matching id',
       function () {
         MarathonStore.__setKeyResponse('groups', new ServiceTree({
-          apps: [{
+          items: [{
             id: '/beta', labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'}
           }]
         }));
@@ -110,7 +110,7 @@ describe('DCOSStore', function () {
 
     beforeEach(function () {
       MarathonStore.__setKeyResponse('groups', new ServiceTree({
-        apps: [{
+        items: [{
           id: '/alpha'
         }]
       }));
@@ -143,7 +143,7 @@ describe('DCOSStore', function () {
 
     beforeEach(function () {
       MarathonStore.__setKeyResponse('groups', new ServiceTree({
-        apps: [{
+        items: [{
           id: '/beta'
         }]
       }));
@@ -185,7 +185,7 @@ describe('DCOSStore', function () {
 
     beforeEach(function () {
       MarathonStore.__setKeyResponse('groups', new ServiceTree({
-        apps: [{
+        items: [{
           id: '/alpha',
           labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'alpha'}
         }]

--- a/src/js/stores/__tests__/MarathonStore-test.js
+++ b/src/js/stores/__tests__/MarathonStore-test.js
@@ -26,7 +26,7 @@ describe('MarathonStore', function () {
 
     it('should return NA health when app has no health check', function () {
       var health = MarathonStore.getFrameworkHealth(
-        MockMarathonResponse.hasNoHealthy.apps[0]
+        MockMarathonResponse.hasNoHealthy.items[0]
       );
       expect(health).not.toEqual(null);
       expect(health.key).toEqual('NA');
@@ -35,7 +35,7 @@ describe('MarathonStore', function () {
 
     it('should return idle when app has no running tasks', function () {
       var health = MarathonStore.getFrameworkHealth(
-        MockMarathonResponse.hasNoRunningTasks.apps[0]
+        MockMarathonResponse.hasNoRunningTasks.items[0]
       );
       expect(health.key).toEqual('IDLE');
     });
@@ -43,7 +43,7 @@ describe('MarathonStore', function () {
     it('should return unhealthy when app has only unhealthy tasks',
       function () {
         var health = MarathonStore.getFrameworkHealth(
-          MockMarathonResponse.hasOnlyUnhealth.apps[0]
+          MockMarathonResponse.hasOnlyUnhealth.items[0]
         );
         expect(health.key).toEqual('UNHEALTHY');
       }
@@ -52,7 +52,7 @@ describe('MarathonStore', function () {
     it('should return unhealthy when app has both healthy and unhealthy tasks',
       function () {
         var health = MarathonStore.getFrameworkHealth(
-          MockMarathonResponse.hasOnlyUnhealth.apps[0]
+          MockMarathonResponse.hasOnlyUnhealth.items[0]
         );
         expect(health.key).toEqual('UNHEALTHY');
       }
@@ -61,7 +61,7 @@ describe('MarathonStore', function () {
     it('should return healthy when app has healthy and no unhealthy tasks',
       function () {
         var health = MarathonStore.getFrameworkHealth(
-          MockMarathonResponse.hasHealth.apps[0]
+          MockMarathonResponse.hasHealth.items[0]
         );
         expect(health.key).toEqual('HEALTHY');
       }
@@ -146,8 +146,8 @@ describe('MarathonStore', function () {
 
   describe('#processMarathonGroups', function () {
 
-    it('should set Marathon health to idle with no apps', function () {
-      MarathonStore.processMarathonGroups({apps: []});
+    it('should set Marathon health to idle with no items', function () {
+      MarathonStore.processMarathonGroups({items: []});
       var marathonApps = MarathonStore.get('apps');
       expect(marathonApps.marathon.health.key).toEqual('IDLE');
     });

--- a/src/js/stores/__tests__/fixtures/MockMarathonResponse.json
+++ b/src/js/stores/__tests__/fixtures/MockMarathonResponse.json
@@ -1,6 +1,6 @@
 {
   "hasVersion": {
-    "apps": [
+    "items": [
       {
         "healthChecks": [],
         "labels": {
@@ -19,7 +19,7 @@
     ]
   },
   "hasNoVersion": {
-    "apps": [
+    "items": [
       {
         "healthChecks": [],
         "labels": {
@@ -37,7 +37,7 @@
     ]
   },
   "hasNoHealthy": {
-    "apps": [
+    "items": [
       {
         "healthChecks": [],
         "labels": {
@@ -56,7 +56,7 @@
   },
 
   "hasHealth": {
-    "apps": [
+    "items": [
       {
         "healthChecks": [
           {
@@ -96,7 +96,7 @@
   },
 
   "hasOnlyUnhealth": {
-    "apps": [
+    "items": [
       {
         "healthChecks": [
           {
@@ -136,7 +136,7 @@
   },
 
   "hasUnhealthAndHealth": {
-    "apps": [
+    "items": [
       {
         "healthChecks": [
           {
@@ -176,7 +176,7 @@
   },
 
   "hasNoRunningTasks": {
-    "apps": [
+    "items": [
       {
         "healthChecks": [
           {
@@ -216,7 +216,7 @@
   },
 
   "hasMetadata": {
-    "apps": [
+    "items": [
       {
         "labels": {
           "DCOS_PACKAGE_SOURCE": "https://github.com/mesosphere/universe/archive/master.zip",

--- a/src/js/structs/ServiceTree.js
+++ b/src/js/structs/ServiceTree.js
@@ -27,16 +27,6 @@ module.exports = class ServiceTree extends Tree {
       this.id = options.id;
     }
 
-    // Append Marathon groups
-    if (options.groups) {
-      this.list = this.list.concat(options.groups);
-    }
-
-    // Append applications
-    if (options.apps) {
-      this.list = this.list.concat(options.apps);
-    }
-
     // Converts items into instances of ServiceTree, Application or Framework
     // based on their properties.
     this.list = this.list.map((item) => {
@@ -44,11 +34,9 @@ module.exports = class ServiceTree extends Tree {
         return item;
       }
 
-      // Check item properties and convert items with an items array or an apps
-      // and groups array (Marathon group structure) into ServiceTree instances.
-      if ((item.items != null && Array.isArray(item.items)) ||
-          (item.groups != null && Array.isArray(item.groups) &&
-          item.apps != null && Array.isArray(item.apps))) {
+      // Check item properties and convert items with an items array (sub trees)
+      // into ServiceTree instances.
+      if ((item.items != null && Array.isArray(item.items))) {
         return new this.constructor(
           Object.assign({filterProperties: this.getFilterProperties()}, item)
         );

--- a/src/js/structs/__tests__/ServiceTree-test.js
+++ b/src/js/structs/__tests__/ServiceTree-test.js
@@ -12,41 +12,26 @@ describe('ServiceTree', function () {
 
     beforeEach(function () {
       this.instance = new ServiceTree({
-        id: '/group/id',
-        apps: [
+        id: '/group',
+        items: [
           {
-            id: 'alpha',
-            cmd: 'cmd'
+            id: 'group/test',
+            items: []
           },
           {
-            id: 'beta',
-            cmd: 'cmd',
+            id: '/group/alpha'
+          },
+          {
+            id: '/group/beta',
             labels: {
               DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'
             }
           },
           {
-            id: 'gamma',
-            cmd: 'cmd',
+            id: '/group/gamma',
             labels: {
               RANDOM_LABEL: 'random'
             }
-          }
-        ],
-        groups: [
-          {
-            id: '/test',
-            apps: [
-              {
-                id: 'foo',
-                cmd: 'cmd'
-              },
-              {
-                id: 'bar',
-                cmd: 'cmd'
-              }
-            ],
-            groups: []
           }
         ],
         filterProperties: {
@@ -62,11 +47,11 @@ describe('ServiceTree', function () {
       expect(tree.getId()).toEqual('/');
     });
 
-    it('sets correct tree (groups) id', function () {
-      expect(this.instance.getId()).toEqual('/group/id');
+    it('sets correct tree (group) id', function () {
+      expect(this.instance.getId()).toEqual('/group');
     });
 
-    it('accepts nested trees (groups)', function () {
+    it('accepts nested trees', function () {
       expect(this.instance.getItems()[0] instanceof ServiceTree).toEqual(true);
     });
 
@@ -81,19 +66,19 @@ describe('ServiceTree', function () {
   describe('#add', function () {
 
     it('adds a service', function () {
-      let tree = new ServiceTree({id: '/test', apps: [], groups: []});
+      let tree = new ServiceTree({id: '/test', items: [],});
       tree.add(new Application({id: 'a'}));
       expect(tree.getItems()[0].get('id')).toEqual('a');
     });
 
     it('adds service like items', function () {
-      let tree = new ServiceTree({id: '/test', apps: [], groups: []});
+      let tree = new ServiceTree({id: '/test', items: []});
       tree.add({id: 'a'});
       expect(tree.getItems()[0].id).toEqual('a');
     });
 
     it('adds two items', function () {
-      let tree = new ServiceTree({id: '/test', apps: [], groups: []});
+      let tree = new ServiceTree({id: '/test', items: []});
       tree.add(new Application({id: 'a'}));
       tree.add(new Application({id: 'b'}));
       expect(tree.getItems()[0].get('id')).toEqual('a');
@@ -103,8 +88,7 @@ describe('ServiceTree', function () {
     it('adds items to current Tree', function () {
       let tree = new ServiceTree({
         id: '/test',
-        apps: [new Application({id: 'a'})],
-        groups: []
+        items: [new Application({id: 'a'})]
       });
       tree.add(new Application({id: 'b'}));
       tree.add(new Application({id: 'c'}));
@@ -120,41 +104,33 @@ describe('ServiceTree', function () {
 
     beforeEach(function () {
       this.instance = new ServiceTree({
-        id: '/group/id',
-        apps: [
+        id: '/group',
+        items: [
           {
-            id: 'alpha',
-            cmd: 'cmd'
+            id: 'group/test',
+            items: [
+              {
+                id: 'group/test/foo',
+              },
+              {
+                id: 'group/test/bar',
+              }
+            ]
           },
           {
-            id: 'beta',
-            cmd: 'cmd',
+            id: '/group/alpha'
+          },
+          {
+            id: '/group/beta',
             labels: {
               DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'
             }
           },
           {
-            id: 'gamma',
-            cmd: 'cmd',
+            id: '/group/gamma',
             labels: {
               RANDOM_LABEL: 'random'
             }
-          }
-        ],
-        groups: [
-          {
-            id: '/test',
-            apps: [
-              {
-                id: 'foo',
-                cmd: 'cmd'
-              },
-              {
-                id: 'bar',
-                cmd: 'cmd'
-              }
-            ],
-            groups: []
           }
         ],
         filterProperties: {
@@ -190,14 +166,27 @@ describe('ServiceTree', function () {
 
     beforeEach(function () {
       this.instance = new ServiceTree({
-        id: '/group/id',
-        apps: [
+        id: '/group',
+        items: [
           {
-            id: 'alpha',
+            id: '/group/test',
+            items: [
+              {
+                id: '/group/test/foo',
+                cmd: 'cmd'
+              },
+              {
+                id: '/group/test/bar',
+                cmd: 'cmd'
+              }
+            ],
+          },
+          {
+            id: '/group/alpha',
             cmd: 'cmd'
           },
           {
-            id: 'beta',
+            id: '/group/beta',
             cmd: 'cmd',
             labels: {
               DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'
@@ -208,26 +197,9 @@ describe('ServiceTree', function () {
           {
             id: 'gamma',
             cmd: 'cmd',
-            labels:
-            {
+            labels: {
               RANDOM_LABEL: 'random'
             }
-          }
-        ],
-        groups: [
-          {
-            id: '/test',
-            apps: [
-              {
-                id: 'foo',
-                cmd: 'cmd'
-              },
-              {
-                id: 'bar',
-                cmd: 'cmd'
-              }
-            ],
-            groups: []
           }
         ],
         filterProperties: {
@@ -244,16 +216,16 @@ describe('ServiceTree', function () {
       }).getItems();
 
       expect(filteredServices.length).toEqual(1);
-      expect(filteredServices[0].id).toEqual('alpha');
+      expect(filteredServices[0].getId()).toEqual('/group/alpha');
     });
 
     it('should filter by name in groups', function () {
       let filteredServices = this.instance.filterItemsByFilter({
-        id: 'foo'
+        id: '/group/test/foo'
       }).getItems();
 
       expect(filteredServices.length).toEqual(1);
-      expect(filteredServices[0].id).toEqual('/test');
+      expect(filteredServices[0].getId()).toEqual('/group/test');
     });
 
     it('should filter by health', function () {
@@ -262,7 +234,7 @@ describe('ServiceTree', function () {
       }).getItems();
 
       expect(filteredServices.length).toEqual(1);
-      expect(filteredServices[0].id).toEqual('beta');
+      expect(filteredServices[0].getId()).toEqual('/group/beta');
     });
 
     it('should perform a logical AND with multiple filters', function () {
@@ -272,7 +244,7 @@ describe('ServiceTree', function () {
       }).getItems();
 
       expect(filteredServices.length).toEqual(1);
-      expect(filteredServices[0].id).toEqual('alpha');
+      expect(filteredServices[0].getId()).toEqual('/group/alpha');
     });
   });
 
@@ -280,41 +252,13 @@ describe('ServiceTree', function () {
 
     beforeEach(function () {
       this.instance = new ServiceTree({
-        id: '/group/id',
-        apps: [
-          {
-            id: 'alpha',
-            cmd: 'cmd'
-          },
-          {
-            id: 'beta',
-            cmd: 'cmd',
-            labels: {
-              DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'
-            }
-          },
-          {
-            id: 'gamma',
-            cmd: 'cmd',
-            labels: {
-              RANDOM_LABEL: 'random'
-            }
-          }
-        ],
-        groups: [
+        items: [
           {
             id: '/test',
-            apps: [
-              {
-                id: 'foo',
-                cmd: 'cmd'
-              },
-              {
-                id: 'bar',
-                cmd: 'cmd'
-              }
-            ],
-            groups: []
+            items: []
+          },
+          {
+            id: '/alpha'
           }
         ],
         filterProperties: {
@@ -337,8 +281,19 @@ describe('ServiceTree', function () {
 
     beforeEach(function () {
       this.instance = new ServiceTree({
-        id: '/group/id',
-        apps: [
+        id: '/',
+        items: [
+          {
+            id: '/test',
+            items: [
+              {
+                id: '/test/foo',
+              },
+              {
+                id: '/test/bar',
+              }
+            ],
+          },
           {
             id: '/alpha',
             cmd: 'cmd'
@@ -349,29 +304,6 @@ describe('ServiceTree', function () {
             labels: {
               DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'
             }
-          },
-          {
-            id: '/gamma',
-            cmd: 'cmd',
-            labels: {
-              RANDOM_LABEL: 'random'
-            }
-          }
-        ],
-        groups: [
-          {
-            id: '/test',
-            apps: [
-              {
-                id: '/foo',
-                cmd: 'cmd'
-              },
-              {
-                id: '/bar',
-                cmd: 'cmd'
-              }
-            ],
-            groups: []
           }
         ]
       });
@@ -382,7 +314,8 @@ describe('ServiceTree', function () {
     });
 
     it('should find matching subtree item', function () {
-      expect(this.instance.findItemById('/foo').getId()).toEqual('/foo');
+      expect(this.instance.findItemById('/test/foo').getId())
+        .toEqual('/test/foo');
     });
 
     it('should find matching subtree', function () {
@@ -392,10 +325,25 @@ describe('ServiceTree', function () {
   });
 
   describe('#getDeployments', function () {
+
     it('should return an empty array', function () {
       let serviceTree = new ServiceTree({
         id: '/group/id',
-        apps: [
+        items: [
+          {
+            id: '/test',
+            items: [
+              {
+                id: '/foo',
+                cmd: 'cmd',
+                deployments: []
+              },
+              {
+                id: '/bar',
+                cmd: 'cmd'
+              }
+            ],
+          },
           {
             id: '/alpha',
             cmd: 'cmd',
@@ -416,23 +364,6 @@ describe('ServiceTree', function () {
               RANDOM_LABEL: 'random'
             }
           }
-        ],
-        groups: [
-          {
-            id: '/test',
-            apps: [
-              {
-                id: '/foo',
-                cmd: 'cmd',
-                deployments: []
-              },
-              {
-                id: '/bar',
-                cmd: 'cmd'
-              }
-            ],
-            groups: []
-          }
         ]
       });
 
@@ -442,7 +373,25 @@ describe('ServiceTree', function () {
     it('should return an array with three deployments', function () {
       let serviceTree = new ServiceTree({
         id: '/group/id',
-        apps: [
+        items: [
+          {
+            id: '/test',
+            items: [
+              {
+                id: '/foo',
+                cmd: 'cmd',
+                deployments: [
+                  {
+                    id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f1'
+                  }
+                ]
+              },
+              {
+                id: '/bar',
+                cmd: 'cmd'
+              }
+            ]
+          },
           {
             id: '/alpha',
             cmd: 'cmd',
@@ -470,27 +419,6 @@ describe('ServiceTree', function () {
             labels: {
               RANDOM_LABEL: 'random'
             }
-          }
-        ],
-        groups: [
-          {
-            id: '/test',
-            apps: [
-              {
-                id: '/foo',
-                cmd: 'cmd',
-                deployments: [
-                  {
-                    id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f1'
-                  }
-                ]
-              },
-              {
-                id: '/bar',
-                cmd: 'cmd'
-              }
-            ],
-            groups: []
           }
         ]
       });

--- a/src/js/utils/MarathonUtil.js
+++ b/src/js/utils/MarathonUtil.js
@@ -1,0 +1,28 @@
+function parseApp(app) {
+  let {id} = app;
+
+  if (!id.startsWith('/') || id.endsWith('/')) {
+    throw new Error(`Id (${id}) must start with a leading slash ("/") ` +
+      'and should not end with a slash.');
+  }
+
+  return app;
+}
+
+const MarathonUtil = {
+  parseGroups({id = '/', groups = [], apps = []}) {
+    if (id !== '/' && (!id.startsWith('/') || id.endsWith('/'))) {
+      throw new Error(`Id (${id}) must start with a leading slash ("/") ` +
+        'and should not end with a slash, except for root id which is only ' +
+        'a slash.');
+    }
+
+    // Parse items
+    let items = [].concat(groups.map(this.parseGroups.bind(this)),
+      apps.map(parseApp));
+
+    return {id, items};
+  }
+};
+
+module.exports = MarathonUtil;

--- a/src/js/utils/__tests__/MarathonUtil-test.js
+++ b/src/js/utils/__tests__/MarathonUtil-test.js
@@ -1,0 +1,72 @@
+jest.dontMock('../MarathonUtil');
+
+var MarathonUtil = require('../MarathonUtil');
+
+describe('MarathonUtil', function () {
+
+  describe('#parseGroups', function () {
+
+    it('should throw error if the provided id doesn\'t start with a slash',
+      function () {
+        expect(function () {
+          MarathonUtil.parseGroups({id: 'malformed/id'});
+        }.bind(this)).toThrow();
+      }
+    );
+
+    it('should throw error if an app id doesn\'t start with a slash',
+      function () {
+        expect(function () {
+          MarathonUtil.parseGroups({id: '/', apps: [{id: 'malformed/id'}]});
+        }.bind(this)).toThrow();
+      }
+    );
+
+    it('should throw error if the provided id ends with a slash',
+      function () {
+        expect(function () {
+          MarathonUtil.parseGroups({id: '/malformed/id/'});
+        }.bind(this)).toThrow();
+      }
+    );
+
+    it('should throw error if an app id ends with a slash',
+      function () {
+        expect(function () {
+          MarathonUtil.parseGroups({id: '/', apps: [{id: '/malformed/id/'}]});
+        }.bind(this)).toThrow();
+      }
+    );
+
+    it('should not throw error if the provided id is only a slash (root id)',
+      function () {
+        expect(function () {
+          MarathonUtil.parseGroups({id: '/'});
+        }.bind(this)).not.toThrow();
+      }
+    );
+
+    it('should throw error if an app id is only a slash (root id)',
+      function () {
+        expect(function () {
+          MarathonUtil.parseGroups({id: '/', apps: [{id: '/'}]});
+        }.bind(this)).toThrow();
+      }
+    );
+
+    it('converts groups to tree', function () {
+      var instance = MarathonUtil.parseGroups({
+        id: '/',
+        apps: [{id: '/alpha'}],
+        groups: [{id: '/foo', apps: [{id: '/foo/beta'}]}]
+      });
+
+      expect(instance).toEqual({
+        id: '/',
+        items: [{id: '/foo', items: [{id: '/foo/beta'}]}, {id: '/alpha'}]
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
Introduce parse groups util and move Marathon data parsing to a "reducer-like" function that will restructure the data before passing it to the application. This applies the new pattern introduced in #269 to the Marathon (`ServiceTree`) data.

/cc @mlunoe