### PR TITLE
DCOS-8637: Remove flush-bottom from resource bar chart's panel options

### DIFF
--- a/src/js/components/charts/ResourceBarChart.js
+++ b/src/js/components/charts/ResourceBarChart.js
@@ -115,7 +115,7 @@ let ResourceBarChart = React.createClass({
     return (
       <div className="chart panel panel-inverse">
         <div className="panel-header panel-header-large no-border flush-bottom">
-          <div className="panel-options button-group flush-bottom">
+          <div className="panel-options button-group">
             {this.getModeButtons()}
           </div>
           <div className="inverse">


### PR DESCRIPTION
Before:
![](https://cl.ly/1v0v313M0p3c/Screen%20Shot%202016-07-28%20at%2011.26.41%20AM.png)

After:
![](https://cl.ly/3O3F2x424608/Screen%20Shot%202016-07-28%20at%2011.26.20%20AM.png)