### PR TITLE
Update empty Jobs page CTA

### DIFF
--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -201,7 +201,8 @@ class JobsTab extends mixin(StoreMixin, QueryParamsMixin, SaveStateMixin) {
         footer={this.getAlertPanelFooter()}
         icon={<Icon id="pages-code" color="white" size="jumbo" />}>
         <p className="flush-bottom">
-          Jobs aren't available yet.
+          Create both one-off or scheduled jobs to perform tasks at a predefined
+          interval.
         </p>
       </AlertPanel>
     );


### PR DESCRIPTION
The empty page now says:

` Create both one-off or scheduled jobs to perform tasks at a predefined interval.`

instead of

`Jobs aren't available yet.`

cc @leemunroe for a nod.