### PR TITLE
DCOS-7919: Sort TaskTable descending by default, newest tasks at top

### DIFF
--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -178,7 +178,7 @@ class TaskTable extends React.Component {
         containerSelector=".gm-scroll-view"
         data={tasks.slice()}
         itemHeight={TableUtil.getRowHeight()}
-        sortBy={{prop: 'updated', order: 'asc'}} />
+        sortBy={{prop: 'updated', order: 'desc'}} />
     );
   }
 }


### PR DESCRIPTION
Unfortunately there is also a bug in the `Table` component, so `reactjs-components` needs a new release before this property will actually take effect. https://github.com/mesosphere/reactjs-components/pull/294