### PR TITLE
Updating mesosphere-shared-reactjs to version 0.0.19

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4418,7 +4418,7 @@
     "mesosphere-shared-reactjs": {
       "version": "0.0.19",
       "from": "mesosphere-shared-reactjs@0.0.19",
-      "resolved": "http://registry.npmjs.org/mesosphere-shared-reactjs/-/mesosphere-shared-reactjs-0.0.19.tgz"
+      "resolved": "https://registry.npmjs.org/mesosphere-shared-reactjs/-/mesosphere-shared-reactjs-0.0.19.tgz"
     },
     "method-override": {
       "version": "2.3.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4416,9 +4416,9 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz"
     },
     "mesosphere-shared-reactjs": {
-      "version": "0.0.18",
-      "from": "mesosphere-shared-reactjs@0.0.18",
-      "resolved": "https://registry.npmjs.org/mesosphere-shared-reactjs/-/mesosphere-shared-reactjs-0.0.18.tgz"
+      "version": "0.0.19",
+      "from": "mesosphere-shared-reactjs@0.0.19",
+      "resolved": "http://registry.npmjs.org/mesosphere-shared-reactjs/-/mesosphere-shared-reactjs-0.0.19.tgz"
     },
     "method-override": {
       "version": "2.3.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "flux": "2.1.1",
     "less-color-lighten": "0.0.1",
     "md5": "2.1.0",
-    "mesosphere-shared-reactjs": "0.0.18",
+    "mesosphere-shared-reactjs": "0.0.19",
     "moment": "2.13.0",
     "prettycron": "0.10.0",
     "query-string": "4.1.0",


### PR DESCRIPTION
Changes in this update:
- Store util have been removed. Was no longer being used (https://github.com/dcos/mesosphere-shared-reactjs/pull/12)
- StoreMixin have stricter checking whether the lister details for components using it (https://github.com/dcos/mesosphere-shared-reactjs/pull/10)