### PR TITLE
DCOS-8454: Fix error frame in service modal to not scroll if shown in small screens

### DIFF
--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -331,15 +331,13 @@ class ServiceFormModal extends mixin(StoreMixin) {
     }
 
     return (
-      <div>
-        <div className="error-field text-danger">
-          <h4 className="text-align-center text-danger flush-top">
-            {errorMessage.message}
-          </h4>
-          <ul>
-            {errorList}
-          </ul>
-        </div>
+      <div className="error-field text-danger">
+        <h4 className="text-align-center text-danger flush-top">
+          {errorMessage.message}
+        </h4>
+        <ul>
+          {errorList}
+        </ul>
       </div>
     );
   }
@@ -372,6 +370,11 @@ class ServiceFormModal extends mixin(StoreMixin) {
     let {jsonDefinition, jsonMode, service} = this.state;
 
     if (jsonMode) {
+      let height = '370px';
+
+      if (this.state.errorMessage) {
+        height = '462px';
+      }
       return (
         <Ace editorProps={{$blockScrolling: true}}
           mode="json"
@@ -379,7 +382,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
           showGutter={true}
           showPrintMargin={false}
           theme="monokai"
-          height="462px"
+          height={height}
           value={jsonDefinition}
           width="100%"/>
       );

--- a/src/styles/components/multiple-form.less
+++ b/src/styles/components/multiple-form.less
@@ -235,6 +235,15 @@ base/forms.less
       background: color-lighten(@red, 60);
       border-bottom: @red 1px solid;
       padding: (@base-spacing-unit / 2) @base-spacing-unit;
+      position: absolute;
+      width: 100%;
+      top: 88px;
+      left: 0;
+      z-index: 5;
+
+      & + div#brace-editor {
+        margin-top: 92px;
+      }
 
       li:before {
         background-color: currentColor;


### PR DESCRIPTION
![](https://s3.amazonaws.com/f.cl.ly/items/2J2r392C1W2O0r1f0m46/Screen%20Recording%202016-07-11%20at%2003.08%20PM.gif?v=b2b3c405)

This fixes a problem when an error is shown in smaller screens and the error message could be scrolled out of the visible area.