### PR TITLE
Update to cosmos v2 for available endpoints

### DIFF
--- a/src/js/components/DisplayPackagesTable.js
+++ b/src/js/components/DisplayPackagesTable.js
@@ -47,7 +47,7 @@ class DisplayPackagesTable extends React.Component {
 
   getHeadline(prop, cosmosPackage) {
     let packageImages = cosmosPackage.getIcons();
-    let name = cosmosPackage.get('name');
+    let name = cosmosPackage.getName();
 
     // Remove initial slash if present
     if (name.charAt(0) === '/') {
@@ -68,7 +68,7 @@ class DisplayPackagesTable extends React.Component {
               {name}
             </h2>
             <p className="flush-bottom">
-              {cosmosPackage.get('currentVersion')}
+              {cosmosPackage.getCurrentVersion()}
             </p>
           </div>
         </div>

--- a/src/js/components/modals/InstallPackageModal.js
+++ b/src/js/components/modals/InstallPackageModal.js
@@ -47,7 +47,7 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
     this.state = {
       currentTab: 'defaultInstall',
       schemaIncorrect: false,
-      truncatedPreinstallNotes: true
+      truncatedPreInstallNotes: true
     };
 
     this.store_listeners = [{
@@ -90,7 +90,7 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
       this.triggerAdvancedSubmit = undefined;
       this.setState({
         currentTab: 'defaultInstall',
-        truncatedPreinstallNotes: true
+        truncatedPreInstallNotes: true
       });
     }
 
@@ -117,7 +117,7 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
 
   onCosmosPackagesStoreDescriptionSuccess() {
     let cosmosPackage = CosmosPackagesStore.getPackageDetails();
-    if (!SchemaUtil.validateSchema(cosmosPackage.get('config'))) {
+    if (!SchemaUtil.validateSchema(cosmosPackage.getConfig())) {
       this.setState({schemaIncorrect: true});
       return;
     }
@@ -172,8 +172,9 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
   }
 
   handleInstallPackage() {
-    let {name, version} = CosmosPackagesStore
-      .getPackageDetails().get('package');
+    let cosmosPackage = CosmosPackagesStore.getPackageDetails();
+    let name = cosmosPackage.getName();
+    let version = cosmosPackage.getCurrentVersion();
     let configuration = this.getPackageConfiguration();
 
     CosmosPackagesStore.installPackage(name, version, configuration);
@@ -187,8 +188,8 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
   }
 
   handlePreinstallNotesToggle() {
-    let truncatedPreinstallNotes = !this.state.truncatedPreinstallNotes;
-    this.setState({truncatedPreinstallNotes});
+    let truncatedPreInstallNotes = !this.state.truncatedPreInstallNotes;
+    this.setState({truncatedPreInstallNotes});
   }
 
   getAdvancedSubmit(triggerSubmit) {
@@ -209,7 +210,7 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
 
     if (isAdvancedInstall && !advancedConfiguration) {
       return SchemaUtil.definitionToJSONDocument(
-        SchemaUtil.schemaToMultipleDefinition(cosmosPackage.get('config'))
+        SchemaUtil.schemaToMultipleDefinition(cosmosPackage.getConfig())
       );
     }
 
@@ -256,7 +257,7 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
     );
   }
 
-  getPreinstallNotes(notes, truncated) {
+  getPreInstallNotes(notes, truncated) {
     if (!notes) {
       return null;
     }
@@ -268,13 +269,13 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
     return (
       <p className="small flush-bottom">
         <span className="mute">
-          {notes}{this.getPreinstallNotesToggle(truncated, notes)}
+          {notes}{this.getPreInstallNotesToggle(truncated, notes)}
         </span>
       </p>
     );
   }
 
-  getPreinstallNotesToggle(truncated, notes) {
+  getPreInstallNotesToggle(truncated, notes) {
     if (notes.length < PREINSTALL_NOTES_CHAR_LIMIT) {
       return null;
     }
@@ -307,11 +308,12 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
       installError
     } = this.internalStorage_get();
     let cosmosPackage = CosmosPackagesStore.getPackageDetails();
-    let preinstallNotes = cosmosPackage.getPreinstallNotes();
-    let {name, version} = cosmosPackage.get('package');
-    let truncated = this.state.truncatedPreinstallNotes;
+    let preInstallNotes = cosmosPackage.getPreInstallNotes();
+    let name = cosmosPackage.getName();
+    let version = cosmosPackage.getCurrentVersion();
+    let truncated = this.state.truncatedPreInstallNotes;
     let packageVersionClasses = classNames({
-      'flush-bottom': !preinstallNotes
+      'flush-bottom': !preInstallNotes
     });
 
     let error;
@@ -342,7 +344,7 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
             </div>
             <p className="h2 short-top short-bottom">{name}</p>
             <p className={packageVersionClasses}>{version}</p>
-            {this.getPreinstallNotes(preinstallNotes, truncated)}
+            {this.getPreInstallNotes(preInstallNotes, truncated)}
             {error}
           </div>
         </div>
@@ -399,7 +401,8 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
   renderReviewAdvancedConfigTabView() {
     let {pendingRequest} = this.internalStorage_get();
     let cosmosPackage = CosmosPackagesStore.getPackageDetails();
-    let {name, version} = cosmosPackage.get('package');
+    let name = cosmosPackage.getName();
+    let version = cosmosPackage.getCurrentVersion();
     let buttonText = 'Install';
 
     if (pendingRequest) {
@@ -521,7 +524,8 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
       return this.getLoadingScreen();
     }
 
-    let {name, version} = cosmosPackage.get('package');
+    let name = cosmosPackage.getName();
+    let version = cosmosPackage.getCurrentVersion();
     let advancedConfigClasses = classNames({
       hidden: currentTab !== 'advancedInstall'
     });
@@ -533,7 +537,7 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
             packageIcon={cosmosPackage.getIcons()['icon-small']}
             packageName={name}
             packageVersion={version}
-            schema={cosmosPackage.get('config')}
+            schema={cosmosPackage.getConfig()}
             onChange={this.handleAdvancedFormChange}
             getTriggerSubmit={this.getAdvancedSubmit} />
         </div>

--- a/src/js/events/CosmosPackagesActions.js
+++ b/src/js/events/CosmosPackagesActions.js
@@ -64,9 +64,19 @@ const CosmosPackagesActions = {
       data: JSON.stringify({packageName, appId}),
       timeout: REQUEST_TIMEOUT,
       success: function (response) {
+        let packages = response.packages || [];
+        // Map list data to match other endpoint structures
+        let data = packages.map(function (item) {
+          let cosmosPackage = item.packageInformation.packageDefinition;
+          cosmosPackage.appId = item.appId;
+          cosmosPackage.resource = item.packageInformation.resourceDefinition;
+
+          return cosmosPackage;
+        });
+
         AppDispatcher.handleServerAction({
           type: REQUEST_COSMOS_PACKAGES_LIST_SUCCESS,
-          data: response.packages,
+          data,
           packageName,
           appId
         });

--- a/src/js/events/CosmosPackagesActions.js
+++ b/src/js/events/CosmosPackagesActions.js
@@ -24,8 +24,8 @@ import Config from '../config/Config';
 
 const REQUEST_TIMEOUT = 10000;
 
-function getContentType(action, actionType) {
-  return `application/vnd.dcos.package.${action}-${actionType}+json;charset=utf-8;version=v1`;
+function getContentType(action, actionType, version = 'v1') {
+  return `application/vnd.dcos.package.${action}-${actionType}+json;charset=utf-8;version=${version}`;
 }
 
 const CosmosPackagesActions = {
@@ -85,7 +85,7 @@ const CosmosPackagesActions = {
   fetchPackageDescription: function (packageName, packageVersion) {
     RequestUtil.json({
       contentType: getContentType('describe', 'request'),
-      headers: {Accept: getContentType('describe', 'response')},
+      headers: {Accept: getContentType('describe', 'response', 'v2')},
       method: 'POST',
       url: `${Config.rootUrl}${Config.cosmosAPIPrefix}/describe`,
       data: JSON.stringify({packageName, packageVersion}),
@@ -112,7 +112,7 @@ const CosmosPackagesActions = {
   installPackage: function (packageName, packageVersion, options = {}) {
     RequestUtil.json({
       contentType: getContentType('install', 'request'),
-      headers: {Accept: getContentType('install', 'response')},
+      headers: {Accept: getContentType('install', 'response', 'v2')},
       method: 'POST',
       url: `${Config.rootUrl}${Config.cosmosAPIPrefix}/install`,
       data: JSON.stringify({packageName, packageVersion, options}),

--- a/src/js/events/CosmosPackagesActions.js
+++ b/src/js/events/CosmosPackagesActions.js
@@ -21,6 +21,7 @@ import {
 } from '../constants/ActionTypes';
 import AppDispatcher from './AppDispatcher';
 import Config from '../config/Config';
+import Util from '../utils/Util';
 
 const REQUEST_TIMEOUT = 10000;
 
@@ -67,9 +68,15 @@ const CosmosPackagesActions = {
         let packages = response.packages || [];
         // Map list data to match other endpoint structures
         let data = packages.map(function (item) {
-          let cosmosPackage = item.packageInformation.packageDefinition;
+          let cosmosPackage = Util.findNestedPropertyInObject(
+            item,
+            'packageInformation.packageDefinition'
+          ) || {};
           cosmosPackage.appId = item.appId;
-          cosmosPackage.resource = item.packageInformation.resourceDefinition;
+          cosmosPackage.resource = Util.findNestedPropertyInObject(
+            item,
+            'packageInformation.resourceDefinition'
+          ) || {};
 
           return cosmosPackage;
         });

--- a/src/js/events/CosmosPackagesActions.js
+++ b/src/js/events/CosmosPackagesActions.js
@@ -40,9 +40,22 @@ const CosmosPackagesActions = {
       data: JSON.stringify({query}),
       timeout: REQUEST_TIMEOUT,
       success: function (response) {
+        let packages = response.packages || [];
+        let data = packages.map(function (cosmosPackage) {
+          if (!cosmosPackage.resource) {
+            cosmosPackage.resource = {};
+          }
+
+          if (cosmosPackage.images) {
+            cosmosPackage.resource.images = cosmosPackage.images;
+            delete cosmosPackage.images;
+          }
+
+          return cosmosPackage;
+        });
         AppDispatcher.handleServerAction({
           type: REQUEST_COSMOS_PACKAGES_SEARCH_SUCCESS,
-          data: response.packages,
+          data,
           query
         });
       },
@@ -77,6 +90,11 @@ const CosmosPackagesActions = {
             item,
             'packageInformation.resourceDefinition'
           ) || {};
+
+          if (cosmosPackage.images) {
+            cosmosPackage.resource.images = cosmosPackage.images;
+            delete cosmosPackage.images;
+          }
 
           return cosmosPackage;
         });

--- a/src/js/events/CosmosPackagesActions.js
+++ b/src/js/events/CosmosPackagesActions.js
@@ -25,7 +25,7 @@ import Util from '../utils/Util';
 
 const REQUEST_TIMEOUT = 10000;
 
-function getContentType(action, actionType, version = 'v1') {
+function getContentType(action, actionType, version = 'v2') {
   return `application/vnd.dcos.package.${action}-${actionType}+json;charset=utf-8;version=${version}`;
 }
 
@@ -33,8 +33,8 @@ const CosmosPackagesActions = {
 
   fetchAvailablePackages: function (query) {
     RequestUtil.json({
-      contentType: getContentType('search', 'request'),
-      headers: {Accept: getContentType('search', 'response')},
+      contentType: getContentType('search', 'request', 'v1'),
+      headers: {Accept: getContentType('search', 'response', 'v1')},
       method: 'POST',
       url: `${Config.rootUrl}${Config.cosmosAPIPrefix}/search`,
       data: JSON.stringify({query}),
@@ -71,8 +71,8 @@ const CosmosPackagesActions = {
 
   fetchInstalledPackages: function (packageName, appId) {
     RequestUtil.json({
-      contentType: getContentType('list', 'request'),
-      headers: {Accept: getContentType('list', 'response')},
+      contentType: getContentType('list', 'request', 'v1'),
+      headers: {Accept: getContentType('list', 'response', 'v1')},
       method: 'POST',
       url: `${Config.rootUrl}${Config.cosmosAPIPrefix}/list`,
       data: JSON.stringify({packageName, appId}),
@@ -124,8 +124,8 @@ const CosmosPackagesActions = {
 
   fetchPackageDescription: function (packageName, packageVersion) {
     RequestUtil.json({
-      contentType: getContentType('describe', 'request'),
-      headers: {Accept: getContentType('describe', 'response', 'v2')},
+      contentType: getContentType('describe', 'request', 'v1'),
+      headers: {Accept: getContentType('describe', 'response')},
       method: 'POST',
       url: `${Config.rootUrl}${Config.cosmosAPIPrefix}/describe`,
       data: JSON.stringify({packageName, packageVersion}),
@@ -155,8 +155,8 @@ const CosmosPackagesActions = {
 
   installPackage: function (packageName, packageVersion, options = {}) {
     RequestUtil.json({
-      contentType: getContentType('install', 'request'),
-      headers: {Accept: getContentType('install', 'response', 'v2')},
+      contentType: getContentType('install', 'request', 'v1'),
+      headers: {Accept: getContentType('install', 'response')},
       method: 'POST',
       url: `${Config.rootUrl}${Config.cosmosAPIPrefix}/install`,
       data: JSON.stringify({packageName, packageVersion, options}),
@@ -182,8 +182,8 @@ const CosmosPackagesActions = {
 
   uninstallPackage: function (packageName, packageVersion, appId, all = false) {
     RequestUtil.json({
-      contentType: getContentType('uninstall', 'request'),
-      headers: {Accept: getContentType('uninstall', 'response')},
+      contentType: getContentType('uninstall', 'request', 'v1'),
+      headers: {Accept: getContentType('uninstall', 'response', 'v1')},
       method: 'POST',
       url: `${Config.rootUrl}${Config.cosmosAPIPrefix}/uninstall`,
       data: JSON.stringify({packageName, packageVersion, appId, all}),
@@ -211,8 +211,8 @@ const CosmosPackagesActions = {
 
   fetchRepositories: function (type) {
     RequestUtil.json({
-      contentType: getContentType('repository.list', 'request'),
-      headers: {Accept: getContentType('repository.list', 'response')},
+      contentType: getContentType('repository.list', 'request', 'v1'),
+      headers: {Accept: getContentType('repository.list', 'response', 'v1')},
       method: 'POST',
       url: `${Config.rootUrl}${Config.cosmosAPIPrefix}/repository/list`,
       data: JSON.stringify({type}),
@@ -234,8 +234,8 @@ const CosmosPackagesActions = {
 
   addRepository: function (name, uri, index) {
     RequestUtil.json({
-      contentType: getContentType('repository.add', 'request'),
-      headers: {Accept: getContentType('repository.add', 'response')},
+      contentType: getContentType('repository.add', 'request', 'v1'),
+      headers: {Accept: getContentType('repository.add', 'response', 'v1')},
       method: 'POST',
       url: `${Config.rootUrl}${Config.cosmosAPIPrefix}/repository/add`,
       data: JSON.stringify({name, uri, index}),
@@ -261,8 +261,8 @@ const CosmosPackagesActions = {
 
   deleteRepository: function (name, uri) {
     RequestUtil.json({
-      contentType: getContentType('repository.delete', 'request'),
-      headers: {Accept: getContentType('repository.delete', 'response')},
+      contentType: getContentType('repository.delete', 'request', 'v1'),
+      headers: {Accept: getContentType('repository.delete', 'response', 'v1')},
       method: 'POST',
       url: `${Config.rootUrl}${Config.cosmosAPIPrefix}/repository/delete`,
       data: JSON.stringify({name, uri}),

--- a/src/js/events/CosmosPackagesActions.js
+++ b/src/js/events/CosmosPackagesActions.js
@@ -96,6 +96,11 @@ const CosmosPackagesActions = {
             delete cosmosPackage.images;
           }
 
+          if (!cosmosPackage.currentVersion && cosmosPackage.version) {
+            cosmosPackage.currentVersion = cosmosPackage.version;
+            delete cosmosPackage.version;
+          }
+
           return cosmosPackage;
         });
 
@@ -125,10 +130,14 @@ const CosmosPackagesActions = {
       url: `${Config.rootUrl}${Config.cosmosAPIPrefix}/describe`,
       data: JSON.stringify({packageName, packageVersion}),
       timeout: REQUEST_TIMEOUT,
-      success: function (response) {
+      success: function (cosmosPackage) {
+        if (!cosmosPackage.currentVersion && cosmosPackage.version) {
+          cosmosPackage.currentVersion = cosmosPackage.version;
+          delete cosmosPackage.version;
+        }
         AppDispatcher.handleServerAction({
           type: REQUEST_COSMOS_PACKAGE_DESCRIBE_SUCCESS,
-          data: response,
+          data: cosmosPackage,
           packageName,
           packageVersion
         });

--- a/src/js/events/__tests__/CosmosPackagesActions-test.js
+++ b/src/js/events/__tests__/CosmosPackagesActions-test.js
@@ -118,17 +118,35 @@ describe('CosmosPackagesActions', function () {
         expect(action.type).toEqual(REQUEST_COSMOS_PACKAGES_LIST_SUCCESS);
       });
 
-      this.configuration.success({packages: [{bar: 'baz'}]});
+      this.configuration.success({
+        packages: [{
+          appId: 'foo',
+          packageInformation: {
+            packageDefinition: {name: 'bar'},
+            resourceDefinition: {bar: 'baz'}
+          }
+        }]
+      });
     });
 
     it('dispatches with the correct data when successful', function () {
       var id = AppDispatcher.register(function (payload) {
         var action = payload.action;
         AppDispatcher.unregister(id);
-        expect(action.data).toEqual([{bar: 'baz'}]);
+        expect(action.data).toEqual(
+          [{appId: 'foo', name: 'bar', resource: {bar: 'baz'}}]
+        );
       });
 
-      this.configuration.success({packages: [{bar: 'baz'}]});
+      this.configuration.success({
+        packages: [{
+          appId: 'foo',
+          packageInformation: {
+            packageDefinition: {name: 'bar'},
+            resourceDefinition: {bar: 'baz'}
+          }
+        }]
+      });
     });
 
     it('dispatches the correct action when unsuccessful', function () {

--- a/src/js/events/__tests__/CosmosPackagesActions-test.js
+++ b/src/js/events/__tests__/CosmosPackagesActions-test.js
@@ -51,7 +51,7 @@ describe('CosmosPackagesActions', function () {
       var id = AppDispatcher.register(function (payload) {
         var action = payload.action;
         AppDispatcher.unregister(id);
-        expect(action.data).toEqual([{bar: 'baz'}]);
+        expect(action.data).toEqual([{bar: 'baz', resource: {}}]);
       });
 
       this.configuration.success({packages: [{bar: 'baz'}]});

--- a/src/js/pages/universe/PackageDetailTab.js
+++ b/src/js/pages/universe/PackageDetailTab.js
@@ -12,7 +12,8 @@ import RequestErrorMsg from '../../components/RequestErrorMsg';
 import StringUtil from '../../utils/StringUtil';
 
 const METHODS_TO_BIND = [
-  'handleInstallModalClose'
+  'handleInstallModalClose',
+  'handleInstallModalOpen'
 ];
 
 class PackageDetailTab extends mixin(StoreMixin) {
@@ -141,7 +142,6 @@ class PackageDetailTab extends mixin(StoreMixin) {
   }
 
   mapLicenses(licenses) {
-    licenses = licenses || [];
     return licenses.map(function (license) {
       let item = {
         label: license.name,
@@ -183,28 +183,32 @@ class PackageDetailTab extends mixin(StoreMixin) {
       return this.getLoadingScreen();
     }
 
-    let packageDetails = cosmosPackage.get('package');
+    let name = cosmosPackage.getName();
+    let version = cosmosPackage.getCurrentVersion();
+    let description = cosmosPackage.getDescription();
+    let preInstallNotes = cosmosPackage.getPreInstallNotes();
+
     let definition = [
       {
         label: 'Description',
-        value: packageDetails.description && <div dangerouslySetInnerHTML={StringUtil.parseMarkdown(packageDetails.description)} />
+        value: description && <div dangerouslySetInnerHTML={StringUtil.parseMarkdown(description)} />
       },
       {
         label: 'Pre-Install Notes',
-        value: packageDetails.preInstallNotes && <div dangerouslySetInnerHTML={StringUtil.parseMarkdown(packageDetails.preInstallNotes)} />
+        value: preInstallNotes && <div dangerouslySetInnerHTML={StringUtil.parseMarkdown(preInstallNotes)} />
       },
       {
         label: 'Information',
         type: 'subItems',
         value: [
-          {label: 'SCM', value: packageDetails.scm},
-          {label: 'Maintainer', value: packageDetails.maintainer}
+          {label: 'SCM', value: cosmosPackage.getSCM()},
+          {label: 'Maintainer', value: cosmosPackage.getMaintainer()}
         ]
       },
       {
         label: 'Licenses',
         type: 'subItems',
-        value: this.mapLicenses(packageDetails.licenses)
+        value: this.mapLicenses(cosmosPackage.getLicenses())
       }
     ];
 
@@ -221,12 +225,12 @@ class PackageDetailTab extends mixin(StoreMixin) {
               </div>
               <div className="media-object-item">
                 <h1 className="inverse flush">
-                  {packageDetails.name}
+                  {name}
                 </h1>
-                <p>{this.getSelectedBadge(cosmosPackage, packageDetails.version)}</p>
+                <p>{this.getSelectedBadge(cosmosPackage, version)}</p>
                 <button
                   className="button button-success"
-                  onClick={this.handleInstallModalOpen.bind(this, cosmosPackage)}>
+                  onClick={this.handleInstallModalOpen}>
                   Install Package
                 </button>
               </div>
@@ -239,8 +243,8 @@ class PackageDetailTab extends mixin(StoreMixin) {
         </div>
         <InstallPackageModal
           open={state.openInstallModal}
-          packageName={packageDetails.name}
-          packageVersion={packageDetails.version}
+          packageName={name}
+          packageVersion={version}
           onClose={this.handleInstallModalClose}/>
       </div>
     );

--- a/src/js/pages/universe/PackagesTab.js
+++ b/src/js/pages/universe/PackagesTab.js
@@ -53,8 +53,8 @@ class PackagesTab extends mixin(StoreMixin) {
     event.stopPropagation();
     this.context.router.transitionTo(
       'universe-packages-detail',
-      {packageName: cosmosPackage.get('name')},
-      {version: cosmosPackage.get('currentVersion')}
+      {packageName: cosmosPackage.getName()},
+      {version: cosmosPackage.getCurrentVersion()}
     );
   }
 
@@ -130,10 +130,10 @@ class PackagesTab extends mixin(StoreMixin) {
             onClick={this.handleDetailOpen.bind(this, cosmosPackage)}>
             {this.getIcon(cosmosPackage)}
             <div className="h2 inverse short">
-              {cosmosPackage.get('name')}
+              {cosmosPackage.getName()}
             </div>
             <p className="inverse flush">
-              {cosmosPackage.get('currentVersion')}
+              {cosmosPackage.getCurrentVersion()}
             </p>
           </Panel>
         </div>
@@ -200,8 +200,8 @@ class PackagesTab extends mixin(StoreMixin) {
     }
 
     if (state.installModalPackage) {
-      packageName = state.installModalPackage.get('name');
-      packageVersion = state.installModalPackage.get('currentVersion');
+      packageName = state.installModalPackage.getName();
+      packageVersion = state.installModalPackage.getCurrentVersion();
     }
 
     let packages = CosmosPackagesStore.getAvailablePackages();

--- a/src/js/pages/universe/__tests__/PackageDetailTab-test.js
+++ b/src/js/pages/universe/__tests__/PackageDetailTab-test.js
@@ -50,8 +50,7 @@ describe('PackageDetailTab', function () {
         .querySelector('.button.button-success');
       TestUtils.Simulate.click(installButton);
 
-      expect(this.instance.handleInstallModalOpen
-          .calls.mostRecent().args[0].get('package').name).toEqual('marathon');
+      expect(this.instance.handleInstallModalOpen).toHaveBeenCalled();
     });
 
   });
@@ -159,14 +158,6 @@ describe('PackageDetailTab', function () {
   });
 
   describe('#mapLicenses', function () {
-
-    it('returns empty array for null', function () {
-      expect(this.instance.mapLicenses(null)).toEqual([]);
-    });
-
-    it('returns array for undefined', function () {
-      expect(this.instance.mapLicenses(undefined)).toEqual([]);
-    });
 
     it('returns array for empty array', function () {
       expect(this.instance.mapLicenses([])).toEqual([]);

--- a/src/js/stores/__tests__/CosmosPackagesStore-test.js
+++ b/src/js/stores/__tests__/CosmosPackagesStore-test.js
@@ -177,10 +177,10 @@ describe('CosmosPackagesStore', function () {
     it('should return the packageDetails it was given', function () {
       CosmosPackagesStore.fetchPackageDescription('foo', 'bar');
       var pkg = CosmosPackagesStore.getPackageDetails();
-      expect(pkg.get('package').name)
-        .toEqual(this.packageDescribeFixture.package.name);
-      expect(pkg.get('package').version)
-        .toEqual(this.packageDescribeFixture.package.version);
+      expect(pkg.getName())
+        .toEqual(this.packageDescribeFixture.name);
+      expect(pkg.getCurrentVersion())
+        .toEqual(this.packageDescribeFixture.version);
     });
 
     it('should pass though query parameters', function () {
@@ -274,9 +274,9 @@ describe('CosmosPackagesStore', function () {
       CosmosPackagesStore.fetchInstalledPackages('foo', 'bar');
       var installedPackage =
         CosmosPackagesStore.getInstalledPackages().getItems()[0];
-      expect(installedPackage.get('packageDefinition').name)
+      expect(installedPackage.getName())
         .toEqual('marathon');
-      expect(installedPackage.get('appId'))
+      expect(installedPackage.getAppId())
         .toEqual('/marathon-user');
     });
 
@@ -292,7 +292,7 @@ describe('CosmosPackagesStore', function () {
       it('stores installedPackages when event is dispatched', function () {
         AppDispatcher.handleServerAction({
           type: REQUEST_COSMOS_PACKAGES_LIST_SUCCESS,
-          data: [{appId: 'bar', packageInformation: {gid: 'foo', bar: 'baz'}}],
+          data: [{appId: 'bar', gid: 'foo', bar: 'baz'}],
           packageName: 'foo',
           appId: 'bar'
         });
@@ -312,7 +312,7 @@ describe('CosmosPackagesStore', function () {
         );
         AppDispatcher.handleServerAction({
           type: REQUEST_COSMOS_PACKAGES_LIST_SUCCESS,
-          data: [{appId: 'bar', packageInformation: {gid: 'foo', bar: 'baz'}}],
+          data: [{appId: 'bar', gid: 'foo', bar: 'baz'}],
           packageName: 'foo',
           appId: 'baz'
         });

--- a/src/js/stores/__tests__/fixtures/MockPackageDescribeResponse.json
+++ b/src/js/stores/__tests__/fixtures/MockPackageDescribeResponse.json
@@ -1,7 +1,5 @@
 {
-  "package": {
-    "packagingVersion": "2.0",
-    "name": "marathon",
-    "version": "0.11.1"
-  }
+  "packagingVersion": "2.0",
+  "name": "marathon",
+  "version": "0.11.1"
 }

--- a/src/js/structs/UniverseInstalledPackagesList.js
+++ b/src/js/structs/UniverseInstalledPackagesList.js
@@ -29,10 +29,7 @@ class UniverseInstalledPackagesList extends List {
       if (item instanceof UniversePackage) {
         return item;
       } else {
-        let installedPackage = item.packageInformation;
-        installedPackage.appId = item.appId;
-
-        return new UniversePackage(installedPackage);
+        return new UniversePackage(item);
       }
     });
   }

--- a/src/js/structs/UniverseInstalledPackagesList.js
+++ b/src/js/structs/UniverseInstalledPackagesList.js
@@ -1,22 +1,22 @@
 import List from './List';
 import UniversePackage from './UniversePackage';
 
-function propertyGetter(item, prop) {
-  return item.get('packageDefinition')[prop];
-}
-
 class UniverseInstalledPackagesList extends List {
   constructor(options = {}) {
     // Specify filter properties if not specified
     if (!options.filterProperties) {
       options.filterProperties = {
-        appId: null, // default getter
-        description: propertyGetter,
-        name: propertyGetter,
-        tags: function (item, prop) {
-          let tags = propertyGetter(item, prop) || [];
-
-          return tags.join(' ');
+        appId: function (item) {
+          return item.getAppId();
+        },
+        description: function (item) {
+          return item.getDescription();
+        },
+        name: function (item) {
+          return item.getName();
+        },
+        tags: function (item) {
+          return item.getTags().join(' ');
         }
       };
     }

--- a/src/js/structs/UniversePackage.js
+++ b/src/js/structs/UniversePackage.js
@@ -77,10 +77,6 @@ class UniversePackage extends Item {
   }
 
   isSelected() {
-    if (this.get('package') && this.get('package').hasOwnProperty('selected')) {
-      return this.get('package').selected;
-    }
-
     return this.get('selected');
   }
 

--- a/src/js/structs/UniversePackage.js
+++ b/src/js/structs/UniversePackage.js
@@ -58,7 +58,7 @@ class UniversePackage extends Item {
   }
 
   getName() {
-    return this.get('packageDefinition').name;
+    return this.get('name');
   }
 
   getScreenshots() {
@@ -77,31 +77,19 @@ class UniversePackage extends Item {
   }
 
   getMaintainer() {
-    return Util.findNestedPropertyInObject(
-      this.get('package'),
-      'maintainer'
-    );
+    return this.get('maintainer');
   }
 
-  getPreinstallNotes() {
-    return Util.findNestedPropertyInObject(
-      this.get('package'),
-      'preInstallNotes'
-    );
+  getPreInstallNotes() {
+    return this.get('preInstallNotes');
   }
 
   getPostInstallNotes() {
-    return Util.findNestedPropertyInObject(
-      this.get('package'),
-      'postInstallNotes'
-    );
+    return this.get('postInstallNotes');
   }
 
   getPostUninstallNotes() {
-    return Util.findNestedPropertyInObject(
-      this.get('packageDefinition'),
-      'postUninstallNotes'
-    );
+    return this.get('postUninstallNotes');
   }
 
   // TODO (John): Use actual data.
@@ -110,7 +98,7 @@ class UniversePackage extends Item {
   }
 
   getCurrentVersion() {
-    return this.get('packageDefinition').version;
+    return this.get('version');
   }
 
   isDecisionPointActive() {

--- a/src/js/structs/UniversePackage.js
+++ b/src/js/structs/UniversePackage.js
@@ -113,6 +113,10 @@ class UniversePackage extends Item {
     return this.get('version');
   }
 
+  getTags() {
+    return this.get('tags') || [];
+  }
+
   isDecisionPointActive() {
     return this._isDecisionPointActive;
   }

--- a/src/js/structs/UniversePackage.js
+++ b/src/js/structs/UniversePackage.js
@@ -43,6 +43,14 @@ class UniversePackage extends Item {
     return this.getActiveBlock() + 10;
   }
 
+  getConfig() {
+    return this.get('config');
+  }
+
+  getDescription() {
+    return this.get('description');
+  }
+
   getDecisionPointCount() {
     return this.getActiveBlock() + 10;
   }
@@ -76,6 +84,10 @@ class UniversePackage extends Item {
     return this.get('selected');
   }
 
+  getLicenses() {
+    return this.get('licenses') || [];
+  }
+
   getMaintainer() {
     return this.get('maintainer');
   }
@@ -90,6 +102,10 @@ class UniversePackage extends Item {
 
   getPostUninstallNotes() {
     return this.get('postUninstallNotes');
+  }
+
+  getSCM() {
+    return this.get('scm');
   }
 
   // TODO (John): Use actual data.

--- a/src/js/structs/UniversePackage.js
+++ b/src/js/structs/UniversePackage.js
@@ -106,7 +106,7 @@ class UniversePackage extends Item {
   }
 
   getCurrentVersion() {
-    return this.get('version');
+    return this.get('currentVersion');
   }
 
   getTags() {

--- a/src/js/structs/UniversePackage.js
+++ b/src/js/structs/UniversePackage.js
@@ -57,10 +57,6 @@ class UniversePackage extends Item {
 
   getIcons() {
     return FrameworkUtil.getServiceImages(
-      this.get('images') ||
-      Util.findNestedPropertyInObject(
-        this.get('resourceDefinition'), 'images'
-      ) ||
       Util.findNestedPropertyInObject(this.get('resource'), 'images')
     );
   }

--- a/src/js/structs/__tests__/UniverseInstalledPackagesList-test.js
+++ b/src/js/structs/__tests__/UniverseInstalledPackagesList-test.js
@@ -6,21 +6,21 @@ describe('UniverseInstalledPackagesList', function () {
   describe('#constructor', function () {
 
     it('creates instances of UniversePackage', function () {
-      var items = [{appId: 'baz', packageInformation: {foo: 'bar'}}];
+      var items = [{appId: 'baz', foo: 'bar'}];
       var list = new UniverseInstalledPackagesList({items});
       items = list.getItems();
       expect(items[0] instanceof UniversePackage).toBeTruthy();
     });
 
     it('should store appId in UniversePackage', function () {
-      var items = [{appId: 'baz', packageInformation: {foo: 'bar'}}];
+      var items = [{appId: 'baz', foo: 'bar'}];
       var list = new UniverseInstalledPackagesList({items});
       items = list.getItems();
       expect(items[0].get('appId')).toEqual('baz');
     });
 
     it('should store packageInformation in UniversePackage', function () {
-      var items = [{appId: 'baz', packageInformation: {foo: 'bar'}}];
+      var items = [{appId: 'baz', foo: 'bar'}];
       var list = new UniverseInstalledPackagesList({items});
       items = list.getItems();
       expect(items[0].get('foo')).toEqual('bar');
@@ -32,74 +32,44 @@ describe('UniverseInstalledPackagesList', function () {
 
     it('should filter by name', function () {
       var items = [
-        {packageInformation: {appId: 'baz', packageDefinition: {name: 'foo'}}},
-        {packageInformation: {appId: 'baz', packageDefinition: {name: 'bar'}}}
+        {appId: 'baz', name: 'foo'},
+        {appId: 'baz', name: 'bar'}
       ];
       var list = new UniverseInstalledPackagesList({items});
       items = list.filterItemsByText('bar').getItems();
       expect(items.length).toEqual(1);
-      expect(items[0].get('packageDefinition').name).toEqual('bar');
+      expect(items[0].getName()).toEqual('bar');
     });
 
     it('should filter by description', function () {
       var items = [
-        {
-          packageInformation: {
-            appId: 'baz',
-            packageDefinition: {description: 'foo'}
-          }
-        },
-        {
-          packageInformation: {
-            appId: 'baz',
-            packageDefinition: {description: 'bar'}
-          }
-        }
+        {appId: 'baz', description: 'foo'},
+        {appId: 'baz', description: 'bar'}
       ];
       var list = new UniverseInstalledPackagesList({items});
       items = list.filterItemsByText('foo').getItems();
       expect(items.length).toEqual(1);
-      expect(items[0].get('packageDefinition').description).toEqual('foo');
+      expect(items[0].getDescription()).toEqual('foo');
     });
 
     it('should filter by tags', function () {
       var items = [
-        {
-          packageInformation: {
-            appId: 'baz',
-            packageDefinition: {tags: ['foo', 'bar']}
-          }
-        },
-        {
-          packageInformation: {
-            appId: 'baz',
-            packageDefinition: {tags: ['foo']}
-          }
-        },
-        {packageInformation: {appId: 'baz', packageDefinition: {tags: []}}}
+        {appId: 'baz', tags: ['foo', 'bar']},
+        {appId: 'baz', tags: ['foo']},
+        {appId: 'baz', tags: []}
       ];
       var list = new UniverseInstalledPackagesList({items});
       items = list.filterItemsByText('foo').getItems();
       expect(items.length).toEqual(2);
-      expect(items[0].get('packageDefinition').tags).toEqual(['foo', 'bar']);
-      expect(items[1].get('packageDefinition').tags).toEqual(['foo']);
+      expect(items[0].getTags()).toEqual(['foo', 'bar']);
+      expect(items[1].getTags()).toEqual(['foo']);
     });
 
     it('should handle filter by tags with null elements', function () {
       var items = [
-        {
-          packageInformation: {
-            appId: 'baz',
-            packageDefinition: {tags: ['foo', 'bar']}
-          }
-        },
-        {
-          packageInformation: {
-            appId: 'baz',
-            packageDefinition: {tags: ['foo']}
-          }
-        },
-        {packageInformation: {appId: 'baz', packageDefinition: {tags: null}}}
+        {appId: 'baz', tags: ['foo', 'bar']},
+        {appId: 'baz', tags: ['foo']},
+        {appId: 'baz', tags: null}
       ];
       var list = new UniverseInstalledPackagesList({items});
       expect(list.filterItemsByText.bind(list, 'foo')).not.toThrow();

--- a/src/js/structs/__tests__/UniversePackage-test.js
+++ b/src/js/structs/__tests__/UniversePackage-test.js
@@ -51,40 +51,17 @@ describe('UniversePackage', function () {
       var pkg = new UniversePackage({'selected': false});
       expect(pkg.isSelected()).toEqual(false);
     });
-
-    it('looks for package if selected is nested and returns true', function () {
-      var pkg = new UniversePackage({
-        'package': {
-          selected: true
-        }
-      });
-      expect(pkg.isSelected()).toEqual(true);
-    });
-
-    it('looks for package and returns false', function () {
-      var pkg = new UniversePackage({
-        'package': {
-          selected: false
-        }
-      });
-      expect(pkg.isSelected()).toEqual(false);
-    });
   });
 
   describe('#getMaintainer', function () {
     it('returns correct value', function () {
-      var pkg = new UniversePackage({package: {maintainer: 'hellothere'}});
+      var pkg = new UniversePackage({maintainer: 'hellothere'});
       expect(pkg.getMaintainer()).toEqual('hellothere');
     });
 
     it('returns null if there is no maintainer info', function () {
-      var pkg = new UniversePackage({package: {}});
+      var pkg = new UniversePackage({});
       expect(pkg.getMaintainer()).toEqual(undefined);
-    });
-
-    it('does not error even if there is no package property', function () {
-      var pkg = new UniversePackage({fake: {}});
-      expect(pkg.getMaintainer()).toEqual(null);
     });
   });
 });

--- a/tests/_fixtures/cosmos/package-describe.json
+++ b/tests/_fixtures/cosmos/package-describe.json
@@ -1,27 +1,25 @@
 {
-  "package": {
-    "packagingVersion": "2.0",
-    "name": "marathon",
-    "version": "0.11.1",
-    "maintainer": "help@dcos.io",
-    "description": "A cluster-wide init and control system for services in cgroups or Docker containers.",
-    "tags": [
-      "init",
-      "long-running"
-    ],
-    "scm": "https://github.com/mesosphere/marathon.git",
-    "website": null,
-    "framework": true,
-    "preInstallNotes": "We recommend a minimum of one node with at least 2 CPU's and 1GB of RAM available for the Marathon Service.",
-    "postInstallNotes": "Marathon DCOS Service has been successfully installed!\n\n\tDocumentation: https://mesosphere.github.io/marathon\n\tIssues: https:/github.com/mesosphere/marathon/issues\n",
-    "postUninstallNotes": "The Marathon DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at http://docs.mesosphere.com/services/marathon/#uninstall to clean up any persisted state",
-    "licenses": [
-      {
-        "name": "Apache License Version 2.0",
-        "url": "https://github.com/mesosphere/marathon/blob/master/LICENSE"
-      }
-    ]
-  },
+  "packagingVersion": "2.0",
+  "name": "marathon",
+  "version": "0.11.1",
+  "maintainer": "help@dcos.io",
+  "description": "A cluster-wide init and control system for services in cgroups or Docker containers.",
+  "tags": [
+    "init",
+    "long-running"
+  ],
+  "scm": "https://github.com/mesosphere/marathon.git",
+  "website": null,
+  "framework": true,
+  "preInstallNotes": "We recommend a minimum of one node with at least 2 CPU's and 1GB of RAM available for the Marathon Service.",
+  "postInstallNotes": "Marathon DCOS Service has been successfully installed!\n\n\tDocumentation: https://mesosphere.github.io/marathon\n\tIssues: https:/github.com/mesosphere/marathon/issues\n",
+  "postUninstallNotes": "The Marathon DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at http://docs.mesosphere.com/services/marathon/#uninstall to clean up any persisted state",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/mesosphere/marathon/blob/master/LICENSE"
+    }
+  ],
   "marathonMustache": "{\n  \"id\": \"{{marathon.framework-name}}\",\n  \"cpus\": {{marathon.cpus}},\n  \"mem\": {{marathon.mem}},\n  \"instances\": {{marathon.instances}},\n  \"constraints\": [[\"hostname\", \"UNIQUE\"]],\n  \"ports\": [\n    {{marathon.http-port}}\n    , 0\n    {{#marathon.enable-https}}\n    , {{marathon.https-port}}\n    {{/marathon.enable-https}}\n  ],\n  \"uris\": {{marathon.uris}},\n  \"healthChecks\": [\n    {\n      \"gracePeriodSeconds\": 120,\n      \"intervalSeconds\": 10,\n      \"maxConsecutiveFailures\": 3,\n      \"path\": \"/v2/info\",\n      \"portIndex\": 0,\n      \"protocol\": \"HTTP\",\n      \"timeoutSeconds\": 5\n    }\n  ],\n  \"container\": {\n    \"type\": \"DOCKER\",\n    \"docker\": {\n      \"image\": \"{{resource.assets.container.docker.5e187be16235}}\",\n      \"network\": \"HOST\"\n    }\n  },\n  \"env\": {\n    \"JVM_OPTS\": \"-Xms{{marathon.jvm-heap-min}}m -Xmx{{marathon.jvm-heap-max}}m\"\n  },\n  \"cmd\": \"LIBPROCESS_PORT=$PORT1 && ./bin/start --master {{mesos.master}} {{#marathon.access-control-allow-origin}} --access_control_allow_origin {{marathon.access-control-allow-origin}} {{/marathon.access-control-allow-origin}} {{#marathon.artifact-store}} --artifact_store {{marathon.artifact-store}} {{/marathon.artifact-store}} {{#marathon.checkpoint}} --checkpoint {{/marathon.checkpoint}} {{#marathon.decline-offer-duration}} --decline_offer_duration {{marathon.decline-offer-duration}} {{/marathon.decline-offer-duration}} {{#marathon.default-accepted-resource-roles}} --default_accepted_resource_roles {{marathon.default-accepted-resource-roles}} {{/marathon.default-accepted-resource-roles}} {{#marathon.disable-http}} --disable_http {{/marathon.disable-http}} --http_port $PORT0 {{#marathon.enable-https}}   --https_port $PORT2   {{#marathon.ssl-keystore-password}} --ssl_keystore_password {{marathon.ssl-keystore-password}} {{/marathon.ssl-keystore-password}}      {{#marathon.ssl-keystore-path}} --ssl_keystore_path {{marathon.ssl-keystore-path}} {{/marathon.ssl-keystore-path}}     {{/marathon.enable-https}} {{#marathon.disable-metrics}} --disable_metrics {{/marathon.disable-metrics}} {{#marathon.enable-tracing}} --enable_tracing {{/marathon.enable-tracing}} {{#marathon.env-vars-prefix}} --env_vars_prefix {{marathon.env-vars-prefix}} {{/marathon.env-vars-prefix}} {{#marathon.event-stream-max-outstanding-messages}} --event_stream_max_outstanding_messages {{marathon.event-stream-max-outstanding-messages}} {{/marathon.event-stream-max-outstanding-messages}} {{#marathon.event-subscriber}} --event_subscriber {{marathon.event-subscriber}} {{/marathon.event-subscriber}} {{#marathon.executor}} --executor {{marathon.executor}} {{/marathon.executor}} {{#marathon.failover-timeout}} --failover_timeout {{marathon.failover-timeout}} {{/marathon.failover-timeout}} {{#marathon.framework-name}} --framework_name {{marathon.framework-name}} {{/marathon.framework-name}} {{#marathon.ha}} --ha {{/marathon.ha}} {{#marathon.http-credentials}} --http_credentials {{marathon.http-credentials}} {{/marathon.http-credentials}} {{#marathon.http-endpoints}} --http_endpoints {{marathon.http-endpoints}} {{/marathon.http-endpoints}} {{#marathon.http-max-concurrent-requests}} --http_max_concurrent_requests {{marathon.http-max-concurrent-requests}} {{/marathon.http-max-concurrent-requests}} {{#marathon.leader-proxy-connection-timeout}} --leader_proxy_connection_timeout {{marathon.leader-proxy-connection-timeout}} {{/marathon.leader-proxy-connection-timeout}} {{#marathon.leader-proxy-read-timeout}} --leader_proxy_read_timeout {{marathon.leader-proxy-read-timeout}} {{/marathon.leader-proxy-read-timeout}} {{#marathon.local-port-max}} --local_port_max {{marathon.local-port-max}} {{/marathon.local-port-max}} {{#marathon.local-port-min}} --local_port_min {{marathon.local-port-min}} {{/marathon.local-port-min}} {{#marathon.mesos-role}} --mesos_role {{marathon.mesos-role}} {{/marathon.mesos-role}} {{#marathon.marathon-store-timeout}} --marathon_store_timeout {{marathon.marathon-store-timeout}} {{/marathon.marathon-store-timeout}} {{#marathon.max-tasks-per-offer}} --max_tasks_per_offer {{marathon.max-tasks-per-offer}} {{/marathon.max-tasks-per-offer}} {{#marathon.max-tasks-per-offer-cycle}} --max_tasks_per_offer_cycle {{marathon.max-tasks-per-offer-cycle}} {{/marathon.max-tasks-per-offer-cycle}} {{#marathon.mesos-authentication-principal}} --mesos_authentication_principal {{marathon.mesos-authentication-principal}} {{/marathon.mesos-authentication-principal}} {{#marathon.mesos-authentication-secret-file}} --mesos_authentication_secret_file {{marathon.mesos-authentication-secret-file}} {{/marathon.mesos-authentication-secret-file}} {{#marathon.min-revive-offers-interval}} --min_revive_offers_interval {{marathon.min-revive-offers-interval}} {{/marathon.min-revive-offers-interval}} {{#marathon.reconciliation-initial-delay}} --reconciliation_initial_delay {{marathon.reconciliation-initial-delay}} {{/marathon.reconciliation-initial-delay}} {{#marathon.reconciliation-interval}} --reconciliation_interval {{marathon.reconciliation-interval}} {{/marathon.reconciliation-interval}} {{#marathon.revive-offers-for-new-apps}} --revive_offers_for_new_apps {{/marathon.revive-offers-for-new-apps}} {{#marathon.scale-apps-initial-delay}} --scale_apps_initial_delay {{marathon.scale-apps-initial-delay}} {{/marathon.scale-apps-initial-delay}} {{#marathon.scale-apps-interval}} --scale_apps_interval {{marathon.scale-apps-interval}} {{/marathon.scale-apps-interval}} {{#marathon.zk-max-versions}} --zk_max_versions {{marathon.zk-max-versions}} {{/marathon.zk-max-versions}} {{#marathon.zk-session-timeout}} --zk_session_timeout {{marathon.zk-session-timeout}} {{/marathon.zk-session-timeout}} {{#marathon.zk-timeout}} --zk_timeout {{marathon.zk-timeout}} {{/marathon.zk-timeout}} --zk {{marathon.zk}} {{#marathon.mesos-leader-ui-url}} --mesos_leader_ui_url {{marathon.mesos-leader-ui-url}} {{/marathon.mesos-leader-ui-url}} {{#marathon.zk-compression}} --zk_compression {{/marathon.zk-compression}} {{^marathon.zk-compression}} --disable_zk_compression {{/marathon.zk-compression}} --zk_compression_threshold {{marathon.zk-compression-threshold}} {{#marathon.max-apps}} --max_apps {{marathon.max.apps}} {{/marathon.max-apps}}\"\n}\n",
   "command": null,
   "config": {
@@ -281,7 +279,7 @@
           },
           "uris": {
             "default": [
-              
+
             ],
             "description": "List of URIs that will be download and made available in the current working directory of Marathon. For example this can be used to download a Java keystore file for SSL configuration.",
             "items": {

--- a/tests/_fixtures/cosmos/package-describe.json
+++ b/tests/_fixtures/cosmos/package-describe.json
@@ -279,7 +279,7 @@
           },
           "uris": {
             "default": [
-
+              
             ],
             "description": "List of URIs that will be download and made available in the current working directory of Marathon. For example this can be used to download a Java keystore file for SSL configuration.",
             "items": {


### PR DESCRIPTION
This PR updates to use the new v2 API endpoints for `/describe` and `/install`

It does not introduce an immediate visual change. Everything should work as before, but the API responses for `/describe` and `/install` changed slightly.

The change is only concerned with Universe actions. Especially pages using `/describe` and `/install`