### PR TITLE
Using service name in stead of creating mesos name

### DIFF
--- a/src/js/components/ServiceDetailTaskTab.js
+++ b/src/js/components/ServiceDetailTaskTab.js
@@ -17,9 +17,7 @@ class ServiceDetailTaskTab extends mixin(StoreMixin) {
   }
 
   render() {
-    let tasks = MesosStateStore.getTasksByFrameworkName(
-      this.props.service.getName()
-    );
+    let tasks = MesosStateStore.getTasksByService(this.props.service);
 
     return (
       <TaskView tasks={tasks} inverseStyle={true}

--- a/src/js/components/ServiceDetailTaskTab.js
+++ b/src/js/components/ServiceDetailTaskTab.js
@@ -17,7 +17,9 @@ class ServiceDetailTaskTab extends mixin(StoreMixin) {
   }
 
   render() {
-    let tasks = MesosStateStore.getTasksByServiceId(this.props.service.getId());
+    let tasks = MesosStateStore.getTasksByFrameworkName(
+      this.props.service.getName()
+    );
 
     return (
       <TaskView tasks={tasks} inverseStyle={true}

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -238,12 +238,11 @@ class MesosStateStore extends GetSetBaseStore {
     return [];
   }
 
-  getTasksByServiceId(serviceId) {
+  getTasksByFrameworkName(frameworkName) {
     // Convert serviceId to Mesos service name
-    let mesosServiceName = serviceId.split('/').slice(1).reverse().join('.');
     let frameworks = this.get('lastMesosState').frameworks;
 
-    if (mesosServiceName === '' || !frameworks) {
+    if (frameworkName === '' || !frameworks) {
       return [];
     }
 
@@ -253,7 +252,7 @@ class MesosStateStore extends GetSetBaseStore {
     return frameworks.reduce(function (serviceTasks, framework) {
       let {tasks = [], completed_tasks = {}, name} = framework;
 
-      if (name === mesosServiceName) {
+      if (name === frameworkName) {
         return serviceTasks.concat(tasks, completed_tasks);
       }
 
@@ -261,7 +260,7 @@ class MesosStateStore extends GetSetBaseStore {
       if (name === 'marathon') {
         return tasks.concat(completed_tasks)
           .filter(function ({name}) {
-            return name === mesosServiceName;
+            return name === frameworkName;
           }).concat(serviceTasks);
       }
 

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -243,12 +243,10 @@ class MesosStateStore extends GetSetBaseStore {
     let frameworks = this.get('lastMesosState').frameworks;
     let serviceName = service.getName();
 
-    if (!(service instanceof Framework)) {
-      // Convert serviceId to Mesos service name
-      serviceName = service.getId().split('/').slice(1).reverse().join('.');
-    }
+    // Convert serviceId to Mesos task name
+    let mesosTaskName = service.getId().split('/').slice(1).reverse().join('.');
 
-    if (!serviceName || !frameworks) {
+    if (!serviceName || !mesosTaskName || !frameworks) {
       return [];
     }
 
@@ -257,8 +255,8 @@ class MesosStateStore extends GetSetBaseStore {
     // the scheduler tasks or a list of Marathon application tasks.
     return frameworks.reduce(function (serviceTasks, framework) {
       let {tasks = [], completed_tasks = {}, name} = framework;
-
-      if (name === serviceName) {
+      // Include tasks from framework match, if service is a Framework
+      if (service instanceof Framework && name === serviceName) {
         return serviceTasks.concat(tasks, completed_tasks);
       }
 
@@ -266,7 +264,7 @@ class MesosStateStore extends GetSetBaseStore {
       if (name === 'marathon') {
         return tasks.concat(completed_tasks)
           .filter(function ({name}) {
-            return name === serviceName;
+            return name === mesosTaskName;
           }).concat(serviceTasks);
       }
 

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -33,7 +33,7 @@ describe('MesosStateStore', function () {
     });
   });
 
-  describe('#getTasksByFrameworkName', function () {
+  describe('#getTasksByService', function () {
     beforeEach(function () {
       this.get = MesosStateStore.get;
       MesosStateStore.get = function () {
@@ -71,7 +71,9 @@ describe('MesosStateStore', function () {
 
     it('should return matching framework tasks including scheduler tasks',
       function () {
-        var tasks = MesosStateStore.getTasksByFrameworkName('spark');
+        var tasks = MesosStateStore.getTasksByService(
+          new Service({id: 'spark'})
+        );
         expect(tasks).toEqual([
           {name: 'spark', id: 'spark.1'},
           {name: '1'},
@@ -82,7 +84,9 @@ describe('MesosStateStore', function () {
     );
 
     it('should return matching application tasks', function () {
-      var tasks = MesosStateStore.getTasksByFrameworkName('alpha');
+      var tasks = MesosStateStore.getTasksByService(
+        new Service({id: 'alpha'})
+      );
       expect(tasks).toEqual([
         {name: 'alpha', id: 'alpha.1'},
         {name: 'alpha', id: 'alpha.2'},
@@ -91,7 +95,9 @@ describe('MesosStateStore', function () {
     });
 
     it('should empty task list if no service matches', function () {
-      var tasks = MesosStateStore.getTasksByFrameworkName('non-existent');
+      var tasks = MesosStateStore.getTasksByService(
+        new Service({id: 'non-existent'})
+      );
       expect(tasks).toEqual([]);
     });
   });

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -33,7 +33,7 @@ describe('MesosStateStore', function () {
     });
   });
 
-  describe('#getTasksByServiceId', function () {
+  describe('#getTasksByFrameworkName', function () {
     beforeEach(function () {
       this.get = MesosStateStore.get;
       MesosStateStore.get = function () {
@@ -71,7 +71,7 @@ describe('MesosStateStore', function () {
 
     it('should return matching framework tasks including scheduler tasks',
       function () {
-        var tasks = MesosStateStore.getTasksByServiceId('/spark');
+        var tasks = MesosStateStore.getTasksByFrameworkName('spark');
         expect(tasks).toEqual([
           {name: 'spark', id: 'spark.1'},
           {name: '1'},
@@ -82,7 +82,7 @@ describe('MesosStateStore', function () {
     );
 
     it('should return matching application tasks', function () {
-      var tasks = MesosStateStore.getTasksByServiceId('/alpha');
+      var tasks = MesosStateStore.getTasksByFrameworkName('alpha');
       expect(tasks).toEqual([
         {name: 'alpha', id: 'alpha.1'},
         {name: 'alpha', id: 'alpha.2'},
@@ -91,7 +91,7 @@ describe('MesosStateStore', function () {
     });
 
     it('should empty task list if no service matches', function () {
-      var tasks = MesosStateStore.getTasksByServiceId('/non-existent');
+      var tasks = MesosStateStore.getTasksByFrameworkName('non-existent');
       expect(tasks).toEqual([]);
     });
   });

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -1,5 +1,6 @@
 jest.dontMock('../MesosStateStore');
 
+var Framework = require('../../structs/Framework');
 var MesosStateStore = require('../MesosStateStore');
 var Service = require('../../structs/Service');
 var Task = require('../../structs/Task');
@@ -87,6 +88,17 @@ describe('MesosStateStore', function () {
     it('should return matching application tasks', function () {
       var tasks = MesosStateStore.getTasksByService(
         new Service({id: '/alpha'})
+      );
+      expect(tasks).toEqual([
+        {name: 'alpha', id: 'alpha.1'},
+        {name: 'alpha', id: 'alpha.2'},
+        {name: 'alpha', id: 'alpha.3'}
+      ]);
+    });
+
+    it('should return matching framework tasks', function () {
+      var tasks = MesosStateStore.getTasksByService(
+        new Framework({labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'alpha'}})
       );
       expect(tasks).toEqual([
         {name: 'alpha', id: 'alpha.1'},

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -1,6 +1,7 @@
 jest.dontMock('../MesosStateStore');
 
 var MesosStateStore = require('../MesosStateStore');
+var Service = require('../../structs/Service');
 var Task = require('../../structs/Task');
 
 describe('MesosStateStore', function () {
@@ -72,7 +73,7 @@ describe('MesosStateStore', function () {
     it('should return matching framework tasks including scheduler tasks',
       function () {
         var tasks = MesosStateStore.getTasksByService(
-          new Service({id: 'spark'})
+          new Service({id: '/spark'})
         );
         expect(tasks).toEqual([
           {name: 'spark', id: 'spark.1'},
@@ -85,7 +86,7 @@ describe('MesosStateStore', function () {
 
     it('should return matching application tasks', function () {
       var tasks = MesosStateStore.getTasksByService(
-        new Service({id: 'alpha'})
+        new Service({id: '/alpha'})
       );
       expect(tasks).toEqual([
         {name: 'alpha', id: 'alpha.1'},
@@ -96,7 +97,7 @@ describe('MesosStateStore', function () {
 
     it('should empty task list if no service matches', function () {
       var tasks = MesosStateStore.getTasksByService(
-        new Service({id: 'non-existent'})
+        new Service({id: '/non-existent'})
       );
       expect(tasks).toEqual([]);
     });

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -74,7 +74,7 @@ describe('MesosStateStore', function () {
     it('should return matching framework tasks including scheduler tasks',
       function () {
         var tasks = MesosStateStore.getTasksByService(
-          new Service({id: '/spark'})
+          new Framework({id: '/spark', labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'spark'}})
         );
         expect(tasks).toEqual([
           {name: 'spark', id: 'spark.1'},
@@ -88,17 +88,6 @@ describe('MesosStateStore', function () {
     it('should return matching application tasks', function () {
       var tasks = MesosStateStore.getTasksByService(
         new Service({id: '/alpha'})
-      );
-      expect(tasks).toEqual([
-        {name: 'alpha', id: 'alpha.1'},
-        {name: 'alpha', id: 'alpha.2'},
-        {name: 'alpha', id: 'alpha.3'}
-      ]);
-    });
-
-    it('should return matching framework tasks', function () {
-      var tasks = MesosStateStore.getTasksByService(
-        new Framework({labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'alpha'}})
       );
       expect(tasks).toEqual([
         {name: 'alpha', id: 'alpha.1'},


### PR DESCRIPTION
Changing to use `DCOS_PACKAGE_FRAMEWORK_NAME` instead of determining the mesos framework name from `appId`

Here are all the tasks in mesos:
![](https://cl.ly/000C3f2h293v/Image%202016-08-01%20at%2015.34.54.png)

Before:
![](https://cl.ly/293F3T100t3B/Image%202016-08-01%20at%2016.07.43.png)

After:
![](https://cl.ly/0J1q003O390U/Image%202016-08-01%20at%2016.06.35.png)