### PR TITLE
Add ExpandingTable

### DIFF
--- a/src/js/components/ExpandingTable.js
+++ b/src/js/components/ExpandingTable.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import {Table} from 'reactjs-components';
+
+class ExpandingTable extends React.Component {
+  constructor() {
+    super(...arguments);
+
+    this.state = {
+      expandedRows: []
+    };
+  }
+
+  defaultRenderer(prop, row) {
+    return row[prop];
+  }
+
+  expandRow(row) {
+    let {expandedRows} = this.state;
+    let rowID = this.getRowID(row);
+    let selectedRowIndex = expandedRows.indexOf(rowID);
+
+    // If the selected row is already expanded, then we want to collapse it.
+    if (selectedRowIndex > -1) {
+      expandedRows.splice(selectedRowIndex, 1);
+    } else {
+      expandedRows.push(rowID);
+    }
+
+    this.setState({expandedRows});
+  }
+
+  getColumns(columns) {
+    // Replace the #render method on each column.
+    return columns.map((column) => {
+      return Object.assign({}, column, {render: this.getRenderer(column)});
+    });
+  }
+
+  getRenderer(column) {
+    // Get the column's #render method if it exists. Otherwise use our default.
+    let renderFn = column.render || this.defaultRenderer;
+
+    return (prop, row) => {
+      let hasChildren = !!row.children;
+      let isExpanded = this.state.expandedRows.indexOf(this.getRowID(row)) > -1;
+
+      // Render the column's top-level item.
+      let cellContent = [
+        <div key={-1}>
+          {renderFn(prop, row, {hasChildren, isExpanded, isParent: true})}
+        </div>
+      ];
+
+      // If there are children, and the expanded row ID matches this row, then
+      // render all children. We need to render a whitespace character if the
+      // property is undefined to retain proper spacing.
+      if (hasChildren && isExpanded) {
+        const whitespace = '\u00A0';
+
+        cellContent = cellContent.concat(
+          row.children.map((child, childIndex) => {
+            return (
+              <div className={this.props.childRowClassName} key={childIndex}>
+                {renderFn(prop, child, {isParent: false}) || whitespace}
+              </div>
+            );
+          }
+        ));
+      }
+
+      return cellContent;
+    };
+  }
+
+  getRowID(row) {
+    return row.id;
+  }
+
+  render() {
+    let {props} = this;
+
+    return <Table {...props} columns={this.getColumns(props.columns)} />;
+  }
+}
+
+ExpandingTable.defaultProps = {
+  childRowClassName: 'text-overflow'
+};
+
+ExpandingTable.propTypes = {
+  childRowClassName: React.PropTypes.string
+};
+
+module.exports = ExpandingTable;

--- a/src/js/components/__tests__/ExpandingTable-test.js
+++ b/src/js/components/__tests__/ExpandingTable-test.js
@@ -1,0 +1,82 @@
+jest.dontMock('../ExpandingTable');
+/* eslint-disable no-unused-vars */
+var React = require('react');
+/* eslint-enable no-unused-vars */
+var ReactDOM = require('react-dom');
+
+var ExpandingTable = require('../ExpandingTable');
+
+describe('ExpandingTable', function () {
+  beforeEach(function () {
+    this.columns = [{heading: function () {}, prop: 'id'}];
+    this.rows = [{id: 'foo'}, {id: 'bar'}];
+    this.container = document.createElement('div');
+  });
+
+  afterEach(function () {
+    ReactDOM.unmountComponentAtNode(this.container);
+  });
+
+  describe('#render', function () {
+
+    describe('#expandRow', function () {
+
+      it('should add a row to state.expandedRows', function () {
+        let instance = ReactDOM.render(
+          <ExpandingTable columns={this.columns} data={this.rows} />,
+          this.container
+        );
+
+        instance.expandRow(this.rows[0]);
+
+        expect(instance.state.expandedRows.indexOf('foo') > -1).toBeTruthy();
+      });
+
+      it('should remove a row from state.expandedRows if already expanded',
+        function () {
+        let instance = ReactDOM.render(
+          <ExpandingTable columns={this.columns} data={this.rows} />,
+          this.container
+        );
+
+        instance.expandRow(this.rows[0]);
+        instance.expandRow(this.rows[0]);
+
+        expect(instance.state.expandedRows.indexOf('foo') === -1).toBeTruthy();
+      });
+
+      it('should allow multiple rows in state.expandedRows',
+        function () {
+        let instance = ReactDOM.render(
+          <ExpandingTable columns={this.columns} data={this.rows} />,
+          this.container
+        );
+
+        instance.expandRow(this.rows[0]);
+        instance.expandRow(this.rows[1]);
+
+        expect(instance.state.expandedRows.indexOf('foo') > -1).toBeTruthy();
+        expect(instance.state.expandedRows.indexOf('bar') > -1).toBeTruthy();
+      });
+
+    });
+
+    describe('#getRenderer', function () {
+
+      it('should proxy the render method on each column', function () {
+        let renderSpy = jasmine.createSpy('renderSpy');
+        this.columns[0].render = renderSpy;
+
+        let instance = ReactDOM.render(
+          <ExpandingTable columns={this.columns} data={this.rows} />,
+          this.container
+        );
+
+        expect(renderSpy).toHaveBeenCalled();
+      });
+
+    });
+
+  });
+
+});

--- a/src/js/components/__tests__/ExpandingTable-test.js
+++ b/src/js/components/__tests__/ExpandingTable-test.js
@@ -29,7 +29,7 @@ describe('ExpandingTable', function () {
 
         instance.expandRow(this.rows[0]);
 
-        expect(instance.state.expandedRows.indexOf('foo') > -1).toBeTruthy();
+        expect(instance.state.expandedRows['foo']).toBeTruthy();
       });
 
       it('should remove a row from state.expandedRows if already expanded',
@@ -42,7 +42,7 @@ describe('ExpandingTable', function () {
         instance.expandRow(this.rows[0]);
         instance.expandRow(this.rows[0]);
 
-        expect(instance.state.expandedRows.indexOf('foo') === -1).toBeTruthy();
+        expect(instance.state.expandedRows['foo']).toBeFalsy();
       });
 
       it('should allow multiple rows in state.expandedRows',
@@ -55,8 +55,8 @@ describe('ExpandingTable', function () {
         instance.expandRow(this.rows[0]);
         instance.expandRow(this.rows[1]);
 
-        expect(instance.state.expandedRows.indexOf('foo') > -1).toBeTruthy();
-        expect(instance.state.expandedRows.indexOf('bar') > -1).toBeTruthy();
+        expect(instance.state.expandedRows['foo']).toBeTruthy();
+        expect(instance.state.expandedRows['bar']).toBeTruthy();
       });
 
     });


### PR DESCRIPTION
This will be used in the Job detail view, which I'll open a PR for soon. Integration tests in that PR will further test the functionality of this table.

Continued from https://github.com/dcos/dcos-ui/pull/299, we decided to move forward with this as it is now. When the other tables are introduced, we will evaluate combining them into a single component.