### PR TITLE
Handle null node health data gracefully

### DIFF
--- a/src/js/structs/CompositeState.js
+++ b/src/js/structs/CompositeState.js
@@ -65,6 +65,10 @@ class CompositeState {
   }
 
   addNodeHealth(data) {
+    if (data == null) {
+      return;
+    }
+
     let oldData = this.data.slaves || [];
     let dataByIP = {};
 

--- a/src/js/structs/__tests__/CompositeState-test.js
+++ b/src/js/structs/__tests__/CompositeState-test.js
@@ -158,6 +158,10 @@ describe('CompositeState', function () {
       }
     );
 
+    it('handles null data gracefully', function () {
+      expect(CompositeState.addNodeHealth).not.toThrow();
+    });
+
   });
 
   describe('#mergeData', function () {


### PR DESCRIPTION
Bug report (credit @MatApple):
![](http://f.cl.ly/items/0h2N2A2w180g1X3n3m0k/Screen%20Recording%202016-07-06%20at%2006.41%20PM.gif)

This PR introduces a check that data is not null before attempting to iterate on it. 