### PR TITLE
Adding Virtual Network detail tab with task detail

### DIFF
--- a/src/js/pages/network/VirtualNetworksTable.js
+++ b/src/js/pages/network/VirtualNetworksTable.js
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import {Link} from 'react-router';
 import React from 'react';
 import {Table} from 'reactjs-components';
 
@@ -30,6 +31,7 @@ class VirtualNetworksTable extends React.Component {
         headerClassName: getClassName,
         heading,
         prop: 'name',
+        render: this.renderName,
         sortable: false
       },
       {
@@ -58,6 +60,20 @@ class VirtualNetworksTable extends React.Component {
   renderHeading(prop) {
     return (
       <span className="table-header-title">{headerMapping[prop]}</span>
+    );
+  }
+
+  renderName(prop, overlay) {
+    let overlayName = overlay.getName();
+
+    return (
+      <Link
+        className="clickable"
+        params={{overlayName}}
+        title={overlayName}
+        to="virtual-networks-tab-detail">
+        {overlayName}
+      </Link>
     );
   }
 

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
@@ -11,6 +11,7 @@ import PageHeader from '../../../components/PageHeader';
 import RequestErrorMsg from '../../../components/RequestErrorMsg';
 import TabsMixin from '../../../mixins/TabsMixin';
 import VirtualNetworksStore from '../../../stores/VirtualNetworksStore';
+import VirtualNetworkUtil from '../../../utils/VirtualNetworkUtil';
 
 const METHODS_TO_BIND = [
   'onVirtualNetworksStoreError',
@@ -19,11 +20,11 @@ const METHODS_TO_BIND = [
 
 class VirtualNetworkDetail extends mixin(StoreMixin, TabsMixin) {
   constructor() {
-    super();
+    super(...arguments);
 
     this.state = {
-      receivedVirtualNetworks: false,
-      errorCount: 0
+      errorCount: 0,
+      receivedVirtualNetworks: false
     };
 
     this.tabs_tabs = {};
@@ -72,13 +73,9 @@ class VirtualNetworkDetail extends mixin(StoreMixin, TabsMixin) {
     this.setState({receivedVirtualNetworks: true, errorCount: 0});
   }
 
-  isLoading() {
-    return !this.state.receivedVirtualNetworks;
-  }
-
   getBasicInfo(overlay) {
     if (!overlay) {
-      return this.getEmptyScreen();
+      return VirtualNetworkUtil.getEmptyNetworkScreen();
     }
 
     let overlayIcon = (
@@ -101,21 +98,6 @@ class VirtualNetworkDetail extends mixin(StoreMixin, TabsMixin) {
     );
   }
 
-  getEmptyScreen() {
-    return (
-      <AlertPanel
-        title="Virtual Network Not Found"
-        iconClassName="icon icon-sprite icon-sprite-jumbo icon-sprite-jumbo-white icon-network flush-top">
-        <p className="flush">
-          {'Could not find the requested virtual network. Go to '}
-          <Link to="virtual-networks-tab">
-            Virtual Networks
-          </Link> overview to see all virtual networks.
-        </p>
-      </AlertPanel>
-    );
-  }
-
   getErrorScreen() {
     return <RequestErrorMsg />;
   }
@@ -133,12 +115,12 @@ class VirtualNetworkDetail extends mixin(StoreMixin, TabsMixin) {
   }
 
   render() {
-    let {errorCount} = this.state;
+    let {errorCount, receivedVirtualNetworks} = this.state;
     if (errorCount >= 3) {
       return this.getErrorScreen();
     }
 
-    if (this.isLoading()) {
+    if (!receivedVirtualNetworks) {
       return this.getLoadingScreen();
     }
 

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
@@ -1,0 +1,163 @@
+import mixin from 'reactjs-mixin';
+/* eslint-disable no-unused-vars */
+const React = require('react');
+/* eslint-enable no-unused-vars */
+import {Link, RouteHandler} from 'react-router';
+import {StoreMixin} from 'mesosphere-shared-reactjs';
+
+import AlertPanel from '../../../components/AlertPanel';
+import Breadcrumbs from '../../../components/Breadcrumbs';
+import PageHeader from '../../../components/PageHeader';
+import RequestErrorMsg from '../../../components/RequestErrorMsg';
+import TabsMixin from '../../../mixins/TabsMixin';
+import VirtualNetworksStore from '../../../stores/VirtualNetworksStore';
+
+const METHODS_TO_BIND = [
+  'onVirtualNetworksStoreError',
+  'onVirtualNetworksStoreSuccess'
+];
+
+class VirtualNetworkDetail extends mixin(StoreMixin, TabsMixin) {
+  constructor() {
+    super();
+
+    this.state = {
+      receivedVirtualNetworks: false,
+      errorCount: 0
+    };
+
+    this.tabs_tabs = {};
+
+    this.store_listeners = [
+      {
+        name: 'virtualNetworks',
+        events: ['success', 'error']
+      }
+    ];
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  componentWillMount() {
+    super.componentWillMount(...arguments);
+    this.updateCurrentTab();
+  }
+
+  componentWillReceiveProps() {
+    super.componentWillReceiveProps(...arguments);
+    this.updateCurrentTab();
+  }
+
+  updateCurrentTab() {
+    let routes = this.context.router.getCurrentRoutes();
+    let currentTab = routes[routes.length - 1].name;
+
+    // Virtual Network Detail Tabs
+    this.tabs_tabs = {
+      'virtual-networks-tab-detail-tasks': 'Tasks',
+      'virtual-networks-tab-detail-details': 'Details'
+    };
+
+    this.setState({currentTab});
+  }
+
+  onVirtualNetworksStoreError() {
+    let errorCount = this.state.errorCount + 1;
+    this.setState({errorCount});
+  }
+
+  onVirtualNetworksStoreSuccess() {
+    this.setState({receivedVirtualNetworks: true, errorCount: 0});
+  }
+
+  isLoading() {
+    return !this.state.receivedVirtualNetworks;
+  }
+
+  getBasicInfo(overlay) {
+    if (!overlay) {
+      return this.getEmptyScreen();
+    }
+
+    let overlayIcon = (
+      <i className="icon icon-sprite icon-sprite-jumbo icon-sprite-jumbo-white icon-network" />
+    );
+
+    let tabs = (
+      <ul className="tabs list-inline flush-bottom container-pod container-pod-short-top inverse">
+        {this.tabs_getRoutedTabs({params: this.props.params})}
+      </ul>
+    );
+
+    return (
+      <PageHeader
+        icon={overlayIcon}
+        iconClassName="icon-app-container"
+        subTitle={overlay.getSubnet()}
+        navigationTabs={tabs}
+        title={overlay.getName()} />
+    );
+  }
+
+  getEmptyScreen() {
+    return (
+      <AlertPanel
+        title="Virtual Network Not Found"
+        iconClassName="icon icon-sprite icon-sprite-jumbo icon-sprite-jumbo-white icon-network flush-top">
+        <p className="flush">
+          {'Could not find the requested virtual network. Go to '}
+          <Link to="virtual-networks-tab">
+            Virtual Networks
+          </Link> overview to see all virtual networks.
+        </p>
+      </AlertPanel>
+    );
+  }
+
+  getErrorScreen() {
+    return <RequestErrorMsg />;
+  }
+
+  getLoadingScreen() {
+    return (
+      <div className="container container-fluid container-pod text-align-center vertical-center inverse">
+        <div className="row">
+          <div className="ball-scale">
+            <div />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    let {errorCount} = this.state;
+    if (errorCount >= 3) {
+      return this.getErrorScreen();
+    }
+
+    if (this.isLoading()) {
+      return this.getLoadingScreen();
+    }
+
+    let overlay = VirtualNetworksStore.getOverlays().findItem((overlay) => {
+      return overlay.getName() === this.props.params.overlayName;
+    });
+
+    return (
+      <div className="flex-container-col flex-grow flex-shrink container-pod container-pod-divider-bottom-align-right container-pod-short-top flush-bottom flush-top">
+        <Breadcrumbs />
+        {this.getBasicInfo(overlay)}
+        <RouteHandler overlay={overlay} />
+      </div>
+    );
+  }
+}
+
+VirtualNetworkDetail.contextTypes = {
+  router: React.PropTypes.func
+};
+
+module.exports = VirtualNetworkDetail;

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
@@ -2,10 +2,9 @@ import mixin from 'reactjs-mixin';
 /* eslint-disable no-unused-vars */
 const React = require('react');
 /* eslint-enable no-unused-vars */
-import {Link, RouteHandler} from 'react-router';
+import {RouteHandler} from 'react-router';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
-import AlertPanel from '../../../components/AlertPanel';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import PageHeader from '../../../components/PageHeader';
 import RequestErrorMsg from '../../../components/RequestErrorMsg';

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js
@@ -13,8 +13,7 @@ class VirtualNetworkDetailsTab extends React.Component {
     }
 
     return (
-      <DescriptionList
-        hash={details} />
+      <DescriptionList hash={details} />
     );
   }
 }

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import Overlay from '../../../structs/Overlay';
+import DescriptionList from '../../../components/DescriptionList';
+
+class VirtualNetworkDetailsTab extends React.Component {
+  render() {
+    let {overlay} = this.props;
+
+    let details = {
+      Name: overlay.getName(),
+      Network: overlay.getSubnet()
+    }
+
+    return (
+      <DescriptionList
+        hash={details} />
+    );
+  }
+}
+
+VirtualNetworkDetailsTab.propTypes = {
+  overlay: React.PropTypes.instanceOf(Overlay)
+}
+
+module.exports = VirtualNetworkDetailsTab;

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
@@ -1,0 +1,291 @@
+import classNames from 'classnames';
+import {Link} from 'react-router';
+import mixin from 'reactjs-mixin';
+/* eslint-disable no-unused-vars */
+import React from 'react';
+/* eslint-enable no-unused-vars */
+import {StoreMixin} from 'mesosphere-shared-reactjs';
+import {Table} from 'reactjs-components';
+
+import AlertPanel from '../../../components/AlertPanel';
+import FilterBar from '../../../components/FilterBar';
+import FilterHeadline from '../../../components/FilterHeadline';
+import FilterInputText from '../../../components/FilterInputText';
+import MesosStateStore from '../../../stores/MesosStateStore';
+import Overlay from '../../../structs/Overlay';
+import RequestErrorMsg from '../../../components/RequestErrorMsg';
+import TaskUtil from '../../../utils/TaskUtil';
+import Util from '../../../utils/Util';
+
+const headerMapping = {
+  id: 'TASK',
+  ip_address: 'AGENT IP',
+  port_mappings: 'PORT MAPPINGS'
+};
+const METHODS_TO_BIND = [
+  'handleSearchStringChange',
+  'renderID',
+  'renderPorts',
+  'resetFilter'
+];
+
+class VirtualNetworkTaskTab extends mixin(StoreMixin) {
+  constructor() {
+    super(...arguments);
+
+    this.state = {
+      tasksDataReceived: false,
+      errorMessage: null
+    };
+
+    this.store_listeners = [{
+      name: 'state',
+      events: ['success', 'error']
+    }];
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  onStateStoreError(errorMessage) {
+    this.setState({tasksDataReceived: true, errorMessage});
+  }
+
+  onStateStoreSuccess() {
+    this.setState({tasksDataReceived: true, errorMessage: null});
+  }
+
+  handleSearchStringChange(searchString) {
+    this.setState({searchString});
+  }
+
+  resetFilter() {
+    this.setState({searchString: ''});
+  }
+
+  isLoading() {
+    return !this.state.tasksDataReceived;
+  }
+
+  getFilteredTasks(tasks, searchString = '') {
+    if (searchString === '') {
+      return tasks;
+    }
+
+    return tasks.filter(function (task) {
+      return task.name.includes(searchString) ||
+        task.id.includes(searchString);
+    });
+  }
+
+  getClassName(prop, sortBy) {
+    return classNames({
+      'highlight': prop === sortBy.prop
+    });
+  }
+
+  getColumns() {
+    let getClassName = this.getClassName;
+    let heading = this.renderHeading;
+
+    return [
+      {
+        className: getClassName,
+        headerClassName: getClassName,
+        heading,
+        prop: 'id',
+        render: this.renderID,
+        sortable: false
+      },
+      {
+        className: getClassName,
+        getValue: function (task) {
+          return Util.findNestedPropertyInObject(
+            task,
+            'statuses.0.container_status.network_infos.0.ip_address'
+          );
+        },
+        headerClassName: getClassName,
+        heading,
+        prop: 'ip_address',
+        sortable: false
+      },
+      {
+        className: getClassName,
+        getValue: TaskUtil.getPortMappings,
+        render: this.renderPorts,
+        headerClassName: getClassName,
+        heading,
+        prop: 'port_mappings',
+        sortable: false
+      }
+    ];
+  }
+
+  getColGroup() {
+    return (
+      <colgroup>
+        <col style={{width: '50%'}} />
+        <col />
+        <col />
+      </colgroup>
+    );
+  }
+
+  getEmptyScreen() {
+    return (
+      <AlertPanel
+        title="Virtual Network Not Found"
+        iconClassName="icon icon-sprite icon-sprite-jumbo icon-sprite-jumbo-white icon-network flush-top">
+        <p className="flush">
+          {'Could not find the requested virtual network. Go to '}
+          <Link to="virtual-networks-tab">
+            Virtual Networks
+          </Link> overview to see all virtual networks.
+        </p>
+      </AlertPanel>
+    );
+  }
+
+  getErrorScreen() {
+    return <RequestErrorMsg />;
+  }
+
+  getLoadingScreen() {
+    return (
+      <div className="container container-fluid container-pod text-align-center vertical-center inverse">
+        <div className="row">
+          <div className="ball-scale">
+            <div />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  getTaskLink(taskID, value, title) {
+    if (!value) {
+      value = taskID;
+    }
+
+    if (!title) {
+      title = taskID;
+    }
+
+    return (
+      <Link
+        className="clickable"
+        params={{overlayName: this.props.overlay.getName(), taskID}}
+        title={title}
+        to="virtual-networks-tab-detail-tasks-detail">
+        {value}
+      </Link>
+    );
+  }
+
+  getTitle(portMappings) {
+    return portMappings.map(function (mapping) {
+      return `${mapping.container_port} > ${mapping.host_port} (${mapping.protocol})`
+    }).join(', ')
+  }
+
+  renderHeading(prop) {
+    return (
+      <span className="table-header-title">{headerMapping[prop]}</span>
+    );
+  }
+
+  renderID(prop, task) {
+    return this.getTaskLink(task.id);
+  }
+
+  renderPorts(prop, task) {
+    let portMappings = TaskUtil.getPortMappings(task);
+    if (!portMappings) {
+      return 'N/A';
+    }
+
+    let title = this.getTitle(portMappings);
+    if (portMappings.length > 3) {
+      portMappings = portMappings.slice(0, 2);
+      portMappings.push({container_port: '...'});
+    }
+
+    let {id} = task;
+    return portMappings.map((mapping, index) => {
+      let mapTo = [];
+
+      if (mapping.host_port) {
+        mapTo.push(
+          <i className="icon icon-sprite icon-sprite-mini icon-chevron flush" />
+        );
+        mapTo.push(this.getTaskLink(
+          id,
+          `${mapping.host_port} (${mapping.protocol})`,
+          title
+        ));
+      }
+
+      return (
+        <div key={index} className="table-cell-value">
+          <div className="table-cell-details-secondary flex-box flex-box-align-vertical-center table-cell-flex-box">
+            <div className="text-overflow service-link inverse">
+              {this.getTaskLink(id, mapping.container_port, title)}
+              {mapTo}
+            </div>
+          </div>
+        </div>
+      );
+    });
+  }
+
+  render() {
+    let {searchString} = this.state;
+    if (this.isLoading()) {
+      return this.getLoadingScreen();
+    }
+
+    let {overlay} = this.props;
+    if (!overlay) {
+      return this.getEmptyScreen();
+    }
+
+    let tasks = MesosStateStore.getTasksFromVirtualNetworkName(
+      overlay.getName()
+    );
+    let filteredTasks = this.getFilteredTasks(tasks, searchString);
+
+    return (
+      <div>
+        <FilterHeadline
+          inverseStyle={true}
+          onReset={this.resetFilter}
+          name="Task"
+          currentLength={filteredTasks.length}
+          totalLength={tasks.length} />
+        <FilterBar>
+          <FilterInputText
+            searchString={searchString}
+            handleFilterChange={this.handleSearchStringChange}
+            inverseStyle={true} />
+        </FilterBar>
+        <Table
+          className="table inverse table-borderless-outer table-borderless-inner-columns flush-bottom"
+          columns={this.getColumns()}
+          colGroup={this.getColGroup()}
+          data={filteredTasks} />
+      </div>
+    );
+  }
+}
+
+VirtualNetworkTaskTab.contextTypes = {
+  router: React.PropTypes.func
+};
+
+VirtualNetworkTaskTab.propTypes = {
+  overlay: React.PropTypes.instanceOf(Overlay)
+}
+
+module.exports = VirtualNetworkTaskTab;

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
@@ -109,15 +109,16 @@ class VirtualNetworkTaskTab extends mixin(StoreMixin) {
         headerClassName: getClassName,
         heading,
         prop: 'ip_address',
+        render: this.renderAgentIP,
         sortable: false
       },
       {
         className: getClassName,
         getValue: TaskUtil.getPortMappings,
-        render: this.renderPorts,
         headerClassName: getClassName,
         heading,
         prop: 'port_mappings',
+        render: this.renderPorts,
         sortable: false
       }
     ];
@@ -173,6 +174,19 @@ class VirtualNetworkTaskTab extends mixin(StoreMixin) {
     return portMappings.map(function (mapping) {
       return `${mapping.container_port} > ${mapping.host_port} (${mapping.protocol})`
     }).join(', ')
+  }
+
+  renderAgentIP(task) {
+    let ipAddress = Util.findNestedPropertyInObject(
+      task,
+      'statuses.0.container_status.network_infos.0.ip_address'
+    );
+
+    if (!ipAddress) {
+      return 'N/A';
+    }
+
+    return ipAddress;
   }
 
   renderHeading(prop) {

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
@@ -15,6 +15,7 @@ import MesosStateStore from '../../../stores/MesosStateStore';
 import Overlay from '../../../structs/Overlay';
 import RequestErrorMsg from '../../../components/RequestErrorMsg';
 import TaskUtil from '../../../utils/TaskUtil';
+import VirtualNetworkUtil from '../../../utils/VirtualNetworkUtil';
 import Util from '../../../utils/Util';
 
 const headerMapping = {
@@ -34,8 +35,8 @@ class VirtualNetworkTaskTab extends mixin(StoreMixin) {
     super(...arguments);
 
     this.state = {
-      tasksDataReceived: false,
-      errorMessage: null
+      errorMessage: null,
+      tasksDataReceived: false
     };
 
     this.store_listeners = [{
@@ -133,21 +134,6 @@ class VirtualNetworkTaskTab extends mixin(StoreMixin) {
     );
   }
 
-  getEmptyScreen() {
-    return (
-      <AlertPanel
-        title="Virtual Network Not Found"
-        iconClassName="icon icon-sprite icon-sprite-jumbo icon-sprite-jumbo-white icon-network flush-top">
-        <p className="flush">
-          {'Could not find the requested virtual network. Go to '}
-          <Link to="virtual-networks-tab">
-            Virtual Networks
-          </Link> overview to see all virtual networks.
-        </p>
-      </AlertPanel>
-    );
-  }
-
   getErrorScreen() {
     return <RequestErrorMsg />;
   }
@@ -241,14 +227,18 @@ class VirtualNetworkTaskTab extends mixin(StoreMixin) {
   }
 
   render() {
-    let {searchString} = this.state;
+    let {errorMessage, searchString} = this.state;
     if (this.isLoading()) {
       return this.getLoadingScreen();
     }
 
+    if (errorMessage) {
+      return this.getErrorScreen();
+    }
+
     let {overlay} = this.props;
     if (!overlay) {
-      return this.getEmptyScreen();
+      return VirtualNetworkUtil.getEmptyNetworkScreen();
     }
 
     let tasks = MesosStateStore.getTasksFromVirtualNetworkName(

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
@@ -7,7 +7,6 @@ import React from 'react';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 import {Table} from 'reactjs-components';
 
-import AlertPanel from '../../../components/AlertPanel';
 import FilterBar from '../../../components/FilterBar';
 import FilterHeadline from '../../../components/FilterHeadline';
 import FilterInputText from '../../../components/FilterInputText';

--- a/src/js/pages/task-details/TaskDetail.js
+++ b/src/js/pages/task-details/TaskDetail.js
@@ -6,14 +6,14 @@ import {RouteHandler} from 'react-router';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
 import Breadcrumbs from '../../components/Breadcrumbs';
+import InternalStorageMixin from '../../mixins/InternalStorageMixin';
 import MarathonStore from '../../stores/MarathonStore';
 import MesosStateStore from '../../stores/MesosStateStore';
 import PageHeader from '../../components/PageHeader';
 import RequestErrorMsg from '../../components/RequestErrorMsg';
+import TabsMixin from '../../mixins/TabsMixin';
 import TaskDirectoryStore from '../../stores/TaskDirectoryStore';
 import TaskStates from '../../constants/TaskStates';
-import InternalStorageMixin from '../../mixins/InternalStorageMixin';
-import TabsMixin from '../../mixins/TabsMixin';
 
 const SERVICES_TABS = {
   'services-task-details-tab': 'Details',
@@ -27,6 +27,12 @@ const NODES_TABS = {
   'nodes-task-details-files': 'Files',
   'nodes-task-details-logs': 'Logs',
   'nodes-task-details-volumes': 'Volumes'
+};
+
+const VIRTUAL_NETWORKS_TABS = {
+  'virtual-networks-tab-detail-tasks-details-tab': 'Details',
+  'virtual-networks-tab-detail-tasks-details-files': 'Files',
+  'virtual-networks-tab-detail-tasks-details-logs': 'Logs'
 };
 
 const METHODS_TO_BIND = [
@@ -64,6 +70,9 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
     this.tabs_tabs = Object.assign({}, SERVICES_TABS);
     if (this.props.params.nodeID != null) {
       this.tabs_tabs = Object.assign({}, NODES_TABS);
+    }
+    if (this.props.params.overlayName != null) {
+      this.tabs_tabs = Object.assign({}, VIRTUAL_NETWORKS_TABS);
     }
     this.updateCurrentTab();
   }

--- a/src/js/pages/task-details/TaskDetailsTab.js
+++ b/src/js/pages/task-details/TaskDetailsTab.js
@@ -9,6 +9,24 @@ import TaskDirectoryStore from '../../stores/TaskDirectoryStore';
 import Units from '../../utils/Units';
 
 class TaskDetailsTab extends React.Component {
+  getContainerInfo(task) {
+    if (task == null || !task.container ||
+      !MesosSummaryStore.get('statesProcessed')) {
+      return null;
+    }
+
+    return (
+      <div>
+        <h5 className="flush-top inverse">
+          Container Configuration
+        </h5>
+        <pre className="mute prettyprint flush-bottom prettyprinted">
+          {JSON.stringify(task.container, null, 4)}
+        </pre>
+      </div>
+    );
+  }
+
   getMesosTaskDetailsDescriptionList(mesosTask) {
     if (mesosTask == null || !MesosSummaryStore.get('statesProcessed')) {
       return null;
@@ -118,6 +136,7 @@ class TaskDetailsTab extends React.Component {
         {this.getMesosTaskDetailsDescriptionList(task)}
         {this.getMesosTaskLabelDescriptionList(task)}
         <MarathonTaskDetailsList taskID={task.id} />
+        {this.getContainerInfo(task)}
       </div>
     );
   }

--- a/src/js/routes/factories/network.js
+++ b/src/js/routes/factories/network.js
@@ -1,11 +1,18 @@
 /* eslint-disable no-unused-vars */
 import React, {PropTypes} from 'react';
 /* eslint-enable no-unused-vars */
-import {Route, Redirect} from 'react-router';
+import {DefaultRoute, Route, Redirect} from 'react-router';
 
 import {Hooks} from 'PluginSDK';
 import NetworkPage from '../../pages/NetworkPage';
 import VirtualNetworksTab from '../../pages/network/VirtualNetworksTab';
+import VirtualNetworkDetail from '../../pages/network/virtual-network-detail/VirtualNetworkDetail';
+import VirtualNetworkTaskTab from '../../pages/network/virtual-network-detail/VirtualNetworkTaskTab';
+import VirtualNetworkDetailsTab from '../../pages/network/virtual-network-detail/VirtualNetworkDetailsTab';
+import TaskDetail from '../../pages/task-details/TaskDetail';
+import TaskDetailsTab from '../../pages/task-details/TaskDetailsTab';
+import TaskFilesTab from '../../pages/task-details/TaskFilesTab';
+import TaskLogsTab from '../../pages/task-details/TaskLogsTab';
 
 let RouteFactory = {
   getNetworkRoutes() {
@@ -25,6 +32,115 @@ let RouteFactory = {
             }
           }
         }
+      },
+      {
+        type: Route,
+        name: 'virtual-networks-tab-detail',
+        path: 'virtual-networks/:overlayName/?',
+        handler: VirtualNetworkDetail,
+        children: [
+          {
+            type: DefaultRoute,
+            name: 'virtual-networks-tab-detail-tasks',
+            handler: VirtualNetworkTaskTab,
+            hideHeaderNavigation: true,
+            buildBreadCrumb: function () {
+              return {
+                parentCrumb: 'virtual-networks-tab',
+                getCrumbs: function (router) {
+                  let {overlayName} = router.getCurrentParams();
+
+                  return [{
+                    label: overlayName,
+                    route: {
+                      to: 'virtual-networks-tab-detail-tasks',
+                      params: {overlayName}
+                    }
+                  }];
+                }
+              }
+            }
+          },
+          {
+            type: Route,
+            name: 'virtual-networks-tab-detail-details',
+            path: 'details/?',
+            handler: VirtualNetworkDetailsTab,
+            hideHeaderNavigation: true,
+            buildBreadCrumb: function () {
+              return {
+                parentCrumb: 'virtual-networks-tab',
+                getCrumbs: function (router) {
+                  let {overlayName} = router.getCurrentParams();
+
+                  return [{
+                    label: overlayName,
+                    route: {
+                      to: 'virtual-networks-tab-detail-details',
+                      params: {overlayName}
+                    }
+                  }];
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        type: Route,
+        name: 'virtual-networks-tab-detail-tasks-detail',
+        path: 'virtual-networks/:overlayName/tasks/:taskID/?',
+        handler: TaskDetail,
+        hideHeaderNavigation: true,
+        buildBreadCrumb: function () {
+          return {
+            parentCrumb: 'virtual-networks-tab-detail-tasks',
+            getCrumbs: function (router) {
+              return [{label: router.getCurrentParams().taskID}];
+            }
+          }
+        },
+        children: [
+          {
+            type: DefaultRoute,
+            name: 'virtual-networks-tab-detail-tasks-details-tab',
+            handler: TaskDetailsTab,
+            hideHeaderNavigation: true,
+            buildBreadCrumb: function () {
+              return {
+                parentCrumb: 'virtual-networks-tab-detail-tasks-detail',
+                getCrumbs: function () { return []; }
+              }
+            }
+          },
+          {
+            type: Route,
+            name: 'virtual-networks-tab-detail-tasks-details-files',
+            path: 'files/?',
+            handler: TaskFilesTab,
+            hideHeaderNavigation: true,
+            buildBreadCrumb: function () {
+              return {
+                parentCrumb: 'virtual-networks-tab-detail-tasks-detail',
+                getCrumbs: function () { return []; }
+              }
+            }
+          },
+          {
+            type: Route,
+            name: 'virtual-networks-tab-detail-tasks-details-logs',
+            dontScroll: true,
+            path: 'logs/?',
+            handler: TaskLogsTab,
+            hideHeaderNavigation: true,
+            buildBreadCrumb: function () {
+              return {
+                parentCrumb: 'virtual-networks-tab-detail-tasks-detail',
+                getCrumbs: function () { return []; }
+              }
+            }
+          }
+        ]
       }
     ];
 

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -251,6 +251,13 @@ class MesosStateStore extends GetSetBaseStore {
     }, []);
   }
 
+  getTasksFromVirtualNetworkName(overlayName) {
+    return MesosStateUtil.getTasksFromVirtualNetworkName(
+      this.get('lastMesosState'),
+      overlayName
+    );
+  }
+
   processStateSuccess(lastMesosState) {
     CompositeState.addState(lastMesosState);
     this.set({lastMesosState});

--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -39,7 +39,9 @@ const MesosStateUtil = {
   getTasksFromVirtualNetworkName: function (state = {}, overlayName) {
     let frameworks = state.frameworks || [];
     return frameworks.reduce(function (memo, framework) {
-      return memo.concat(framework.tasks.filter(function (task) {
+      let tasks = framework.tasks || [];
+
+      return memo.concat(tasks.filter(function (task) {
         return Util.findNestedPropertyInObject(
           task,
           'container.network_infos.0.name'

--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -1,3 +1,4 @@
+import Util from './Util';
 const RESOURCE_KEYS = ['cpus', 'disk', 'mem'];
 
 const MesosStateUtil = {
@@ -33,6 +34,18 @@ const MesosStateUtil = {
 
       return memo;
     }, {});
+  },
+
+  getTasksFromVirtualNetworkName: function (state = {}, overlayName) {
+    let frameworks = state.frameworks || [];
+    return frameworks.reduce(function (memo, framework) {
+      return memo.concat(framework.tasks.filter(function (task) {
+        return Util.findNestedPropertyInObject(
+          task,
+          'container.network_infos.0.name'
+        ) === overlayName;
+      }));
+    }, []);
   }
 
 };

--- a/src/js/utils/TaskUtil.js
+++ b/src/js/utils/TaskUtil.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars */
 import React from 'react';
 /* eslint-enable no-unused-vars */
+import Util from './Util';
 
 const TaskUtil = {
 
@@ -26,6 +27,24 @@ const TaskUtil = {
     return (
       <i className={iconClassName}></i>
     );
+  },
+
+  getPortMappings(task) {
+    let container = task.container;
+    if (!container || !container.type) {
+      return null;
+    }
+
+    let portMappings = Util.findNestedPropertyInObject(
+      container,
+      `${container.type.toLowerCase()}.port_mappings`
+    );
+
+    if (!Array.isArray(portMappings)) {
+      return null;
+    }
+
+    return portMappings;
   }
 
 };

--- a/src/js/utils/VirtualNetworkUtil.js
+++ b/src/js/utils/VirtualNetworkUtil.js
@@ -1,0 +1,18 @@
+const VirtualNetworkUtil = {
+  getEmptyNetworkScreen() {
+    return (
+      <AlertPanel
+        title="Virtual Network Not Found"
+        iconClassName="icon icon-sprite icon-sprite-jumbo icon-sprite-jumbo-white icon-network flush-top">
+        <p className="flush">
+          {'Could not find the requested virtual network. Go to '}
+          <Link to="virtual-networks-tab">
+            Virtual Networks
+          </Link> overview to see all virtual networks.
+        </p>
+      </AlertPanel>
+    );
+  }
+}
+
+module.exports = VirtualNetworkUtil;

--- a/src/js/utils/VirtualNetworkUtil.js
+++ b/src/js/utils/VirtualNetworkUtil.js
@@ -1,3 +1,9 @@
+import AlertPanel from '../components/AlertPanel';
+import {Link} from 'react-router';
+/* eslint-disable no-unused-vars */
+import React from 'react';
+/* eslint-enable no-unused-vars */
+
 const VirtualNetworkUtil = {
   getEmptyNetworkScreen() {
     return (

--- a/src/js/utils/__tests__/MesosStateUtil-test.js
+++ b/src/js/utils/__tests__/MesosStateUtil-test.js
@@ -1,0 +1,51 @@
+let MesosStateUtil = require('../MesosStateUtil');
+
+describe('MesosStateUtil', function () {
+
+  describe('#getTasksFromVirtualNetworkName', function () {
+
+    beforeEach(function () {
+      this.instance = MesosStateUtil.getTasksFromVirtualNetworkName(
+        {frameworks: [
+          {id: 'foo'},
+          {id: 'bar'},
+          {id: 'baz', tasks: [{container: {network_infos:[{name: 'alpha'}]}}]},
+          {id: 'qux', tasks: [
+            {container: {network_infos:[{name: 'alpha'}]}},
+            {container: {network_infos:[{name: 'beta'}]}}
+          ]}
+        ]},
+        'alpha'
+      );
+    });
+
+    it('should handle empty object well', function () {
+      expect(MesosStateUtil.getTasksFromVirtualNetworkName({}, 'foo'))
+        .toEqual([]);
+    });
+
+    it('should throw when a null state is provided', function () {
+      expect(function () {
+        MesosStateUtil.getTasksFromVirtualNetworkName(null, 'foo')
+      }).toThrow();
+    });
+
+    it('should handle empty undefined well', function () {
+      expect(MesosStateUtil.getTasksFromVirtualNetworkName(undefined, 'foo'))
+        .toEqual([]);
+    });
+
+    it('should filter tasks that doesn\'t have the overlay name', function () {
+      expect(this.instance.length).toEqual(2);
+    });
+
+    it('should find tasks from different frameworks', function () {
+      expect(this.instance).toEqual([
+        {container: {network_infos:[{name: 'alpha'}]}},
+        {container: {network_infos:[{name: 'alpha'}]}}
+      ]);
+    });
+
+  });
+
+});

--- a/src/js/utils/__tests__/TaskUtil-test.js
+++ b/src/js/utils/__tests__/TaskUtil-test.js
@@ -1,0 +1,45 @@
+let TaskUtil = require('../TaskUtil');
+
+describe('TaskUtil', function () {
+
+  describe('#getPortMappings', function () {
+
+    beforeEach(function () {
+      this.instance = TaskUtil.getPortMappings(
+        {container: {type: 'FOO', foo: {port_mappings: ['foo', 'bar', 'baz']}}}
+      );
+    });
+
+    it('should handle empty container well', function () {
+      expect(TaskUtil.getPortMappings({}))
+        .toEqual(null);
+    });
+
+    it('should handle empty type well', function () {
+      expect(TaskUtil.getPortMappings({contianer: {}}))
+        .toEqual(null);
+    });
+
+    it('should handle empty info well', function () {
+      expect(TaskUtil.getPortMappings({contianer: {type: 'FOO'}}))
+        .toEqual(null);
+    });
+
+    it('should handle empty port mappings well', function () {
+      expect(TaskUtil.getPortMappings({contianer: {type: 'FOO', foo: {}}}))
+        .toEqual(null);
+    });
+
+    it('should handle if port mappings are is not an array', function () {
+      expect(TaskUtil.getPortMappings(
+        {contianer: {type: 'FOO', foo: {port_mappings: 0}}}
+      )).toEqual(null);
+    });
+
+    it('should provide port_mappings when available', function () {
+      expect(this.instance).toEqual(['foo', 'bar', 'baz']);
+    });
+
+  });
+
+});


### PR DESCRIPTION
Sorry for the big PR, needed to work fast to get these final features in :disappointed_relieved:

In MesosStateUtil.js always return `true` in line 43 to see tasks show up.
And in VirtualNetworkTaskTab.js on line 204 you can add this line to see port mappings:
```
task.container = {'type':'DOCKER','docker':{'image':'busybox','network':'USER','port_mappings':[{'host_port':23409,'container_port':23409,'protocol':'tcp'},{'host_port':10003,'container_port':10003,'protocol':'tcp'}, {'host_port':10003,'container_port':10003,'protocol':'tcp'}, {'host_port':10003,'container_port':10003,'protocol':'tcp'}, {'host_port':10003,'container_port':10003,'protocol':'tcp'}, {'host_port':10003,'container_port':10003,'protocol':'tcp'}, {'host_port':10003,'container_port':10003,'protocol':'tcp'}, {'host_port':10003,'container_port':10003,'protocol':'tcp'}, {'host_port':10003,'container_port':10003,'protocol':'tcp'}, {'host_port':10003,'container_port':10003,'protocol':'tcp'}],'privileged':false,'force_pull_image':false},'network_infos':[{'ip_addresses':[{}],'name':'overlay-1','labels':{}}]};
```

![](http://cl.ly/1K0y2Q0l0T0D/Image%202016-06-21%20at%2017.31.20.png)
<img src="http://cl.ly/0b3g1y2J2i02/Image%202016-06-21%20at%2017.32.05.png" width="50%" />
![](http://cl.ly/0I3K3s333y33/Image%202016-06-21%20at%2018.21.29.png)