### PR TITLE
DCOS-8371: Add detailed error message on scale

### DIFF
--- a/src/js/components/modals/ServiceScaleFormModal.js
+++ b/src/js/components/modals/ServiceScaleFormModal.js
@@ -67,10 +67,9 @@ class ServiceScaleFormModal extends mixin(StoreMixin) {
 
   onMarathonStoreServiceEditError({message:errorMsg = '', details: details}) {
     this.resetState();
-    let isErrorMsgToShort = errorMsg.toLowerCase() === 'object is not valid' &&
-      details.length !== 0;
+    let hasDetails = details && details.length !== 0;
 
-    if (isErrorMsgToShort) {
+    if (hasDetails) {
       this.setState({
         errorMsg: details.reduce(function (memo, error) {
 

--- a/src/js/components/modals/ServiceScaleFormModal.js
+++ b/src/js/components/modals/ServiceScaleFormModal.js
@@ -65,8 +65,22 @@ class ServiceScaleFormModal extends mixin(StoreMixin) {
     this.props.onClose();
   }
 
-  onMarathonStoreServiceEditError({message:errorMsg}) {
+  onMarathonStoreServiceEditError({message:errorMsg = '', details: details}) {
     this.resetState();
+    let isErrorMsgToShort = errorMsg.toLowerCase() === 'object is not valid' &&
+      details.length !== 0;
+
+    if (isErrorMsgToShort) {
+      this.setState({
+        errorMsg: details.reduce(function (memo, error) {
+
+          return `${memo} ${error.errors.join(' ')}`;
+        }, '')
+      });
+
+      return;
+    }
+
     this.setState({
       errorMsg
     });


### PR DESCRIPTION
![screen shot 2016-07-19 at 11 08 55](https://cloud.githubusercontent.com/assets/156010/16945199/6bf69b0a-4da4-11e6-98c5-332f36cfbe9e.png)

This shows a more detailed error on scale if `object is not valid` is the error message which is provided by marathon.