### PR TITLE
DCOS-8207: Fix port transformation to priotize on port mappings

### DIFF
--- a/src/js/schemas/service-schema/Networking.js
+++ b/src/js/schemas/service-schema/Networking.js
@@ -34,13 +34,14 @@ const Networking = {
       duplicable: true,
       addLabel: 'Add an endpoint',
       getter: function (service) {
-        let portMappings = service.getPortDefinitions();
+        let container = service.getContainerSettings();
+        let portMappings = null;
+        if (container && container.docker && container.docker.portMappings) {
+          portMappings = container.docker.portMappings;
+        }
 
         if (portMappings == null) {
-          let container = service.getContainerSettings();
-          if (container && container.docker && container.docker.portMappings) {
-            portMappings = container.docker.portMappings;
-          }
+          portMappings = service.getPortDefinitions();
 
           if (portMappings == null) {
             return null;


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/156010/16485266/48b2f066-3ebe-11e6-8618-cb9a227c8b28.png)

To test this create an app with ports defined in bridge mode e.g. port `80` and then edit the app go either to the network tab which should show the defined port or check the json in the json form.

![image](https://cloud.githubusercontent.com/assets/156010/16485298/811691c4-3ebe-11e6-8192-33c3d5376f29.png)
