### PR TITLE
Explicitly set PageHeader border position

### DIFF
--- a/src/styles/components/page-header.less
+++ b/src/styles/components/page-header.less
@@ -9,6 +9,7 @@
 
     &:after {
       background: @border-color-inverse;
+      bottom: -1px;
       content: '';
       height: 1px;
       left: 0;


### PR DESCRIPTION
This PR fixes the positioning of the `:after` element. Thomas saw the bug in the dev channel Chrome, I saw it in IE.

Before:
![](http://cl.ly/452e3V2F3Z2o/Screen%20Shot%202016-06-27%20at%201.27.00%20PM.png)

After:
![](http://cl.ly/1S3k1r2t1W0d/Screen%20Shot%202016-06-27%20at%201.26.19%20PM.png)