### PR TITLE
Change global service search headline

### DIFF
--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -249,6 +249,21 @@ var ServicesTab = React.createClass({
   },
 
   getHeadline: function (services, filteredServices, hasFiltersApplied) {
+    if (this.state.searchString) {
+      return (
+        <ul className="breadcrumb-style-headline list-unstyled list-inline inverse">
+          <li className="h4 inverse">
+            Showing results for "{this.state.searchString}"
+          </li>
+          <li className="h4 clickable" onClick={this.resetFilter}>
+            <a className="small">
+              (Clear)
+            </a>
+          </li>
+        </ul>
+      );
+    }
+
     if (hasFiltersApplied) {
       return (
         <FilterHeadline


### PR DESCRIPTION
![px](https://s3.amazonaws.com/f.cl.ly/items/2r272v0b313Z2l110e42/Image%202016-07-19%20at%203.42.47%20PM.png)

before it was: "showing 3 of 11 services". designers wanted to simply show this