### PR TITLE
Hide Header Navigation on Detail Pages

### DIFF
--- a/src/js/pages/JobsPage.js
+++ b/src/js/pages/JobsPage.js
@@ -4,6 +4,7 @@ import {RouteHandler} from 'react-router';
 
 import IconJobs from '../../img/components/icons/pages-code.svg?name=IconJobs';
 import Page from '../components/Page';
+import RouterUtil from '../utils/RouterUtil';
 import SidebarActions from '../events/SidebarActions';
 import TabsMixin from '../mixins/TabsMixin';
 
@@ -33,6 +34,10 @@ class JobsPage extends mixin(TabsMixin) {
   }
 
   getNavigation() {
+    if (RouterUtil.shouldHideNavigation(this.context.router)) {
+      return null;
+    }
+
     return (
       <ul className="tabs list-inline flush-bottom inverse">
         {this.tabs_getRoutedTabs()}

--- a/src/js/pages/ServicesPage.js
+++ b/src/js/pages/ServicesPage.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {RouteHandler} from 'react-router';
 
 import Page from '../components/Page';
+import RouterUtil from '../utils/RouterUtil';
 import TabsMixin from '../mixins/TabsMixin';
 
 var ServicesPage = React.createClass({
@@ -45,6 +46,10 @@ var ServicesPage = React.createClass({
   },
 
   getNavigation: function () {
+    if (RouterUtil.shouldHideNavigation(this.context.router)) {
+      return null;
+    }
+
     return (
       <ul className="tabs list-inline flush-bottom inverse">
         {this.tabs_getRoutedTabs()}

--- a/src/js/pages/SystemPage.js
+++ b/src/js/pages/SystemPage.js
@@ -4,8 +4,9 @@ import mixin from 'reactjs-mixin';
 import React from 'react';
 /* eslint-enable no-unused-vars */
 import {Hooks} from 'PluginSDK';
-import Page from '../components/Page';
 import NotificationStore from '../stores/NotificationStore';
+import Page from '../components/Page';
+import RouterUtil from '../utils/RouterUtil';
 import SidebarActions from '../events/SidebarActions';
 import TabsUtil from '../utils/TabsUtil';
 import TabsMixin from '../mixins/TabsMixin';
@@ -114,6 +115,10 @@ class SystemPage extends mixin(TabsMixin) {
   }
 
   getNavigation() {
+    if (RouterUtil.shouldHideNavigation(this.context.router)) {
+      return null;
+    }
+
     let routes = this.context.router.getCurrentRoutes();
     let currentRoute = routes[routes.length - 2].name;
 
@@ -129,10 +134,18 @@ class SystemPage extends mixin(TabsMixin) {
   }
 
   getSubNavigation() {
+    if (RouterUtil.shouldHideNavigation(this.context.router)) {
+      return null;
+    }
+
     return (
-      <ul className="tabs list-inline flush-bottom inverse">
-        {this.tabs_getRoutedTabs()}
-      </ul>
+      <div className="container-pod container-pod-short flush-top">
+        <div className="container-pod container-pod-divider-bottom container-pod-divider-inverse container-pod-divider-bottom-align-right flush-top flush-bottom">
+           <ul className="tabs list-inline flush-bottom inverse">
+            {this.tabs_getRoutedTabs()}
+          </ul>
+        </div>
+      </div>
     );
   }
 
@@ -141,11 +154,7 @@ class SystemPage extends mixin(TabsMixin) {
       <Page
         title="System"
         navigation={this.getNavigation()}>
-        <div className="container-pod container-pod-short flush-top">
-          <div className="container-pod container-pod-divider-bottom container-pod-divider-inverse container-pod-divider-bottom-align-right flush-top flush-bottom">
-            {this.getSubNavigation()}
-          </div>
-        </div>
+        {this.getSubNavigation()}
         <RouteHandler currentTab={this.state.currentTab} />
       </Page>
     );

--- a/src/js/pages/UniversePage.js
+++ b/src/js/pages/UniversePage.js
@@ -5,6 +5,7 @@ import React from 'react';
 import {RouteHandler} from 'react-router';
 
 import Page from '../components/Page';
+import RouterUtil from '../utils/RouterUtil';
 import SidebarActions from '../events/SidebarActions';
 import TabsMixin from '../mixins/TabsMixin';
 
@@ -38,6 +39,10 @@ class UniversePage extends mixin(TabsMixin) {
   }
 
   getNavigation() {
+    if (RouterUtil.shouldHideNavigation(this.context.router)) {
+      return null;
+    }
+
     return (
       <ul className="tabs list-inline flush-bottom inverse">
         {this.tabs_getRoutedTabs()}

--- a/src/js/plugin-bridge/PluginModules.js
+++ b/src/js/plugin-bridge/PluginModules.js
@@ -31,6 +31,7 @@ module.exports = {
     LocalStorageUtil: 'LocalStorageUtil',
     Maths: 'Maths',
     ResourceTableUtil: 'ResourceTableUtil',
+    RouterUtil: 'RouterUtil',
     StoreMixinConfig: 'StoreMixinConfig',
     StringUtil: 'StringUtil',
     TableUtil: 'TableUtil',

--- a/src/js/routes/factories/system.js
+++ b/src/js/routes/factories/system.js
@@ -43,6 +43,7 @@ let RouteFactory = {
             name: 'system-overview-units-unit-nodes-detail',
             path: 'components/:unitID/?',
             handler: UnitsHealthDetail,
+            hideHeaderNavigation: true,
             buildBreadCrumb: function () {
               return {
                 parentCrumb: 'system-overview-units',
@@ -61,6 +62,7 @@ let RouteFactory = {
             name: 'system-overview-units-unit-nodes-node-detail',
             path: 'components/:unitID/nodes/:unitNodeID/?',
             handler: UnitsHealthNodeDetail,
+            hideHeaderNavigation: true,
             buildBreadCrumb: function () {
               return {
                 parentCrumb: 'system-overview-units-unit-nodes-detail',

--- a/src/js/routes/jobs.js
+++ b/src/js/routes/jobs.js
@@ -18,7 +18,8 @@ let jobsRoutes = {
           type: Route,
           handler: JobDetailPage,
           name: 'jobs-page-detail',
-          path: ':id/?'
+          path: ':id/?',
+          hideHeaderNavigation: true
         }
       ]
     }

--- a/src/js/routes/nodes.js
+++ b/src/js/routes/nodes.js
@@ -62,6 +62,7 @@ let nodesRoutes = {
       name: 'node-detail',
       path: ':nodeID/?',
       handler: NodeDetailPage,
+      hideHeaderNavigation: true,
       buildBreadCrumb: function () {
         return {
           parentCrumb: 'nodes-page',
@@ -80,6 +81,7 @@ let nodesRoutes = {
           path: 'tasks/:taskID/?',
           name: 'nodes-task-details',
           handler: TaskDetail,
+          hideHeaderNavigation: true,
           buildBreadCrumb: function () {
             return {
               parentCrumb: 'node-detail',
@@ -97,6 +99,7 @@ let nodesRoutes = {
               type: DefaultRoute,
               name: 'nodes-task-details-tab',
               handler: TaskDetailsTab,
+              hideHeaderNavigation: true,
               buildBreadCrumb: function () {
                 return {
                   parentCrumb: 'nodes-task-details',
@@ -109,6 +112,7 @@ let nodesRoutes = {
               name: 'nodes-task-details-files',
               path: 'files/?',
               handler: TaskFilesTab,
+              hideHeaderNavigation: true,
               buildBreadCrumb: function () {
                 return {
                   parentCrumb: 'nodes-task-details',
@@ -122,6 +126,7 @@ let nodesRoutes = {
               dontScroll: true,
               path: 'logs/?',
               handler: TaskLogsTab,
+              hideHeaderNavigation: true,
               buildBreadCrumb: function () {
                 return {
                   parentCrumb: 'nodes-task-details',
@@ -138,6 +143,7 @@ let nodesRoutes = {
       name: 'node-detail-health',
       path: ':nodeID/:unitNodeID/:unitID/?',
       handler: UnitsHealthNodeDetailPage,
+      hideHeaderNavigation: true,
       children: [
         {
           type: DefaultRoute,

--- a/src/js/routes/services.js
+++ b/src/js/routes/services.js
@@ -60,6 +60,7 @@ let serviceRoutes = {
           type: Route,
           name: 'services-detail',
           path: ':id/?',
+          hideHeaderNavigation: true,
           buildBreadCrumb: function () {
             return {
               parentCrumb: 'services-page',
@@ -72,6 +73,7 @@ let serviceRoutes = {
               path: 'tasks/:taskID/?',
               name: 'services-task-details',
               handler: TaskDetail,
+              hideHeaderNavigation: true,
               buildBreadCrumb: function () {
                 return {
                   parentCrumb: 'services-detail',
@@ -89,6 +91,7 @@ let serviceRoutes = {
                   type: DefaultRoute,
                   name: 'services-task-details-tab',
                   handler: TaskDetailsTab,
+                  hideHeaderNavigation: true,
                   buildBreadCrumb: function () {
                     return {
                       parentCrumb: 'services-task-details',
@@ -101,6 +104,7 @@ let serviceRoutes = {
                   name: 'services-task-details-files',
                   path: 'files/?',
                   handler: TaskFilesTab,
+                  hideHeaderNavigation: true,
                   buildBreadCrumb: function () {
                     return {
                       parentCrumb: 'services-task-details',
@@ -114,6 +118,7 @@ let serviceRoutes = {
                   dontScroll: true,
                   path: 'logs/?',
                   handler: TaskLogsTab,
+                  hideHeaderNavigation: true,
                   buildBreadCrumb: function () {
                     return {
                       parentCrumb: 'services-task-details',

--- a/src/js/routes/universe.js
+++ b/src/js/routes/universe.js
@@ -21,7 +21,8 @@ let universeRoutes = {
       type: Route,
       name: 'universe-packages-detail',
       path: 'packages/:packageName?:packageVersion?',
-      handler: PackageDetailTab
+      handler: PackageDetailTab,
+      hideHeaderNavigation: true
     },
     {
       type: Route,

--- a/src/js/utils/RouterUtil.js
+++ b/src/js/utils/RouterUtil.js
@@ -54,6 +54,10 @@ const RouterUtil = {
         }
       });
 
+      if (originalConfiguration.hideHeaderNavigation) {
+        route.hideHeaderNavigation = originalConfiguration.hideHeaderNavigation;
+      }
+
       return route;
     });
   },
@@ -70,6 +74,17 @@ const RouterUtil = {
     let routes = createRoutesFromReactChildren(elementRoutes[0]);
 
     return RouterUtil.setRouteConfiguration(routes, originalRoutes);
+  },
+
+  /**
+   * Checks if a page should hide the header navigation tabs
+   * @param  {Object} router instance of react-router
+   * @return {Bool} should hide Page Navigation
+   */
+  shouldHideNavigation(router) {
+    let routes = router.getCurrentRoutes();
+
+    return !!routes[routes.length - 1].hideHeaderNavigation;
   }
 
 };


### PR DESCRIPTION
This hides the Page navigation tabs and the sub tabs when configured to do so.