### PR TITLE
[2 of 2 Debug Tab] Add service debug tab stats table

### DIFF
--- a/src/js/components/ServiceDetailDebugTab.js
+++ b/src/js/components/ServiceDetailDebugTab.js
@@ -3,6 +3,7 @@ import React from 'react';
 import DateUtil from '../utils/DateUtil';
 import DescriptionList from './DescriptionList';
 import Service from '../structs/Service';
+import TaskStatsTable from './TaskStatsTable';
 
 class ServiceDetailDebugTab extends React.Component {
   getValueText(value) {
@@ -72,6 +73,18 @@ class ServiceDetailDebugTab extends React.Component {
     return <DescriptionList hash={LastVersionChangeValueMapping} />;
   }
 
+  getTaskStats() {
+    let {taskStats} = this.props.service;
+
+    if (taskStats == null || Object.keys(taskStats).length === 0) {
+      return (
+        <p>This app does not have task statistics</p>
+      );
+    }
+
+    return <TaskStatsTable taskStats={taskStats} />
+  }
+
   render() {
     return (
       <div>
@@ -83,6 +96,10 @@ class ServiceDetailDebugTab extends React.Component {
           Last Task Failure
         </h5>
         {this.getLastTaskFailureInfo()}
+        <h5 className="inverse flush-top">
+          Task Statistics
+        </h5>
+        {this.getTaskStats()}
       </div>
     );
   }

--- a/src/js/components/ServiceDetailDebugTab.js
+++ b/src/js/components/ServiceDetailDebugTab.js
@@ -74,7 +74,7 @@ class ServiceDetailDebugTab extends React.Component {
   }
 
   getTaskStats() {
-    let {taskStats} = this.props.service;
+    let taskStats = this.props.service.getTaskStats();
 
     if (taskStats == null || Object.keys(taskStats).length === 0) {
       return (

--- a/src/js/components/ServiceDetailDebugTab.js
+++ b/src/js/components/ServiceDetailDebugTab.js
@@ -76,7 +76,7 @@ class ServiceDetailDebugTab extends React.Component {
   getTaskStats() {
     let taskStats = this.props.service.getTaskStats();
 
-    if (taskStats == null || Object.keys(taskStats).length === 0) {
+    if (taskStats.getList().getItems().length === 0) {
       return (
         <p>This app does not have task statistics</p>
       );

--- a/src/js/components/TaskStatsTable.js
+++ b/src/js/components/TaskStatsTable.js
@@ -37,15 +37,7 @@ class TaskStatsTable extends React.Component {
 
   getColumns() {
     let getClassName = this.getClassName;
-    let heading = this.renderHeading({
-      caption: '',
-      running: 'Running',
-      healthy: 'Healthy',
-      unhealthy: 'Unhealthy',
-      staged: 'Staged',
-      averageSeconds: 'Average Seconds',
-      medianSeconds: 'Median Seconds'
-    });
+    let heading = this.renderHeading;
 
     return [
       {
@@ -109,32 +101,20 @@ class TaskStatsTable extends React.Component {
     ];
   }
 
-  renderHeading(config) {
-    return function (prop, order, sortBy) {
-      let title = config[prop];
-      let caret = {
-        before: null,
-        after: null
-      };
-      let caretClassSet = classNames(
-        `caret caret--${order}`,
-        {'caret--visible': prop === sortBy.prop}
-      );
+  renderHeading(prop) {
+    let headerMapping = {
+      caption: '',
+      running: 'Running',
+      healthy: 'Healthy',
+      unhealthy: 'Unhealthy',
+      staged: 'Staged',
+      averageSeconds: 'Average Seconds',
+      medianSeconds: 'Median Seconds'
+    }
 
-      if (taskStatus.includes(prop)) {
-        caret.before = <span className={caretClassSet} />;
-      } else {
-        caret.after = <span className={caretClassSet} />;
-      }
-
-      return (
-        <span>
-          {caret.before}
-          <span className="table-header-title">{title}</span>
-          {caret.after}
-        </span>
-      );
-    };
+    return (
+      <span className="table-header-title">{headerMapping[prop]}</span>
+    );
   }
 
   getColGroup() {

--- a/src/js/components/TaskStatsTable.js
+++ b/src/js/components/TaskStatsTable.js
@@ -30,7 +30,6 @@ class TaskStatsTable extends React.Component {
   getClassName(prop, sortBy, row) {
     return classNames({
       'highlight': prop === sortBy.prop,
-      'clickable': row == null, // this is a header
       'text-align-right': taskStatus.includes(prop),
       'hidden-mini': taskStatus.includes(prop)
     });

--- a/src/js/components/TaskStatsTable.js
+++ b/src/js/components/TaskStatsTable.js
@@ -1,0 +1,182 @@
+import classNames from 'classnames';
+import moment from 'moment';
+import React from 'react';
+import {Table} from 'reactjs-components';
+
+const taskStatus = ['running','healthy','unhealthy','staged'];
+const keyCaptionMap = {
+  startedAfterLastScaling: 'Started After Last Scaling',
+  withLatestConfig: 'With Latest Config',
+  withOutdatedConfig: 'With Outdated Config',
+  totalSummary: 'Total Summary'
+};
+
+class TaskStatsTable extends React.Component {
+  getTaskStats() {
+    let {taskStats} = this.props;
+
+    let data = [];
+    Object.keys(keyCaptionMap).forEach(function (key) {
+      if (!taskStats[key]) {
+        return;
+      }
+
+      data.push(Object.assign({}, {caption: keyCaptionMap[key]}, taskStats[key].stats));
+    });
+
+    return data;
+  }
+
+  getClassName(prop, sortBy, row) {
+    return classNames({
+      'highlight': prop === sortBy.prop,
+      'clickable': row == null, // this is a header
+      'text-align-right': taskStatus.includes(prop),
+      'hidden-mini': taskStatus.includes(prop)
+    });
+  }
+
+  getColumns() {
+    let getClassName = this.getClassName;
+    let heading = this.renderHeading({
+      caption: '',
+      running: 'Running',
+      healthy: 'Healthy',
+      unhealthy: 'Unhealthy',
+      staged: 'Staged',
+      averageSeconds: 'Average Seconds',
+      medianSeconds: 'Median Seconds'
+    });
+
+    return [
+      {
+        className: getClassName,
+        headerClassName: getClassName,
+        heading,
+        prop: 'caption',
+        render: function (prop, taskStats) {
+          return taskStats[prop];
+        },
+        sortable: false
+      },
+      {
+        className: getClassName,
+        headerClassName: getClassName,
+        heading,
+        prop: 'running',
+        render: this.getStatus,
+        sortable: false
+      },
+      {
+        className: getClassName,
+        headerClassName: getClassName,
+        heading,
+        prop: 'healthy',
+        render: this.getStatus,
+        sortable: false
+      },
+      {
+        className: getClassName,
+        headerClassName: getClassName,
+        heading,
+        prop: 'unhealthy',
+        render: this.getStatus,
+        sortable: false
+      },
+      {
+        className: getClassName,
+        headerClassName: getClassName,
+        heading,
+        prop: 'staged',
+        render: this.getStatus,
+        sortable: false
+      },
+      {
+        className: getClassName,
+        headerClassName: getClassName,
+        heading,
+        prop: 'averageSeconds',
+        render: this.renderTime,
+        sortable: false
+      },
+      {
+        className: getClassName,
+        headerClassName: getClassName,
+        heading,
+        prop: 'medianSeconds',
+        render: this.renderTime,
+        sortable: false
+      }
+    ];
+  }
+
+  renderHeading(config) {
+    return function (prop, order, sortBy) {
+      let title = config[prop];
+      let caret = {
+        before: null,
+        after: null
+      };
+      let caretClassSet = classNames(
+        `caret caret--${order}`,
+        {'caret--visible': prop === sortBy.prop}
+      );
+
+      if (taskStatus.includes(prop)) {
+        caret.before = <span className={caretClassSet} />;
+      } else {
+        caret.after = <span className={caretClassSet} />;
+      }
+
+      return (
+        <span>
+          {caret.before}
+          <span className="table-header-title">{title}</span>
+          {caret.after}
+        </span>
+      );
+    };
+  }
+
+  getColGroup() {
+    return (
+      <colgroup>
+        <col style={{width: '20%'}} />
+        <col style={{width: '95px'}} className="hidden-mini" />
+        <col style={{width: '90px'}} className="hidden-mini" />
+        <col style={{width: '105px'}} className="hidden-mini" />
+        <col style={{width: '90px'}} className="hidden-mini" />
+        <col />
+        <col />
+      </colgroup>
+    );
+  }
+
+  getStatus(prop, taskStats) {
+    return taskStats.counts[prop];
+  }
+
+  renderTime(prop, taskStats) {
+    let lifeTimeSeconds = taskStats.lifeTime[prop];
+    let seconds = new Number(parseFloat(lifeTimeSeconds).toFixed(2))
+      .toLocaleString();
+    let humanReadable = moment.duration(
+      parseInt(lifeTimeSeconds),
+      'seconds'
+    ).humanize();
+
+    return `${seconds} sec (${humanReadable})`;
+  }
+
+  render() {
+    return (
+      <Table
+        className="table inverse table-borderless-outer table-borderless-inner-columns flush-bottom"
+        columns={this.getColumns()}
+        colGroup={this.getColGroup()}
+        data={this.getTaskStats()} />
+    );
+  }
+}
+
+module.exports = TaskStatsTable;

--- a/src/js/components/TaskStatsTable.js
+++ b/src/js/components/TaskStatsTable.js
@@ -27,7 +27,7 @@ class TaskStatsTable extends React.Component {
     return data;
   }
 
-  getClassName(prop, sortBy, row) {
+  getClassName(prop, sortBy) {
     return classNames({
       'highlight': prop === sortBy.prop,
       'text-align-right': taskStatus.includes(prop),

--- a/src/js/structs/TaskStat.js
+++ b/src/js/structs/TaskStat.js
@@ -2,49 +2,61 @@ import Item from './Item';
 
 class TaskStat extends Item {
 
-  constructor(item = {}) {
-    super(item.stats || {});
+  getName() {
+    return this.get('name');
   }
 
   getHealthyTaskCount() {
-    if (this.get('counts')) {
-      return this.get('counts').healthy || 0;
+    let stats = this.get('stats') || {};
+    if (stats.counts) {
+      return stats.counts.healthy || 0;
     }
+
     return 0;
   }
 
   getRunningTaskCount() {
-    if (this.get('counts')) {
-      return this.get('counts').running || 0;
+    let stats = this.get('stats') || {};
+    if (stats.counts) {
+      return stats.counts.running || 0;
     }
+
     return 0;
   }
 
   getStagedTaskCount() {
-    if (this.get('counts')) {
-      return this.get('counts').staged || 0;
+    let stats = this.get('stats') || {};
+    if (stats.counts) {
+      return stats.counts.staged || 0;
     }
+
     return 0;
   }
 
   getUnhealthyTaskCount() {
-    if (this.get('counts')) {
-      return this.get('counts').unhealthy || 0;
+    let stats = this.get('stats') || {};
+    if (stats.counts) {
+      return stats.counts.unhealthy || 0;
     }
+
     return 0;
   }
 
   getAverageLifeTime() {
-    if (this.get('lifeTime')) {
-      return this.get('lifeTime').averageSeconds || 0;
+    let stats = this.get('stats') || {};
+    if (stats.lifeTime) {
+      return stats.lifeTime.averageSeconds || 0;
     }
+
     return 0;
   }
 
   getMedianLifeTime() {
-    if (this.get('lifeTime')) {
-      return this.get('lifeTime').medianSeconds || 0;
+    let stats = this.get('stats') || {};
+    if (stats.lifeTime) {
+      return stats.lifeTime.medianSeconds || 0;
     }
+
     return 0;
   }
 }

--- a/src/js/structs/TaskStat.js
+++ b/src/js/structs/TaskStat.js
@@ -3,7 +3,8 @@ import Item from './Item';
 class TaskStat extends Item {
 
   isEmpty() {
-    return this.get('stats') == null;
+    return typeof this.get('stats') !== 'object' ||
+      !Object.keys(this.get('stats')).length;
   }
 
   getName() {

--- a/src/js/structs/TaskStat.js
+++ b/src/js/structs/TaskStat.js
@@ -2,6 +2,10 @@ import Item from './Item';
 
 class TaskStat extends Item {
 
+  isEmpty() {
+    return this.get('stats') == null;
+  }
+
   getName() {
     return this.get('name');
   }

--- a/src/js/structs/TaskStats.js
+++ b/src/js/structs/TaskStats.js
@@ -1,5 +1,13 @@
 import Item from './Item';
+import List from './List';
 import TaskStat from './TaskStat';
+
+const functionMap = {
+  withLatestConfig: 'getStatsForTasksWithLatestConfig',
+  startedAfterLastScaling: 'getStatsForTasksStaredAfterLastScaling',
+  withOutdatedConfig: 'getStatsForTasksWithOutdatedConfig',
+  totalSummary: 'getStatsForAllTasks'
+};
 
 class TaskStats extends Item {
 
@@ -8,7 +16,10 @@ class TaskStats extends Item {
    * config as the latest app version.
    */
   getStatsForTasksWithLatestConfig() {
-    return new TaskStat(this.get('withLatestConfig'));
+    let stat = this.get('withLatestConfig') || {};
+    stat.name = 'withLatestConfig';
+
+    return new TaskStat(stat);
   }
 
   /**
@@ -16,7 +27,10 @@ class TaskStats extends Item {
    * the last scaling or restart operation.
    */
   getStatsForTasksStaredAfterLastScaling() {
-    return new TaskStat(this.get('startedAfterLastScaling'));
+    let stat = this.get('startedAfterLastScaling') || {};
+    stat.name = 'startedAfterLastScaling';
+
+    return new TaskStat(stat);
   }
 
   /**
@@ -25,14 +39,28 @@ class TaskStats extends Item {
    * operation.
    */
   getStatsForTasksWithOutdatedConfig() {
-    return new TaskStat(this.get('withOutdatedConfig'));
+    let stat = this.get('withOutdatedConfig') || {};
+    stat.name = 'withOutdatedConfig';
+
+    return new TaskStat(stat);
   }
 
   /**
    * @return {TaskStat} task statistics about all tasks
    */
   getStatsForAllTasks() {
-    return new TaskStat(this.get('totalSummary'));
+    let stat = this.get('totalSummary') || {};
+    stat.name = 'totalSummary';
+
+    return new TaskStat(stat);
+  }
+
+  getList() {
+    let items = Object.keys(functionMap).map((key) => {
+      return this[functionMap[key]]();
+    });
+
+    return new List({items});
   }
 
 }

--- a/src/js/structs/TaskStats.js
+++ b/src/js/structs/TaskStats.js
@@ -55,9 +55,17 @@ class TaskStats extends Item {
     return new TaskStat(stat);
   }
 
+  /**
+   * @return {List} with each of the non-empty types of TaskStat available
+   */
   getList() {
-    let items = Object.keys(functionMap).map((key) => {
-      return this[functionMap[key]]();
+    let items = [];
+
+    Object.keys(functionMap).forEach((key) => {
+      let stat = this[functionMap[key]]();
+      if (!stat.isEmpty()) {
+        items.push(stat);
+      }
     });
 
     return new List({items});

--- a/src/js/structs/__tests__/TaskStat-test.js
+++ b/src/js/structs/__tests__/TaskStat-test.js
@@ -26,6 +26,12 @@ describe('TaskStat', function () {
       expect(statistics.isEmpty()).toEqual(true);
     });
 
+    it('returns true if stats with no keys have been provided', function () {
+      let statistics = new TaskStat({stats: {}});
+
+      expect(statistics.isEmpty()).toEqual(true);
+    });
+
     it('returns false if stats have been provided', function () {
       let statistics = new TaskStat({stats: {counts: {}}});
 

--- a/src/js/structs/__tests__/TaskStat-test.js
+++ b/src/js/structs/__tests__/TaskStat-test.js
@@ -2,6 +2,38 @@ const TaskStat = require('../TaskStat');
 
 describe('TaskStat', function () {
 
+  describe('#getName', function () {
+
+    it('returns undefined if no name have been provided', function () {
+      let statistics = new TaskStat({});
+
+      expect(statistics.getName()).toEqual(undefined);
+    });
+
+    it('returns name if name have been provided', function () {
+      let statistics = new TaskStat({name: 'foo'});
+
+      expect(statistics.getName()).toEqual('foo');
+    });
+
+  });
+
+  describe('#isEmpty', function () {
+
+    it('returns true if no stats have been provided', function () {
+      let statistics = new TaskStat({});
+
+      expect(statistics.isEmpty()).toEqual(true);
+    });
+
+    it('returns false if stats have been provided', function () {
+      let statistics = new TaskStat({stats: {counts: {}}});
+
+      expect(statistics.isEmpty()).toEqual(false);
+    });
+
+  });
+
   describe('#getHealthyTaskCount', function () {
 
     it('returns defaults to zero (0) if data is undefined', function () {

--- a/src/js/structs/__tests__/TaskStats-test.js
+++ b/src/js/structs/__tests__/TaskStats-test.js
@@ -1,3 +1,4 @@
+const List = require('../List');
 const TaskStats = require('../TaskStats');
 const TaskStat = require('../TaskStat');
 
@@ -90,6 +91,37 @@ describe('TaskStats', function () {
       }).getStatsForAllTasks();
 
       expect(statistics.getHealthyTaskCount()).toEqual(1);
+    });
+
+  });
+
+  describe('#getList', function () {
+
+    it('returns List instance', function () {
+      let statisticsList = new TaskStats({totalSummary: {}}).getList();
+
+      expect(statisticsList instanceof List).toBeTruthy();
+    });
+
+    it('should only return items with stats', function () {
+      let statisticsList = new TaskStats({
+        totalSummary: {
+          stats: {
+            counts: {healthy: 1}
+          }
+        },
+        startedAfterLastScaling: {
+          stats: {
+            counts: {healthy: 1}
+          }
+        },
+        withOutdatedConfig: {
+          stats: {}
+        },
+        withLatestConfig: {}
+      }).getList();
+
+      expect(statisticsList.getItems().length).toEqual(2);
     });
 
   });

--- a/src/js/utils/DateUtil.js
+++ b/src/js/utils/DateUtil.js
@@ -57,6 +57,10 @@ const DateUtil = {
     }
 
     return moment(str).valueOf();
+  },
+
+  getDuration: function (time, formatKey = 'seconds') {
+    return moment.duration(time, formatKey).humanize();
   }
 };
 


### PR DESCRIPTION
---
~~⚠️ Dependent on this PR: https://github.com/dcos/dcos-ui/pull/381
ℹ️ Reviewer look here for the diff between the two branches: https://github.com/dcos/dcos-ui/compare/mlunoe/add-service-debug-tab...mlunoe/add-service-debug-tab-stats-table?expand=1~~

---

![](http://cl.ly/3D0N010r2u1t/Image%202016-06-14%20at%2019.28.51.png)
Task with no statistics (the scenario will happen for each section, when information is not available):
![](http://cl.ly/2H3E0u190l47/Image%202016-06-09%20at%2015.02.51.png)