### PR TITLE
DCOS-8479: Adding over-capacity animation on the css

### DIFF
--- a/src/styles/components/progressbar.less
+++ b/src/styles/components/progressbar.less
@@ -41,7 +41,13 @@
     }
 
     &.color-3, &.over-capacity {
-      background-color: @blue;
+      animation: candy-stripe 1s linear infinite;
+      background-size: 16px 16px;
+      background-image: linear-gradient(-45deg, color-lighten(@green, -30) 0,
+      color-lighten(@green, -30) 25%, color-lighten(@green, -50) 25%,
+      color-lighten(@green, -50) 50%, color-lighten(@green, -30) 50%,
+      color-lighten(@green, -30) 75%, color-lighten(@green, -50) 75%,
+      color-lighten(@green, -50) 100%);
     }
 
     &.color-4, &.healthy {


### PR DESCRIPTION
Adding the animated progress bar for the `over-capacity` CSS state in the status progress bar.

![image](https://cloud.githubusercontent.com/assets/883486/17300016/e29b5b94-5810-11e6-979f-b40a39c45abd.png)
