### PR TITLE
Fix split-content-button for Firefox

### DIFF
--- a/src/js/components/ServiceDetailConfigurationTab.js
+++ b/src/js/components/ServiceDetailConfigurationTab.js
@@ -136,9 +136,12 @@ class ServiceDetailConfigurationTab extends React.Component {
       versionItems.push({
         id: version,
         html: (
-          <span className="text-overflow" title={itemCaption}>
-            {itemCaption}
-          </span>
+          <div className="button-split-content-wrapper">
+            <span className="button-split-content-item text-overflow"
+              title={itemCaption}>
+              {itemCaption}
+            </span>
+          </div>
         )
       });
     }

--- a/src/js/components/SidebarLabelsFilter.js
+++ b/src/js/components/SidebarLabelsFilter.js
@@ -74,9 +74,12 @@ class SidebarLabelsFilters extends mixin(QueryParamsMixin) {
       return Object.assign({}, label, {
         id: `filter-label-${i}`,
         html: (
-          <a className="text-overflow" title={labelText}>
-            {labelText}
-          </a>
+          <div className="button-split-content-wrapper">
+            <a className="button-split-content-item text-overflow"
+              title={labelText}>
+              {labelText}
+            </a>
+          </div>
         )
       });
     });
@@ -84,8 +87,13 @@ class SidebarLabelsFilters extends mixin(QueryParamsMixin) {
     let labelOptions = [{
       className: 'hidden',
       id: '0',
-      html: 'Labels',
-      selectedHtml: <span className="button-split-content-label">Labels</span>,
+      html: (
+        <div className="button-split-content-wrapper">
+          <span className="button-split-content-item">
+            Labels
+          </span>
+        </div>
+      ),
       selectable: false
     }].concat(availableLabels);
 

--- a/src/styles/components/buttons.less
+++ b/src/styles/components/buttons.less
@@ -155,11 +155,18 @@ components/buttons.less
   }
 
   .button-split-content {
+    text-align: left;
 
-    align-items: center;
-    display: flex;
-    flex-flow: row nowrap;
-    justify-content: space-between;
+    .button-split-content-wrapper {
+      align-items: center;
+      display: flex;
+      flex-flow: row nowrap;
+      justify-content: space-between;
+    }
+
+    .button-split-content-item {
+      flex: 0 0 auto;
+    }
 
     .button-split-content-label {
       flex: 1 1 auto;

--- a/src/styles/components/dropdown-menus.less
+++ b/src/styles/components/dropdown-menus.less
@@ -64,6 +64,39 @@ components/dropdown-menus.less
   .dropdown-toggle {
     white-space: nowrap;
 
+    &.button-split-content {
+
+      &:after {
+        display: none;
+      }
+
+      .button-split-content-wrapper {
+
+        .button-split-content-item {
+
+          &:first-child {
+            flex-grow: 1;
+          }
+        }
+
+        &:after {
+          &:extend(.button.dropdown-toggle:after all);
+          margin-top: 0;
+        }
+      }
+
+      &.button-inverse {
+
+        .button-split-content-wrapper {
+
+          &:after {
+            &:extend(.button.button-inverse.dropdown-toggle:after all);
+            margin-top: 0;
+          }
+        }
+      }
+    }
+
     .badge-container {
 
       display: inline-flex;


### PR DESCRIPTION
Firefox doesn't support `display: flex;` for `button` elements ([read about it](https://bugzilla.mozilla.org/show_bug.cgi?id=984869#c2)), so this circumvents the issue by adding additional DOM nodes which receive the appropriate `flex` properties.

Tested in IE10/Edge, Safari, Firefox, and the ever-so-lovely Chrome.