### PR TITLE
[3 of n: Icons] Introduce Icon component

### DIFF
--- a/src/js/components/Icon.js
+++ b/src/js/components/Icon.js
@@ -1,0 +1,60 @@
+import classNames from 'classnames';
+import React from 'react';
+
+import Util from '../utils/Util';
+
+class Icon extends React.Component {
+  render() {
+    let {props} = this;
+
+    let additionalProps = Util.omit(
+      props,
+      ['className', 'color', 'family', 'id', 'size']
+    );
+    let classes = classNames('icon',
+      {
+        [`icon-${props.color}`]: !!props.color,
+        [`icon-${props.size}`]: !!props.size
+      },
+      props.className
+    );
+    let iconID = `#icon-${props.family}--${props.id}`;
+
+    return (
+      <svg className={classes} {...additionalProps}>
+        <use xlinkHref={iconID} />
+      </svg>
+    );
+  }
+}
+
+Icon.defaultProps = {
+  family: 'medium',
+  size: 'medium'
+};
+
+Icon.propTypes = {
+  className: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ]),
+  color: React.PropTypes.string,
+  family: React.PropTypes.oneOf([
+    'tiny',
+    'mini',
+    'small',
+    'medium'
+  ]),
+  id: React.PropTypes.string.isRequired,
+  size: React.PropTypes.oneOf([
+    'tiny',
+    'mini',
+    'small',
+    'medium',
+    'large',
+    'jumbo'
+  ])
+};
+
+module.exports = Icon;


### PR DESCRIPTION
This is a simple component to make using icons as simple as possible (hopefully). The only thing that may be confusing is the `family` vs. `size` props. From @ashenden's "ICONS ICONS ICONS" email:
>Though our names imply size (e.g. "icon-small”) we think of them as a collection/family.  We could very well call these “icon-banana” or “icon-little-outline-style".  The name is only useful for letting us quickly relate the icons in this collection to each other.  It just so happens that those same names map nicely to the sizes we have in product.

For now we have only four families. If you need an icon larger than `meidum`, then use the `medium` family and whatever size you need.

What size/family do you think should be default? I've defaulted to `medium` but I'm not sure what's best. 