### PR TITLE
Show stale service IDs on deployments

### DIFF
--- a/src/js/pages/__tests__/DeploymentsTab-test.js
+++ b/src/js/pages/__tests__/DeploymentsTab-test.js
@@ -33,8 +33,8 @@ describe('DeploymentsTab', function () {
           totalSteps: 3,
           affectedApps: ['service-1', 'service-2'],
           affectedServices: [
-            new Service({name: 'service-1', deployments: []}),
-            new Service({name: 'service-2', deployments: []})
+            new Service({id: '1', name: 'service-1', deployments: []}),
+            new Service({id: '2', name: 'service-2', deployments: []})
           ]
         }
       ]

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -10,6 +10,7 @@ import {StoreMixin} from 'mesosphere-shared-reactjs';
 
 import AlertPanel from '../../components/AlertPanel';
 import DCOSStore from '../../stores/DCOSStore';
+import defaultServiceImage from '../../../img/services/icon-service-default-small@2x.png';
 import Icon from '../../components/Icon';
 import MarathonActions from '../../events/MarathonActions';
 import NestedServiceLinks from '../../components/NestedServiceLinks';
@@ -95,8 +96,22 @@ class DeploymentsTab extends mixin(StoreMixin) {
       <dl className="deployment-services-list flush-top flush-bottom tree-list">
         <dt className="deployment-id text-uppercase">{deployment.getId()}</dt>
         {this.renderAffectedServicesList(deployment.getAffectedServices())}
+        {this.renderStaleServicesList(deployment.getStaleServiceIds())}
       </dl>
     );
+  }
+
+  renderStaleServicesList(serviceIds) {
+    return serviceIds.map(function (serviceId, index) {
+      return (
+        <dd key={`stale_${index}`}>
+          <span className="icon icon-small icon-image-container icon-app-container deployment-service-icon">
+            <img src={defaultServiceImage} />
+          </span>
+          {serviceId}
+        </dd>
+      );
+    });
   }
 
   renderAffectedServicesList(services) {
@@ -105,7 +120,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
       const image = service.getImages()['icon-small'];
 
       return (
-        <dd key={index}>
+        <dd key={`service_${index}`}>
           <Link to="services-detail" params={{id}} className="deployment-service-name">
             <span className="icon icon-small icon-image-container icon-app-container deployment-service-icon">
               <img src={image} />

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -105,7 +105,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
     if (serviceIds == null) {
       return;
     }
-    return serviceIds.map(function (serviceId, index) {
+    return serviceIds.map(function (serviceId) {
       return (
         <dd key={`stale_${serviceId}`}>
           <span className="icon icon-small icon-image-container icon-app-container deployment-service-icon">
@@ -118,7 +118,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
   }
 
   renderAffectedServicesList(services) {
-    return services.map(function (service, index) {
+    return services.map(function (service) {
       const id = encodeURIComponent(service.getId());
       const image = service.getImages()['icon-small'];
 

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -107,7 +107,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
     }
     return serviceIds.map(function (serviceId, index) {
       return (
-        <dd key={`stale_${index}`}>
+        <dd key={`stale_${serviceId}`}>
           <span className="icon icon-small icon-image-container icon-app-container deployment-service-icon">
             <img src={defaultServiceImage} />
           </span>
@@ -123,7 +123,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
       const image = service.getImages()['icon-small'];
 
       return (
-        <dd key={`service_${index}`}>
+        <dd key={`service_${id}`}>
           <Link to="services-detail" params={{id}} className="deployment-service-name">
             <span className="icon icon-small icon-image-container icon-app-container deployment-service-icon">
               <img src={image} />

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -102,6 +102,9 @@ class DeploymentsTab extends mixin(StoreMixin) {
   }
 
   renderStaleServicesList(serviceIds) {
+    if (serviceIds == null) {
+      return;
+    }
     return serviceIds.map(function (serviceId, index) {
       return (
         <dd key={`stale_${index}`}>

--- a/src/js/stores/DCOSStore.js
+++ b/src/js/stores/DCOSStore.js
@@ -149,12 +149,17 @@ class DCOSStore extends EventEmitter {
         let services = ids.reduce(function (memo, id) {
           let service = serviceTree.findItemById(id);
           if (service != null) {
-            memo.push(service);
+            memo.affected.push(service);
+          } else {
+            memo.stale.push(id);
           }
           return memo;
-        }, []);
+        }, {affected: [], stale: []});
 
-        return Object.assign({affectedServices: services}, deployment);
+        return Object.assign({
+          affectedServices: services.affected,
+          staleServiceIds: services.stale
+        }, deployment);
       });
 
     this.emit(DCOS_CHANGE);

--- a/src/js/structs/Deployment.js
+++ b/src/js/structs/Deployment.js
@@ -25,6 +25,13 @@ module.exports = class Deployment extends Item {
   }
 
   /**
+   * @return {Array.<string>} an array of stale service IDs.
+   */
+  getStaleServiceIds() {
+    return this.get('staleServiceIds');
+  }
+
+  /**
    * @return {ServiceList} list of services affected by this deployment.
    */
   getAffectedServices() {


### PR DESCRIPTION
**Background** - when a service is deploying for the first time, rolling back its deployment removes the service configuration. When this happens it's possible for a deployment to exist with references to services which no longer exist in the `MarathonStore`/`DCOSStore`. 

**Previous behaviour** - the deployment was shown but the deleted services were not.

**New behaviour** - the deployment is show and the deleted service IDs are also shown.

![](https://s3.amazonaws.com/f.cl.ly/items/260K3A0O1c211x272b1K/Screen%20Shot%202016-07-18%20at%205.50.58%20PM.png?v=a02183f6)

Paired with @mlunoe 