### PR TITLE
Fix wide dropdown width

### DIFF
--- a/src/styles/components/dropdown-menus.less
+++ b/src/styles/components/dropdown-menus.less
@@ -40,12 +40,6 @@ components/dropdown-menus.less
       display: block;
       width: 100%;
 
-      .dropdown-menu {
-
-        width: 100%;
-
-      }
-
     }
 
   }


### PR DESCRIPTION
This is an intermediary fix for the "wide dropdown" so that it doesn't render off the viewport. A real fix needs to be introduced in `reactjs-components`, which I have documented here: https://mesosphere.atlassian.net/browse/DCOS-8991

Before:
![](https://cl.ly/0v2e3K3s1N0y/Image%202016-08-01%20at%2012.35.48%20PM.png)

After: 
![](https://cl.ly/2j1n2B170V1L/Screen%20Shot%202016-08-01%20at%2012.35.11%20PM.png)