### PR TITLE
[8] Deployments Table - styling

### DIFF
--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -81,10 +81,10 @@ class DeploymentsTab extends mixin(StoreMixin) {
 
       return (
         <dd key={index}>
-          <span className="icon icon-small icon-image-container icon-app-container deployment-service-icon">
-            <img src={image} />
-          </span>
           <Link to="services-detail" params={{id}} className="deployment-service-name">
+            <span className="icon icon-small icon-image-container icon-app-container deployment-service-icon">
+              <img src={image} />
+            </span>
             {StringUtil.capitalize(service.getName())}
           </Link>
         </dd>

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -16,7 +16,6 @@ import ResourceTableUtil from '../../utils/ResourceTableUtil';
 import ServicesBreadcrumb from '../../components/ServicesBreadcrumb';
 import StringUtil from '../../utils/StringUtil';
 
-const columnClassNameGetter = ResourceTableUtil.getClassName;
 const columnHeading = ResourceTableUtil.renderHeading({
   id: 'AFFECTED SERVICES',
   startTime: 'STARTED',
@@ -24,6 +23,7 @@ const columnHeading = ResourceTableUtil.renderHeading({
   status: 'STATUS',
   action: ''
 });
+const COLLAPSING_COLUMNS = ['location', 'startTime', 'action'];
 const METHODS_TO_BIND = [
   'renderAffectedServices',
   'renderAffectedServicesList',
@@ -35,6 +35,16 @@ const METHODS_TO_BIND = [
   'handleRollbackCancel',
   'handleRollbackConfirm'
 ];
+
+// collapsing columns are tightly coupled to the left-align caret property;
+// this wrapper allows ordinary columns to collapse.
+function columnClassNameGetter(prop, sortBy, row) {
+  let classSet = ResourceTableUtil.getClassName(prop, sortBy, row);
+  if (COLLAPSING_COLUMNS.includes(prop)) {
+    return classNames(classSet, 'hidden-mini');
+  }
+  return classSet;
+}
 
 class DeploymentsTab extends mixin(StoreMixin) {
 

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -194,6 +194,18 @@ class DeploymentsTab extends mixin(StoreMixin) {
     ];
   }
 
+  getColGroup() {
+    return (
+      <colgroup>
+        <col />
+        <col className="hidden-mini" />
+        <col className="hidden-mini" style={{width: '120px'}} />
+        <col style={{width: '240px'}} />
+        <col className="hidden-mini" style={{width: '120px'}} />
+      </colgroup>
+    );
+  }
+
   renderEmpty() {
     return (
       <AlertPanel
@@ -219,6 +231,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
         <Table
           className="table inverse table-borderless-outer table-borderless-inner-columns flush-bottom deployments-table"
           columns={this.getColumns()}
+          colGroup={this.getColGroup()}
           data={deploymentsItems.slice()} />
         {this.renderRollbackModal()}
       </div>

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -135,7 +135,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
 
     return (
       <div>
-        <div className="deployment-step">{title}</div>
+        <span className="deployment-step">{title}</span>
         <ol className="deployment-status-list list-unstyled flush-bottom">{items}</ol>
       </div>
     );
@@ -180,9 +180,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
         render: this.renderLocation
       },
       {
-        className: function () {
-          return classNames(columnClassNameGetter(...arguments), 'align-top');
-        },
+        className: columnClassNameGetter,
         heading: columnHeading,
         prop: 'startTime',
         render: this.renderStartTime
@@ -194,9 +192,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
         render: this.renderStatus
       },
       {
-        className: function () {
-          return classNames(columnClassNameGetter(...arguments), 'align-top');
-        },
+        className: columnClassNameGetter,
         heading: columnHeading,
         prop: 'action',
         render: this.renderAction

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -74,7 +74,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
           <span className="icon icon-small icon-image-container icon-app-container deployment-service-icon">
             <img src={image} />
           </span>
-          <Link to="services-detail" params={{id}}>
+          <Link to="services-detail" params={{id}} className="deployment-service-name">
             {StringUtil.capitalize(service.getName())}
           </Link>
         </dd>

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -258,7 +258,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
       let listOfServiceNames = StringUtil.humanizeArray(serviceNames);
       let serviceCount = serviceNames.length;
 
-      let application = StringUtil.pluralize('application', serviceCount);
+      let service = StringUtil.pluralize('service', serviceCount);
       let its = (serviceCount === 1) ? 'its' : 'their';
       let version = StringUtil.pluralize('version', serviceCount);
 
@@ -278,7 +278,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
             <p>
               This will stop the current deployment of {listOfServiceNames} and
               start a new deployment to revert the
-              affected {application} to {its} previous {version}.
+              affected {service} to {its} previous {version}.
             </p>
           </div>
         </Confirm>

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -207,7 +207,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
   getColGroup() {
     return (
       <colgroup>
-        <col />
+        <col style={{width: '300px'}} />
         <col className="hidden-mini" />
         <col className="hidden-mini" style={{width: '120px'}} />
         <col style={{width: '240px'}} />

--- a/src/styles/components/deployments-table.less
+++ b/src/styles/components/deployments-table.less
@@ -1,10 +1,7 @@
 .deployments-table {
 
   td {
-    vertical-align: bottom;
-    &.align-top {
-      vertical-align: top;
-    }
+    vertical-align: top;
   }
 
   .deployment-services-list,
@@ -29,6 +26,15 @@
     .text-overflow;
   }
 
+  .deployment-location-list {
+    padding-top: 25px;
+  }
+
+  .deployment-location-list li,
+  .deployment-status-list li {
+    margin-bottom: 0;
+  }
+
   .deployment-breadcrumb {
     .breadcrumbs {
       .text-overflow;
@@ -49,6 +55,7 @@
   }
 
   .deployment-step {
+    display: inline-block;
     margin-bottom: 8px;
   }
   .deployment-status-list {

--- a/src/styles/components/deployments-table.less
+++ b/src/styles/components/deployments-table.less
@@ -17,13 +17,22 @@
 
   .deployment-id {
     margin-bottom: 8px;
+    .text-overflow;
   }
 
   .deployment-service-icon {
     margin: 0 8px;
   }
 
+  .deployment-service-name {
+    .text-overflow;
+  }
+
   .deployment-breadcrumb {
+    .breadcrumbs {
+      .text-overflow;
+    }
+      
     .crumb {
       line-height: 32px;
       font-size: @body-text-font-size;

--- a/src/styles/components/deployments-table.less
+++ b/src/styles/components/deployments-table.less
@@ -22,6 +22,7 @@
 
   .deployment-service-icon {
     margin: 0 8px;
+    flex-shrink: 0;
   }
 
   .deployment-service-name {

--- a/src/styles/components/tree-list.less
+++ b/src/styles/components/tree-list.less
@@ -10,6 +10,7 @@
       content: '';
       display: inline-block;
       align-self: flex-start;
+      flex-shrink: 0;
 
       margin: 0 0 12px;
       width: 20px;


### PR DESCRIPTION
This PR brings the styling of the deployments table into line with the designs. 

Before and after:
![](https://s3.amazonaws.com/f.cl.ly/items/0C2j1B2g0K3l3L3X3B3A/Screen%20Recording%202016-06-13%20at%2003.19%20PM.gif?v=d3891620)

- [x] Column widths are correctly set
- [x] Long group and service names do not overflow the line
- [x] Location, start time and action columns are removed on narrow screens

- [x] Would be great to have @leemunroe's opinion on this. 

NB: this PR depends on #388