### PR TITLE
Using the h4 class to not have nested header elements

### DIFF
--- a/src/js/components/modals/JobFormModal.js
+++ b/src/js/components/modals/JobFormModal.js
@@ -283,9 +283,9 @@ class JobFormModal extends mixin(StoreMixin) {
     return (
       <div className="header-flex">
         <div className="header-left">
-          <h4 className="flush-top flush-bottom text-color-neutral">
+          <span className="h4 flush-top flush-bottom text-color-neutral">
             {heading}
-          </h4>
+          </span>
         </div>
         <div className="header-right">
           <ToggleButton

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -467,9 +467,9 @@ class ServiceFormModal extends mixin(StoreMixin) {
     let title = (
       <div className="header-flex">
         <div className="header-left">
-          <h4 className="flush-top flush-bottom text-color-neutral">
+          <span className="h4 flush-top flush-bottom text-color-neutral">
             {titleText}
-          </h4>
+          </span>
         </div>
         <div className="header-right">
           <ToggleButton


### PR DESCRIPTION
This is a quick fix to not have nested header element. We need to look into making the modal header able to do what we need it to do, and this is a symptom of it.