### PR TITLE
DCOS-8588: Allow dropdown menus to appear outside of scrolling containers

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5425,9 +5425,9 @@
       "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz"
     },
     "reactjs-components": {
-      "version": "0.14.0-beta.33",
-      "from": "reactjs-components@0.14.0-beta.33",
-      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.14.0-beta.33.tgz"
+      "version": "0.14.0-beta.36",
+      "from": "reactjs-components@0.14.0-beta.36",
+      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.14.0-beta.36.tgz"
     },
     "reactjs-mixin": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-gemini-scrollbar": "2.1.0",
     "react-redux": "4.4.0",
     "react-router": "0.13.5",
-    "reactjs-components": "0.14.0-beta.33",
+    "reactjs-components": "0.14.0-beta.36",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
     "tv4": "1.2.7",

--- a/plugins/oauth/components/UserDropup.js
+++ b/plugins/oauth/components/UserDropup.js
@@ -182,6 +182,8 @@ class UserDropup extends mixin(StoreMixin) {
           dropdownMenuListClassName="dropdown-menu-list"
           items={this.getDropdownMenu(userMenuItems)}
           persistentID="default-item"
+          scrollContainer=".gm-scroll-view"
+          scrollContainerParentSelector=".gm-prevented"
           transition={true}
           wrapperClassName="sidebar-footer-user-dropdown dropdown" />
         <div className="open">

--- a/src/js/components/FilterByFormTab.js
+++ b/src/js/components/FilterByFormTab.js
@@ -51,6 +51,8 @@ class FilterByFormTab extends React.Component {
         items={this.getDropdownItems()}
         onItemSelection={this.onItemSelection}
         persistentID={this.props.currentTab}
+        scrollContainer=".gm-scroll-view"
+        scrollContainerParentSelector=".gm-prevented"
         transition={true}
         transitionName="dropdown-menu" />
     );

--- a/src/js/components/FilterByService.js
+++ b/src/js/components/FilterByService.js
@@ -102,6 +102,8 @@ var FilterByService = React.createClass({
         initialID={this.getSelectedId(this.props.byServiceFilter)}
         onItemSelection={this.handleItemSelection}
         ref={(ref) => this.dropdown = ref}
+        scrollContainer=".gm-scroll-view"
+        scrollContainerParentSelector=".gm-prevented"
         transition={true}
         transitionName="dropdown-menu" />
     );

--- a/src/js/components/FilterByTaskState.js
+++ b/src/js/components/FilterByTaskState.js
@@ -68,6 +68,8 @@ class FilterByTaskState extends React.Component {
         items={this.getDropdownItems()}
         onItemSelection={this.onItemSelection}
         persistentID={currentStatus}
+        scrollContainer=".gm-scroll-view"
+        scrollContainerParentSelector=".gm-prevented"
         transition={true}
         transitionName="dropdown-menu" />
     );

--- a/src/js/components/ServiceDetailConfigurationTab.js
+++ b/src/js/components/ServiceDetailConfigurationTab.js
@@ -156,6 +156,8 @@ class ServiceDetailConfigurationTab extends React.Component {
         key="version-dropdown"
         onItemSelection={this.handleVersionSelection}
         persistentID={this.state.selectedVersionID}
+        scrollContainer=".gm-scroll-view"
+        scrollContainerParentSelector=".gm-prevented"
         transition={true}
         transitionName="dropdown-menu"
         wrapperClassName="dropdown" />

--- a/src/js/components/ServiceInfo.js
+++ b/src/js/components/ServiceInfo.js
@@ -56,14 +56,17 @@ class ServiceInfo extends React.Component {
       </button>,
       <Dropdown
         key="actions-dropdown"
+        anchorRight={true}
         buttonClassName="button button-stroke button-inverse dropdown-toggle"
         dropdownMenuClassName="dropdown-menu"
         dropdownMenuListClassName="dropdown-menu-list"
         dropdownMenuListItemClassName="clickable"
-        wrapperClassName="dropdown anchor-right flush-bottom"
+        wrapperClassName="dropdown flush-bottom"
         items={dropdownItems}
         persistentID={ServiceActionItem.MORE}
         onItemSelection={this.props.onActionsItemSelection}
+        scrollContainer=".gm-scroll-view"
+        scrollContainerParentSelector=".gm-prevented"
         transition={true}
         transitionName="dropdown-menu" />
     ];

--- a/src/js/components/ServicesTable.js
+++ b/src/js/components/ServicesTable.js
@@ -473,14 +473,17 @@ var ServicesTable = React.createClass({
     return (
       <Dropdown
         key="actions-dropdown"
+        anchorRight={true}
         buttonClassName="button button-mini dropdown-toggle button-link button-inverse table-display-on-row-hover"
         dropdownMenuClassName="dropdown-menu"
         dropdownMenuListClassName="dropdown-menu-list"
         dropdownMenuListItemClassName="clickable"
-        wrapperClassName="dropdown anchor-right flush-bottom table-cell-icon"
+        wrapperClassName="dropdown flush-bottom table-cell-icon"
         items={dropdownItems}
         persistentID={ServiceActionItem.MORE}
         onItemSelection={this.onActionsItemSelection.bind(this, service)}
+        scrollContainer=".gm-scroll-view"
+        scrollContainerParentSelector=".gm-prevented"
         transition={true}
         transitionName="dropdown-menu" />
     );

--- a/src/js/components/SidebarLabelsFilter.js
+++ b/src/js/components/SidebarLabelsFilter.js
@@ -106,6 +106,8 @@ class SidebarLabelsFilters extends mixin(QueryParamsMixin) {
         items={labelOptions}
         onItemSelection={this.handleActionSelection}
         persistentID="0"
+        scrollContainer=".gm-scroll-view"
+        scrollContainerParentSelector=".gm-prevented"
         transition={true}
         transitionName="dropdown-menu"
         wrapperClassName="dropdown dropdown-wide" />

--- a/src/js/components/UnitHealthDropdown.js
+++ b/src/js/components/UnitHealthDropdown.js
@@ -51,6 +51,8 @@ class UnitHealthDropdown extends mixin(InternalStorageMixin) {
         items={this.internalStorage_get().dropdownItems}
         onItemSelection={onHealthSelection}
         ref={(ref) => this.dropdown = ref}
+        scrollContainer=".gm-scroll-view"
+        scrollContainerParentSelector=".gm-prevented"
         transition={true}
         wrapperClassName="dropdown" />
     );

--- a/src/js/components/modals/ActionsModal.js
+++ b/src/js/components/modals/ActionsModal.js
@@ -168,6 +168,8 @@ class ActionsModal extends mixin(StoreMixin) {
           initialID={DEFAULT_ID}
           items={this.getDropdownItems(itemType)}
           onItemSelection={this.handleItemSelection}
+          scrollContainer=".gm-scroll-view"
+          scrollContainerParentSelector=".gm-prevented"
           transition={true}
           transitionName="dropdown-menu"
           wrapperClassName="dropdown text-align-left" />

--- a/src/js/pages/jobs/JobDetailPage.js
+++ b/src/js/pages/jobs/JobDetailPage.js
@@ -193,6 +193,7 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
         Run Now
       </button>,
       <Dropdown
+        anchorRight={true}
         buttonClassName="dropdown-toggle button button-inverse button-stroke"
         dropdownMenuClassName="dropdown-menu inverse"
         dropdownMenuListClassName="dropdown-menu-list"
@@ -202,8 +203,10 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
         key="more"
         onItemSelection={this.handleMoreDropdownSelection}
         persistentID="more"
+        scrollContainer=".gm-scroll-view"
+        scrollContainerParentSelector=".gm-prevented"
         transition={true}
-        wrapperClassName="dropdown anchor-right" />
+        wrapperClassName="dropdown" />
     ];
   }
 

--- a/src/js/pages/system/OrganizationTab.js
+++ b/src/js/pages/system/OrganizationTab.js
@@ -263,6 +263,8 @@ class OrganizationTab extends mixin(InternalStorageMixin) {
           initialID={initialID}
           items={dropdownItems}
           onItemSelection={this.handleActionSelection}
+          scrollContainer=".gm-scroll-view"
+          scrollContainerParentSelector=".gm-prevented"
           transition={true}
           transitionName="dropdown-menu"
           wrapperClassName="dropdown" />

--- a/src/js/pages/task-details/TaskLogsTab.js
+++ b/src/js/pages/task-details/TaskLogsTab.js
@@ -247,6 +247,8 @@ class TaskLogsTab extends React.Component {
         initialID={selectedName}
         items={this.getDropdownItems(logFiles)}
         onItemSelection={this.onItemSelection.bind(this)}
+        scrollContainer=".gm-scroll-view"
+        scrollContainerParentSelector=".gm-prevented"
         transition={true}
         transitionName="dropdown-menu"
         wrapperClassName="dropdown form-group" />

--- a/src/styles/components/dropdown-menus.less
+++ b/src/styles/components/dropdown-menus.less
@@ -25,17 +25,6 @@ components/dropdown-menus.less
 
   .dropdown {
 
-    &.anchor-right {
-
-      .dropdown-menu {
-
-        left: auto;
-        right: 0;
-
-      }
-
-    }
-
     &.open {
 
       .dropdown-menu {
@@ -152,6 +141,12 @@ components/dropdown-menus.less
 
     }
 
+  }
+
+  .dropdown-menu {
+    // Overrides default Canvas styles.
+    float: initial;
+    left: initial;
   }
 
   .dropdown-menu-list {


### PR DESCRIPTION
Here's the scroll event handler working with both native overlay scrollbars and Gemini overlay scrollbars:

Native:
![](https://cl.ly/0z013N3E2v2B/Screen%20Recording%202016-07-28%20at%2011.05%20AM.gif)

Gemini:
![](http://d2o91f3ic3idaw.cloudfront.net/items/3o1g3j36172t1g3Z310H/Screen%20Recording%202016-07-28%20at%2011.03%20AM.gif?v=3fe22daa)