### PR TITLE
Version bump reactjs-components@0.14.0.bet-40

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5425,9 +5425,9 @@
       "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz"
     },
     "reactjs-components": {
-      "version": "0.14.0-beta.38",
-      "from": "reactjs-components@0.14.0-beta.38",
-      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.14.0-beta.38.tgz"
+      "version": "0.14.0-beta.40",
+      "from": "reactjs-components@0.14.0-beta.40",
+      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.14.0-beta.40.tgz"
     },
     "reactjs-mixin": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-gemini-scrollbar": "2.1.0",
     "react-redux": "4.4.0",
     "react-router": "0.13.5",
-    "reactjs-components": "0.14.0-beta.38",
+    "reactjs-components": "0.14.0-beta.40",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
     "tv4": "1.2.7",


### PR DESCRIPTION
Integration tests passing:
![](https://cl.ly/3L1D3l1b0d0F/Screen%20Shot%202016-08-05%20at%2010.53.23%20AM.png)