### PR TITLE
Add current group to the the app id field in the create modal

### DIFF
--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -145,6 +145,9 @@ class ServiceFormModal extends mixin(StoreMixin) {
 
   resetState() {
     let model = ServiceUtil.createFormModelFromSchema(ServiceSchema);
+    if (this.props.id) {
+      model.general.id = this.props.id;
+    }
     let service = ServiceUtil.createServiceFromFormModel(model);
     if (this.props.service) {
       service = this.props.service;
@@ -404,10 +407,12 @@ ServiceFormModal.defaultProps = {
   isEdit: false,
   onClose: function () {},
   open: false,
+  id: null,
   service: null
 };
 
 ServiceFormModal.propTypes = {
+  id: React.PropTypes.string,
   isEdit: React.PropTypes.bool,
   open: React.PropTypes.bool,
   onClose: React.PropTypes.func,

--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -256,6 +256,8 @@ var ServicesTab = React.createClass({
     // Find item in root tree and default to root tree if there is no match
     let item = DCOSStore.serviceTree.findItemById(id) || DCOSStore.serviceTree;
 
+    let service = new Service({id: item.getId().replace(/^(\/.+)$/, '$1/')});
+
     // Make sure to grow when logs are displayed
     let routes = this.context.router.getCurrentRoutes();
     let classes = classNames({
@@ -270,6 +272,7 @@ var ServicesTab = React.createClass({
           parentGroupId={item.getId()}
           onClose={this.handleCloseGroupFormModal}/>
         <ServiceFormModal open={state.isServiceFormModalShown}
+          service={service}
           onClose={this.handleCloseServiceFormModal}/>
       </div>
     );

--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -264,7 +264,7 @@ var ServicesTab = React.createClass({
     // `/group/another-group` will be given by `getId` except on root then the
     // return value of `getId` would be `/` so in most cases we want to append a
     // `/` so that the user can begin typing the `id` of their application.
-    let service = new Service({id: item.getId().replace(/^(\/.+)$/, '$1/')});
+    let serviceId = item.getId().replace(/^(\/.+)$/, '$1/');
 
     // Make sure to grow when logs are displayed
     let routes = this.context.router.getCurrentRoutes();
@@ -280,7 +280,7 @@ var ServicesTab = React.createClass({
           parentGroupId={item.getId()}
           onClose={this.handleCloseGroupFormModal}/>
         <ServiceFormModal open={state.isServiceFormModalShown}
-          service={service}
+          id={serviceId}
           onClose={this.handleCloseServiceFormModal}/>
       </div>
     );

--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -256,6 +256,14 @@ var ServicesTab = React.createClass({
     // Find item in root tree and default to root tree if there is no match
     let item = DCOSStore.serviceTree.findItemById(id) || DCOSStore.serviceTree;
 
+    // The regular expression `/^(\/.+)$/` is looking for the beginning of the
+    // string and matches if the string starts with a `/` and does contain more
+    // characters after the slash. This is combined into a group and then
+    // replaced with the first group which is the complete string and a `/` is
+    // appended. This is needed because in most case a path like
+    // `/group/another-group` will be given by `getId` except on root then the
+    // return value of `getId` would be `/` so in most cases we want to append a
+    // `/` so that the user can begin typing the `id` of their application.
     let service = new Service({id: item.getId().replace(/^(\/.+)$/, '$1/')});
 
     // Make sure to grow when logs are displayed

--- a/tests/_fixtures/marathon-1-group/groups.json
+++ b/tests/_fixtures/marathon-1-group/groups.json
@@ -1,0 +1,21 @@
+{
+  "apps": [
+    
+  ],
+  "groups": [
+    {
+      "id": "/services",
+      "dependencies": [
+        
+      ],
+      "version": "2016-06-20T16:28:19.283Z",
+      "apps": [
+        
+      ],
+      "groups": [
+        
+      ]
+    }
+  ],
+  "id": "/"
+}

--- a/tests/_support/spec_helper.js
+++ b/tests/_support/spec_helper.js
@@ -48,6 +48,10 @@ Cypress.addParentCommand('configureCluster', function (configuration) {
       .route(/state-summary/, 'fx:marathon-1-task/summary')
       .route(/state/, 'fx:marathon-1-task/state');
   }
+  if (configuration.mesos === '1-empty-group') {
+    cy
+      .route(/marathon\/v2\/groups/, 'fx:marathon-1-group/groups')
+  }
 
   if (configuration.mesos === '1-for-each-health') {
     cy

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1,0 +1,80 @@
+describe('Service Form Modal', function () {
+  context('Root level', function () {
+    beforeEach(function () {
+      cy.configureCluster({
+        mesos: '1-empty-group',
+        nodeHealth: true
+      });
+      cy.visitUrl({url: '/services'});
+    });
+
+    it('has the right active navigation entry', function () {
+      cy.get('.page-navigation-list .tab-item.active')
+        .should('to.have.text', 'Services');
+    });
+
+    it('Opens the right modal on click', function () {
+      cy.get('.filter-bar-right .filter-bar-item')
+        .contains('Deploy Service')
+        .click();
+      cy.get('.modal-form').should('to.have.length', 1);
+    });
+
+    it('contains the right group id in the modal', function () {
+      cy.get('.filter-bar-right .filter-bar-item')
+        .contains('Deploy Service')
+        .click();
+      cy.get('.modal-form input[name="id"]').should(function (nodeList) {
+        expect(nodeList[0].value).to.equal('/');
+      });
+    });
+
+    it('contains the right JSON in the JSON editor', function () {
+      cy.get('.filter-bar-right .filter-bar-item')
+        .contains('Deploy Service')
+        .click();
+      cy.get('.modal-form-title-label').click();
+
+      cy.get('.ace_content').should(function (nodeList) {
+        expect(nodeList[0].textContent).to.contain('"id": "/"');
+      });
+    });
+  });
+
+  context('Group level', function () {
+    beforeEach(function () {
+      cy.configureCluster({
+        mesos: '1-empty-group',
+        nodeHealth: true
+      });
+      cy.visitUrl({url: '/services/%2Fservices/'});
+    });
+
+    it('Opens the right modal on click', function () {
+      cy.get('.panel-footer .button')
+        .contains('Deploy Service')
+        .click();
+      cy.get('.modal-form').should('to.have.length', 1);
+    });
+
+    it('contains the right group id in the modal', function () {
+      cy.get('.panel-footer .button')
+        .contains('Deploy Service')
+        .click();
+      cy.get('.modal-form input[name="id"]').should(function (nodeList) {
+        expect(nodeList[0].value).to.equal('/services/');
+      });
+    });
+
+    it('contains the right JSON in the JSON editor', function () {
+      cy.get('.panel-footer .button')
+        .contains('Deploy Service')
+        .click();
+      cy.get('.modal-form-title-label').click();
+
+      cy.get('.ace_content').should(function (nodeList) {
+        expect(nodeList[0].textContent).to.contain('"id": "/services/"');
+      });
+    });
+  });
+});


### PR DESCRIPTION
This adds the current group to the create modal so that the application id is prefilled with the current group id.

![image](https://cloud.githubusercontent.com/assets/156010/16200438/a5c7fcfa-370d-11e6-8b7d-26a59dd9ad6d.png)

The regular expression `/^(\/.+)$/` is looking for the beginning of the string and matches if the string starts with a `/` and does contain more characters after the slash. This is combined into a group and then replaced with the first group which is the complete string and a `/` is appended. This is needed because in most case a path like `/group/another-group` will be given by `getId` except on root then the return value of `getId` would be `/` so in most cases we want to append a `/` so that the user can begin typing the id of their application.

another approach could be this
```JS
let applicationId = item.getId();
if (applicationId !== '/') {
  applicationId = applicationId + '/';
}
let service = new Service({id: applicationId});
```
I prefer the regex way because it is shorter, but I am also fine with changing to the solution proposed above.