### PR TITLE
DCOS-8052: Refactor FilterHeadline

### DIFF
--- a/src/js/components/FilterHeadline.js
+++ b/src/js/components/FilterHeadline.js
@@ -77,7 +77,7 @@ FilterHeadline.propTypes = {
   currentLength: PropTypes.number.isRequired,
   inverseStyle: PropTypes.bool,
   // Optional prop used to force the "Clear" button to show even when n of n
-  // items are currenetly displayed.
+  // items are currently displayed.
   isFiltering: PropTypes.bool,
   name: PropTypes.string.isRequired,
   onReset: PropTypes.func.isRequired,

--- a/src/js/components/FilterHeadline.js
+++ b/src/js/components/FilterHeadline.js
@@ -22,25 +22,25 @@ class FilterHeadline extends React.Component {
   }
 
   render() {
-    let {currentLength, inverseStyle, name, totalLength} = this.props;
+    let {currentLength, inverseStyle, isFiltering, name, totalLength} = this.props;
     name = StringUtil.pluralize(name, totalLength);
 
     let filteredClassSet = classNames({
       'h4': true,
       'inverse': inverseStyle,
-      'hidden': filteredLength === totalLength
+      'hidden': (isFiltering == null && currentLength === totalLength) || (isFiltering != null && !isFiltering)
     });
 
     let unfilteredClassSet = classNames({
       'h4': true,
       'inverse': inverseStyle,
-      'hidden': filteredLength !== totalLength
+      'hidden': (isFiltering == null && currentLength !== totalLength) || (isFiltering != null && isFiltering)
     });
 
     let anchorClassSet = classNames({
       'h4 clickable': true,
       'inverse': inverseStyle,
-      'hidden': filteredLength === totalLength
+      'hidden': (isFiltering == null && currentLength === totalLength) || (isFiltering != null && !isFiltering)
     });
 
     let listClassSet = classNames({
@@ -55,7 +55,7 @@ class FilterHeadline extends React.Component {
         </li>
         <li className={anchorClassSet} onClick={this.handleReset}>
           <a className="small">
-            (Show all)
+            (Clear)
           </a>
         </li>
         <li className={unfilteredClassSet}>
@@ -73,6 +73,9 @@ FilterHeadline.defaultProps = {
 FilterHeadline.propTypes = {
   currentLength: PropTypes.number.isRequired,
   inverseStyle: PropTypes.bool,
+  // Optional prop used to force the "Clear" button to show even when n of n
+  // items are currenetly displayed.
+  isFiltering: PropTypes.bool,
   name: PropTypes.string.isRequired,
   onReset: PropTypes.func.isRequired,
   totalLength: PropTypes.number.isRequired

--- a/src/js/components/FilterHeadline.js
+++ b/src/js/components/FilterHeadline.js
@@ -23,7 +23,9 @@ class FilterHeadline extends React.Component {
 
   render() {
     let {currentLength, inverseStyle, isFiltering, name, totalLength} = this.props;
-    let hideFilteredClasses = (isFiltering == null && currentLength === totalLength) || (isFiltering != null && !isFiltering);
+    let hideFilteredClasses =
+      (isFiltering == null && currentLength === totalLength) ||
+      (isFiltering != null && !isFiltering);
     name = StringUtil.pluralize(name, totalLength);
 
     let filteredClassSet = classNames({

--- a/src/js/components/FilterHeadline.js
+++ b/src/js/components/FilterHeadline.js
@@ -1,5 +1,5 @@
-import React, {PropTypes} from 'react';
 import classNames from 'classnames';
+import React, {PropTypes} from 'react';
 
 import StringUtil from '../utils/StringUtil';
 
@@ -9,7 +9,7 @@ const METHODS_TO_BIND = [
 
 class FilterHeadline extends React.Component {
   constructor() {
-    super();
+    super(...arguments);
 
     METHODS_TO_BIND.forEach((method) => {
       this[method] = this[method].bind(this);
@@ -23,24 +23,25 @@ class FilterHeadline extends React.Component {
 
   render() {
     let {currentLength, inverseStyle, isFiltering, name, totalLength} = this.props;
+    let hideFilteredClasses = (isFiltering == null && currentLength === totalLength) || (isFiltering != null && !isFiltering);
     name = StringUtil.pluralize(name, totalLength);
 
     let filteredClassSet = classNames({
       'h4': true,
       'inverse': inverseStyle,
-      'hidden': (isFiltering == null && currentLength === totalLength) || (isFiltering != null && !isFiltering)
+      'hidden': hideFilteredClasses
     });
 
     let unfilteredClassSet = classNames({
       'h4': true,
       'inverse': inverseStyle,
-      'hidden': (isFiltering == null && currentLength !== totalLength) || (isFiltering != null && isFiltering)
+      'hidden': !hideFilteredClasses
     });
 
     let anchorClassSet = classNames({
       'h4 clickable': true,
       'inverse': inverseStyle,
-      'hidden': (isFiltering == null && currentLength === totalLength) || (isFiltering != null && !isFiltering)
+      'hidden': hideFilteredClasses
     });
 
     let listClassSet = classNames({

--- a/src/js/components/FilterHeadline.js
+++ b/src/js/components/FilterHeadline.js
@@ -1,50 +1,43 @@
-var classNames = require('classnames');
-var React = require('react');
+import React, {PropTypes} from 'react';
+import classNames from 'classnames';
 
 import StringUtil from '../utils/StringUtil';
 
-var FilterHeadline = React.createClass({
+const METHODS_TO_BIND = [
+  'handleReset'
+];
 
-  displayName: 'FilterHeadline',
+class FilterHeadline extends React.Component {
+  constructor() {
+    super();
 
-  propTypes: {
-    onReset: React.PropTypes.func.isRequired,
-    name: React.PropTypes.string.isRequired,
-    currentLength: React.PropTypes.number.isRequired,
-    totalLength: React.PropTypes.number.isRequired,
-    inverseStyle: React.PropTypes.bool
-  },
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
 
-  getDefaultProps: function () {
-    return {
-      inverseStyle: false
-    };
-  },
-
-  handleReset: function (e) {
+  handleReset(e) {
     e.preventDefault();
     this.props.onReset();
-  },
+  }
 
-  render: function () {
-    var filteredLength = this.props.currentLength;
-    var totalLength = this.props.totalLength;
-    let inverseStyle = this.props.inverseStyle;
-    let name = StringUtil.pluralize(this.props.name, totalLength);
+  render() {
+    let {currentLength, inverseStyle, name, totalLength} = this.props;
+    name = StringUtil.pluralize(name, totalLength);
 
-    var filteredClassSet = classNames({
+    let filteredClassSet = classNames({
       'h4': true,
       'inverse': inverseStyle,
       'hidden': filteredLength === totalLength
     });
 
-    var unfilteredClassSet = classNames({
+    let unfilteredClassSet = classNames({
       'h4': true,
       'inverse': inverseStyle,
       'hidden': filteredLength !== totalLength
     });
 
-    var anchorClassSet = classNames({
+    let anchorClassSet = classNames({
       'h4 clickable': true,
       'inverse': inverseStyle,
       'hidden': filteredLength === totalLength
@@ -58,7 +51,7 @@ var FilterHeadline = React.createClass({
     return (
       <ul className={listClassSet}>
         <li className={filteredClassSet}>
-          Showing {filteredLength} of {totalLength} {name}
+          Showing {currentLength} of {totalLength} {name}
         </li>
         <li className={anchorClassSet} onClick={this.handleReset}>
           <a className="small">
@@ -71,6 +64,18 @@ var FilterHeadline = React.createClass({
       </ul>
     );
   }
-});
+}
+
+FilterHeadline.defaultProps = {
+  inverseStyle: false
+};
+
+FilterHeadline.propTypes = {
+  currentLength: PropTypes.number.isRequired,
+  inverseStyle: PropTypes.bool,
+  name: PropTypes.string.isRequired,
+  onReset: PropTypes.func.isRequired,
+  totalLength: PropTypes.number.isRequired
+};
 
 module.exports = FilterHeadline;


### PR DESCRIPTION
Bring `FilterHeadline` to es6 and add a new prop that forces showing the `clear` button for clearing the filters even if `n of n` objects are being displayed.

before 
![doesn't show 'clear' menu when n of n objects are filtered](https://cl.ly/3b280I050X32/Image%202016-07-07%20at%204.11.38%20PM.png)


after
![shows 'clear' menu when n of n objects are filtered](https://cl.ly/2c2f0p1P3U2i/Image%202016-07-07%20at%204.20.19%20PM.png)