### PR TITLE
Fix hidden page content due to shrinking page content

### DIFF
--- a/src/styles/components/scrollbar.less
+++ b/src/styles/components/scrollbar.less
@@ -35,6 +35,7 @@
 }
 
 .gm-prevented {
+  flex: 1 1 auto;
   overflow: auto;
 }
 


### PR DESCRIPTION
This PR fixes a bug where the page component content (`.page-content`) wouldn't grow to fill its parent when the user's OS has native overlay scrollbars.

I tested it in Chrome, Firefox, Safari, and IE11/Edge, but this seemingly innocuous change has the potential to break scrolling so it's worth being tested by others.

On OS X, you can toggle the overlay scrollbars vs. "normal" scrollbars in System Preferences > General:
![](https://cl.ly/2v1T053c0K0v/Screen%20Shot%202016-07-22%20at%209.35.11%20AM.png)

If you're using a mouse, set it to "when scrolling" and you'll get overlay scrollbars. If you're using a trackpad, set it to "Automatically..." or "when scrolling."