### PR TITLE
DCOS-8432 Add version column to Tasks list

### DIFF
--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -9,6 +9,7 @@ import ResourceTableUtil from '../utils/ResourceTableUtil';
 import TaskStates from '../constants/TaskStates';
 import TaskTableHeaderLabels from '../constants/TaskTableHeaderLabels';
 import TaskUtil from '../utils/TaskUtil';
+import TableUtil from '../utils/TableUtil';
 import Units from '../utils/Units';
 
 const METHODS_TO_BIND = [
@@ -34,6 +35,15 @@ class TaskTable extends React.Component {
 
   getStatusValue(task) {
     return TaskStates[task.state].displayName;
+  }
+
+  getVersionValue(task) {
+    let marathonTask = MarathonStore.getTaskFromTaskID(task.id);
+    if (marathonTask == null) {
+      return null;
+    }
+
+    return marathonTask.version;
   }
 
   getColumns() {
@@ -106,12 +116,20 @@ class TaskTable extends React.Component {
       {
         cacheCell: true,
         className,
+        getValue: this.getVersionValue,
         headerClassName: className,
         heading,
         prop: 'version',
         render: this.renderVersion,
         sortable: true,
-        sortFunction
+        sortFunction: TableUtil.getSortFunction('id', (task) => {
+          let version = this.getVersionValue(task);
+          if (version == null) {
+            return null;
+          }
+
+          return new Date(version);
+        })
       }
     ];
   }

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -104,6 +104,7 @@ class TaskTable extends React.Component {
         sortFunction
       },
       {
+        cacheCell: true,
         className,
         headerClassName: className,
         heading,

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -4,6 +4,7 @@ import React from 'react';
 
 import CheckboxTable from './CheckboxTable';
 import Icon from './Icon';
+import MarathonStore from '../stores/MarathonStore';
 import ResourceTableUtil from '../utils/ResourceTableUtil';
 import TaskStates from '../constants/TaskStates';
 import TaskTableHeaderLabels from '../constants/TaskTableHeaderLabels';
@@ -14,7 +15,8 @@ const METHODS_TO_BIND = [
   'renderHeadline',
   'renderLog',
   'renderStatus',
-  'renderStats'
+  'renderStats',
+  'renderVersion'
 ];
 
 class TaskTable extends React.Component {
@@ -100,6 +102,15 @@ class TaskTable extends React.Component {
         render: ResourceTableUtil.renderUpdated,
         sortable: true,
         sortFunction
+      },
+      {
+        className,
+        headerClassName: className,
+        heading,
+        prop: 'version',
+        render: this.renderVersion,
+        sortable: true,
+        sortFunction
       }
     ];
   }
@@ -114,6 +125,7 @@ class TaskTable extends React.Component {
         <col style={{width: '85px'}} className="hidden-mini" />
         <col style={{width: '110px'}} className="hidden-mini" />
         <col style={{width: '120px'}} />
+        <col style={{width: '180px'}} className="hidden-mini"/>
       </colgroup>
     );
   }
@@ -216,6 +228,27 @@ class TaskTable extends React.Component {
           {this.getStatusValue(task)}
         </span>
       </div>
+    );
+  }
+
+  renderVersion(prop, task) {
+    let marathonTask = MarathonStore.getTaskFromTaskID(task.id);
+    if (marathonTask == null) {
+      return null;
+    }
+
+    let version = marathonTask.version;
+
+    if (version == null) {
+      return null;
+    }
+
+    let localeVersion = new Date(version).toLocaleString();
+
+    return (
+      <span>
+        {localeVersion}
+      </span>
     );
   }
 

--- a/src/js/constants/TaskTableHeaderLabels.js
+++ b/src/js/constants/TaskTableHeaderLabels.js
@@ -4,8 +4,9 @@ var TaskTableHeaderLabels = {
   mem: 'MEM',
   id: 'TASK NAME',
   name: 'TASK NAME',
-  status: 'STATUS',
-  updated: 'UPDATED'
+  state: 'STATUS',
+  updated: 'UPDATED',
+  version: 'VERSION'
 };
 
 module.exports = TaskTableHeaderLabels;

--- a/src/js/utils/ResourceTableUtil.js
+++ b/src/js/utils/ResourceTableUtil.js
@@ -18,7 +18,8 @@ const LEFT_ALIGN_PROPS = [
   'mem',
   'mtime',
   'priority',
-  'size'
+  'size',
+  'version'
 ];
 
 function leftAlignCaret(prop) {


### PR DESCRIPTION
So,

Mesos tasks don't carry the Marathon version, so there is no right way to have this information for a completed task. The right solution to this would be that either Mesos starts storing the version info (maybe as a label) or Marathon starts keeping track of completed tasks.

The only possible solution without any major change is to take the Mesos Task ID and use it to grab the equivalent Marathon Task which contains the `version` we need to render the value. This means, however, that we can't display the version of completed tasks.

So when looking at the full, unfiltered task list, this means:

![screen shot 2016-07-14 at 16 22 23](https://cloud.githubusercontent.com/assets/1078545/16843205/976152a2-49e0-11e6-9809-ae509686e04c.png)

@leemunroe @pyronicide @air can you please chime in and let us know if this is good enough for 1.8 ?
 