### PR TITLE
Add concurrency policy to schedule

### DIFF
--- a/src/js/utils/JobUtil.js
+++ b/src/js/utils/JobUtil.js
@@ -90,6 +90,9 @@ const JobUtil = {
 
     let [schedule = {}] = job.getSchedules();
     if (schedule.id != null && schedule.cron != null) {
+      if (schedule.concurrencyPolicy == null) {
+        schedule.concurrencyPolicy = 'ALLOW';
+      }
       spec.schedules = [schedule];
     }
 

--- a/src/js/utils/__tests__/JobUtil-test.js
+++ b/src/js/utils/__tests__/JobUtil-test.js
@@ -101,5 +101,25 @@ describe('JobUtil', function () {
           }
         });
     });
+
+    it('should add concurrencyPolicy if schedule is defined', function () {
+      const job = new Job({
+        id: 'test',
+        run: {
+          cmd: 'sleep 1000;'
+        },
+        schedules: [{
+          id: 'every-minute',
+          cron: '* * * * *'
+        }]
+      });
+
+      expect(JobUtil.createJobSpecFromJob(job).schedules[0]).toEqual(
+        {
+          id: 'every-minute',
+          concurrencyPolicy: 'ALLOW',
+          cron: '* * * * *'
+        });
+    });
   });
 });


### PR DESCRIPTION
Add a concurrency policy to the job schedule if it's undefined, as a schedule without a policy is invalid.

This is a hotfix, and we will replace it with a schedule struct that has proper defaults. We will also provide this as an option in the create/edit modal once we support other policies.