### PR TITLE
DCOS-7823: Introduce collapsing string component

### DIFF
--- a/src/js/components/CollapsingString.js
+++ b/src/js/components/CollapsingString.js
@@ -46,8 +46,8 @@ class CollapsingString extends React.Component {
       return false;
     }
 
-    return !DeepEqual(this.props, nextProps)
-      || !DeepEqual(this.state, nextState);
+    return !DeepEqual(this.state, nextState)
+      || !DeepEqual(this.props, nextProps);
   }
 
   getParentWidth() {

--- a/src/js/components/CollapsingString.js
+++ b/src/js/components/CollapsingString.js
@@ -1,0 +1,166 @@
+import DeepEqual from 'deep-equal';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import DOMUtils from '../utils/DOMUtils';
+
+const METHODS_TO_BIND = ['updateDimensions'];
+
+class CollapsingString extends React.Component {
+  constructor() {
+    super(...arguments);
+
+    this.state = {
+      collapsed: false,
+      parentWidth: null,
+      stringWidth: null
+    };
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  componentDidMount() {
+    if (global.window != null) {
+      window.addEventListener('resize', this.updateDimensions);
+      window.addEventListener('focus', this.updateDimensions);
+    }
+
+    this.updateDimensions();
+  }
+
+  componentDidUpdate() {
+    this.updateDimensions();
+  }
+
+  componentWillUnmount() {
+    if (global.window != null) {
+      window.removeEventListener('resize', this.updateDimensions);
+      window.removeEventListener('focus', this.updateDimensions);
+    }
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    if (nextState.parentWidth === null) {
+      return false;
+    }
+
+    if (this.state.collapsed !== nextState.collapsed
+      || this.state.stringWidth !== nextState.stringWidth
+      || this.state.parentWidth !== nextState.parentWidth) {
+      return true;
+    }
+
+    return !DeepEqual(this.props, nextProps);
+  }
+
+  getParentWidth() {
+    let parent = null;
+    let node = ReactDOM.findDOMNode(this);
+
+    if (this.props.parentSelector != null) {
+      parent = DOMUtils.closest(node, this.props.parentSelector);
+    } else {
+      parent = node.parentNode;
+    }
+
+    return DOMUtils.getComputedWidth(parent);
+  }
+
+  getStringWidth() {
+    if (this.refs.fullString) {
+      return DOMUtils.getComputedWidth(this.refs.fullString);
+    }
+
+    return null;
+  }
+
+  shouldCollapse(parentWidth, stringWidth) {
+    if (parentWidth == null || stringWidth == null) {
+      return false;
+    }
+
+    return stringWidth >= parentWidth;
+  }
+
+  updateDimensions() {
+    let parentWidth = this.getParentWidth();
+
+    // Return early if the string isn't collapsed and the parent is growing.
+    if (this.state.parentWidth != null && parentWidth >= this.state.parentWidth
+      && !this.state.collapsed) {
+      return;
+    }
+
+    // Return early if the string is collapsed and the parent is shrinking.
+    if (this.state.parentWidth != null && parentWidth <= this.state.parentWidth
+      && this.state.collapsed) {
+      return;
+    }
+
+    let stringWidth = null;
+
+    if (this.refs.fullString != null) {
+      stringWidth = this.getStringWidth();
+    }
+
+    this.setState({
+      collapsed: this.shouldCollapse(parentWidth, stringWidth),
+      parentWidth,
+      stringWidth
+    });
+  }
+
+  render() {
+    let fullString = this.props.string;
+    let stringEnding = null;
+
+    if (this.state.collapsed) {
+      stringEnding = (
+        <span className={this.props.truncatedStringEndClassName}>
+          {fullString.substring(fullString.length - this.props.endLength)}
+        </span>
+      );
+    }
+
+    return (
+      <div className={this.props.wrapperClassName} title={fullString}>
+        <span className={this.props.fullStringClassName} ref="fullString">
+          {fullString}
+        </span>
+        <div className={this.props.truncatedWrapperClassName}>
+          <span className={this.props.truncatedStringStartClassName}>
+            {fullString}
+          </span>
+          {stringEnding}
+        </div>
+      </div>
+    );
+  }
+}
+
+CollapsingString.defaultProps = {
+  endLength: 15,
+  fullStringClassName: 'collapsing-string-full-string',
+  truncatedStringEndClassName: 'collapsing-string-truncated-end',
+  truncatedStringStartClassName: 'collapsing-string-truncated-start',
+  truncatedWrapperClassName: 'collapsing-string-truncated-wrapper',
+  wrapperClassName: 'collapsing-string'
+}
+
+CollapsingString.propTypes = {
+  // The number of characters to keep visible at the end of the string.
+  endLength: React.PropTypes.number,
+  fullStringClassName: React.PropTypes.string,
+  // The selector for the parent whose width should be referenced. By default,
+  // the node's direct parent will be used.
+  parentSelector: React.PropTypes.string,
+  string: React.PropTypes.string.isRequired,
+  truncatedStringEndClassName: React.PropTypes.string,
+  truncatedStringStartClassName: React.PropTypes.string,
+  truncatedWrapperClassName: React.PropTypes.string,
+  wrapperClassName: React.PropTypes.string
+};
+
+module.exports = CollapsingString;

--- a/src/js/components/CollapsingString.js
+++ b/src/js/components/CollapsingString.js
@@ -46,13 +46,8 @@ class CollapsingString extends React.Component {
       return false;
     }
 
-    if (this.state.collapsed !== nextState.collapsed
-      || this.state.stringWidth !== nextState.stringWidth
-      || this.state.parentWidth !== nextState.parentWidth) {
-      return true;
-    }
-
-    return !DeepEqual(this.props, nextProps);
+    return !DeepEqual(this.props, nextProps)
+      || !DeepEqual(this.state, nextState);
   }
 
   getParentWidth() {
@@ -147,7 +142,7 @@ CollapsingString.defaultProps = {
   truncatedStringStartClassName: 'collapsing-string-truncated-start',
   truncatedWrapperClassName: 'collapsing-string-truncated-wrapper',
   wrapperClassName: 'collapsing-string'
-}
+};
 
 CollapsingString.propTypes = {
   // The number of characters to keep visible at the end of the string.

--- a/src/js/components/CollapsingString.js
+++ b/src/js/components/CollapsingString.js
@@ -54,10 +54,18 @@ class CollapsingString extends React.Component {
     let parent = null;
     let node = ReactDOM.findDOMNode(this);
 
+    if (node == null) {
+      return 0;
+    }
+
     if (this.props.parentSelector != null) {
       parent = DOMUtils.closest(node, this.props.parentSelector);
     } else {
       parent = node.parentNode;
+    }
+
+    if (parent == null) {
+      parent = global.document.body;
     }
 
     return DOMUtils.getComputedWidth(parent);
@@ -82,9 +90,10 @@ class CollapsingString extends React.Component {
   updateDimensions() {
     let parentWidth = this.getParentWidth();
 
-    // Return early if the string isn't collapsed and the parent is growing.
-    if (this.state.parentWidth != null && parentWidth >= this.state.parentWidth
-      && !this.state.collapsed) {
+    // Return early if the parent width is 0, or the string isn't collapsed
+    // and the parent is growing.
+    if (parentWidth === 0 || (this.state.parentWidth != null
+      && parentWidth >= this.state.parentWidth && !this.state.collapsed)) {
       return;
     }
 

--- a/src/styles/components/collapsing-string.less
+++ b/src/styles/components/collapsing-string.less
@@ -1,0 +1,31 @@
+.collapsing-string {
+  position: relative;
+  white-space: nowrap;
+}
+
+.collapsing-string-full-string {
+  left: 0;
+  position: absolute;
+  top: 0;
+  visibility: hidden;
+}
+
+.collapsing-string-truncated-wrapper {
+  display: flex;
+}
+
+.collapsing-string-truncated-start,
+.collapsing-string-truncated-end {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.collapsing-string-truncated-start {
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+.collapsing-string-truncated-end {
+  flex: 0 0 auto;
+  max-width: 100%;
+}

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -131,6 +131,7 @@ Components
 @import "components/charts/index.less";
 @import "components/charts/dialchart.less";
 @import "components/code.less";
+@import "components/collapsing-string.less";
 @import "components/dashboard-health-list.less";
 @import "components/deployments-table.less";
 @import "components/description-list.less";


### PR DESCRIPTION
The user specifies a number of characters that should not be truncated at the end of the string, or the default of 15 characters is used.

![](https://s3.amazonaws.com/f.cl.ly/items/1D1x2v2I1T0p2W0r3L0R/Screen%20Recording%202016-07-05%20at%2001.50%20PM.gif?v=49814edb)

I opted not to use `classnames/dedupe` here because I thought the performance hit would not be worth it, as I don't expect we'll need to override these classnames. But let me know if you feel otherwise!