### PR TITLE
Fix defaults in schema

### DIFF
--- a/src/js/schemas/service-schema/General.js
+++ b/src/js/schemas/service-schema/General.js
@@ -24,7 +24,7 @@ let General = {
           type: 'number',
           default: 1,
           getter: function (service) {
-            return `${service.getCpus() || 0}`;
+            return `${service.getCpus() || this.default}`;
           }
         },
         mem: {
@@ -32,7 +32,7 @@ let General = {
           type: 'number',
           default: 128,
           getter: function (service) {
-            return `${service.getMem() || 0}`;
+            return `${service.getMem() || this.default}`;
           }
         },
         disk: {
@@ -40,7 +40,7 @@ let General = {
           type: 'number',
           default: 0,
           getter: function (service) {
-            return `${service.getDisk() || 0}`;
+            return `${service.getDisk() || this.default}`;
           }
         },
         instances: {
@@ -48,7 +48,7 @@ let General = {
           type: 'number',
           default: 1,
           getter: function (service) {
-            return `${service.getInstancesCount() || 0}`;
+            return `${service.getInstancesCount() || this.default}`;
           }
         }
       }


### PR DESCRIPTION
This should fix the defaults in the schema. Parsing those values in the getter to a string with the default value of `'0'` didn't worked very fine. I am now referencing the default.

![image](https://cloud.githubusercontent.com/assets/156010/16303041/f360375a-394e-11e6-888c-15b4ddaefc71.png)


Unit tests pass
![image](https://cloud.githubusercontent.com/assets/156010/16303937/84f89956-3953-11e6-829a-4cdb69bd62c2.png)


Integration tests still running