### PR TITLE
[Log View Bug] Bug fix: log view scroll

### DIFF
--- a/src/js/components/Breadcrumbs.js
+++ b/src/js/components/Breadcrumbs.js
@@ -238,7 +238,7 @@ class Breadcrumbs extends mixin(StoreMixin) {
 
   render() {
     let classSet = classNames(
-      'list-unstyled breadcrumb',
+      'list-unstyled breadcrumb flex-no-shrink',
       {collapsed: this.state.collapsed},
       this.props.breadcrumbClasses
     );

--- a/src/js/components/Breadcrumbs.js
+++ b/src/js/components/Breadcrumbs.js
@@ -238,7 +238,7 @@ class Breadcrumbs extends mixin(StoreMixin) {
 
   render() {
     let classSet = classNames(
-      'list-unstyled breadcrumb flex-no-shrink',
+      'list-unstyled breadcrumb',
       {collapsed: this.state.collapsed},
       this.props.breadcrumbClasses
     );

--- a/src/js/components/Page.js
+++ b/src/js/components/Page.js
@@ -79,7 +79,9 @@ var Page = React.createClass({
   getTitle: function (title) {
     if (!title) {
       return null;
-    } else if (React.isValidElement(title)) {
+    }
+
+    if (React.isValidElement(title)) {
       return title;
     }
 
@@ -128,7 +130,7 @@ var Page = React.createClass({
         {content}
       </GeminiScrollbar>
     );
-  }
+  },
 
   render: function () {
     let {className, navigation, dontScroll, title} = this.props;

--- a/src/js/components/Page.js
+++ b/src/js/components/Page.js
@@ -1,4 +1,4 @@
-var classNames = require('classnames');
+import classNames from 'classnames/dedupe';
 var GeminiScrollbar = require('react-gemini-scrollbar');
 var React = require('react');
 import {StoreMixin} from 'mesosphere-shared-reactjs';
@@ -42,7 +42,7 @@ var Page = React.createClass({
   },
 
   onSidebarStoreWidthChange: function () {
-    GeminiUtil.updateWithRef(this.refs.pageRef);
+    GeminiUtil.updateWithRef(this.refs.gemini);
   },
 
   getChildren: function () {
@@ -95,20 +95,54 @@ var Page = React.createClass({
     );
   },
 
-  render: function () {
-    let {className, navigation, title} = this.props;
+  getContent: function () {
+    let {dontScroll} = this.props;
+    let contentClassSet = classNames('page-content inverse', {
+      'flex-container-col flex-grow flex-shrink': dontScroll
+    });
+    let contentInnerClassSet = classNames(
+      'flex-container-col container container-fluid',
+      'container-pod container-pod-short-top',
+      {'flex-grow flex-shrink': dontScroll}
+    );
 
-    let classSet = classNames('page flex-container-col', className);
+    let content = (
+      <div className={contentInnerClassSet}>
+        {this.getChildren()}
+      </div>
+    );
+
+    if (dontScroll) {
+      return (
+        <div className={contentClassSet}>
+          {content}
+        </div>
+      );
+    }
+
+    return (
+      <GeminiScrollbar
+        autoshow={true}
+        className={contentClassSet}
+        ref="gemini">
+        {content}
+      </GeminiScrollbar>
+    );
+  }
+
+  render: function () {
+    let {className, navigation, dontScroll, title} = this.props;
+
+    let classSet = classNames(
+      'page',
+      {'flex-grow flex-shrink': dontScroll},
+      className
+    );
 
     return (
       <div className={classSet}>
         {this.getPageHeader(title, navigation)}
-        <GeminiScrollbar autoshow={true} className="page-content
-          container-scrollable inverse" ref="pageRef">
-          <div className="flex-container-col container container-fluid container-pod container-pod-short-top">
-            {this.getChildren()}
-          </div>
-        </GeminiScrollbar>
+        {this.getContent()}
       </div>
     );
   }

--- a/src/js/components/Page.js
+++ b/src/js/components/Page.js
@@ -14,7 +14,12 @@ var Page = React.createClass({
   mixins: [InternalStorageMixin, StoreMixin],
 
   propTypes: {
-    className: React.PropTypes.string,
+    className: React.PropTypes.oneOfType([
+      React.PropTypes.array,
+      React.PropTypes.object,
+      React.PropTypes.string
+    ]),
+    dontScroll: React.PropTypes.bool,
     navigation: React.PropTypes.oneOfType([
       React.PropTypes.object,
       React.PropTypes.string

--- a/src/js/components/PageHeader.js
+++ b/src/js/components/PageHeader.js
@@ -78,7 +78,7 @@ class PageHeader extends React.Component {
     } = this.props;
 
     let pageHeaderClasses = classNames(
-      'page-header',
+      'page-header flex-no-shrink',
       {'has-tabs': !!navigationTabs},
       className
     );

--- a/src/js/pages/ServicesPage.js
+++ b/src/js/pages/ServicesPage.js
@@ -53,9 +53,13 @@ var ServicesPage = React.createClass({
   },
 
   render: function () {
+    // Make sure to grow when logs are displayed
+    let routes = this.context.router.getCurrentRoutes();
+
     return (
       <Page
         navigation={this.getNavigation()}
+        dontScroll={routes[routes.length - 1].dontScroll}
         title="Services">
         <RouteHandler />
       </Page>

--- a/src/js/pages/__tests__/ServicesTab-test.js
+++ b/src/js/pages/__tests__/ServicesTab-test.js
@@ -43,7 +43,12 @@ describe('ServicesTab', function () {
 
     it('are set to the default values if not stored', function () {
       ReactDOM.render(
-        JestUtil.stubRouterContext(ServicesTab, {params: {id: '/'}}),
+        JestUtil.stubRouterContext(ServicesTab, {params: {id: '/'}},
+        {
+          getCurrentRoutes: function () {
+            return [{name: 'services-task-details-tab'}];
+          }
+        }),
         this.container
       );
       expect(QueryParamsMixin.setQueryParam).toHaveBeenCalledWith(
@@ -62,7 +67,12 @@ describe('ServicesTab', function () {
         }
       });
       ReactDOM.render(
-        JestUtil.stubRouterContext(ServicesTab, {params: {id: '/'}}),
+        JestUtil.stubRouterContext(ServicesTab, {params: {id: '/'}},
+        {
+          getCurrentRoutes: function () {
+            return [{name: 'services-task-details-tab'}];
+          }
+        }),
         this.container
       );
       expect(QueryParamsMixin.setQueryParam).toHaveBeenCalledWith(
@@ -79,7 +89,12 @@ describe('ServicesTab', function () {
 
     it('renders the service table', function () {
       var instance = ReactDOM.render(
-        JestUtil.stubRouterContext(ServicesTab, {params: {id: '/'}}),
+        JestUtil.stubRouterContext(ServicesTab, {params: {id: '/'}},
+        {
+          getCurrentRoutes: function () {
+            return [{name: 'services-task-details-tab'}];
+          }
+        }),
         this.container
       );
 
@@ -90,7 +105,12 @@ describe('ServicesTab', function () {
 
     it('renders the service detail', function () {
       var instance = ReactDOM.render(
-        JestUtil.stubRouterContext(ServicesTab, {params: {id: '/alpha'}}),
+        JestUtil.stubRouterContext(ServicesTab, {params: {id: '/alpha'}},
+        {
+          getCurrentRoutes: function () {
+            return [{name: 'services-task-details-tab'}];
+          }
+        }),
         this.container
       );
 
@@ -102,7 +122,12 @@ describe('ServicesTab', function () {
     it('renders loading screen', function () {
       DCOSStore.dataProcessed = false;
       var instance = ReactDOM.render(
-        JestUtil.stubRouterContext(ServicesTab, {params: {id: '/'}}),
+        JestUtil.stubRouterContext(ServicesTab, {params: {id: '/'}},
+        {
+          getCurrentRoutes: function () {
+            return [{name: 'services-task-details-tab'}];
+          }
+        }),
         this.container
       );
 
@@ -115,7 +140,12 @@ describe('ServicesTab', function () {
     it('renders correct empty panel', function () {
       DCOSStore.serviceTree = new ServiceTree({id: '/'});
       var instance = ReactDOM.render(
-        JestUtil.stubRouterContext(ServicesTab, {params: {id: '/'}}),
+        JestUtil.stubRouterContext(ServicesTab, {params: {id: '/'}},
+        {
+          getCurrentRoutes: function () {
+            return [{name: 'services-task-details-tab'}];
+          }
+        }),
         this.container
       );
 

--- a/src/js/pages/nodes/NodeDetailPage.js
+++ b/src/js/pages/nodes/NodeDetailPage.js
@@ -204,6 +204,7 @@ class NodeDetailPage extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) 
     let node = this.internalStorage_get().node;
     let {params} = this.props;
 
+    // TODO (DCOS-7580): Clean up NodeDetailPage routed and unrouted views
     if (!node) {
       return (
         <Page title="Nodes">
@@ -213,8 +214,13 @@ class NodeDetailPage extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) 
     }
 
     if (params.taskID) {
+      // Make sure to grow when logs are displayed
+      let routes = this.context.router.getCurrentRoutes();
+
       return (
-        <Page title="Nodes">
+        <Page
+          dontScroll={routes[routes.length - 1].dontScroll}
+          title="Nodes">
           <RouteHandler />
         </Page>
       );

--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -1,5 +1,5 @@
-import React from 'react';
 import classNames from 'classnames';
+import React from 'react';
 import {RouteHandler} from 'react-router';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 

--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import {RouteHandler} from 'react-router';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
@@ -259,8 +260,14 @@ var ServicesTab = React.createClass({
     // Find item in root tree and default to root tree if there is no match
     let item = DCOSStore.serviceTree.findItemById(id) || DCOSStore.serviceTree;
 
+    // Make sure to grow when logs are displayed
+    let routes = this.context.router.getCurrentRoutes();
+    let classes = classNames({
+      'flex-container-col flex-grow flex-shrink': routes[routes.length - 1].dontScroll
+    });
+
     return (
-      <div>
+      <div className={classes}>
         {this.getContents(item)}
         <ServiceGroupFormModal
           open={state.isServiceGroupFormModalShown}

--- a/src/js/routes/nodes.js
+++ b/src/js/routes/nodes.js
@@ -119,6 +119,7 @@ let nodesRoutes = {
             {
               type: Route,
               name: 'nodes-task-details-logs',
+              dontScroll: true,
               path: 'logs/?',
               handler: TaskLogsTab,
               buildBreadCrumb: function () {

--- a/src/js/routes/services.js
+++ b/src/js/routes/services.js
@@ -111,6 +111,7 @@ let serviceRoutes = {
                 {
                   type: Route,
                   name: 'services-task-details-logs',
+                  dontScroll: true,
                   path: 'logs/?',
                   handler: TaskLogsTab,
                   buildBreadCrumb: function () {

--- a/src/js/utils/RouterUtil.js
+++ b/src/js/utils/RouterUtil.js
@@ -46,9 +46,13 @@ const RouterUtil = {
         );
       }
 
-      if (originalConfiguration.buildBreadCrumb) {
-        route.buildBreadCrumb = originalConfiguration.buildBreadCrumb;
-      }
+      // Transfer any property that is not already present on route,
+      // but available in originalConfiguration
+      Object.keys(originalConfiguration).forEach(function (prop) {
+        if (!route.hasOwnProperty(prop)) {
+          route[prop] = originalConfiguration[prop];
+        }
+      });
 
       return route;
     });

--- a/src/styles/components/breadcrumbs.less
+++ b/src/styles/components/breadcrumbs.less
@@ -34,7 +34,7 @@ Breadcrumbs
 
 .breadcrumb {
   display: flex;
-  flex: 0;
+  flex: 0 0;
   font-size: @base-spacing-unit * .65;
   line-height: @base-spacing-unit;
   list-style: none !important;

--- a/src/styles/layout/page.less
+++ b/src/styles/layout/page.less
@@ -3,6 +3,7 @@
 .page {
   display: flex;
   flex: 1;
+  flex-direction: column;
   height: 100%;
   left: 0px;
   overflow: hidden;

--- a/tests/_fixtures/chronos/jobs.json
+++ b/tests/_fixtures/chronos/jobs.json
@@ -38,8 +38,10 @@
           }
         ]
       },
-      "cmd": "./bar",
-      "args": [],
+      "cmd": "/bar",
+      "args": [
+        
+      ],
       "user": "marathon",
       "env": {
         "ENV_VAR": "bar"
@@ -118,8 +120,10 @@
           }
         ]
       },
-      "cmd": "./foo",
-      "args": [],
+      "cmd": "/foo",
+      "args": [
+        
+      ],
       "user": "marathon",
       "env": {
         "DRY_RUN": "false",
@@ -205,8 +209,10 @@
           }
         ]
       },
-      "cmd": "./alpha",
-      "args": [],
+      "cmd": "/alpha",
+      "args": [
+        
+      ],
       "user": "marathon",
       "env": {
         "ENV_VAR": "alpha"
@@ -285,8 +291,10 @@
           }
         ]
       },
-      "cmd": "./beta",
-      "args": [],
+      "cmd": "/beta",
+      "args": [
+        
+      ],
       "user": "marathon",
       "env": {
         "DRY_RUN": "false",


### PR DESCRIPTION
---
~~⚠️ Dependent on this branch: https://github.com/dcos/dcos-ui/pull/358~~

~~ℹ️ REVIEWER LOOK HERE (diff between this and its depending branch): https://github.com/dcos/dcos-ui/compare/mlunoe/make-task-detail-tabs-routable...mlunoe/bug-fix-log-view-scroll?expand=1~~

---
Node Detail Page log tab scrolls within log view:
![](http://cl.ly/1y2E2P2x3Z1Y/Image%202016-06-08%20at%2013.43.13.png)

Scrolls whole page on any other nodes detail page
![](http://cl.ly/3j3V1m2b0O2m/Image%202016-06-08%20at%2013.43.53.png)

Service Detail Page log tab scrolls within log view:
![](http://cl.ly/2f1i1d1i0d0a/Image%202016-06-08%20at%2013.48.20.png)

Scrolls whole page on any other service detail page
![](http://cl.ly/3W310k2G3D3B/Image%202016-06-08%20at%2013.48.52.png)