### PR TITLE
Refactor PageHeader

### DIFF
--- a/src/js/components/PageHeader.js
+++ b/src/js/components/PageHeader.js
@@ -93,9 +93,13 @@ class PageHeader extends React.Component {
       <div className={pageHeaderClasses}>
         <div className={pageHeaderHeadingClasses}>
           <div className="page-header-content">
-            {this.getIcon()}
-            <div className="page-header-text">
-              {this.getTitle()}
+            <h1 className="page-header-main-content">
+              {this.getIcon()}
+              <div className="page-header-heading">
+                {this.getTitle()}
+              </div>
+            </h1>
+            <div className="page-header-sub-heading">
               {this.getSubTitle()}
             </div>
           </div>

--- a/src/js/components/PageHeader.js
+++ b/src/js/components/PageHeader.js
@@ -10,10 +10,7 @@ class PageHeader extends React.Component {
       return null;
     }
 
-    let iconClasses = classNames(
-      'icon icon-image-container',
-      iconClassName
-    );
+    let iconClasses = classNames('icon icon-large', iconClassName);
 
     return (
       <div className="page-header-icon">
@@ -32,12 +29,12 @@ class PageHeader extends React.Component {
     }
 
     let titleClasses = classNames(
-      'flush-top inverse',
+      'h1 flush inverse',
       titleClassName
     );
 
     return (
-      <h1 className={titleClasses}>{title}</h1>
+      <span className={titleClasses}>{title}</span>
     );
   }
 
@@ -57,14 +54,18 @@ class PageHeader extends React.Component {
   }
 
   renderActionButtons() {
-    let {actionButtons} = this.props;
+    let {actionButtons, buttonCollectionClassNames} = this.props;
+    let buttonCollectionClasses = classNames(
+      'button-collection',
+      buttonCollectionClassNames
+    );
 
     if (actionButtons.length === 0) {
       return null;
     }
 
     return (
-      <div className="button-collection">
+      <div className={buttonCollectionClasses}>
         {actionButtons}
       </div>
     );
@@ -74,7 +75,8 @@ class PageHeader extends React.Component {
     let {
       children,
       className,
-      pageHeaderHeadingClassNames,
+      pageHeaderContentWrapperClassNames,
+      pageHeaderContentHeadingClassNames,
       navigationTabs
     } = this.props;
 
@@ -84,27 +86,32 @@ class PageHeader extends React.Component {
       className
     );
 
-    let pageHeaderHeadingClasses = classNames(
-      'page-header-heading',
-      pageHeaderHeadingClassNames
+    let pageHeaderContentWrapperClasses = classNames(
+      'page-header-content-wrapper',
+      pageHeaderContentWrapperClassNames
+    );
+
+    let pageHeaderContentHeadingClasses = classNames(
+      'page-header-content-heading',
+      pageHeaderContentHeadingClassNames
     );
 
     return (
       <div className={pageHeaderClasses}>
-        <div className={pageHeaderHeadingClasses}>
-          <div className="page-header-content">
-            <h1 className="page-header-main-content">
+        <div className={pageHeaderContentWrapperClasses}>
+          <div className={pageHeaderContentHeadingClasses}>
+            <div className="page-header-content-primary">
               {this.getIcon()}
-              <div className="page-header-heading">
+              <div className="page-header-title">
                 {this.getTitle()}
               </div>
-            </h1>
-            <div className="page-header-sub-heading">
-              {this.getSubTitle()}
+            </div>
+            <div className="page-header-content-secondary">
+              {this.renderActionButtons()}
             </div>
           </div>
-          <div className="page-header-actions">
-            {this.renderActionButtons()}
+          <div className="page-header-sub-heading">
+            {this.getSubTitle()}
           </div>
         </div>
         {children}
@@ -133,7 +140,7 @@ PageHeader.propTypes = {
     React.PropTypes.string,
     React.PropTypes.object,
   ]),
-  pageHeaderHeadingClassNames: React.PropTypes.oneOfType([
+  pageHeaderContentWrapperClassNames: React.PropTypes.oneOfType([
     React.PropTypes.string,
     React.PropTypes.object,
   ]),

--- a/src/js/components/PageHeader.js
+++ b/src/js/components/PageHeader.js
@@ -121,6 +121,12 @@ class PageHeader extends React.Component {
   }
 }
 
+const classPropType = React.PropTypes.oneOfType([
+  React.PropTypes.array,
+  React.PropTypes.object,
+  React.PropTypes.string
+]);
+
 PageHeader.defaultProps = {
   actionButtons: []
 };
@@ -132,30 +138,12 @@ PageHeader.propTypes = {
   subTitle: React.PropTypes.node,
   title: React.PropTypes.string,
 
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.object,
-  ]),
-  pageHeaderClassNames: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.object,
-  ]),
-  pageHeaderContentWrapperClassNames: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.object,
-  ]),
-  titleClassName: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.object,
-  ]),
-  iconClassName: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.object,
-  ]),
-  subTitleClassName: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.object,
-  ])
+  className: classPropType,
+  pageHeaderClassNames: classPropType,
+  pageHeaderContentWrapperClassNames: classPropType,
+  titleClassName: classPropType,
+  iconClassName: classPropType,
+  subTitleClassName: classPropType
 };
 
 module.exports = PageHeader;

--- a/src/js/components/ServiceInfo.js
+++ b/src/js/components/ServiceInfo.js
@@ -140,7 +140,7 @@ class ServiceInfo extends React.Component {
       <PageHeader
         actionButtons={this.getActionButtons()}
         icon={serviceIcon}
-        iconClassName="icon-app-container"
+        iconClassName="icon-image-container icon-app-container"
         subTitle={this.getSubHeader(service)}
         navigationTabs={tabs}
         title={service.getName()} />

--- a/src/js/components/__tests__/ServiceDetail-test.js
+++ b/src/js/components/__tests__/ServiceDetail-test.js
@@ -57,7 +57,7 @@ describe('ServiceDetail', function () {
   describe('#render', function () {
 
     it('renders service info name', function () {
-      expect(this.node.querySelector('h1').textContent).toEqual('test');
+      expect(this.node.querySelector('.h1').textContent).toEqual('test');
     });
 
   });

--- a/src/js/components/__tests__/ServiceInfo-test.js
+++ b/src/js/components/__tests__/ServiceInfo-test.js
@@ -52,13 +52,13 @@ describe('ServiceInfo', function () {
 
     it('renders health state', function () {
       expect(
-        this.node.querySelectorAll('.page-header-sub-heading')[0].children[0].children[0].textContent
+        this.node.querySelector('.page-header-sub-heading').children[0].children[0].textContent
       ).toEqual('Healthy');
     });
 
     it('renders number of running tasks', function () {
       expect(
-        this.node.querySelectorAll('.page-header-sub-heading')[0].children[0].children[1].textContent
+        this.node.querySelector('.page-header-sub-heading').children[0].children[1].textContent
       ).toEqual('2 Running Tasks');
     });
 

--- a/src/js/components/__tests__/ServiceInfo-test.js
+++ b/src/js/components/__tests__/ServiceInfo-test.js
@@ -41,7 +41,7 @@ describe('ServiceInfo', function () {
     });
 
     it('renders name', function () {
-      expect(this.node.querySelector('h1').textContent).toEqual('test');
+      expect(this.node.querySelector('.h1').textContent).toEqual('test');
     });
 
     it('renders image', function () {
@@ -52,13 +52,13 @@ describe('ServiceInfo', function () {
 
     it('renders health state', function () {
       expect(
-        this.node.querySelectorAll('.page-header-text')[0].children[1].children[0].textContent
+        this.node.querySelectorAll('.page-header-sub-heading')[0].children[0].children[0].textContent
       ).toEqual('Healthy');
     });
 
     it('renders number of running tasks', function () {
       expect(
-        this.node.querySelectorAll('.page-header-text')[0].children[1].children[1].textContent
+        this.node.querySelectorAll('.page-header-sub-heading')[0].children[0].children[1].textContent
       ).toEqual('2 Running Tasks');
     });
 

--- a/src/js/pages/system/UnitsHealthDetail.js
+++ b/src/js/pages/system/UnitsHealthDetail.js
@@ -158,7 +158,7 @@ class UnitsHealthDetail extends mixin(StoreMixin) {
       <div className="flex-container-col">
         <Breadcrumbs />
         <PageHeader
-          icon={<Icon color="white" id="shapes" size="jumbo" />}
+          icon={<Icon color="white" id="shapes" size="large" />}
           subTitle={this.getSubTitle(unit)}
           title={unit.getTitle()} />
         <FilterHeadline

--- a/src/js/pages/system/UnitsHealthNodeDetail.js
+++ b/src/js/pages/system/UnitsHealthNodeDetail.js
@@ -139,7 +139,7 @@ class UnitsHealthNodeDetail extends mixin(StoreMixin) {
       <div className="flex-container-col">
         <Breadcrumbs />
         <PageHeader
-          icon={<Icon color="white" id="heart-pulse" size="jumbo" />}
+          icon={<Icon color="white" id="heart-pulse" size="large" />}
           subTitle={this.getSubTitle(unit, node)}
           title={`${unit.getTitle()} Health Check`} />
         <div className="flex-container-col flex-grow no-overflow">

--- a/src/js/pages/task-details/TaskDetail.js
+++ b/src/js/pages/task-details/TaskDetail.js
@@ -198,7 +198,7 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
     return (
       <PageHeader
         icon={taskIcon}
-        iconClassName="icon-app-container"
+        iconClassName="icon-app-container icon-image-container"
         subTitle={TaskStates[task.state].displayName}
         navigationTabs={navigationTabs}
         title={task.getName()} />

--- a/src/styles/components/page-header.less
+++ b/src/styles/components/page-header.less
@@ -54,6 +54,7 @@
 
 .page-header-content {
   flex: 1 1 auto;
+  flex-direction: column;
 }
 
 .page-header-actions {

--- a/src/styles/components/page-header.less
+++ b/src/styles/components/page-header.less
@@ -26,38 +26,23 @@
   }
 }
 
-.page-header-heading {
-  display: flex;
-  flex-wrap: wrap;
-}
-
 .page-header-icon {
+  flex: 0 0 auto;
   padding-right: @base-spacing-unit * 1/4;
-
-  .icon {
-    max-height: 64px;
-    max-width: 64px;
-  }
 }
 
-.page-header-text {
-
-  h1 {
-    margin-bottom: @base-spacing-unit * 1/3;
-  }
+.page-header-content-primary,
+.page-header-content-secondary {
+  display: flex;
 }
 
-.page-header-content,
-.page-header-actions {
-  display: inline-flex;
-}
-
-.page-header-content {
+.page-header-content-primary {
+  align-items: center;
+  display: flex;
   flex: 1 1 auto;
-  flex-direction: column;
 }
 
-.page-header-actions {
+.page-header-content-secondary {
   flex: 0 1 auto;
   margin-left: 0;
   margin-top: @base-spacing-unit * 1/4;
@@ -66,6 +51,16 @@
   &:last-child {
     padding-right: 0;
   }
+
+  .button-collection {
+    margin-bottom: 0;
+  }
+}
+
+.page-header-content-heading {
+  align-items: center;
+  display: flex;
+  margin-bottom: @base-spacing-unit * 1/2;
 }
 
 & when (@screen-mini-enabled) {
@@ -106,13 +101,9 @@
       }
     }
 
-    .page-header-actions {
+    .page-header-content-secondary {
       margin-left: auto;
       margin-top: 0;
-    }
-
-    .page-header-heading {
-      flex-wrap: nowrap;
     }
 
     .page-header-icon {

--- a/tests/pages/jobs/JobDetails-cy.js
+++ b/tests/pages/jobs/JobDetails-cy.js
@@ -12,16 +12,16 @@ describe('Job Details', function () {
   context('Job Details Header', function () {
 
     it('renders the proper job name', function () {
-      cy.get('.page-header-heading').should('contain',
+      cy.get('.page-header-title').should('contain',
         'Foo Description');
     });
 
     it('renders the proper job status', function () {
-      cy.get('.page-header-heading').should('contain', 'Failed');
+      cy.get('.page-header-sub-heading').should('contain', 'Failed');
     });
 
     it('renders the relative time of the longest running task', function () {
-      cy.get('.page-header-heading').should('contain', '32 yrs ago');
+      cy.get('.page-header-sub-heading').should('contain', '32 yrs ago');
     });
 
   });

--- a/tests/pages/nodes/node/NodeDetail-cy.js
+++ b/tests/pages/nodes/node/NodeDetail-cy.js
@@ -17,7 +17,7 @@ describe('Nodes Detail Page', function () {
       }).click();
 
       cy.hash().should('match', /nodes\/[a-zA-Z0-9-]+/);
-      cy.get('.page-content h1').should(function ($title) {
+      cy.get('.page-content .h1').should(function ($title) {
         expect($title).to.contain(nodeName);
       });
     });

--- a/tests/pages/services/TasksTable-cy.js
+++ b/tests/pages/services/TasksTable-cy.js
@@ -11,7 +11,7 @@ describe('Tasks Table', function () {
     it('displays task detail page on task click', function () {
       cy.visitUrl({url: '/services/%2Fcassandra/'});
       cy.get('a[title="server-0"]').click();
-      cy.get('.page-content h1').should('to.have.text', 'server-0');
+      cy.get('.page-content .h1').should('to.have.text', 'server-0');
     });
 
     context('Files tab', function () {

--- a/tests/pages/services/VolumesTable-cy.js
+++ b/tests/pages/services/VolumesTable-cy.js
@@ -49,7 +49,7 @@ describe('Volumes', function () {
     });
 
     it('displays the correct status in the header', function () {
-      cy.get('.page-header-heading .emphasize').should('contain', 'Attached');
+      cy.get('.page-header-sub-heading .emphasize').should('contain', 'Attached');
     });
 
     it('displays the details of the volume', function () {

--- a/tests/pages/system/overview/components/UnitsHealthTab-cy.js
+++ b/tests/pages/system/overview/components/UnitsHealthTab-cy.js
@@ -75,14 +75,14 @@ describe('Units Tab [0e2]', function () {
     });
 
     it('renders unit title [0ea]', function () {
-      cy.get('.page-content h1').contains('Mesos DNS').should(function ($title) {
+      cy.get('.page-content .h1').contains('Mesos DNS').should(function ($title) {
         expect($title).to.exist;
       });
     });
 
     it('renders unit health [0eb]', function () {
       cy.wait(2000);
-      cy.get('.page-content .page-header-text')
+      cy.get('.page-content .page-header-sub-heading')
         .find('.text-danger')
         .should(function ($health) {
           expect($health).to.contain('Unhealthy');
@@ -117,14 +117,14 @@ describe('Units Tab [0e2]', function () {
     });
 
     it('renders health check title [0ei]', function () {
-      cy.get('.page-content h1').contains('Mesos DNS Health Check').should(function ($title) {
+      cy.get('.page-content .h1').contains('Mesos DNS Health Check').should(function ($title) {
         expect($title).to.exist;
       });
     });
 
     it('renders node health [0ej]', function () {
       cy.wait(2000);
-      cy.get('.page-content .page-header-text')
+      cy.get('.page-content .page-header-sub-heading')
         .find('.text-success')
         .should(function ($health) {
           expect($health).to.contain('Healthy');


### PR DESCRIPTION
Per @ashenden's request, the `PageHeader` will now vertically align the icon, text heading, and action buttons. The sub-heading is now left-aligned underneath all three of these elements.

Relevant integration tests passing:
![](https://cl.ly/3N2f3B3u0a30/Screen%20Shot%202016-07-13%20at%203.28.45%20PM.png)