### PR TITLE
Prevent dropdown toggle from wrapping

### DIFF
--- a/src/styles/components/dropdown-menus.less
+++ b/src/styles/components/dropdown-menus.less
@@ -62,6 +62,7 @@ components/dropdown-menus.less
   }
 
   .dropdown-toggle {
+    white-space: nowrap;
 
     .badge-container {
 


### PR DESCRIPTION
Before:
![](https://s3.amazonaws.com/f.cl.ly/items/380T2X3v3L0o2U2K3917/Screen%20Shot%202016-06-27%20at%205.35.49%20PM.png?v=68250e97)

After:
![](http://cl.ly/1d0k3G2Q2W0V/Screen%20Shot%202016-06-27%20at%205.36.09%20PM.png)