### PR TITLE
Misc. Jobs history fixes

### DIFF
--- a/src/js/pages/jobs/JobRunHistoryTable.js
+++ b/src/js/pages/jobs/JobRunHistoryTable.js
@@ -220,16 +220,16 @@ class JobRunHistoryTable extends React.Component {
 
   render() {
     let {job} = this.props;
-    let activeRunCount = job.getActiveRuns().getItems().length;
+    let totalRunCount = job.getJobRuns().getItems().length;
 
     return (
       <div>
         <FilterHeadline
-          currentLength={activeRunCount}
+          currentLength={totalRunCount}
           inverseStyle={true}
           name="Run"
           onReset={function () {}}
-          totalLength={activeRunCount} />
+          totalLength={totalRunCount} />
         <ExpandingTable
           className="job-run-history-table table table-hover inverse table-borderless-outer table-borderless-inner-columns flush-bottom"
           childRowClassName="job-run-history-table-child"

--- a/src/js/pages/jobs/JobRunHistoryTable.js
+++ b/src/js/pages/jobs/JobRunHistoryTable.js
@@ -237,7 +237,7 @@ class JobRunHistoryTable extends React.Component {
           colGroup={this.getColGroup()}
           data={this.getData(job)}
           ref="expandingTable"
-          sortBy={{prop: 'status', order: 'asc'}} />
+          sortBy={{prop: 'startedAt', order: 'desc'}} />
       </div>
     );
   }

--- a/tests/pages/jobs/JobDetails-cy.js
+++ b/tests/pages/jobs/JobDetails-cy.js
@@ -30,7 +30,7 @@ describe('Job Details', function () {
 
     it('shows the correct number of jobs in the filter header', function () {
       cy.get('.page-content .list-inline.list-unstyled').should('contain',
-        '2 Runs');
+        '13 Runs');
     });
 
     it('renders the correct number of jobs in the table', function () {


### PR DESCRIPTION
1. Show the actual count of job history
2. sort the runs by `Started`, in descending order instead of by `Status`


*before*:
![image](https://cloud.githubusercontent.com/assets/1078545/16768671/84302d30-4845-11e6-9a1b-a80486e53e58.png)


*after*:

![image](https://cloud.githubusercontent.com/assets/1078545/16768677/9170a7fe-4845-11e6-8c2b-d2aac982a518.png)

