### PR TITLE
DCOS-8857 & DCOS-9112 & DCOS-9113 & DCOS-9111 Unicon support

### DIFF
--- a/src/js/components/ConfigurationView.js
+++ b/src/js/components/ConfigurationView.js
@@ -59,12 +59,16 @@ class ConfigurationView extends mixin(StoreMixin) {
 
     let {docker} = container;
 
+    let parameters = docker.parameters || [];
+
+    parameters = parameters.map(({key, value}) => `${key} : ${value}`);
+
     let headerValueMapping = {
       'Force Pull Image': docker.forcePullImage,
       'Image': docker.image,
       'Network': docker.network,
       'Parameters': StringUtil.arrayToJoinedString(
-        docker.parameters.map(({key, value}) => `${key} : ${value}`)
+        parameters
       ),
       'Privileged': docker.privileged
     };

--- a/src/js/components/ConfigurationView.js
+++ b/src/js/components/ConfigurationView.js
@@ -60,8 +60,9 @@ class ConfigurationView extends mixin(StoreMixin) {
     let {docker} = container;
 
     let parameters = docker.parameters || [];
-
-    parameters = parameters.map(({key, value}) => `${key} : ${value}`);
+    parameters = parameters.map(function ({key, value}) {
+      return `${key} : ${value}`;
+    });
 
     let headerValueMapping = {
       'Force Pull Image': docker.forcePullImage,

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -182,7 +182,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
 
     let warningMessage = null;
     let jsonMode = false;
-    if (this.shouldDisableForm(service.getContainerSettings())) {
+    if (this.shouldDisableForm(service)) {
       warningMessage = {
         message: 'Your config contains attributes we currently only support ' +
         'in the JSON mode.'
@@ -246,7 +246,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
         .getAppDefinitionFromService(service), null, 2);
     }
 
-    if (this.shouldDisableForm()) {
+    if (this.shouldDisableForm(this.state.service)) {
       nextState.warningMessage = {
         message: 'Your config contains attributes we currently only support ' +
         'in the JSON mode.'
@@ -273,7 +273,9 @@ class ServiceFormModal extends mixin(StoreMixin) {
     });
   }
 
-  shouldDisableForm(containerSettings = this.state.service.getContainerSettings()) {
+  shouldDisableForm(service) {
+    let containerSettings = service.getContainerSettings();
+
     return containerSettings != null && containerSettings.type === 'MESOS' &&
       ((containerSettings.docker &&
       containerSettings.docker.image != null) ||
@@ -527,8 +529,8 @@ class ServiceFormModal extends mixin(StoreMixin) {
   getToggleButton() {
     let classSet = 'modal-form-title-label';
 
-    if (this.shouldDisableForm()) {
-      classSet = `${classSet} blend-out`;
+    if (this.shouldDisableForm(this.state.service)) {
+      classSet = `${classSet} disabled`;
     }
 
     return (<ToggleButton

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -182,7 +182,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
 
     let warningMessage = null;
     let jsonMode = false;
-    if (this.shouldDisableForm()) {
+    if (this.shouldDisableForm(service.getContainerSettings())) {
       warningMessage = {
         message: 'Your config contains attributes we currently only support ' +
         'in the JSON mode.'
@@ -273,9 +273,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
     });
   }
 
-  shouldDisableForm() {
-    let containerSettings = this.state.service.getContainerSettings();
-
+  shouldDisableForm(containerSettings = this.state.service.getContainerSettings()) {
     return containerSettings != null && containerSettings.type === 'MESOS' &&
       ((containerSettings.docker &&
       containerSettings.docker.image != null) ||
@@ -544,7 +542,6 @@ class ServiceFormModal extends mixin(StoreMixin) {
 
   getWarningMessage() {
     let {warningMessage} = this.state;
-    console.log(warningMessage);
     if (!warningMessage) {
       return null;
     }

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -551,9 +551,9 @@ class ServiceFormModal extends mixin(StoreMixin) {
     return (
       <div>
         <div className="warning-field">
-          <h4 className="text-align-center flush-top">
+          <div className="text-align-center flush-top">
             {warningMessage.message}
-          </h4>
+          </div>
         </div>
       </div>
     );

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -179,12 +179,23 @@ class ServiceFormModal extends mixin(StoreMixin) {
       service = props.service;
     }
 
+    let errorMessage = null;
+    let jsonMode = false;
+    let containerSettings = service.getContainerSettings();
+    if (containerSettings != null && containerSettings.type === 'MESOS' &&
+      containerSettings.docker.image != null) {
+      errorMessage = {
+        message: 'Your configuration is too advanced for the form.'
+      };
+      jsonMode = true;
+    }
+
     this.setState({
       defaultTab: '',
-      errorMessage: null,
+      errorMessage,
       force: false,
       jsonDefinition: service.toJSON(),
-      jsonMode: false,
+      jsonMode,
       model,
       pendingRequest: false,
       service
@@ -225,7 +236,15 @@ class ServiceFormModal extends mixin(StoreMixin) {
       nextState.jsonDefinition = JSON.stringify(ServiceUtil
         .getAppDefinitionFromService(service), null, 2);
     }
-    nextState.jsonMode = !this.state.jsonMode;
+    let containerSettings = this.state.service.getContainerSettings();
+    if (containerSettings != null && containerSettings.type === 'MESOS' &&
+      containerSettings.docker.image != null) {
+      nextState.errorMessage = {
+        message: 'Your configuration is too advanced for the form.'
+      };
+    } else {
+      nextState.jsonMode = !this.state.jsonMode;
+    }
     this.setState(nextState);
   }
 

--- a/src/js/constants/ServiceConfig.js
+++ b/src/js/constants/ServiceConfig.js
@@ -6,6 +6,7 @@ let ServiceConfig = {
     'versions',
     'versionInfo',
     'deployments',
+    'queue',
     'tasks',
     'taskStats',
     'tasksHealthy',

--- a/src/styles/components/multiple-form.less
+++ b/src/styles/components/multiple-form.less
@@ -228,7 +228,7 @@ base/forms.less
 
   .modal-form {
 
-    .blend-out {
+    .disabled {
       opacity: 0.5;
       .toggle-button:checked + span:before{
         background-color: @gray;

--- a/src/styles/components/multiple-form.less
+++ b/src/styles/components/multiple-form.less
@@ -228,6 +228,14 @@ base/forms.less
 
   .modal-form {
 
+    .blend-out {
+      opacity: 0.5;
+      .toggle-button:checked + span:before{
+        background-color: @gray;
+        border-color: @gray;
+      }
+    }
+
     .error-field {
       background: color-lighten(@red, 60);
       border-bottom: @red 1px solid;
@@ -236,6 +244,12 @@ base/forms.less
       li:before {
         background-color: currentColor;
       }
+    }
+
+    .warning-field {
+      background: color-lighten(@yellow, 30);
+      border-bottom: @yellow 1px solid;
+      padding: (@base-spacing-unit / 2) @base-spacing-unit;
     }
 
     label {


### PR DESCRIPTION
This adds support for the Unicon feature. It will lock you into JSON mode as soon as you provide a config which is not parseable in the form.

![image](https://cloud.githubusercontent.com/assets/156010/17440006/fa6cf1a2-5b2a-11e6-9ee2-ac048a42dad9.png)

![unicorn mov](https://cloud.githubusercontent.com/assets/156010/17440088/5d678b32-5b2b-11e6-8e51-2e3ce30ed7e0.gif)

If you want to test this please ask me directly.
