### PR TITLE
Increase timeout for node state as server can take a while to respond

### DIFF
--- a/src/js/events/TaskDirectoryActions.js
+++ b/src/js/events/TaskDirectoryActions.js
@@ -82,6 +82,7 @@ var TaskDirectoryActions = {
       return function (task, cb) {
         return RequestUtil.json({
           url: TaskDirectoryActions.getNodeStateJSON(task),
+          timeout: 5000,
           success: function (response) {
             resolve();
             cb(response);


### PR DESCRIPTION
This timeout for node state can be increased because it is specific to a single node. We do not rely on this data for any charting. A cluster on the other side of the world will take up to ~3.5 seconds to respond to node state requests and thus make any task related view fail.

State requests to master take <= 1.5 seconds so no need to change behavior there.

Top request is made to master `/mesos/master/state`
Bottom request is made to a node directory `/agent/75784894-fdf8-4119-8d64-b618167ebc5d-S0/slave(1)/state`

![](https://cl.ly/0h0g3F3F2Y3a/Image%202016-07-28%20at%2012.25.10%20PM.png)