### PR TITLE
Allow components to be rendered in DescriptionList dt

### DIFF
--- a/src/js/components/DescriptionList.js
+++ b/src/js/components/DescriptionList.js
@@ -21,16 +21,6 @@ class DescriptionList extends React.Component {
     return Object.keys(hash).map((key, index) => {
       let value = hash[key];
 
-      // Check if we need to render a component in the dt
-      if (renderKeys.includes(key)) {
-        return (
-          <dl key={index} className="flex-box row">
-            <dt className={dtClassName}>{value.key}</dt>
-            <dd className={ddClassName}>{value.value}</dd>
-          </dl>
-        );
-      }
-
       // Check whether we are trying to render an object that is not a
       // React component
       if (typeof value === 'object' && !Array.isArray(value) &&
@@ -47,6 +37,11 @@ class DescriptionList extends React.Component {
 
       if (typeof value === 'boolean') {
         value = value.toString();
+      }
+
+      // Check if we need to render a component in the dt
+      if (renderKeys.hasOwnProperty(key)) {
+        key = renderKeys[key];
       }
 
       return (
@@ -79,7 +74,7 @@ DescriptionList.defaultProps = {
   dtClassName: 'column-3 text-mute',
   headlineClassName: 'inverse flush-top',
   key: '',
-  renderKeys: []
+  renderKeys: {}
 };
 
 DescriptionList.propTypes = {
@@ -90,9 +85,9 @@ DescriptionList.propTypes = {
   headline: React.PropTypes.node,
   hash: React.PropTypes.object,
   key: React.PropTypes.string,
-  // An array of keys in `hash` containing an object value with keys `key`
-  // and `value` to be rendered as components.
-  renderKeys: React.PropTypes.array
+  // Optional object with keys consisting of keys in `props.hash` to be
+  // replaced, and with corresponding values of the replacement to be rendered.
+  renderKeys: React.PropTypes.object
 };
 
 module.exports = DescriptionList;

--- a/src/js/components/DescriptionList.js
+++ b/src/js/components/DescriptionList.js
@@ -16,10 +16,20 @@ class DescriptionList extends React.Component {
   }
 
   getItems() {
-    let {hash, dtClassName, ddClassName} = this.props;
+    let {dtClassName, ddClassName, hash, renderKeys} = this.props;
 
     return Object.keys(hash).map((key, index) => {
       let value = hash[key];
+
+      // Check if we need to render a component in the dt
+      if (renderKeys.includes(key)) {
+        return (
+          <dl key={index} className="flex-box row">
+            <dt className={dtClassName}>{value.key}</dt>
+            <dd className={ddClassName}>{value.value}</dd>
+          </dl>
+        );
+      }
 
       // Check whether we are trying to render an object that is not a
       // React component
@@ -68,7 +78,8 @@ DescriptionList.defaultProps = {
   ddClassName: 'column-9 text-overflow-break-word',
   dtClassName: 'column-3 text-mute',
   headlineClassName: 'inverse flush-top',
-  key: ''
+  key: '',
+  renderKeys: []
 };
 
 DescriptionList.propTypes = {
@@ -78,7 +89,10 @@ DescriptionList.propTypes = {
   headlineClassName: React.PropTypes.string,
   headline: React.PropTypes.node,
   hash: React.PropTypes.object,
-  key: React.PropTypes.string
+  key: React.PropTypes.string,
+  // An array of keys in `hash` containing an object value with keys `key`
+  // and `value` to be rendered as components.
+  renderKeys: React.PropTypes.array
 };
 
 module.exports = DescriptionList;


### PR DESCRIPTION
Previously, only strings could be rendered in DescriptionList `dt` because it was required to be a valid key value in an object. This PR extends the capabilities of DescriptionList so that `dt`s can contain components.