### PR TITLE
Use ms in DateUtil#msToRelativeTime instead of seconds

### DIFF
--- a/src/js/components/TaskDirectoryTable.js
+++ b/src/js/components/TaskDirectoryTable.js
@@ -82,9 +82,11 @@ class TaskDirectoryTable extends React.Component {
   }
 
   renderDate(prop, directoryItem) {
+    let ms = directoryItem.get(prop) * 1000;
+
     return (
-      <span title={DateUtil.msToDateStr(directoryItem.get(prop) * 1000)}>
-        {DateUtil.msToRelativeTime(directoryItem.get(prop))}
+      <span title={DateUtil.msToDateStr(ms)}>
+        {DateUtil.msToRelativeTime(ms)}
       </span>
     );
   }

--- a/src/js/utils/DateUtil.js
+++ b/src/js/utils/DateUtil.js
@@ -18,7 +18,7 @@ const DateUtil = {
   },
 
   msToRelativeTime: function (ms) {
-    return moment.unix(ms).fromNow();
+    return moment(ms).fromNow();
   },
 
    /**

--- a/src/js/utils/ResourceTableUtil.js
+++ b/src/js/utils/ResourceTableUtil.js
@@ -109,8 +109,9 @@ var ResourceTableUtil = {
       return 'N/A';
     }
 
-    let exactTime = DateUtil.msToDateStr(updatedAt.toFixed(3) * 1000);
-    let relativeTime = DateUtil.msToRelativeTime(updatedAt);
+    let ms = updatedAt.toFixed(3) * 1000;
+    let exactTime = DateUtil.msToDateStr(ms);
+    let relativeTime = DateUtil.msToRelativeTime(ms);
 
     return <span title={exactTime}>{relativeTime}</span>;
   },


### PR DESCRIPTION
Previously the method `msToRelativeTime` expected seconds, now it will take milliseconds as its name suggests