### PR TITLE
Allow schema utils to take options

### DIFF
--- a/src/js/components/SchemaForm.js
+++ b/src/js/components/SchemaForm.js
@@ -202,13 +202,13 @@ class SchemaForm extends mixin(StoreMixin, InternalStorageMixin) {
 
   getNewDefinition() {
     let {model, schema} = this.props;
-    let definition = SchemaUtil.schemaToMultipleDefinition(
+    let definition = SchemaUtil.schemaToMultipleDefinition({
       schema,
-      this.getSubHeader,
-      this.getLabel,
-      this.getRemoveRowButton,
-      this.getAddNewRowButton
-    );
+      renderSubheader: this.getSubHeader,
+      renderLabel: this.getLabel,
+      renderRemove: this.getRemoveRowButton,
+      renderAdd: this.getAddNewRowButton
+    });
 
     if (model) {
       SchemaFormUtil.mergeModelIntoDefinition(

--- a/src/js/components/ServiceForm.js
+++ b/src/js/components/ServiceForm.js
@@ -398,13 +398,13 @@ class ServiceForm extends SchemaForm {
 
     schema = Hooks.applyFilter('serviceFormSchema', schema);
 
-    let definition = SchemaUtil.schemaToMultipleDefinition(
+    let definition = SchemaUtil.schemaToMultipleDefinition({
       schema,
-      this.getSubHeader,
-      this.getLabel,
-      this.getRemoveRowButton,
-      this.getAddNewRowButton
-    );
+      renderSubheader: this.getSubHeader,
+      renderLabel: this.getLabel,
+      renderRemove: this.getRemoveRowButton,
+      renderAdd: this.getAddNewRowButton
+    });
 
     SchemaFormUtil.mergeModelIntoDefinition(
       model,

--- a/src/js/components/modals/InstallPackageModal.js
+++ b/src/js/components/modals/InstallPackageModal.js
@@ -210,7 +210,9 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
 
     if (isAdvancedInstall && !advancedConfiguration) {
       return SchemaUtil.definitionToJSONDocument(
-        SchemaUtil.schemaToMultipleDefinition(cosmosPackage.getConfig())
+        SchemaUtil.schemaToMultipleDefinition({
+          schema: cosmosPackage.getConfig()
+        })
       );
     }
 

--- a/src/js/utils/__tests__/SchemaUtil-test.js
+++ b/src/js/utils/__tests__/SchemaUtil-test.js
@@ -20,9 +20,10 @@ describe('SchemaUtil', function () {
         };
 
         this.subheaderRender = jasmine.createSpy();
-        this.result = SchemaUtil.schemaToMultipleDefinition(
-          schema, this.subheaderRender
-        );
+        this.result = SchemaUtil.schemaToMultipleDefinition({
+          schema,
+          renderSubheader: this.subheaderRender
+        });
       });
 
       it('sets the title of the definition', function () {
@@ -71,9 +72,9 @@ describe('SchemaUtil', function () {
         };
 
         this.subheaderRender = jasmine.createSpy();
-        this.result = SchemaUtil.schemaToMultipleDefinition(
-          schema, this.subheaderRender
-        );
+        this.result = SchemaUtil.schemaToMultipleDefinition({
+          schema, renderSubheader: this.subheaderRender
+        });
       });
 
       it('creates a nested definition correctly', function () {


### PR DESCRIPTION
A much much needed change for schema utils. The functionality is the same. The only thing that changes is instead of taking an insane amount of arguments in a specific order, it now takes an options object which it will derive the needed arguments

# Before
![px](https://cl.ly/0i1j2Y2H1O3o/Image%202016-07-14%20at%201.44.05%20PM.png)

# After
![px](https://cl.ly/3F110J0W1V1i/Image%202016-07-14%20at%201.43.13%20PM.png)