### PR TITLE
Memoize task IDs

### DIFF
--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -37,7 +37,8 @@ class MesosStateStore extends GetSetBaseStore {
     super(...arguments);
 
     this.getSet_data = {
-      lastMesosState: {}
+      lastMesosState: {},
+      taskCache: {}
     };
 
     this.dispatcherIndex = AppDispatcher.register((payload) => {
@@ -147,8 +148,12 @@ class MesosStateStore extends GetSetBaseStore {
   }
 
   getTaskFromTaskID(taskID) {
+    let taskCache = this.get('taskCache');
+    let foundTask = taskCache[taskID];
+    if (foundTask != null) {
+      return foundTask;
+    }
     let services = this.get('lastMesosState').frameworks;
-    let foundTask = null;
 
     services.some(function (service) {
       let tasks = service.tasks.concat(service.completed_tasks);
@@ -164,6 +169,7 @@ class MesosStateStore extends GetSetBaseStore {
       return null;
     }
 
+    taskCache[taskID] = foundTask;
     return new Task(foundTask);
   }
 
@@ -260,7 +266,7 @@ class MesosStateStore extends GetSetBaseStore {
 
   processStateSuccess(lastMesosState) {
     CompositeState.addState(lastMesosState);
-    this.set({lastMesosState});
+    this.set({lastMesosState, taskCache: {}});
     this.emit(MESOS_STATE_CHANGE);
   }
 

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -151,7 +151,7 @@ class MesosStateStore extends GetSetBaseStore {
     let taskCache = this.get('taskCache');
     let foundTask = taskCache[taskID];
     if (foundTask != null) {
-      return foundTask;
+      return new Task(foundTask);
     }
     let services = this.get('lastMesosState').frameworks;
 
@@ -169,8 +169,10 @@ class MesosStateStore extends GetSetBaseStore {
       return null;
     }
 
-    taskCache[taskID] = foundTask;
-    return new Task(foundTask);
+    let result = new Task(foundTask);
+    taskCache[taskID] = result;
+
+    return result;
   }
 
   getSchedulerTaskFromServiceName(serviceName) {

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -147,6 +147,11 @@ describe('MesosStateStore', function () {
       MesosStateStore.get = this.get;
     });
 
+    it('should return null from an unknown task ID', function () {
+      var result = MesosStateStore.getTaskFromTaskID('not-a-task-id');
+      expect(result).toBeNull();
+    });
+
     it('should return an instance of Task', function () {
       var result = MesosStateStore.getTaskFromTaskID(1);
       expect(result instanceof Task).toBeTruthy();

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -127,13 +127,19 @@ describe('MesosStateStore', function () {
   describe('#getTaskFromTaskID', function () {
     beforeEach(function () {
       this.get = MesosStateStore.get;
-      MesosStateStore.get = function () {
-        return {
-          frameworks: [{
-            tasks: [{id: 1}],
-            completed_tasks: [{id: 2}]
-          }]
-        };
+      let data = {
+        frameworks: [{
+          tasks: [{id: 1}],
+          completed_tasks: [{id: 2}]
+        }]
+      };
+      MesosStateStore.processStateSuccess(data);
+      let taskCache = MesosStateStore.indexTasksByID(data);
+      MesosStateStore.get = function (id) {
+        if (id === 'taskCache') {
+          return taskCache;
+        }
+        return data;
       };
     });
 


### PR DESCRIPTION
This is the simplest possible implementation of a task ID cache - we simply memoize in order to make repeated calls to `getTaskByTaskID(taskID)` inexpensive. 

Potential improvements: smarter cache-busting (we bust on every poll at present); denormalization on data load. 