### PR TITLE
Apply overflow: hidden to body

### DIFF
--- a/src/styles/layout/foundation.less
+++ b/src/styles/layout/foundation.less
@@ -29,6 +29,10 @@ body,
 
 }
 
+body {
+  overflow: hidden;
+}
+
 ::selection {
 
   background: color-lighten(@purple, 0);


### PR DESCRIPTION
All content overflow is handled within `div#canvas`, which will always fill the viewport, so this shouldn't be a problem. It prevents the ugly scrollbar from appearing when the user dropup menu is animating closed. I tested this in all browsers, but please try to break it.