### PR TITLE
Info bubble to explain what service status means

### DIFF
--- a/src/js/components/ServicesTable.js
+++ b/src/js/components/ServicesTable.js
@@ -209,6 +209,7 @@ var ServicesTable = React.createClass({
         className,
         headerClassName: className,
         prop: 'status',
+        helpText: 'At-a-glance overview of the global application or group state',
         render: this.renderStatus,
         sortable: true,
         sortFunction: ServiceTableUtil.propCompareFunctionFactory,

--- a/src/js/utils/ResourceTableUtil.js
+++ b/src/js/utils/ResourceTableUtil.js
@@ -2,9 +2,11 @@ const classNames = require('classnames');
 /* eslint-disable no-unused-vars */
 const React = require('react');
 /* eslint-enable no-unused-vars */
+import {Tooltip} from 'reactjs-components';
 
 import DateUtil from '../utils/DateUtil';
 const HealthSorting = require('../constants/HealthSorting');
+import Icon from '../components/Icon';
 const MarathonStore = require('../stores/MarathonStore');
 import TableUtil from '../utils/TableUtil';
 import Util from '../utils/Util';
@@ -93,6 +95,7 @@ var ResourceTableUtil = {
         `caret caret--${order}`,
         {'caret--visible': prop === sortBy.prop}
       );
+      let helpIcon = null;
 
       if (leftAlignCaret(prop) || prop === 'TASK_RUNNING') {
         caret.before = <span className={caretClassSet} />;
@@ -100,10 +103,22 @@ var ResourceTableUtil = {
         caret.after = <span className={caretClassSet} />;
       }
 
+      if (this.helpText != null) {
+        helpIcon = (
+          <Tooltip
+            content={this.helpText}
+            wrapText={true}
+            wrapperClassName="tooltip-wrapper text-align-center table-header-help-icon">
+            <Icon id="ring-question" size="mini" family="mini" color="grey" />
+          </Tooltip>
+        );
+      }
+
       return (
         <span>
           {caret.before}
           <span className="table-header-title">{title}</span>
+          {helpIcon}
           {caret.after}
         </span>
       );

--- a/src/styles/components/tables.less
+++ b/src/styles/components/tables.less
@@ -39,6 +39,12 @@ components/tables.less
 
     }
 
+    .table-header-help-icon {
+
+      margin-left: @base-spacing-unit * 0.25;
+
+    }
+
     > thead,
     > tbody,
     > tfoot {


### PR DESCRIPTION
Feature request:

> https://www.dropbox.com/s/cy834bpvqp5zq2i/Screenshot%202016-07-08%2011.52.40.png?dl=0
> What are the different states? The marathon UI has a nice standard of showing an info bubble next to puzzling concepts.

In action:

![](https://s3.amazonaws.com/f.cl.ly/items/1z380p2z1l222G2K2D13/Screen%20Recording%202016-07-15%20at%2003.49%20PM.gif?v=bc721a8a)