### PR TITLE
Don't include fixtures in build

### DIFF
--- a/webpack/webpack.production.babel.js
+++ b/webpack/webpack.production.babel.js
@@ -55,6 +55,8 @@ module.exports = Object.assign({}, webpackConfig, {
     // Don't include images in /icons/_exports
     new webpack.IgnorePlugin(/icons\/_exports\//),
 
+    new webpack.IgnorePlugin(/tests\/_fixtures\//),
+
     new CompressionPlugin({
       asset: '[path].gz[query]',
       algorithm: 'gzip',


### PR DESCRIPTION
Part 1: Make sure fixtures aren't bundled in build.

Part 2 will come later. That includes moving fixture assignment to the dev server.