### PR TITLE
[1 of 2] Add svg-react-loader

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5736,6 +5736,11 @@
       "from": "supports-color@>=3.1.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
     },
+    "svg-react-loader": {
+      "version": "0.3.5",
+      "from": "svg-react-loader@>=0.3.5 <0.4.0",
+      "resolved": "https://registry.npmjs.org/svg-react-loader/-/svg-react-loader-0.3.5.tgz"
+    },
     "svgo": {
       "version": "0.6.6",
       "from": "svgo@>=0.6.1 <0.7.0",
@@ -6472,6 +6477,16 @@
       "version": "2.0.1",
       "from": "xml-name-validator@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
+    },
+    "xml2js": {
+      "version": "0.4.16",
+      "from": "xml2js@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.16.tgz"
+    },
+    "xmlbuilder": {
+      "version": "4.2.1",
+      "from": "xmlbuilder@>=4.1.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz"
     },
     "xregexp": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "reactjs-components": "0.14.0-beta.26",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
+    "svg-react-loader": "^0.3.5",
     "tv4": "1.2.7",
     "underscore": "1.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "reactjs-components": "0.14.0-beta.26",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
-    "svg-react-loader": "^0.3.5",
+    "svg-react-loader": "0.3.5",
     "tv4": "1.2.7",
     "underscore": "1.7.0"
   },


### PR DESCRIPTION
This will allow us to load all SVG icons without having to manually covert them to React components. In a future PR, all icons in the application will be replaced with SVGs using this loader.

Example:
`import IconAdd from 'babel!svg-react!../img/icons/icon-add.svg?name=IconAdd';`

Read more here: https://github.com/jhamlet/svg-react-loader