### PR TITLE
Introduce service task failure data

### DIFF
--- a/src/js/events/MarathonActions.js
+++ b/src/js/events/MarathonActions.js
@@ -71,7 +71,8 @@ module.exports = {
           {name: 'embed', value: 'group.apps'},
           {name: 'embed', value: 'group.apps.deployments'},
           {name: 'embed', value: 'group.apps.counts'},
-          {name: 'embed', value: 'group.apps.tasks'}
+          {name: 'embed', value: 'group.apps.tasks'},
+          {name: 'embed', value: 'group.apps.lastTaskFailure'}
         ];
 
         RequestUtil.json({

--- a/src/js/structs/Service.js
+++ b/src/js/structs/Service.js
@@ -90,6 +90,10 @@ module.exports = class Service extends Item {
     return this.getVersionInfo().lastScalingAt;
   }
 
+  getLastTaskFailure() {
+    return this.get('lastTaskFailure');
+  }
+
   getMem() {
     return this.get('mem');
   }

--- a/src/js/structs/__tests__/Service-test.js
+++ b/src/js/structs/__tests__/Service-test.js
@@ -376,6 +376,34 @@ describe('Service', function () {
 
     it('returns correct task summary', function () {
       let service = new Service({
+        lastTaskFailure: {
+          appId: '/toggle',
+          host: '10.141.141.10',
+          message: 'Abnormal executor termination',
+          state: 'TASK_FAILED',
+          taskId: 'toggle.cc427e60-5046-11e4-9e34-56847afe9799',
+          timestamp: '2014-09-12T23:23:41.711Z',
+          version: '2014-09-12T23:28:21.737Z'
+        }
+      });
+
+      expect(service.getLastTaskFailure()).toEqual({
+        appId: '/toggle',
+        host: '10.141.141.10',
+        message: 'Abnormal executor termination',
+        state: 'TASK_FAILED',
+        taskId: 'toggle.cc427e60-5046-11e4-9e34-56847afe9799',
+        timestamp: '2014-09-12T23:23:41.711Z',
+        version: '2014-09-12T23:28:21.737Z'
+      });
+    });
+
+  });
+
+  describe('#getLastTaskFailure', function () {
+
+    it('returns correct task summary', function () {
+      let service = new Service({
         tasksStaged: 0,
         tasksRunning: 1,
         tasksHealthy: 1,


### PR DESCRIPTION
Fetch service task (last) failure data alongside groups and provide getter - this is needed to implement the service debug tab.

/cc @mlunoe 