### PR TITLE
Show progress bars in deployments

### DIFF
--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -15,6 +15,7 @@ import Icon from '../../components/Icon';
 import MarathonActions from '../../events/MarathonActions';
 import NestedServiceLinks from '../../components/NestedServiceLinks';
 import ResourceTableUtil from '../../utils/ResourceTableUtil';
+import StatusBar from '../../components/StatusBar';
 import StringUtil from '../../utils/StringUtil';
 import TimeAgo from '../../components/TimeAgo';
 
@@ -171,6 +172,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
     const currentStep = deployment.getCurrentStep();
     const totalSteps = deployment.getTotalSteps();
     const title = `Step ${currentStep} of ${totalSteps}`;
+    const statusBar = this.renderStatusBar(currentStep, totalSteps);
     const services = deployment.getAffectedServices();
 
     let currentActions = {};
@@ -198,9 +200,24 @@ class DeploymentsTab extends mixin(StoreMixin) {
 
     return (
       <div>
+        {statusBar}
         <span className="deployment-step">{title}</span>
         <ol className="deployment-status-list list-unstyled flush-bottom">{items}</ol>
       </div>
+    );
+  }
+
+  renderStatusBar(currentStep, totalSteps) {
+    let data = [
+      {className: 'color-4', value: currentStep - 1},
+      {className: 'staged', value: 1},
+      {className: '', value: totalSteps - currentStep}
+    ];
+
+    return (
+      <StatusBar
+        className="progress-bar flex-box status-bar deployment-status-bar"
+        data={data} />
     );
   }
 

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -168,7 +168,9 @@ class DeploymentsTab extends mixin(StoreMixin) {
   }
 
   renderStatus(prop, deployment) {
-    const title = `Step ${deployment.getCurrentStep()} of ${deployment.getTotalSteps()}`;
+    const currentStep = deployment.getCurrentStep();
+    const totalSteps = deployment.getTotalSteps();
+    const title = `Step ${currentStep} of ${totalSteps}`;
     const services = deployment.getAffectedServices();
 
     let currentActions = {};

--- a/src/styles/components/deployments-table.less
+++ b/src/styles/components/deployments-table.less
@@ -47,6 +47,7 @@
 
   .deployment-step {
     display: inline-block;
+    margin-left: @base-spacing-unit * 0.25;
     margin-bottom: 8px;
   }
   .deployment-status-list {


### PR DESCRIPTION
NB: I've used the existing progress bar styles for the deployments progress bar, which aren't exactly the same as the design. I'd like to update all progress bars to SVG eventually in order to address the disparity there. 

Design:
![design](https://cloud.githubusercontent.com/assets/2989362/17200824/5d0ad8e6-543d-11e6-9655-5f4f6aa0dae1.png)

Implementation:
![implementation](https://cloud.githubusercontent.com/assets/2989362/17200826/6149dfa6-543d-11e6-8abe-8aecf763e04d.png)
