### PR TITLE
DCOS-8978: Fixing bug that drops empty environment variables

### DIFF
--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -251,9 +251,18 @@ const ServiceUtil = {
       if (environmentVariables != null && environmentVariables.environmentVariables != null) {
         definition.env = environmentVariables.environmentVariables
           .reduce(function (variableMap, variable) {
+
+            // The 'undefined' value is not rendered by the JSON.stringify,
+            // so make sure empty environment variables are not left unrendered
+            let value = variable.value;
+            if (value == null) {
+              value = '';
+            }
+
+            // Pass it through the registered plugins
             variableMap[variable.key] = Hooks.applyFilter(
               'serviceVariableValue',
-              variable.value,
+              value,
               variable,
               definition
             );

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -42,6 +42,40 @@ describe('ServiceUtil', function () {
         .toEqual(expectedService);
     });
 
+    describe('environmentVariables', function () {
+
+      it('should keep undefined values as ""', function() {
+        let service = ServiceUtil.createServiceFromFormModel({
+          environmentVariables: {
+            environmentVariables: [
+              { key: 'a', value: 'correct' },
+              { key: 'b', value: undefined }
+            ]
+          }
+        });
+        expect(service.env).toEqual({
+          a: 'correct',
+          b: ''
+        });
+      });
+
+      it('should keep null values as ""', function() {
+        let service = ServiceUtil.createServiceFromFormModel({
+          environmentVariables: {
+            environmentVariables: [
+              { key: 'a', value: 'correct' },
+              { key: 'b', value: null }
+            ]
+          }
+        });
+        expect(service.env).toEqual({
+          a: 'correct',
+          b: ''
+        });
+      });
+
+    });
+
     describe('networking', function () {
 
       describe('host mode', function () {


### PR DESCRIPTION
The `JSON.stringify` function is dropping keys with `undefined` values. This pull request makes sure that no environment variable value is in this state.