### PR TITLE
Rename job run structs

### DIFF
--- a/src/js/structs/Job.js
+++ b/src/js/structs/Job.js
@@ -1,10 +1,10 @@
 import DateUtil from '../utils/DateUtil';
 import Item from './Item';
-import JobActiveRunList from './JobActiveRunList';
+import JobRunList from './JobRunList';
 
 module.exports = class Job extends Item {
   getActiveRuns() {
-    return new JobActiveRunList({items: this.get('activeRuns')});
+    return new JobRunList({items: this.get('activeRuns')});
   }
 
   getCommand() {

--- a/src/js/structs/JobRun.js
+++ b/src/js/structs/JobRun.js
@@ -2,7 +2,7 @@ import DateUtil from '../utils/DateUtil';
 import Item from './Item';
 import JobTaskList from './JobTaskList';
 
-module.exports = class JobActiveRun extends Item {
+class JobRun extends Item {
   getDateCreated() {
     return DateUtil.strToMs(this.get('createdAt'));
   }
@@ -18,4 +18,6 @@ module.exports = class JobActiveRun extends Item {
   getTasks() {
     return new JobTaskList({items: this.get('tasks')});
   }
-};
+}
+
+module.exports = JobRun;

--- a/src/js/structs/JobRunList.js
+++ b/src/js/structs/JobRunList.js
@@ -1,7 +1,7 @@
 import List from './List';
-import JobActiveRun from './JobActiveRun';
+import JobRun from './JobRun';
 
-class JobActiveRunList extends List {
+class JobRunList extends List {
   getLongestRunningActiveRun() {
     let sortedRuns = this.getItems().sort(function (a, b) {
       if (a.getDateCreated() == null && b.getDateCreated() == null) {
@@ -23,6 +23,6 @@ class JobActiveRunList extends List {
   }
 }
 
-JobActiveRunList.type = JobActiveRun;
+JobRunList.type = JobRun;
 
-module.exports = JobActiveRunList;
+module.exports = JobRunList;

--- a/src/js/structs/__tests__/Job-test.js
+++ b/src/js/structs/__tests__/Job-test.js
@@ -1,5 +1,5 @@
 let Job = require('../Job');
-let JobActiveRunList = require('../JobActiveRunList');
+let JobRunList = require('../JobRunList');
 
 describe('Job', function () {
 
@@ -8,7 +8,7 @@ describe('Job', function () {
     it('returns an instance of JobActiveRunList', function () {
       let job = new Job({id: 'foo', activeRuns: []});
 
-      expect(job.getActiveRuns() instanceof JobActiveRunList).toBeTruthy();
+      expect(job.getActiveRuns() instanceof JobRunList).toBeTruthy();
     });
 
   });

--- a/src/js/structs/__tests__/JobRun-test.js
+++ b/src/js/structs/__tests__/JobRun-test.js
@@ -1,19 +1,19 @@
 let moment = require('moment');
 
-let JobActiveRun = require('../JobActiveRun');
+let JobRun = require('../JobRun');
 let JobTaskList = require('../JobTaskList');
 
-describe('JobActiveRun', function () {
+describe('JobRun', function () {
 
   describe('#getDateCreated', function () {
 
     it('should return null if createdAt is undefined', function () {
-      let activeRun = new JobActiveRun({foo: 'bar'});
+      let activeRun = new JobRun({foo: 'bar'});
       expect(activeRun.getDateCreated()).toEqual(null);
     });
 
     it('should return the correct value in milliseconds', function () {
-      let activeRun = new JobActiveRun({createdAt: '1990-01-03T02:00:00Z-1'});
+      let activeRun = new JobRun({createdAt: '1990-01-03T02:00:00Z-1'});
       expect(activeRun.getDateCreated()).toEqual(631332000000);
     });
 
@@ -22,7 +22,7 @@ describe('JobActiveRun', function () {
   describe('#getJobID', function () {
 
     it('should return the jobId', function () {
-      let activeRun = new JobActiveRun({jobId: 'foo'});
+      let activeRun = new JobRun({jobId: 'foo'});
       expect(activeRun.getJobID()).toEqual('foo');
     });
 
@@ -31,7 +31,7 @@ describe('JobActiveRun', function () {
   describe('#getStatus', function () {
 
     it('should return the id', function () {
-      let activeRun = new JobActiveRun({status: 'foo'});
+      let activeRun = new JobRun({status: 'foo'});
       expect(activeRun.getStatus()).toEqual('foo');
     });
 
@@ -40,7 +40,7 @@ describe('JobActiveRun', function () {
   describe('#getTasks', function () {
 
     it('should return an instance of JobTaskList', function () {
-      let activeRun = new JobActiveRun({id: 'foo', tasks: []});
+      let activeRun = new JobRun({id: 'foo', tasks: []});
       expect(activeRun.getTasks() instanceof JobTaskList).toBeTruthy();
     });
 

--- a/src/js/structs/__tests__/JobRunList-test.js
+++ b/src/js/structs/__tests__/JobRunList-test.js
@@ -1,13 +1,13 @@
 let moment = require('moment');
 
-let JobActiveRunList = require('../JobActiveRunList');
+let JobRunList = require('../JobRunList');
 
-describe('JobActiveRunList', function () {
+describe('JobRunList', function () {
 
   describe('#getLongestRunningActiveRun', function () {
 
     it('returns the longest running active run', function () {
-      let activeRunList = new JobActiveRunList({
+      let activeRunList = new JobRunList({
         items: [
           {'createdAt': '1990-01-03T00:00:00Z-1'},
           {'createdAt': '1985-01-03T00:00:00Z-1'},
@@ -20,7 +20,7 @@ describe('JobActiveRunList', function () {
     });
 
     it('returns the longest running active run', function () {
-      let activeRunList = new JobActiveRunList({
+      let activeRunList = new JobRunList({
         items: [
           {'createdAt': '1990-01-03T00:10:00Z-1'},
           {'createdAt': '1990-01-03T00:05:00Z-1'},


### PR DESCRIPTION
Adjust the job run and job run list struct naming as they will serve as the base class for all job runs, including old once (history).