### PR TITLE
Update mesosphere-shared-reactjs v0.0.17

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4016,9 +4016,9 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz"
     },
     "mesosphere-shared-reactjs": {
-      "version": "0.0.16",
-      "from": "mesosphere-shared-reactjs@0.0.16",
-      "resolved": "https://registry.npmjs.org/mesosphere-shared-reactjs/-/mesosphere-shared-reactjs-0.0.16.tgz"
+      "version": "0.0.17",
+      "from": "mesosphere-shared-reactjs@0.0.17",
+      "resolved": "https://registry.npmjs.org/mesosphere-shared-reactjs/-/mesosphere-shared-reactjs-0.0.17.tgz"
     },
     "method-override": {
       "version": "2.3.5",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "flux": "2.1.1",
     "less-color-lighten": "0.0.1",
     "md5": "2.1.0",
-    "mesosphere-shared-reactjs": "0.0.16",
+    "mesosphere-shared-reactjs": "0.0.17",
     "moment": "2.13.0",
     "query-string": "4.1.0",
     "react": "0.14.7",


### PR DESCRIPTION
Updating mesosphere-shared-reactjs to version 0.0.17, which will provide us with the functionality of using es6 classes as first argument of ClassUtil, to be extended by a child es6 class

See PR here: https://github.com/dcos/mesosphere-shared-reactjs/pull/8