### PR TITLE
DCOS-8421: Change the way services are filtered on id search

### DIFF
--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -267,7 +267,13 @@ var ServicesTab = React.createClass({
         other: state.filterOther,
         status: state.filterStatus,
         id: state.searchString
-      }).flattenItems().getItems();
+      });
+
+      if (!state.searchString) {
+        filteredServices = filteredServices.flattenItems();
+      }
+
+      filteredServices = filteredServices.getItems();
     }
 
     return (

--- a/src/js/structs/ServiceTree.js
+++ b/src/js/structs/ServiceTree.js
@@ -107,11 +107,11 @@ module.exports = class ServiceTree extends Tree {
       if (filter.id) {
         let filterProperties = Object.assign({}, this.getFilterProperties(), {
           name: function (item) {
-            return item.getId();
+            return item.getName();
           }
         });
 
-        services = this.filterItemsByText(filter.id, filterProperties).getItems();
+        services = this.flattenItems().filterItemsByText(filter.id, filterProperties).getItems();
       }
 
       if (filter.health != null && filter.health.length !== 0) {

--- a/src/js/structs/__tests__/ServiceTree-test.js
+++ b/src/js/structs/__tests__/ServiceTree-test.js
@@ -226,7 +226,7 @@ describe('ServiceTree', function () {
       }).getItems();
 
       expect(filteredServices.length).toEqual(1);
-      expect(filteredServices[0].getId()).toEqual('/group/test');
+      expect(filteredServices[0].getId()).toEqual('/group/test/foo');
     });
 
     it('should filter by health', function () {


### PR DESCRIPTION
This changes the way services are filtered. This delivers a less verbose list.

![search mov](https://cloud.githubusercontent.com/assets/156010/16842065/508ebfb2-49dc-11e6-9306-6f93d7efed6e.gif)
