### PR TITLE
DCOS-8167: Properly handle Job status

### DIFF
--- a/src/js/constants/JobStates.js
+++ b/src/js/constants/JobStates.js
@@ -18,6 +18,14 @@ const JobStates = {
   SUCCESS: {
     stateTypes: ['success'],
     displayName: 'Success'
+  },
+  COMPLETED: {
+    stateTypes: ['success'],
+    displayName: 'Completed'
+  },
+  SCHEDULED: {
+    stateTypes: [],
+    displayName: 'Scheduled'
   }
 };
 

--- a/src/js/pages/jobs/JobsTable.js
+++ b/src/js/pages/jobs/JobsTable.js
@@ -4,16 +4,11 @@ import React from 'react';
 import {Table} from 'reactjs-components';
 
 import Icon from '../../components/Icon';
+import JobStates from '../../constants/JobStates';
 import JobTableHeaderLabels from '../../constants/JobTableHeaderLables';
 import ResourceTableUtil from '../../utils/ResourceTableUtil';
 import TableUtil from '../../utils/TableUtil';
 import Tree from '../../structs/Tree';
-
-const JOBS_STATUS = {
-  active: 'Running',
-  completed: 'Completed',
-  scheduled: 'Scheduled'
-};
 
 const METHODS_TO_BIND = [
   'renderHeadline'
@@ -154,14 +149,15 @@ class JobsTable extends React.Component {
   }
 
   renderStatusColumn(prop, row) {
-    let value = row[prop];
-    let statusClasses = classNames({
-      'text-muted': value === 'completed',
-      'text-color-white': value !== 'completed'
-    });
-    let statusText = JOBS_STATUS[value];
+    let jobState = JobStates[row[prop]];
 
-    return <span className={statusClasses}>{statusText}</span>;
+    let statusClasses = classNames({
+      'text-success': jobState.stateTypes.includes('success'),
+      'text-danger': jobState.stateTypes.includes('failure'),
+      'text-color-white': jobState.stateTypes.includes('active')
+    });
+
+    return <span className={statusClasses}>{jobState.displayName}</span>;
   }
 
   render() {

--- a/src/js/structs/Job.js
+++ b/src/js/structs/Job.js
@@ -96,11 +96,11 @@ module.exports = class Job extends Item {
       let schedule = this.getSchedules()[0];
 
       if (!!schedule && schedule.enabled) {
-        return 'scheduled';
+        return 'SCHEDULED';
       }
     }
 
-    return 'completed';
+    return 'COMPLETED';
   }
 
   getStatus() {

--- a/src/js/structs/__tests__/Job-test.js
+++ b/src/js/structs/__tests__/Job-test.js
@@ -313,7 +313,7 @@ describe('Job', function () {
         }]
       });
 
-      expect(job.getScheduleStatus()).toEqual('scheduled');
+      expect(job.getScheduleStatus()).toEqual('SCHEDULED');
     });
 
     it('returns completed if there are no active runs and no enabled schedule', function () {
@@ -325,7 +325,7 @@ describe('Job', function () {
         }]
       });
 
-      expect(job.getScheduleStatus()).toEqual('completed');
+      expect(job.getScheduleStatus()).toEqual('COMPLETED');
     });
 
     it('returns completed if there are no active runs and no schedule', function () {
@@ -334,7 +334,7 @@ describe('Job', function () {
         activeRuns: []
       });
 
-      expect(job.getScheduleStatus()).toEqual('completed');
+      expect(job.getScheduleStatus()).toEqual('COMPLETED');
     });
 
   });


### PR DESCRIPTION
The Jobs table wasn't making use of the `JobStates` constant previously.

Before:
![](https://photos-2.dropbox.com/t/2/AAAuu396AH1_deZdO6zYtZOrnL2Q9xSCftFgWzppc6zNEw/12/400777/png/32x32/3/1467241200/0/2/Screenshot%202016-06-29%2008.44.05.png/EK36PxjZrcT4AyAHKAc/h-aLCOVX_PT4mqmakaiSKSEtToi1AQhvhRkwCpBrVf0?size_mode=3&size=2048x1536)

After:
![](http://cl.ly/1O0n1f401240/Screen%20Shot%202016-06-29%20at%2011.28.48%20AM.png)