### PR TITLE
[1 of 4: Icons] Remove high-specificity icon styles

### DIFF
--- a/src/js/components/DisplayPackagesTable.js
+++ b/src/js/components/DisplayPackagesTable.js
@@ -59,7 +59,7 @@ class DisplayPackagesTable extends React.Component {
         onClick={this.props.onDetailOpen.bind(this, cosmosPackage)}>
         <div className="media-object media-object-align-middle">
           <div className="media-object-item">
-            <div className="icon icon-large icon-image-container icon-app-container icon-default-white">
+            <div className="icon icon-margin-right icon-large icon-image-container icon-app-container icon-default-white">
               <img src={packageImages['icon-large']} />
             </div>
           </div>

--- a/src/js/components/HostTable.js
+++ b/src/js/components/HostTable.js
@@ -65,7 +65,7 @@ var HostTable = React.createClass({
     if (!node.isActive()) {
       headline = (
         <Tooltip anchor="start" content="Connection to node lost">
-          <i className="icon icon-sprite icon-sprite-mini icon-sprite-mini-white
+          <i className="icon icon-margin-right icon-sprite icon-sprite-mini icon-sprite-mini-white
             icon-alert" />
           {headline}
         </Tooltip>

--- a/src/js/components/PackagesTable.js
+++ b/src/js/components/PackagesTable.js
@@ -105,7 +105,7 @@ class PackagesTable extends React.Component {
 
     return (
       <div className="package-table-heading flex-box flex-box-align-vertical-center table-cell-flex-box">
-        <span className="icon icon-small icon-image-container icon-app-container">
+        <span className="icon icon-margin-right icon-small icon-image-container icon-app-container">
           <img src={packageImages['icon-small']} />
         </span>
         <span className="headline text-overflow">

--- a/src/js/components/ServicesTable.js
+++ b/src/js/components/ServicesTable.js
@@ -57,8 +57,8 @@ var ServicesTable = React.createClass({
       <a className="table-display-on-row-hover"
         href={Cluster.getServiceLink(service.getName())} target="_blank"
         title="Open in a new window">
-        <IconNewWindow className="icon icon-new-window icon-align-right
-          icon-margin-wide" />
+        <IconNewWindow className="icon icon-new-window icon-margin-left
+          icon-margin-left-wide" />
       </a>
     );
   },
@@ -75,7 +75,7 @@ var ServicesTable = React.createClass({
       // Get serviceTree image/icon
       itemImage = (
       <span
-        className="icon icon-small icon-image-container icon-app-container">
+        className="icon icon-small icon-image-container icon-app-container icon-margin-right">
           <i className="icon icon-sprite icon-sprite-mini icon-directory "/>
         </span>
       );
@@ -85,7 +85,7 @@ var ServicesTable = React.createClass({
       // Get framework image/icon
       itemImage = (
         <span
-          className="icon icon-small icon-image-container icon-app-container">
+          className="icon icon-small icon-image-container icon-app-container icon-margin-right">
           <img src={service.getImages()['icon-small']}/>
         </span>
       );

--- a/src/js/components/TaskDirectoryTable.js
+++ b/src/js/components/TaskDirectoryTable.js
@@ -42,11 +42,13 @@ class TaskDirectoryTable extends React.Component {
       );
     }
 
-    let iconClass = classNames({
-      'icon icon-sprite icon-sprite-mini': true,
-      'icon-file': !directoryItem.isDirectory(),
-      'icon-directory': directoryItem.isDirectory()
-    });
+    let iconClass = classNames(
+      'icon icon-sprite icon-sprite-mini icon-margin-right',
+      {
+        'icon-file': !directoryItem.isDirectory(),
+        'icon-directory': directoryItem.isDirectory()
+      }
+    );
 
     let openLogView;
     if (directoryItem.isLogFile()) {
@@ -55,7 +57,7 @@ class TaskDirectoryTable extends React.Component {
           className="table-cell-icon table-cell-icon-mini table-display-on-row-hover fade-in-on-hover clickable"
           onClick={this.props.onOpenLogClick.bind(this, directoryItem, this.props.directoryPath)}>
           <i
-            className="icon icon-sprite icon-sprite-mini icon-search icon-align-right" />
+            className="icon icon-sprite icon-sprite-mini icon-search icon-margin-left" />
         </div>
       );
     }

--- a/src/js/pages/jobs/JobsTable.js
+++ b/src/js/pages/jobs/JobsTable.js
@@ -115,7 +115,7 @@ class JobsTable extends React.Component {
     if (job.isGroup) {
       itemImage = (
         <span
-          className="icon icon-small icon-image-container icon-app-container">
+          className="icon icon-margin-right icon-small icon-image-container icon-app-container">
           <i className="icon icon-sprite icon-sprite-mini icon-directory "/>
         </span>
       );

--- a/src/js/utils/TaskUtil.js
+++ b/src/js/utils/TaskUtil.js
@@ -16,7 +16,7 @@ const TaskUtil = {
 
   getTaskStatusIcon(task) {
     let taskStatus = TaskUtil.getTaskStatusSlug(task);
-    let iconClassName = `icon icon-sprite icon-sprite-mini icon-${taskStatus}`;
+    let iconClassName = `icon icon-sprite icon-sprite-mini icon-${taskStatus} icon-margin-right`;
 
     // 'staging', 'finished', and 'starting' all use their monochromatic colors.
     if (taskStatus !== 'staging' && taskStatus !== 'finished' &&

--- a/src/styles/components/icons.less
+++ b/src/styles/components/icons.less
@@ -187,6 +187,31 @@ Icon (huge)
 
     }
 
+    &.icon-margin-right {
+
+      margin-right: @base-spacing-unit * 0.25;
+
+      &.icon-margin-right-wide {
+
+        margin-right: @base-spacing-unit * 0.5;
+
+      }
+
+    }
+
+    &.icon-margin-left {
+
+      margin-left: @base-spacing-unit * 0.25;
+      margin-right: 0;
+
+      &.icon-margin-left-wide {
+
+        margin-left: @base-spacing-unit * 0.5;
+
+      }
+
+    }
+
   }
 
   .icon.icon-micro {
@@ -1248,7 +1273,50 @@ Icon (huge)
 
 }
 
+& when (@icon-enabled) and (@screen-small-enabled) {
 
+  @media (min-width: @screen-small) {
+
+    .icon {
+
+      &.icon-margin-right {
+        margin-right: @base-spacing-unit-screen-small * 0.25;
+      }
+    }
+
+  }
+
+}
+
+& when (@icon-enabled) and (@screen-medium-enabled) {
+
+  @media (min-width: @screen-medium) {
+
+    .icon {
+
+      &.icon-margin-right {
+        margin-right: @base-spacing-unit-screen-medium * 0.15;
+      }
+    }
+
+  }
+
+}
+
+& when (@icon-enabled) and (@screen-large-enabled) {
+
+  @media (min-width: @screen-large) {
+
+    .icon {
+
+      &.icon-margin-right {
+        margin-right: @base-spacing-unit-screen-large * 0.15;
+      }
+    }
+
+  }
+
+}
 
 
 

--- a/src/styles/components/tables.less
+++ b/src/styles/components/tables.less
@@ -62,31 +62,6 @@ components/tables.less
 
           }
 
-          .icon {
-
-            margin-right: @base-spacing-unit * 0.25;
-
-            &.icon-margin-wide {
-
-              margin-right: @base-spacing-unit * 0.5;
-
-            }
-
-            &.icon-align-right {
-
-              margin-left: @base-spacing-unit * 0.25;
-              margin-right: 0;
-
-              &.icon-margin-wide {
-
-                margin-left: @base-spacing-unit * 0.5;
-
-              }
-
-            }
-
-          }
-
           .button-collection {
 
             align-items: center;
@@ -435,12 +410,6 @@ components/tables.less
               > th,
               > td {
 
-                .icon {
-
-                  margin-right: @base-spacing-unit-screen-small * 0.25;
-
-                }
-
                 .button {
 
                   &.button-link {
@@ -535,12 +504,6 @@ components/tables.less
 
               > th,
               > td {
-
-                .icon {
-
-                  margin-right: @base-spacing-unit-screen-medium * 0.15;
-
-                }
 
                 .button {
 
@@ -647,12 +610,6 @@ components/tables.less
 
               > th,
               > td {
-
-                .icon {
-
-                  margin-right: @base-spacing-unit-screen-large * 0.15;
-
-                }
 
                 .button {
 


### PR DESCRIPTION
Previously we gave ALL `.icon` elements inside `table`s a margin, and the CSS was very specific.

I've introduced new classes, `.icon-margin-right` and `.icon-margin-left` and applied them where we relied on the general class for margins.