### PR TITLE
DCOS-8593: Use .make-row mixin for screen-x-large

### DIFF
--- a/src/styles/layout/grid.less
+++ b/src/styles/layout/grid.less
@@ -60,5 +60,9 @@
 
     .make-grid(x-large);
 
+    .row {
+      .make-row(@grid-gutter-width-screen-x-large);
+    }
+
   }
 }


### PR DESCRIPTION
This PR makes use of the `.make-row` mixin in Canvas, which just applies a negative horizontal margin with the provided variable. We had just forgotten to do this in the past, so when the column padding increased at `@screen-x-large`, the row's negative margin did not increase accordingly.