### PR TITLE
DCOS-8546: Reduce text on gargantuan button

### DIFF
--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -347,7 +347,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
 
   getSubmitText() {
     if (this.props.isEdit) {
-      return 'Change and deploy configuration';
+      return 'Deploy Changes';
     }
     return 'Deploy';
   }

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -25,7 +25,7 @@ describe('Service Actions', function () {
           delay: 500
         });
       cy.get('.modal .button-collection .button-success')
-        .contains('Change and deploy configuration')
+        .contains('Deploy Changes')
         .click();
       cy.get('.modal').should('to.have.length', 0);
     });


### PR DESCRIPTION
This button is too big, the designers have placed it on a restrictive diet.

![offensively large button](https://s3.amazonaws.com/f.cl.ly/items/451R1c1C131a0u230e3Q/Image%202016-07-13%20at%204.20.08%20PM.png?v=5f1ed5b4)