### PR TITLE
DCOS-8466: add scale button to service detail page

### DIFF
--- a/src/js/components/ServiceInfo.js
+++ b/src/js/components/ServiceInfo.js
@@ -26,9 +26,6 @@ class ServiceInfo extends React.Component {
       html: '',
       selectedHtml: 'More'
     }, {
-      id: ServiceActionItem.SCALE,
-      html: 'Scale'
-    }, {
       className: classNames({
         hidden: service.getInstancesCount() === 0
       }),

--- a/src/js/components/ServiceInfo.js
+++ b/src/js/components/ServiceInfo.js
@@ -40,6 +40,13 @@ class ServiceInfo extends React.Component {
     }];
 
     let actionButtons = [(
+      <button className="button flush-bottom  button-primary"
+        key="action-button-scale"
+        onClick={() =>
+          this.props.onActionsItemSelection({id: ServiceActionItem.SCALE})}>
+        Scale
+      </button>
+    ),(
       <button className="button flush-bottom button-stroke button-inverse"
         key="action-button-edit"
         onClick={() =>

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -146,8 +146,7 @@ describe('Service Actions', function () {
         });
 
       cy.visitUrl({url: '/services/%2Fcassandra-healthy/'});
-      cy.get('.button-collection .button').contains('More').click();
-      cy.get('.dropdown-menu-list li').contains('Scale').click();
+      cy.get('.button-collection .button').contains('Scale').click();
     });
 
     it('opens the correct service scale dialog', function () {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/156010/16766916/0e2281f4-483d-11e6-8359-aa45e9897b92.png)

This PR does remove the scale option from the dropdown and adds a clear call to action button for the scale function. 