### PR TITLE
[2 of 3: CollapsingString] Adjust PageHeader styles for use with CollapsingString

### DIFF
--- a/src/styles/components/page-header.less
+++ b/src/styles/components/page-header.less
@@ -40,12 +40,14 @@
   align-items: center;
   display: flex;
   flex: 1 1 auto;
+  min-width: 0;
 }
 
 .page-header-content-secondary {
   flex: 0 1 auto;
   margin-left: 0;
   margin-top: @base-spacing-unit * 1/4;
+  padding-left: @base-spacing-unit;
   white-space: nowrap;
 
   &:last-child {
@@ -55,6 +57,11 @@
   .button-collection {
     margin-bottom: 0;
   }
+}
+
+.page-header-title {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .page-header-content-heading {


### PR DESCRIPTION
This PR adjsuts flex properties to account for the `CollapsingString` component which will be used to render the heading string in `PageHeader`.

Previously the page header didn't shrink reliably because we allowed it to spill to multiple lines. Also, the icon and action buttons would shrink, when they shouldn't.

By itself, this PR shouldn't introduce any visible changes. But here's a screenshot of it in use with the `CollapsingString` component:
![](https://s3.amazonaws.com/f.cl.ly/items/433i0Q3c0g340K3T0I1C/Screen%20Shot%202016-07-07%20at%202.54.10%20PM.png?v=bf140ade)
(imagine that's a very long string instead of just the text `marathon-user` repeated many times)