### PR TITLE
Remove Kenny from maintainer list

### DIFF
--- a/Authors.md
+++ b/Authors.md
@@ -13,4 +13,4 @@ Pierluigi Cau | pierlo@mesosphere.com | Current Maintainer
 Philipp Hinrichsen | philipph@mesosphere.com | Current Maintainer
 Philip Norman | philip@mesosphere.com | Current Maintainer
 Felix Gertz | felix@mesosphere.com | Current Maintainer
-Kenny Tran | kennyt8tran@gmail.com | Contributor
+Kenny Tran | kenny8tran@gmail.com | Contributor

--- a/Authors.md
+++ b/Authors.md
@@ -7,10 +7,10 @@ Rafael Corral | rafael@mesosphere.com | Current Maintainer
 Michael Lunøe | mlunoe@mesosphere.com | Current Maintainer
 John Furrow | johnf@mesosphere.com | Current Maintainer
 Chris Sun | christine.sun@mesosphere.com | Current Maintainer
-Kenny Tran | kennyt@mesosphere.com | Current Maintainer
 Mat Appelman | mat@mesosphere.com | Current Maintainer
 Orlando Hohmeier | orlando@mesosphere.com | Current Maintainer
 Pierluigi Cau | pierlo@mesosphere.com | Current Maintainer
 Philipp Hinrichsen | philipph@mesosphere.com | Current Maintainer
 Philip Norman | philip@mesosphere.com | Current Maintainer
 Felix Gertz | felix@mesosphere.com | Current Maintainer
+Kenny Tran | kennyt8tran@gmail.com | Contributor


### PR DESCRIPTION
I changed `Current Maintainer` to `Contributor`. If you guys only want maintainers in the file, feel free to remove me