### PR TITLE
Fix animating of healthbar in service table

### DIFF
--- a/src/js/components/ServicesTable.js
+++ b/src/js/components/ServicesTable.js
@@ -143,6 +143,7 @@ var ServicesTable = React.createClass({
 
   renderStatus: function (prop, service) {
     let instanceCount = service.getInstancesCount();
+    let serviceId = service.getId();
     let serviceStatus = service.getStatus();
     let serviceStatusClassSet = StatusMapping[serviceStatus] || '';
     let taskSummary = service.getTasksSummary();
@@ -157,7 +158,10 @@ var ServicesTable = React.createClass({
     return (
       <div className="status-bar-wrapper">
         <span className="status-bar-indicator">
-          <HealthBar tasksSummary={taskSummary} instancesCount={instanceCount} />
+          <HealthBar
+            key={serviceId}
+            tasksSummary={taskSummary}
+            instancesCount={instanceCount} />
         </span>
         <span className="status-bar-text">
           <span className={serviceStatusClassSet}>{serviceStatus}</span>


### PR DESCRIPTION
Prevents health bar in services table from caching previous props and animating.
[DCOS-8542](https://mesosphere.atlassian.net/browse/DCOS-8544)

Before:
![](https://cl.ly/30071s1b2k2x/Screen%20Recording%202016-07-18%20at%2003.59%20PM.gif)

After fix:
![](https://cl.ly/1a0Q1U1I0T1D/Screen%20Recording%202016-07-18%20at%2003.54%20PM.gif)