### PR TITLE
Update job tree parsing

### DIFF
--- a/src/js/events/ChronosActions.js
+++ b/src/js/events/ChronosActions.js
@@ -16,7 +16,7 @@ const ChronosActions = {
       return function () {
         RequestUtil.json({
           url: `${Config.rootUrl}/chronos/jobs`,
-          data: [{name: 'embed', value: 'activeJobs'}],
+          data: [{name: 'embed', value: 'activeRuns'}],
           success: function (response) {
             try {
               let data = ChronosUtil.parseJobs(response);

--- a/src/js/events/ChronosActions.js
+++ b/src/js/events/ChronosActions.js
@@ -16,7 +16,10 @@ const ChronosActions = {
       return function () {
         RequestUtil.json({
           url: `${Config.rootUrl}/chronos/jobs`,
-          data: [{name: 'embed', value: 'activeRuns'}],
+          data: [
+            {name: 'embed', value: 'activeRuns'},
+            {name: 'embed', value: 'schedules'}
+          ],
           success: function (response) {
             try {
               let data = ChronosUtil.parseJobs(response);

--- a/src/js/utils/ChronosUtil.js
+++ b/src/js/utils/ChronosUtil.js
@@ -15,10 +15,9 @@ function addJob(parent, item, jobsAlreadyAdded) {
 
   const itemId = item.id;
 
-  if (itemId !== '/' && (!itemId.startsWith('/') || itemId.endsWith('/'))) {
-    throw new Error(`Id (${itemId}) must start with a leading slash ("/") ` +
-      'and should not end with a slash, except for root id which is only ' +
-      'a slash.');
+  if ((itemId.startsWith('.') || itemId.endsWith('.'))) {
+    throw new Error(`Id (${itemId}) must not start with a leading dot (".") ` +
+      'and should not end with a dot.');
   }
 
   if (!itemId.startsWith(id)) {
@@ -33,11 +32,11 @@ function addJob(parent, item, jobsAlreadyAdded) {
     return;
   }
 
-  // Get the parent id (e.g. /group) by matching every thing but the item
-  // name including the preceding slash "/" (e.g. /id).
-  const [parentId] = itemId.match(/\/.*?(?=\/?[^/]+\/?$)/) || [null];
+  // Get the parent id (e.g. group) by matching everything but the item
+  // name including the preceding dot "." (e.g. ".name").
+  const [parentId] = itemId.match(/.*?(?=\.?[^.]+\.?$)/)
 
-  if (!parentId) {
+  if (parentId == null) {
     return;
   }
 
@@ -78,7 +77,7 @@ module.exports = {
    * }} jobs and groups in a tree structure
    */
   parseJobs(jobs) {
-    let rootTree = {id: '/'};
+    let rootTree = {id: ''};
     let jobsAlreadyAdded = {
       [rootTree.id]: rootTree
     };

--- a/src/js/utils/__tests__/ChronosUtil-test.js
+++ b/src/js/utils/__tests__/ChronosUtil-test.js
@@ -4,46 +4,38 @@ describe('ChronosUtil', function () {
 
   describe('#addJob', function () {
 
-    it('should throw error if the provided id doesn\'t start with a slash',
+    it('should throw error if the provided id  starts with a dot',
       function () {
         expect(function () {
-          ChronosUtil.parseJobs({id: 'malformed/id'});
+          ChronosUtil.parseJobs({id: '.malformed.id'});
         }.bind(this)).toThrow();
       }
     );
 
-    it('should throw error if the provided id ends with a slash',
+    it('should throw error if the provided id ends with a dot',
       function () {
         expect(function () {
-          ChronosUtil.parseJobs({id: '/malformed/id/'});
+          ChronosUtil.parseJobs({id: 'malformed.id.'});
         }.bind(this)).toThrow();
-      }
-    );
-
-    it('should not throw error if the provided id is only a slash (root id)',
-      function () {
-        expect(function () {
-          ChronosUtil.parseJobs({id: '/'});
-        }.bind(this)).not.toThrow();
       }
     );
 
     it('adds a job to the tree', function () {
-      var instance = ChronosUtil.parseJobs({id: '/alpha'});
+      var instance = ChronosUtil.parseJobs({id: 'alpha'});
 
-      expect(instance.items[0].id).toEqual('/alpha');
+      expect(instance.items[0].id).toEqual('alpha');
     });
 
     it('adds nested items at the correct location based on id/path matching',
       function () {
 
-        var instance = ChronosUtil.parseJobs({id: '/group/foo/bar'});
+        var instance = ChronosUtil.parseJobs({id: 'group.foo.bar'});
 
-        expect(instance.items[0].id).toEqual('/group');
+        expect(instance.items[0].id).toEqual('group');
         expect(instance.items[0].items[0].id)
-          .toEqual('/group/foo');
+          .toEqual('group.foo');
         expect(instance.items[0].items[0].items[0].id)
-          .toEqual('/group/foo/bar');
+          .toEqual('group.foo.bar');
       }
     );
 
@@ -61,7 +53,7 @@ describe('ChronosUtil', function () {
 
     it('should return root group if empty array is passed', function () {
       var instance = ChronosUtil.parseJobs([]);
-      expect(instance.id).toEqual('/');
+      expect(instance.id).toEqual('');
       expect(instance.items).toEqual(undefined);
     });
 
@@ -71,32 +63,32 @@ describe('ChronosUtil', function () {
 
     beforeEach(function () {
       this.instance = ChronosUtil.parseJobs([
-        {id: '/group'},
-        {id: '/group/foo'},
-        {id: '/group/bar'},
-        {id: '/group/alpha'},
-        {id: '/group/beta', cmd: '>beta', description: 'First beta'},
-        {id: '/group/beta', label: 'Beta', description: 'Second beta'},
-        {id: '/group/wibble/wobble'}
+        {id: 'group'},
+        {id: 'group.foo'},
+        {id: 'group.bar'},
+        {id: 'group.alpha'},
+        {id: 'group.beta', cmd: '>beta', description: 'First beta'},
+        {id: 'group.beta', label: 'Beta', description: 'Second beta'},
+        {id: 'group.wibble.wobble'}
       ]);
     });
 
     it('nests everything under root', function () {
-      expect(this.instance.id).toEqual('/');
+      expect(this.instance.id).toEqual('');
     });
 
     it('consolidates jobs into common parent', function () {
       expect(this.instance.items.length).toEqual(1);
-      expect(this.instance.items[0].id).toEqual('/group');
+      expect(this.instance.items[0].id).toEqual('group');
     });
 
-    it('defaults id to slash (root group id)', function () {
+    it('defaults id to empty string (root group id)', function () {
       let tree = ChronosUtil.parseJobs([]);
-      expect(tree.id).toEqual('/');
+      expect(tree.id).toEqual('');
     });
 
     it('sets correct tree id', function () {
-      expect(this.instance.items[0].id).toEqual('/group');
+      expect(this.instance.items[0].id).toEqual('group');
     });
 
     it('accepts nested trees (groups)', function () {
@@ -108,17 +100,17 @@ describe('ChronosUtil', function () {
     });
 
     it('converts a single item into a subitem of root', function () {
-      let instance = ChronosUtil.parseJobs({id: '/group/job'});
+      let instance = ChronosUtil.parseJobs({id: 'group.job'});
 
-      expect(instance.id).toEqual('/');
-      expect(instance.items[0].id).toEqual('/group');
-      expect(instance.items[0].items[0].id).toEqual('/group/job');
+      expect(instance.id).toEqual('');
+      expect(instance.items[0].id).toEqual('group');
+      expect(instance.items[0].items[0].id).toEqual('group.job');
     });
 
     it('merges data of items that are defined multiple times', function () {
       let result = this.instance.items[0].items[3];
       expect(result).toEqual({
-        id: '/group/beta',
+        id: 'group.beta',
         cmd: '>beta',
         label: 'Beta',
         description: 'Second beta'

--- a/tests/_fixtures/chronos/jobs.json
+++ b/tests/_fixtures/chronos/jobs.json
@@ -1,19 +1,21 @@
 [
   {
-    "id": "/bar",
+    "id": "bar",
     "description": "Bar Description",
     "labels": {
       "name": "bar",
       "project": "metronome",
       "stage": "test"
     },
-    "schedule": {
-      "schedule": "0 1 6 9 *",
+    "schedule": [{
+      "id": "every-once-in-a-while",
+      "description": "lorem ipsum",
+      "cron": "0 1 6 9 *",
       "timezone": "America/Chicago",
       "startingDeadlineSeconds": 60,
       "concurrencyPolicy": "allow",
       "enabled": true
-    },
+    }],
     "run": {
       "cpus": 1,
       "mem": 1,
@@ -35,7 +37,7 @@
           }
         ]
       },
-      "cmd": "/bar",
+      "cmd": "./bar",
       "args": [],
       "user": "marathon",
       "env": {
@@ -65,8 +67,8 @@
     },
     "activeRuns": [
       {
-        "id": "/bar/1990-01-03t00:00:00z-1",
-        "jobId": "/bar",
+        "id": "bar.1990-01-03t00:00:00z-1",
+        "jobId": "bar",
         "status": "active",
         "createdAt": "1990-01-03t00:00:00z-1",
         "tasks": [
@@ -80,7 +82,7 @@
     ]
   },
   {
-    "id": "/foo",
+    "id": "foo",
     "description": "Foo Description",
     "labels": {
       "name": "foo",
@@ -115,7 +117,7 @@
           }
         ]
       },
-      "cmd": "/foo",
+      "cmd": "./foo",
       "args": [],
       "user": "marathon",
       "env": {
@@ -127,8 +129,8 @@
       },
       "volumes": [
         {
-          "containerPath": "/logs",
-          "hostPath": "/var/log/mesosphere/foo",
+          "containerPath": "logs",
+          "hostPath": "var/log/mesosphere/foo",
           "mode": "RW"
         }
       ],
@@ -146,8 +148,8 @@
     },
     "activeRuns": [
       {
-        "id": "/foo/1990-01-03t00:00:00z-1",
-        "jobId": "/foo",
+        "id": "foo.1990-01-03t00:00:00z-1",
+        "jobId": "foo",
         "status": "active",
         "createdAt": "1990-01-03t00:00:00z-1",
         "tasks": [
@@ -167,7 +169,7 @@
     ]
   },
   {
-    "id": "/group/alpha",
+    "id": "group.alpha",
     "description": "Bar Description",
     "labels": {
       "name": "alpha",
@@ -202,7 +204,7 @@
           }
         ]
       },
-      "cmd": "/alpha",
+      "cmd": "./alpha",
       "args": [],
       "user": "marathon",
       "env": {
@@ -213,8 +215,8 @@
       },
       "volumes": [
         {
-          "containerPath": "/logs",
-          "hostPath": "/var/log/mesosphere/alpha",
+          "containerPath": "logs",
+          "hostPath": "var/log/mesosphere/alpha",
           "mode": "RW"
         }
       ],
@@ -232,8 +234,8 @@
     },
     "activeRuns": [
       {
-        "id": "/alpha/1990-01-03t00:00:00z-1",
-        "jobId": "/alpha",
+        "id": "alpha.1990-01-03t00:00:00z-1",
+        "jobId": "alpha",
         "status": "active",
         "createdAt": "1990-01-03t00:00:00z-1",
         "tasks": [
@@ -247,7 +249,7 @@
     ]
   },
   {
-    "id": "/group/beta",
+    "id": "group.beta",
     "description": "Foo Description",
     "labels": {
       "name": "beta",
@@ -282,7 +284,7 @@
           }
         ]
       },
-      "cmd": "/beta",
+      "cmd": "./beta",
       "args": [],
       "user": "marathon",
       "env": {
@@ -294,8 +296,8 @@
       },
       "volumes": [
         {
-          "containerPath": "/logs",
-          "hostPath": "/var/log/mesosphere/beta",
+          "containerPath": "logs",
+          "hostPath": "var/log/mesosphere/beta",
           "mode": "RW"
         }
       ],
@@ -313,8 +315,8 @@
     },
     "activeRuns": [
       {
-        "id": "/beta/1990-01-03t00:00:00z-1",
-        "jobId": "/beta",
+        "id": "beta.1990-01-03t00:00:00z-1",
+        "jobId": "beta",
         "status": "active",
         "createdAt": "1990-01-03t00:00:00z-1",
         "tasks": [


### PR DESCRIPTION
Align `ChronosUtil.parseJobs` and the fetch jobs calls with the latest API adjustments:

* Fix fetchJobs activeRuns embed param
* Change the job id/namespace matching to the new id pattern
* Add missing embed schedules param

/cc @jfurrow 