### PR TITLE
Update documentation link and text

### DIFF
--- a/src/js/components/AccessDeniedPage.js
+++ b/src/js/components/AccessDeniedPage.js
@@ -45,7 +45,7 @@ module.exports = class AccessDeniedPage extends React.Component {
                 Please contact your {Config.productName} administrator.
               </p>
               <p className="flush-bottom">
-                See the <a href={MetadataStore.buildDocsURI('/administration/security/managing-authentication/')} target="_blank">Security and Authentication</a> documentation for more information.
+                See the security <a href={MetadataStore.buildDocsURI('/administration/id-and-access-mgt/')} target="_blank">documentation</a> for more information.
               </p>
             </AlertPanel>
           </div>


### PR DESCRIPTION
Update documentation link and text:
![](https://cl.ly/1t1Q0V3t0R0v/Screen%20Recording%202016-07-29%20at%2010.41.gif)

Before the link was not working, now it points to where the enterprise and open documentation will appear