### PR TITLE
Do not throw when localVolumnes is not defined on marathon task

### DIFF
--- a/src/js/utils/MarathonUtil.js
+++ b/src/js/utils/MarathonUtil.js
@@ -48,6 +48,10 @@ function parseApp(app) {
       status = VolumeStatus.ATTACHED;
     }
 
+    if (!Array.isArray(localVolumes)) {
+      return;
+    }
+
     localVolumes.forEach(function ({containerPath, persistenceId:id}) {
       let volumeDefinition =
         volumeDefinitionMap.get(containerPath);

--- a/src/js/utils/__tests__/MarathonUtil-test.js
+++ b/src/js/utils/__tests__/MarathonUtil-test.js
@@ -191,6 +191,55 @@ describe('MarathonUtil', function () {
       expect(instance.items[0].volumes[0].status).toEqual('Detached');
     });
 
+    it('doesn\'t throw when localVolumes is null', function () {
+      var instance = MarathonUtil.parseGroups.bind(MarathonUtil, {
+        id: '/',
+        apps: [{
+          id: '/alpha', container: {
+            volumes: [{
+              containerPath: 'path',
+              mode: 'RW',
+              persistent: {
+                size: 2048
+              }
+            }]
+          },
+          tasks: [
+            {
+              host: '0.0.0.1',
+              localVolumes: null
+            }
+          ]
+        }]
+      });
+
+      expect(instance).not.toThrow();
+    });
+
+    it('doesn\'t throw when localVolumes is not present', function () {
+      var instance = MarathonUtil.parseGroups.bind(MarathonUtil, {
+        id: '/',
+        apps: [{
+          id: '/alpha', container: {
+            volumes: [{
+              containerPath: 'path',
+              mode: 'RW',
+              persistent: {
+                size: 2048
+              }
+            }]
+          },
+          tasks: [
+            {
+              host: '0.0.0.1'
+            }
+          ]
+        }]
+      });
+
+      expect(instance).not.toThrow();
+    });
+
     it('doesn\'t adds volumes array to all services', function () {
       var instance = MarathonUtil.parseGroups({
         id: '/',


### PR DESCRIPTION
Fixes this issue:
![](http://cl.ly/2F2o1v2i2S2E/Image%202016-06-06%20at%2014.58.20.png)

Bug introduced here: https://github.com/dcos/dcos-ui/pull/327