### PR TITLE
[ServiceSchema] Add checkbox fields to docker section

### DIFF
--- a/src/js/schemas/service-schema/ContainerSettings.js
+++ b/src/js/schemas/service-schema/ContainerSettings.js
@@ -32,6 +32,32 @@ let ContainerSettings = {
         }
         return null;
       }
+    },
+    forcePullImage: {
+      title: 'Force pull image on every launch',
+      type: 'boolean',
+      getter: function (service) {
+        let container = service.getContainerSettings();
+        if (container && container.docker &&
+          container.docker.forcePullImage
+        ) {
+          return container.docker.forcePullImage;
+        }
+        return null;
+      }
+    },
+    privileged: {
+      title: 'Extend runtime privileges',
+      type: 'boolean',
+      getter: function (service) {
+        let container = service.getContainerSettings();
+        if (container && container.docker &&
+          container.docker.privileged
+        ) {
+          return container.docker.privileged;
+        }
+        return null;
+      }
     }
   },
   required: []

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -66,6 +66,14 @@ const ServiceUtil = {
           definition.container.docker.network =
             containerSettings.network.toUpperCase();
         }
+        if (containerSettings.forcePullImage != null) {
+          definition.container.docker.forcePullImage =
+            containerSettings.forcePullImage;
+        }
+        if (containerSettings.privileged != null) {
+          definition.container.docker.privileged =
+            containerSettings.privileged;
+        }
       }
     }
     return new Service(definition);


### PR DESCRIPTION
This adds the two checkbox fields to the docker section of the Service Schema

![image](https://cloud.githubusercontent.com/assets/156010/15861777/b365f3f2-2ccd-11e6-982a-7af5adc3370b.png)
