### PR TITLE
Reduce multiple form column padding

### DIFF
--- a/src/styles/components/multiple-form.less
+++ b/src/styles/components/multiple-form.less
@@ -8,6 +8,7 @@ base/forms.less
 --------------------------------------------------------------------------------
 ----------------------------------------------------------------------------- */
 
+@multiple-form-modal-column-padding-horizontal: @base-spacing-unit * 1/4;
 
 
 
@@ -188,6 +189,12 @@ base/forms.less
           width: auto;
         }
       }
+    }
+
+    // Override column padding.
+    [class*="column-"] {
+      padding-left: @multiple-form-modal-column-padding-horizontal;
+      padding-right: @multiple-form-modal-column-padding-horizontal;
     }
 
   }


### PR DESCRIPTION
Overrides the default column padding for columns within `.multiple-form-modal` for all screen sizes.

![](http://cl.ly/3Y0V20030J2P/Screen%20Shot%202016-06-28%20at%201.49.08%20PM.png)