### PR TITLE
Add universe link to service form

### DIFF
--- a/src/js/schemas/service-schema/General.js
+++ b/src/js/schemas/service-schema/General.js
@@ -4,7 +4,11 @@ import React from 'react';
 
 let General = {
   title: 'General',
-  description: 'Configure your container',
+  description: (
+    <span>
+      Configure your container or <a href="/#/universe/packages/">browse all DC/OS Universe services</a>.
+    </span>
+  ),
   type: 'object',
   properties: {
     id: {


### PR DESCRIPTION
This adds a link to the Universe page to the General service form.

![link](https://cloud.githubusercontent.com/assets/859154/16341693/bc94fefa-3a2e-11e6-8271-3a3590b9061b.png)

I've tried to use the react-router-Link-component, but this doesn't work out because there is no `context.router` in the `General.js`-object.

Kind of overengineered!