### PR TITLE
Fix layout on service search results view

### DIFF
--- a/src/js/components/FilterHeadline.js
+++ b/src/js/components/FilterHeadline.js
@@ -22,7 +22,7 @@ class FilterHeadline extends React.Component {
   }
 
   render() {
-    let {currentLength, inverseStyle, isFiltering, name, totalLength} = this.props;
+    let {className, currentLength, inverseStyle, isFiltering, name, totalLength} = this.props;
     let hideFilteredClasses =
       (isFiltering == null && currentLength === totalLength) ||
       (isFiltering != null && !isFiltering);
@@ -49,7 +49,7 @@ class FilterHeadline extends React.Component {
     let listClassSet = classNames({
       'list-unstyled list-inline': true,
       'inverse': inverseStyle
-    });
+    }, className);
 
     return (
       <ul className={listClassSet}>
@@ -74,6 +74,7 @@ FilterHeadline.defaultProps = {
 };
 
 FilterHeadline.propTypes = {
+  className: PropTypes.string,
   currentLength: PropTypes.number.isRequired,
   inverseStyle: PropTypes.bool,
   // Optional prop used to force the "Clear" button to show even when n of n

--- a/src/js/components/ServicesTable.js
+++ b/src/js/components/ServicesTable.js
@@ -187,10 +187,16 @@ var ServicesTable = React.createClass({
   getColumns: function () {
     let className = ResourceTableUtil.getClassName;
     let heading = ResourceTableUtil.renderHeading(ServiceTableHeaderLabels);
+    let {isFiltered} = this.props;
 
     return [
       {
-        className,
+        className: function () {
+          return classNames([
+            className.apply(this, arguments),
+            {'table-cell-short': isFiltered}
+          ]);
+        },
         headerClassName: className,
         prop: 'name',
         render: this.renderHeadline,

--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -237,6 +237,7 @@ var ServicesTab = React.createClass({
     if (hasFiltersApplied) {
       return (
         <FilterHeadline
+          className="breadcrumb-style-headline"
           inverseStyle={true}
           onReset={this.resetFilter}
           name="Service"

--- a/src/styles/components/breadcrumbs.less
+++ b/src/styles/components/breadcrumbs.less
@@ -142,3 +142,11 @@ Breadcrumbs
     }
   }
 }
+
+.breadcrumb-style-headline {
+  margin-bottom: @base-spacing-unit * 2/3;
+  .h4 {
+    font-size: @base-spacing-unit * .65;
+    line-height: @base-spacing-unit;
+  }
+}

--- a/src/styles/components/breadcrumbs.less
+++ b/src/styles/components/breadcrumbs.less
@@ -146,7 +146,7 @@ Breadcrumbs
 .breadcrumb-style-headline {
   margin-bottom: @base-spacing-unit * 2/3;
   .h4 {
-    font-size: @base-spacing-unit * .65;
+    font-size: @body-text-font-size * 1.2;
     line-height: @base-spacing-unit;
   }
 }

--- a/src/styles/components/tables.less
+++ b/src/styles/components/tables.less
@@ -224,6 +224,12 @@ components/tables.less
 
     }
 
+    .table-cell-short {
+
+      padding-top: @table-cell-short-padding-vertical;
+      padding-bottom: @table-cell-short-padding-vertical;
+
+    }
 
 
 

--- a/src/styles/components/tables.less
+++ b/src/styles/components/tables.less
@@ -220,6 +220,7 @@ components/tables.less
     .table-cell-details-secondary {
 
       font-size: @body-text-font-size * 0.85;
+      line-height: @body-text-font-size * 1.16;
 
     }
 

--- a/src/styles/variables/variables-tables.less
+++ b/src/styles/variables/variables-tables.less
@@ -111,6 +111,7 @@ Table Cell Styles
 @table-cell-padding-vertical:                                                   @base-spacing-unit * 0.25;
 @table-cell-height:                                                             @base-spacing-unit;
 
+@table-cell-short-padding-vertical:                                             @base-spacing-unit * 0.5;
 
 
 /* -----------------------------------------------------------------------------


### PR DESCRIPTION
Bug report: 


> If I search or apply a filter to services, the table/layout shifts, which is jarring and looks like a mistake.
> ![](https://s3.amazonaws.com/f.cl.ly/items/3l2Y2Z2n2G0S1k2N0e2H/Screen%20Recording%202016-07-11%20at%2003.13%20PM.gif?v=d9511b48)
> I think there are 2 issues here:
> 1. The title/breadcrumb is changing style - let's keep it the same i.e. where it changes from "Services" to "Showing 9 of 13 Services", keep this the same font size
> 2. The row height changes due to adding the service location - ideally we can keep the row the same height, similar to how Marathon works today

With this PR:
![](https://s3.amazonaws.com/f.cl.ly/items/3g0Q1K0Q0t3K2O2i213Z/Screen%20Recording%202016-07-13%20at%2005.07%20PM.gif?v=2733b862)