### PR TITLE
[5] Deployments Table - Introduce service rows

### DIFF
--- a/src/js/components/ServicesBreadcrumb.js
+++ b/src/js/components/ServicesBreadcrumb.js
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React from 'react';
 import {Link} from 'react-router';
 
@@ -74,9 +75,15 @@ class ServicesBreadcrumb extends React.Component {
       );
     }
 
+    const classes = classNames('flex-box control-group', this.props.className);
+    const h4Classes = classNames(
+      'breadcrumbs flush-top inverse',
+      this.props.h4ClassNames
+    );
+
     return (
-      <div className="flex-box control-group">
-        <h4 className="breadcrumbs flush-top inverse">
+      <div className={classes}>
+        <h4 className={h4Classes}>
           {breadcrumbNodes}
         </h4>
       </div>
@@ -85,6 +92,8 @@ class ServicesBreadcrumb extends React.Component {
 }
 
 ServicesBreadcrumb.propTypes = {
+  className: React.PropTypes.string,
+  h4ClassName: React.PropTypes.string,
   serviceTreeItem: React.PropTypes.object.isRequired,
   taskID: React.PropTypes.string
 };

--- a/src/js/components/ServicesBreadcrumb.js
+++ b/src/js/components/ServicesBreadcrumb.js
@@ -75,15 +75,15 @@ class ServicesBreadcrumb extends React.Component {
       );
     }
 
-    const classes = classNames('flex-box control-group', this.props.className);
-    const h4Classes = classNames(
+    const classSet = classNames('flex-box control-group', this.props.className);
+    const h4ClassSet = classNames(
       'breadcrumbs flush-top inverse',
       this.props.h4ClassNames
     );
 
     return (
-      <div className={classes}>
-        <h4 className={h4Classes}>
+      <div className={classSet}>
+        <h4 className={h4ClassSet}>
           {breadcrumbNodes}
         </h4>
       </div>

--- a/src/js/components/ServicesBreadcrumb.js
+++ b/src/js/components/ServicesBreadcrumb.js
@@ -76,14 +76,14 @@ class ServicesBreadcrumb extends React.Component {
     }
 
     const classSet = classNames('flex-box control-group', this.props.className);
-    const h4ClassSet = classNames(
+    const headerClassSet = classNames(
       'breadcrumbs flush-top inverse',
-      this.props.h4ClassNames
+      this.props.headerClassNames
     );
 
     return (
       <div className={classSet}>
-        <h4 className={h4ClassSet}>
+        <h4 className={headerClassSet}>
           {breadcrumbNodes}
         </h4>
       </div>
@@ -93,7 +93,7 @@ class ServicesBreadcrumb extends React.Component {
 
 ServicesBreadcrumb.propTypes = {
   className: React.PropTypes.string,
-  h4ClassName: React.PropTypes.string,
+  headerClassName: React.PropTypes.string,
   serviceTreeItem: React.PropTypes.object.isRequired,
   taskID: React.PropTypes.string
 };

--- a/src/js/pages/__tests__/DeploymentsTab-test.js
+++ b/src/js/pages/__tests__/DeploymentsTab-test.js
@@ -4,6 +4,7 @@ jest.unmock('../../structs/DeploymentsList');
 jest.unmock('../../structs/Deployment');
 jest.unmock('../../mixins/GetSetMixin');
 
+import JestUtil from '../../utils/JestUtil';
 /* eslint-disable no-unused-vars */
 import React from 'react';
 /* eslint-enable no-unused-vars */
@@ -12,6 +13,7 @@ import ReactDOM from 'react-dom';
 import DCOSStore from '../../stores/DCOSStore';
 import DeploymentsTab from '../services/DeploymentsTab';
 import DeploymentsList from '../../structs/DeploymentsList';
+import Service from '../../structs/Service';
 
 describe('DeploymentsTab', function () {
 
@@ -27,18 +29,24 @@ describe('DeploymentsTab', function () {
           id: 'deployment-id',
           version: '2001-01-01T01:01:01.001Z',
           currentStep: 2,
-          totalSteps: 3
+          totalSteps: 3,
+          affectedApps: ['service-1', 'service-2'],
+          affectedServices: [
+            new Service({name: 'service-1', deployments: []}),
+            new Service({name: 'service-2', deployments: []})
+          ]
         }
       ]
     });
     DCOSStore.deploymentsList = deployments;
     this.container = document.createElement('div');
     this.instance = ReactDOM.render(
-      <DeploymentsTab />,
+      JestUtil.stubRouterContext(DeploymentsTab, {}),
       this.container
     );
     this.node = ReactDOM.findDOMNode(this.instance);
     this.tbody = this.node.querySelector('tbody');
+    this.trs = this.tbody.querySelectorAll('tr');
     this.tds = this.tbody.querySelectorAll('td');
   });
 
@@ -54,20 +62,46 @@ describe('DeploymentsTab', function () {
     });
 
     it('should render one row per deployment', function () {
-      let trs = this.tbody.querySelectorAll('tr');
-      expect(trs.length).toEqual(1);
+      expect(this.trs.length).toEqual(1);
     });
 
-    it('should render the deployment ID', function () {
-      expect(this.tds[0].textContent).toEqual('deployment-id');
+    describe('affected services column', function () {
+      it('should render the deployment ID', function () {
+        let dt = this.tds[0].querySelector('dt');
+        expect(dt.textContent).toEqual('deployment-id');
+      });
+      it('should render each affected application', function () {
+        let dds = this.tds[0].querySelectorAll('dd');
+        expect(dds.length).toEqual(2);
+      });
     });
 
-    it('should render the deployment start time', function () {
-      expect(this.tds[1].textContent).toEqual('15 years ago');
+    describe('location column', function () {
+      it('should render a location for each service', function () {
+        let lis = this.tds[1].querySelectorAll('li');
+        expect(lis.length).toEqual(2);
+      });
     });
 
-    it('should render the deployment progress', function () {
-      expect(this.tds[2].textContent).toEqual('Step 2 of 3');
+    describe('timing column', function () {
+      it('should render the deployment start time', function () {
+        expect(this.tds[2].textContent).toEqual('15 years ago');
+      });
+      it('should render a `time` element', function () {
+        let time = this.tds[2].querySelector('time');
+        expect(time.getAttribute('dateTime')).toEqual('2001-01-01T01:01:01.001Z');
+      });
+    });
+
+    describe('status column', function () {
+      it('should render the deployment progress', function () {
+        let deploymentStep = this.tds[3].querySelector('.deployment-step');
+        expect(deploymentStep.textContent).toEqual('Step 2 of 3');
+      });
+      it('should render the status of each application', function () {
+        let lis = this.tds[3].querySelectorAll('li');
+        expect(lis.length).toEqual(2);
+      });
     });
 
   });

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -1,3 +1,5 @@
+import classNames from 'classnames';
+import {Link} from 'react-router';
 import moment from 'moment';
 import mixin from 'reactjs-mixin';
 /* eslint-disable no-unused-vars */
@@ -9,39 +11,22 @@ import {Table} from 'reactjs-components';
 import AlertPanel from '../../components/AlertPanel';
 import DCOSStore from '../../stores/DCOSStore';
 import ResourceTableUtil from '../../utils/ResourceTableUtil';
-import StringUtil from '../../utils/StringUtil'
+import ServicesBreadcrumb from '../../components/ServicesBreadcrumb';
+import StringUtil from '../../utils/StringUtil';
 
 const columnClassNameGetter = ResourceTableUtil.getClassName;
 const columnHeading = ResourceTableUtil.renderHeading({
-  id: 'DEPLOYMENT',
+  id: 'AFFECTED SERVICES',
   startTime: 'STARTED',
+  location: 'LOCATION',
   status: 'STATUS'
 });
-const columns = [
-  {
-    className: columnClassNameGetter,
-    heading: columnHeading,
-    prop: 'id',
-    render: function (prop, deployment) {
-      return deployment.getId();
-    }
-  },
-  {
-    className: columnClassNameGetter,
-    heading: columnHeading,
-    prop: 'startTime',
-    render: function (prop, deployment) {
-      return moment(deployment.getStartTime()).fromNow();
-    }
-  },
-  {
-    className: columnClassNameGetter,
-    heading: columnHeading,
-    prop: 'status',
-    render: function (prop, deployment) {
-      return `Step ${deployment.getCurrentStep()} of ${deployment.getTotalSteps()}`;
-    }
-  }
+const METHODS_TO_BIND = [
+  'renderAffectedServices',
+  'renderAffectedServicesList',
+  'renderLocation',
+  'renderStartTime',
+  'renderStatus'
 ];
 
 class DeploymentsTab extends mixin(StoreMixin) {
@@ -53,10 +38,121 @@ class DeploymentsTab extends mixin(StoreMixin) {
     this.store_listeners = [
       {name: 'dcos', events: ['change'], suppressUpdate: true}
     ];
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    }, this);
   }
 
   onDcosStoreChange() {
     this.setState({deployments: DCOSStore.deploymentsList});
+  }
+
+  renderAffectedServices(prop, deployment) {
+    return (
+      <dl className="deployment-services-list flush-top flush-bottom tree-list">
+        <dt className="deployment-id text-uppercase">{deployment.id}</dt>
+        {this.renderAffectedServicesList(deployment.getAffectedServices())}
+      </dl>
+    );
+  }
+
+  renderAffectedServicesList(services) {
+    return services.map(function (service, index) {
+      const id = encodeURIComponent(service.getId());
+      const image = service.getImages()['icon-small'];
+
+      return (
+        <dd key={index}>
+          <span className="icon icon-small icon-image-container icon-app-container deployment-service-icon">
+            <img src={image} />
+          </span>
+          <Link to="services-detail" params={{id}}>
+            {StringUtil.capitalize(service.getName())}
+          </Link>
+        </dd>
+      );
+    });
+  }
+
+  renderLocation(prop, deployment) {
+    const services = deployment.getAffectedServices();
+    const items = services.map(function (service, index) {
+      return (
+        <li key={index}>
+          <ServicesBreadcrumb
+            className="deployment-breadcrumb"
+            h4ClassNames="flush-bottom"
+            serviceTreeItem={service} />
+        </li>
+      );
+    });
+
+    return (
+      <ol className="deployment-location-list list-unstyled flush-bottom">
+        {items}
+      </ol>
+    );
+  }
+
+  renderStartTime(prop, deployment) {
+    const time = deployment.getStartTime();
+
+    return (
+      <time dateTime={time.toISOString()} className="deployment-start-time">
+        {moment(time).fromNow()}
+      </time>
+    );
+  }
+
+  renderStatus(prop, deployment) {
+    const title = `Step ${deployment.getCurrentStep()} of ${deployment.getTotalSteps()}`;
+    const services = deployment.getAffectedServices();
+    const items = services.map(function (service, index) {
+      return (
+        <li key={index}>
+          {service.getStatus()}
+        </li>
+      );
+    });
+
+    return (
+      <div>
+        <div className="deployment-step">{title}</div>
+        <ol className="deployment-status-list list-unstyled flush-bottom">{items}</ol>
+      </div>
+    );
+  }
+
+  getColumns() {
+    return [
+      {
+        className: columnClassNameGetter,
+        heading: columnHeading,
+        prop: 'id',
+        render: this.renderAffectedServices
+      },
+      {
+        className: columnClassNameGetter,
+        heading: columnHeading,
+        prop: 'location',
+        render: this.renderLocation
+      },
+      {
+        className: function () {
+          return classNames(columnClassNameGetter(...arguments), 'align-top');
+        },
+        heading: columnHeading,
+        prop: 'startTime',
+        render: this.renderStartTime
+      },
+      {
+        className: columnClassNameGetter,
+        heading: columnHeading,
+        prop: 'status',
+        render: this.renderStatus
+      }
+    ];
   }
 
   renderEmpty() {
@@ -82,9 +178,8 @@ class DeploymentsTab extends mixin(StoreMixin) {
           {deploymentsCount} Active {deploymentsLabel}
         </h4>
         <Table
-          className="table inverse table-borderless-outer
-              table-borderless-inner-columns flush-bottom"
-          columns={columns}
+          className="table inverse table-borderless-outer table-borderless-inner-columns flush-bottom deployments-table"
+          columns={this.getColumns()}
           data={deploymentsItems.slice()} />
       </div>
     );

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -82,7 +82,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
         <li key={index}>
           <ServicesBreadcrumb
             className="deployment-breadcrumb"
-            h4ClassNames="flush-bottom"
+            headerClassNames="flush-bottom"
             serviceTreeItem={service} />
         </li>
       );

--- a/src/styles/components/deployments-table.less
+++ b/src/styles/components/deployments-table.less
@@ -1,0 +1,49 @@
+.deployments-table {
+
+  td {
+    vertical-align: bottom;
+    &.align-top {
+      vertical-align: top;
+    }
+  }
+
+  .deployment-services-list,
+  .deployment-start-time,
+  .deployment-step,
+  .deployment-status-list {
+    font-size: @body-text-font-size;
+  }
+
+  .deployment-id {
+    margin-bottom: 8px;
+  }
+
+  .deployment-service-icon {
+    margin: 0 8px;
+  }
+
+  .deployment-breadcrumb {
+    .crumb {
+      line-height: 32px;
+      font-size: @body-text-font-size;
+      // Don't display the service itself
+      &:last-child {
+        display: none;
+      }
+    }
+    .icon.forward {
+      margin: 0 0 0 8px;
+      width: 12.5px;
+    }
+  }
+
+  .deployment-step {
+    margin-bottom: 8px;
+  }
+  .deployment-status-list {
+    li {
+      line-height: 32px;
+    }
+  }
+
+}

--- a/src/styles/components/tree-list.less
+++ b/src/styles/components/tree-list.less
@@ -1,0 +1,30 @@
+@tree-list-border-color: @neutral;
+.tree-list {
+  dd {
+    margin-left: 12px;
+    border-left: 1px solid @tree-list-border-color;
+    display: flex;
+    align-items: center;
+
+    &:before {
+      content: '';
+      display: inline-block;
+      align-self: flex-start;
+
+      margin: 0 0 12px;
+      width: 20px;
+      height: 20px;
+      border-bottom: 1px solid @tree-list-border-color;
+
+    }
+
+    &:last-child {
+      border-left: 0;
+      &:before {
+        border-left: 1px solid @tree-list-border-color;
+      }
+    }
+
+  }
+}
+

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -159,5 +159,6 @@ Components
 @import "components/tabs.less";
 @import "components/toggle-button.less";
 @import "components/tooltip.less";
+@import "components/tree-list.less";
 @import "components/typography.less";
 @import "components/user-dropdown-menu.less";

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -135,6 +135,7 @@ Components
 @import "components/charts/dialchart.less";
 @import "components/code.less";
 @import "components/dashboard-health-list.less";
+@import "components/deployments-table.less";
 @import "components/description-list.less";
 @import "components/dropdown-menus.less";
 @import "components/filter-bar.less";


### PR DESCRIPTION
![](https://s3.amazonaws.com/f.cl.ly/items/2e3c11211T3c3B1S1c3Q/Image%202016-06-09%20at%201.51.18%20AM.png?v=dfe16883)

This PR introduces services to the deployments tables and adds styles for them. The `tree-list` will hopefully eventually be contributed upstream to Canvas-UI, but for the moment has been added as a dcos-ui specific component. 

__NB: I have had to create a new feature branch after the last one got badly out of synch. See #370 for more detail.__