### PR TITLE
Allow suffix suppression in DateUtil#msToRelativeTime

### DIFF
--- a/src/js/utils/DateUtil.js
+++ b/src/js/utils/DateUtil.js
@@ -17,8 +17,8 @@ const DateUtil = {
     return dateStr;
   },
 
-  msToRelativeTime: function (ms) {
-    return moment(ms).fromNow();
+  msToRelativeTime: function (ms, suppressRelativeTime = false) {
+    return moment(ms).fromNow(suppressRelativeTime);
   },
 
    /**

--- a/src/js/utils/__tests__/DateUtil-test.js
+++ b/src/js/utils/__tests__/DateUtil-test.js
@@ -33,6 +33,24 @@ describe('DateUtil', function () {
     });
   });
 
+  describe('#msToRelativeTime', function () {
+    it('defaults to returning the suffix', function () {
+      let date = new Date();
+      date.setYear(date.getFullYear() - 1);
+      let result = DateUtil.msToRelativeTime(date.getTime());
+
+      expect(result).toEqual('a year ago');
+    });
+
+    it('suppresses the suffix if specified', function () {
+      let date = new Date();
+      date.setYear(date.getFullYear() - 1);
+      let result = DateUtil.msToRelativeTime(date.getTime(), true);
+
+      expect(result).toEqual('a year');
+    });
+  });
+
   describe('#dateToRelativeTime', function () {
     it('returns "in a year" if the date in a year from now', function () {
       let date = new Date();


### PR DESCRIPTION
This passes a boolean to `moment#fromNow` which will suppress the suffix when set to `true`. It defaults to `false`, which behaves the same way it did before.

Tests passing locally:
![](http://cl.ly/3v2q3Q0t2f1X/Screen%20Shot%202016-06-10%20at%2012.38.16%20PM.png)