### PR TITLE
Add VIP fields to portMappings in user mode

### DIFF
--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -2,6 +2,7 @@ import {Hooks} from 'PluginSDK';
 import Service from '../structs/Service';
 import VolumeConstants from '../constants/VolumeConstants';
 
+const VIP_ADDRESS = '0.0.0.0';
 const getFindPropertiesRecursive = function (service, item) {
 
   return Object.keys(item).reduce(function (memo, subItem) {
@@ -299,6 +300,9 @@ const ServiceUtil = {
                   portMapping.hostPort = lbPort;
                 } else {
                   portMapping.servicePort = lbPort;
+                  portMapping.labels = {
+                    'VIP_0': `${VIP_ADDRESS}:${lbPort}`
+                  };
                 }
               }
 

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -332,7 +332,7 @@ describe('ServiceUtil', function () {
             .not.toContain('servicePort');
         });
 
-        it('should add both containerPort and servicePort when discovery is on', function () {
+        it('should add a servicePort when discovery is on', function () {
           let service = ServiceUtil.createServiceFromFormModel({
             containerSettings: { image: 'redis' },
             networking: {
@@ -340,11 +340,33 @@ describe('ServiceUtil', function () {
               ports: [ { lbPort: 1234, discovery: true } ]
             }
           });
-          expect(service.container.docker.portMappings).toEqual([
-            {containerPort: 1234, servicePort: 1234, protocol: 'tcp'}
-          ]);
+          expect(service.container.docker.portMappings[0].servicePort)
+            .toEqual(1234);
         });
 
+        it('should not add a VIP label when discovery is off', function () {
+          let service = ServiceUtil.createServiceFromFormModel({
+            containerSettings: { image: 'redis' },
+            networking: {
+              networkType: 'user',
+              ports: [ { lbPort: 1234 } ]
+            }
+          });
+          expect(Object.keys(service.container.docker.portMappings[0]))
+            .not.toContain('labels');
+        });
+
+        it('should add the appropriate VIP label when discovery is on', function () {
+         let service = ServiceUtil.createServiceFromFormModel({
+            containerSettings: { image: 'redis' },
+            networking: {
+              networkType: 'user',
+              ports: [ { lbPort: 1234, discovery: true } ]
+            }
+          });
+          expect(service.container.docker.portMappings[0].labels)
+            .toEqual({'VIP_0': '0.0.0.0:1234'});
+        });
 
         describe('an empty networking ports member', function () {
 

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -174,7 +174,11 @@ describe('ServiceUtil', function () {
         });
 
         it('should not add a portMappings field if no ports were passed in', function () {
-          expect(Object.keys(this.serviceEmptyPorts.container.docker))
+          let service = ServiceUtil.createServiceFromFormModel({
+            containerSettings: { image: 'redis' },
+            networking: { networkType: 'bridge' }
+          });
+          expect(Object.keys(service.container.docker))
             .not.toContain('portMappings');
         });
 
@@ -278,7 +282,7 @@ describe('ServiceUtil', function () {
         it('sets the docker network property correctly', function () {
           let service = ServiceUtil.createServiceFromFormModel({
             containerSettings: { image: 'redis' },
-            networking: { networkType: 'user' }
+            networking: { networkType: 'prod' }
           });
           expect(service.container.docker.network).toEqual('USER');
         });


### PR DESCRIPTION
Report:
```
https://www.dropbox.com/s/czcjqqa7wxucz3f/Screenshot%202016-06-24%2017.27.09.png?dl=0
This generates:
https://www.dropbox.com/s/79l69cymf0h34ko/Screenshot%202016-06-24%2017.27.31.png?dl=0
Which is missing the VIP.
```
Note that the first screenshot shows host mode, I believe this to be an error in the report based on the most recent requirements I have of the modal -> JSON transformation. I have therefore fixed VIP addition in User mode. 

New behaviour:
 - User mode is correctly detected (previously required `networkType=user`, now requires `networkType≠bridge|host`
 - VIP label is added in user mode.

Limitation:
It's still not clear where the VIP IP address is added, so I've set it to 0.0.0.0 in a constant. 