### PR TITLE
Force Firefox to obey flex-shrink

### DIFF
--- a/src/styles/layout/foundation.less
+++ b/src/styles/layout/foundation.less
@@ -146,6 +146,7 @@ Flex Container Column
 .flex-shrink {
 
   flex-shrink: 1;
+  min-height: 0;
 
 }
 


### PR DESCRIPTION
Without a `min-height` of `0`, Firefox doesn't allow the containers to shrink beyond their intrinsic height.

Before:
![](https://s3.amazonaws.com/f.cl.ly/items/1Z3S2p2c2m212K1A3W0a/Screen%20Shot%202016-06-27%20at%208.24.09%20PM.png?v=15dbbce6)

After:
![](https://s3.amazonaws.com/f.cl.ly/items/25140F421h3u13463n2B/Screen%20Shot%202016-06-27%20at%208.23.54%20PM.png?v=0b7c4aa7)