### PR TITLE
Copy changes to volumes tab

### DIFF
--- a/src/js/schemas/service-schema/Volumes.js
+++ b/src/js/schemas/service-schema/Volumes.js
@@ -46,7 +46,7 @@ const Volumes = {
       }
     },
     dockerVolumes: {
-      title: 'Docker Volumes',
+      title: 'Docker Container Volumes',
       description: (
         <span>
           Create a stateful application using Docker volumes. <a href="https://docs.docker.com/engine/tutorials/dockervolumes/" target="_blank">Learn more about Docker volumes.</a>
@@ -103,7 +103,7 @@ const Volumes = {
       ),
       type: 'array',
       duplicable: true,
-      addLabel: 'Add Network Volume',
+      addLabel: 'Add External Volume',
       getter: function (service) {
         let containerSettings = service.getContainerSettings();
 
@@ -123,7 +123,7 @@ const Volumes = {
       itemShape: {
         properties: {
           externalName: {
-            title: 'External Name',
+            title: 'Volume Name',
             type: 'string'
           },
           containerPath: {


### PR DESCRIPTION
`Add Network Volume` > `Add External Volume`

`Docker Volumes` > `Docker Container Volumes`

`External Name` > `Volume Name`

Changes reflect Marathon today, and we no longer refer to external as network volumes.

![image](https://cloud.githubusercontent.com/assets/15963/17156523/25fd1002-533f-11e6-9d7f-bfc8c3f3f777.png)
