### PR TITLE
DCOS-8374: Explicitly set breadcrumb flex-basis for Safari

### DIFF
--- a/src/styles/components/breadcrumbs.less
+++ b/src/styles/components/breadcrumbs.less
@@ -34,7 +34,7 @@ Breadcrumbs
 
 .breadcrumb {
   display: flex;
-  flex: 0 0;
+  flex: 0 0 auto;
   font-size: @base-spacing-unit * .65;
   line-height: @base-spacing-unit;
   list-style: none !important;


### PR DESCRIPTION
Integration tests passing on a frankie branch, which includes this:
![](https://s3.amazonaws.com/f.cl.ly/items/3M3f0f0m0N1i2S3z1J26/Screen%20Shot%202016-07-12%20at%202.43.36%20PM.png?v=2fe45bf8)
![](https://s3.amazonaws.com/f.cl.ly/items/160i0D0Z1g421A2U042s/Screen%20Shot%202016-07-12%20at%202.43.47%20PM.png?v=b7a08b47)