### PR TITLE
DCOS-8722: Remove the id in edit mode from the jobs form add job name to title

### DIFF
--- a/src/js/components/JobForm.js
+++ b/src/js/components/JobForm.js
@@ -19,6 +19,14 @@ class JobForm extends SchemaForm {
 
   componentWillMount() {
     this.multipleDefinition = this.getNewDefinition();
+    // On edit hide the id field.
+    if (this.props.edit) {
+      this.multipleDefinition.general.definition.forEach(function (definition) {
+        if (definition.name === 'id') {
+          definition.formElementClass = 'hidden';
+        }
+      });
+    }
     this.props.getTriggerSubmit(this.handleExternalSubmit);
   }
 
@@ -44,6 +52,7 @@ JobForm.defaultProps = {
 
 JobForm.propTypes = {
   className: React.PropTypes.string,
+  edit: React.PropTypes.bool,
   getTriggerSubmit: React.PropTypes.func,
   onChange: React.PropTypes.func,
   schema: React.PropTypes.object

--- a/src/js/components/JobForm.js
+++ b/src/js/components/JobForm.js
@@ -20,7 +20,7 @@ class JobForm extends SchemaForm {
   componentWillMount() {
     this.multipleDefinition = this.getNewDefinition();
     // On edit hide the id field.
-    if (this.props.edit) {
+    if (this.props.isEdit) {
       this.multipleDefinition.general.definition.forEach(function (definition) {
         if (definition.name === 'id') {
           definition.formElementClass = 'hidden';
@@ -46,13 +46,14 @@ class JobForm extends SchemaForm {
 JobForm.defaultProps = {
   className: 'multiple-form row',
   getTriggerSubmit: function () {},
+  isEdit: false,
   onChange: function () {},
   schema: {}
 };
 
 JobForm.propTypes = {
   className: React.PropTypes.string,
-  edit: React.PropTypes.bool,
+  isEdit: React.PropTypes.bool,
   getTriggerSubmit: React.PropTypes.func,
   onChange: React.PropTypes.func,
   schema: React.PropTypes.object

--- a/src/js/components/JobForm.js
+++ b/src/js/components/JobForm.js
@@ -19,15 +19,22 @@ class JobForm extends SchemaForm {
 
   componentWillMount() {
     this.multipleDefinition = this.getNewDefinition();
+    this.props.getTriggerSubmit(this.handleExternalSubmit);
+  }
+
+  getNewDefinition() {
+    let multipleDefinition = super.getNewDefinition();
+
     // On edit hide the id field.
     if (this.props.isEdit) {
-      this.multipleDefinition.general.definition.forEach(function (definition) {
+      multipleDefinition.general.definition.forEach(function (definition) {
         if (definition.name === 'id') {
           definition.formElementClass = 'hidden';
         }
       });
     }
-    this.props.getTriggerSubmit(this.handleExternalSubmit);
+
+    return multipleDefinition;
   }
 
   getDataTriple() {

--- a/src/js/components/modals/JobFormModal.js
+++ b/src/js/components/modals/JobFormModal.js
@@ -13,6 +13,7 @@ import Job from '../../structs/Job';
 import JobForm from '../JobForm';
 import JobUtil from '../../utils/JobUtil';
 import JobSchema from '../../schemas/JobSchema';
+import StringUtil from '../../utils/StringUtil';
 import ToggleButton from '../ToggleButton';
 
 const METHODS_TO_BIND = [
@@ -247,6 +248,7 @@ class JobFormModal extends mixin(StoreMixin) {
       <JobForm
         onChange={this.handleFormChange}
         model={formModel}
+        edit={this.props.isEdit}
         schema={JobSchema} />
     );
   }
@@ -276,7 +278,7 @@ class JobFormModal extends mixin(StoreMixin) {
   getModalTitle() {
     let heading = ' New Job';
     if (this.props.isEdit) {
-      heading = 'Edit Job';
+      heading = `Edit ${StringUtil.capitalize(this.props.job.getName())}`;
     }
 
     return (

--- a/src/js/components/modals/JobFormModal.js
+++ b/src/js/components/modals/JobFormModal.js
@@ -13,7 +13,6 @@ import Job from '../../structs/Job';
 import JobForm from '../JobForm';
 import JobUtil from '../../utils/JobUtil';
 import JobSchema from '../../schemas/JobSchema';
-import StringUtil from '../../utils/StringUtil';
 import ToggleButton from '../ToggleButton';
 
 const METHODS_TO_BIND = [
@@ -278,7 +277,7 @@ class JobFormModal extends mixin(StoreMixin) {
   getModalTitle() {
     let heading = ' New Job';
     if (this.props.isEdit) {
-      heading = `Edit ${StringUtil.capitalize(this.props.job.getName())}`;
+      heading = `Edit Job (${this.props.job.getName()})`;
     }
 
     return (

--- a/src/js/components/modals/JobFormModal.js
+++ b/src/js/components/modals/JobFormModal.js
@@ -248,7 +248,7 @@ class JobFormModal extends mixin(StoreMixin) {
       <JobForm
         onChange={this.handleFormChange}
         model={formModel}
-        edit={this.props.isEdit}
+        isEdit={this.props.isEdit}
         schema={JobSchema} />
     );
   }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/156010/16987256/8a9f08c0-4e8b-11e6-82e3-de105a8752f2.png)

This will remove the id field in edit mode of the job form modal and add the job name to the title. 