### PR TITLE
[4 of n: Icons] Implement sidebar icons

### DIFF
--- a/src/js/components/HostTable.js
+++ b/src/js/components/HostTable.js
@@ -5,6 +5,7 @@ import {StoreMixin} from 'mesosphere-shared-reactjs';
 import {Tooltip} from 'reactjs-components';
 
 var HostTableHeaderLabels = require('../constants/HostTableHeaderLabels');
+import Icon from '../components/Icon';
 var InternalStorageMixin = require('../mixins/InternalStorageMixin');
 var ResourceTableUtil = require('../utils/ResourceTableUtil');
 var ProgressBar = require('./charts/ProgressBar');
@@ -22,7 +23,7 @@ var HostTable = React.createClass({
   statics: {
     routeConfig: {
       label: 'Nodes',
-      icon: 'datacenter',
+      icon: <Icon id="servers" />,
       matches: /^\/nodes/
     }
   },

--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -107,28 +107,15 @@ var Sidebar = React.createClass({
       var route = this.context.router.namedRoutes[routeKey];
       // Figure out if current route is active
       var isActive = route.handler.routeConfig.matches.test(currentPath);
-      let isIconSVG = React.isValidElement(route.handler.routeConfig.icon);
-      let icon = null;
-      let iconClasses = classNames('sidebar-menu-item-icon icon icon-medium', {
-        [`icon-${route.handler.routeConfig.icon}`]: !isIconSVG,
-        'icon-sprite icon-sprite-medium': !isIconSVG,
-        'icon-sprite-medium-color': isActive,
-        'icon-sprite-medium-black': !isActive
-      });
+      let icon = React.cloneElement(
+        route.handler.routeConfig.icon,
+        {className: 'sidebar-menu-item-icon icon icon-medium'}
+      );
 
       var itemClassSet = classNames({
         'sidebar-menu-item': true,
         'selected': isActive
       });
-
-      if (isIconSVG) {
-        icon = React.cloneElement(
-          route.handler.routeConfig.icon,
-          {className: iconClasses}
-        );
-      } else {
-        icon = <i className={iconClasses}></i>;
-      }
 
       let sidebarText = (
         <span className="sidebar-menu-item-label h4 flush">

--- a/src/js/pages/DashboardPage.js
+++ b/src/js/pages/DashboardPage.js
@@ -7,6 +7,7 @@ import Config from '../config/Config';
 import DCOSStore from '../stores/DCOSStore';
 var HealthSorting = require('../constants/HealthSorting');
 var HostTimeSeriesChart = require('../components/charts/HostTimeSeriesChart');
+import Icon from '../components/Icon';
 var InternalStorageMixin = require('../mixins/InternalStorageMixin');
 var MesosSummaryStore = require('../stores/MesosSummaryStore');
 var Page = require('../components/Page');
@@ -41,7 +42,7 @@ var DashboardPage = React.createClass({
   statics: {
     routeConfig: {
       label: 'Dashboard',
-      icon: 'dashboard',
+      icon: <Icon id="gauge" />,
       matches: /^\/dashboard/
     },
 

--- a/src/js/pages/JobsPage.js
+++ b/src/js/pages/JobsPage.js
@@ -2,6 +2,7 @@ import mixin from 'reactjs-mixin';
 import React from 'react';
 import {RouteHandler} from 'react-router';
 
+import Icon from '../components/Icon';
 import Page from '../components/Page';
 import RouterUtil from '../utils/RouterUtil';
 import SidebarActions from '../events/SidebarActions';
@@ -59,7 +60,7 @@ JobsPage.contextTypes = {
 
 JobsPage.routeConfig = {
   label: 'Jobs',
-  icon: 'jobs',
+  icon: <Icon id="pages-code" />,
   matches: /^\/jobs/
 };
 

--- a/src/js/pages/NetworkPage.js
+++ b/src/js/pages/NetworkPage.js
@@ -4,6 +4,8 @@ import mixin from 'reactjs-mixin';
 import React from 'react';
 /* eslint-enable no-unused-vars */
 import {Hooks} from 'PluginSDK';
+
+import Icon from '../components/Icon';
 import Page from '../components/Page';
 import RouterUtil from '../utils/RouterUtil';
 import SidebarActions from '../events/SidebarActions';
@@ -124,7 +126,7 @@ NetworkPage.contextTypes = {
 
 NetworkPage.routeConfig = {
   label: 'Network',
-  icon: 'network',
+  icon: <Icon id="network-hierarchical" />,
   matches: /^\/network/
 };
 

--- a/src/js/pages/ServicesPage.js
+++ b/src/js/pages/ServicesPage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {RouteHandler} from 'react-router';
 
+import Icon from '../components/Icon';
 import Page from '../components/Page';
 import RouterUtil from '../utils/RouterUtil';
 import TabsMixin from '../mixins/TabsMixin';
@@ -18,7 +19,7 @@ var ServicesPage = React.createClass({
   statics: {
     routeConfig: {
       label: 'Services',
-      icon: 'services',
+      icon: <Icon id="services" />,
       matches: /^\/services/
     }
   },

--- a/src/js/pages/SystemPage.js
+++ b/src/js/pages/SystemPage.js
@@ -4,6 +4,8 @@ import mixin from 'reactjs-mixin';
 import React from 'react';
 /* eslint-enable no-unused-vars */
 import {Hooks} from 'PluginSDK';
+
+import Icon from '../components/Icon';
 import NotificationStore from '../stores/NotificationStore';
 import Page from '../components/Page';
 import RouterUtil from '../utils/RouterUtil';
@@ -167,7 +169,7 @@ SystemPage.contextTypes = {
 
 SystemPage.routeConfig = {
   label: 'System',
-  icon: 'system',
+  icon: <Icon id="gears" />,
   matches: /^\/system/
 };
 

--- a/src/js/pages/UniversePage.js
+++ b/src/js/pages/UniversePage.js
@@ -4,6 +4,7 @@ import React from 'react';
 /* eslint-enable no-unused-vars */
 import {RouteHandler} from 'react-router';
 
+import Icon from '../components/Icon';
 import Page from '../components/Page';
 import RouterUtil from '../utils/RouterUtil';
 import SidebarActions from '../events/SidebarActions';
@@ -67,7 +68,7 @@ UniversePage.contextTypes = {
 
 UniversePage.routeConfig = {
   label: 'Universe',
-  icon: 'universe',
+  icon: <Icon id="packages" />,
   matches: /^\/universe/
 };
 

--- a/src/styles/layout/sidebar.less
+++ b/src/styles/layout/sidebar.less
@@ -226,7 +226,6 @@ Sidebar
 
           flex: 0 0 auto;
           margin-right: (@base-spacing-unit * 0.5);
-          .opacity(0.60);
 
         }
 
@@ -268,12 +267,6 @@ Sidebar
 
             }
 
-            .sidebar-menu-item-icon {
-
-              .opacity(0.80);
-
-            }
-
           }
 
           &:active {
@@ -287,12 +280,6 @@ Sidebar
 
             }
 
-            .sidebar-menu-item-icon {
-
-              .opacity(0.60);
-
-            }
-
           }
 
         }
@@ -302,12 +289,6 @@ Sidebar
           .box-shadow(inset 2px 0px 0px 0px @purple);
           background-color: fade(@purple, 10%);
 
-          .sidebar-menu-item-icon {
-
-            .opacity(1);
-
-          }
-
           a {
 
             color: @purple;
@@ -315,12 +296,6 @@ Sidebar
             .sidebar-menu-item-label {
 
               color: @purple;
-
-            }
-
-            &:hover .sidebar-menu-item-icon {
-
-              .opacity(1);
 
             }
 


### PR DESCRIPTION
This PR introduces the sidebar icons. It also removes the logic in the sidebar which rendered both SVG icons and sprited icons, and fixes the opacity that was previously applied to the sprited icons.

![](https://s3.amazonaws.com/f.cl.ly/items/021I3K253e2E1J0r3y1E/Screen%20Shot%202016-06-22%20at%201.55.47%20PM.png?v=b1ea7f92)