### PR TITLE
Fix service table filtering

### DIFF
--- a/src/js/components/ServiceSidebarFilters.js
+++ b/src/js/components/ServiceSidebarFilters.js
@@ -20,6 +20,10 @@ function getCountByFilters(services) {
   const volumesKey = ServiceOther.VOLUMES.key;
 
   return services.reduce(function (memo, service) {
+    if (service instanceof ServiceTree) {
+      return memo;
+    }
+
     let serviceStatus = service.getServiceStatus();
     let serviceHealth = service.getHealth();
 
@@ -40,18 +44,6 @@ function getCountByFilters(services) {
         memo.otherCount[universeKey] = 1;
       } else {
         memo.otherCount[universeKey]++;
-      }
-    } else if (service instanceof ServiceTree) {
-      let frameworks = service
-        .filterItemsByFilter({other: [ServiceOther.UNIVERSE.key]})
-        .getItems();
-
-      if (frameworks.length > 0) {
-        if (memo.otherCount[universeKey] === undefined) {
-          memo.otherCount[universeKey] = 1;
-        } else {
-          memo.otherCount[universeKey]++;
-        }
       }
     }
 

--- a/src/js/structs/ServiceTree.js
+++ b/src/js/structs/ServiceTree.js
@@ -118,7 +118,9 @@ module.exports = class ServiceTree extends Tree {
         services = services.reduce(function (memo, service) {
           filter.health.forEach(function (healthValue) {
             if (service instanceof ServiceTree) {
-              memo = memo.concat(service.filterItemsByFilter({health: [healthValue]}).getItems());
+              memo = memo.concat(
+                service.filterItemsByFilter({health: [healthValue]}).getItems()
+              );
               return;
             }
 
@@ -135,7 +137,9 @@ module.exports = class ServiceTree extends Tree {
         services = services.reduce(function (memo, service) {
           filter.labels.forEach(function (label) {
             if (service instanceof ServiceTree) {
-              memo = memo.concat(service.filterItemsByFilter({labels: [label]}).getItems());
+              memo = memo.concat(
+                service.filterItemsByFilter({labels: [label]}).getItems()
+              );
               return;
             }
 
@@ -166,7 +170,9 @@ module.exports = class ServiceTree extends Tree {
           filter.other.forEach(function (otherKey) {
             if (parseInt(otherKey, 10) === ServiceOther.UNIVERSE.key) {
               if (service instanceof ServiceTree) {
-                memo = memo.concat(service.filterItemsByFilter({other: [otherKey]}).getItems());
+                memo = memo.concat(
+                  service.filterItemsByFilter({other: [otherKey]}).getItems()
+                );
               }
 
               if (service instanceof Framework) {
@@ -189,7 +195,9 @@ module.exports = class ServiceTree extends Tree {
         services = services.reduce(function (memo, service) {
           filter.status.some(function (statusValue) {
             if (service instanceof ServiceTree) {
-              memo = memo.concat(service.filterItemsByFilter({status: [statusValue]}).getItems());
+              memo = memo.concat(
+                service.filterItemsByFilter({status: [statusValue]}).getItems()
+              );
               return;
             }
 


### PR DESCRIPTION
the filtering now matches marathon-ui exactly. please try it out

before, the sidebar filtering would include groups. we no longer do that (unless you're doing a global search with the search string)

we also search through all the children now