### PR TITLE
VIPs in modal

### DIFF
--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -2,7 +2,6 @@ import {Hooks} from 'PluginSDK';
 import Service from '../structs/Service';
 import VolumeConstants from '../constants/VolumeConstants';
 
-const VIP_ADDRESS = '0.0.0.0';
 const getFindPropertiesRecursive = function (service, item) {
 
   return Object.keys(item).reduce(function (memo, subItem) {
@@ -290,7 +289,7 @@ const ServiceUtil = {
               });
             }
           } else {
-            definition.container.docker.portMappings = networking.ports.map(function (port) {
+            definition.container.docker.portMappings = networking.ports.map(function (port, index) {
               let portMapping = {containerPort: 0, protocol: 'tcp'};
 
               if (port.protocol != null) {
@@ -306,9 +305,10 @@ const ServiceUtil = {
                   portMapping.hostPort = lbPort;
                 } else {
                   portMapping.servicePort = lbPort;
-                  portMapping.labels = {
-                    'VIP_0': `${VIP_ADDRESS}:${lbPort}`
-                  };
+                  portMapping.labels = {};
+                  if (general != null) {
+                    portMapping.labels[`VIP_${index}`] = `${general.id}:${lbPort}`;
+                  }
                 }
               }
 

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -305,10 +305,10 @@ const ServiceUtil = {
                   portMapping.hostPort = lbPort;
                 } else {
                   portMapping.servicePort = lbPort;
-                  portMapping.labels = {};
-                  if (general != null) {
-                    portMapping.labels[`VIP_${index}`] = `${general.id}:${lbPort}`;
-                  }
+                }
+                portMapping.labels = {};
+                if (general != null) {
+                  portMapping.labels[`VIP_${index}`] = `${general.id}:${lbPort}`;
                 }
               }
 

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -269,10 +269,15 @@ const ServiceUtil = {
           if (networkType === 'host' || !isContainerApp) {
             // Avoid specifying an empty portDefinitions by default
             if (networking.ports.length > 0) {
-              definition.portDefinitions = networking.ports.map(function (port) {
+              definition.portDefinitions = networking.ports.map(function (port, index) {
                 let portMapping = {port: 0, protocol: 'tcp'};
                 if (port.discovery === true) {
-                  portMapping.port = parseInt(port.lbPort || 0, 10);
+                  let lbPort = parseInt(port.lbPort || 0, 10);
+                  portMapping.port = lbPort;
+                  if (general != null) {
+                    portMapping.labels = {};
+                    portMapping.labels[`VIP_${index}`] = `${general.id}:${lbPort}`;
+                  }
                 }
                 if (port.protocol != null) {
                   portMapping.protocol = port.protocol;

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -253,9 +253,20 @@ describe('ServiceUtil', function () {
               ports: [ { lbPort: 1234, discovery: true } ]
             }
           });
-          expect(service.container.docker.portMappings).toEqual([
-            {containerPort: 1234, hostPort: 1234, protocol: 'tcp'}
-          ]);
+          expect(service.container.docker.portMappings[0].hostPort).toEqual(1234);
+        });
+
+        it('should add a VIP label when discovery is on', function () {
+          let service = ServiceUtil.createServiceFromFormModel({
+            general: { id: '/foo/bar' },
+            containerSettings: { image: 'redis' },
+            networking: {
+              networkType: 'bridge',
+              ports: [ { lbPort: 1234, discovery: true } ]
+            }
+          });
+          expect(service.container.docker.portMappings[0].labels)
+            .toEqual({VIP_0: '/foo/bar:1234'});
         });
 
         it('sets the docker network property correctly', function () {

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -98,6 +98,33 @@ describe('ServiceUtil', function () {
           expect(service.portDefinitions[0].port).toEqual(0);
         });
 
+        it('should add a VIP label when discovery is on', function () {
+          let service = ServiceUtil.createServiceFromFormModel({
+              general: { id: '/foo/bar'},
+            networking: {
+              networkType: 'host',
+              ports: [ {lbPort: 1234, discovery: true} ]
+            }
+          });
+          expect(service.portDefinitions[0].labels)
+            .toEqual({VIP_0: '/foo/bar:1234'});
+        });
+
+        it('increments the VIP index', function () {
+          let service = ServiceUtil.createServiceFromFormModel({
+              general: { id: '/foo/bar'},
+            networking: {
+              networkType: 'host',
+              ports: [
+                {lbPort: 1234, discovery: true},
+                {lbPort: 4321, discovery: true}
+              ]
+            }
+          });
+          expect(service.portDefinitions[1].labels)
+            .toEqual({VIP_1: '/foo/bar:4321'});
+        });
+
         describe('an empty networking ports member', function () {
 
           beforeEach(function () {

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -75,9 +75,7 @@ describe('ServiceUtil', function () {
               ports: [ {lbPort: 1234, discovery: true} ]
             }
           });
-          expect(service.portDefinitions).toEqual([
-            {port: 1234, protocol: 'tcp'}
-          ]);
+          expect(service.portDefinitions[0].port).toEqual(1234);
         });
 
         it('should override the port to 0 when discovery is off', function () {
@@ -87,9 +85,7 @@ describe('ServiceUtil', function () {
               ports: [ {lbPort: 1234, discovery: false} ]
             }
           });
-          expect(service.portDefinitions).toEqual([
-            {port: 0, protocol: 'tcp'}
-          ]);
+          expect(service.portDefinitions[0].port).toEqual(0);
         });
 
         it('should default the port to 0 when discovery is on', function () {
@@ -99,9 +95,7 @@ describe('ServiceUtil', function () {
               ports: [ {discovery: true} ]
             }
           });
-          expect(service.portDefinitions).toEqual([
-            {port: 0, protocol: 'tcp'}
-          ]);
+          expect(service.portDefinitions[0].port).toEqual(0);
         });
 
         describe('an empty networking ports member', function () {

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -380,13 +380,14 @@ describe('ServiceUtil', function () {
         it('should add the appropriate VIP label when discovery is on', function () {
          let service = ServiceUtil.createServiceFromFormModel({
             containerSettings: { image: 'redis' },
+            general: { id: '/foo/bar' },
             networking: {
               networkType: 'user',
               ports: [ { lbPort: 1234, discovery: true } ]
             }
           });
           expect(service.container.docker.portMappings[0].labels)
-            .toEqual({'VIP_0': '0.0.0.0:1234'});
+            .toEqual({VIP_0: '/foo/bar:1234'});
         });
 
         describe('an empty networking ports member', function () {


### PR DESCRIPTION
This PR 
 - introduces VIP labels to portDefinitions in host mode
 - fixes the VIP labels in user mode (previously was always 0.0.0.0)
 - extends the user mode VIP labels to bridged mode

VIP labels are now constructed from the app ID and the specified port. 
