### PR TITLE
Don't use abbreviations for docker volumes

### DIFF
--- a/src/js/schemas/service-schema/Volumes.js
+++ b/src/js/schemas/service-schema/Volumes.js
@@ -70,12 +70,11 @@ const Volumes = {
           },
           mode: {
             title: 'Mode',
-            description: 'RO = Read Only, RW = Read and Write',
             fieldType: 'select',
             default: 'ro',
             options: [
-              {html: 'RO', id: 'ro'},
-              {html: 'RW', id: 'rw'}
+              {html: 'Read Only', id: 'ro'},
+              {html: 'Read and Write', id: 'rw'}
             ]
           }
         }


### PR DESCRIPTION
It was abbreviated before because there wasn't enough space. there is enough space now due to RJSC changes not counting JSX elements into width calculation

# Before
![px](https://s3.amazonaws.com/f.cl.ly/items/3c3G35362c2L301J2J1p/Image%202016-06-28%20at%2010.07.41%20AM.png)


# After
![px](https://s3.amazonaws.com/f.cl.ly/items/412Z0Q3H352o1E0S2z36/Image%202016-06-28%20at%2010.07.15%20AM.png)