### PR TITLE
Move jasmine.clock installation to specific tests

### DIFF
--- a/jest/setupTestFramework.js
+++ b/jest/setupTestFramework.js
@@ -1,6 +1,3 @@
-// Install jasmine clock to fake time passing
-jasmine.clock().install();
-
 if (process.env.TEAMCITY_VERSION != null) {
   var jasmineReporters = require('jasmine-reporters/src/teamcity_reporter');
   jasmine.getEnv().addReporter(new jasmineReporters.TeamCityReporter());

--- a/src/js/pages/__tests__/DeploymentsTab-test.js
+++ b/src/js/pages/__tests__/DeploymentsTab-test.js
@@ -44,7 +44,6 @@ describe('DeploymentsTab', function () {
   });
 
   afterEach(function () {
-    jasmine.clock().uninstall();
     ReactDOM.unmountComponentAtNode(this.container);
   });
 

--- a/src/js/pages/__tests__/DeploymentsTab-test.js
+++ b/src/js/pages/__tests__/DeploymentsTab-test.js
@@ -17,6 +17,10 @@ import MarathonStore from '../../stores/MarathonStore';
 describe('DeploymentsTab', function () {
 
   beforeEach(function () {
+    // Clean up application timers.
+    jasmine.clock().uninstall();
+    // Install our custom jasmine timers.
+    jasmine.clock().install();
     jasmine.clock().mockDate(new Date(2016, 3, 19));
     let deployments = new DeploymentsList({
       items: [

--- a/src/js/stores/__tests__/ChronosStore-test.js
+++ b/src/js/stores/__tests__/ChronosStore-test.js
@@ -17,16 +17,21 @@ const JobTree = require('../../structs/JobTree');
 describe('ChronosStore', function () {
 
   beforeEach(function () {
+    // Clean up application timers
+    jasmine.clock().uninstall();
+    // Install our custom jasmine timers
+    jasmine.clock().install();
     ChronosActions.fetchJobs = jasmine.createSpy('fetchJobs');
   });
 
   afterEach(function () {
+    jasmine.clock().uninstall();
     ChronosStore.removeAllListeners();
   });
 
   describe('constructor', function () {
 
-    it('should call the fetchJobs 2 times', function () {
+    it('should call the fetchJobs 3 times', function () {
       ChronosStore.addChangeListener(
         EventTypes.CHRONOS_JOBS_CHANGE,
         function () {}
@@ -35,7 +40,7 @@ describe('ChronosStore', function () {
       jasmine.clock().tick(2 * Config.getRefreshRate());
       // Finish up outstanding timers
       jest.runOnlyPendingTimers();
-      expect(ChronosActions.fetchJobs.calls.count()).toEqual(2);
+      expect(ChronosActions.fetchJobs.calls.count()).toEqual(3);
     });
 
   });

--- a/src/js/stores/__tests__/ChronosStore-test.js
+++ b/src/js/stores/__tests__/ChronosStore-test.js
@@ -25,7 +25,6 @@ describe('ChronosStore', function () {
   });
 
   afterEach(function () {
-    jasmine.clock().uninstall();
     ChronosStore.removeAllListeners();
   });
 


### PR DESCRIPTION
Previously we were running `jasmine.clock().install()` in `setupTestFramework`, which worked for some tests, but one of those tests altered the behavior of timing functions for all subsequent tests.

This PR will "uninstall" all application timers (which are created with `global.setTimeout` and `global.setInterval`), then "install" the mock Jasmine timers. It looks funny to see the `uninstall` and `install` methods called consecutively, but it's necessary as far as I can tell due to our use of `global.set{Interval|Timeout}`. Read about it here: https://github.com/jasmine/jasmine/issues/895#issuecomment-127370465