### PR TITLE
DCOS-8000 - Ensure that the sidebar filters have the correct width

### DIFF
--- a/src/js/components/ServiceSidebarFilters.js
+++ b/src/js/components/ServiceSidebarFilters.js
@@ -78,7 +78,7 @@ class ServiceSidebarFilters extends React.Component {
     } = getCountByFilters(props.services);
 
     return (
-      <div>
+      <div className="flex-no-shrink">
         <SidebarFilter
           countByValue={healthCount}
           filterType={ServiceFilterTypes.HEALTH}


### PR DESCRIPTION
Add the `flex-no-shrink` class to ensure that the service sidebar filters don't shrink to smaller than their their content's default minimum size.

| Before | After |
|:---------:|:---------:|
| <img width="1438" alt="" src="https://cloud.githubusercontent.com/assets/647035/16384662/1e7301f0-3c8a-11e6-90ad-97e7b42610ec.png"> | ![](https://cloud.githubusercontent.com/assets/647035/16384646/092883f6-3c8a-11e6-949c-d7855ffd0931.png) |