### PR TITLE
DCOS-8905: Jobs detail dropdown style

### DIFF
--- a/src/js/pages/jobs/JobDetailPage.js
+++ b/src/js/pages/jobs/JobDetailPage.js
@@ -195,7 +195,7 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
       <Dropdown
         anchorRight={true}
         buttonClassName="dropdown-toggle button button-inverse button-stroke"
-        dropdownMenuClassName="dropdown-menu inverse"
+        dropdownMenuClassName="dropdown-menu"
         dropdownMenuListClassName="dropdown-menu-list"
         dropdownMenuListItemClassName="clickable"
         initialID="more"


### PR DESCRIPTION
Change the Jobs detail page dropdown menu to non-inverse style, to match the dropdowns in Services page.

![](https://cl.ly/1p3U1Z0A1346/Image%202016-08-03%20at%2011.50.45%20AM.png)