### PR TITLE
Add default values to the service deploy modal schema

### DIFF
--- a/src/js/schemas/service-schema/General.js
+++ b/src/js/schemas/service-schema/General.js
@@ -22,6 +22,7 @@ let General = {
           title: 'CPUs',
           description: 'The amount of CPUs which are used for the service',
           type: 'number',
+          default: 1,
           getter: function (service) {
             return `${service.getCpus() || ''}`;
           }
@@ -29,6 +30,7 @@ let General = {
         mem: {
           title: 'Mem (MiB)',
           type: 'number',
+          default: 128,
           getter: function (service) {
             return `${service.getMem() || ''}`;
           }
@@ -36,6 +38,7 @@ let General = {
         disk: {
           title: 'Disk (MiB)',
           type: 'number',
+          default: 0,
           getter: function (service) {
             return `${service.getDisk() || ''}`;
           }
@@ -43,8 +46,9 @@ let General = {
         instances: {
           title: 'Instances',
           type: 'number',
+          default: 1,
           getter: function (service) {
-            return `${service.getInstancesCount() || 0}`;
+            return `${service.getInstancesCount() || ''}`;
           }
         }
       }

--- a/src/js/schemas/service-schema/General.js
+++ b/src/js/schemas/service-schema/General.js
@@ -24,7 +24,7 @@ let General = {
           type: 'number',
           default: 1,
           getter: function (service) {
-            return `${service.getCpus() || ''}`;
+            return `${service.getCpus() || 0}`;
           }
         },
         mem: {
@@ -32,7 +32,7 @@ let General = {
           type: 'number',
           default: 128,
           getter: function (service) {
-            return `${service.getMem() || ''}`;
+            return `${service.getMem() || 0}`;
           }
         },
         disk: {
@@ -48,7 +48,7 @@ let General = {
           type: 'number',
           default: 1,
           getter: function (service) {
-            return `${service.getInstancesCount() || ''}`;
+            return `${service.getInstancesCount() || 0}`;
           }
         }
       }

--- a/src/js/schemas/service-schema/General.js
+++ b/src/js/schemas/service-schema/General.js
@@ -40,7 +40,7 @@ let General = {
           type: 'number',
           default: 0,
           getter: function (service) {
-            return `${service.getDisk() || ''}`;
+            return `${service.getDisk() || 0}`;
           }
         },
         instances: {

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -11,7 +11,8 @@ const getFindPropertiesRecursive = function (service, item) {
       Object.keys(item[subItem].properties).forEach(function (key) {
         memo[key] = item[subItem].properties[key].default;
 
-        if (item[subItem].properties[key].getter) {
+        if (item[subItem].properties[key].getter &&
+          !!item[subItem].properties[key].getter(service)) {
           memo[key] = item[subItem].properties[key].getter(service);
         }
       });

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -16,6 +16,7 @@ const getFindPropertiesRecursive = function (service, item) {
           memo[key] = item[subItem].properties[key].getter(service);
         }
       });
+
       return memo;
     }
 

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -77,4 +77,64 @@ describe('Service Form Modal', function () {
       });
     });
   });
+
+  context('default values', function () {
+    beforeEach(function () {
+      cy.configureCluster({
+        mesos: '1-empty-group',
+        nodeHealth: true
+      });
+      cy.visitUrl({url: '/services'});
+    });
+
+    it('contains right cpus default value', function () {
+      cy.get('.filter-bar-right .filter-bar-item')
+        .contains('Deploy Service')
+        .click();
+      cy.get('.modal-form input[name="cpus"]').should(function (nodeList) {
+        expect(nodeList[0].value).to.equal('1');
+      });
+    });
+
+    it('contains right mem default value', function () {
+      cy.get('.filter-bar-right .filter-bar-item')
+        .contains('Deploy Service')
+        .click();
+      cy.get('.modal-form input[name="mem"]').should(function (nodeList) {
+        expect(nodeList[0].value).to.equal('128');
+      });
+    });
+
+    it('contains right instances default value', function () {
+      cy.get('.filter-bar-right .filter-bar-item')
+        .contains('Deploy Service')
+        .click();
+      cy.get('.modal-form input[name="instances"]').should(function (nodeList) {
+        expect(nodeList[0].value).to.equal('1');
+      });
+    });
+
+    it('contains right disk default value', function () {
+      cy.get('.filter-bar-right .filter-bar-item')
+        .contains('Deploy Service')
+        .click();
+      cy.get('.modal-form input[name="disk"]').should(function (nodeList) {
+        expect(nodeList[0].value).to.equal('0');
+      });
+    });
+
+    it('contains the right JSON in the JSON editor', function () {
+      cy.get('.filter-bar-right .filter-bar-item')
+        .contains('Deploy Service')
+        .click();
+      cy.get('.modal-form-title-label').click();
+
+      cy.get('.ace_content').should(function (nodeList) {
+        expect(nodeList[0].textContent).to.contain('"disk": 0');
+        expect(nodeList[0].textContent).to.contain('"cpus": 1');
+        expect(nodeList[0].textContent).to.contain('"instances": 1');
+        expect(nodeList[0].textContent).to.contain('"mem": 128');
+      });
+    });
+  });
 });


### PR DESCRIPTION
This adds default values to the Service Schema according to the marathon ui values.

```JSON
{
  "id": null,
  "cmd": null,
  "cpus": 1,
  "mem": 128,
  "disk": 0,
  "instances": 1
}
```
![image](https://cloud.githubusercontent.com/assets/156010/16234970/6a1281c8-37d3-11e6-9ff8-ab9eb7d45cce.png)
