### PR TITLE
DCOS-8375: Reset dropdown filters on filter clear

### DIFF
--- a/src/js/components/FilterByService.js
+++ b/src/js/components/FilterByService.js
@@ -93,8 +93,9 @@ var FilterByService = React.createClass({
         dropdownMenuListItemClassName="clickable"
         wrapperClassName="dropdown"
         items={this.getDropdownItems()}
-        onItemSelection={this.handleItemSelection}
         initialID={this.getSelectedId(this.props.byServiceFilter)}
+        onItemSelection={this.handleItemSelection}
+        ref={(ref) => this.dropdown = ref}
         transition={true}
         transitionName="dropdown-menu" />
     );

--- a/src/js/components/FilterByService.js
+++ b/src/js/components/FilterByService.js
@@ -84,6 +84,12 @@ var FilterByService = React.createClass({
     return id;
   },
 
+  setDropdownValue: function (id) {
+    this.dropdown.setState({
+      selectedID: id
+    });
+  },
+
   render: function () {
     return (
       <Dropdown

--- a/src/js/components/HealthTab.js
+++ b/src/js/components/HealthTab.js
@@ -86,7 +86,7 @@ class HealthTab extends React.Component {
 
   resetFilter() {
     if (this.healthFilter !== null && this.healthFilter.dropdown !== null) {
-      this.healthFilter.dropdown.setState({selectedID: 'all'});
+      this.healthFilter.setDropdownValue('all');
     }
 
     this.setState({

--- a/src/js/components/HealthTab.js
+++ b/src/js/components/HealthTab.js
@@ -85,6 +85,10 @@ class HealthTab extends React.Component {
   }
 
   resetFilter() {
+    if (this.healthFilter !== null && this.healthFilter.dropdown !== null) {
+      this.healthFilter.dropdown.setState({selectedID: 'all'});
+    }
+
     this.setState({
       searchString: '',
       healthFilter: 'all'
@@ -141,7 +145,8 @@ class HealthTab extends React.Component {
             initialID="all"
             className="button dropdown-toggle text-align-left button-inverse"
             dropdownMenuClassName="dropdown-menu inverse"
-            onHealthSelection={this.handleHealthSelection} />
+            onHealthSelection={this.handleHealthSelection}
+            ref={(ref) => this.healthFilter = ref} />
         </FilterBar>
         <Table
           className="table table-borderless-outer

--- a/src/js/components/UnitHealthDropdown.js
+++ b/src/js/components/UnitHealthDropdown.js
@@ -44,6 +44,7 @@ class UnitHealthDropdown extends mixin(InternalStorageMixin) {
         initialID={initialID}
         items={this.internalStorage_get().dropdownItems}
         onItemSelection={onHealthSelection}
+        ref={(ref) => this.dropdown = ref}
         transition={true}
         wrapperClassName="dropdown" />
     );

--- a/src/js/components/UnitHealthDropdown.js
+++ b/src/js/components/UnitHealthDropdown.js
@@ -33,6 +33,12 @@ class UnitHealthDropdown extends mixin(InternalStorageMixin) {
     return items;
   }
 
+  setDropdownValue(id) {
+    this.dropdown.setState({
+      selectedID: id
+    });
+  }
+
   render() {
     let {className, dropdownMenuClassName, initialID, onHealthSelection} = this.props;
 

--- a/src/js/pages/NodesPage.js
+++ b/src/js/pages/NodesPage.js
@@ -139,9 +139,16 @@ var NodesPage = React.createClass({
   },
 
   resetFilter: function () {
-    var state = Object.assign({}, DEFAULT_FILTER_OPTIONS);
-    this.internalStorage_update(getMesosHosts(state));
+    let state = Object.assign({}, DEFAULT_FILTER_OPTIONS);
+
     this.setState(state);
+    this.internalStorage_update(getMesosHosts(state));
+
+    if (this.serviceFilter !== null && this.serviceFilter.dropdown !== null) {
+      this.serviceFilter.dropdown.setState({
+        selectedID: 'default'
+      });
+    }
   },
 
   handleSearchStringChange: function (searchString) {
@@ -268,9 +275,10 @@ var NodesPage = React.createClass({
           <div className="form-group flush-bottom">
             <FilterByService
               byServiceFilter={state.byServiceFilter}
+              handleFilterChange={this.handleByServiceFilterChange}
+              ref={(ref) => this.serviceFilter = ref}
               services={data.services}
-              totalHostsCount={data.totalNodes}
-              handleFilterChange={this.handleByServiceFilterChange} />
+              totalHostsCount={data.totalNodes} />
           </div>
           {this.getViewTypeRadioButtons(this.resetFilter)}
         </FilterBar>

--- a/src/js/pages/NodesPage.js
+++ b/src/js/pages/NodesPage.js
@@ -145,9 +145,7 @@ var NodesPage = React.createClass({
     this.internalStorage_update(getMesosHosts(state));
 
     if (this.serviceFilter !== null && this.serviceFilter.dropdown !== null) {
-      this.serviceFilter.dropdown.setState({
-        selectedID: 'default'
-      });
+      this.serviceFilter.setDropdownValue('default');
     }
   },
 

--- a/src/js/pages/system/UnitsHealthDetail.js
+++ b/src/js/pages/system/UnitsHealthDetail.js
@@ -128,7 +128,7 @@ class UnitsHealthDetail extends mixin(StoreMixin) {
 
   resetFilter() {
     if (this.healthFilter !== null && this.healthFilter.dropdown !== null) {
-      this.healthFilter.dropdown.setState({selectedID: 'all'});
+      this.healthFilter.setDropdownValue('all');
     }
 
     this.setState({

--- a/src/js/pages/system/UnitsHealthDetail.js
+++ b/src/js/pages/system/UnitsHealthDetail.js
@@ -127,6 +127,10 @@ class UnitsHealthDetail extends mixin(StoreMixin) {
   }
 
   resetFilter() {
+    if (this.healthFilter !== null && this.healthFilter.dropdown !== null) {
+      this.healthFilter.dropdown.setState({selectedID: 'all'});
+    }
+
     this.setState({
       searchString: '',
       healthFilter: 'all'
@@ -179,7 +183,8 @@ class UnitsHealthDetail extends mixin(StoreMixin) {
             className="button dropdown-toggle text-align-left button-inverse"
             dropdownMenuClassName="dropdown-menu inverse"
             initialID="all"
-            onHealthSelection={this.handleHealthSelection} />
+            onHealthSelection={this.handleHealthSelection}
+            ref={(ref) => this.healthFilter = ref} />
         </FilterBar>
         <div className="flex-container-col flex-grow no-overflow">
           {this.getNodesTable(unit, visibleData)}


### PR DESCRIPTION
Dropdowns were not being reset when search filters were cleared. This PR fixes that.

before:
(Dropdown still shows 'Unhealthy' after filter is cleared)
![filters are cleared but dropdown is still displaying old filter param noo](https://cl.ly/380d1h1y1V0L/Screen%20Recording%202016-07-06%20at%2005.35%20PM.gif)

after:
(Dropdown resets to default text 'Filter By Service' after filter is cleared)
![dropdown resetting upon clearing filters. aw yus.](https://cl.ly/262I3w0X112q/Screen%20Recording%202016-07-08%20at%2001.45%20PM.gif)