### PR TITLE
Cleanup styles for form elements in modals

### DIFF
--- a/src/styles/components/multiple-form.less
+++ b/src/styles/components/multiple-form.less
@@ -143,10 +143,7 @@ base/forms.less
       .multiple-form-right-column {
         // Make right column scroll
         flex: 1 1;
-        padding-bottom: @base-spacing-unit;
-        padding-right: 0;
-        padding-left: 0;
-        padding-top: @base-spacing-unit;
+        padding: @base-spacing-unit 0;
       }
 
     }

--- a/src/styles/components/multiple-form.less
+++ b/src/styles/components/multiple-form.less
@@ -121,8 +121,6 @@ base/forms.less
 
       .form-row-element {
         padding-bottom: @base-spacing-unit * 2/3;
-        padding-left: @base-spacing-unit;
-        padding-right: @base-spacing-unit;
       }
 
       .media-object-item {
@@ -130,10 +128,11 @@ base/forms.less
       }
 
       .multiple-form-left-column {
-        height: auto;
         flex: 0 0 auto;
+        height: auto;
         max-height: 300px;
         overflow: auto;
+        padding-right: 0;
 
         &:first-child {
           border-bottom: 1px solid color-lighten(@neutral, 80);
@@ -146,12 +145,14 @@ base/forms.less
         flex: 1 1;
         padding-bottom: @base-spacing-unit;
         padding-right: 0;
+        padding-left: 0;
         padding-top: @base-spacing-unit;
       }
 
     }
 
     .form-panel {
+      padding-left: @base-spacing-unit;
       padding-right: @base-spacing-unit;
 
       > .form > *:last-child {
@@ -168,8 +169,17 @@ base/forms.less
 
   @media (max-width: @screen-mini-max) {
 
-    .multiple-form-modal .multiple-form .form-row-element {
-      padding-left: @base-spacing-unit * 4/3;
+    .multiple-form-modal {
+
+      .multiple-form {
+
+        .form-panel {
+          padding-left: @base-spacing-unit-screen-mini;
+          padding-right: @base-spacing-unit-screen-mini;
+        }
+
+      }
+
     }
 
   }
@@ -202,6 +212,68 @@ base/forms.less
         .multiple-form-right-column {
           // Override gemini width styles
           width: 67%;
+        }
+      }
+
+    }
+
+  }
+
+}
+
+& when (@screen-small-enabled) {
+
+  @media (max-width: @screen-small) {
+
+    .multiple-form-modal {
+
+      .multiple-form {
+
+        .form-panel {
+          padding-left: @base-spacing-unit-screen-small;
+          padding-right: @base-spacing-unit-screen-small;
+        }
+
+      }
+
+    }
+
+  }
+
+}
+
+& when (@screen-medium-enabled) {
+
+  @media (max-width: @screen-medium) {
+
+    .multiple-form-modal {
+
+      .multiple-form {
+
+        .form-panel {
+          padding-left: @base-spacing-unit-screen-medium;
+          padding-right: @base-spacing-unit-screen-medium;
+        }
+
+      }
+
+    }
+
+  }
+
+}
+
+& when (@screen-large-enabled) {
+
+  @media (max-width: @screen-large) {
+
+    .multiple-form-modal {
+
+      .multiple-form {
+
+        .form-panel {
+          padding-left: @base-spacing-unit-screen-large;
+          padding-right: @base-spacing-unit-screen-large;
         }
 
       }

--- a/src/styles/components/multiple-form.less
+++ b/src/styles/components/multiple-form.less
@@ -165,27 +165,6 @@ base/forms.less
 
 }
 
-& when (@screen-mini-enabled) {
-
-  @media (max-width: @screen-mini-max) {
-
-    .multiple-form-modal {
-
-      .multiple-form {
-
-        .form-panel {
-          padding-left: @base-spacing-unit-screen-mini;
-          padding-right: @base-spacing-unit-screen-mini;
-        }
-
-      }
-
-    }
-
-  }
-
-}
-
 & when (@screen-small-enabled) {
 
   @media (min-width: @screen-small) {
@@ -212,68 +191,6 @@ base/forms.less
         .multiple-form-right-column {
           // Override gemini width styles
           width: 67%;
-        }
-      }
-
-    }
-
-  }
-
-}
-
-& when (@screen-small-enabled) {
-
-  @media (max-width: @screen-small) {
-
-    .multiple-form-modal {
-
-      .multiple-form {
-
-        .form-panel {
-          padding-left: @base-spacing-unit-screen-small;
-          padding-right: @base-spacing-unit-screen-small;
-        }
-
-      }
-
-    }
-
-  }
-
-}
-
-& when (@screen-medium-enabled) {
-
-  @media (max-width: @screen-medium) {
-
-    .multiple-form-modal {
-
-      .multiple-form {
-
-        .form-panel {
-          padding-left: @base-spacing-unit-screen-medium;
-          padding-right: @base-spacing-unit-screen-medium;
-        }
-
-      }
-
-    }
-
-  }
-
-}
-
-& when (@screen-large-enabled) {
-
-  @media (max-width: @screen-large) {
-
-    .multiple-form-modal {
-
-      .multiple-form {
-
-        .form-panel {
-          padding-left: @base-spacing-unit-screen-large;
-          padding-right: @base-spacing-unit-screen-large;
         }
 
       }

--- a/src/styles/components/side-tabs.less
+++ b/src/styles/components/side-tabs.less
@@ -65,8 +65,6 @@
 
   .sidebar-tabs {
 
-    padding-left: @base-spacing-unit-screen-mini;
-
     .sidebar-menu-item {
       .text-styling(
         @heading-h3-text-color,
@@ -78,15 +76,17 @@
         @heading-h3-text-transform,
         @heading-h3-text-shadow
       );
-
-      a {
-        padding-bottom: (@base-spacing-unit-screen-mini * 0.3);
-        padding-right: @base-spacing-unit-screen-mini;
-        padding-top: (@base-spacing-unit-screen-mini * 0.3);
-      }
     }
 
   }
+}
+
+@media (min-width: @screen-small) {
+
+  .sidebar-tabs {
+
+  }
+
 }
 
 @media (min-width: @screen-small) {
@@ -102,65 +102,6 @@
           color: @purple;
         }
 
-      }
-
-    }
-
-  }
-
-}
-
-@media (max-width: @screen-small) {
-
-  .sidebar-tabs {
-
-    padding-left: @base-spacing-unit-screen-small;
-
-    .sidebar-menu-item {
-
-      a {
-        padding-bottom: (@base-spacing-unit-screen-small * 0.3);
-        padding-right: @base-spacing-unit-screen-small;
-        padding-top: (@base-spacing-unit-screen-small * 0.3);
-      }
-
-    }
-  }
-
-}
-
-@media (max-width: @screen-medium) {
-
-  .sidebar-tabs {
-
-    padding-left: @base-spacing-unit-screen-medium;
-
-    .sidebar-menu-item {
-
-      a {
-        padding-bottom: (@base-spacing-unit-screen-medium * 0.3);
-        padding-right: @base-spacing-unit-screen-medium;
-        padding-top: (@base-spacing-unit-screen-medium * 0.3);
-      }
-
-    }
-
-  }
-
-}
-
-@media (max-width: @screen-large) {
-
-  .sidebar-tabs {
-
-    padding-left: @base-spacing-unit-screen-large;
-
-    .sidebar-menu-item {
-
-      a {
-        padding-bottom: (@base-spacing-unit-screen-large * 0.3);
-        padding-right: @base-spacing-unit-screen-large;
-        padding-top: (@base-spacing-unit-screen-large * 0.3);
       }
 
     }

--- a/src/styles/components/side-tabs.less
+++ b/src/styles/components/side-tabs.less
@@ -1,7 +1,7 @@
 .sidebar-tabs {
 
   padding-top: @base-spacing-unit * 0.5;
-  padding-left: @base-spacing-unit * 4/3;
+  padding-left: @base-spacing-unit;
 
   /* -----------------------------------------------------------------------------
   Sidebar Menu Item
@@ -65,17 +65,25 @@
 
   .sidebar-tabs {
 
+    padding-left: @base-spacing-unit-screen-mini;
+
     .sidebar-menu-item {
       .text-styling(
-          @heading-h3-text-color,
-          @heading-h3-text-font-family,
-          @heading-h3-text-font-size,
-          @heading-h3-text-font-style,
-          @heading-h3-text-font-weight,
-          @heading-h3-text-line-height,
-          @heading-h3-text-transform,
-          @heading-h3-text-shadow
-        );
+        @heading-h3-text-color,
+        @heading-h3-text-font-family,
+        @heading-h3-text-font-size,
+        @heading-h3-text-font-style,
+        @heading-h3-text-font-weight,
+        @heading-h3-text-line-height,
+        @heading-h3-text-transform,
+        @heading-h3-text-shadow
+      );
+
+      a {
+        padding-bottom: (@base-spacing-unit-screen-mini * 0.3);
+        padding-right: @base-spacing-unit-screen-mini;
+        padding-top: (@base-spacing-unit-screen-mini * 0.3);
+      }
     }
 
   }
@@ -94,6 +102,65 @@
           color: @purple;
         }
 
+      }
+
+    }
+
+  }
+
+}
+
+@media (max-width: @screen-small) {
+
+  .sidebar-tabs {
+
+    padding-left: @base-spacing-unit-screen-small;
+
+    .sidebar-menu-item {
+
+      a {
+        padding-bottom: (@base-spacing-unit-screen-small * 0.3);
+        padding-right: @base-spacing-unit-screen-small;
+        padding-top: (@base-spacing-unit-screen-small * 0.3);
+      }
+
+    }
+  }
+
+}
+
+@media (max-width: @screen-medium) {
+
+  .sidebar-tabs {
+
+    padding-left: @base-spacing-unit-screen-medium;
+
+    .sidebar-menu-item {
+
+      a {
+        padding-bottom: (@base-spacing-unit-screen-medium * 0.3);
+        padding-right: @base-spacing-unit-screen-medium;
+        padding-top: (@base-spacing-unit-screen-medium * 0.3);
+      }
+
+    }
+
+  }
+
+}
+
+@media (max-width: @screen-large) {
+
+  .sidebar-tabs {
+
+    padding-left: @base-spacing-unit-screen-large;
+
+    .sidebar-menu-item {
+
+      a {
+        padding-bottom: (@base-spacing-unit-screen-large * 0.3);
+        padding-right: @base-spacing-unit-screen-large;
+        padding-top: (@base-spacing-unit-screen-large * 0.3);
       }
 
     }

--- a/src/styles/layout/modal.less
+++ b/src/styles/layout/modal.less
@@ -156,22 +156,16 @@
     width: 100%;
   }
 
-  .form-row-element {
-    &:first-child {
-      padding-left: 0;
-    }
-
-    &:last-child {
-      padding-right: 0;
-    }
-  }
-
   .row {
     margin-left: 0;
     margin-right: 0;
 
-    [class*="column-"] {
-      padding: 0;
+    [class*="column-"]:first-child {
+      padding-left: 0;
+    }
+
+    [class*="column-"]:last-child {
+      padding-right: 0;
     }
 
     &:last-child .form-group {


### PR DESCRIPTION
Large:
<img src="http://cl.ly/272t3N0C0N3V/Image%202016-06-03%20at%2016.59.22.png" width="50%" />

Medium:
<img src="http://cl.ly/0J3Q2a1S2p1y/Image%202016-06-03%20at%2016.59.49.png" width="50%" />

Small:
<img src="http://cl.ly/2y1U0R1s3a2a/Image%202016-06-03%20at%2017.01.09.png" width="50%" />

Mini:
<img src="http://cl.ly/0V310J0f301w/Image%202016-06-03%20at%2017.01.31.png" width="50%" />

And no changes to other modal forms:
<img src="http://cl.ly/0O2f18090J1E/Image%202016-06-03%20at%2017.02.35.png" width="50%" />
<img src="http://cl.ly/163u3q1u1J2U/Image%202016-06-03%20at%2017.03.21.png" width="50%" />