### PR TITLE
Graphs no longer jump on load

### DIFF
--- a/src/js/utils/MesosSummaryUtil.js
+++ b/src/js/utils/MesosSummaryUtil.js
@@ -70,7 +70,7 @@ const MesosSummaryUtil = {
 
   addTimestampsToData: function (data, timeStep) {
     var length = data.length;
-    var timeNow = Date.now() - timeStep;
+    var timeNow = Date.now() + timeStep;
 
     return data.map(function (datum, i) {
       var timeDelta = (-length + i) * timeStep;


### PR DESCRIPTION
The ball still jumps due to the implementation of the ball not animating in the beginning. Feel free to test this.

# Before
![px](https://cl.ly/1e2m2O1w1j2k/Screen%20Recording%202016-07-11%20at%2001.49%20PM.gif)

# After

![px](https://cl.ly/1D3u0X440B38/Screen%20Recording%202016-07-11%20at%2001.48%20PM.gif)