### PR TITLE
[1 of 3: CollapsingString] Use greater than, not greater than or equal to

### DIFF
--- a/src/js/components/CollapsingString.js
+++ b/src/js/components/CollapsingString.js
@@ -84,7 +84,7 @@ class CollapsingString extends React.Component {
       return false;
     }
 
-    return stringWidth >= parentWidth;
+    return stringWidth > parentWidth;
   }
 
   updateDimensions() {


### PR DESCRIPTION
Previously the string would collapse if the string width matched exactly the parent width. This is not desirable.