### PR TITLE
Reduce specificity of form-element-inline

### DIFF
--- a/src/styles/components/multiple-form.less
+++ b/src/styles/components/multiple-form.less
@@ -22,11 +22,18 @@ base/forms.less
 
   --------------------------------------------------------------------------------
   ----------------------------------------------------------------------------- */
+  .form-element-inline {
+    display: inline-block;
+
+    & + .form-element-inline {
+      margin-left: @base-spacing-unit;
+    }
+  }
+
   .horizontal-center {
 
     .form-element-inline {
       border-radius: 0;
-      display: inline-block;
 
       .form-element-inline-text {
         flex: none;


### PR DESCRIPTION
Removes the requirement of `form-element-inline` to be inside of `horizontal-center`.

Example:
![](http://cl.ly/3r2p4718363O/Screen%20Shot%202016-06-16%20at%202.20.11%20PM.png)