### PR TITLE
Feature - Service versions rollback buttons

### DIFF
--- a/src/js/components/ServiceDetailConfigurationTab.js
+++ b/src/js/components/ServiceDetailConfigurationTab.js
@@ -27,10 +27,25 @@ class ServiceDetailConfigurationTab extends React.Component {
   }
 
   componentWillMount() {
+    let {service} = this.props;
+
     this.setState({
-      selectedVersionID: this.props.service.getVersion()
+      selectedVersionID: service.getVersion()
     });
-    DCOSStore.fetchServiceVersions(this.props.service.getId());
+    DCOSStore.fetchServiceVersions(service.getId());
+  }
+
+  componentWillReceiveProps({service:nextService}) {
+    let {service} = this.props;
+
+    if (service.getVersion() === nextService.getVersion()) {
+      return;
+    }
+
+    this.setState({
+      selectedVersionID: nextService.getVersion()
+    });
+    DCOSStore.fetchServiceVersions(service.getId());
   }
 
   handleApplyButtonClick() {

--- a/src/js/components/ServiceDetailConfigurationTab.js
+++ b/src/js/components/ServiceDetailConfigurationTab.js
@@ -5,11 +5,13 @@ import ConfigurationView from './ConfigurationView';
 import DCOSStore from '../stores/DCOSStore';
 import MarathonStore from '../stores/MarathonStore';
 import Service from '../structs/Service';
+import ServiceFormModal from './modals/ServiceFormModal';
 import ServiceUtil from '../utils/ServiceUtil';
 
 const METHODS_TO_BIND = [
   'handleApplyButtonClick',
   'handleEditButtonClick',
+  'handleCloseServiceFormModal',
   'handleVersionSelection'
 ];
 
@@ -18,7 +20,8 @@ class ServiceDetailConfigurationTab extends React.Component {
     super(...arguments);
 
     this.state = {
-      selectedVersionID: null
+      selectedVersionID: null,
+      serviceToEdit: null
     };
 
     METHODS_TO_BIND.forEach(method => {
@@ -60,7 +63,18 @@ class ServiceDetailConfigurationTab extends React.Component {
   }
 
   handleEditButtonClick() {
+    let serviceConfiguration =
+      this.props.service.getVersions().get(this.state.selectedVersionID);
 
+    this.setState({
+      serviceToEdit: new Service(serviceConfiguration)
+    });
+  }
+
+  handleCloseServiceFormModal() {
+    this.setState({
+      serviceToEdit: null
+    });
   }
 
   handleVersionSelection(versionItem) {
@@ -147,7 +161,7 @@ class ServiceDetailConfigurationTab extends React.Component {
 
   render() {
     let {service} = this.props;
-    let {selectedVersionID} = this.state;
+    let {selectedVersionID, serviceToEdit} = this.state;
 
     let localeVersion = new Date(selectedVersionID).toLocaleString();
     let headline = `Current Version (${localeVersion})`;
@@ -163,6 +177,10 @@ class ServiceDetailConfigurationTab extends React.Component {
           headline={headline}
           service={service}
           versionID={selectedVersionID} />
+        <ServiceFormModal isEdit={true}
+          open={serviceToEdit != null}
+          service={serviceToEdit}
+          onClose={this.handleCloseServiceFormModal} />
       </div>
     );
   }

--- a/src/js/components/ServiceDetailConfigurationTab.js
+++ b/src/js/components/ServiceDetailConfigurationTab.js
@@ -171,7 +171,7 @@ class ServiceDetailConfigurationTab extends React.Component {
     }
 
     return (
-      <div>
+      <div className="tab">
         {this.getVersionsActions()}
         <ConfigurationView
           headline={headline}

--- a/src/js/components/ServiceDetailConfigurationTab.js
+++ b/src/js/components/ServiceDetailConfigurationTab.js
@@ -3,7 +3,9 @@ import React from 'react';
 
 import ConfigurationView from './ConfigurationView';
 import DCOSStore from '../stores/DCOSStore';
+import MarathonStore from '../stores/MarathonStore';
 import Service from '../structs/Service';
+import ServiceUtil from '../utils/ServiceUtil';
 
 const METHODS_TO_BIND = [
   'handleApplyButtonClick',
@@ -32,7 +34,14 @@ class ServiceDetailConfigurationTab extends React.Component {
   }
 
   handleApplyButtonClick() {
+    let serviceConfiguration =
+      this.props.service.getVersions().get(this.state.selectedVersionID);
 
+    MarathonStore.editService(
+      ServiceUtil.getAppDefinitionFromService(
+        new Service(serviceConfiguration)
+      )
+    );
   }
 
   handleEditButtonClick() {

--- a/src/js/components/ServiceDetailConfigurationTab.js
+++ b/src/js/components/ServiceDetailConfigurationTab.js
@@ -6,6 +6,8 @@ import DCOSStore from '../stores/DCOSStore';
 import Service from '../structs/Service';
 
 const METHODS_TO_BIND = [
+  'handleApplyButtonClick',
+  'handleEditButtonClick',
   'handleVersionSelection'
 ];
 
@@ -29,19 +31,61 @@ class ServiceDetailConfigurationTab extends React.Component {
     DCOSStore.fetchServiceVersions(this.props.service.getId());
   }
 
+  handleApplyButtonClick() {
+
+  }
+
+  handleEditButtonClick() {
+
+  }
+
   handleVersionSelection(versionItem) {
     this.setState({
       selectedVersionID: versionItem.id
     });
   }
 
-  getVersionsDropdown() {
-    let {service} = this.props;
-    let versions = service.getVersions();
+  getVersionsActions() {
+    let versions = this.props.service.getVersions();
 
     if (versions.size < 2) {
       return null;
     }
+
+    return (
+      <div className="button-collection">
+        {this.getVersionsDropdown()}
+        {this.getRollbackButtons()}
+      </div>
+    )
+  }
+
+  getRollbackButtons() {
+    let {service} = this.props;
+    let {selectedVersionID} = this.state;
+
+    if (service.getVersion() === selectedVersionID) {
+      return null;
+    }
+
+    return [(
+      <button className="button button-stroke button-inverse"
+        key="version-button-edit"
+        onClick={() => this.handleEditButtonClick()}>
+        Edit
+      </button>
+    ), (
+      <button className="button button-stroke button-inverse"
+        key="version-button-apply"
+        onClick={() => this.handleApplyButtonClick()}>
+        Apply
+      </button>
+    )];
+  }
+
+  getVersionsDropdown() {
+    let {service} = this.props;
+    let versions = service.getVersions();
 
     let versionItems = [];
     for (let version of versions.keys()) {
@@ -68,6 +112,7 @@ class ServiceDetailConfigurationTab extends React.Component {
         dropdownMenuListClassName="dropdown-menu-list"
         dropdownMenuListItemClassName="clickable"
         items={versionItems}
+        key="version-dropdown"
         onItemSelection={this.handleVersionSelection}
         persistentID={this.state.selectedVersionID}
         transition={true}
@@ -89,7 +134,7 @@ class ServiceDetailConfigurationTab extends React.Component {
 
     return (
       <div>
-        {this.getVersionsDropdown()}
+        {this.getVersionsActions()}
         <ConfigurationView
           headline={headline}
           service={service}

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -132,7 +132,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
   componentWillReceiveProps(nextProps) {
     super.componentWillReceiveProps(...arguments);
     if (!this.props.open && nextProps.open) {
-      this.resetState();
+      this.resetState(nextProps);
     }
   }
 
@@ -143,15 +143,17 @@ class ServiceFormModal extends mixin(StoreMixin) {
       state.errorMessage !== nextState.errorMessage;
   }
 
-  resetState() {
+  resetState(props = this.props) {
     let model = ServiceUtil.createFormModelFromSchema(ServiceSchema);
-    if (this.props.id) {
-      model.general.id = this.props.id;
+    if (props.id) {
+      model.general.id = props.id;
     }
     let service = ServiceUtil.createServiceFromFormModel(model);
-    if (this.props.service) {
-      service = this.props.service;
+
+    if (props.service) {
+      service = props.service;
     }
+
     this.setState({
       errorMessage: null,
       jsonDefinition: JSON.stringify({id:'', cmd:''}, null, 2),

--- a/tests/_support/spec_helper.js
+++ b/tests/_support/spec_helper.js
@@ -33,12 +33,12 @@ Cypress.addParentCommand('configureCluster', function (configuration) {
   if (configuration.mesos === '1-task-healthy') {
     cy
       .route(/service\/marathon\/v2\/apps/, 'fx:marathon-1-task/app')
-      .route(/service\/marathon\/v2\/apps\/\/sleep\/versions\/2015-08-28T01:26:14.620Z/,
-        'fx:marathon-1-task/app-version-1')
-      .route(/service\/marathon\/v2\/apps\/\/sleep\/versions\/2015-02-28T05:12:12.221Z/,
-        'fx:marathon-1-task/app-version-2')
       .route(/service\/marathon\/v2\/apps\/\/sleep\/versions/,
         'fx:marathon-1-task/versions')
+      .route(/service\/marathon\/v2\/apps\/\/sleep\/versions\/2015\-08\-28T01:26:14\.620Z/,
+        'fx:marathon-1-task/app-version-1')
+      .route(/service\/marathon\/v2\/apps\/\/sleep\/versions\/2015\-02\-28T05:12:12\.221Z/,
+        'fx:marathon-1-task/app-version-2')
       .route(/service\/marathon\/v2\/groups/, 'fx:marathon-1-task/groups')
       .route(/service\/marathon\/v2\/deployments/, 'fx:marathon-1-task/deployments')
       .route(/chronos\/v1\/jobs/, 'fx:chronos/jobs')

--- a/tests/pages/services/ServiceVersions-cy.js
+++ b/tests/pages/services/ServiceVersions-cy.js
@@ -8,7 +8,7 @@ describe('Service Versions', function () {
       });
 
       cy.visitUrl({url: '/services/%2Fsleep/'});
-      cy.wait(1000);
+      cy.wait(1500);
       cy.get('.tab-item .tab-item-label-text')
         .contains('Configuration').click();
       cy.wait(1000);
@@ -43,6 +43,64 @@ describe('Service Versions', function () {
         .contains('Previous Version (' +
           new Date('2015-02-28T05:12:12.221Z').toLocaleString() + ')')
         .should('to.have.length', 1);
+    });
+
+    it('applies the selected service version', function () {
+      cy
+        .route({
+          method: 'PUT',
+          url: /marathon\/v2\/apps\/\/sleep/,
+          response: {
+            "deploymentId": "5ed4c0c5-9ff8-4a6f-a0cd-f57f59a34b43",
+            "version": "2015-09-29T15:59:51.164Z"
+          },
+          delay: 500
+        });
+
+      cy.get('.page-content .dropdown .button span')
+        .contains(new Date('2015-08-28T01:26:14.620Z').toLocaleString())
+        .parent()
+        .click();
+
+      cy.wait(1500);
+
+      cy.get('.page-content .dropdown .dropdown-menu-list ul li:eq(1)')
+        .click();
+
+      cy.wait(1500);
+
+      cy.get('.page-content h4')
+        .contains('Previous Version (' +
+          new Date('2015-02-28T05:12:12.221Z').toLocaleString() + ')')
+        .should('to.have.length', 1);
+
+      cy.get('.page-content .tab button.button')
+        .contains('Apply').click();
+    });
+
+    it('opens correct edit modal of the selected service version', function () {
+      cy.get('.page-content .dropdown .button span')
+        .contains(new Date('2015-08-28T01:26:14.620Z').toLocaleString())
+        .parent()
+        .click();
+
+      cy.wait(1500);
+
+      cy.get('.page-content .dropdown .dropdown-menu-list ul li:eq(1)')
+        .click();
+
+      cy.wait(1500);
+
+      cy.get('.page-content h4')
+        .contains('Previous Version (' +
+          new Date('2015-02-28T05:12:12.221Z').toLocaleString() + ')')
+        .should('to.have.length', 1);
+
+      cy.get('.page-content .tab button.button')
+        .contains('Edit').click();
+
+      cy.get('.modal .form-panel textarea[name="cmd"]')
+        .should('to.have.value', 'sleep 1000');
     });
   });
 


### PR DESCRIPTION
* [x] Implements functionality (Edit and direct Apply) for rollback a service by a given version
* [x] Integration tests
* [x] Styling completed

![nogap](https://cloud.githubusercontent.com/assets/859154/16151351/c9b66af2-349c-11e6-83f8-71454c5285d7.png)

@ashenden Is there an straight-forward way of putting a gap between the dropdown and the edit button?
I've already invested some time to solve this actually easy problem, but gave up to proceeded with the implementation of functionality.
I don't want to add a specific class only for that.
Maybe you have a hint?

![current-structure](https://cloud.githubusercontent.com/assets/859154/16151441/50d6c3b0-349d-11e6-93e2-3bda1c9d78af.png)
