### PR TITLE
[Jobs Table: 1 of 2] Add additional structs for Jobs table

### DIFF
--- a/src/js/structs/Job.js
+++ b/src/js/structs/Job.js
@@ -34,19 +34,19 @@ module.exports = class Job extends Item {
   }
 
   getLastRunStatus() {
-    let {lastFailureAt, lastSuccessAt} = this.get('status');
+    let {lastFailureAt = null, lastSuccessAt = null} = this.get('status');
     let status = 'N/A';
     let time = null;
 
-    if (lastFailureAt != null) {
+    if (lastFailureAt !== null) {
       lastFailureAt = DateUtil.strToMs(lastFailureAt);
     }
 
-    if (lastSuccessAt != null) {
+    if (lastSuccessAt !== null) {
       lastSuccessAt = DateUtil.strToMs(lastSuccessAt);
     }
 
-    if (lastFailureAt != null || lastSuccessAt != null) {
+    if (lastFailureAt !== null || lastSuccessAt !== null) {
       if (lastFailureAt > lastSuccessAt) {
         status = 'Failed';
         time = lastFailureAt;

--- a/src/js/structs/Job.js
+++ b/src/js/structs/Job.js
@@ -34,7 +34,7 @@ module.exports = class Job extends Item {
   }
 
   getLastRunStatus() {
-    let {lastFailureAt = null, lastSuccessAt = null} = this.get('status');
+    let {lastFailureAt = null, lastSuccessAt = null} = this.getStatus();
     let status = 'N/A';
     let time = null;
 
@@ -84,5 +84,9 @@ module.exports = class Job extends Item {
     }
 
     return 'completed';
+  }
+
+  getStatus() {
+    return this.get('status') || {};
   }
 };

--- a/src/js/structs/Job.js
+++ b/src/js/structs/Job.js
@@ -1,3 +1,4 @@
+import DateUtil from '../utils/DateUtil';
 import Item from './Item';
 import JobActiveRunList from './JobActiveRunList';
 
@@ -32,11 +33,56 @@ module.exports = class Job extends Item {
     return mem;
   }
 
+  getLastRunStatus() {
+    let {lastFailureAt, lastSuccessAt} = this.get('status');
+    let status = 'N/A';
+    let time = null;
+
+    if (lastFailureAt != null) {
+      lastFailureAt = DateUtil.strToMs(lastFailureAt);
+    }
+
+    if (lastSuccessAt != null) {
+      lastSuccessAt = DateUtil.strToMs(lastSuccessAt);
+    }
+
+    if (lastFailureAt != null || lastSuccessAt != null) {
+      if (lastFailureAt > lastSuccessAt) {
+        status = 'Failed';
+        time = lastFailureAt;
+      } else {
+        status = 'Success';
+        time = lastSuccessAt;
+      }
+    }
+
+    return {status, time};
+  }
+
   getName() {
     return this.getId().split('.').pop();
   }
 
   getSchedules() {
-    return this.get('schedules');
+    return this.get('schedules') || [];
+  }
+
+  getScheduleStatus() {
+    let activeRuns = this.getActiveRuns();
+
+    if (activeRuns.getItems().length > 0) {
+      let longestRunningActiveRun = activeRuns.getLongestRunningActiveRun();
+      return longestRunningActiveRun.getStatus();
+    }
+
+    if (this.getSchedules().length > 0) {
+      let schedule = this.getSchedules()[0];
+
+      if (!!schedule && schedule.enabled) {
+        return 'scheduled';
+      }
+    }
+
+    return 'completed';
   }
 };

--- a/src/js/structs/__tests__/Job-test.js
+++ b/src/js/structs/__tests__/Job-test.js
@@ -263,4 +263,27 @@ describe('Job', function () {
 
   });
 
+  describe('#getStatus', function () {
+
+    it('returns the status key', function () {
+      let job = new Job({
+        id: '/foo',
+        status: {
+          lastRunAt: 0
+        }
+      });
+
+      expect(job.getStatus()).toEqual({lastRunAt: 0});
+    });
+
+    it('returns empty object when status is undefined', function () {
+      let job = new Job({
+        id: '/foo'
+      });
+
+      expect(job.getStatus()).toEqual({});
+    });
+
+  });
+
 });

--- a/src/js/structs/__tests__/Job-test.js
+++ b/src/js/structs/__tests__/Job-test.js
@@ -150,13 +150,14 @@ describe('Job', function () {
       expect(job.getLastRunStatus().status).toEqual('Failed');
     });
 
-    it('returns N/A if both are undefiend', function () {
+    it('returns N/A status if both are undefiend', function () {
       let job = new Job({
         id: 'test.job',
         status: {}
       });
 
       expect(job.getLastRunStatus().status).toEqual('N/A');
+      expect(job.getLastRunStatus().time).toEqual(null);
     });
 
     it('returns success if lastFailureAt is undefiend', function () {
@@ -168,6 +169,17 @@ describe('Job', function () {
       });
 
       expect(job.getLastRunStatus().status).toEqual('Success');
+    });
+
+    it('returns success if lastFailureAt is undefiend', function () {
+      let job = new Job({
+        id: 'test.job',
+        status: {
+          lastFailureAt: '1990-04-30T00:00:00Z'
+        }
+      });
+
+      expect(job.getLastRunStatus().status).toEqual('Failed');
     });
 
   });

--- a/src/js/structs/__tests__/Job-test.js
+++ b/src/js/structs/__tests__/Job-test.js
@@ -112,6 +112,66 @@ describe('Job', function () {
 
   });
 
+  describe('#getLastRunStatus', function () {
+
+    it('returns an object with the time in ms', function () {
+      let job = new Job({
+        id: 'test.job',
+        status: {
+          lastSuccessAt: '1990-04-30T00:00:00Z',
+          lastFailureAt: '1985-04-30T00:00:00Z'
+        }
+      });
+
+      expect(job.getLastRunStatus().time).toEqual(641433600000);
+    });
+
+    it('returns the most recent status', function () {
+      let job = new Job({
+        id: 'test.job',
+        status: {
+          lastSuccessAt: '1990-04-30T00:00:00Z',
+          lastFailureAt: '1985-04-30T00:00:00Z'
+        }
+      });
+
+      expect(job.getLastRunStatus().status).toEqual('Success');
+    });
+
+    it('returns the most recent status', function () {
+      let job = new Job({
+        id: 'test.job',
+        status: {
+          lastSuccessAt: '1985-04-30T00:00:00Z',
+          lastFailureAt: '1990-04-30T00:00:00Z'
+        }
+      });
+
+      expect(job.getLastRunStatus().status).toEqual('Failed');
+    });
+
+    it('returns N/A if both are undefiend', function () {
+      let job = new Job({
+        id: 'test.job',
+        status: {}
+      });
+
+      expect(job.getLastRunStatus().status).toEqual('N/A');
+    });
+
+    it('returns success if lastFailureAt is undefiend', function () {
+      let job = new Job({
+        id: 'test.job',
+        status: {
+          lastSuccessAt: '1990-04-30T00:00:00Z'
+        }
+      });
+
+      expect(job.getLastRunStatus().status).toEqual('Success');
+    });
+
+  });
+
   describe('#getName', function () {
 
     it('returns correct name', function () {
@@ -128,6 +188,65 @@ describe('Job', function () {
       let job = new Job({id: '/foo', schedules: ['bar']});
 
       expect(job.getSchedules()).toEqual(['bar']);
+    });
+
+    it('returns an empty array if schedules is undefined', function () {
+      let job = new Job({id: '/foo'});
+
+      expect(job.getSchedules()).toEqual([]);
+    });
+
+  });
+
+  describe('#getScheduleStatus', function () {
+
+    it('returns the longest running job\'s status', function () {
+      let job = new Job({
+        id: '/foo',
+        activeRuns: [{
+          status: 'foo',
+          createdAt: '1985-01-03t00:00:00z-1'
+        }, {
+          status: 'bar',
+          createdAt: '1990-01-03t00:00:00z-1'
+        }],
+        schedules: ['bar']
+      });
+
+      expect(job.getScheduleStatus()).toEqual('foo');
+    });
+
+    it('returns scheduled if there are no active runs and the schedule is enabled', function () {
+      let job = new Job({
+        id: '/foo',
+        activeRuns: [],
+        schedules: [{
+          enabled: true
+        }]
+      });
+
+      expect(job.getScheduleStatus()).toEqual('scheduled');
+    });
+
+    it('returns completed if there are no active runs and no enabled schedule', function () {
+      let job = new Job({
+        id: '/foo',
+        activeRuns: [],
+        scheduled: [{
+          enabled: false
+        }]
+      });
+
+      expect(job.getScheduleStatus()).toEqual('completed');
+    });
+
+    it('returns completed if there are no active runs and no schedule', function () {
+      let job = new Job({
+        id: '/foo',
+        activeRuns: []
+      });
+
+      expect(job.getScheduleStatus()).toEqual('completed');
     });
 
   });


### PR DESCRIPTION
These structs will be later used by the Jobs table.

This PR introduces two methods on the `Jobs` struct:
* `#getLastRunStatus` retrieves the status and time of the most recent run
* `#getScheduleStatus` retrieves the status of the schedule
