### PR TITLE
Allow use of title for schema tabs

### DIFF
--- a/src/js/utils/SchemaUtil.js
+++ b/src/js/utils/SchemaUtil.js
@@ -120,7 +120,7 @@ let SchemaUtil = {
       let requiredProps = topLevelPropertyObject.required;
       let definitionForm = multipleDefinition[topLevelProp] = {};
 
-      definitionForm.title = topLevelProp;
+      definitionForm.title = topLevelPropertyObject.title || topLevelProp;
       definitionForm.description = topLevelPropertyObject.description;
       definitionForm.definition = [];
       Object.keys(secondLevelProperties).forEach(function (secondLevelProp) {


### PR DESCRIPTION
So in the `ServiceSchema` if you made the `title` in `General` into `WTF???` it would look like this: 

![px](http://cl.ly/3c1O0f3U1x0h/Image%202016-06-03%20at%207.19.01%20AM.png)

@Poltergeist @aldipower 