### PR TITLE
Fix breadcrumb item filter logic

### DIFF
--- a/src/js/components/ManualBreadcrumbs.js
+++ b/src/js/components/ManualBreadcrumbs.js
@@ -94,7 +94,7 @@ class ManualBreadcrumbs extends React.Component {
     let listItems = [...ReactDOM.findDOMNode(this).children]
       .filter(function (_, index) {
         // Filter out even nodes containing '>'
-        return index % 2;
+        return index % 2 === 0;
       });
 
     return listItems


### PR DESCRIPTION
Before:
![](https://cl.ly/0T3f0a353N1W/Screen%20Shot%202016-07-28%20at%201.01.49%20PM.png)

After
![](https://cl.ly/3s1X311B2K2p/Screen%20Shot%202016-07-28%20at%201.01.35%20PM.png)