### PR TITLE
DCOS-8414: Recalibrate checkboxes when filtered tasks changes

### DIFF
--- a/src/js/components/TaskView.js
+++ b/src/js/components/TaskView.js
@@ -126,7 +126,10 @@ class TaskView extends mixin(SaveStateMixin, StoreMixin) {
     return this.state.mesosStateErrorCount >= 5;
   }
 
-  getFilteredTasks(filterByStatus, tasks, searchString) {
+  getFilteredTasks() {
+    let {tasks} = this.props;
+    let {filterByStatus, searchString} = this.state;
+
     if (searchString !== '') {
       tasks = StringUtil.filterByString(tasks, 'id', searchString);
     }
@@ -241,7 +244,7 @@ class TaskView extends mixin(SaveStateMixin, StoreMixin) {
       });
     });
 
-    tasks = this.getFilteredTasks(filterByStatus, tasks, searchString);
+    tasks = this.getFilteredTasks();
 
     let rightAlignLastNChildren = 0;
     let hasCheckedTasks = Object.keys(checkedItems).length !== 0;

--- a/src/js/components/TaskView.js
+++ b/src/js/components/TaskView.js
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import deepEqual from 'deep-equal';
 import mixin from 'reactjs-mixin';
 import React from 'react';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
@@ -58,6 +59,23 @@ class TaskView extends mixin(SaveStateMixin, StoreMixin) {
   componentWillMount() {
     this.saveState_key = `taskView#${this.props.itemID}`;
     super.componentWillMount();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    let tasks = this.filterByCurrentStatus(nextProps.tasks);
+    let prevTasks = this.filterByCurrentStatus(this.props.tasks);
+
+    if (!deepEqual(tasks, prevTasks)) {
+      let checkedItems = {};
+
+      tasks.forEach(function (task) {
+        if (prevTasks[task.id]) {
+          checkedItems[task.id] = true;
+        }
+      });
+
+      this.setState({checkedItems});
+    }
   }
 
   onStateStoreSuccess() {

--- a/src/js/components/TaskView.js
+++ b/src/js/components/TaskView.js
@@ -1,5 +1,4 @@
 import classNames from 'classnames';
-import deepEqual from 'deep-equal';
 import mixin from 'reactjs-mixin';
 import React from 'react';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
@@ -62,21 +61,16 @@ class TaskView extends mixin(SaveStateMixin, StoreMixin) {
   }
 
   componentWillReceiveProps(nextProps) {
-    let {filterByStatus, searchString} = this.state;
-    let tasks = this.getFilteredTasks(filterByStatus, nextProps.tasks, searchString);
-    let prevTasks = this.getFilteredTasks(filterByStatus, this.props.tasks, searchString);
+    let prevCheckedItems = this.state.checkedItems;
+    let checkedItems = {};
 
-    if (!deepEqual(tasks, prevTasks)) {
-      let checkedItems = {};
+    nextProps.tasks.forEach(function (task) {
+      if (prevCheckedItems[task.id]) {
+        checkedItems[task.id] = true;
+      }
+    });
 
-      tasks.forEach(function (task) {
-        if (prevTasks[task.id]) {
-          checkedItems[task.id] = true;
-        }
-      });
-
-      this.setState({checkedItems});
-    }
+    this.setState({checkedItems});
   }
 
   onStateStoreSuccess() {

--- a/src/js/components/TaskView.js
+++ b/src/js/components/TaskView.js
@@ -112,16 +112,6 @@ class TaskView extends mixin(SaveStateMixin, StoreMixin) {
     this.setState({checkedItems: {}, killAction: ''});
   }
 
-  filterByCurrentStatus(tasks, filterByStatus) {
-    if (filterByStatus === 'all') {
-      return tasks;
-    }
-
-    return tasks.filter(function (task) {
-      return TaskStates[task.state].stateTypes.includes(filterByStatus);
-    });
-  }
-
   hasLoadingError() {
     return this.state.mesosStateErrorCount >= 5;
   }
@@ -134,7 +124,11 @@ class TaskView extends mixin(SaveStateMixin, StoreMixin) {
       tasks = StringUtil.filterByString(tasks, 'id', searchString);
     }
 
-    tasks = this.filterByCurrentStatus(tasks, filterByStatus);
+    if (filterByStatus !== 'all') {
+      tasks = tasks.filter(function (task) {
+        return TaskStates[task.state].stateTypes.includes(filterByStatus);
+      });
+    }
 
     return tasks;
   }
@@ -232,8 +226,7 @@ class TaskView extends mixin(SaveStateMixin, StoreMixin) {
   getContent() {
     let {inverseStyle, tasks} = this.props;
     let {checkedItems, filterByStatus, searchString} = this.state;
-
-    let totalNumberOfTasks = tasks.length;
+    let filteredTasks = this.getFilteredTasks();
 
     // Get task states based on TaskStates types
     let taskStates = tasks.map(function (task) {
@@ -244,10 +237,9 @@ class TaskView extends mixin(SaveStateMixin, StoreMixin) {
       });
     });
 
-    tasks = this.getFilteredTasks();
-
     let rightAlignLastNChildren = 0;
     let hasCheckedTasks = Object.keys(checkedItems).length !== 0;
+
     if (hasCheckedTasks) {
       rightAlignLastNChildren = 1;
     }
@@ -255,12 +247,12 @@ class TaskView extends mixin(SaveStateMixin, StoreMixin) {
     return (
       <div className="flex-container-col flex-grow">
         <FilterHeadline
-          currentLength={tasks.length}
+          currentLength={filteredTasks.length}
           inverseStyle={inverseStyle}
           isFiltering={filterByStatus !== 'all' || searchString !== ''}
           onReset={this.resetFilter}
           name="Task"
-          totalLength={totalNumberOfTasks} />
+          totalLength={tasks.length} />
         <FilterBar rightAlignLastNChildren={rightAlignLastNChildren}>
           <FilterInputText
             className="flush-bottom"
@@ -276,7 +268,7 @@ class TaskView extends mixin(SaveStateMixin, StoreMixin) {
             selectedFilter={filterByStatus} />
           {this.getKillButtons(hasCheckedTasks)}
         </FilterBar>
-        {this.getTaskTable(tasks, checkedItems)}
+        {this.getTaskTable(filteredTasks, checkedItems)}
         {this.getKillTaskModal(checkedItems, hasCheckedTasks)}
       </div>
     );


### PR DESCRIPTION
Bug fix for TaskTable checkboxes not updating when task table gets new tasks/loses tasks:

![checkbox confusion](https://cl.ly/3M3H0u1b3Q2j/Screen%20Recording%202016-07-07%20at%2004.40%20PM.gif)