### PR TITLE
Fix failing integration test

### DIFF
--- a/tests/pages/jobs/JobDetails-cy.js
+++ b/tests/pages/jobs/JobDetails-cy.js
@@ -69,7 +69,7 @@ describe('Job Details', function () {
     });
 
     it('expands a second table row when clicking another job run', function () {
-      cy.get('.job-run-history-table tbody tr .job-run-history-job-id')
+      cy.get('.job-run-history-table tbody tr .is-expandable')
         .as('tableRows');
       cy.get('@tableRows').first().as('tableRowA');
       cy.get('@tableRows').last().as('tableRowB');


### PR DESCRIPTION
The expandable row wasn't necessarily the last row in the table. This ensures that it only selects elements which are expandable.