### PR TITLE
DCOS-8058: Add client side resource validation

### DIFF
--- a/src/js/schemas/service-schema/General.js
+++ b/src/js/schemas/service-schema/General.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-unused-vars */
 import React from 'react';
 /* eslint-enable no-unused-vars */
+import MesosConstants from '../../constants/MesosConstants';
+import ResourceValidatorUtil from '../../utils/ResourceValidatorUtil';
 
 let General = {
   title: 'General',
@@ -29,14 +31,34 @@ let General = {
           default: 1,
           getter: function (service) {
             return `${service.getCpus() || this.default}`;
+          },
+          externalValidator: function ({general}, definition) {
+            if (!ResourceValidatorUtil.isValidCPUSValue(general.cpus)) {
+              definition.showError = 'CPUs must be a number greater than ' +
+                `or equal to ${MesosConstants.MIN_CPUS}`;
+
+              return false;
+            }
+
+            return true;
           }
         },
         mem: {
-          title: 'Mem (MiB)',
+          title: 'Memory (MiB)',
           type: 'number',
           default: 128,
           getter: function (service) {
             return `${service.getMem() || this.default}`;
+          },
+          externalValidator: function ({general}, definition) {
+            if (!ResourceValidatorUtil.isValidMemoryValue(general.mem)) {
+              definition.showError = 'Memory must be a number greater than ' +
+                `or equal to ${MesosConstants.MIN_MEM}`;
+
+              return false;
+            }
+
+            return true;
           }
         },
         disk: {
@@ -45,6 +67,15 @@ let General = {
           default: 0,
           getter: function (service) {
             return `${service.getDisk() || this.default}`;
+          },
+          externalValidator: function ({general}, definition) {
+            if (!ResourceValidatorUtil.isValidDiskValue(general.disk)) {
+              definition.showError = 'Disk must be a non-negative number';
+
+              return false;
+            }
+
+            return true;
           }
         },
         instances: {

--- a/src/js/utils/ResourceValidatorUtil.js
+++ b/src/js/utils/ResourceValidatorUtil.js
@@ -1,0 +1,26 @@
+import MesosConstants from '../constants/MesosConstants';
+
+const ResourceValidatorUtil = {
+  isValidCPUSValue(value) {
+    const cpus = parseFloat(value);
+
+    return !Number.isNaN(cpus) && !!cpus.toString().match(/^[0-9\.]+$/) &&
+      cpus >= MesosConstants.MIN_CPUS;
+  },
+
+  isValidDiskValue(value) {
+    const disk = parseFloat(value);
+
+    return !Number.isNaN(disk) && !!disk.toString().match(/^[0-9\.]+$/) &&
+      disk >= 0;
+  },
+
+  isValidMemoryValue(value) {
+    const memory = parseFloat(value);
+
+    return !Number.isNaN(memory) && !!memory.toString().match(/^[0-9\.]+$/) &&
+      memory >= MesosConstants.MIN_MEM;
+  }
+};
+
+module.exports = ResourceValidatorUtil;

--- a/src/js/utils/__tests__/ResourceValidatorUtil-test.js
+++ b/src/js/utils/__tests__/ResourceValidatorUtil-test.js
@@ -1,0 +1,108 @@
+jest.dontMock('../ResourceValidatorUtil');
+
+var ResourceValidatorUtil = require('../ResourceValidatorUtil');
+
+describe('ResourceValidatorUtil', function () {
+
+  describe('#isValidCPUSValue', function () {
+    it('should properly handle empty strings', function () {
+      expect(ResourceValidatorUtil.isValidCPUSValue('')).toBe(false);
+    });
+
+    it('should properly handle  undefined values', function () {
+      expect(ResourceValidatorUtil.isValidCPUSValue()).toBe(false);
+    });
+
+    it('should properly handle wrong value types', function () {
+      expect(ResourceValidatorUtil.isValidCPUSValue('not a number 666'))
+        .toBe(false);
+    });
+
+    it('should handle number like inputs', function () {
+      expect(ResourceValidatorUtil.isValidCPUSValue(0.001)).toBe(false);
+      expect(ResourceValidatorUtil.isValidCPUSValue('0.0001')).toBe(false);
+      expect(ResourceValidatorUtil.isValidCPUSValue(0.01)).toBe(true);
+      expect(ResourceValidatorUtil.isValidCPUSValue('0.01')).toBe(true);
+      expect(ResourceValidatorUtil.isValidCPUSValue(2)).toBe(true);
+      expect(ResourceValidatorUtil.isValidCPUSValue('2')).toBe(true);
+    });
+
+    it('should verify that CPUs is greater or equal to 0.01', function () {
+      expect(ResourceValidatorUtil.isValidCPUSValue(0.001)).toBe(false);
+      expect(ResourceValidatorUtil.isValidCPUSValue(0.01)).toBe(true);
+      expect(ResourceValidatorUtil.isValidCPUSValue(5)).toBe(true);
+      expect(ResourceValidatorUtil.isValidCPUSValue(2)).toBe(true);
+    });
+
+  });
+
+  describe('#isValidDiskValue', function () {
+    it('should properly handle empty strings', function () {
+      expect(ResourceValidatorUtil.isValidDiskValue('')).toBe(false);
+    });
+
+    it('should properly handle undefined values', function () {
+      expect(ResourceValidatorUtil.isValidDiskValue()).toBe(false);
+    });
+
+    it('should properly handle wrong value types', function () {
+      expect(ResourceValidatorUtil.isValidDiskValue('not a number 666'))
+        .toBe(false);
+    });
+
+    it('should handle number like inputs', function () {
+      expect(ResourceValidatorUtil.isValidDiskValue('-0.1')).toBe(false);
+      expect(ResourceValidatorUtil.isValidDiskValue(-0.1)).toBe(false);
+      expect(ResourceValidatorUtil.isValidDiskValue('0.1')).toBe(true);
+      expect(ResourceValidatorUtil.isValidDiskValue(0.1)).toBe(true);
+    });
+
+    it('should verify that Disk is a positive number', function () {
+      expect(ResourceValidatorUtil.isValidDiskValue(-1)).toBe(false);
+      expect(ResourceValidatorUtil.isValidDiskValue(-0.001)).toBe(false);
+      expect(ResourceValidatorUtil.isValidDiskValue(0.001)).toBe(true);
+      expect(ResourceValidatorUtil.isValidDiskValue(1)).toBe(true);
+    });
+  });
+
+  describe('#isValidMemoryValue', function () {
+    it('should properly handle empty strings', function () {
+      expect(ResourceValidatorUtil.isValidMemoryValue('')).toBe(false);
+    });
+
+    it('should properly handle undefined values', function () {
+      expect(ResourceValidatorUtil.isValidMemoryValue()).toBe(false);
+    });
+
+    it('should properly handle wrong value types', function () {
+      expect(ResourceValidatorUtil.isValidMemoryValue('not a number 666'))
+        .toBe(false);
+    });
+
+    it('should handle number like inputs', function () {
+      expect(ResourceValidatorUtil.isValidMemoryValue(0.01)).toBe(false);
+      expect(ResourceValidatorUtil.isValidMemoryValue('0.01')).toBe(false);
+      expect(ResourceValidatorUtil.isValidMemoryValue(32)).toBe(true);
+      expect(ResourceValidatorUtil.isValidMemoryValue('32')).toBe(true);
+    });
+
+    it('should verify that Memory is greater or equal to 32', function () {
+      expect(ResourceValidatorUtil.isValidCPUSValue(0.001)).toBe(false);
+      expect(ResourceValidatorUtil.isValidCPUSValue(0.01)).toBe(true);
+      expect(ResourceValidatorUtil.isValidCPUSValue(5)).toBe(true);
+      expect(ResourceValidatorUtil.isValidCPUSValue(2)).toBe(true);
+    });
+
+    it('looks like a number greater or equal to 32', function () {
+      expect(ResourceValidatorUtil.isValidMemoryValue(0.0001)).toBe(false);
+      expect(ResourceValidatorUtil.isValidMemoryValue(0.1)).toBe(false);
+      expect(ResourceValidatorUtil.isValidMemoryValue(5)).toBe(false);
+      expect(ResourceValidatorUtil.isValidMemoryValue(31)).toBe(false);
+      expect(ResourceValidatorUtil.isValidMemoryValue(32)).toBe(true);
+      expect(ResourceValidatorUtil.isValidMemoryValue(32.7)).toBe(true);
+      expect(ResourceValidatorUtil.isValidMemoryValue(500)).toBe(true);
+    });
+  });
+
+});
+


### PR DESCRIPTION
<img width="951" alt="" src="https://cloud.githubusercontent.com/assets/647035/16922594/8896e852-4d16-11e6-82e1-62aeec020a32.png">
---
ℹ️  You will see these validation errors only on the second click or after switching the tabs. This is know issue which will hopefully be fixed with https://github.com/mesosphere/reactjs-components/pull/303. 

/cc @kennyt 
