### PR TITLE
DCOS-8464 Reset filters when query params are removed

### DIFF
--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -87,6 +87,21 @@ var ServicesTab = React.createClass({
     });
   },
 
+  componentWillReceiveProps: function () {
+    const queryParams = this.getQueryParamObject();
+    const {state} = this;
+
+    // Reset filter defaults when query params are deleted externally
+    Object.keys(DEFAULT_FILTER_OPTIONS).forEach(stateKey => {
+      if (queryParams[stateKey] == null &&
+        (state[stateKey] != null && state[stateKey].length > 0)) {
+        this.setState({
+          [stateKey]: DEFAULT_FILTER_OPTIONS[stateKey]
+        });
+      }
+    });
+  },
+
   onMarathonStoreGroupsError: function () {
     this.setState({marathonErrorCount: this.state.marathonErrorCount + 1});
   },


### PR DESCRIPTION
Reset the local state when query params representing a filter are reset externally:
Relevant integration tests are passing.

![labels](https://cloud.githubusercontent.com/assets/1078545/16920226/1c8ba804-4d0d-11e6-8dd2-238c7a1b5677.gif)
