### PR TITLE
DCOS-8067 - Sort sidebar filter by label order

### DIFF
--- a/src/js/components/SidebarFilter.js
+++ b/src/js/components/SidebarFilter.js
@@ -167,7 +167,7 @@ class SidebarFilter extends mixin(QueryParamsMixin) {
             this.getFormLabel(filterLabels[filterLabel], filterLabel),
           labelClass: labelClassSet
         };
-    });
+      });
   }
 
   getHealthNodes() {

--- a/src/js/components/SidebarFilter.js
+++ b/src/js/components/SidebarFilter.js
@@ -139,30 +139,34 @@ class SidebarFilter extends mixin(QueryParamsMixin) {
     let {filterLabels, filterValues} = this.props;
     let {selectedNodes} = this.state;
 
-    return Object.keys(filterValues).map(filterValue => {
-      let value = filterValues[filterValue].toString();
-      let checked = selectedNodes.indexOf(value) > -1;
+    return Object.keys(filterLabels)
+      .filter(filterLabel => {
+        return filterValues[filterLabel] != null;
+      })
+      .map(filterLabel => {
+        let value = filterValues[filterLabel];
+        let checked = selectedNodes.indexOf(value.toString()) > -1;
 
-      let labelClassSet = classNames(
-        'side-list-item form-row-element form-element-checkbox inverse',
-        'row row-flex flex-align-items-center vertical-center flush clickable',
-        {
-          'filter-active': this.getCountByValue(filterValue) > 0,
-          'filter-checked': checked
-        }
-      );
+        let labelClassSet = classNames(
+          'side-list-item form-row-element form-element-checkbox inverse',
+          'row row-flex flex-align-items-center vertical-center flush clickable',
+          {
+            'filter-active': this.getCountByValue(filterLabel) > 0,
+            'filter-checked': checked
+          }
+        );
 
-      return {
-        checked,
-        checkboxLabelClass: 'form-element-checkbox-label flex-grow',
-        value: checked,
-        fieldType: 'checkbox',
-        formElementClass: 'form-row-element checkbox flush',
-        name: filterValue,
-        label:
-          this.getFormLabel(filterLabels[filterValue], filterValue),
-        labelClass: labelClassSet
-      };
+        return {
+          checked,
+          checkboxLabelClass: 'form-element-checkbox-label flex-grow',
+          value: checked,
+          fieldType: 'checkbox',
+          formElementClass: 'form-row-element checkbox flush',
+          name: filterLabel,
+          label:
+            this.getFormLabel(filterLabels[filterLabel], filterLabel),
+          labelClass: labelClassSet
+        };
     });
   }
 

--- a/src/js/components/SidebarFilter.js
+++ b/src/js/components/SidebarFilter.js
@@ -140,10 +140,10 @@ class SidebarFilter extends mixin(QueryParamsMixin) {
     let {selectedNodes} = this.state;
 
     return Object.keys(filterLabels)
-      .filter(filterLabel => {
+      .filter(function (filterLabel) {
         return filterValues[filterLabel] != null;
       })
-      .map(filterLabel => {
+      .map((filterLabel) => {
         let value = filterValues[filterLabel];
         let checked = selectedNodes.indexOf(value.toString()) > -1;
 


### PR DESCRIPTION
This sorts the sidebar filters by the order of the labels instead of the filter values.

![filterorder](https://cloud.githubusercontent.com/assets/859154/16954776/750da3e0-4dd2-11e6-8518-9aa8bdbeca9a.png)
