### PR TITLE
DCOS-8187: Prevent hostPort to be set

### DIFF
--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -306,7 +306,7 @@ const ServiceUtil = {
               portMapping.containerPort = lbPort;
               if (port.discovery === true) {
                 if (networkType === 'bridge') {
-                  portMapping.hostPort = lbPort;
+                  portMapping.hostPort = 0;
                 } else {
                   portMapping.servicePort = lbPort;
                 }

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -245,7 +245,7 @@ describe('ServiceUtil', function () {
             .not.toContain('hostPort');
         });
 
-        it('should add both containerPort and hostPort when discovery is on', function () {
+        it('should have default hostPort when discovery is on', function () {
           let service = ServiceUtil.createServiceFromFormModel({
             containerSettings: { image: 'redis' },
             networking: {
@@ -253,7 +253,7 @@ describe('ServiceUtil', function () {
               ports: [ { lbPort: 1234, discovery: true } ]
             }
           });
-          expect(service.container.docker.portMappings[0].hostPort).toEqual(1234);
+          expect(service.container.docker.portMappings[0].hostPort).toEqual(0);
         });
 
         it('should add a VIP label when discovery is on', function () {


### PR DESCRIPTION
This will default set the hostPort to 0 which will make it possible to deploy a bridged application with any port not only free ones.