### PR TITLE
Fix force update on service modal

### DIFF
--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -208,7 +208,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
   }
 
   shouldForceUpdate(message = this.state.errorMessage) {
-    return message && message.message && /force=update/.test(message.message);
+    return message && message.message && /force=true/.test(message.message);
   }
 
   onMarathonStoreServiceEditSuccess() {
@@ -305,7 +305,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
       });
     }
 
-    if (this.shouldForceUpdate(errorMessage.message)) {
+    if (this.shouldForceUpdate(errorMessage)) {
       return (
         <div className="error-field text-danger">
           <h4 className="text-align-center text-danger flush-top">


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/156010/16375633/9f92e4cc-3c5c-11e6-9171-1902b522f15a.png)

![image](https://cloud.githubusercontent.com/assets/156010/16375948/48f4854c-3c5e-11e6-94b9-37c8bcc54b0f.png)

Ci test `Service Versions Configuration Tab opens correct edit modal of the selected service version` is failing rest passes I try to find out what is the problem there and fix it in another PR. +=> #538 