### PR TITLE
Fix an error when deploying service from JSON mode

### DIFF
--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -117,7 +117,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
 
   handleSubmit() {
     if (this.state.jsonMode) {
-      let jsonDefinition = this.state;
+      let jsonDefinition = this.state.jsonDefinition;
       MarathonStore.createService(JSON.parse(jsonDefinition));
       this.setState({
         errorMessage: null,


### PR DESCRIPTION
When deploying a service from JSON mode, the jsonDefinition is:

```
{
  "service": {
    "_itemData": {
      "container": {
        "docker": {}
      },
      "instances": 1,
      "mem": 32,
      "cpus": 0.2,
      "cmd": "sleep 10000",
      "id": "fadfa"
    },
    "container": {
      "docker": {}
    },
    "instances": 1,
    "mem": 32,
    "cpus": 0.2,
    "cmd": "sleep 10000",
    "id": "fadfa"
  },
  "model": {
    "Container Settings": {},
    "General": {
      "cmd": "sleep 10000",
      "instances": 1,
      "mem": 32,
      "cpus": 0.2,
      "id": "fadfa"
    }
  },
  "jsonMode": true,
  "jsonDefinition": "{\n  \"id\": \"fadfa\",\n  \"cpus\": 0.2,\n  \"mem\": 32,\n  \"instances\": 1,\n  \"cmd\": \"sleep 10000\"\n}",
  "errorMessage": null
}
```

We can see that there is a `jsonDefinition` inside `jsonDefinition`, and this inside `jsonDefinition` is what createService function should use.