### PR TITLE
Fix missing table borders in minified CSS

### DIFF
--- a/webpack/webpack.production.babel.js
+++ b/webpack/webpack.production.babel.js
@@ -80,11 +80,11 @@ module.exports = Object.assign({}, webpackConfig, {
       },
       {
         test: /\.css$/,
-        loader: ExtractTextPlugin.extract('style', 'css!postcss')
+        loader: ExtractTextPlugin.extract('style', 'css?-mergeLonghand!postcss')
       },
       {
         test: /\.less$/,
-        loader: ExtractTextPlugin.extract('style', 'css!postcss!less')
+        loader: ExtractTextPlugin.extract('style', 'css?-mergeLonghand!postcss!less')
       },
       {
         test: /\.png$/,


### PR DESCRIPTION
Fixes missing table borders in minified CSS. Bug in cssnano http://cssnano.co/optimisations/#mergelonghand