### PR TITLE
Make sure to add to firstIndex in order to not accidentally reverse values

### DIFF
--- a/src/js/utils/SchemaFormUtil.js
+++ b/src/js/utils/SchemaFormUtil.js
@@ -39,6 +39,7 @@ function setDefinitionValue(thingToSet, definition, renderRemove) {
         renderRemove(definitionToSet.definition, prop, propID)
       );
       definitionToSet.definition.splice(firstIndex, 0, instanceDefinition);
+      firstIndex++;
     });
   }
 

--- a/src/js/utils/SchemaFormUtil.js
+++ b/src/js/utils/SchemaFormUtil.js
@@ -38,8 +38,7 @@ function setDefinitionValue(thingToSet, definition, renderRemove) {
       instanceDefinition.push(
         renderRemove(definitionToSet.definition, prop, propID)
       );
-      definitionToSet.definition.splice(firstIndex, 0, instanceDefinition);
-      firstIndex++;
+      definitionToSet.definition.splice(firstIndex++, 0, instanceDefinition);
     });
   }
 


### PR DESCRIPTION
Array values in service form will no longer reverse when switching from json/form