### PR TITLE
Add unusccessful block for time series charts

### DIFF
--- a/src/js/components/charts/TimeSeriesChart.js
+++ b/src/js/components/charts/TimeSeriesChart.js
@@ -142,7 +142,6 @@ var TimeSeriesChart = React.createClass({
             height={props.height}
             x={x}
             y={0}
-            fill="black"
             className="unsuccessful-block"
             transitionDuration={props.refreshRate}
             transform={`translate(${-nextY}, 0)`}
@@ -428,6 +427,7 @@ var TimeSeriesChart = React.createClass({
     var yScale = this.getYScale(height, props.maxY);
     var clipPath = 'url(#' + store.clipPathID + ')';
     var maskID = this.internalStorage_get().maskID;
+    var unsuccessfulBlocks = this.createUnsuccessfulBlocks(props.data[0].values, xTimeScale);
 
     return (
       <div className="timeseries-chart">
@@ -460,6 +460,9 @@ var TimeSeriesChart = React.createClass({
           ref="movingEls"
           className="moving-elements">
           <g transform={'translate(' + margin.left + ',' + margin.top + ')'}>
+            <g className="area path-color-7" clipPath={clipPath}>
+              {unsuccessfulBlocks}
+            </g>
             <g ref="masking" mask={`url(#${maskID})`} clipPath={clipPath}>
               {this.getAreaList(props, yScale, xTimeScale)}
             </g>
@@ -468,7 +471,7 @@ var TimeSeriesChart = React.createClass({
           <defs>
             <mask ref="maskDef" id={store.maskID}>
               <rect x="0" y="0" width={width} height={height} fill="white" />
-              {this.createUnsuccessfulBlocks(props.data[0].values, xTimeScale)}
+              {unsuccessfulBlocks}
             </mask>
           </defs>
         </svg>

--- a/src/styles/components/charts/index.less
+++ b/src/styles/components/charts/index.less
@@ -37,6 +37,15 @@
     text-shadow: 0px 0px 10px fade(@white, 6%);
   }
 
+  .unsuccessful-block {
+    fill: @black;
+  }
+
+  [class*="path-color"] .unsuccessful-block {
+    fill: inherit;
+    fill-opacity: 1;
+  }
+
   .arc,
   .area,
   .bar rect {


### PR DESCRIPTION
Before:
![](https://cl.ly/143A2t3W1V3D/Screen%20Recording%202016-07-28%20at%2012.15.gif)

After:
![](https://cl.ly/0F3B0M2M3E2K/Screen%20Recording%202016-07-28%20at%2012.17.gif)

Done in collaboration with @jfurrow 