### PR TITLE
DCOS-8392 Update Jobs struct to get last run status from history

### DIFF
--- a/src/js/constants/JobTableHeaderLables.js
+++ b/src/js/constants/JobTableHeaderLables.js
@@ -1,7 +1,7 @@
 const JobTableHeaderLabels = {
   name: 'JOB NAME',
   status: 'STATUS',
-  lastRunStatus: 'LAST RUN'
+  lastRun: 'LAST RUN'
 };
 
 module.exports = JobTableHeaderLabels;

--- a/src/js/events/MetronomeActions.js
+++ b/src/js/events/MetronomeActions.js
@@ -53,7 +53,8 @@ const MetronomeActions = {
           url: `${Config.metronomeAPI}/v1/jobs`,
           data: [
             {name: 'embed', value: 'activeRuns'},
-            {name: 'embed', value: 'schedules'}
+            {name: 'embed', value: 'schedules'},
+            {name: 'embed', value: 'history'}
           ],
           success: function (response) {
             try {

--- a/src/js/pages/jobs/JobsTable.js
+++ b/src/js/pages/jobs/JobsTable.js
@@ -73,7 +73,7 @@ class JobsTable extends React.Component {
       let status = null;
 
       if (!isGroup) {
-        let lastRunsSummary= job.getLastRunsSummary();
+        let lastRunsSummary = job.getLastRunsSummary();
 
         lastRun = {
           status: job.getLastRunStatus().status,

--- a/src/js/pages/jobs/JobsTable.js
+++ b/src/js/pages/jobs/JobsTable.js
@@ -58,7 +58,7 @@ class JobsTable extends React.Component {
         className,
         heading,
         headerClassName: className,
-        prop: 'lastRunStatus',
+        prop: 'lastRun',
         render: this.renderLastRunStatusColumn
       }
     ];
@@ -68,12 +68,19 @@ class JobsTable extends React.Component {
   getData() {
     return this.props.jobs.map(function (job) {
       let isGroup = job instanceof Tree;
-      let lastRunStatus = null;
+      let lastRun = null;
       let schedules = null;
       let status = null;
 
       if (!isGroup) {
-        lastRunStatus = job.getLastRunStatus().status;
+        let lastRunsSummary= job.getLastRunsSummary();
+
+        lastRun = {
+          status: job.getLastRunStatus().status,
+          lastSuccessAt: lastRunsSummary.lastSuccessAt,
+          lastFailureAt: lastRunsSummary.lastFailureAt
+        };
+
         schedules = job.getSchedules();
         status = job.getScheduleStatus();
       }
@@ -84,7 +91,7 @@ class JobsTable extends React.Component {
         name: job.getName(),
         schedules,
         status,
-        lastRunStatus
+        lastRun
       };
     });
   }
@@ -176,13 +183,43 @@ class JobsTable extends React.Component {
   }
 
   renderLastRunStatusColumn(prop, row) {
-    let value = row[prop];
+    let {lastFailureAt, lastSuccessAt, status} = row[prop];
     let statusClasses = classNames({
-      'text-success': value === 'Success',
-      'text-danger': value === 'Failed'
+      'text-success': status === 'Success',
+      'text-danger': status === 'Failed'
     });
+    let nodes = [];
+    let statusNode = <span className={statusClasses}>{status}</span>;
 
-    return <span className={statusClasses}>{value}</span>;
+    if (lastFailureAt == null && lastSuccessAt == null) {
+      return statusNode;
+    }
+
+    if (lastSuccessAt != null) {
+      nodes.push(
+        <p className="flush-bottom" key="tooltip-success-at">
+          <span className="text-success">Last Success: </span>
+          {new Date(lastSuccessAt).toLocaleString()}
+        </p>
+      );
+    }
+
+    if (lastFailureAt != null) {
+      nodes.push(
+        <p className="flush-bottom" key="tooltip-failure-at">
+          <span className="text-danger">Last Failure: </span>
+          {new Date(lastFailureAt).toLocaleString()}
+        </p>
+      );
+    }
+
+    return (
+      <Tooltip
+        wrapperClassName="tooltip-wrapper"
+        content={nodes}>
+        {statusNode}
+      </Tooltip>
+    );
   }
 
   renderStatusColumn(prop, {[prop]:statusKey, isGroup}) {

--- a/src/js/structs/Job.js
+++ b/src/js/structs/Job.js
@@ -62,8 +62,13 @@ module.exports = class Job extends Item {
     return mem;
   }
 
+  // TODO DCOS-8898 only get history summary
+  getLastRunsSummary() {
+    return this.get('history') || {};
+  }
+
   getLastRunStatus() {
-    let {lastFailureAt, lastSuccessAt} = this.get('history') || {};
+    let {lastFailureAt, lastSuccessAt} = this.getLastRunsSummary();
     let status = 'N/A';
     let time = null;
 

--- a/src/js/structs/Job.js
+++ b/src/js/structs/Job.js
@@ -63,7 +63,7 @@ module.exports = class Job extends Item {
   }
 
   getLastRunStatus() {
-    let {lastFailureAt = null, lastSuccessAt = null} = this.getStatus();
+    let {lastFailureAt, lastSuccessAt} = this.get('history') || {};
     let status = 'N/A';
     let time = null;
 
@@ -121,7 +121,4 @@ module.exports = class Job extends Item {
     return 'COMPLETED';
   }
 
-  getStatus() {
-    return this.get('status') || {};
-  }
 };

--- a/src/js/structs/__tests__/Job-test.js
+++ b/src/js/structs/__tests__/Job-test.js
@@ -230,7 +230,7 @@ describe('Job', function () {
     it('returns an object with the time in ms', function () {
       let job = new Job({
         id: 'test.job',
-        status: {
+        history: {
           lastSuccessAt: '1990-04-30T00:00:00Z',
           lastFailureAt: '1985-04-30T00:00:00Z'
         }
@@ -242,7 +242,7 @@ describe('Job', function () {
     it('returns the most recent status', function () {
       let job = new Job({
         id: 'test.job',
-        status: {
+        history: {
           lastSuccessAt: '1990-04-30T00:00:00Z',
           lastFailureAt: '1985-04-30T00:00:00Z'
         }
@@ -254,7 +254,7 @@ describe('Job', function () {
     it('returns the most recent status', function () {
       let job = new Job({
         id: 'test.job',
-        status: {
+        history: {
           lastSuccessAt: '1985-04-30T00:00:00Z',
           lastFailureAt: '1990-04-30T00:00:00Z'
         }
@@ -266,7 +266,7 @@ describe('Job', function () {
     it('returns N/A status if both are undefiend', function () {
       let job = new Job({
         id: 'test.job',
-        status: {}
+        history: {}
       });
 
       expect(job.getLastRunStatus().status).toEqual('N/A');
@@ -276,7 +276,7 @@ describe('Job', function () {
     it('returns success if lastFailureAt is undefiend', function () {
       let job = new Job({
         id: 'test.job',
-        status: {
+        history: {
           lastSuccessAt: '1990-04-30T00:00:00Z'
         }
       });
@@ -287,7 +287,7 @@ describe('Job', function () {
     it('returns success if lastSuccessAt is undefiend', function () {
       let job = new Job({
         id: 'test.job',
-        status: {
+        history: {
           lastFailureAt: '1990-04-30T00:00:00Z'
         }
       });
@@ -372,29 +372,6 @@ describe('Job', function () {
       });
 
       expect(job.getScheduleStatus()).toEqual('UNSCHEDULED');
-    });
-
-  });
-
-  describe('#getStatus', function () {
-
-    it('returns the status key', function () {
-      let job = new Job({
-        id: '/foo',
-        status: {
-          lastRunAt: 0
-        }
-      });
-
-      expect(job.getStatus()).toEqual({lastRunAt: 0});
-    });
-
-    it('returns empty object when status is undefined', function () {
-      let job = new Job({
-        id: '/foo'
-      });
-
-      expect(job.getStatus()).toEqual({});
     });
 
   });

--- a/tests/_fixtures/metronome/jobs.json
+++ b/tests/_fixtures/metronome/jobs.json
@@ -63,7 +63,7 @@
         "activeDeadlineSeconds": 120
       }
     },
-    "status": {
+    "history": {
       "successCount": 1,
       "failureCount": 1,
       "lastSuccessAt": "1990-01-02T00:00:00Z",
@@ -138,7 +138,7 @@
         "activeDeadlineSeconds": 120
       }
     },
-    "status": {
+    "history": {
       "successCount": 1,
       "failureCount": 1,
       "lastSuccessAt": "1990-01-02T00:00:00Z",
@@ -230,7 +230,7 @@
         "activeDeadlineSeconds": 120
       }
     },
-    "status": {
+    "history": {
       "successCount": 1,
       "failureCount": 0,
       "lastSuccessAt": "1990-01-02T00:00:00Z",
@@ -317,7 +317,7 @@
         "activeDeadlineSeconds": 120
       }
     },
-    "status": {
+    "history": {
       "successCount": 1,
       "failureCount": 1,
       "lastSuccessAt": "1990-01-02T00:00:00Z",


### PR DESCRIPTION
The API introduced a change where the status property is removed and we
need to embed the history to grab the last run status.

![screen shot 2016-07-28 at 14 40 26](https://cloud.githubusercontent.com/assets/1078545/17212782/7d263b22-54d1-11e6-8382-366dff13354c.png)

Relevant tests are passing:

![screen shot 2016-07-28 at 14 40 17](https://cloud.githubusercontent.com/assets/1078545/17212785/7f14084c-54d1-11e6-990b-18b6dee8226d.png)
