### PR TITLE
[9] Deployments Table - rollback and remove for 'starting' deployments

### DIFF
--- a/src/js/pages/__tests__/DeploymentsTab-test.js
+++ b/src/js/pages/__tests__/DeploymentsTab-test.js
@@ -11,6 +11,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import DCOSStore from '../../stores/DCOSStore';
+import Deployment from '../../structs/Deployment';
 import DeploymentsTab from '../services/DeploymentsTab';
 import DeploymentsList from '../../structs/DeploymentsList';
 import Service from '../../structs/Service';
@@ -52,6 +53,30 @@ describe('DeploymentsTab', function () {
 
   afterEach(function () {
     ReactDOM.unmountComponentAtNode(this.container);
+  });
+
+  describe('#getRollbackModalText', function () {
+
+    it('should return a removal message when passed a starting deployment', function () {
+      let text = DeploymentsTab.prototype.getRollbackModalText(new Deployment({
+        id: 'deployment-id',
+        affectedApps: ['app1'],
+        affectedServices: [new Service({name: 'app1'})],
+        steps: [{actions: [{type: 'StartApplication'}]}]
+      }));
+      expect(text).toContain('remove the affected service');
+    });
+
+    it('should return a revert message when passed a non-starting deployment', function () {
+      let text = DeploymentsTab.prototype.getRollbackModalText(new Deployment({
+        id: 'deployment-id',
+        affectedApps: ['app1'],
+        affectedServices: [new Service({name: 'app1'})],
+        steps: [{actions: [{type: 'ScaleApplication'}]}]
+      }));
+      expect(text).toContain('revert the affected service');
+    });
+
   });
 
   describe('#render', function () {

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -143,10 +143,14 @@ class DeploymentsTab extends mixin(StoreMixin) {
 
   renderAction(prop, deployment) {
     if (deployment != null) {
+      let linkText = 'Rollback';
+      if (deployment.isStarting()) {
+        linkText = linkText + ' & Remove';
+      }
       return (
         <a className="deployment-rollback button button-link button-danger table-display-on-row-hover"
             onClick={this.handleRollbackClick.bind(null, deployment)}>
-          Rollback
+          {linkText}
         </a>
       );
     }

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -211,7 +211,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
         <col className="hidden-mini" />
         <col className="hidden-mini" style={{width: '120px'}} />
         <col style={{width: '240px'}} />
-        <col className="hidden-mini" style={{width: '120px'}} />
+        <col className="hidden-mini" style={{width: '160px'}} />
       </colgroup>
     );
   }
@@ -251,17 +251,6 @@ class DeploymentsTab extends mixin(StoreMixin) {
   renderRollbackModal() {
     let {deploymentToRollback} = this.state;
     if (deploymentToRollback != null) {
-      let serviceNames = deploymentToRollback.getAffectedServices()
-        .map(function (service) {
-          return StringUtil.capitalize(service.getName());
-        });
-      let listOfServiceNames = StringUtil.humanizeArray(serviceNames);
-      let serviceCount = serviceNames.length;
-
-      let service = StringUtil.pluralize('service', serviceCount);
-      let its = (serviceCount === 1) ? 'its' : 'their';
-      let version = StringUtil.pluralize('version', serviceCount);
-
       return (
         <Confirm
           closeByBackdropClick={true}
@@ -275,15 +264,33 @@ class DeploymentsTab extends mixin(StoreMixin) {
           rightButtonText="Continue Rollback">
           <div className="container-pod container-pod-short text-align-center">
             <h3 className="flush-top">You're About To Rollback The Deployment</h3>
-            <p>
-              This will stop the current deployment of {listOfServiceNames} and
-              start a new deployment to revert the
-              affected {service} to {its} previous {version}.
-            </p>
+            <p>{this.getRollbackModalText(deploymentToRollback)}</p>
           </div>
         </Confirm>
       );
     }
+  }
+
+  getRollbackModalText(deploymentToRollback) {
+    let serviceNames = deploymentToRollback.getAffectedServices()
+      .map(function (service) {
+        return StringUtil.capitalize(service.getName());
+      });
+    let listOfServiceNames = StringUtil.humanizeArray(serviceNames);
+    let serviceCount = serviceNames.length;
+
+    let service = StringUtil.pluralize('service', serviceCount);
+    let its = (serviceCount === 1) ? 'its' : 'their';
+    let version = StringUtil.pluralize('version', serviceCount);
+
+    if (deploymentToRollback.isStarting()) {
+      return `This will stop the current deployment of ${listOfServiceNames}
+              and start a new deployment to remove the affected ${service}.`
+    }
+
+    return `This will stop the current deployment of ${listOfServiceNames} and
+            start a new deployment to revert the affected ${service} to ${its}
+            previous ${version}.`
   }
 
   render() {

--- a/src/js/stores/MarathonStore.js
+++ b/src/js/stores/MarathonStore.js
@@ -345,7 +345,7 @@ class MarathonStore extends GetSetBaseStore {
     if (id != null) {
       let deployments = this.get('deployments')
         .filterItems(function (deployment) {
-          return deployment.id !== id;
+          return deployment.getId() !== id;
         });
       this.set({deployments});
       this.emit(MARATHON_DEPLOYMENTS_CHANGE);

--- a/src/js/structs/Deployment.js
+++ b/src/js/structs/Deployment.js
@@ -62,4 +62,18 @@ module.exports = class Deployment extends Item {
     return this.get('totalSteps');
   }
 
+  /**
+   * @return {boolean} true if this deployment starts a new service.
+   */
+  isStarting() {
+    let steps = this.get('steps');
+    if (steps != null) {
+      return this.get('steps').some(function (step) {
+        return step.actions.some(function (action) {
+          return action.type === 'StartApplication';
+        });
+      });
+    }
+  }
+
 }

--- a/src/js/structs/__tests__/Deployment-test.js
+++ b/src/js/structs/__tests__/Deployment-test.js
@@ -53,5 +53,43 @@ describe('Deployment', function () {
     });
   });
 
+  describe('#isStarting', function () {
+
+    it('flags deployments of newly-created services', function () {
+      let deployment = new Deployment({
+        id: 'deployment-id',
+        affectedApps: ['app1'],
+        steps: [{
+          actions: [
+            {app: 'app1', type: 'StartApplication'},
+            {app: 'app1', type: 'ScaleApplication'}
+          ]
+        }]
+      });
+
+      expect(deployment.isStarting()).toEqual(true);
+    });
+    
+    it('flags deployments which update services', function () {
+      let deployment = new Deployment({
+        id: 'deployment-id',
+        affectedApps: ['app1'],
+        steps: [{
+          actions: [
+            {app: 'app1', type: 'ScaleApplication'}
+          ]
+        }]
+      });
+
+      expect(deployment.isStarting()).toEqual(false);
+    });
+
+    it('gracefully handles deployments without steps', function () {
+      let deployment = new Deployment({id: 'deployment-id'});
+      expect(deployment.isStarting.bind(deployment)).not.toThrow(); 
+    });
+
+  });
+
 });
 


### PR DESCRIPTION
This functionality was added after talking with @leemunroe 

This PR introduces a distinction between a starting and a non-starting deployment. A deployment is considered to be starting if it deploys a service for the first time (or in more exact terms, if one of its actions is of type `StartApplication`)

When a deployment starts an application, rolling it back also deletes the linked service. We felt that this was not sufficiently well telegraphed to the user, and that both the rollback link and the accompanying modal should reflect this. 

This PR therefore

- [x] Adds an `isStarting` method to the `Deployment` struct
- [x] Shows a 'Rollback and Remove' link on starting deployments
- [x] Shows updated rollback modal text on starting deployments

![](https://s3.amazonaws.com/f.cl.ly/items/0I1L3S0K093c140f3L3e/Screen%20Recording%202016-06-13%20at%2006.25%20PM.gif?v=86362b0c)

NB this PR depends on #401 