### PR TITLE
Use break-word classname for DescriptionList key

### DIFF
--- a/src/js/components/DescriptionList.js
+++ b/src/js/components/DescriptionList.js
@@ -71,7 +71,7 @@ class DescriptionList extends React.Component {
 DescriptionList.defaultProps = {
   className: '',
   ddClassName: 'column-9 text-overflow-break-word',
-  dtClassName: 'column-3 text-mute',
+  dtClassName: 'column-3 text-mute text-overflow-break-word',
   headlineClassName: 'inverse flush-top',
   key: '',
   renderKeys: {}


### PR DESCRIPTION
![px](https://cl.ly/2M172s1x3p2R/Image%202016-07-12%20at%2011.28.13%20AM.png)

Integration tests passing on a frankie branch, which includes this:
![](https://s3.amazonaws.com/f.cl.ly/items/3M3f0f0m0N1i2S3z1J26/Screen%20Shot%202016-07-12%20at%202.43.36%20PM.png?v=2fe45bf8)
![](https://s3.amazonaws.com/f.cl.ly/items/160i0D0Z1g421A2U042s/Screen%20Shot%202016-07-12%20at%202.43.47%20PM.png?v=b7a08b47)