### PR TITLE
Adjust validate-tests script

### DIFF
--- a/scripts/validate-tests
+++ b/scripts/validate-tests
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-! egrep --quiet -R "describe\.only\(|it\.only\(" ./src && \
+! egrep --quiet -R "fdescribe\\(|fit\(" ./src && \
 ! egrep --quiet -R "context\.only\(|it\.only\(" ./tests


### PR DESCRIPTION
Change the validation pattern to check for the new Jasmin 2 `fit` instead of the old `it.only`.

Run the following command to test the script. It should echo "valid" if there is no `f(it|describe)` nor `(context|it).only` and "invalid" if you add "f" or "only" to one of the tests.
```
eval scripts/validate-tests && echo "valid" || echo "invalid"
```