### PR TITLE
[6] Deployments Table - improve data interpolation

### DIFF
--- a/src/js/stores/DCOSStore.js
+++ b/src/js/stores/DCOSStore.js
@@ -139,6 +139,10 @@ class DCOSStore extends EventEmitter {
 
     this.data.marathon.serviceTree = serviceTree;
     this.data.dataProcessed = true;
+
+    // Populate deployments with services data immediately
+    this.onMarathonDeploymentsChange();
+
     this.emit(DCOS_CHANGE);
   }
 

--- a/src/js/stores/DCOSStore.js
+++ b/src/js/stores/DCOSStore.js
@@ -107,6 +107,9 @@ class DCOSStore extends EventEmitter {
   }
 
   onMarathonDeploymentsChange() {
+    if (!this.data.dataProcessed) {
+      return;
+    }
     let deploymentsList = MarathonStore.get('deployments');
     let serviceTree = MarathonStore.get('groups');
 

--- a/src/js/stores/DCOSStore.js
+++ b/src/js/stores/DCOSStore.js
@@ -123,7 +123,13 @@ class DCOSStore extends EventEmitter {
     this.data.marathon.deploymentsList = deploymentsList
       .mapItems(function (deployment) {
         let ids = deployment.getAffectedServiceIds();
-        let services = ids.map(serviceTree.findItemById.bind(serviceTree));
+        let services = ids.reduce(function (memo, id) {
+          let service = serviceTree.findItemById(id);
+          if (service != null) {
+            memo.push(service);
+          }
+          return memo;
+        }, []);
 
         return Object.assign({affectedServices: services}, deployment);
       });

--- a/src/js/stores/__tests__/DCOSStore-test.js
+++ b/src/js/stores/__tests__/DCOSStore-test.js
@@ -53,7 +53,7 @@ describe('DCOSStore', function () {
           totalSteps: 3
         }
       ]}));
-      MarathonStore.__setKeyResponse('groups', new ServiceTree({apps: [
+      MarathonStore.__setKeyResponse('groups', new ServiceTree({items: [
         {id: '/app1', cmd: 'sleep 1000'},
         {id: '/app2', cmd: 'sleep 1000'}
       ]}));
@@ -105,6 +105,22 @@ describe('DCOSStore', function () {
       it('should update the notification store', function () {
         expect(NotificationStore.addNotification)
           .toHaveBeenCalledWith('services-deployments', 'deployment-count', 1);
+      });
+
+    });
+
+    describe('when the deployments endpoint references stale services', function () {
+
+      beforeEach(function () {
+        DCOSStore.onMarathonDeploymentsChange();
+        MarathonStore.__setKeyResponse('groups', new ServiceTree({apps: []}));
+        DCOSStore.onMarathonGroupsChange();
+      });
+
+      it('should trim stale services', function () {
+        let deployment = DCOSStore.deploymentsList.last();
+        let services = deployment.getAffectedServices();
+        expect(services.length).toEqual(0);
       });
 
     });

--- a/src/js/stores/__tests__/DCOSStore-test.js
+++ b/src/js/stores/__tests__/DCOSStore-test.js
@@ -76,6 +76,12 @@ describe('DCOSStore', function () {
         expect(NotificationStore.addNotification).not.toHaveBeenCalled();
       });
 
+      it('should be called as soon as groups endpoint data arrives', function () {
+        spyOn(DCOSStore, 'onMarathonDeploymentsChange');
+        DCOSStore.onMarathonGroupsChange();
+        expect(DCOSStore.onMarathonDeploymentsChange).toHaveBeenCalled();
+      });
+
     });
 
     describe('when the groups endpoint is already populated', function () {

--- a/src/js/stores/__tests__/DCOSStore-test.js
+++ b/src/js/stores/__tests__/DCOSStore-test.js
@@ -42,11 +42,8 @@ describe('DCOSStore', function () {
   });
 
   describe('#onMarathonDeploymentsChange', function () {
+
     beforeEach(function () {
-      MarathonStore.__setKeyResponse('groups', new ServiceTree({apps: [
-        {id: '/app1', cmd: 'sleep 1000'},
-        {id: '/app2', cmd: 'sleep 1000'}
-      ]}));
       MarathonStore.__setKeyResponse('deployments', new DeploymentsList({items: [
         {
           id: 'deployment-id',
@@ -56,25 +53,54 @@ describe('DCOSStore', function () {
           totalSteps: 3
         }
       ]}));
+      MarathonStore.__setKeyResponse('groups', new ServiceTree({apps: [
+        {id: '/app1', cmd: 'sleep 1000'},
+        {id: '/app2', cmd: 'sleep 1000'}
+      ]}));
       spyOn(NotificationStore, 'addNotification');
-      DCOSStore.onMarathonGroupsChange();
-      DCOSStore.onMarathonDeploymentsChange();
+      // DCOSStore is a singleton, need to reset it manually
+      DCOSStore.data.dataProcessed = false;
     });
 
-    it('should update the deployments list', function () {
-      expect(DCOSStore.deploymentsList.getItems().length).toEqual(1);
-      expect(DCOSStore.deploymentsList.last().id).toEqual('deployment-id')
+    describe('when the groups endpoint is not populated', function () {
+
+      beforeEach(function () {
+        DCOSStore.onMarathonDeploymentsChange();
+      });
+
+      it('should not update the deployments list', function () {
+        expect(DCOSStore.deploymentsList.getItems().length).toEqual(0);
+      });
+
+      it('should not update the notification store', function () {
+        expect(NotificationStore.addNotification).not.toHaveBeenCalled();
+      });
+
     });
 
-    it('should populate the deployments with relevant services', function () {
-      let deployment = DCOSStore.deploymentsList.last();
-      let services = deployment.getAffectedServices();
-      expect(services.length).toEqual(2);
-    });
+    describe('when the groups endpoint is already populated', function () {
 
-    it('should update the notification store', function () {
-      expect(NotificationStore.addNotification)
-        .toHaveBeenCalledWith('services-deployments', 'deployment-count', 1);
+      beforeEach(function () {
+        DCOSStore.onMarathonGroupsChange();
+        DCOSStore.onMarathonDeploymentsChange();
+      });
+
+      it('should update the deployments list', function () {
+        expect(DCOSStore.deploymentsList.getItems().length).toEqual(1);
+        expect(DCOSStore.deploymentsList.last().id).toEqual('deployment-id')
+      });
+
+      it('should populate the deployments with relevant services', function () {
+        let deployment = DCOSStore.deploymentsList.last();
+        let services = deployment.getAffectedServices();
+        expect(services.length).toEqual(2);
+      });
+
+      it('should update the notification store', function () {
+        expect(NotificationStore.addNotification)
+          .toHaveBeenCalledWith('services-deployments', 'deployment-count', 1);
+      });
+
     });
 
   });


### PR DESCRIPTION
Previously, we assumed that groups data was available from the Marathon store when we populated the DCOS Store with deployments data. This was not only bad in theory but also in practice, as the deployments endpoint is significantly quicker than the groups endpoint and the race condition thus created was almost always tripped.

This PR:
- [x] ensures that the deployments are not processed until the groups data has been received
- [x] invokes the deployments processing code immediately after the groups data has been received
- [x] ensures that if the deployments service data is stale (ie, the deployment contains references to deleted services), those services are trimmed

Outside the scope of this feature we should either update the name of the `dataProcessed` attribute of `DCOSStore` to reflect that it only relates to groups data, or extend it so that it is only true when all endpoints have returned some data, or (my preference) remove it entirely, since IMO components should not have to perform any sort of introspection against stores. 