### PR TITLE
Remove duplicate validateForm hack

### DIFF
--- a/src/js/components/ServiceForm.js
+++ b/src/js/components/ServiceForm.js
@@ -104,7 +104,7 @@ class ServiceForm extends SchemaForm {
     this.props.onChange(...arguments);
   }
 
-  validateForm(secondTimeLucky) {
+  validateForm() {
     let model = this.triggerTabFormSubmit();
 
     let validated = true;
@@ -123,9 +123,6 @@ class ServiceForm extends SchemaForm {
     });
 
     this.forceUpdate();
-    if (!secondTimeLucky) {
-      this.validateForm(true);
-    }
 
     return {
       isValidated: validated,

--- a/src/js/components/ServiceForm.js
+++ b/src/js/components/ServiceForm.js
@@ -123,11 +123,6 @@ class ServiceForm extends SchemaForm {
     });
 
     this.forceUpdate();
-
-    // Due to an as-yet untraced bug in the SchemaForm, the render resulting
-    // from the initial invocation of validateForm does not cause error
-    // messages to be shown, but the second render does. Hence we validate
-    // twice.
     if (!secondTimeLucky) {
       this.validateForm(true);
     }


### PR DESCRIPTION
The `validateForm` hack committed in #868 is no longer necessary. 

Kill it with fire. 