### PR TITLE
DCOS-8075 - Remove NA from status filter if empty

### DIFF
--- a/src/js/components/SidebarFilter.js
+++ b/src/js/components/SidebarFilter.js
@@ -167,7 +167,7 @@ class SidebarFilter extends mixin(QueryParamsMixin) {
             this.getFormLabel(filterLabels[filterLabel], filterLabel),
           labelClass: labelClassSet
         };
-    });
+      });
   }
 
   getHealthNodes() {

--- a/src/js/components/SidebarFilter.js
+++ b/src/js/components/SidebarFilter.js
@@ -142,7 +142,7 @@ class SidebarFilter extends mixin(QueryParamsMixin) {
     let {selectedNodes} = this.state;
 
     return Object.keys(filterLabels)
-      .filter(function (filterLabel) {
+      .filter((filterLabel) => {
         let filterValue = filterValues[filterLabel];
 
         return filterValue != null &&

--- a/src/js/components/SidebarFilter.js
+++ b/src/js/components/SidebarFilter.js
@@ -5,6 +5,8 @@ import mixin from 'reactjs-mixin';
 import React from 'react';
 
 import QueryParamsMixin from '../mixins/QueryParamsMixin';
+import ServiceFilterTypes from '../constants/ServiceFilterTypes';
+import ServiceStatusTypes from '../constants/ServiceStatusTypes';
 
 class SidebarFilter extends mixin(QueryParamsMixin) {
   constructor() {
@@ -136,12 +138,17 @@ class SidebarFilter extends mixin(QueryParamsMixin) {
   }
 
   getHealthCheckboxes() {
-    let {filterLabels, filterValues} = this.props;
+    let {filterLabels, filterType, filterValues} = this.props;
     let {selectedNodes} = this.state;
 
     return Object.keys(filterLabels)
       .filter(function (filterLabel) {
-        return filterValues[filterLabel] != null;
+        let filterValue = filterValues[filterLabel];
+
+        return filterValue != null &&
+          !(filterType === ServiceFilterTypes.STATUS &&
+          filterValue === ServiceStatusTypes.NA &&
+          this.getCountByValue(filterValue) === 0);
       })
       .map((filterLabel) => {
         let value = filterValues[filterLabel];


### PR DESCRIPTION
If there are no services with a N/A status this status isn't shown anymore in the status filters sidebar.

Dependend on PR #762 

![filterorder](https://cloud.githubusercontent.com/assets/859154/16955787/45a79b20-4dd6-11e6-89b2-5689c9180b26.png)
