### PR TITLE
Worst-case-scenario fix for deploy button issue

### DIFF
--- a/src/js/components/ServiceForm.js
+++ b/src/js/components/ServiceForm.js
@@ -104,7 +104,7 @@ class ServiceForm extends SchemaForm {
     this.props.onChange(...arguments);
   }
 
-  validateForm() {
+  validateForm(secondTimeLucky) {
     let model = this.triggerTabFormSubmit();
 
     let validated = true;
@@ -123,6 +123,9 @@ class ServiceForm extends SchemaForm {
     });
 
     this.forceUpdate();
+    if (!secondTimeLucky) {
+      this.validateForm(true);
+    }
 
     return {
       isValidated: validated,

--- a/src/js/components/ServiceForm.js
+++ b/src/js/components/ServiceForm.js
@@ -123,6 +123,11 @@ class ServiceForm extends SchemaForm {
     });
 
     this.forceUpdate();
+
+    // Due to an as-yet untraced bug in the SchemaForm, the render resulting
+    // from the initial invocation of validateForm does not cause error
+    // messages to be shown, but the second render does. Hence we validate
+    // twice.
     if (!secondTimeLucky) {
       this.validateForm(true);
     }


### PR DESCRIPTION
When creating a new service, invalid field values are not flagged to the user until the deploy button is hit twice. 

This fix is terrible, let's not use it. 