### PR TITLE
Listen for Job events in JobsTab

### DIFF
--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -45,7 +45,8 @@ class JobsTab extends mixin(StoreMixin, QueryParamsMixin, SaveStateMixin) {
     this.saveState_properties = saveState_properties;
 
     this.store_listeners = [
-      {name: 'dcos', events: ['change']}
+      {name: 'dcos', events: ['change']},
+      {name: 'metronome', events: ['change', 'jobCreateSuccess']}
     ];
 
     METHODS_TO_BIND.forEach((method) => {


### PR DESCRIPTION
We weren't listening for these events previously, so the table didn't update when a new job was added, nor when the job list was fetched.