### PR TITLE
[0 of n: Icons] Replace icons in tests with empty React elements

### DIFF
--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -16,7 +16,7 @@ module.exports = {
       if (babel.util.canCompile(filename)) {
         // This will match:
         // import IconFoo from '../../icons/icon-medium/pages-code.svg?name=foo';
-        var matches = src.match(/(\w+) (.*?) (\w+)(.*?)(icons)(.*?)\.svg(\?.*?)$/img);
+        var matches = src.match(/^(\w+) (.*?) (\w+|=) '(.*?)(icons)(.*?)\.svg(\?.*?)';$/img);
         if (matches && matches.length) {
           for (var i = 0; i < matches.length; i++) {
             var importMatch = matches[i].match(/^(\w+) (\w+)/);

--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -14,6 +14,18 @@ module.exports = {
       }
       // Run our modules through Babel before running tests
       if (babel.util.canCompile(filename)) {
+        // This will match:
+        // import IconFoo from '../../icons/icon-medium/pages-code.svg?name=foo';
+        var matches = src.match(/(\w+) (.*?) (\w+)(.*?)(icons)(.*?)\.svg(\?.*?)$/img);
+        if (matches && matches.length) {
+          for (var i = 0; i < matches.length; i++) {
+            var importMatch = matches[i].match(/^(\w+) (\w+)/);
+            // It'll replace all matches with:
+            // var IconFoo = React.createClass(...);
+            src = src.replace(matches[i], 'var ' + importMatch[2] + ' = React.createClass({render: function () { return React.createElement("div", null); } });');
+          }
+        }
+
         src = babel.transform(src, {
           auxiliaryCommentBefore: ' istanbul ignore next ',
           filename,


### PR DESCRIPTION
Icons will break tests because they need to be run through a Webpack loader first. This replaces all icons with empty React elements.

Huge thanks to @rcorral for the help here!