### PR TITLE
Feature - 1066 Service Actions dialogs

### DIFF
--- a/src/js/components/ServiceDetail.js
+++ b/src/js/components/ServiceDetail.js
@@ -15,7 +15,9 @@ import TabsMixin from '../mixins/TabsMixin';
 const METHODS_TO_BIND = [
   'onActionsItemSelection',
   'onAcceptDestroyConfirmDialog',
+  'onAcceptSuspendConfirmDialog',
   'onCancelDestroyConfirmDialog',
+  'onCancelSuspendConfirmDialog',
   'onCloseServiceFormModal'
 ];
 
@@ -34,7 +36,8 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
     this.state = {
       currentTab: Object.keys(this.tabs_tabs).shift(),
       isServiceFormModalShown: false,
-      isServiceDestroyConfirmShown: false
+      isServiceDestroyConfirmShown: false,
+      isServiceSuspendConfirmShown: false
     };
 
     METHODS_TO_BIND.forEach((method) => {
@@ -50,6 +53,9 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
       case ServiceActionItem.DESTROY:
         this.setState({isServiceDestroyConfirmShown: true});
         break;
+      case ServiceActionItem.SUSPEND:
+        this.setState({isServiceSuspendConfirmShown: true});
+        break;
     }
   }
 
@@ -57,8 +63,16 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
     this.setState({isServiceDestroyConfirmShown: false});
   }
 
+  onAcceptSuspendConfirmDialog() {
+    this.setState({isServiceSuspendConfirmShown: false});
+  }
+
   onCancelDestroyConfirmDialog() {
     this.setState({isServiceDestroyConfirmShown: false});
+  }
+
+  onCancelSuspendConfirmDialog() {
+    this.setState({isServiceSuspendConfirmShown: false});
   }
 
   onCloseServiceFormModal() {
@@ -85,6 +99,29 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
         rightButtonText="Destroy Service"
         rightButtonClassName="button button-danger"
         rightButtonCallback={this.onAcceptDestroyConfirmDialog} />
+    );
+  }
+
+  getSuspendConfirmDialog() {
+    const {service} = this.props;
+
+    let message = (
+      <div className="container-pod flush-top container-pod-short-bottom">
+        <h4 className="flush-top">Suspend Service</h4>
+        <p>Are you sure you want to suspend {service.getId()}
+        by scaling to 0 instances?</p>
+      </div>
+    );
+
+    return  (
+      <Confirm children={message}
+        open={this.state.isServiceSuspendConfirmShown}
+        onClose={this.onCancelSuspendConfirmDialog}
+        leftButtonText="Cancel"
+        leftButtonCallback={this.onCancelSuspendConfirmDialog}
+        rightButtonText="Suspend Service"
+        rightButtonClassName="button button-warning"
+        rightButtonCallback={this.onAcceptSuspendConfirmDialog} />
     );
   }
 
@@ -128,6 +165,7 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
           service={service}
           onClose={this.onCloseServiceFormModal} />
         {this.getDestroyConfirmDialog()}
+        {this.getSuspendConfirmDialog()}
       </div>
 
     );

--- a/src/js/components/ServiceDetail.js
+++ b/src/js/components/ServiceDetail.js
@@ -17,10 +17,7 @@ const METHODS_TO_BIND = [
   'onActionsItemSelection',
   'onAcceptDestroyConfirmDialog',
   'onAcceptSuspendConfirmDialog',
-  'onCancelDestroyConfirmDialog',
-  'onCancelSuspendConfirmDialog',
-  'onCloseScaleFormModal',
-  'onCloseServiceFormModal'
+  'closeDialog'
 ];
 
 class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
@@ -37,10 +34,7 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
 
     this.state = {
       currentTab: Object.keys(this.tabs_tabs).shift(),
-      isServiceFormModalShown: false,
-      isServiceDestroyConfirmShown: false,
-      isServiceScaleFormModalShown: false,
-      isServiceSuspendConfirmShown: false
+      serviceActionDialog: null
     };
 
     METHODS_TO_BIND.forEach((method) => {
@@ -49,44 +43,24 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
   }
 
   onActionsItemSelection(item) {
-    switch (item.id) {
-      case ServiceActionItem.EDIT:
-        this.setState({isServiceFormModalShown: true});
-        break;
-      case ServiceActionItem.DESTROY:
-        this.setState({isServiceDestroyConfirmShown: true});
-        break;
-      case ServiceActionItem.SCALE:
-        this.setState({isServiceScaleFormModalShown: true});
-        break;
-      case ServiceActionItem.SUSPEND:
-        this.setState({isServiceSuspendConfirmShown: true});
-        break;
-    }
+    this.setState({
+      serviceActionDialog:
+        Object.values(ServiceActionItem).find(function (actionItem) {
+          return actionItem === item.id;
+        })
+    });
   }
 
   onAcceptDestroyConfirmDialog() {
-    this.setState({isServiceDestroyConfirmShown: false});
+    this.closeDialog();
   }
 
   onAcceptSuspendConfirmDialog() {
-    this.setState({isServiceSuspendConfirmShown: false});
+    this.closeDialog();
   }
 
-  onCancelDestroyConfirmDialog() {
-    this.setState({isServiceDestroyConfirmShown: false});
-  }
-
-  onCancelSuspendConfirmDialog() {
-    this.setState({isServiceSuspendConfirmShown: false});
-  }
-
-  onCloseScaleFormModal() {
-    this.setState({isServiceScaleFormModalShown: false});
-  }
-
-  onCloseServiceFormModal() {
-    this.setState({isServiceFormModalShown: false});
+  closeDialog() {
+    this.setState({serviceActionDialog: null});
   }
 
   getDestroyConfirmDialog() {
@@ -101,10 +75,10 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
 
     return  (
       <Confirm children={message}
-        open={this.state.isServiceDestroyConfirmShown}
-        onClose={this.onCancelDestroyConfirmDialog}
+        open={this.state.serviceActionDialog === ServiceActionItem.DESTROY}
+        onClose={this.closeDialog}
         leftButtonText="Cancel"
-        leftButtonCallback={this.onCancelDestroyConfirmDialog}
+        leftButtonCallback={this.closeDialog}
         rightButtonText="Destroy Service"
         rightButtonClassName="button button-danger"
         rightButtonCallback={this.onAcceptDestroyConfirmDialog} />
@@ -123,10 +97,10 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
 
     return  (
       <Confirm children={message}
-        open={this.state.isServiceSuspendConfirmShown}
-        onClose={this.onCancelSuspendConfirmDialog}
+        open={this.state.serviceActionDialog === ServiceActionItem.SUSPEND}
+        onClose={this.closeDialog}
         leftButtonText="Cancel"
-        leftButtonCallback={this.onCancelSuspendConfirmDialog}
+        leftButtonCallback={this.closeDialog}
         rightButtonText="Suspend Service"
         rightButtonClassName="button button-primary"
         rightButtonCallback={this.onAcceptSuspendConfirmDialog} />
@@ -136,9 +110,9 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
   getServiceScaleFormModal() {
     return (
       <ServiceScaleFormModal
-        open={this.state.isServiceScaleFormModalShown}
+        open={this.state.serviceActionDialog === ServiceActionItem.SCALE}
         service={this.props.service}
-        onClose={this.onCloseScaleFormModal} />
+        onClose={this.closeDialog} />
     );
   }
 
@@ -178,9 +152,9 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
           {this.tabs_getTabView()}
         </div>
         <ServiceFormModal isEdit={true}
-          open={this.state.isServiceFormModalShown}
+          open={this.state.serviceActionDialog === ServiceActionItem.EDIT}
           service={service}
-          onClose={this.onCloseServiceFormModal} />
+          onClose={this.closeDialog} />
         {this.getDestroyConfirmDialog()}
         {this.getServiceScaleFormModal()}
         {this.getSuspendConfirmDialog()}

--- a/src/js/components/ServiceDetail.js
+++ b/src/js/components/ServiceDetail.js
@@ -9,6 +9,7 @@ import ServiceDetailConfigurationTab from './ServiceDetailConfigurationTab';
 import ServiceDetailTaskTab from './ServiceDetailTaskTab';
 import ServiceFormModal from './modals/ServiceFormModal';
 import ServiceInfo from './ServiceInfo';
+import ServiceScaleFormModal from './modals/ServiceScaleFormModal';
 import ServicesBreadcrumb from './ServicesBreadcrumb';
 import TabsMixin from '../mixins/TabsMixin';
 
@@ -18,6 +19,7 @@ const METHODS_TO_BIND = [
   'onAcceptSuspendConfirmDialog',
   'onCancelDestroyConfirmDialog',
   'onCancelSuspendConfirmDialog',
+  'onCloseScaleFormModal',
   'onCloseServiceFormModal'
 ];
 
@@ -37,6 +39,7 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
       currentTab: Object.keys(this.tabs_tabs).shift(),
       isServiceFormModalShown: false,
       isServiceDestroyConfirmShown: false,
+      isServiceScaleFormModalShown: false,
       isServiceSuspendConfirmShown: false
     };
 
@@ -52,6 +55,9 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
         break;
       case ServiceActionItem.DESTROY:
         this.setState({isServiceDestroyConfirmShown: true});
+        break;
+      case ServiceActionItem.SCALE:
+        this.setState({isServiceScaleFormModalShown: true});
         break;
       case ServiceActionItem.SUSPEND:
         this.setState({isServiceSuspendConfirmShown: true});
@@ -75,6 +81,10 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
     this.setState({isServiceSuspendConfirmShown: false});
   }
 
+  onCloseScaleFormModal() {
+    this.setState({isServiceScaleFormModalShown: false});
+  }
+
   onCloseServiceFormModal() {
     this.setState({isServiceFormModalShown: false});
   }
@@ -85,8 +95,7 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
     let message = (
       <div className="container-pod flush-top container-pod-short-bottom">
         <h4 className="text-danger flush-top">Destroy Service</h4>
-        <p>Are you sure you want to destroy {service.getId()}?
-        This action is irreversible.</p>
+        <p>Are you sure you want to destroy {service.getId()}? This action is irreversible.</p>
       </div>
     );
 
@@ -108,8 +117,7 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
     let message = (
       <div className="container-pod flush-top container-pod-short-bottom">
         <h4 className="flush-top">Suspend Service</h4>
-        <p>Are you sure you want to suspend {service.getId()}
-        by scaling to 0 instances?</p>
+        <p>Are you sure you want to suspend {service.getId()} by scaling to 0 instances?</p>
       </div>
     );
 
@@ -125,9 +133,18 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
     );
   }
 
+  getServiceScaleFormModal() {
+    return (
+      <ServiceScaleFormModal
+        open={this.state.isServiceScaleFormModalShown}
+        service={this.props.service}
+        onClose={this.onCloseScaleFormModal} />
+    );
+  }
+
   renderConfigurationTabView() {
     return (
-      <ServiceDetailConfigurationTab service={this.props.service}/>
+      <ServiceDetailConfigurationTab service={this.props.service} />
     );
   }
 
@@ -141,7 +158,7 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
 
   renderTasksTabView() {
     return (
-      <ServiceDetailTaskTab service={this.props.service}/>
+      <ServiceDetailTaskTab service={this.props.service} />
     );
   }
 
@@ -165,6 +182,7 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
           service={service}
           onClose={this.onCloseServiceFormModal} />
         {this.getDestroyConfirmDialog()}
+        {this.getServiceScaleFormModal()}
         {this.getSuspendConfirmDialog()}
       </div>
 

--- a/src/js/components/ServiceDetail.js
+++ b/src/js/components/ServiceDetail.js
@@ -1,3 +1,4 @@
+import {Confirm} from 'reactjs-components';
 import mixin from 'reactjs-mixin';
 import React from 'react';
 
@@ -13,6 +14,8 @@ import TabsMixin from '../mixins/TabsMixin';
 
 const METHODS_TO_BIND = [
   'onActionsItemSelection',
+  'onAcceptDestroyConfirmDialog',
+  'onCancelDestroyConfirmDialog',
   'onCloseServiceFormModal'
 ];
 
@@ -30,7 +33,8 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
 
     this.state = {
       currentTab: Object.keys(this.tabs_tabs).shift(),
-      isServiceFormModalShown: false
+      isServiceFormModalShown: false,
+      isServiceDestroyConfirmShown: false
     };
 
     METHODS_TO_BIND.forEach((method) => {
@@ -39,13 +43,49 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
   }
 
   onActionsItemSelection(item) {
-    if (item.id === ServiceActionItem.EDIT) {
-      this.setState({isServiceFormModalShown: true});
+    switch (item.id) {
+      case ServiceActionItem.EDIT:
+        this.setState({isServiceFormModalShown: true});
+        break;
+      case ServiceActionItem.DESTROY:
+        this.setState({isServiceDestroyConfirmShown: true});
+        break;
     }
+  }
+
+  onAcceptDestroyConfirmDialog() {
+    this.setState({isServiceDestroyConfirmShown: false});
+  }
+
+  onCancelDestroyConfirmDialog() {
+    this.setState({isServiceDestroyConfirmShown: false});
   }
 
   onCloseServiceFormModal() {
     this.setState({isServiceFormModalShown: false});
+  }
+
+  getDestroyConfirmDialog() {
+    const {service} = this.props;
+
+    let message = (
+      <div className="container-pod flush-top container-pod-short-bottom">
+        <h4 className="text-danger flush-top">Destroy Service</h4>
+        <p>Are you sure you want to destroy {service.getId()}?
+        This action is irreversible.</p>
+      </div>
+    );
+
+    return  (
+      <Confirm children={message}
+        open={this.state.isServiceDestroyConfirmShown}
+        onClose={this.onCancelDestroyConfirmDialog}
+        leftButtonText="Cancel"
+        leftButtonCallback={this.onCancelDestroyConfirmDialog}
+        rightButtonText="Destroy Service"
+        rightButtonClassName="button button-danger"
+        rightButtonCallback={this.onAcceptDestroyConfirmDialog} />
+    );
   }
 
   renderConfigurationTabView() {
@@ -87,6 +127,7 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
           open={this.state.isServiceFormModalShown}
           service={service}
           onClose={this.onCloseServiceFormModal} />
+        {this.getDestroyConfirmDialog()}
       </div>
 
     );

--- a/src/js/components/ServiceDetail.js
+++ b/src/js/components/ServiceDetail.js
@@ -94,7 +94,7 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
 
     let message = (
       <div className="container-pod flush-top container-pod-short-bottom">
-        <h4 className="text-danger flush-top">Destroy Service</h4>
+        <h2 className="text-danger text-align-center flush-top">Destroy Service</h2>
         <p>Are you sure you want to destroy {service.getId()}? This action is irreversible.</p>
       </div>
     );
@@ -116,7 +116,7 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
 
     let message = (
       <div className="container-pod flush-top container-pod-short-bottom">
-        <h4 className="flush-top">Suspend Service</h4>
+        <h2 className="text-align-center flush-top">Suspend Service</h2>
         <p>Are you sure you want to suspend {service.getId()} by scaling to 0 instances?</p>
       </div>
     );
@@ -128,7 +128,7 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
         leftButtonText="Cancel"
         leftButtonCallback={this.onCancelSuspendConfirmDialog}
         rightButtonText="Suspend Service"
-        rightButtonClassName="button button-warning"
+        rightButtonClassName="button button-primary"
         rightButtonCallback={this.onAcceptSuspendConfirmDialog} />
     );
   }

--- a/src/js/components/modals/ServiceScaleFormModal.js
+++ b/src/js/components/modals/ServiceScaleFormModal.js
@@ -1,0 +1,97 @@
+import mixin from 'reactjs-mixin';
+/* eslint-disable no-unused-vars */
+import React from 'react';
+/* eslint-enable no-unused-vars */
+import {StoreMixin} from 'mesosphere-shared-reactjs';
+
+import FormModal from '../FormModal';
+
+const METHODS_TO_BIND = [
+  'handleScaleSubmit',
+  'resetState'
+];
+
+const buttonDefinition = [
+  {
+    text: 'Cancel',
+    className: 'button button-medium',
+    isClose: true
+  },
+  {
+    text: 'Scale Service',
+    className: 'button button-warning button-medium',
+    isSubmit: true
+  }
+];
+
+class ServiceGroupFormModal extends mixin(StoreMixin) {
+  constructor() {
+    super();
+
+    this.state = {
+      disableForm: false
+    };
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  resetState() {
+    this.setState({
+      disableForm: false
+    });
+  }
+
+  handleScaleSubmit({instances}) {
+    this.resetState();
+    this.props.onClose();
+  }
+
+  getScaleFormDefinition() {
+    let {service} = this.props;
+    let instancesCount = service.getInstancesCount();
+
+    return [
+      {
+        fieldType: 'number',
+        min: 0,
+        name: 'instances',
+        placeholder: instancesCount,
+        value: instancesCount,
+        required: true,
+        showLabel: false,
+        writeType: 'input'
+      }
+    ];
+  }
+
+  render() {
+    let {props, state} = this;
+
+    return (
+      <FormModal
+        ref="form"
+        buttonDefinition={buttonDefinition}
+        disabled={state.disableForm}
+        onClose={props.onClose}
+        onSubmit={this.handleScaleSubmit}
+        onChange={this.resetState}
+        open={props.open}
+        definition={this.getScaleFormDefinition()}>
+        <h2 className="modal-header-title text-align-center flush-top">
+          Scale Service
+        </h2>
+        <p className="text-align-center flush-top">
+          How many instances would you like to scale to?
+        </p>
+      </FormModal>
+    );
+  }
+}
+
+ServiceGroupFormModal.propTypes = {
+  service: React.PropTypes.object.isRequired
+};
+
+module.exports = ServiceGroupFormModal;

--- a/src/js/components/modals/ServiceScaleFormModal.js
+++ b/src/js/components/modals/ServiceScaleFormModal.js
@@ -19,7 +19,7 @@ const buttonDefinition = [
   },
   {
     text: 'Scale Service',
-    className: 'button button-warning button-medium',
+    className: 'button button-primary button-medium',
     isSubmit: true
   }
 ];


### PR DESCRIPTION
This implements the dialogs/confirm-boxes for the service actions (scale, suspend, destroy).
There is no real action behind them, this will follow next.

Destroy:
![confirm-destroy](https://cloud.githubusercontent.com/assets/859154/15862844/367131f0-2cd1-11e6-8754-61aa4b7c7253.png)

Scale:
![confirm-scale](https://cloud.githubusercontent.com/assets/859154/15862846/3685abda-2cd1-11e6-8940-8f52c2f9595d.png)

Suspend:
![confirm-suspend](https://cloud.githubusercontent.com/assets/859154/15862845/3676d57e-2cd1-11e6-97cc-e0875f286ae0.png)
