### PR TITLE
Call #getSchedules only if we are rendering a job

### DIFF
--- a/src/js/pages/jobs/JobsTable.js
+++ b/src/js/pages/jobs/JobsTable.js
@@ -69,10 +69,12 @@ class JobsTable extends React.Component {
     return this.props.jobs.map(function (job) {
       let isGroup = job instanceof Tree;
       let lastRunStatus = null;
+      let schedules = null;
       let status = null;
 
       if (!isGroup) {
         lastRunStatus = job.getLastRunStatus().status;
+        schedules = job.getSchedules();
         status = job.getScheduleStatus();
       }
 
@@ -80,7 +82,7 @@ class JobsTable extends React.Component {
         id: job.getId(),
         isGroup,
         name: job.getName(),
-        schedules: job.getSchedules(),
+        schedules,
         status,
         lastRunStatus
       };


### PR DESCRIPTION
Fixes failing integration tests.
![](https://cl.ly/2i0b3G472A2q/Screen%20Shot%202016-07-25%20at%202.11.46%20PM.png)