### PR TITLE
Alter service destroy message to better emphasize service

### DIFF
--- a/src/js/components/ServiceDetail.js
+++ b/src/js/components/ServiceDetail.js
@@ -122,11 +122,12 @@ class ServiceDetail extends mixin(InternalStorageMixin, StoreMixin, TabsMixin) {
   getDestroyConfirmDialog() {
     const {service} = this.props;
     const {state} = this;
+    const serviceID = (<span className="emphasize">{service.getId()}</span>);
 
     let message = (
       <div className="container-pod flush-top container-pod-short-bottom">
         <h2 className="text-danger text-align-center flush-top">Destroy Service</h2>
-        <p>Are you sure you want to destroy {service.getId()}? This action is irreversible.</p>
+        <p>Destroying {serviceID} is irreversible. Are you sure you want to continue?</p>
         {this.getErrorMessage()}
       </div>
     );


### PR DESCRIPTION
Objections were made against the "?" that seemed like a query parameter.
Before:
![](https://cl.ly/0Y1F1s0T3M3H/Image%202016-07-13%20at%205.25.57%20PM.png)

After:
![](https://cl.ly/1A2r2g3E2u3D/Image%202016-07-13%20at%205.25.36%20PM.png)