### PR TITLE
Add Nested Service Links Component

### DIFF
--- a/src/js/components/NestedServiceLinks.js
+++ b/src/js/components/NestedServiceLinks.js
@@ -1,0 +1,178 @@
+import classNames from 'classnames/dedupe';
+import {Link} from 'react-router';
+import React, {PropTypes} from 'react';
+
+class NestedServiceLinks extends React.Component {
+
+  getMinorLink(label, params, key, classes) {
+    return (
+      <div key={key} className="table-cell-value">
+        <div className={classes}>
+          <Link to="services-detail"
+              params={params}
+              title={label}>
+            {label}
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  getCrumbDivider(key) {
+    return (
+      <div key={key}>
+        <i className="icon icon-sprite icon-sprite-mini icon-chevron flush" />
+      </div>
+    );
+  }
+
+  getMinorLinks() {
+    let componentKey = 0;
+    let {minorLinkClassName, taskID} = this.props;
+    let minorLinkClasses = classNames(
+      'text-overflow service-link',
+      minorLinkClassName
+    );
+    let nestedGroups = this.getServicePathParts();
+    let popCount = 1;
+
+    if (taskID != null) {
+      popCount = 0;
+    }
+    nestedGroups = nestedGroups.slice(0, nestedGroups.length - popCount);
+
+    let links = nestedGroups.reduce((components, part, index) => {
+      let id = encodeURIComponent(nestedGroups.slice(0, index + 1).join('/'));
+
+      components.push(
+        this.getMinorLink(part, {id}, componentKey++, minorLinkClasses)
+      );
+
+      if (index !== nestedGroups.length - 1) {
+        components.push(this.getCrumbDivider(componentKey++));
+      }
+
+      return components;
+    }, []);
+
+    return [this.getServicesLink(componentKey++), ...links];
+  }
+
+  getMajorLink() {
+    let label;
+    let params;
+    let {serviceID, taskID} = this.props;
+    let routeName;
+
+    if (taskID != null) {
+      label = taskID;
+      params = {
+        id: serviceID,
+        taskID
+      }
+      routeName = 'services-task-details';
+    } else {
+      label = this.getServicePathParts().pop();
+      params = {id: serviceID};
+      routeName = 'services-detail';
+    }
+
+    return (
+      <Link to={routeName}
+        params={params}
+        title={label}>
+        <span className="text-overflow">
+          {label}
+        </span>
+      </Link>
+    );
+  }
+
+  getServicesLink(key) {
+    let minorLinkClasses = classNames(
+      'text-overflow service-link',
+      this.props.minorLinkClassName
+    );
+
+    return (
+       <div key={key} className="table-cell-value">
+        <div className={minorLinkClasses}>
+          <Link to="services-page"
+              title="services">
+            services
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  getServicePathParts() {
+    return decodeURIComponent(this.props.serviceID).split('/');
+  }
+
+  render() {
+    let {
+      className,
+      majorLinkClassName,
+      minorLinkWrapperClassName
+    } = this.props;
+
+    let classes = classNames(
+      'container container-fluid container-pod',
+      'flush flush-top flush-bottom',
+      className
+    );
+
+    let majorLinkClasses = classNames(
+      'text-overflow',
+      majorLinkClassName
+    );
+
+    let minorLinkWrapperClasses = classNames(
+      'table-cell-details-secondary flex-box',
+      'flex-box-align-vertical-center table-cell-flex-box',
+      minorLinkWrapperClassName
+    );
+
+    return (
+      <div className={classes}>
+        <div className={majorLinkClasses}>
+          {this.getMajorLink()}
+        </div>
+        <div className={minorLinkWrapperClasses}>
+          {this.getMinorLinks()}
+        </div>
+      </div>
+    );
+  }
+}
+
+NestedServiceLinks.defaultProps = {
+  taskID: null,
+  className: 'inverse',
+  minorLinkClassName: 'inverse'
+};
+
+NestedServiceLinks.propTypes = {
+  serviceID: PropTypes.string.isRequired,
+  taskID: PropTypes.string,
+  // Classes
+  className: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ]),
+  majorLinkClassName: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ]),
+  minorLinkClassName: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ]),
+  minorLinkWrapperClassName: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ])
+};
+
+module.exports = NestedServiceLinks;

--- a/src/js/components/NestedServiceLinks.js
+++ b/src/js/components/NestedServiceLinks.js
@@ -153,26 +153,20 @@ NestedServiceLinks.defaultProps = {
   minorLinkClassName: 'inverse'
 };
 
+const classPropType = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
+]);
+
 NestedServiceLinks.propTypes = {
   serviceID: PropTypes.string.isRequired,
   taskID: PropTypes.string,
   // Classes
-  className: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.object,
-  ]),
-  majorLinkClassName: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.object,
-  ]),
-  minorLinkClassName: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.object,
-  ]),
-  minorLinkWrapperClassName: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.object,
-  ])
+  className: classPropType,
+  majorLinkClassName: classPropType,
+  minorLinkClassName: classPropType,
+  minorLinkWrapperClassName: classPropType
 };
 
 module.exports = NestedServiceLinks;

--- a/src/js/plugin-bridge/PluginModules.js
+++ b/src/js/plugin-bridge/PluginModules.js
@@ -62,6 +62,7 @@ module.exports = {
     FormModal: 'FormModal',
     IconInfo: 'icons/IconInfo',
     MesosphereLogo: 'icons/MesosphereLogo',
+    NestedServiceLinks: 'NestedServiceLinks',
     Page: 'Page',
     PageHeader: 'PageHeader',
     RequestErrorMsg: 'RequestErrorMsg',

--- a/src/styles/components/nested-service-links.less
+++ b/src/styles/components/nested-service-links.less
@@ -1,0 +1,26 @@
+/* -----------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+NestedServiceLinks
+
+--------------------------------------------------------------------------------
+----------------------------------------------------------------------------- */
+
+.nested-service-link-container {
+  padding-top: @base-spacing-unit * 0.5 !important;
+  padding-bottom: @base-spacing-unit * 0.5 !important;
+}
+
+.service-link {
+
+  &.inverse {
+
+    a {
+      color: color-lighten(@neutral, 30) !important;
+
+      &:hover {
+        color: color-lighten(@neutral, 60);
+      }
+    }
+  }
+}

--- a/src/styles/components/nested-service-links.less
+++ b/src/styles/components/nested-service-links.less
@@ -6,20 +6,23 @@ NestedServiceLinks
 --------------------------------------------------------------------------------
 ----------------------------------------------------------------------------- */
 
-.nested-service-link-container {
-  padding-top: @base-spacing-unit * 0.5 !important;
-  padding-bottom: @base-spacing-unit * 0.5 !important;
-}
+table > tbody > tr > td {
 
-.service-link {
+  &.nested-service-link-container {
+    padding-top: @base-spacing-unit * 0.5;
+    padding-bottom: @base-spacing-unit * 0.5;
+  }
 
-  &.inverse {
+  .service-link {
 
-    a {
-      color: color-lighten(@neutral, 30) !important;
+    &.inverse {
 
-      &:hover {
-        color: color-lighten(@neutral, 60);
+      a {
+        color: color-lighten(@neutral, 30);
+
+        &:hover {
+          color: color-lighten(@neutral, 60);
+        }
       }
     }
   }

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -145,6 +145,7 @@ Components
 @import "components/login-modal.less";
 @import "components/media.less";
 @import "components/multiple-form.less";
+@import "components/nested-service-links.less";
 @import "components/nodes-grid-view.less";
 @import "components/page-header.less";
 @import "components/progressbar.less";


### PR DESCRIPTION
Splits an AppId into a bunch of links to the service and parent groups. Optionally takes a taskId, creating clickable links for the task and parent service/groups.

Currently restricted to use within a table cell using existing classes. Could be altered without much trouble to work outside of a table but I don't currently see where we'd do that.

![](http://cl.ly/240m460G220b/Screen%20Recording%202016-06-01%20at%2010.46%20AM.gif)