### PR TITLE
Enable eslint no useless escapes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -63,7 +63,6 @@
     "comma-dangle":  0,
     "object-shorthand": 0,
     "no-var": 0,
-    "no-useless-escape": 0,
     "arrow-body-style": 0,
     "object-curly-spacing": 0,
     "react/jsx-closing-bracket-location": 0,

--- a/src/js/utils/Validator.js
+++ b/src/js/utils/Validator.js
@@ -18,8 +18,8 @@ var Validator = {
   isWellFormedServiceIdPath: function (str) {
     // This RegExp is taken from the ID field explanation described here:
     // https://mesosphere.github.io/marathon/docs/rest-api.html#post-v2-apps
-    var idMatchRegExp = '^(([a-z0-9]|[a-z0-9][a-z0-9\-]*' +
-      '[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$';
+    var idMatchRegExp = '^(([a-z0-9]|[a-z0-9][a-z0-9-]*' +
+      '[a-z0-9]).)*([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])$';
     return str.split('/').every((pathSegement) => {
       return pathSegement == null ||
         pathSegement.length === 0 ||


### PR DESCRIPTION
We can safely remove these escapes. It doesn't have any effect on functionality. http://eslint.org/docs/rules/no-useless-escape