### PR TITLE
Fix SchemaForm SideTabs

### DIFF
--- a/src/js/components/SideTabs.js
+++ b/src/js/components/SideTabs.js
@@ -26,16 +26,16 @@ class SideTabs extends React.Component {
     let {selectedTab, tabs} = this.props;
 
     return tabs.map((tab, index) => {
-      let {title} = tab;
+      let {title, value} = tab;
       let classes = classNames('sidebar-menu-item clickable visible-block', {
-        selected: title === selectedTab
+        selected: value === selectedTab || title === selectedTab
       });
 
       return (
         <li
           className={classes}
           key={index}
-          onClick={this.handleTabClick.bind(this, title)}>
+          onClick={this.handleTabClick.bind(this, value)}>
           <a>{title}</a>
         </li>
       );

--- a/src/js/utils/SchemaUtil.js
+++ b/src/js/utils/SchemaUtil.js
@@ -126,6 +126,7 @@ let SchemaUtil = {
       let definitionForm = multipleDefinition[topLevelProp] = {};
 
       definitionForm.title = topLevelPropertyObject.title || topLevelProp;
+      definitionForm.value = topLevelProp;
       definitionForm.description = topLevelPropertyObject.description;
       definitionForm.definition = [];
       Object.keys(secondLevelProperties).forEach(function (secondLevelProp) {


### PR DESCRIPTION
With the introduction of the new title attribute for schema sections there was a bug introduced which made it impossible to navigate to a section with a title attribute.