### PR TITLE
DCOS-8463: handle docker params as an array of objects

### DIFF
--- a/src/js/components/ConfigurationView.js
+++ b/src/js/components/ConfigurationView.js
@@ -63,7 +63,9 @@ class ConfigurationView extends mixin(StoreMixin) {
       'Force Pull Image': docker.forcePullImage,
       'Image': docker.image,
       'Network': docker.network,
-      'Parameters': StringUtil.arrayToJoinedString(docker.parameters),
+      'Parameters': StringUtil.arrayToJoinedString(
+        docker.parameters.map(({key, value}) => `${key} : ${value}`)
+      ),
       'Privileged': docker.privileged
     };
 

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -49,6 +49,7 @@ const responseAttributePathToFieldIdMap = {
   '/container/docker/privileged': 'dockerPrivileged',
   '/container/docker/parameters({INDEX})/key':
     'dockerParameters/{INDEX}/key',
+  '/container/docker/parameters': 'dockerParameters',
   '/container/docker/parameters({INDEX})/value':
     'dockerParameters/{INDEX}/value',
   '/container/volumes({INDEX})/containerPath':

--- a/src/js/schemas/service-schema/ContainerSettings.js
+++ b/src/js/schemas/service-schema/ContainerSettings.js
@@ -67,14 +67,7 @@ const ContainerSettings = {
         if (container && container.docker &&
           container.docker.parameters
         ) {
-          let parameters = container.docker.parameters;
-
-          return Object.keys(parameters).map(function (key) {
-            return {
-              key,
-              value: parameters[key]
-            };
-          });
+          return container.docker.parameters;
         }
         return null;
       },

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -121,10 +121,7 @@ const ServiceUtil = {
         }
         if (containerSettings.parameters != null) {
           definition.container.docker.parameters =
-            containerSettings.parameters.reduce(function (memo, item) {
-              memo[item.key] = item.value;
-              return memo;
-            }, {});
+            containerSettings.parameters;
         }
       }
 

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -520,6 +520,28 @@ describe('ServiceUtil', function () {
           .toEqual(expectedService);
       });
     });
+
+    describe('container settings', function () {
+      beforeEach(function () {
+        this.service = ServiceUtil.createServiceFromFormModel({
+          containerSettings: {
+            image: 'redis',
+            parameters: [
+              {key: 'key-a', value: 'value-a'}
+            ]
+          }
+        });
+      });
+
+      it('should correctly parse docker parameters', function () {
+        expect(this.service.container.docker.parameters).toBeDefined();
+      });
+
+      it('should convert parameters to an array of objects', function () {
+        expect(this.service.container.docker.parameters[0].key).toEqual('key-a');
+        expect(this.service.container.docker.parameters[0].value).toEqual('value-a');
+      });
+    });
   });
 
   describe('#createFormModelFromSchema', function () {


### PR DESCRIPTION
For some reason the previous implementation converted docker parameters to a record-like object, which produced an error when creating an app:
![image](https://cloud.githubusercontent.com/assets/1078545/16730764/099d5a32-4775-11e6-8927-ad5da135ec1d.png)


Docker Parameters should instead be an array of `{key: k, value: v}` objects as per the Marathon Docs: 

https://mesosphere.github.io/marathon/docs/native-docker.html

This PR does the following:

- intercept and use correct top-level dockerParameters mapping for server-side error
- treat docker parameters as an array
- add some basic unit tests

Full workflow GIF:

![params](https://cloud.githubusercontent.com/assets/1078545/16730901/ac213800-4775-11e6-8f29-93b3ccdab429.gif)

Tests are passing locally.



