### PR TITLE
Adds defaults to composite sate.

### DIFF
--- a/src/js/pages/SystemPage.js
+++ b/src/js/pages/SystemPage.js
@@ -44,7 +44,7 @@ let SYSTEM_TABS;
 
 class SystemPage extends mixin(TabsMixin) {
   constructor() {
-    super();
+    super(...arguments);
 
     // Get top level tabs
     SYSTEM_TABS = TabsUtil.sortTabs(

--- a/src/js/structs/CompositeState.js
+++ b/src/js/structs/CompositeState.js
@@ -100,4 +100,4 @@ class CompositeState {
   }
 }
 
-module.exports = new CompositeState();
+module.exports = new CompositeState({frameworks: [], slaves: []});


### PR DESCRIPTION
So that if the Marathon response comes before Mesos there's no error.