### PR TITLE
Fix dropdown arrow in Safari

### DIFF
--- a/src/js/components/SidebarLabelsFilter.js
+++ b/src/js/components/SidebarLabelsFilter.js
@@ -85,6 +85,7 @@ class SidebarLabelsFilters extends mixin(QueryParamsMixin) {
       className: 'hidden',
       id: '0',
       html: 'Labels',
+      selectedHtml: <span className="button-split-content-label">Labels</span>,
       selectable: false
     }].concat(availableLabels);
 

--- a/src/styles/components/buttons.less
+++ b/src/styles/components/buttons.less
@@ -161,6 +161,16 @@ components/buttons.less
     flex-flow: row nowrap;
     justify-content: space-between;
 
+    .button-split-content-label {
+      flex: 1 1 auto;
+      text-align: left;
+    }
+
+    &:after {
+      align-self: center;
+      flex: 0 0 auto;
+    }
+
   }
 
   .button-inverse .badge {


### PR DESCRIPTION
Fixes dropdown arrow alignment in Safari.

Before:
![](https://cl.ly/2W2O252P2k3i/Screen%20Shot%202016-07-19%20at%202.21.47%20PM.png)
After:
![](https://cl.ly/0T1H1G1Z3F0V/Screen%20Shot%202016-07-19%20at%202.18.12%20PM.png)