### PR TITLE
DCOS-8138 & DCOS-8139: volumes error messages while editing an application

### DIFF
--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -83,6 +83,8 @@ const responseAttributePathToFieldIdMap = {
   '/portDefinitions({INDEX})/name': 'portDefinitions/{INDEX}/name',
   '/portDefinitions({INDEX})/port': 'portDefinitions/{INDEX}/port',
   '/portDefinitions({INDEX})/protocol': 'portDefinitions/{INDEX}/protocol',
+  '/value/isResident': 'Residency',
+  '/value/upgradeStrategy': 'Update Strategy',
   '/container/docker/portMappings': 'dockerPortMappings',
   '/container/docker/portMappings({INDEX})/containerPort':
     'dockerPortMappings/{INDEX}/port',

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -150,7 +150,11 @@ class ServiceFormModal extends mixin(StoreMixin) {
     if (props.id) {
       model.general.id = props.id;
     }
-    let service = ServiceUtil.createServiceFromFormModel(model, ServiceSchema);
+    let service = ServiceUtil.createServiceFromFormModel(
+      model,
+      ServiceSchema,
+      this.props.isEdit
+    );
     if (props.service) {
       service = props.service;
     }
@@ -188,7 +192,11 @@ class ServiceFormModal extends mixin(StoreMixin) {
     let nextState = {};
     if (!this.state.jsonMode) {
       let {model} = this.triggerSubmit();
-      let service = ServiceUtil.createServiceFromFormModel(model, ServiceSchema);
+      let service = ServiceUtil.createServiceFromFormModel(
+        model,
+        ServiceSchema,
+        this.props.isEdit
+      );
       nextState.model = model;
       nextState.service = service;
       nextState.jsonDefinition = JSON.stringify(ServiceUtil
@@ -255,7 +263,11 @@ class ServiceFormModal extends mixin(StoreMixin) {
       if (!isValidated) {
         return;
       }
-      let service = ServiceUtil.createServiceFromFormModel(model, ServiceSchema);
+      let service = ServiceUtil.createServiceFromFormModel(
+        model,
+        ServiceSchema,
+        this.props.isEdit
+      );
       this.setState({service, model, errorMessage: null});
       marathonAction(
         ServiceUtil.getAppDefinitionFromService(service),

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -60,7 +60,7 @@ const pruneHealthCheckAttributes = function (healthCheckSchema, healthCheck) {
 };
 
 const ServiceUtil = {
-  createServiceFromFormModel: function (formModel, schema) {
+  createServiceFromFormModel: function (formModel, schema, isEdit = false) {
     let definition = {};
 
     if (formModel != null) {
@@ -177,10 +177,12 @@ const ServiceUtil = {
           if (externalVolumes.length > 0) {
             volumesList = volumesList.concat(externalVolumes);
           }
-          definition.updateStrategy = {
-            maximumOverCapacity: 0,
-            minimumHealthCapacity: 0
-          };
+          if (!isEdit) {
+            definition.updateStrategy = {
+              maximumOverCapacity: 0,
+              minimumHealthCapacity: 0
+            };
+          }
         }
 
         if (volumes.localVolumes) {
@@ -195,14 +197,16 @@ const ServiceUtil = {
 
           if (localVolumes.length > 0) {
             volumesList = volumesList.concat(localVolumes);
-            definition.updateStrategy = {
-              maximumOverCapacity: 0,
-              minimumHealthCapacity: 0
-            };
-            definition.residency = {
-              relaunchEscalationTimeoutSeconds: 10,
-              taskLostBehavior: 'WAIT_FOREVER'
-            };
+            if (!isEdit) {
+              definition.updateStrategy = {
+                maximumOverCapacity: 0,
+                minimumHealthCapacity: 0
+              };
+              definition.residency = {
+                relaunchEscalationTimeoutSeconds: 10,
+                taskLostBehavior: 'WAIT_FOREVER'
+              };
+            }
           }
         }
 


### PR DESCRIPTION
This adds the nice error message from marathon which is provided if the user adds a network or local volume to an already existing application.

![image](https://cloud.githubusercontent.com/assets/156010/16470178/fe675ca4-3e54-11e6-8ced-fe7b796d610d.png)

This is currently not possible in marathon. It is only possible to add volumes to a new service. In this PR the automatic addition of updateStrategy and residency is prevented while editing a configuration.