### PR TITLE
Fix for out-of-date service status

### DIFF
--- a/src/js/stores/DCOSStore.js
+++ b/src/js/stores/DCOSStore.js
@@ -178,12 +178,20 @@ class DCOSStore extends EventEmitter {
   onMarathonQueueChange(nextQueue) {
     let {marathon:{queue}} = this.data;
 
+    let queuedAppIDs = [];
     nextQueue.forEach((entry) => {
       if (entry.app == null) {
         return;
       }
 
+      queuedAppIDs.push(entry.app.id);
       queue.set(entry.app.id, entry);
+    });
+
+    queue.forEach((entry) => {
+      if (queuedAppIDs.indexOf(entry.app.id) === -1) {
+        queue.delete(entry.app.id);
+      }
     });
 
     this.emit(DCOS_CHANGE);

--- a/src/js/stores/__tests__/DCOSStore-test.js
+++ b/src/js/stores/__tests__/DCOSStore-test.js
@@ -242,6 +242,14 @@ describe('DCOSStore', function () {
         .toEqual('Delayed');
     });
 
+    it('should correctly convert running apps from waiting state', function () {
+      expect(DCOSStore.serviceTree.getItems()[0].getStatus())
+        .toEqual('Waiting');
+      DCOSStore.onMarathonQueueChange([]);
+      expect(DCOSStore.serviceTree.getItems()[0].getStatus())
+        .not.toEqual('Waiting');
+    });
+
   });
 
   describe('#processMarathonServiceVersion', function () {

--- a/src/js/structs/Service.js
+++ b/src/js/structs/Service.js
@@ -161,7 +161,7 @@ module.exports = class Service extends Item {
       return ServiceStatus.DELAYED;
     }
 
-    if (deployments.length > 0) {
+    if (deployments != null && deployments.length > 0) {
       return ServiceStatus.DEPLOYING;
     }
 

--- a/src/js/structs/__tests__/Service-test.js
+++ b/src/js/structs/__tests__/Service-test.js
@@ -457,6 +457,17 @@ describe('Service', function () {
         .toEqual(ServiceStatus.NA);
     });
 
+    it('tolerates a missing deployments field', function () {
+      let service = new Service({
+        tasksStaged: 0,
+        tasksRunning: 0,
+        tasksHealthy: 0,
+        tasksUnhealthy: 0,
+        instances: 1
+      });
+      expect(service.getServiceStatus.bind(service)).not.toThrow();
+    });
+
   });
 
   describe('#getLastTaskFailure', function () {


### PR DESCRIPTION
This PR introduces a check on every queue update to make sure that services are not incorrectly marked as queued. This fixes several apparent bugs in which service metadata appeared to have become out of date. 

Before/after:
![](https://s3.amazonaws.com/f.cl.ly/items/3J1R3w2t113Z1T141V3O/Screen%20Recording%202016-07-21%20at%2005.09%20PM.gif?v=9365c4a4)