### PR TITLE
[2 of 2] Render SVG sidebar icons if they exist

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5736,6 +5736,11 @@
       "from": "supports-color@>=3.1.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
     },
+    "svg-react-loader": {
+      "version": "0.3.5",
+      "from": "svg-react-loader@>=0.3.5 <0.4.0",
+      "resolved": "https://registry.npmjs.org/svg-react-loader/-/svg-react-loader-0.3.5.tgz"
+    },
     "svgo": {
       "version": "0.6.6",
       "from": "svgo@>=0.6.1 <0.7.0",
@@ -6472,6 +6477,16 @@
       "version": "2.0.1",
       "from": "xml-name-validator@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
+    },
+    "xml2js": {
+      "version": "0.4.16",
+      "from": "xml2js@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.16.tgz"
+    },
+    "xmlbuilder": {
+      "version": "4.2.1",
+      "from": "xmlbuilder@>=4.1.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz"
     },
     "xregexp": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "reactjs-components": "0.14.0-beta.26",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
+    "svg-react-loader": "^0.3.5",
     "tv4": "1.2.7",
     "underscore": "1.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "reactjs-components": "0.14.0-beta.26",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
-    "svg-react-loader": "^0.3.5",
+    "svg-react-loader": "0.3.5",
     "tv4": "1.2.7",
     "underscore": "1.7.0"
   },

--- a/src/img/components/icons/pages.svg
+++ b/src/img/components/icons/pages.svg
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 32 32" xml:space="preserve">
 <path fill-opacity="0.2" opacity="0.9" d="M24,25h4V3H10v2h13c0.6,0,1,0.5,1,1V25z"/>
 <path d="M29,1H9C8.4,1,8,1.4,8,2v3H3C2.4,5,2,5.4,2,6v24c0,0.6,0.4,1,1,1h20c0.6,0,1-0.4,1-1v-3h5c0.6,0,1-0.4,1-1V2
 	C30,1.5,29.6,1,29,1z M22,29H4V7h18V29z M28,25h-4V6c0-0.6-0.4-1-1-1H10V3h18V25z M6,25h10v1H6V25z M6,22h14v1H6V22z M6,19h14v1H6

--- a/src/img/components/icons/pages.svg
+++ b/src/img/components/icons/pages.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve">
+<path fill-opacity="0.2" opacity="0.9" d="M24,25h4V3H10v2h13c0.6,0,1,0.5,1,1V25z"/>
+<path d="M29,1H9C8.4,1,8,1.4,8,2v3H3C2.4,5,2,5.4,2,6v24c0,0.6,0.4,1,1,1h20c0.6,0,1-0.4,1-1v-3h5c0.6,0,1-0.4,1-1V2
+	C30,1.5,29.6,1,29,1z M22,29H4V7h18V29z M28,25h-4V6c0-0.6-0.4-1-1-1H10V3h18V25z M6,25h10v1H6V25z M6,22h14v1H6V22z M6,19h14v1H6
+	V19z M6,16h14v1H6V16z M6,13h14v1H6V13z M6,10h14v1H6V10z"/>
+</svg>

--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -106,18 +106,28 @@ var Sidebar = React.createClass({
       var route = this.context.router.namedRoutes[routeKey];
       // Figure out if current route is active
       var isActive = route.handler.routeConfig.matches.test(currentPath);
-      var iconClasses = {
-        'sidebar-menu-item-icon icon icon-sprite icon-sprite-medium': true,
+      let isIconSVG = React.isValidElement(route.handler.routeConfig.icon);
+      let icon = null;
+      let iconClasses = classNames('sidebar-menu-item-icon icon icon-medium', {
+        [`icon-${route.handler.routeConfig.icon}`]: !isIconSVG,
+        'icon-sprite icon-sprite-medium': !isIconSVG,
         'icon-sprite-medium-color': isActive,
         'icon-sprite-medium-black': !isActive
-      };
-
-      iconClasses[`icon-${route.handler.routeConfig.icon}`] = true;
+      });
 
       var itemClassSet = classNames({
         'sidebar-menu-item': true,
         'selected': isActive
       });
+
+      if (isIconSVG) {
+        icon = React.cloneElement(
+          route.handler.routeConfig.icon,
+          {className: iconClasses}
+        );
+      } else {
+        icon = <i className={iconClasses}></i>;
+      }
 
       let sidebarText = (
         <span className="sidebar-menu-item-label h4 flush">
@@ -139,7 +149,7 @@ var Sidebar = React.createClass({
       return (
         <li className={itemClassSet} key={route.name}>
           <Link to={route.name}>
-            <i className={classNames(iconClasses)}></i>
+            {icon}
             {sidebarText}
           </Link>
         </li>

--- a/src/js/pages/JobsPage.js
+++ b/src/js/pages/JobsPage.js
@@ -2,6 +2,7 @@ import mixin from 'reactjs-mixin';
 import React from 'react';
 import {RouteHandler} from 'react-router';
 
+import IconJobs from 'babel!svg-react!../../img/components/icons/pages.svg?name=IconJobs';
 import Page from '../components/Page';
 import SidebarActions from '../events/SidebarActions';
 import TabsMixin from '../mixins/TabsMixin';
@@ -54,7 +55,7 @@ JobsPage.contextTypes = {
 
 JobsPage.routeConfig = {
   label: 'Jobs',
-  icon: 'jobs',
+  icon: <IconJobs />,
   matches: /^\/jobs/
 };
 


### PR DESCRIPTION
This allows us to specify both SVG components and strings as page icon. This should only be necessary for a short time until we move all icons to SVG.

Also depends on #414 

![](https://s3.amazonaws.com/f.cl.ly/items/1A1Q392A080a3Z0T1D1J/Screen%20Recording%202016-06-13%20at%2004.30%20PM.gif?v=f62c932b)