### PR TITLE
Show jobs header navigation when inside jobs group

### DIFF
--- a/src/js/routes/jobs.js
+++ b/src/js/routes/jobs.js
@@ -57,7 +57,6 @@ let jobsRoutes = {
           handler: JobDetailPage,
           name: 'jobs-page-detail',
           path: ':id/?',
-          hideHeaderNavigation: true,
           buildBreadCrumb: function () {
             return {
               parentCrumb: 'jobs-page',


### PR DESCRIPTION
Always show the header navigation for Jobs