### PR TITLE
Add select field to SchemaForm

### DIFF
--- a/src/js/constants/ServiceSchema.js
+++ b/src/js/constants/ServiceSchema.js
@@ -74,6 +74,21 @@ let SERVICE_SCHEMA = {
             }
             return null;
           }
+        },
+        network: {
+          title: 'Network',
+          fieldType: 'select',
+          options: [
+            'Host',
+            'Bridged'
+          ],
+          getter: function (service) {
+            let container = service.getContainerSettings();
+            if (container && container.docker && container.docker.network) {
+              return container.docker.network.toLowerCase();
+            }
+            return null;
+          }
         }
       },
       required: []

--- a/src/js/utils/SchemaUtil.js
+++ b/src/js/utils/SchemaUtil.js
@@ -52,6 +52,11 @@ function schemaToFieldDefinition(fieldName, fieldProps, formParent, isRequired, 
     definition.checked = value;
   }
 
+  if (fieldProps.fieldType === 'select') {
+    definition.fieldType = 'select';
+    definition.options = fieldProps.options;
+  }
+
   if (fieldProps.type === 'boolean') {
     definition.fieldType = 'checkbox';
     definition.checked = fieldProps.default || false;

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -33,6 +33,10 @@ const ServiceUtil = {
           docker: {
             image: formModel['Container Settings'].image
           }
+        };
+        if (formModel['Container Settings'].network != null) {
+          definition.container.docker.network =
+            formModel['Container Settings'].network.toUpperCase();
         }
       }
     }


### PR DESCRIPTION
This adds a select field to the SchemaForm

![image](https://cloud.githubusercontent.com/assets/156010/15780471/26f20c72-29a2-11e6-90ae-3f86e87bb99c.png)

It also adds the network dropdown to the container settings section of the create modal.