### PR TITLE
Show service status, not health, in service info

### DIFF
--- a/src/js/components/ServiceInfo.js
+++ b/src/js/components/ServiceInfo.js
@@ -6,7 +6,6 @@ import Cluster from '../utils/Cluster';
 import Framework from '../structs/Framework';
 import HealthBar from './HealthBar';
 import HealthStatus from '../constants/HealthStatus';
-import HealthLabels from '../constants/HealthLabels';
 import PageHeader from './PageHeader';
 import Service from '../structs/Service';
 import ServiceActionItem from '../constants/ServiceActionItem';
@@ -81,6 +80,7 @@ class ServiceInfo extends React.Component {
 
   getSubHeader(service) {
     let serviceHealth = service.getHealth();
+    let serviceStatus = service.getStatus();
     let tasksSummary = service.getTasksSummary();
     let runningTasksCount = tasksSummary.tasksRunning;
     let instancesCount = service.getInstancesCount();
@@ -88,7 +88,7 @@ class ServiceInfo extends React.Component {
     let subHeaderItems = [
       {
         classes: `media-object-item ${HealthStatus[serviceHealth.key].classNames}`,
-        label: HealthLabels[HealthStatus[serviceHealth.key].key],
+        label: serviceStatus,
         shouldShow: serviceHealth.key != null
       },
       {

--- a/src/js/components/__tests__/ServiceDetail-test.js
+++ b/src/js/components/__tests__/ServiceDetail-test.js
@@ -28,6 +28,7 @@ describe('ServiceDetail', function () {
     cpus: 1,
     mem: 2048,
     disk: 0,
+    deployments: [],
     tasksStaged: 0,
     tasksRunning: 2,
     tasksHealthy: 2,

--- a/src/js/components/__tests__/ServiceInfo-test.js
+++ b/src/js/components/__tests__/ServiceInfo-test.js
@@ -15,6 +15,7 @@ describe('ServiceInfo', function () {
     id: '/group/test',
     healthChecks: [{path: '', protocol: 'HTTP'}],
     cpus: 1,
+    deployments: [],
     mem: 2048,
     disk: 0,
     tasksStaged: 0,
@@ -50,10 +51,10 @@ describe('ServiceInfo', function () {
       ).toEqual('foo.png');
     });
 
-    it('renders health state', function () {
+    it('renders app status, not health state', function () {
       expect(
         this.node.querySelector('.page-header-sub-heading').children[0].children[0].textContent
-      ).toEqual('Healthy');
+      ).toEqual('Running');
     });
 
     it('renders number of running tasks', function () {


### PR DESCRIPTION
Original bug report:

> https://www.dropbox.com/s/n404b53m1i6ustf/Screenshot%202016-07-08%2011.58.50.png?dl=0
> This is in the middle of a deployment. I'd like to see something to know that marathon's still trying to do something.

Implementation:
![](https://s3.amazonaws.com/f.cl.ly/items/1c0N3u1M2p1m1H3x3z07/Screen%20Recording%202016-07-15%20at%2006.09%20PM.gif?v=ca6ce5d2)