### PR TITLE
Rename AGENT IP column to CONTAINER IP

### DIFF
--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
@@ -20,7 +20,7 @@ import Util from '../../../utils/Util';
 
 const headerMapping = {
   id: 'TASK',
-  ip_address: 'AGENT IP',
+  ip_address: 'CONTAINER IP',
   port_mappings: 'PORT MAPPINGS'
 };
 const METHODS_TO_BIND = [


### PR DESCRIPTION
In virtual networks we are displaying Container IP not Agent IP. This PR changes the name of the column to be correct