### PR TITLE
Hide navigation tabs in service detail

### DIFF
--- a/src/js/routes/services.js
+++ b/src/js/routes/services.js
@@ -62,6 +62,7 @@ let serviceRoutes = {
           type: Route,
           name: 'services-detail',
           path: ':id/?',
+          hideHeaderNavigation: true,
           buildBreadCrumb: function () {
             return {
               parentCrumb: 'services-page',


### PR DESCRIPTION
Executive designer decision: all detail pages should hide navigation tabs

![px](http://cl.ly/2B133m3x3A0z/Image%202016-07-05%20at%204.03.33%20PM.png)