### PR TITLE
Allow checkbox labels to be rendered

### DIFF
--- a/src/js/schemas/service-schema/ContainerSettings.js
+++ b/src/js/schemas/service-schema/ContainerSettings.js
@@ -28,7 +28,6 @@ const ContainerSettings = {
       type: 'group',
       properties: {
         privileged: {
-          title: 'Extend runtime privileges',
           label: 'Extend runtime privileges',
           showLabel: false,
           type: 'boolean',
@@ -43,7 +42,6 @@ const ContainerSettings = {
           }
         },
         forcePullImage: {
-          title: 'Force pull image on launch',
           label: 'Force pull image on launch',
           showLabel: false,
           type: 'boolean',

--- a/src/js/schemas/service-schema/ContainerSettings.js
+++ b/src/js/schemas/service-schema/ContainerSettings.js
@@ -29,6 +29,8 @@ const ContainerSettings = {
       properties: {
         privileged: {
           title: 'Extend runtime privileges',
+          label: 'Extend runtime privileges',
+          showLabel: false,
           type: 'boolean',
           getter: function (service) {
             let container = service.getContainerSettings();
@@ -41,7 +43,9 @@ const ContainerSettings = {
           }
         },
         forcePullImage: {
-          title: 'Force pull image on every launch',
+          title: 'Force pull image on launch',
+          label: 'Force pull image on launch',
+          showLabel: false,
           type: 'boolean',
           getter: function (service) {
             let container = service.getContainerSettings();

--- a/src/js/schemas/service-schema/HealthChecks.js
+++ b/src/js/schemas/service-schema/HealthChecks.js
@@ -125,6 +125,8 @@ let HealthChecks = {
             ]
           },
           ignoreHttp1xx: {
+            label: 'Ignore HTTP informational status codes 100 to 199',
+            showLabel: false,
             title: 'Ignore HTTP informational status codes 100 to 199',
             type: 'boolean',
             shouldShow: function (service) {

--- a/src/js/schemas/service-schema/HealthChecks.js
+++ b/src/js/schemas/service-schema/HealthChecks.js
@@ -127,7 +127,6 @@ let HealthChecks = {
           ignoreHttp1xx: {
             label: 'Ignore HTTP informational status codes 100 to 199',
             showLabel: false,
-            title: 'Ignore HTTP informational status codes 100 to 199',
             type: 'boolean',
             shouldShow: function (service) {
               return service.protocol == null || service.protocol === 'HTTP';

--- a/src/js/schemas/service-schema/Networking.js
+++ b/src/js/schemas/service-schema/Networking.js
@@ -70,6 +70,8 @@ const Networking = {
             options: ['tcp', 'udp', 'udp,tcp']
           },
           discovery: {
+            label: 'Discovery',
+            showLabel: false,
             title: 'Discovery',
             type: 'boolean'
           }

--- a/src/js/utils/SchemaUtil.js
+++ b/src/js/utils/SchemaUtil.js
@@ -18,7 +18,7 @@ function getValueFromSchemaProperty(fieldProps) {
   return value;
 }
 
-function getLabelFromSchemaProperty(fieldName, fieldProps, isRequired, renderLabel, definition) {
+function setLabelFromSchemaProperty(fieldName, fieldProps, isRequired, renderLabel, definition) {
   let label = fieldProps.title || fieldName;
 
   if (isRequired) {
@@ -55,7 +55,7 @@ function schemaToFieldDefinition(fieldName, fieldProps, formParent, isRequired, 
     valueType: fieldProps.type
   };
 
-  getLabelFromSchemaProperty(fieldName, fieldProps, isRequired, renderLabel, definition);
+  setLabelFromSchemaProperty(fieldName, fieldProps, isRequired, renderLabel, definition);
 
   if (typeof value === 'boolean') {
     definition.checked = value;

--- a/src/js/utils/SchemaUtil.js
+++ b/src/js/utils/SchemaUtil.js
@@ -18,7 +18,7 @@ function getValueFromSchemaProperty(fieldProps) {
   return value;
 }
 
-function getLabelFromSchemaProperty(fieldName, fieldProps, isRequired, renderLabel) {
+function getLabelFromSchemaProperty(fieldName, fieldProps, isRequired, renderLabel, definition) {
   let label = fieldProps.title || fieldName;
 
   if (isRequired) {
@@ -26,15 +26,21 @@ function getLabelFromSchemaProperty(fieldName, fieldProps, isRequired, renderLab
   }
 
   if (renderLabel && fieldProps.description) {
-    return renderLabel(fieldProps.description, label);
+    label = renderLabel(fieldProps.description, label);
   }
 
-  return label;
+  // Set the label property of checkboxes if a label is defined.
+  if (fieldProps.type === 'boolean' && fieldProps.label != null
+    && fieldProps.label !== '') {
+    definition.label = fieldProps.label;
+    return;
+  }
+
+  definition.showLabel = label;
 }
 
 function schemaToFieldDefinition(fieldName, fieldProps, formParent, isRequired, renderLabel, renderRemove) {
   let value = getValueFromSchemaProperty(fieldProps);
-  let label = getLabelFromSchemaProperty(fieldName, fieldProps, isRequired, renderLabel);
 
   let definition = {
     fieldType: 'text',
@@ -43,12 +49,13 @@ function schemaToFieldDefinition(fieldName, fieldProps, formParent, isRequired, 
     isRequired,
     required: false,
     showError: false,
-    showLabel: label,
     writeType: 'input',
     validation: function () { return true; },
     value,
     valueType: fieldProps.type
   };
+
+  getLabelFromSchemaProperty(fieldName, fieldProps, isRequired, renderLabel, definition);
 
   if (typeof value === 'boolean') {
     definition.checked = value;

--- a/src/styles/components/multiple-form.less
+++ b/src/styles/components/multiple-form.less
@@ -95,11 +95,8 @@ base/forms.less
     .form-row-element {
 
       &.checkbox {
-        &:extend(.align-self-flex-end);
-
-        &.column-1 {
-          align-self: flex-start;
-        }
+        align-items: flex-end;
+        display: flex;
 
         .form-element-checkbox {
           padding-bottom: 6px;

--- a/src/styles/components/multiple-form.less
+++ b/src/styles/components/multiple-form.less
@@ -92,6 +92,21 @@ base/forms.less
 
   .multiple-form-modal {
 
+    .form-row-element {
+
+      &.checkbox {
+        &:extend(.align-self-flex-end);
+
+        &.column-1 {
+          align-self: flex-start;
+        }
+
+        .form-element-checkbox {
+          padding-bottom: 6px;
+        }
+      }
+    }
+
     .form-header {
       margin: 0;
     }


### PR DESCRIPTION
This PR enables `SchemaForm` checkboxes to be rendered with a label inside the `<label>` element. 

The properties that are changed may be a little confusing, but `SchemaUtil` previously would override the `showLabel` property on all `SchemaForm`s, which is what gets displayed on top of a checkbox, whereas the `label` property renders within the `<label>` element.

Before:
![](https://s3.amazonaws.com/f.cl.ly/items/3j3X2R2U1Z290X0O0R0U/Screen%20Shot%202016-06-27%20at%209.45.52%20AM.png?v=cb61f0a2)

After:
![](http://cl.ly/281x0n1n2x3z/Screen%20Shot%202016-06-27%20at%2012.56.54%20PM.png)