### PR TITLE
Add extra margin for LDAP dropdown

### DIFF
--- a/src/styles/components/dropdown-menus.less
+++ b/src/styles/components/dropdown-menus.less
@@ -124,15 +124,19 @@ components/dropdown-menus.less
 
   }
 
-
-  .dropdown-menu-down-leave {
-    z-index: @z-index-dropdown;
-  }
-
-
+  .dropdown-menu-down-leave,
   .dropdown-menu-up-leave {
     z-index: @z-index-dropdown;
   }
 
+  // This ugly hack is necessary to force the scrolling parent element to be
+  // large enough to display the dropdown menu. This can and should be removed
+  // when the dropdown menu renders with the <Portal /> component.
+  .directory-form-encryption-dropdown {
+
+    .dropdown {
+      margin-bottom: 125px;
+    }
+  }
 
 }


### PR DESCRIPTION
This PR adds extra padding to a specific dropdown to allow users to scroll within the modal, revealing all the options. Without it, the dropdown's menu is partially obscured.

We can remove this when the dropdown implements `Portal` which will allow the dropdown menu to render outside of scrolling elements.