### PR TITLE
Add Help tooltip to JSON editor in Service Modal

### DIFF
--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -1,6 +1,6 @@
 import Ace from 'react-ace';
 import mixin from 'reactjs-mixin';
-import {Modal} from 'reactjs-components';
+import {Modal, Tooltip} from 'reactjs-components';
 import React from 'react';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
@@ -8,6 +8,8 @@ import 'brace/mode/json';
 import 'brace/theme/monokai';
 import 'brace/ext/language_tools';
 
+import Config from '../../config/Config';
+import Icon from '../Icon';
 import MarathonStore from '../../stores/MarathonStore';
 import ServiceForm from '../ServiceForm';
 import Service from '../../structs/Service';
@@ -373,16 +375,38 @@ class ServiceFormModal extends mixin(StoreMixin) {
     let {jsonDefinition, jsonMode, service} = this.state;
 
     if (jsonMode) {
+      let toolTipContent = (
+        <div>
+          Use the JSON editor to enter Marathon Application definitions manually.
+          {' '}
+          <a href={Config.marathonJSONDocsURI} target="_blank">
+            Read more here.
+          </a>
+        </div>
+      );
+
       return (
-        <Ace editorProps={{$blockScrolling: true}}
-          mode="json"
-          onChange={this.handleJSONChange}
-          showGutter={true}
-          showPrintMargin={false}
-          theme="monokai"
-          height="462px"
-          value={jsonDefinition}
-          width="100%"/>
+        <div className="ace-editor-container">
+          <Ace editorProps={{$blockScrolling: true}}
+            mode="json"
+            onChange={this.handleJSONChange}
+            showGutter={true}
+            showPrintMargin={false}
+            theme="monokai"
+            height="462px"
+            value={jsonDefinition}
+            width="100%"/>
+          <Tooltip
+            content={toolTipContent}
+            interactive={true}
+            wrapperClassName="tooltip-wrapper media-object-item json-editor-help"
+            wrapText={true}
+            maxWidth={300}
+            position="left"
+            scrollContainer=".gm-scroll-view">
+            <Icon color="grey" id="ring-question" size="mini" family="mini" />
+          </Tooltip>
+        </div>
       );
     }
 

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -379,7 +379,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
         <div>
           Use the JSON editor to enter Marathon Application definitions manually.
           {' '}
-          <a href={Config.marathonJSONDocsURI} target="_blank">
+          <a href={`${Config.marathonDocsURI}generated/api.html#v2_apps_post`} target="_blank">
             Read more here.
           </a>
         </div>

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -380,7 +380,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
           Use the JSON editor to enter Marathon Application definitions manually.
           {' '}
           <a href={`${Config.marathonDocsURI}generated/api.html#v2_apps_post`} target="_blank">
-            Read more here.
+            View API docs.
           </a>
         </div>
       );

--- a/src/js/config/Config.js
+++ b/src/js/config/Config.js
@@ -11,6 +11,7 @@ var Config = {
   secretsAPIPrefix: '/secrets/v1',
   delayAfterErrorCount: 5,
   documentationURI: 'https://dcos.io/docs',
+  marathonJSONDocsURI: 'https://mesosphere.github.io/marathon/docs/generated/api.html#v2_apps_post',
   downloadsURI: 'https://downloads.dcos.io',
   environment: '@@ENV',
   historyLength: 31,

--- a/src/js/config/Config.js
+++ b/src/js/config/Config.js
@@ -11,7 +11,7 @@ var Config = {
   secretsAPIPrefix: '/secrets/v1',
   delayAfterErrorCount: 5,
   documentationURI: 'https://dcos.io/docs',
-  marathonJSONDocsURI: 'https://mesosphere.github.io/marathon/docs/generated/api.html#v2_apps_post',
+  marathonDocsURI: 'https://mesosphere.github.io/marathon/docs/',
   downloadsURI: 'https://downloads.dcos.io',
   environment: '@@ENV',
   historyLength: 31,

--- a/src/styles/components/ace-editor.less
+++ b/src/styles/components/ace-editor.less
@@ -1,0 +1,3 @@
+.ace-editor-container {
+  position: relative;
+}

--- a/src/styles/components/tooltip.less
+++ b/src/styles/components/tooltip.less
@@ -13,3 +13,10 @@
     }
   }
 }
+
+.json-editor-help {
+  position: absolute;
+  top: @base-spacing-unit;
+  right: @base-spacing-unit;
+  z-index: 100;
+}

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -122,6 +122,7 @@ Components
 --------------------------------------------------------------------------------
 ----------------------------------------------------------------------------- */
 
+@import "components/ace-editor.less";
 @import "components/application-loading-indicator.less";
 @import "components/badges.less";
 @import "components/banner-plugin.less";


### PR DESCRIPTION
[DCOS-8445](https://mesosphere.atlassian.net/browse/DCOS-8445). Until we figure out how to do contextual help globally, this is what we've got. Currently configure the docs endpoint in Config.js. Perhaps these docs will end up living in dcos.io at some point.

![](https://cl.ly/3m2N150P3v24/Screen%20Recording%202016-07-18%20at%2007.39%20PM.gif)