### PR TITLE
DCOS-8267 - Use better wording for create modal

### DIFF
--- a/src/js/components/modals/JobFormModal.js
+++ b/src/js/components/modals/JobFormModal.js
@@ -252,9 +252,9 @@ class JobFormModal extends mixin(StoreMixin) {
   }
 
   getModalFooter() {
-    let submitLabel = 'Deploy';
+    let submitLabel = 'Create Job';
     if (this.props.isEdit) {
-      submitLabel = 'Change and deploy';
+      submitLabel = 'Save Job';
     }
 
     return (
@@ -274,7 +274,7 @@ class JobFormModal extends mixin(StoreMixin) {
   }
 
   getModalTitle() {
-    let heading = ' Create new Job';
+    let heading = ' New Job';
     if (this.props.isEdit) {
       heading = 'Edit Job';
     }

--- a/tests/pages/jobs/JobActions-cy.js
+++ b/tests/pages/jobs/JobActions-cy.js
@@ -25,7 +25,7 @@ describe('Job Actions', function () {
           delay: 500
         });
       cy.get('.modal .button-collection .button-success')
-        .contains('Change and deploy')
+        .contains('Save Job')
         .click();
       cy.get('.modal').should('to.have.length', 0);
     });


### PR DESCRIPTION
Change `Deploy` button labels to better describe the create/update in Jobs.

Before:

![image](https://cloud.githubusercontent.com/assets/1078545/16563665/a1f33008-4203-11e6-8374-98d9827f4c02.png)
![image](https://cloud.githubusercontent.com/assets/1078545/16563672/a851bc08-4203-11e6-9d06-4a99fdcd7aff.png)


After:

![image](https://cloud.githubusercontent.com/assets/1078545/16563699/cbb8e82e-4203-11e6-98c5-9e5de4eb4a4a.png)

![image](https://cloud.githubusercontent.com/assets/1078545/16563707/d4f7886e-4203-11e6-8538-2e5cd19a98e9.png)


cc @leemunroe 