### PR TITLE
Transform fillRule attribute to fill-rule

### DIFF
--- a/src/js/utils/ReactSVG.js
+++ b/src/js/utils/ReactSVG.js
@@ -3,7 +3,13 @@ var DOMProperty = require('react/lib/DOMProperty');
 var svgAttrs = ['dominant-baseline', 'shape-rendering', 'mask'];
 // hack for getting react to render svg attributes
 DOMProperty.injection.injectDOMPropertyConfig({
+  DOMAttributeNames: {
+    fillRule: 'fill-rule'
+  },
   isCustomAttribute: function (attribute) {
     return svgAttrs.includes(attribute);
+  },
+  Properties: {
+    fillRule: DOMProperty.injection.MUST_USE_ATTRIBUTE
   }
 });


### PR DESCRIPTION
Forces the `fillRule` prop, generated by `svg-react-loader`, to be rendered as `fill-rule`. This is necessary for SVG icons in React 0.14, but can be removed in React 15.x.

In all its glory...
![](https://s3.amazonaws.com/f.cl.ly/items/470q3J1z1a3v0k1N1V46/Screen%20Shot%202016-06-20%20at%2010.12.08%20PM.png?v=fd019352)