### PR TITLE
Change form error logic and styling

### DIFF
--- a/src/js/components/ServiceForm.js
+++ b/src/js/components/ServiceForm.js
@@ -28,7 +28,7 @@ class ServiceForm extends SchemaForm {
 
   handleFormChange() {
     // Handle the form change in the way service needs here.
-    this.props.onChange();
+    this.props.onChange(...arguments);
     return;
   }
 

--- a/src/js/components/ServiceForm.js
+++ b/src/js/components/ServiceForm.js
@@ -28,13 +28,15 @@ class ServiceForm extends SchemaForm {
 
   handleFormChange() {
     // Handle the form change in the way service needs here.
+    this.props.onChange();
     return;
   }
 
   getDataTriple() {
     let model = this.triggerTabFormSubmit();
     return {
-      model: SchemaFormUtil.processFormModel(model, this.multipleDefinition)
+      model: SchemaFormUtil.processFormModel(model, this.multipleDefinition),
+      isValid: this.validateForm()
     };
   }
 

--- a/src/js/components/ServiceForm.js
+++ b/src/js/components/ServiceForm.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import SchemaForm from './SchemaForm';
-import SchemaFormUtil from '../utils/SchemaFormUtil';
 
 const METHODS_TO_BIND = [
   'handleFormChange',
@@ -32,16 +31,10 @@ class ServiceForm extends SchemaForm {
     return;
   }
 
-  getDataTriple() {
-    let model = this.triggerTabFormSubmit();
-    return {
-      model: SchemaFormUtil.processFormModel(model, this.multipleDefinition),
-      isValid: this.validateForm()
-    };
-  }
-
   validateForm() {
+    this.model = this.triggerTabFormSubmit();
     // Handle the form change in the way service needs here.
+    this.isValidated = true;
     return true;
   }
 }

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -227,8 +227,9 @@ class ServiceFormModal extends mixin(StoreMixin) {
       return;
     }
     if (this.triggerSubmit) {
-      let {model, isValid} = this.triggerSubmit();
-      if (!isValid) {
+      let {model, isValidated} = this.triggerSubmit();
+
+      if (!isValidated) {
         return;
       }
       let service = ServiceUtil.createServiceFromFormModel(model);

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -28,6 +28,74 @@ const METHODS_TO_BIND = [
   'onMarathonStoreServiceEditSuccess'
 ];
 
+const serverResponseMappings = {
+  'error.path.missing': 'Specify a path',
+  'error.minLength': 'Field may not be blank',
+  'error.expected.jsnumber': 'A number is expected',
+  'error.expected.jsstring': 'A string is expected'
+};
+
+const responseAttributePathToFieldIdMap = {
+  'id': 'appId',
+  'apps': 'appId',
+  '/id': 'appId',
+  '/acceptedResourceRoles': 'acceptedResourceRoles',
+  '/cmd': 'cmd',
+  '/constraints': 'constraints',
+  '/constraints({INDEX})': 'constraints',
+  '/container/docker/forcePullImage': 'dockerForcePullImage',
+  '/container/docker/image': 'dockerImage',
+  '/container/docker/network': 'dockerNetwork',
+  '/container/docker/privileged': 'dockerPrivileged',
+  '/container/docker/parameters({INDEX})/key':
+    'dockerParameters/{INDEX}/key',
+  '/container/docker/parameters({INDEX})/value':
+    'dockerParameters/{INDEX}/value',
+  '/container/volumes({INDEX})/containerPath':
+    'containerVolumes/{INDEX}/containerPath',
+  '/container/volumes({INDEX})/hostPath':
+    'containerVolumes/{INDEX}/hostPath',
+  '/container/volumes({INDEX})/mode':
+    'containerVolumes/{INDEX}/mode',
+  '/cpus': 'cpus',
+  '/disk': 'disk',
+  '/env': 'env',
+  '/executor': 'executor',
+  '/healthChecks({INDEX})/command/value':
+    'healthChecks/{INDEX}/command',
+  '/healthChecks({INDEX})/path':
+    'healthChecks/{INDEX}/path',
+  '/healthChecks({INDEX})/intervalSeconds':
+    'healthChecks/{INDEX}/intervalSeconds',
+  '/healthChecks({INDEX})/port':
+    'healthChecks/{INDEX}/port',
+  '/healthChecks({INDEX})/portIndex':
+    'healthChecks/{INDEX}/portIndex',
+  '/healthChecks({INDEX})/timeoutSeconds':
+    'healthChecks/{INDEX}/timeoutSeconds',
+  '/healthChecks({INDEX})/gracePeriodSeconds':
+    'healthChecks/{INDEX}/gracePeriodSeconds',
+  '/healthChecks({INDEX})/maxConsecutiveFailures':
+    'healthChecks/{INDEX}/maxConsecutiveFailures',
+  '/instances': 'instances',
+  '/mem': 'mem',
+  '/portDefinitions': 'portDefinitions',
+  '/portDefinitions({INDEX})/name': 'portDefinitions/{INDEX}/name',
+  '/portDefinitions({INDEX})/port': 'portDefinitions/{INDEX}/port',
+  '/portDefinitions({INDEX})/protocol': 'portDefinitions/{INDEX}/protocol',
+  '/container/docker/portMappings': 'dockerPortMappings',
+  '/container/docker/portMappings({INDEX})/containerPort':
+    'dockerPortMappings/{INDEX}/port',
+  '/container/docker/portMappings({INDEX})/protocol':
+    'dockerPortMappings/{INDEX}/protocol',
+  '/container/docker/portMappings({INDEX})/hostPort': 'dockerPortMappings',
+  '/container/docker/portMappings({INDEX})/servicePort': 'dockerPortMappings',
+  '/labels': 'labels',
+  '/uris': 'uris',
+  '/user': 'user',
+  '/': 'general'
+};
+
 class ServiceFormModal extends mixin(StoreMixin) {
   constructor() {
     super(...arguments);
@@ -83,6 +151,9 @@ class ServiceFormModal extends mixin(StoreMixin) {
   }
 
   handleClearError() {
+    if (this.state.errorMessage == null) {
+      return;
+    }
     this.setState({
       errorMessage: null
     });
@@ -156,7 +227,10 @@ class ServiceFormModal extends mixin(StoreMixin) {
       return;
     }
     if (this.triggerSubmit) {
-      let {model} = this.triggerSubmit();
+      let {model, isValid} = this.triggerSubmit();
+      if (!isValid) {
+        return;
+      }
       let service = ServiceUtil.createServiceFromFormModel(model);
       this.setState({service, model, errorMessage: null});
       marathonAction(ServiceUtil.getAppDefinitionFromService(service));
@@ -173,19 +247,50 @@ class ServiceFormModal extends mixin(StoreMixin) {
       return null;
     }
 
+    // TODO: Refcator the var name
+    let msgs = null;
+    if (errorMessage.details != null) {
+      msgs = errorMessage.details.map(function ({path, errors}) {
+        let fieldId = 'general';
+
+        // Check if attributePath contains an index like path(0)/attribute
+        // Matches as defined: [0] : '(0)', [1]: '0'
+        var matches = path.match(/\(([0-9]+)\)/);
+        if (matches != null) {
+          let resolvePath = responseAttributePathToFieldIdMap[
+            path.replace(matches[0], '({INDEX})')
+            ];
+          if (resolvePath != null) {
+            fieldId = resolvePath.replace('{INDEX}', matches[1]);
+          }
+        } else {
+          fieldId = responseAttributePathToFieldIdMap[path];
+        }
+        errors = errors.map(function (error) {
+          if (serverResponseMappings[error]) {
+            return serverResponseMappings[error];
+          }
+          return error;
+        });
+
+        return (
+          <li key={path}>
+            {`${fieldId}: ${errors}`}
+          </li>
+        );
+      });
+    }
+
     return (
       <div>
-        <h4 className="text-align-center text-danger flush-top">
-          {errorMessage.message}
-        </h4>
-        <pre className="text-danger">
-          {JSON.stringify(errorMessage.details, null, 2)}
-        </pre>
-        <button
-          className="button button-small button-danger flush-bottom"
-          onClick={this.handleClearError}>
-          clear
-        </button>
+        <div className="error-field text-danger">
+          <h4 className="text-align-center text-danger flush-top">
+            {errorMessage.message}
+          </h4>
+          <ul>
+            {msgs}
+          </ul>
+        </div>
       </div>
     );
   }
@@ -241,6 +346,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
       <ServiceForm
         getTriggerSubmit={this.getTriggerSubmit}
         model={model}
+        onChange={this.handleClearError}
         schema={ServiceSchema}/>
     );
   }
@@ -257,7 +363,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
         backdropClass="modal-backdrop default-cursor"
         maxHeightPercentage={.9}
         bodyClass=""
-        modalWrapperClass="multiple-form-modal"
+        modalWrapperClass="multiple-form-modal service-deploy-modal"
         innerBodyClass=""
         open={this.props.open}
         showCloseButton={false}

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -247,19 +247,18 @@ class ServiceFormModal extends mixin(StoreMixin) {
       return null;
     }
 
-    // TODO: Refcator the var name
-    let msgs = null;
+    let errorList = null;
     if (errorMessage.details != null) {
-      msgs = errorMessage.details.map(function ({path, errors}) {
+      errorList = errorMessage.details.map(function ({path, errors}) {
         let fieldId = 'general';
 
         // Check if attributePath contains an index like path(0)/attribute
         // Matches as defined: [0] : '(0)', [1]: '0'
-        var matches = path.match(/\(([0-9]+)\)/);
+        let matches = path.match(/\(([0-9]+)\)/);
         if (matches != null) {
           let resolvePath = responseAttributePathToFieldIdMap[
             path.replace(matches[0], '({INDEX})')
-            ];
+          ];
           if (resolvePath != null) {
             fieldId = resolvePath.replace('{INDEX}', matches[1]);
           }
@@ -288,7 +287,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
             {errorMessage.message}
           </h4>
           <ul>
-            {msgs}
+            {errorList}
           </ul>
         </div>
       </div>

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -363,7 +363,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
         backdropClass="modal-backdrop default-cursor"
         maxHeightPercentage={.9}
         bodyClass=""
-        modalWrapperClass="multiple-form-modal service-deploy-modal"
+        modalWrapperClass="multiple-form-modal modal-form"
         innerBodyClass=""
         open={this.props.open}
         showCloseButton={false}

--- a/src/styles/components/multiple-form.less
+++ b/src/styles/components/multiple-form.less
@@ -160,6 +160,20 @@ base/forms.less
 
   }
 
+  .service-deploy-modal {
+
+    .error-field {
+      background: color-lighten(@red, 60);
+      border-bottom: @red 1px solid;
+      padding: (@base-spacing-unit / 2) @base-spacing-unit;
+
+      li:before {
+        background-color: currentColor;
+      }
+    }
+
+  }
+
 }
 
 & when (@screen-small-enabled) {

--- a/src/styles/components/multiple-form.less
+++ b/src/styles/components/multiple-form.less
@@ -160,7 +160,7 @@ base/forms.less
 
   }
 
-  .service-deploy-modal {
+  .modal-form {
 
     .error-field {
       background: color-lighten(@red, 60);


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/156010/16014285/e5471cc6-3190-11e6-939a-73e4f01fbb73.png)

This adds the mappings from `marathon-ui` for the `errorMessages` to give a cleaner display of the path.