### PR TITLE
Fix undefined environment variable

### DIFF
--- a/src/js/schemas/service-schema/EnvironmentVariables.js
+++ b/src/js/schemas/service-schema/EnvironmentVariables.js
@@ -21,12 +21,20 @@ let EnvironmentVariables = {
         if (variableMap == null) {
           return [];
         }
-        return Object.keys(variableMap).map(function (key) {
-          return Hooks.applyFilter('variablesGetter', {
+
+        return Object.keys(variableMap).reduce(function (memo, key) {
+          if ((key == null || key === 'undefined')
+            && (variableMap[key] === 'undefined' || variableMap[key] == null)) {
+            return;
+          }
+
+          memo.push(Hooks.applyFilter('variablesGetter', {
             key,
             value: variableMap[key]
-          }, service);
-        });
+          }, service));
+
+          return memo;
+        }, []);
       },
       itemShape: {
         properties: {


### PR DESCRIPTION
Prevents undefined key/values being set when we build the model and update the definition.

Example of what would happen if you set a container image and command.
![](https://cl.ly/3T1X2f441l00/Image%202016-07-14%20at%2012.51.15%20PM.png)