### PR TITLE
Ensure ports are only added if either name or lbPort is set

### DIFF
--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -266,7 +266,7 @@ const ServiceUtil = {
         let networkType = networking.networkType;
         if (networking.ports != null) {
           networking.ports = networking.ports.filter(function (port) {
-            return port.name != null || port.lbPort != null;
+            return port.name != null || port.lbPort != null || port.discovery;
           });
         }
         if (networking.ports != null && networking.ports.length > 0) {

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -264,6 +264,11 @@ const ServiceUtil = {
       if (networking != null) {
         let isContainerApp = containerSettings != null && containerSettings.image != null;
         let networkType = networking.networkType;
+        if (networking.ports != null) {
+          networking.ports = networking.ports.filter(function (port) {
+            return port.name != null || port.lbPort != null;
+          });
+        }
         if (networking.ports != null && networking.ports.length > 0) {
           if (networkType === 'host' || !isContainerApp) {
             // Avoid specifying an empty portDefinitions by default

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -125,35 +125,17 @@ describe('ServiceUtil', function () {
             .toEqual({VIP_1: '/foo/bar:4321'});
         });
 
-        describe('an empty networking ports member', function () {
-
-          beforeEach(function () {
+        it('should not add any port definitions if ports is emoty',
+          function () {
             let service = ServiceUtil.createServiceFromFormModel({
               networking: {
                 networkType: 'host',
                 ports: [{}]
               }
             });
-            this.portDefinition = service.portDefinitions[0];
-          });
-
-          it('defaults port number to 0', function () {
-            expect(this.portDefinition.port).toEqual(0);
-          });
-
-          it('defaults protocol to tcp', function () {
-            expect(this.portDefinition.protocol).toEqual('tcp');
-          });
-
-          it('does not include a name by default', function () {
-            expect(Object.keys(this.portDefinition)).not.toContain('name');
-          });
-
-          it('does not include labels by default', function () {
-            expect(Object.keys(this.portDefinition)).not.toContain('labels');
-          });
-
-        });
+            expect(service.portDefinitions).not.toBeDefined();
+          }
+        );
 
       });
 
@@ -163,7 +145,7 @@ describe('ServiceUtil', function () {
             containerSettings: { image: 'redis' },
             networking: {
               networkType: 'host',
-              ports: [{}]
+              ports: [{lbPort: 1234}]
             }
           });
         });
@@ -189,7 +171,7 @@ describe('ServiceUtil', function () {
             containerSettings: { image: 'redis' },
             networking: {
               networkType: 'bridge',
-              ports: []
+              ports: [{lbPort: 1234}]
             }
           });
         });
@@ -277,36 +259,17 @@ describe('ServiceUtil', function () {
           expect(service.container.docker.network).toEqual('BRIDGE');
         });
 
-        describe('an empty networking ports member', function () {
-
-          beforeEach(function () {
+        it('should not add any port definitions if ports is emoty',
+          function () {
             let service = ServiceUtil.createServiceFromFormModel({
-              containerSettings: { image: 'redis' },
               networking: {
-                networkType: 'bridge',
+                networkType: 'host',
                 ports: [{}]
               }
             });
-            this.portMapping = service.container.docker.portMappings[0];
-          });
-
-          it('defaults containerPort to 0', function () {
-            expect(this.portMapping.containerPort).toEqual(0);
-          });
-
-          it('defaults protocol to tcp', function () {
-            expect(this.portMapping.protocol).toEqual('tcp');
-          });
-
-          it('does not include a name by default', function () {
-            expect(Object.keys(this.portMapping)).not.toContain('name');
-          });
-
-          it('does not include labels by default', function () {
-            expect(Object.keys(this.portMapping)).not.toContain('labels');
-          });
-
-        });
+            expect(service.portDefinitions).not.toBeDefined();
+          }
+        );
 
       });
 
@@ -401,9 +364,8 @@ describe('ServiceUtil', function () {
             .toEqual({VIP_0: '/foo/bar:1234'});
         });
 
-        describe('an empty networking ports member', function () {
-
-          beforeEach(function () {
+        it('should not add any port definitions if ports is emoty',
+          function () {
             let service = ServiceUtil.createServiceFromFormModel({
               containerSettings: { image: 'redis' },
               networking: {
@@ -411,28 +373,11 @@ describe('ServiceUtil', function () {
                 ports: [{}]
               }
             });
-            this.portMapping = service.container.docker.portMappings[0];
-          });
-
-          it('defaults containerPort to 0', function () {
-            expect(this.portMapping.containerPort).toEqual(0);
-          });
-
-          it('defaults protocol to tcp', function () {
-            expect(this.portMapping.protocol).toEqual('tcp');
-          });
-
-          it('does not include a name by default', function () {
-            expect(Object.keys(this.portMapping)).not.toContain('name');
-          });
-
-          it('does not include labels by default', function () {
-            expect(Object.keys(this.portMapping)).not.toContain('labels');
-          });
-        });
+            expect(service.portDefinitions).not.toBeDefined();
+          }
+        );
 
       });
-
     });
 
     describe('should return a service with', function() {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/156010/16469347/c853ae14-3e50-11e6-835b-145fb8939d84.png)
Before when the user opened the deploy service modal and toggled to the JSON mode one port was set by default. This fix makes sure that only ports with a set name or lbPort are added.