### PR TITLE
Adjust PageHeader component styling

### DIFF
--- a/src/js/components/PageHeader.js
+++ b/src/js/components/PageHeader.js
@@ -11,7 +11,7 @@ class PageHeader extends React.Component {
     }
 
     let iconClasses = classNames(
-      'icon icon-large icon-image-container',
+      'icon icon-large icon-app-container icon-image-container',
       iconClassName
     );
 

--- a/src/styles/components/page-header.less
+++ b/src/styles/components/page-header.less
@@ -20,6 +20,7 @@
 
 .page-header-container-left, .page-header-container-right {
 
+  align-items: center;
   display: inline-flex;
   flex: 0 0 auto;
   flex-wrap: wrap;


### PR DESCRIPTION
It looks like we forgot one of the icon classes to give it rounded corners. I also added `align-items: center` to help align the icon with the header.

Before:
![](http://cl.ly/240e1s2i2I3J/Screen%20Shot%202016-06-07%20at%201.50.47%20PM.png)

After:
![](http://cl.ly/3u3c2l3K0y2H/Screen%20Shot%202016-06-07%20at%202.00.44%20PM.png)