### PR TITLE
Fix docs version formatting

### DIFF
--- a/src/js/stores/MetadataStore.js
+++ b/src/js/stores/MetadataStore.js
@@ -70,6 +70,7 @@ class MetadataStore extends GetSetBaseStore {
   buildDocsURI(path) {
     let metadata = this.get('dcosMetadata');
     let version = metadata && metadata.version || 'latest';
+    version = version.split('-')[0];
     let docsVersion = version.replace(/(.*?)\.(.*?)\..*/, '$1.$2');
     return `${Config.documentationURI}/${docsVersion}${path}`;
   }


### PR DESCRIPTION
Make sure we only route to major doc versions. No patch versions or prerelease (anything after `-`)