### PR TITLE
Pad out tooltip content on Services StatusBar

### DIFF
--- a/src/js/components/HealthBar.js
+++ b/src/js/components/HealthBar.js
@@ -27,7 +27,7 @@ class HealthBar extends React.Component {
       let classSet = classNames(HealthBarStates[task].className, 'dot icon');
 
       return (
-        <div key={index}>
+        <div key={index} className="tooltip-line-item">
           <span className={classSet} />
           {` ${tasksSummary[task]} ${HealthBarStates[task].label} `}
           <span className="health-bar-tooltip-instances-total">

--- a/src/styles/components/tooltip.less
+++ b/src/styles/components/tooltip.less
@@ -11,5 +11,10 @@
     &:after {
       border-color: @tooltip-background-color;
     }
+
+    .tooltip-line-item {
+      padding-bottom: @container-pod-super-short-padding-vertical / 6;
+      padding-top: @container-pod-super-short-padding-vertical / 6;
+    }
   }
 }


### PR DESCRIPTION
Before:
![](https://cl.ly/3E1K2H0b2l34/Image%202016-07-18%20at%206.07.47%20PM.png)

After:
![](https://cl.ly/2y1k031Y1A1L/Image%202016-07-18%20at%206.12.16%20PM.png)