### PR TITLE
Use 1/3rd of the end of the string by default

### DIFF
--- a/src/js/components/CollapsingString.js
+++ b/src/js/components/CollapsingString.js
@@ -118,12 +118,13 @@ class CollapsingString extends React.Component {
 
   render() {
     let fullString = this.props.string;
+    let endLength = this.props.endLength || Math.floor(fullString.length * 1/3);
     let stringEnding = null;
 
     if (this.state.collapsed) {
       stringEnding = (
         <span className={this.props.truncatedStringEndClassName}>
-          {fullString.substring(fullString.length - this.props.endLength)}
+          {fullString.substring(fullString.length - endLength)}
         </span>
       );
     }
@@ -145,7 +146,6 @@ class CollapsingString extends React.Component {
 }
 
 CollapsingString.defaultProps = {
-  endLength: 15,
   fullStringClassName: 'collapsing-string-full-string',
   truncatedStringEndClassName: 'collapsing-string-truncated-end',
   truncatedStringStartClassName: 'collapsing-string-truncated-start',

--- a/src/js/components/CollapsingString.js
+++ b/src/js/components/CollapsingString.js
@@ -118,8 +118,12 @@ class CollapsingString extends React.Component {
 
   render() {
     let fullString = this.props.string;
-    let endLength = this.props.endLength || Math.floor(fullString.length * 1/3);
+    let endLength = this.props.endLength;
     let stringEnding = null;
+
+    if (endLength == null) {
+      endLength = Math.floor(fullString.length * 1/3);
+    }
 
     if (this.state.collapsed) {
       stringEnding = (


### PR DESCRIPTION
@kennyt had the great suggestion of using 1/3rd of the length of the string as the default number of characters to display, instead of the arbitrary 15 I had selected previously.