### PR TITLE
Refactor PageHeader component

### DIFF
--- a/src/js/components/Page.js
+++ b/src/js/components/Page.js
@@ -59,7 +59,7 @@ var Page = React.createClass({
     }
 
     return (
-      <div className="page-header-navigation">
+      <div className="page-navigation-list">
         <div className="container container-fluid container-pod container-pod-short flush-bottom">
           {navigation}
         </div>
@@ -69,7 +69,7 @@ var Page = React.createClass({
 
   getPageHeader: function (title, navigation) {
     return (
-      <div className="page-header">
+      <div className="page-navigation">
         {this.getTitle(title)}
         {this.getNavigation(navigation, title)}
       </div>
@@ -84,9 +84,9 @@ var Page = React.createClass({
     }
 
     return (
-      <div className="page-header-context">
+      <div className="page-navigation-context">
         <div className="container container-fluid container-pod container-pod-short">
-          <h1 className="page-header-title inverse flush">
+          <h1 className="page-navigation-title inverse flush">
             <SidebarToggle />
             {title}
           </h1>

--- a/src/js/components/PageHeader.js
+++ b/src/js/components/PageHeader.js
@@ -11,12 +11,12 @@ class PageHeader extends React.Component {
     }
 
     let iconClasses = classNames(
-      'icon icon-large icon-image-container',
+      'icon icon-image-container',
       iconClassName
     );
 
     return (
-      <div className="media-object-item">
+      <div className="page-header-icon">
         <div className={iconClasses}>
           {icon}
         </div>
@@ -32,7 +32,7 @@ class PageHeader extends React.Component {
     }
 
     let titleClasses = classNames(
-      'flush inverse',
+      'flush-top inverse',
       titleClassName
     );
 
@@ -72,50 +72,36 @@ class PageHeader extends React.Component {
   render() {
     let {
       className,
-      dividerClassName,
-      mediaWrapperClassName,
+      pageHeaderHeadingClassNames,
       navigationTabs
     } = this.props;
 
-    let classes = classNames(
-      'container container-fluid container-pod container-pod-short',
-      'flush flush-top',
+    let pageHeaderClasses = classNames(
+      'page-header',
+      {'has-tabs': !!navigationTabs},
       className
     );
 
-    let dividerClasses = classNames(
-      'container-pod container-pod-short flush-top',
-      'container-pod-divider-bottom container-pod-divider-bottom-align-right',
-      'container-pod-divider-inverse',
-      {'flush-bottom': !!navigationTabs},
-      dividerClassName
-    );
-
-    let mediaWrapperClasses = classNames(
-      'media-object-spacing-wrapper media-object-spacing-narrow',
-      'media-object-offset',
-      mediaWrapperClassName
+    let pageHeaderHeadingClasses = classNames(
+      'page-header-heading',
+      pageHeaderHeadingClassNames
     );
 
     return (
-      <div className={classes}>
-        <div className={dividerClasses}>
-          <div className={mediaWrapperClasses}>
-            <div className="media-object flex-box flex-box-align-vertical-center page-header-container">
-              <div className="page-header-container-left">
-                {this.getIcon()}
-                <div className="media-object-item">
-                  {this.getTitle()}
-                  {this.getSubTitle()}
-                </div>
-              </div>
-              <div className="page-header-container-right">
-                {this.renderActionButtons()}
-              </div>
+      <div className={pageHeaderClasses}>
+        <div className={pageHeaderHeadingClasses}>
+          <div className="page-header-content">
+            {this.getIcon()}
+            <div className="page-header-text">
+              {this.getTitle()}
+              {this.getSubTitle()}
             </div>
           </div>
-          {navigationTabs}
+          <div className="page-header-actions">
+            {this.renderActionButtons()}
+          </div>
         </div>
+        {navigationTabs}
       </div>
     );
   }
@@ -136,11 +122,11 @@ PageHeader.propTypes = {
     React.PropTypes.string,
     React.PropTypes.object,
   ]),
-  dividerClassName: React.PropTypes.oneOfType([
+  pageHeaderClassNames: React.PropTypes.oneOfType([
     React.PropTypes.string,
     React.PropTypes.object,
   ]),
-  mediaWrapperClassName: React.PropTypes.oneOfType([
+  pageHeaderHeadingClassNames: React.PropTypes.oneOfType([
     React.PropTypes.string,
     React.PropTypes.object,
   ]),

--- a/src/js/components/ServiceInfo.js
+++ b/src/js/components/ServiceInfo.js
@@ -104,11 +104,6 @@ class ServiceInfo extends React.Component {
       );
     }
 
-    const mediaWrapperClassNames = {
-      'media-object-spacing-narrow': false,
-      'media-object-offset': false
-    };
-
     const tabs = (
       <ul className="tabs list-inline flush-bottom container-pod
         container-pod-short-top inverse">
@@ -120,9 +115,9 @@ class ServiceInfo extends React.Component {
       <PageHeader
         actionButtons={this.getActionButtons()}
         icon={serviceIcon}
+        iconClassName="icon-app-container"
         subTitle={this.getSubHeader(service)}
         navigationTabs={tabs}
-        mediaWrapperClassName={mediaWrapperClassNames}
         title={service.getName()} />
     );
   }

--- a/src/js/components/SidebarToggle.js
+++ b/src/js/components/SidebarToggle.js
@@ -55,10 +55,10 @@ var SidebarToggle = React.createClass({
 
   render: function () {
     return (
-      <div className="page-header-sidebar-toggle" onClick={this.onClick}>
-        <i className="page-header-sidebar-toggle-icon icon icon-menu icon-sprite
+      <div className="page-navigation-sidebar-toggle" onClick={this.onClick}>
+        <i className="page-navigation-sidebar-toggle-icon icon icon-menu icon-sprite
           icon-sprite-medium icon-sprite-medium-white"></i>
-        <span className="page-header-sidebar-toggle-label">
+        <span className="page-navigation-sidebar-toggle-label">
           Show/Hide Sidebar
         </span>
       </div>

--- a/src/js/components/TaskDetail.js
+++ b/src/js/components/TaskDetail.js
@@ -177,6 +177,7 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
     return (
       <PageHeader
         icon={taskIcon}
+        iconClassName="icon-app-container"
         subTitle={TaskStates[task.state].displayName}
         navigationTabs={tabs}
         mediaWrapperClassName={mediaWrapperClassNames}

--- a/src/js/components/__tests__/ServiceInfo-test.js
+++ b/src/js/components/__tests__/ServiceInfo-test.js
@@ -52,13 +52,13 @@ describe('ServiceInfo', function () {
 
     it('renders health state', function () {
       expect(
-        this.node.querySelectorAll('.media-object-item')[2].textContent
+        this.node.querySelectorAll('.page-header-text')[0].children[1].children[0].textContent
       ).toEqual('Healthy');
     });
 
     it('renders number of running tasks', function () {
       expect(
-        this.node.querySelectorAll('.media-object-item')[3].textContent
+        this.node.querySelectorAll('.page-header-text')[0].children[1].children[1].textContent
       ).toEqual('2 Running Tasks');
     });
 

--- a/src/styles/components/page-header.less
+++ b/src/styles/components/page-header.less
@@ -1,29 +1,166 @@
-.page-header-container {
-
+.page-header {
   display: flex;
-  flex-wrap: wrap-reverse;
+  margin-bottom: @base-spacing-unit;
+  position: relative;
+  flex-direction: column;
   width: 100%;
 
+  &.has-tabs {
+
+    &:after {
+      background: @border-color-inverse;
+      content: '';
+      height: 1px;
+      left: 0;
+      position: absolute;
+      right: @grid-container-fluid-gutter-width * -1;
+      width: auto;
+      z-index: @z-index-header-border;
+    }
+
+    .tabs {
+      position: relative;
+      z-index: @z-index-header-tabs;
+    }
+  }
 }
 
-.page-header-container-right {
+.page-header-heading {
+  display: flex;
+  flex-wrap: wrap;
+}
 
-  margin-left: auto;
+.page-header-icon {
+  padding-right: @base-spacing-unit * 1/4;
+
+  .icon {
+    height: 64px;
+    width: 64px;
+  }
+}
+
+.page-header-text {
+
+  h1 {
+    margin-bottom: @base-spacing-unit * 1/3;
+  }
+}
+
+.page-header-content,
+.page-header-actions {
+  display: inline-flex;
+}
+
+.page-header-content {
+  flex: 1 1 auto;
+}
+
+.page-header-actions {
+  flex: 0 1 auto;
+  margin-left: 0;
+  margin-top: @base-spacing-unit * 1/4;
+  white-space: nowrap;
 
   &:last-child {
-
     padding-right: 0;
+  }
+}
+
+& when (@screen-mini-enabled) {
+
+  @media (min-width: @screen-mini) {
+
+    .page-header {
+      margin-bottom: @base-spacing-unit-screen-mini;
+
+      &.has-tabs {
+
+        &:after {
+          right: @grid-container-fluid-gutter-width-screen-mini * -1;
+        }
+      }
+    }
+
+    .page-header-icon {
+      padding-right: @base-spacing-unit-screen-mini * 1/4;
+    }
 
   }
 
 }
 
-.page-header-container-left, .page-header-container-right {
+& when (@screen-small-enabled) {
 
-  display: inline-flex;
-  flex: 0 0 auto;
-  flex-wrap: wrap;
-  max-width: 100%;
-  width: auto;
+  @media (min-width: @screen-small) {
+
+    .page-header {
+      margin-bottom: @base-spacing-unit-screen-small;
+
+      &.has-tabs {
+
+        &:after {
+          right: @grid-container-fluid-gutter-width-screen-small * -1;
+        }
+      }
+    }
+
+    .page-header-actions {
+      margin-left: auto;
+      margin-top: 0;
+    }
+
+    .page-header-heading {
+      flex-wrap: nowrap;
+    }
+
+    .page-header-icon {
+      padding-right: @base-spacing-unit-screen-small * 1/4;
+    }
+
+  }
+
+}
+
+& when (@screen-medium-enabled) {
+
+  @media (min-width: @screen-medium) {
+
+    .page-header {
+
+      &.has-tabs {
+
+        &:after {
+          right: @grid-container-fluid-gutter-width-screen-medium * -1;
+        }
+      }
+    }
+
+    .page-header-icon {
+      padding-right: @base-spacing-unit-screen-medium * 1/4;
+    }
+
+  }
+
+}
+
+& when (@screen-large-enabled) {
+
+  @media (min-width: @screen-large) {
+
+    .page-header {
+
+      &.has-tabs {
+
+        &:after {
+          right: @grid-container-fluid-gutter-width-screen-large * -1;
+        }
+      }
+    }
+
+    .page-header-icon {
+      padding-right: @base-spacing-unit-screen-large * 1/4;
+    }
+
+  }
 
 }

--- a/src/styles/components/scrollbar.less
+++ b/src/styles/components/scrollbar.less
@@ -2,6 +2,7 @@
   right: 3px;
   bottom: 3px;
   border-radius: 4px;
+  z-index: @gemini-scrollbar-handle;
 }
 
 .gm-scrollbar.-vertical {

--- a/src/styles/layout/page.less
+++ b/src/styles/layout/page.less
@@ -1,4 +1,4 @@
-@page-header-font-size: @body-text-font-size * 1.4;
+@page-navigation-font-size: @body-text-font-size * 1.4;
 
 .page {
   display: flex;
@@ -11,13 +11,13 @@
   transition: left 0.3s ease-in-out, margin-left 0.3s ease-in-out;
   width: 100%;
 
-  .page-header {
+  .page-navigation {
     .clearfix();
-    background-color: @page-header-background-color;
+    background-color: @page-navigation-background-color;
 
-    .page-header-navigation {
+    .page-navigation-list {
 
-      font-size: @page-header-font-size;
+      font-size: @page-navigation-font-size;
 
       .tab-item {
         .tab-item-label {
@@ -32,7 +32,7 @@
       }
     }
 
-    .page-header-context {
+    .page-navigation-context {
       width: 100%;
 
       .tabs {
@@ -46,7 +46,7 @@
                 .opacity(1);
               }
 
-              .page-header-title {
+              .page-navigation-title {
                 color: @white;
               }
 
@@ -55,7 +55,7 @@
           }
 
           &:not(.active) {
-            .page-header-title {
+            .page-navigation-title {
               color: color-lighten(@neutral, 40);
             }
           }
@@ -63,29 +63,29 @@
       }
 
       /* Page Header Sidebar Toggle */
-      .page-header-sidebar-toggle {
+      .page-navigation-sidebar-toggle {
         position: relative;
         float: left;
         cursor: pointer;
-        z-index: @z-index-page-header-sidebar-toggle;
+        z-index: @z-index-page-navigation-sidebar-toggle;
 
-        .page-header-sidebar-toggle-icon {
+        .page-navigation-sidebar-toggle-icon {
           margin-right: (@base-spacing-unit * 1.0);
           .opacity(0.40);
         }
 
-        .page-header-sidebar-toggle-label {
+        .page-navigation-sidebar-toggle-label {
           display: none;
         }
 
         &:hover {
-           .page-header-sidebar-toggle-icon {
+           .page-navigation-sidebar-toggle-icon {
             .opacity(0.80);
           }
         }
 
         &:active {
-           .page-header-sidebar-toggle-icon {
+           .page-navigation-sidebar-toggle-icon {
             .opacity(0.40);
           }
         }
@@ -93,12 +93,12 @@
     }
 
     /* Page Header Actions */
-    .page-header-actions {
+    .page-navigation-actions {
       float: right;
     }
 
     /* Page Header Navigation */
-    .page-header-navigation {
+    .page-navigation-navigation {
       clear: both;
     }
   }
@@ -145,9 +145,9 @@
   @media (max-width: @screen-mini-max) {
     .page {
 
-      .page-header {
+      .page-navigation {
 
-        .page-header-navigation {
+        .page-navigation-navigation {
 
           .container-pod {
             padding-top: 0;
@@ -168,13 +168,13 @@
       transition: none;
       width: auto;
 
-      .page-header {
+      .page-navigation {
 
-        .page-header-context {
+        .page-navigation-context {
           display: none;
         }
 
-        .page-header-navigation {
+        .page-navigation-navigation {
 
           padding-top: @base-spacing-unit-screen-small * 0.2;
 
@@ -190,9 +190,9 @@
 
     .page {
 
-      .page-header {
+      .page-navigation {
 
-        .page-header-navigation {
+        .page-navigation-navigation {
 
           padding-top: @base-spacing-unit-screen-medium * 0.2;
 
@@ -208,9 +208,9 @@
 
     .page {
 
-      .page-header {
+      .page-navigation {
 
-        .page-header-navigation {
+        .page-navigation-navigation {
 
           padding-top: @base-spacing-unit-screen-large * 0.2;
 

--- a/src/styles/variables/variables-layout.less
+++ b/src/styles/variables/variables-layout.less
@@ -123,7 +123,7 @@ Body
 Page
 ----------------------------------------------------------------------------- */
 
-@page-header-background-color:                                                  color-lighten(@neutral, -50);
+@page-navigation-background-color:                                              color-lighten(@neutral, -50);
 
 
 

--- a/src/styles/variables/variables-z-index.less
+++ b/src/styles/variables/variables-z-index.less
@@ -21,13 +21,16 @@ Z-Index Depths
 @z-index-dropdown-chart-details:                                                @z-index-side-panel + 20;
 @z-index-dygraph-chart:                                                         @z-index-side-panel + 10;
 @z-index-dygraph-hover-label:                                                   100;
+@gemini-scrollbar-handle:                                                       @z-index-header-tabs + 1;
 @z-index-header:                                                                1000;
+@z-index-header-border:                                                         1;
+@z-index-header-tabs:                                                           @z-index-header-border + 1;
 @z-index-modal-backdrop:                                                        @z-index-modal + 1;
 @z-index-modal-container:                                                       @z-index-modal + 2;
 @z-index-nodes-grid:                                                            2;
 @z-index-overlay:                                                               @z-index-side-panel + 10;
 @z-index-overlay-header:                                                        @z-index-side-panel + 2;
-@z-index-page-header-sidebar-toggle:                                            100;
+@z-index-page-navigation-sidebar-toggle:                                            100;
 @z-index-side-panel:                                                            2000;
 @z-index-side-panel-container:                                                  @z-index-side-panel + 4;
 @z-index-side-panel-expand-button:                                              @z-index-side-panel + 10;

--- a/tests/pages/jobs/JobsOverview-cy.js
+++ b/tests/pages/jobs/JobsOverview-cy.js
@@ -9,7 +9,7 @@ describe('Jobs Overview', function () {
     });
 
     it('has the right active navigation entry', function () {
-      cy.get('.page-header-navigation .tab-item.active')
+      cy.get('.page-navigation-list .tab-item.active')
         .should('to.have.text', 'Jobs');
     });
 

--- a/tests/pages/system/overview/components/UnitsHealthTab-cy.js
+++ b/tests/pages/system/overview/components/UnitsHealthTab-cy.js
@@ -82,7 +82,7 @@ describe('Units Tab [0e2]', function () {
 
     it('renders unit health [0eb]', function () {
       cy.wait(2000);
-      cy.get('.page-content .container-pod.flush-top')
+      cy.get('.page-content .page-header-text')
         .find('.text-danger')
         .should(function ($health) {
           expect($health).to.contain('Unhealthy');
@@ -124,7 +124,7 @@ describe('Units Tab [0e2]', function () {
 
     it('renders node health [0ej]', function () {
       cy.wait(2000);
-      cy.get('.page-content .container-pod.flush-top')
+      cy.get('.page-content .page-header-text')
         .find('.text-success')
         .should(function ($health) {
           expect($health).to.contain('Healthy');

--- a/tests/pages/universe/installed/InstalledPackagesTab-cy.js
+++ b/tests/pages/universe/installed/InstalledPackagesTab-cy.js
@@ -11,7 +11,7 @@ xdescribe('Installed Packages Tab', function () {
 
   it('activates the correct tab', function () {
     cy
-      .get('.page-header-navigation .tab-item.active .tab-item-label')
+      .get('.page-navigation-list .tab-item.active .tab-item-label')
       .should('contain', 'Installed');
   });
 


### PR DESCRIPTION
The `PageHeader` component was a little difficult to work with previously, due to its inheritance of multiple unrelated style components. This PR introduces styles specifically for the `PageHeader` that more closely match the design. Its behavior at smaller viewport widths is more consistent as well.

I also decided to change the classname of our page's tabbed navigation, which was previously called `page-header`. I think this will help clarify the roles of the elements.