### PR TITLE
Update reactjs-components to v0.14.0-beta.26

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4929,9 +4929,9 @@
       "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz"
     },
     "reactjs-components": {
-      "version": "0.14.0-beta.24",
-      "from": "reactjs-components@0.14.0-beta.24",
-      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.14.0-beta.24.tgz"
+      "version": "0.14.0-beta.26",
+      "from": "reactjs-components@0.14.0-beta.26",
+      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.14.0-beta.26.tgz"
     },
     "reactjs-mixin": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-gemini-scrollbar": "2.1.0",
     "react-redux": "4.4.0",
     "react-router": "0.13.5",
-    "reactjs-components": "0.14.0-beta.24",
+    "reactjs-components": "0.14.0-beta.26",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
     "tv4": "1.2.7",


### PR DESCRIPTION
This release includes two changes:
https://github.com/mesosphere/reactjs-components/pull/280: Form return updated model on change
https://github.com/mesosphere/reactjs-components/pull/279: Making form element classes more customizable

No changes to dcos-ui needed