### PR TITLE
Display svg icons correctly

### DIFF
--- a/src/styles/components/icons.less
+++ b/src/styles/components/icons.less
@@ -115,6 +115,10 @@ Icon (huge)
 
   .icon {
 
+    svg {
+      display: block;
+    }
+
     &.icon-image-container {
 
       overflow: hidden;


### PR DESCRIPTION
SVG icons being clipped without `display: block property`