### PR TITLE
Service page: Sidebar Labels filter

### DIFF
--- a/src/js/components/ServiceSidebarFilters.js
+++ b/src/js/components/ServiceSidebarFilters.js
@@ -10,6 +10,7 @@ import ServiceStatusLabels from '../constants/ServiceStatusLabels';
 import ServiceStatusTypes from '../constants/ServiceStatusTypes';
 import ServiceTree from '../structs/ServiceTree';
 import HealthLabels from '../constants/HealthLabels';
+import SidebarLabelsFilter from './SidebarLabelsFilter';
 import SidebarFilter from './SidebarFilter';
 
 const PropTypes = React.PropTypes;
@@ -92,6 +93,7 @@ class ServiceSidebarFilters extends React.Component {
           filterLabels={ServiceStatusLabels}
           handleFilterChange={props.handleFilterChange}
           title="STATUS" />
+        <SidebarLabelsFilter {...props}/>
         <SidebarFilter
           countByValue={otherCount}
           filterType={ServiceFilterTypes.OTHER}

--- a/src/js/components/SidebarLabelsFilter.js
+++ b/src/js/components/SidebarLabelsFilter.js
@@ -81,6 +81,7 @@ class SidebarLabelsFilters extends mixin(QueryParamsMixin) {
     });
 
     let labelOptions = [{
+      className: 'hidden',
       id: '0',
       html: 'Labels',
       selectable: false

--- a/src/js/components/SidebarLabelsFilter.js
+++ b/src/js/components/SidebarLabelsFilter.js
@@ -1,0 +1,216 @@
+import classNames from 'classnames';
+import {Dropdown} from 'reactjs-components';
+import mixin from 'reactjs-mixin';
+import React from 'react';
+
+import QueryParamsMixin from '../mixins/QueryParamsMixin';
+import Service from '../structs/Service';
+import ServiceTree from '../structs/ServiceTree';
+import ServiceUtil from '../utils/ServiceUtil';
+import ServiceFilterTypes from '../constants/ServiceFilterTypes';
+
+const PropTypes = React.PropTypes;
+
+const METHODS_TO_BIND = [
+  'handleActionSelection',
+  'updateSelectedLabels'
+];
+
+class SidebarLabelsFilters extends mixin(QueryParamsMixin) {
+  constructor() {
+    super(...arguments);
+
+    METHODS_TO_BIND.forEach(method => {
+      this[method] = this[method].bind(this);
+    });
+
+    this.state = {
+      availableLabels: [],
+      selectedLabels: []
+    };
+  }
+
+  componentWillMount() {
+    this.setState({
+      availableLabels: this.getAvailableLabels(this.props.services)
+    }, this.updateSelectedLabels());
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      availableLabels: this.getAvailableLabels(nextProps.services)
+    }, this.updateSelectedLabels());
+  }
+
+  getAvailableLabels(services) {
+    return services.reduce(function (memo, item) {
+      if (item instanceof Service) {
+        let labels = ServiceUtil.convertServiceLabelsToArray(item);
+        labels.forEach(function ({key, value}) {
+          let index = memo.findIndex(function (label) {
+            return label.key === key && label.value === value;
+          });
+
+          if (0 > index) {
+            memo = memo.concat([{key, value}]);
+          }
+        });
+      }
+      if (item instanceof ServiceTree) {
+        memo = memo.concat(item.getLabels());
+      }
+
+      return memo;
+    },  [])
+    .sort((a, b) => a.key.localeCompare(b.key));
+  }
+
+  getLabelsDropdown() {
+    let {state} = this;
+    let availableLabels = state.availableLabels.map(function (label, i) {
+      let labelText = `${label.key} : ${label.value}`;
+
+      return Object.assign({}, label, {
+        id: `filter-label-${i}`,
+        html: (
+          <a className="text-overflow" title={labelText}>
+            {labelText}
+          </a>
+        )
+      });
+    });
+
+    let labelOptions = [{
+      id: '0',
+      html: 'Labels',
+      selectable: false
+    }].concat(availableLabels);
+
+    return (
+      <Dropdown
+        buttonClassName="button button-inverse dropdown-toggle button-wide button-split-content"
+        dropdownMenuClassName="dropdown-menu inverse"
+        dropdownMenuListClassName="dropdown-menu-list"
+        dropdownMenuListItemClassName="clickable"
+        items={labelOptions}
+        onItemSelection={this.handleActionSelection}
+        persistentID="0"
+        transition={true}
+        transitionName="dropdown-menu"
+        wrapperClassName="dropdown dropdown-wide" />
+    );
+  }
+
+  getSelectedLabels() {
+    let {selectedLabels} = this.state;
+
+    if (selectedLabels == null || selectedLabels.length === 0) {
+      return null;
+    }
+
+    const labelClassName = classNames(
+      'label-pill badge text-muted text-overflow inverse'
+    );
+
+    const removeLabelClassNames = classNames(
+      'badge text-muted inverse clickable text-align-center remove-filter'
+    );
+
+    let labelNodes = selectedLabels.map(({key, value}, i) => {
+      let labelText = `${key} : ${value}`;
+      return (
+        <li className={labelClassName} key={i} title={labelText}>
+          <div className="text-overflow pill-wrap">
+            <span className="text-overflow">{labelText}</span>
+            <a className={removeLabelClassNames}
+               onClick={this.handleActionSelection.bind(this, {key, value})}>
+              x
+            </a>
+          </div>
+        </li>
+      );
+    });
+
+    if (labelNodes.length === 0) {
+      return null;
+    }
+
+    const labelsListClassNames = classNames(
+      'container-pod container-pod-super-super-short flush-bottom list-unstyled'
+    );
+
+    return (
+      <ul className={labelsListClassNames}>
+        {labelNodes}
+      </ul>
+    )
+  }
+
+  handleActionSelection({key, value}) {
+    const {selectedLabels} = this.state;
+    const stringify = JSON.stringify;
+    let nextSelectedLabels = selectedLabels.slice();
+
+    let labelIndex = selectedLabels.findIndex(function (item) {
+      return item.key === key && item.value === value;
+    });
+
+    if (labelIndex > -1) {
+      nextSelectedLabels.splice(labelIndex, 1);
+    } else {
+      nextSelectedLabels = nextSelectedLabels.concat([{key, value}]);
+    }
+
+    if (stringify(nextSelectedLabels) !== stringify(selectedLabels)) {
+      let labels = nextSelectedLabels.map(label => {
+        return [label.key, label.value];
+      });
+
+      this.setQueryParam(ServiceFilterTypes.LABELS, labels);
+      this.props.handleFilterChange(labels, ServiceFilterTypes.LABELS);
+    }
+  }
+
+  updateSelectedLabels() {
+    const state = this.state;
+    const stringify = JSON.stringify;
+    let {router} = this.context;
+    let query = Object.assign({}, router.getCurrentQuery());
+    let selectedLabels = query[ServiceFilterTypes.LABELS];
+    let nextSelectedLabels = [];
+
+    if (selectedLabels != null) {
+      nextSelectedLabels = selectedLabels.map(label => {
+        let [key, value] = this.decodeQueryParamArray(label);
+
+        return {key, value};
+      });
+    }
+
+    if (stringify(nextSelectedLabels) !== stringify(state.selectedLabels)) {
+      this.setState({selectedLabels: nextSelectedLabels});
+    }
+  }
+
+  render() {
+    if (this.state.availableLabels.length === 0) {
+      return null;
+    }
+
+    return (
+      <div className="side-list sidebar-filters hidden-medium hidden-small hidden-mini">
+        <div className="flex-box flex-align-right flush">
+        </div>
+        {this.getLabelsDropdown()}
+        {this.getSelectedLabels()}
+      </div>
+    );
+  }
+}
+
+SidebarLabelsFilters.propTypes = {
+  handleFilterChange: PropTypes.func.isRequired,
+  services: PropTypes.array.isRequired
+};
+
+module.exports = SidebarLabelsFilters;

--- a/src/js/constants/ServiceFilterTypes.js
+++ b/src/js/constants/ServiceFilterTypes.js
@@ -2,6 +2,7 @@ const ServiceFilterTypes = {
   HEALTH: 'filterHealth',
   OTHER: 'filterOther',
   STATUS: 'filterStatus',
+  LABELS: 'filterLabels',
   TEXT: 'searchString'
 };
 

--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -28,6 +28,7 @@ var DEFAULT_FILTER_OPTIONS = {
   filterHealth: null,
   filterOther: null,
   filterStatus: null,
+  filterLabels: null,
   searchString: ''
 };
 
@@ -220,6 +221,7 @@ var ServicesTab = React.createClass({
     let services = item.getItems();
     let filteredServices = item.filterItemsByFilter({
       health: state.filterHealth,
+      labels: state.filterLabels,
       other: state.filterOther,
       status: state.filterStatus,
       id: state.searchString

--- a/src/js/structs/ServiceTree.js
+++ b/src/js/structs/ServiceTree.js
@@ -5,6 +5,7 @@ import HealthStatus from '../constants/HealthStatus';
 import Service from './Service';
 import ServiceOther from '../constants/ServiceOther';
 import ServiceStatus from '../constants/ServiceStatus';
+import ServiceUtil from '../utils/ServiceUtil';
 import Tree from './Tree';
 import VolumeList from '../structs/VolumeList';
 
@@ -116,6 +117,21 @@ module.exports = class ServiceTree extends Tree {
         services = services.filter(function (service) {
           return filter.health.some(function (healthValue) {
             return service.getHealth().value === parseInt(healthValue, 10);
+          });
+        });
+      }
+
+      if (filter.labels != null && filter.labels.length > 0) {
+        services = services.filter(function (service) {
+          return filter.labels.some(function (label) {
+            let serviceLabels = ServiceUtil.convertServiceLabelsToArray(
+              service
+            );
+
+            return serviceLabels.find(function (serviceLabel) {
+              return serviceLabel.key === label[0] &&
+                serviceLabel.value === label[1];
+            }) != null;
           });
         });
       }
@@ -252,5 +268,19 @@ module.exports = class ServiceTree extends Tree {
     }, []);
 
     return new VolumeList({items});
+  }
+
+  getLabels() {
+    return this.reduceItems(function (serviceTreeLabels, item) {
+      ServiceUtil.convertServiceLabelsToArray(item)
+        .forEach(function ({key, value}) {
+          if (0 > serviceTreeLabels.findIndex(function (label) {
+            return label.key === key && label.value === value;
+          })) {
+            serviceTreeLabels = serviceTreeLabels.concat([{key, value}]);
+          }
+        });
+      return serviceTreeLabels;
+    }, []);
   }
 };

--- a/src/js/structs/ServiceTree.js
+++ b/src/js/structs/ServiceTree.js
@@ -132,10 +132,10 @@ module.exports = class ServiceTree extends Tree {
               );
             }
 
-            return serviceLabels.find(function (serviceLabel) {
+            return serviceLabels.some(function (serviceLabel) {
               return serviceLabel.key === label[0] &&
                 serviceLabel.value === label[1];
-            }) != null;
+            });
           });
         });
       }

--- a/src/js/structs/ServiceTree.js
+++ b/src/js/structs/ServiceTree.js
@@ -124,9 +124,13 @@ module.exports = class ServiceTree extends Tree {
       if (filter.labels != null && filter.labels.length > 0) {
         services = services.filter(function (service) {
           return filter.labels.some(function (label) {
-            let serviceLabels = ServiceUtil.convertServiceLabelsToArray(
-              service
-            );
+            let serviceLabels = service.getLabels();
+
+            if (service instanceof Service) {
+              serviceLabels = ServiceUtil.convertServiceLabelsToArray(
+                service
+              );
+            }
 
             return serviceLabels.find(function (serviceLabel) {
               return serviceLabel.key === label[0] &&

--- a/src/js/structs/__tests__/ServiceTree-test.js
+++ b/src/js/structs/__tests__/ServiceTree-test.js
@@ -801,4 +801,81 @@ describe('ServiceTree', function () {
 
   });
 
+  describe('#getLabels', function () {
+
+    beforeEach(function () {
+      this.instance = new ServiceTree();
+    });
+
+    it('returns an array with all the labels in the group', function () {
+      this.instance.add(new Framework({
+        id: '/chronos',
+        labels: {
+          'label_one': 'value_one'
+        }
+      }));
+
+      this.instance.add(new Framework({
+        id: '/cassandra',
+        labels: {
+          'label_one': 'value_two',
+          'label_two': 'value_three'
+        }
+      }));
+
+      this.instance.add(new Service({
+        id: '/sleeper'
+      }));
+
+      let labels = this.instance.getLabels();
+      expect(labels.length).toEqual(3);
+      expect(labels).toEqual([
+        {key: 'label_one', value: 'value_one'},
+        {key: 'label_one', value:  'value_two'},
+        {key: 'label_two', value:  'value_three'}
+      ]);
+    });
+
+    it('filters out duplicate label key-value tuples', function () {
+      this.instance.add(new Framework({
+        id: '/chronos',
+        labels: {
+          'label_one': 'value_one'
+        }
+      }));
+
+      this.instance.add(new Service({
+        id: '/sleeper',
+        labels: {
+          'label_one': 'value_one',
+          'label_two': 'value_one'
+        }
+      }));
+
+      let labels = this.instance.getLabels();
+      expect(labels.length).toEqual(2);
+      expect(labels).toEqual([
+        {key: 'label_one', value: 'value_one'},
+        {key: 'label_two', value:  'value_one'}
+      ]);
+    });
+
+    it('returns an empty array if no labels are found', function () {
+      this.instance.add(new Framework({
+        id: '/chronos'
+      }));
+
+      let labels = this.instance.getLabels();
+      expect(labels.length).toEqual(0);
+      expect(labels).toEqual([]);
+    });
+
+    it('returns an empty array if tree is empty', function () {
+      let labels = this.instance.getLabels();
+      expect(labels.length).toEqual(0);
+      expect(labels).toEqual([]);
+    });
+
+  });
+
 });

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -132,6 +132,19 @@ const ServiceUtil = {
     });
 
     return appDefinition;
+  },
+
+  convertServiceLabelsToArray: function (service) {
+    if (!(service instanceof Service)) {
+      return [];
+    }
+
+    let labels = service.getLabels();
+    if (labels == null) {
+      return [];
+    }
+
+    return Object.keys(labels).map(key => ({key, value: labels[key]}));
   }
 };
 

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -107,4 +107,43 @@ describe('ServiceUtil', function () {
       });
     });
   });
+
+  describe('#convertServiceLabelsToArray', function ()  {
+    it('should return an array of key-value tuples', function () {
+      let service = new Service({
+        id: '/test',
+        cmd: 'sleep 1000;',
+        labels: {
+          'label_one': 'value_one',
+          'label_two': 'value_two'
+        }
+      });
+
+      let serviceLabels = ServiceUtil.convertServiceLabelsToArray(service);
+      expect(serviceLabels.length).toEqual(2);
+      expect(serviceLabels).toEqual([
+        {key: 'label_one', value: 'value_one'},
+        {key: 'label_two', value: 'value_two'}
+      ]);
+    });
+
+    it('should return an empty array if no labels are found', function () {
+      let service = new Service({
+        id: '/test',
+        cmd: 'sleep 1000;'
+      });
+
+      let serviceLabels = ServiceUtil.convertServiceLabelsToArray(service);
+      expect(serviceLabels.length).toEqual(0);
+      expect(serviceLabels).toEqual([]);
+    });
+
+    it('only performs the conversion on a Service', function () {
+      let service = {};
+      let serviceLabels = ServiceUtil.convertServiceLabelsToArray(service);
+      expect(serviceLabels.length).toEqual(0);
+      expect(serviceLabels).toEqual([]);
+    });
+  });
+
 });

--- a/src/styles/components/service-sidebar.less
+++ b/src/styles/components/service-sidebar.less
@@ -14,6 +14,10 @@
       max-width: 500px;
       min-width: 100%;
       width: auto;
+
+      .text-overflow {
+        max-width: none;
+      }
     }
   }
 

--- a/src/styles/components/service-sidebar.less
+++ b/src/styles/components/service-sidebar.less
@@ -8,4 +8,30 @@
       color: @white;
     }
   }
+
+  .dropdown.dropdown-wide {
+    .dropdown-menu {
+      max-width: 500px;
+      min-width: 100%;
+      width: auto;
+    }
+  }
+
+  .badge.label-pill {
+    .pill-wrap {
+      padding: 0 @base-spacing-unit 0 @base-spacing-unit / 4;
+    }
+
+    .remove-filter {
+      background-color: transparent;
+      position: absolute;
+      right: 0;
+      z-index: 2;
+
+      &:hover {
+        color: @white;
+        text-decoration: none;
+      }
+    }
+  }
 }

--- a/tests/pages/services/SidebarFilter-cy.js
+++ b/tests/pages/services/SidebarFilter-cy.js
@@ -74,8 +74,6 @@ describe('Sidebar Filter', function () {
       cy.get('tbody tr:visible').should('to.have.length', 1);
     });
 
-
-
     it('filters correctly on two filters', function () {
       cy.get('.sidebar-filters .label').contains('Healthy').click();
       cy.get('.sidebar-filters .label').contains('Unhealthy').click();

--- a/tests/pages/services/SidebarFilter-cy.js
+++ b/tests/pages/services/SidebarFilter-cy.js
@@ -2,13 +2,21 @@ describe('Sidebar Filter', function () {
   context('Filters services table', function () {
     beforeEach(function () {
       // Remove once responsive filters are in place
-      cy.viewport(1280, 600);
+      cy.viewport(1280, 800);
 
       cy.configureCluster({
         mesos: '1-for-each-health',
         nodeHealth: true
       });
       cy.visitUrl({url: '/services'});
+    });
+
+    it('filters correctly on Labels', function () {
+      cy.get('.sidebar-filters .dropdown').contains('Labels').click();
+      cy.get('.sidebar-filters .dropdown-menu .is-selectable').first().click();
+      cy.get('tbody tr:visible').should('to.have.length', 4);
+      cy.get('.sidebar-filters ul.list-unstyled li')
+        .should('to.have.length', 1);
     });
 
     it('filters correctly on Idle', function () {
@@ -65,6 +73,8 @@ describe('Sidebar Filter', function () {
       cy.get('.sidebar-filters .label').contains('Volumes').click();
       cy.get('tbody tr:visible').should('to.have.length', 1);
     });
+
+
 
     it('filters correctly on two filters', function () {
       cy.get('.sidebar-filters .label').contains('Healthy').click();


### PR DESCRIPTION
This adds the sidebar labels filter to the Services Page.


![labels12](https://cloud.githubusercontent.com/assets/1078545/16090202/c2f3028a-332e-11e6-9c00-93e66038c567.gif)

Verified by @leemunroe ™️ 

NOTES
----

I am having trouble getting the dropdown ellipsis styling to look right

- [x] when using `.text-overflow` inside a dropdown element, a weird hover artifact can be seen:
![image](https://cloud.githubusercontent.com/assets/1078545/16090248/f35f1f80-332e-11e6-843c-94e43e7821e7.png)

- [x] Integration tests pass locally
![image](https://cloud.githubusercontent.com/assets/1078545/16090295/2a8e9666-332f-11e6-800f-e20646bf2157.png)

- [x] how can we avoid having the persistent item (`Labels`) to show up inside of the open dropdown?

OUT OF SCOPE
----

- [ ] at some point we'll have to introduce a hash map so we can avoid storing the full key/value label strings in the URL – with really long labels this may end up getting us into trouble – out of scope
