### PR TITLE
DCOS-8058: Add client side container validation

### DIFF
--- a/src/js/schemas/service-schema/ContainerSettings.js
+++ b/src/js/schemas/service-schema/ContainerSettings.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars */
 import React from 'react';
 /* eslint-enable no-unused-vars */
+import ContainerValidatorUtil from '../../utils/ContainerValidatorUtil';
 
 const ContainerSettings = {
   title: 'Container Settings',
@@ -24,6 +25,21 @@ const ContainerSettings = {
               return container.docker.image;
             }
             return null;
+          },
+          externalValidator: function ({containerSettings}, definition) {
+            const {image} = containerSettings;
+
+            if (image == null ||
+              ContainerValidatorUtil.isValidDockerImage(image)) {
+              return true;
+            }
+
+            definition.showError = 'Container Image  must not contain ' +
+              'whitespace and should not contain any other characters ' +
+              'than lowercase letters, digits, hyphens, underscores, ' +
+              'and colons.';
+
+            return false;
           }
         }
       }

--- a/src/js/utils/ContainerValidatorUtil.js
+++ b/src/js/utils/ContainerValidatorUtil.js
@@ -1,0 +1,13 @@
+const ContainerValidatorUtil = {
+  isValidDockerImage(dockerImage) {
+    if (typeof dockerImage !== 'string' || dockerImage === '') {
+      return false;
+    }
+
+    // The pattern is based on Dockers `validContainerName` regexp:
+    // https://github.com/docker/docker/blob/f63cdf0260/runtime.go#L33
+    return /^[a-zA-Z0-9_\-/:.]+$/.test(dockerImage);
+  }
+};
+
+module.exports = ContainerValidatorUtil;

--- a/src/js/utils/__tests__/ContainerValidatorUtil-test.js
+++ b/src/js/utils/__tests__/ContainerValidatorUtil-test.js
@@ -1,0 +1,30 @@
+jest.dontMock('../ContainerValidatorUtil');
+
+var ContainerValidatorUtil = require('../ContainerValidatorUtil');
+
+describe('ContainerValidatorUtil', function () {
+
+  describe('#isValidDockerImage', function () {
+    it('should properly handle empty strings', function () {
+      expect(ContainerValidatorUtil.isValidDockerImage('')).toBe(false);
+    });
+
+    it('should properly handle undefined values', function () {
+      expect(ContainerValidatorUtil.isValidDockerImage()).toBe(false);
+    });
+
+    it('should properly handle white spaces', function () {
+      expect(ContainerValidatorUtil.isValidDockerImage('white space')).toBe(false);
+    });
+
+    it('should verify that the images are well-formed', function () {
+      expect(ContainerValidatorUtil.isValidDockerImage('docker/image-name')).toBe(true);
+      expect(ContainerValidatorUtil.isValidDockerImage('docker/imageName:latest')).toBe(true);
+      expect(ContainerValidatorUtil.isValidDockerImage('docker/image-name:v1.2.0-RC5')).toBe(true);
+      expect(ContainerValidatorUtil.isValidDockerImage('docker/Image_name:v1.2.0-RC5')).toBe(true);
+    });
+
+  });
+
+});
+


### PR DESCRIPTION
![](https://cloud.githubusercontent.com/assets/647035/16951552/c5535136-4dc5-11e6-9b3b-85ce71889500.png)
---
ℹ️  You will see this validation error only on the second click or after switching the tabs. This is know issue which will hopefully be fixed with https://github.com/mesosphere/reactjs-components/pull/303. 
