### PR TITLE
[1 of 2] Extract #getTaskEndpoints method to TaskUtil

### DIFF
--- a/src/js/components/MarathonTaskDetailsList.js
+++ b/src/js/components/MarathonTaskDetailsList.js
@@ -2,53 +2,29 @@ import React from 'react';
 
 import DescriptionList from './DescriptionList';
 import MarathonStore from '../stores/MarathonStore';
+import TaskUtil from '../utils/TaskUtil';
 
 class MarathonTaskDetailsList extends React.Component {
   getTaskEndpoints(task) {
-    if ((task.ports == null || task.ports.length === 0) &&
-        (task.ipAddresses == null || task.ipAddresses.length === 0)) {
-      return 'None';
+    let endpoints = TaskUtil.getTaskEndpoints(task);
+
+    let endpointURLs = endpoints.hosts.reduce(function (memo, host) {
+      return memo.concat(endpoints.ports.map(function (port) {
+        return `${host}:${port}`;
+      }));
+    }, []);
+
+    if (endpointURLs.length) {
+      return endpointURLs.map(function (endpoint, index) {
+        return (
+          <a key={index} className="visible-block" href={`//${endpoint}`} target="_blank">
+            {endpoint}
+          </a>
+        );
+      });
     }
 
-    let service = MarathonStore.getServiceFromTaskID(task.id);
-
-    if (service != null &&
-      service.ipAddress != null &&
-      service.ipAddress.discovery != null &&
-      service.ipAddress.discovery.ports != null &&
-      task.ipAddresses != null &&
-      task.ipAddresses.length > 0) {
-
-      let ports = service.ipAddress.discovery.ports;
-      let endpoints = task.ipAddresses.reduce(function (memo, address) {
-        ports.forEach(function (port) {
-          memo.push(`${address.ipAddress}:${port.number}`);
-        });
-
-        return memo;
-      }, []);
-
-      if (endpoints.length) {
-        return endpoints.map(function (endpoint, index) {
-          return (
-            <a key={index} className="visible-block" href={`//${endpoint}`} target="_blank">
-              {endpoint}
-            </a>
-          );
-        });
-      }
-
-      return 'n/a';
-    }
-
-    return task.ports.map(function (port, index) {
-      let endpoint = `${task.host}:${port}`;
-      return (
-        <a key={index} className="visible-block" href={`//${endpoint}`} target="_blank">
-          {endpoint}
-        </a>
-      );
-    });
+    return 'n/a';
   }
 
   getTaskStatus(task) {

--- a/src/js/utils/TaskUtil.js
+++ b/src/js/utils/TaskUtil.js
@@ -7,9 +7,9 @@ import Util from './Util';
 
 const TaskUtil = {
 
-  getTaskEndpoints(task = {}) {
-    if ((task.ports == null || task.ports.length === 0) &&
-      (task.ipAddresses == null || task.ipAddresses.length === 0)) {
+  getTaskEndpoints(task) {
+    if (task == null || ((task.ports == null || task.ports.length === 0) &&
+      (task.ipAddresses == null || task.ipAddresses.length === 0))) {
       return {hosts: [], ports: []};
     }
 

--- a/src/js/utils/TaskUtil.js
+++ b/src/js/utils/TaskUtil.js
@@ -9,7 +9,7 @@ const TaskUtil = {
 
   getTaskEndpoints(task = {}) {
     if ((task.ports == null || task.ports.length === 0) &&
-        (task.ipAddresses == null || task.ipAddresses.length === 0)) {
+      (task.ipAddresses == null || task.ipAddresses.length === 0)) {
       return {hosts: [], ports: []};
     }
 

--- a/src/js/utils/TaskUtil.js
+++ b/src/js/utils/TaskUtil.js
@@ -1,9 +1,34 @@
 /* eslint-disable no-unused-vars */
 import React from 'react';
 /* eslint-enable no-unused-vars */
+
+import MarathonStore from '../stores/MarathonStore';
 import Util from './Util';
 
 const TaskUtil = {
+
+  getTaskEndpoints(task = {}) {
+    if ((task.ports == null || task.ports.length === 0) &&
+        (task.ipAddresses == null || task.ipAddresses.length === 0)) {
+      return {hosts: [], ports: []};
+    }
+
+    let hosts = [task.host];
+    let ports = task.ports || [];
+    let service = MarathonStore.getServiceFromTaskID(task.id);
+
+    if (service != null &&
+      service.ipAddress != null &&
+      service.ipAddress.discovery != null &&
+      service.ipAddress.discovery.ports != null &&
+      task.ipAddresses != null &&
+      task.ipAddresses.length > 0) {
+      hosts = task.ipAddresses;
+      ports = service.ipAddress.discovery.ports;
+    }
+
+    return {hosts, ports};
+  },
 
   getTaskStatusSlug(task) {
     return task.state.substring('TASK_'.length).toLowerCase();

--- a/src/js/utils/__tests__/TaskUtil-test.js
+++ b/src/js/utils/__tests__/TaskUtil-test.js
@@ -1,6 +1,131 @@
+jest.dontMock('../../stores/MarathonStore');
+
+let MarathonStore = require('../../stores/MarathonStore');
 let TaskUtil = require('../TaskUtil');
 
 describe('TaskUtil', function () {
+
+  describe('#getTaskEndpoints', function () {
+
+    beforeEach(function () {
+      this.MarathonStoreGetServiceFromTaskID = MarathonStore.getServiceFromTaskID;
+      MarathonStore.getServiceFromTaskID = function () { return null; };
+    });
+
+    afterEach(function () {
+      MarathonStore.getServiceFromTaskID = this.MarathonStoreGetServiceFromTaskID;
+    });
+
+    it('should return an array of hosts and ports', function () {
+      let endpoints = TaskUtil.getTaskEndpoints(
+        {ports: [0, 1, 2, 3], host: '0.0.0.1'}
+      );
+
+      expect(endpoints.hosts).toEqual(['0.0.0.1']);
+      expect(endpoints.ports).toEqual([0, 1, 2, 3]);
+    });
+
+    it('should return empty arrays for ports and host if the ports and ' +
+      'ipAddresses values are undefined', function () {
+      let endpoints = TaskUtil.getTaskEndpoints({foo: 'bar'});
+
+      expect(endpoints.hosts).toEqual([]);
+      expect(endpoints.ports).toEqual([]);
+    });
+
+    it('should return empty arrays for ports and host if the ports and ' +
+      'ipAddresses values are arrays of length 0', function () {
+      let endpoints = TaskUtil.getTaskEndpoints({ports: [], ipAddresses: []});
+
+      expect(endpoints.hosts).toEqual([]);
+      expect(endpoints.ports).toEqual([]);
+    });
+
+    it('should return an empty array for ports if ports are undefined',
+      function () {
+      let endpoints = TaskUtil.getTaskEndpoints({foo: 'bar'});
+
+      expect(endpoints.hosts).toEqual([]);
+      expect(endpoints.ports).toEqual([]);
+    });
+
+    it('should return an array of hosts as defined by the ipAddresses key on ' +
+      ' the task and ports as defined by a service', function () {
+      MarathonStore.getServiceFromTaskID = function () {
+        return {
+          ipAddress: {
+            discovery: {
+              ports: [0, 1, 2, 3]
+            }
+          }
+        };
+      };
+
+      let endpoints = TaskUtil.getTaskEndpoints({
+        ports: [0],
+        ipAddresses: ['0.0.0.1']
+      });
+
+      expect(endpoints.hosts).toEqual(['0.0.0.1']);
+      expect(endpoints.ports).toEqual([0, 1, 2, 3]);
+    });
+
+    it('should fallback to an array of hosts and ports as defined on a task ' +
+      'if the service does not return ports',
+      function () {
+      MarathonStore.getServiceFromTaskID = function () {
+        return {
+          ipAddress: {
+            discovery: {}
+          }
+        };
+      };
+
+      let endpoints = TaskUtil.getTaskEndpoints({
+        host: '0.0.0.1',
+        ports: [0],
+        ipAddresses: ['0.0.0.2']
+      });
+
+      expect(endpoints.hosts).toEqual(['0.0.0.1']);
+      expect(endpoints.ports).toEqual([0]);
+    });
+
+    it('should fallback to an array of hosts and ports as defined on a task ' +
+      'if the service does not return discovery',
+      function () {
+      MarathonStore.getServiceFromTaskID = function () {
+        return {
+          ipAddress: {}
+        };
+      };
+
+      let endpoints = TaskUtil.getTaskEndpoints({
+        host: '0.0.0.1',
+        ports: [0],
+        ipAddresses: ['0.0.0.2']
+      });
+
+      expect(endpoints.hosts).toEqual(['0.0.0.1']);
+      expect(endpoints.ports).toEqual([0]);
+    });
+
+    it('should fallback to an array of hosts and ports as defined on a task ' +
+      'if the service does not return ipAddress',
+      function () {
+      MarathonStore.getServiceFromTaskID = function () { return {}; };
+
+      let endpoints = TaskUtil.getTaskEndpoints({
+        host: '0.0.0.1',
+        ports: [0],
+        ipAddresses: ['0.0.0.2']
+      });
+
+      expect(endpoints.hosts).toEqual(['0.0.0.1']);
+      expect(endpoints.ports).toEqual([0]);
+    });
+
+  });
 
   describe('#getPortMappings', function () {
 

--- a/src/js/utils/__tests__/TaskUtil-test.js
+++ b/src/js/utils/__tests__/TaskUtil-test.js
@@ -25,6 +25,14 @@ describe('TaskUtil', function () {
       expect(endpoints.ports).toEqual([0, 1, 2, 3]);
     });
 
+    it('should return empty arrays for ports and host if the task is undefined',
+      function () {
+      let endpoints = TaskUtil.getTaskEndpoints();
+
+      expect(endpoints.hosts).toEqual([]);
+      expect(endpoints.ports).toEqual([]);
+    });
+
     it('should return empty arrays for ports and host if the ports and ' +
       'ipAddresses values are undefined', function () {
       let endpoints = TaskUtil.getTaskEndpoints({foo: 'bar'});


### PR DESCRIPTION
This PR extracts the endpoint logic from `MarathonTaskDetailsList#getTaskEndpoints` into a method on `TaskUtil` so it can be used elsewhere.