### PR TITLE
Introduce job form component

### DIFF
--- a/src/js/components/JobForm.js
+++ b/src/js/components/JobForm.js
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import SchemaForm from './SchemaForm';
+import SchemaFormUtil from '../utils/SchemaFormUtil';
+
+const METHODS_TO_BIND = [
+  'handleFormChange',
+  'validateForm'
+];
+
+class JobForm extends SchemaForm {
+  constructor() {
+    super();
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  componentWillMount() {
+    this.multipleDefinition = this.getNewDefinition();
+    this.props.getTriggerSubmit(this.handleExternalSubmit);
+  }
+
+  getDataTriple() {
+    let model = this.triggerTabFormSubmit();
+    return {
+      model: SchemaFormUtil.processFormModel(model, this.multipleDefinition)
+    };
+  }
+
+  validateForm() {
+    // TODO: Overwrite the default behaviour until DCOS-7669 is fixed.
+    return true;
+  }
+}
+
+JobForm.defaultProps = {
+  className: 'multiple-form row',
+  getTriggerSubmit: function () {},
+  onChange: function () {},
+  schema: {}
+};
+
+JobForm.propTypes = {
+  className: React.PropTypes.string,
+  getTriggerSubmit: React.PropTypes.func,
+  onChange: React.PropTypes.func,
+  schema: React.PropTypes.object
+};
+
+module.exports = JobForm;


### PR DESCRIPTION
Introduce a job form component – it's mainly needed to work around an issue (DCOS-7669) with the schema form, but might also serve other needs in the future.

/cc @kennyt @Poltergeist 