### PR TITLE
Introduce n/a status as a fallback

### DIFF
--- a/src/js/constants/ServiceStatus.js
+++ b/src/js/constants/ServiceStatus.js
@@ -13,6 +13,10 @@ var SERVICE_STATUS = {
   SUSPENDED: {
     key: ServiceStatusTypes.SUSPENDED,
     displayName: ServiceStatusLabels.SUSPENDED
+  },
+  NA: {
+    key: ServiceStatusTypes.NA,
+    displayName: ServiceStatusLabels.NA
   }
 };
 

--- a/src/js/constants/ServiceStatusLabels.js
+++ b/src/js/constants/ServiceStatusLabels.js
@@ -1,7 +1,8 @@
 var ServiceStatusLabels = {
   RUNNING: 'Running',
   DEPLOYING: 'Deploying',
-  SUSPENDED: 'Suspended'
+  SUSPENDED: 'Suspended',
+  NA: 'N/A'
 };
 
 module.exports = ServiceStatusLabels;

--- a/src/js/constants/ServiceStatusTypes.js
+++ b/src/js/constants/ServiceStatusTypes.js
@@ -1,7 +1,8 @@
 var ServiceStatusTypes = {
   RUNNING: 0,
   DEPLOYING: 1,
-  SUSPENDED: 2
+  SUSPENDED: 2,
+  NA: 4
 };
 
 module.exports = ServiceStatusTypes;

--- a/src/js/structs/Service.js
+++ b/src/js/structs/Service.js
@@ -139,6 +139,8 @@ module.exports = class Service extends Item {
     if (instances === 0) {
       return ServiceStatus.SUSPENDED;
     }
+
+    return ServiceStatus.NA;
   }
 
   getTasksSummary() {

--- a/src/js/structs/__tests__/Service-test.js
+++ b/src/js/structs/__tests__/Service-test.js
@@ -370,6 +370,19 @@ describe('Service', function () {
       expect(service.getStatus()).toEqual(ServiceStatus.DEPLOYING.displayName);
     });
 
+    it('returns correct status for deploying app', function () {
+      let service = new Service({
+        tasksStaged: 0,
+        tasksRunning: 0,
+        tasksHealthy: 0,
+        tasksUnhealthy: 0,
+        instances: 1,
+        deployments: []
+      });
+
+      expect(service.getStatus()).toEqual(ServiceStatus.NA.displayName);
+    });
+
   });
 
   describe('#getServiceStatus', function () {
@@ -414,6 +427,20 @@ describe('Service', function () {
 
       expect(service.getServiceStatus())
         .toEqual(ServiceStatus.DEPLOYING);
+    });
+
+    it('returns n/a status object when no other status is found', function () {
+      let service = new Service({
+        tasksStaged: 0,
+        tasksRunning: 0,
+        tasksHealthy: 0,
+        tasksUnhealthy: 0,
+        instances: 1,
+        deployments: []
+      });
+
+      expect(service.getServiceStatus())
+        .toEqual(ServiceStatus.NA);
     });
 
   });


### PR DESCRIPTION
This prevents exceptions when none of the existing statuses match.