### PR TITLE
Show loading gif on deployments page

### DIFF
--- a/src/js/pages/__tests__/DeploymentsTab-test.js
+++ b/src/js/pages/__tests__/DeploymentsTab-test.js
@@ -41,6 +41,7 @@ describe('DeploymentsTab', function () {
         }
       ]
     });
+    DCOSStore.dataProcessed = true;
     DCOSStore.deploymentsList = deployments;
     this.container = document.createElement('div');
     this.instance = ReactDOM.render(

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -313,6 +313,18 @@ class DeploymentsTab extends mixin(StoreMixin) {
     );
   }
 
+  renderLoading() {
+    return (
+      <div className="container container-fluid container-pod text-align-center vertical-center inverse">
+        <div className="row">
+          <div className="ball-scale">
+            <div />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   renderPopulated(deploymentsItems) {
     let deploymentsCount = deploymentsItems.length;
     let deploymentsLabel = StringUtil.pluralize('Deployment', deploymentsCount);
@@ -396,7 +408,11 @@ class DeploymentsTab extends mixin(StoreMixin) {
 
   render() {
     let deployments = DCOSStore.deploymentsList.getItems();
+    let loading = !DCOSStore.dataProcessed;
 
+    if (loading) {
+      return this.renderLoading();
+    }
     if (deployments.length === 0) {
       return this.renderEmpty();
     } else {


### PR DESCRIPTION
Original bug report:

> Deployments shouldn't render till we have the list from the API	
> ![](https://cl.ly/2P3C223x1v0N/Screen%20Recording%202016-07-28%20at%2011.06%20AM.gif)

Implementation:

![Loading ball gif as with ServicePage](https://d3vv6lp55qjaqc.cloudfront.net/items/3Z3q2y1Y3Q3O1I0I410z/Screen%20Recording%202016-08-01%20at%2010.44%20PM.gif?v=044e667a)
