### PR TITLE
Always show the services breadcrumb.

### DIFF
--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -206,15 +206,8 @@ var ServicesTab = React.createClass({
       );
     }
 
-    let shift = 1;
-
-    // Only show when there's a path
-    if (this.props.params.id && this.props.params.id.length) {
-      shift = 0;
-    }
-
     return (
-      <Breadcrumbs shift={shift} />
+      <Breadcrumbs />
     );
   },
 


### PR DESCRIPTION
![img](http://cl.ly/1s032i2Z3F0e/Image%202016-06-16%20at%2012.08.28%20PM.png)

ref to why this is being done: https://github.com/dcos/dcos-ui/pull/416#issuecomment-226187779