### PR TITLE
Introduce OTHER sidebar filters

### DIFF
--- a/src/js/components/ServiceSidebarFilters.js
+++ b/src/js/components/ServiceSidebarFilters.js
@@ -9,46 +9,50 @@ import SidebarFilter from './SidebarFilter';
 
 const PropTypes = React.PropTypes;
 
-function getCountByHealth(services) {
-  return services.reduce(function (acc, service) {
-    let serviceHealth = service.getHealth();
-    if (acc[serviceHealth.value] === undefined) {
-      acc[serviceHealth.value] = 1;
-    } else {
-      acc[serviceHealth.value]++;
-    }
-    return acc;
-  }, {});
-}
+function getCountByFilters(services) {
 
-function getCountByStatus(services) {
-  return services.reduce(function (acc, service) {
+  return services.reduce(function (memo, service) {
     let serviceStatus = service.getServiceStatus();
+    let serviceHealth = service.getHealth();
 
-    if (acc[serviceStatus.key] === undefined) {
-      acc[serviceStatus.key] = 1;
+    if (memo.statusCount[serviceStatus.key] === undefined) {
+      memo.statusCount[serviceStatus.key] = 1;
     } else {
-      acc[serviceStatus.key]++;
+      memo.statusCount[serviceStatus.key]++;
     }
-    return acc;
-  }, {});
+
+    if (memo.healthCount[serviceHealth.value] === undefined) {
+      memo.healthCount[serviceHealth.value] = 1;
+    } else {
+      memo.healthCount[serviceHealth.value]++;
+    }
+
+    }
+
+    return memo;
+  }, {healthCount: {}, statusCount: {}, otherCount: {}});
 }
 
 class ServiceSidebarFilters extends React.Component {
   render() {
     let {props} = this;
+    let {
+      healthCount,
+      statusCount,
+      otherCount
+    } = getCountByFilters(props.services);
 
     return (
       <div>
         <SidebarFilter
-          countByValue={getCountByHealth(props.services)}
+          countByValue={healthCount}
           filterType={ServiceFilterTypes.HEALTH}
           filterValues={HealthTypes}
           filterLabels={HealthLabels}
           handleFilterChange={props.handleFilterChange}
           title="HEALTH" />
         <SidebarFilter
-          countByValue={getCountByStatus(props.services)}
+          countByValue={statusCount}
           filterType={ServiceFilterTypes.STATUS}
           filterValues={ServiceStatusTypes}
           filterLabels={ServiceStatusLabels}

--- a/src/js/constants/ServiceFilterTypes.js
+++ b/src/js/constants/ServiceFilterTypes.js
@@ -1,5 +1,6 @@
 const ServiceFilterTypes = {
   HEALTH: 'filterHealth',
+  OTHER: 'filterOther',
   STATUS: 'filterStatus',
   TEXT: 'searchString'
 };

--- a/src/js/constants/ServiceOther.js
+++ b/src/js/constants/ServiceOther.js
@@ -1,0 +1,15 @@
+import ServiceOtherLabels from './ServiceOtherLabels';
+import ServiceOtherTypes from './ServiceOtherTypes';
+
+var SERVICE_OTHER = {
+  UNIVERSE: {
+    key: ServiceOtherTypes.UNIVERSE,
+    displayName: ServiceOtherLabels.UNIVERSE
+  },
+  VOLUMES: {
+    key: ServiceOtherTypes.VOLUMES,
+    displayName: ServiceOtherLabels.VOLUMES
+  }
+};
+
+module.exports = SERVICE_OTHER;

--- a/src/js/constants/ServiceOtherLabels.js
+++ b/src/js/constants/ServiceOtherLabels.js
@@ -1,0 +1,6 @@
+var ServiceOtherLabels = {
+  UNIVERSE: 'Universe',
+  VOLUMES: 'Volumes'
+};
+
+module.exports = ServiceOtherLabels;

--- a/src/js/constants/ServiceOtherTypes.js
+++ b/src/js/constants/ServiceOtherTypes.js
@@ -1,0 +1,6 @@
+var ServiceOtherTypes = {
+  UNIVERSE: 0,
+  VOLUMES: 1
+};
+
+module.exports = ServiceOtherTypes;

--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -27,6 +27,7 @@ import SidePanels from '../../components/SidePanels';
 
 var DEFAULT_FILTER_OPTIONS = {
   filterHealth: null,
+  filterOther: null,
   filterStatus: null,
   searchString: ''
 };
@@ -213,6 +214,7 @@ var ServicesTab = React.createClass({
     let services = item.getItems();
     let filteredServices = item.filterItemsByFilter({
       health: state.filterHealth,
+      other: state.filterOther,
       status: state.filterStatus,
       id: state.searchString
     }).getItems();

--- a/src/js/structs/ServiceTree.js
+++ b/src/js/structs/ServiceTree.js
@@ -3,8 +3,10 @@ import Framework from './Framework';
 import HealthSorting from '../constants/HealthSorting';
 import HealthStatus from '../constants/HealthStatus';
 import Service from './Service';
+import ServiceOther from '../constants/ServiceOther';
 import ServiceStatus from '../constants/ServiceStatus';
 import Tree from './Tree';
+import VolumeList from '../structs/VolumeList';
 
 module.exports = class ServiceTree extends Tree {
   /**
@@ -118,6 +120,26 @@ module.exports = class ServiceTree extends Tree {
         });
       }
 
+      if (filter.other != null && filter.other.length !== 0) {
+        services = services.filter(function (service) {
+          return filter.other.some(function (otherKey) {
+
+            if (parseInt(otherKey, 10) === ServiceOther.UNIVERSE.key) {
+              if (service instanceof ServiceTree) {
+                return service.getFrameworks().length > 0;
+              }
+
+              return service instanceof Framework;
+            }
+
+            if (parseInt(otherKey, 10) === ServiceOther.VOLUMES.key) {
+              let volumes = service.getVolumes();
+              return volumes.list && volumes.list.length > 0;
+            }
+          });
+        });
+      }
+
       if (filter.status != null && filter.status.length !== 0) {
         services = services.filter(function (service) {
           return filter.status.some(function (statusValue) {
@@ -204,5 +226,27 @@ module.exports = class ServiceTree extends Tree {
       return taskSummary;
     }, {tasksHealthy: 0, tasksRunning: 0, tasksStaged: 0, tasksUnhealthy: 0,
       tasksUnknown: 0});
+  }
+
+  getFrameworks() {
+    return this.reduceItems(function (frameworks, item) {
+      if (item instanceof Framework) {
+        frameworks.push(item);
+      }
+      return frameworks;
+    }, []);
+  }
+
+  getVolumes() {
+    let items = this.reduceItems(function (serviceTreeVolumes, item) {
+      if (item instanceof Service) {
+        let itemVolumes = item.getVolumes().getItems();
+        if (itemVolumes && itemVolumes.length) {
+          serviceTreeVolumes.push(itemVolumes);
+        }
+      }
+      return serviceTreeVolumes;
+    }, []);
+    return new VolumeList({items});
   }
 };

--- a/src/js/structs/ServiceTree.js
+++ b/src/js/structs/ServiceTree.js
@@ -134,6 +134,7 @@ module.exports = class ServiceTree extends Tree {
 
             if (parseInt(otherKey, 10) === ServiceOther.VOLUMES.key) {
               let volumes = service.getVolumes();
+
               return volumes.list && volumes.list.length > 0;
             }
           });
@@ -233,6 +234,7 @@ module.exports = class ServiceTree extends Tree {
       if (item instanceof Framework) {
         frameworks.push(item);
       }
+
       return frameworks;
     }, []);
   }
@@ -245,8 +247,10 @@ module.exports = class ServiceTree extends Tree {
           serviceTreeVolumes.push(itemVolumes);
         }
       }
+
       return serviceTreeVolumes;
     }, []);
+
     return new VolumeList({items});
   }
 };

--- a/src/js/structs/__tests__/ServiceTree-test.js
+++ b/src/js/structs/__tests__/ServiceTree-test.js
@@ -5,6 +5,7 @@ let HealthTypes = require('../../constants/HealthTypes');
 let Service = require('../Service');
 let ServiceTree = require('../ServiceTree');
 let ServiceStatus = require('../../constants/ServiceStatus');
+let VolumeList = require('../../structs/VolumeList');
 
 describe('ServiceTree', function () {
 
@@ -743,6 +744,59 @@ describe('ServiceTree', function () {
         tasksUnhealthy: 1,
         tasksUnknown: 2
       });
+    });
+
+  });
+
+  describe('#getVolumes', function () {
+
+    beforeEach(function () {
+      this.instance = new ServiceTree();
+    });
+
+    it('returns a VolumeList with all the volumes in the group', function () {
+      this.instance.add(new Service({
+        id: '/persistent',
+        volumes: [{
+          containerPath: 'data',
+          mode: 'RW',
+          persistent: {size: 100}
+        }]
+      }));
+
+      this.instance.add(new Service({
+        id: '/persistent2',
+        volumes: [{
+          containerPath: 'data',
+          mode: 'RW',
+          persistent: {size: 100}
+        }]
+      }));
+
+      let volumeList = this.instance.getVolumes();
+      expect(volumeList).toEqual(jasmine.any(VolumeList));
+      expect(volumeList.getItems().length).toEqual(2);
+    });
+
+  });
+
+  describe('#getFrameworks', function () {
+
+    beforeEach(function () {
+      this.instance = new ServiceTree();
+    });
+
+    it('returns an array with all the Frameworks in the group', function () {
+      this.instance.add(new Framework({
+        id: '/chronos'
+      }));
+
+      this.instance.add(new Service({
+        id: '/sleeper'
+      }));
+
+      let frameworks = this.instance.getFrameworks();
+      expect(frameworks.length).toEqual(1);
     });
 
   });

--- a/tests/pages/services/SidebarFilter-cy.js
+++ b/tests/pages/services/SidebarFilter-cy.js
@@ -56,6 +56,16 @@ describe('Sidebar Filter', function () {
       cy.get('tbody tr:visible').should('to.have.length', 1);
     });
 
+    it('filters correctly on Universe', function () {
+      cy.get('.sidebar-filters .label').contains('Universe').click();
+      cy.get('tbody tr:visible').should('to.have.length', 4);
+    });
+
+    it('filters correctly on Volumes', function () {
+      cy.get('.sidebar-filters .label').contains('Volumes').click();
+      cy.get('tbody tr:visible').should('to.have.length', 1);
+    });
+
     it('filters correctly on two filters', function () {
       cy.get('.sidebar-filters .label').contains('Healthy').click();
       cy.get('.sidebar-filters .label').contains('Unhealthy').click();


### PR DESCRIPTION
This adds support for the OTHER sidebar filters. 
This group of filters is meant for miscellaneous criteria, for example `Universe` (only show Frameworks) and `Volumes` (apps with attached volumes).

![other](https://cloud.githubusercontent.com/assets/1078545/15932810/61c489e6-2e5d-11e6-9b9d-d39e671102bc.gif)

