### PR TITLE
Show ip addresses for task when using ip per task

### DIFF
--- a/src/js/components/MarathonTaskDetailsList.js
+++ b/src/js/components/MarathonTaskDetailsList.js
@@ -2,44 +2,13 @@ import React from 'react';
 
 import DescriptionList from './DescriptionList';
 import MarathonStore from '../stores/MarathonStore';
-import Util from '../utils/Util';
+import TaskUtil from '../utils/TaskUtil';
 
 class MarathonTaskDetailsList extends React.Component {
-  getHostList(task) {
-    let {ipAddresses} = task;
-    if (ipAddresses && ipAddresses.length) {
-      return ipAddresses.map(function (address) {
-        return address.ipAddress;
-      });
-    }
-
-    if (!task.host) {
-      return [];
-    }
-
-    return [task.host];
-  }
-
-  getPortList(task) {
-    let service = MarathonStore.getServiceFromTaskID(task.id);
-    let ports = Util.findNestedPropertyInObject(
-      service,
-      'ipAddress.discovery.ports'
-    );
-
-    // If there are no service ports, use task ports
-    if (!ports || !ports.length) {
-      return task.ports;
-    }
-
-    return ports.map(function (port) {
-      return port.number;
-    });
-  }
-
   getTaskEndpoints(task) {
-    let hosts = this.getHostList(task) || [];
-    let ports = this.getPortList(task) || [];
+    let service = MarathonStore.getServiceFromTaskID(task.id);
+    let hosts = TaskUtil.getHostList(task);
+    let ports = TaskUtil.getPortList(task, service);
     if (!hosts.length && !ports.length) {
       return 'None';
     }

--- a/src/js/components/MarathonTaskDetailsList.js
+++ b/src/js/components/MarathonTaskDetailsList.js
@@ -71,6 +71,15 @@ class MarathonTaskDetailsList extends React.Component {
     });
   }
 
+  getTaskPorts(task) {
+    let {ports} = task;
+    if (!ports || !ports.length) {
+      return 'None';
+    }
+
+    return ports.join(', ');
+  }
+
   getTaskStatus(task) {
     if (task == null || task.status == null) {
       return 'Unknown';
@@ -99,7 +108,7 @@ class MarathonTaskDetailsList extends React.Component {
 
     let headerValueMapping = {
       'Host': task.host,
-      'Ports': task.ports.join(', '),
+      'Ports': this.getTaskPorts(task),
       'Endpoints': this.getTaskEndpoints(task),
       'Status': this.getTaskStatus(task),
       'Staged at': this.getTimeField(task.stagedAt),

--- a/src/js/components/__tests__/MarathonTaskDetailsList-test.js
+++ b/src/js/components/__tests__/MarathonTaskDetailsList-test.js
@@ -1,0 +1,102 @@
+jest.dontMock('../MarathonTaskDetailsList');
+/* eslint-disable no-unused-vars */
+var React = require('react');
+/* eslint-enable no-unused-vars */
+var ReactDOM = require('react-dom');
+var TestUtils = require('react-addons-test-utils');
+
+var MarathonTaskDetailsList = require('../MarathonTaskDetailsList');
+var MarathonStore = require('../../stores/MarathonStore');
+
+describe('MarathonTaskDetailsList', function () {
+
+  beforeEach(function () {
+    this.getServiceFromTaskID = MarathonStore.getServiceFromTaskID;
+    this.container = document.createElement('div');
+  });
+
+  afterEach(function () {
+    MarathonStore.getServiceFromTaskID = this.getServiceFromTaskID;
+    ReactDOM.unmountComponentAtNode(this.container);
+  });
+
+  describe('#getTaskEndpoints', function () {
+
+    it('returns None if ipAddresses, ports and host is not set', function () {
+      var instance = ReactDOM.render(
+        <MarathonTaskDetailsList taskID="foo" />,
+        this.container
+      );
+      expect(instance.getTaskEndpoints({})).toEqual('None');
+    });
+
+    it('returns a list of ipAddresses if ports is not defined', function () {
+      var instance = ReactDOM.render(
+        <MarathonTaskDetailsList taskID="foo" />,
+        this.container
+      );
+      expect(instance.getTaskEndpoints({
+        ipAddresses: [{ipAddress: 'foo'}, {ipAddress: 'bar'}]
+      })).toEqual('foo, bar');
+    });
+
+    it('returns host if ports and ipAddresses are not defined', function () {
+      var instance = ReactDOM.render(
+        <MarathonTaskDetailsList taskID="foo" />,
+        this.container
+      );
+      expect(instance.getTaskEndpoints({host: 'foo'}))
+        .toEqual('foo');
+    });
+
+    it('returns host with ports if ipAddresses are not defined', function () {
+      var instance = ReactDOM.render(
+        <MarathonTaskDetailsList taskID="foo" />,
+        this.container
+      );
+      var result = instance.getTaskEndpoints({host: 'foo', ports: [1, 2]});
+
+      expect(result.length).toEqual(2);
+      expect(result[0].props.children).toEqual('foo:1');
+    });
+
+    it('uses service ports if available', function () {
+      MarathonStore.getServiceFromTaskID = function () {
+        return {
+          ipAddress: {discovery : {ports: [{number: 3}]}}
+        };
+      };
+      var instance = ReactDOM.render(
+        <MarathonTaskDetailsList taskID="foo" />,
+        this.container
+      );
+      var result = instance.getTaskEndpoints({host: 'foo', ports: [1, 2]});
+
+      expect(result.length).toEqual(1);
+      expect(result[0].props.children).toEqual('foo:3');
+    });
+
+    it('defaults to ipAddresses and service ports', function () {
+      MarathonStore.getServiceFromTaskID = function () {
+        return {
+          ipAddress: {discovery : {ports: [{number: 3}]}}
+        };
+      };
+      var instance = ReactDOM.render(
+        <MarathonTaskDetailsList taskID="foo" />,
+        this.container
+      );
+      var result = instance.getTaskEndpoints({
+        host: 'foo',
+        ipAddresses: [{ipAddress: 'foo'}, {ipAddress: 'bar'}],
+        ports: [1, 2]
+      });
+
+      expect(result.length).toEqual(2);
+      expect(result[0].props.children).toEqual('foo:3');
+      expect(result[1].props.children).toEqual('bar:3');
+    });
+
+  })
+
+});

--- a/src/js/components/__tests__/MarathonTaskDetailsList-test.js
+++ b/src/js/components/__tests__/MarathonTaskDetailsList-test.js
@@ -5,13 +5,17 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 var TestUtils = require('react-addons-test-utils');
 
-var MarathonTaskDetailsList = require('../MarathonTaskDetailsList');
 var MarathonStore = require('../../stores/MarathonStore');
+var MarathonTaskDetailsList = require('../MarathonTaskDetailsList');
+var Service = require('../../structs/Service');
 
 describe('MarathonTaskDetailsList', function () {
 
   beforeEach(function () {
     this.getServiceFromTaskID = MarathonStore.getServiceFromTaskID;
+    MarathonStore.getServiceFromTaskID = function () {
+      return new Service();
+    };
     this.container = document.createElement('div');
   });
 
@@ -36,7 +40,10 @@ describe('MarathonTaskDetailsList', function () {
         this.container
       );
       expect(instance.getTaskEndpoints({
-        ipAddresses: [{ipAddress: 'foo'}, {ipAddress: 'bar'}]
+        ipAddresses: [
+          new Service({ipAddress: 'foo'}),
+          new Service({ipAddress: 'bar'})
+        ]
       })).toEqual('foo, bar');
     });
 
@@ -62,9 +69,9 @@ describe('MarathonTaskDetailsList', function () {
 
     it('uses service ports if available', function () {
       MarathonStore.getServiceFromTaskID = function () {
-        return {
+        return new Service({
           ipAddress: {discovery : {ports: [{number: 3}]}}
-        };
+        });
       };
       var instance = ReactDOM.render(
         <MarathonTaskDetailsList taskID="foo" />,
@@ -78,9 +85,9 @@ describe('MarathonTaskDetailsList', function () {
 
     it('defaults to ipAddresses and service ports', function () {
       MarathonStore.getServiceFromTaskID = function () {
-        return {
+        return new Service({
           ipAddress: {discovery : {ports: [{number: 3}]}}
-        };
+        });
       };
       var instance = ReactDOM.render(
         <MarathonTaskDetailsList taskID="foo" />,
@@ -88,7 +95,10 @@ describe('MarathonTaskDetailsList', function () {
       );
       var result = instance.getTaskEndpoints({
         host: 'foo',
-        ipAddresses: [{ipAddress: 'foo'}, {ipAddress: 'bar'}],
+        ipAddresses: [
+          new Service({ipAddress: 'foo'}),
+          new Service({ipAddress: 'bar'})
+        ],
         ports: [1, 2]
       });
 

--- a/src/js/components/__tests__/MarathonTaskDetailsList-test.js
+++ b/src/js/components/__tests__/MarathonTaskDetailsList-test.js
@@ -101,6 +101,6 @@ describe('MarathonTaskDetailsList', function () {
       expect(result[1].props.children).toEqual('bar:3');
     });
 
-  })
+  });
 
 });

--- a/src/js/components/__tests__/MarathonTaskDetailsList-test.js
+++ b/src/js/components/__tests__/MarathonTaskDetailsList-test.js
@@ -5,9 +5,9 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 var TestUtils = require('react-addons-test-utils');
 
-var MarathonStore = require('../../stores/MarathonStore');
-var MarathonTaskDetailsList = require('../MarathonTaskDetailsList');
-var Service = require('../../structs/Service');
+let MarathonStore = require('../../stores/MarathonStore');
+let MarathonTaskDetailsList = require('../MarathonTaskDetailsList');
+let Service = require('../../structs/Service');
 
 describe('MarathonTaskDetailsList', function () {
 
@@ -27,7 +27,7 @@ describe('MarathonTaskDetailsList', function () {
   describe('#getTaskEndpoints', function () {
 
     it('returns None if ipAddresses, ports and host is not set', function () {
-      var instance = ReactDOM.render(
+      let instance = ReactDOM.render(
         <MarathonTaskDetailsList taskID="foo" />,
         this.container
       );
@@ -35,7 +35,7 @@ describe('MarathonTaskDetailsList', function () {
     });
 
     it('returns a list of ipAddresses if ports is not defined', function () {
-      var instance = ReactDOM.render(
+      let instance = ReactDOM.render(
         <MarathonTaskDetailsList taskID="foo" />,
         this.container
       );
@@ -48,7 +48,7 @@ describe('MarathonTaskDetailsList', function () {
     });
 
     it('returns host if ports and ipAddresses are not defined', function () {
-      var instance = ReactDOM.render(
+      let instance = ReactDOM.render(
         <MarathonTaskDetailsList taskID="foo" />,
         this.container
       );
@@ -57,11 +57,11 @@ describe('MarathonTaskDetailsList', function () {
     });
 
     it('returns host with ports if ipAddresses are not defined', function () {
-      var instance = ReactDOM.render(
+      let instance = ReactDOM.render(
         <MarathonTaskDetailsList taskID="foo" />,
         this.container
       );
-      var result = instance.getTaskEndpoints({host: 'foo', ports: [1, 2]});
+      let result = instance.getTaskEndpoints({host: 'foo', ports: [1, 2]});
 
       expect(result.length).toEqual(2);
       expect(result[0].props.children).toEqual('foo:1');
@@ -73,11 +73,11 @@ describe('MarathonTaskDetailsList', function () {
           ipAddress: {discovery : {ports: [{number: 3}]}}
         });
       };
-      var instance = ReactDOM.render(
+      let instance = ReactDOM.render(
         <MarathonTaskDetailsList taskID="foo" />,
         this.container
       );
-      var result = instance.getTaskEndpoints({host: 'foo', ports: [1, 2]});
+      let result = instance.getTaskEndpoints({host: 'foo', ports: [1, 2]});
 
       expect(result.length).toEqual(1);
       expect(result[0].props.children).toEqual('foo:3');
@@ -89,11 +89,11 @@ describe('MarathonTaskDetailsList', function () {
           ipAddress: {discovery : {ports: [{number: 3}]}}
         });
       };
-      var instance = ReactDOM.render(
+      let instance = ReactDOM.render(
         <MarathonTaskDetailsList taskID="foo" />,
         this.container
       );
-      var result = instance.getTaskEndpoints({
+      let result = instance.getTaskEndpoints({
         host: 'foo',
         ipAddresses: [
           new Service({ipAddress: 'foo'}),

--- a/src/js/components/__tests__/MarathonTaskDetailsList-test.js
+++ b/src/js/components/__tests__/MarathonTaskDetailsList-test.js
@@ -40,10 +40,7 @@ describe('MarathonTaskDetailsList', function () {
         this.container
       );
       expect(instance.getTaskEndpoints({
-        ipAddresses: [
-          new Service({ipAddress: 'foo'}),
-          new Service({ipAddress: 'bar'})
-        ]
+        ipAddresses: [{ipAddress: 'foo'}, {ipAddress: 'bar'}]
       })).toEqual('foo, bar');
     });
 
@@ -95,10 +92,7 @@ describe('MarathonTaskDetailsList', function () {
       );
       let result = instance.getTaskEndpoints({
         host: 'foo',
-        ipAddresses: [
-          new Service({ipAddress: 'foo'}),
-          new Service({ipAddress: 'bar'})
-        ],
+        ipAddresses: [{ipAddress: 'foo'}, {ipAddress: 'bar'}],
         ports: [1, 2]
       });
 

--- a/src/js/utils/TaskUtil.js
+++ b/src/js/utils/TaskUtil.js
@@ -2,6 +2,7 @@
 import React from 'react';
 /* eslint-enable no-unused-vars */
 import Util from './Util';
+import Service from '../structs/Service';
 
 const TaskUtil = {
   /**
@@ -9,7 +10,7 @@ const TaskUtil = {
    * @param  {object} task to return ip or host list from
    * @return {Array.<string>} an array of ip addresses or hosts
    */
-  getHostList(task) {
+  getHostList(task = {}) {
     let {ipAddresses} = task;
     if (ipAddresses && ipAddresses.length) {
       return ipAddresses.map(function (address) {
@@ -31,7 +32,7 @@ const TaskUtil = {
    * @param  {Service} service to get ports from
    * @return {Array.<number>} an array of port numbers
    */
-  getPortList(task, service) {
+  getPortList(task = {}, service = new Service()) {
     let ports = Util.findNestedPropertyInObject(
       service.getIpAddress(),
       'discovery.ports'

--- a/src/js/utils/TaskUtil.js
+++ b/src/js/utils/TaskUtil.js
@@ -4,6 +4,48 @@ import React from 'react';
 import Util from './Util';
 
 const TaskUtil = {
+  /**
+   * Returns a list of ips or hosts from task
+   * @param  {object} task to return ip or host list from
+   * @return {Array.<string>} an array of ip addresses or hosts
+   */
+  getHostList(task) {
+    let {ipAddresses} = task;
+    if (ipAddresses && ipAddresses.length) {
+      return ipAddresses.map(function (address) {
+        return address.ipAddress;
+      });
+    }
+
+    if (!task.host) {
+      return [];
+    }
+
+    return [task.host];
+  },
+
+  /**
+   * Returns a list of ports, if ports is available on service it will return
+   * those, otherwise it will fall back on ports on the task
+   * @param  {object} task to return ports from
+   * @param  {Service} service to get ports from
+   * @return {Array.<number>} an array of port numbers
+   */
+  getPortList(task, service) {
+    let ports = Util.findNestedPropertyInObject(
+      service.getIpAddress(),
+      'discovery.ports'
+    );
+
+    // If there are no service ports, use task ports
+    if (!ports || !ports.length) {
+      return task.ports || [];
+    }
+
+    return ports.map(function (port) {
+      return port.number;
+    });
+  },
 
   getTaskStatusSlug(task) {
     return task.state.substring('TASK_'.length).toLowerCase();

--- a/src/js/utils/__tests__/TaskUtil-test.js
+++ b/src/js/utils/__tests__/TaskUtil-test.js
@@ -1,6 +1,61 @@
 let TaskUtil = require('../TaskUtil');
+let Service = require('../../structs/Service');
 
 describe('TaskUtil', function () {
+
+  describe('#getHostList', function () {
+
+    it('returns empty array if ipAddresses and host is not set', function () {
+      expect(TaskUtil.getHostList({})).toEqual([]);
+    });
+
+    it('prefers ipAddresses if both are defined', function () {
+      expect(TaskUtil.getHostList({
+        ipAddresses: [{ipAddress: 'foo'}, {ipAddress: 'bar'}],
+        host: 'baz'
+      })).toEqual(['foo', 'bar']);
+    });
+
+    it('returns host if ipAddresses is empty', function () {
+      expect(TaskUtil.getHostList({ipAddresses: [], host: 'foo'}))
+        .toEqual(['foo']);
+    });
+
+    it('returns an empty array if task is not defined', function () {
+      expect(TaskUtil.getHostList()).toEqual([]);
+    });
+
+  });
+
+  describe('#getPortList', function () {
+
+    it('returns task ports if Service is not defined', function () {
+      expect(TaskUtil.getPortList({ports: [1, 2]})).toEqual([1, 2]);
+    });
+
+    it('returns an empty array if neither are defined', function () {
+      expect(TaskUtil.getPortList()).toEqual([]);
+    });
+
+    it('uses service ports if available', function () {
+      let result = TaskUtil.getPortList(
+        {},
+        new Service({ipAddress: {discovery : {ports: [{number: 3}]}}})
+      );
+
+      expect(result).toEqual([3]);
+    });
+
+    it('prefers service ports if both are available', function () {
+      let result = TaskUtil.getPortList(
+        {ports: [1, 2]},
+        new Service({ipAddress: {discovery : {ports: [{number: 3}]}}})
+      );
+
+      expect(result).toEqual([3]);
+    });
+
+  });
 
   describe('#getPortMappings', function () {
 

--- a/tests/pages/jobs/JobDetails-cy.js
+++ b/tests/pages/jobs/JobDetails-cy.js
@@ -54,11 +54,12 @@ describe('Job Details', function () {
     });
 
     it('expands the table row when clicking a job run', function () {
-      cy.get('.job-run-history-table tbody tr:nth-child(2)').as('tableRow');
+      cy.get('.job-run-history-table tbody tr').as('tableRow');
 
-      cy.get('@tableRow').find('.job-run-history-job-id').click();
+      cy.get('@tableRow').find('.job-run-history-job-id').first().click();
 
-      cy.get('@tableRow').find('.job-run-history-job-id').should('have.class', 'is-expanded');
+      cy.get('@tableRow').find('.job-run-history-job-id').first()
+        .should('have.class', 'is-expanded');
 
       cy.get('@tableRow').find('td:first-child .job-run-history-table-child')
         .should(function ($children) {
@@ -68,11 +69,13 @@ describe('Job Details', function () {
     });
 
     it('expands a second table row when clicking another job run', function () {
-      cy.get('.job-run-history-table tbody tr:nth-child(2)').as('tableRowA');
-      cy.get('.job-run-history-table tbody tr:nth-child(14)').as('tableRowB');
+      cy.get('.job-run-history-table tbody tr .job-run-history-job-id')
+        .as('tableRows');
+      cy.get('@tableRows').first().as('tableRowA');
+      cy.get('@tableRows').last().as('tableRowB');
 
-      cy.get('@tableRowA').find('.job-run-history-job-id').click();
-      cy.get('@tableRowB').find('.job-run-history-job-id').click();
+      cy.get('@tableRowA').click();
+      cy.get('@tableRowB').click();
 
       cy.get('.job-run-history-table .job-run-history-table-child')
         .should(function ($children) {

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -51,14 +51,14 @@ describe('Service Form Modal', function () {
     });
 
     it('Opens the right modal on click', function () {
-      cy.get('.panel-footer .button')
+      cy.get('.filter-bar .button')
         .contains('Deploy Service')
         .click();
       cy.get('.modal-form').should('to.have.length', 1);
     });
 
     it('contains the right group id in the modal', function () {
-      cy.get('.panel-footer .button')
+      cy.get('.filter-bar .button')
         .contains('Deploy Service')
         .click();
       cy.get('.modal-form input[name="id"]').should(function (nodeList) {
@@ -67,7 +67,7 @@ describe('Service Form Modal', function () {
     });
 
     it('contains the right JSON in the JSON editor', function () {
-      cy.get('.panel-footer .button')
+      cy.get('.filter-bar .button')
         .contains('Deploy Service')
         .click();
       cy.get('.modal-form-title-label').click();

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -54,6 +54,7 @@ describe('Service Form Modal', function () {
       cy.get('.filter-bar .button')
         .contains('Deploy Service')
         .click();
+
       cy.get('.modal-form').should('to.have.length', 1);
     });
 
@@ -61,6 +62,7 @@ describe('Service Form Modal', function () {
       cy.get('.filter-bar .button')
         .contains('Deploy Service')
         .click();
+
       cy.get('.modal-form input[name="id"]').should(function (nodeList) {
         expect(nodeList[0].value).to.equal('/services/');
       });
@@ -70,6 +72,7 @@ describe('Service Form Modal', function () {
       cy.get('.filter-bar .button')
         .contains('Deploy Service')
         .click();
+
       cy.get('.modal-form-title-label').click();
 
       cy.get('.ace_content').should(function (nodeList) {


### PR DESCRIPTION
- Showing IPs even if ports are not defined (new feature)
- Using task ports as fallback for service ports not being available (unchanged)
- Using task host as fallback for ipAddresses if not available (behaviour changed)
![](https://cl.ly/3Z2c2T3c3X1s/Image%202016-07-11%20at%2017.31.04.png)
![](https://cl.ly/1d060m1W3Z04/Image%202016-07-11%20at%2017.31.35.png)
![](https://cl.ly/0T2v200W1o46/Screen%20Shot%202016-07-11%20at%2017.31.55.png)