### PR TITLE
Adding crude test of history server data in MesosSummaryActions

### DIFF
--- a/src/js/events/MesosSummaryActions.js
+++ b/src/js/events/MesosSummaryActions.js
@@ -18,9 +18,9 @@ function testHistoryServerResponse(response) {
   // If the response is an empty object, that means something is whack
   // Fall back to making requests to Mesos
   // TODO (DCOS-7764): This should be improved to validate against a schema
-  if (response === {} ||
-      Array.isArray(response.frameworks) ||
-      Array.isArray(response.slaves)) {
+  if (!Object.keys(response).length ||
+      !Array.isArray(response.frameworks) ||
+      !Array.isArray(response.slaves)) {
     _historyServiceOnline = false;
   }
 }

--- a/src/js/events/MesosSummaryActions.js
+++ b/src/js/events/MesosSummaryActions.js
@@ -17,6 +17,7 @@ var _historyServiceOnline = true;
 function testHistoryServerResponse(response) {
   // If the response is an empty object, that means something is whack
   // Fall back to making requests to Mesos
+  // TODO (DCOS-7764): This should be improved to validate against a schema
   if (response === {} ||
       Array.isArray(response.frameworks) ||
       Array.isArray(response.slaves)) {

--- a/src/js/events/MesosSummaryActions.js
+++ b/src/js/events/MesosSummaryActions.js
@@ -17,7 +17,9 @@ var _historyServiceOnline = true;
 function testHistoryServerResponse(response) {
   // If the response is an empty object, that means something is whack
   // Fall back to making requests to Mesos
-  if (response === {}) {
+  if (response === {} ||
+      Array.isArray(response.frameworks) ||
+      Array.isArray(response.slaves)) {
     _historyServiceOnline = false;
   }
 }


### PR DESCRIPTION
This will make sure to fall back to `mesos/summary` endpoint if the data from history server doesn't validate according to this crude test.

More will be done to validate the data that is received from the server later.