### PR TITLE
Hide service breadcrumb on root view

### DIFF
--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -246,9 +246,11 @@ var ServicesTab = React.createClass({
       );
     }
 
-    return (
-      <Breadcrumbs />
-    );
+    if (this.context.router.getCurrentPathname().match(/^\/services\/?$/) === null) {
+      return (
+        <Breadcrumbs />
+      );
+    }
   },
 
   getServiceTreeView(serviceTree) {


### PR DESCRIPTION
Remove redundant breadcrumb title on root `/services` view 

![](http://cl.ly/1K2f1k2k2o2E/Image%202016-07-01%20at%202.04.15%20PM.png)