### PR TITLE
Fix job tree rendering

### DIFF
--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -181,14 +181,14 @@ class JobsTab extends mixin(StoreMixin, QueryParamsMixin, SaveStateMixin) {
       );
     }
 
+    if (item instanceof JobTree && item.getItems().length > 0) {
+      return this.getJobTreeView(item);
+    }
+
     if (this.props.params.id) {
       return (
         <RouteHandler />
       );
-    }
-
-    if (item instanceof JobTree && item.getItems().length > 0) {
-      return this.getJobTreeView(item);
     }
 
     // Render empty panel


### PR DESCRIPTION
Make sure we're only rendering the job detail view, if we're actually looking at a job.

/cc @jfurrow 