### PR TITLE
Refactor the task detail tab configuration

### DIFF
--- a/src/js/pages/task-details/TaskDetail.js
+++ b/src/js/pages/task-details/TaskDetail.js
@@ -15,26 +15,6 @@ import TabsMixin from '../../mixins/TabsMixin';
 import TaskDirectoryStore from '../../stores/TaskDirectoryStore';
 import TaskStates from '../../constants/TaskStates';
 
-const SERVICES_TABS = {
-  'services-task-details-tab': 'Details',
-  'services-task-details-files': 'Files',
-  'services-task-details-logs': 'Logs',
-  'services-task-details-volumes': 'Volumes'
-};
-
-const NODES_TABS = {
-  'nodes-task-details-tab': 'Details',
-  'nodes-task-details-files': 'Files',
-  'nodes-task-details-logs': 'Logs',
-  'nodes-task-details-volumes': 'Volumes'
-};
-
-const VIRTUAL_NETWORKS_TABS = {
-  'virtual-networks-tab-detail-tasks-details-tab': 'Details',
-  'virtual-networks-tab-detail-tasks-details-files': 'Files',
-  'virtual-networks-tab-detail-tasks-details-logs': 'Logs'
-};
-
 const METHODS_TO_BIND = [
   'onTaskDirectoryStoreError',
   'onTaskDirectoryStoreSuccess'
@@ -67,14 +47,25 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
 
   componentWillMount() {
     super.componentWillMount(...arguments);
-    this.tabs_tabs = Object.assign({}, SERVICES_TABS);
-    if (this.props.params.nodeID != null) {
-      this.tabs_tabs = Object.assign({}, NODES_TABS);
+
+    // TODO: DCOS-7871 Refactor the TabsMixin to generalize this solution:
+    let routes = this.context.router.getCurrentRoutes();
+    let currentRoute = routes.find(function (route) {
+      return route.handler === TaskDetail;
+    });
+
+    if (currentRoute != null) {
+      this.tabs_tabs = currentRoute.children.reduce(function (tabs, {name, title}) {
+        if (name !== null) {
+          tabs[name] = title || name;
+        }
+
+        return tabs;
+      }, this.tabs_tabs);
+
+      this.updateCurrentTab();
     }
-    if (this.props.params.overlayName != null) {
-      this.tabs_tabs = Object.assign({}, VIRTUAL_NETWORKS_TABS);
-    }
-    this.updateCurrentTab();
+
   }
 
   updateCurrentTab() {

--- a/src/js/routes/factories/network.js
+++ b/src/js/routes/factories/network.js
@@ -111,7 +111,8 @@ let RouteFactory = {
                 parentCrumb: 'virtual-networks-tab-detail-tasks-detail',
                 getCrumbs: function () { return []; }
               }
-            }
+            },
+            title: 'Details'
           },
           {
             type: Route,
@@ -124,7 +125,8 @@ let RouteFactory = {
                 parentCrumb: 'virtual-networks-tab-detail-tasks-detail',
                 getCrumbs: function () { return []; }
               }
-            }
+            },
+            title: 'Files'
           },
           {
             type: Route,
@@ -138,7 +140,8 @@ let RouteFactory = {
                 parentCrumb: 'virtual-networks-tab-detail-tasks-detail',
                 getCrumbs: function () { return []; }
               }
-            }
+            },
+            title: 'Logs'
           }
         ]
       }

--- a/src/js/routes/nodes.js
+++ b/src/js/routes/nodes.js
@@ -134,7 +134,8 @@ let nodesRoutes = {
                   parentCrumb: 'nodes-task-details',
                   getCrumbs: function () { return []; }
                 }
-              }
+              },
+              title: 'Details'
             },
             {
               type: Route,
@@ -147,7 +148,8 @@ let nodesRoutes = {
                   parentCrumb: 'nodes-task-details',
                   getCrumbs: function () { return []; }
                 }
-              }
+              },
+              title: 'Files'
             },
             {
               type: Route,
@@ -161,7 +163,8 @@ let nodesRoutes = {
                   parentCrumb: 'nodes-task-details',
                   getCrumbs: function () { return []; }
                 }
-              }
+              },
+              title: 'Logs'
             },
             {
               type: Route,
@@ -173,7 +176,8 @@ let nodesRoutes = {
                   parentCrumb: 'nodes-task-details',
                   getCrumbs: function () { return []; }
                 }
-              }
+              },
+              title: 'Volumes'
             }
           ]
         }

--- a/src/js/routes/services.js
+++ b/src/js/routes/services.js
@@ -144,7 +144,8 @@ let serviceRoutes = {
                       parentCrumb: 'services-task-details',
                       getCrumbs: function () { return []; }
                     }
-                  }
+                  },
+                  title:'Details'
                 },
                 {
                   type: Route,
@@ -157,7 +158,8 @@ let serviceRoutes = {
                       parentCrumb: 'services-task-details',
                       getCrumbs: function () { return []; }
                     }
-                  }
+                  },
+                  title:'Files'
                 },
                 {
                   type: Route,
@@ -171,7 +173,8 @@ let serviceRoutes = {
                       parentCrumb: 'services-task-details',
                       getCrumbs: function () { return []; }
                     }
-                  }
+                  },
+                  title:'Logs'
                 },
                 {
                   type: Route,
@@ -183,7 +186,8 @@ let serviceRoutes = {
                       parentCrumb: 'services-task-details',
                       getCrumbs: function () { return []; }
                     }
-                  }
+                  },
+                  title:'Volumes'
                 }
               ]
             }


### PR DESCRIPTION
Use the route definition (`Route.prototype.children`) instead of configuring a set of tabs that must match the corresponding route configurations. This prevents configuration errors and enables us to
reuse the task detail in more places (e.g. jobs)