### PR TITLE
Fix the agent IP path for tasks

### DIFF
--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
@@ -25,12 +25,13 @@ const headerMapping = {
 };
 const METHODS_TO_BIND = [
   'handleSearchStringChange',
+  'renderAgentIP',
   'renderID',
   'renderPorts',
   'resetFilter'
 ];
 
-const agentIPPath = 'statuses.0.container_status.network_infos.0.ip_addresses.0.ip_address';
+const agentIPPath = 'statuses.0.container_status.network_infos.0.ip_addresses';
 
 class VirtualNetworkTaskTab extends mixin(StoreMixin) {
   constructor() {
@@ -103,9 +104,7 @@ class VirtualNetworkTaskTab extends mixin(StoreMixin) {
       },
       {
         className: getClassName,
-        getValue: function (task) {
-          return Util.findNestedPropertyInObject(task, agentIPPath);
-        },
+        getValue: this.getAgentIP,
         headerClassName: getClassName,
         heading,
         prop: 'ip_address',
@@ -176,8 +175,20 @@ class VirtualNetworkTaskTab extends mixin(StoreMixin) {
     }).join(', ')
   }
 
+  getAgentIP(task) {
+    let ipAddresses = Util.findNestedPropertyInObject(task, agentIPPath);
+
+    if (!ipAddresses || !Array.isArray(ipAddresses)) {
+      return ipAddresses;
+    }
+
+    return ipAddresses.map(function (ipAddress) {
+      return ipAddress.ip_address;
+    }).join(', ');
+  }
+
   renderAgentIP(prop, task) {
-    let ipAddress = Util.findNestedPropertyInObject(task, agentIPPath);
+    let ipAddress = this.getAgentIP(task);
 
     if (!ipAddress) {
       return 'N/A';

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
@@ -30,6 +30,8 @@ const METHODS_TO_BIND = [
   'resetFilter'
 ];
 
+const agentIPPath = 'statuses.0.container_status.network_infos.0.ip_addresses.0.ip_address';
+
 class VirtualNetworkTaskTab extends mixin(StoreMixin) {
   constructor() {
     super(...arguments);
@@ -102,10 +104,7 @@ class VirtualNetworkTaskTab extends mixin(StoreMixin) {
       {
         className: getClassName,
         getValue: function (task) {
-          return Util.findNestedPropertyInObject(
-            task,
-            'statuses.0.container_status.network_infos.0.ip_address'
-          );
+          return Util.findNestedPropertyInObject(task, agentIPPath);
         },
         headerClassName: getClassName,
         heading,
@@ -177,11 +176,8 @@ class VirtualNetworkTaskTab extends mixin(StoreMixin) {
     }).join(', ')
   }
 
-  renderAgentIP(task) {
-    let ipAddress = Util.findNestedPropertyInObject(
-      task,
-      'statuses.0.container_status.network_infos.0.ip_address'
-    );
+  renderAgentIP(prop, task) {
+    let ipAddress = Util.findNestedPropertyInObject(task, agentIPPath);
 
     if (!ipAddress) {
       return 'N/A';


### PR DESCRIPTION
they didn't want it on the task detail, but really wanted the information shown on the virtual networks tasks table. the agent ip column was always `N/A` even though the data was there. this fixes that

![px](https://s3.amazonaws.com/f.cl.ly/items/3v300u370d3h0T110c0p/Image%202016-06-29%20at%203.07.46%20PM.png)