### PR TITLE
Fix spelling of 'occurred'

### DIFF
--- a/src/js/components/CosmosErrorMessage.js
+++ b/src/js/components/CosmosErrorMessage.js
@@ -62,7 +62,7 @@ class CosmosErrorMessage extends React.Component {
 CosmosErrorMessage.defaultProps = {
   className: 'text-overflow-break-word column-small-8 column-small-offset-2 column-medium-6 column-medium-offset-3',
   error: {message: 'Please try again.'},
-  header: 'An Error Occured',
+  header: 'An Error Occurred',
   headerClass: 'h3 text-align-center flush-top',
   wrapperClass: 'row'
 };

--- a/src/js/components/__tests__/MesosLogView-test.js
+++ b/src/js/components/__tests__/MesosLogView-test.js
@@ -229,7 +229,7 @@ describe('MesosLogView', function () {
 
   describe('#render', function () {
 
-    it('should call getErrorScreen when error occured', function () {
+    it('should call getErrorScreen when error occurred', function () {
       this.instance.state.hasLoadingError = 3;
       this.instance.getErrorScreen = jasmine.createSpy('getErrorScreen');
 
@@ -237,7 +237,7 @@ describe('MesosLogView', function () {
       expect(this.instance.getErrorScreen).toHaveBeenCalled();
     });
 
-    it('ignores getErrorScreen when error has not occured', function () {
+    it('ignores getErrorScreen when error has not occurred', function () {
       this.instance.state.hasLoadingError = 2;
       this.instance.getErrorScreen = jasmine.createSpy('getErrorScreen');
 

--- a/src/js/components/modals/__tests__/InstallPackageModal-test.js
+++ b/src/js/components/modals/__tests__/InstallPackageModal-test.js
@@ -110,7 +110,7 @@ describe('InstallPackageModal', function () {
       ));
 
       var result = node.querySelector('.h3.text-align-center.flush-top');
-      expect(result.textContent).toEqual('An Error Occured');
+      expect(result.textContent).toEqual('An Error Occurred');
     });
 
     it('should display install success', function () {

--- a/src/js/pages/task-details/__tests__/TaskDetail-test.js
+++ b/src/js/pages/task-details/__tests__/TaskDetail-test.js
@@ -131,7 +131,7 @@ describe('TaskDetail', function () {
       ReactDOM.unmountComponentAtNode(this.container);
     });
 
-    it('should call getErrorScreen when error occured', function () {
+    it('should call getErrorScreen when error occurred', function () {
       this.instance.state = {
         directory: new TaskDirectory({items: [{nlink: 1, path: '/stdout'}]}),
         taskDirectoryErrorCount: 3
@@ -141,7 +141,7 @@ describe('TaskDetail', function () {
       expect(this.instance.getErrorScreen).toHaveBeenCalled();
     });
 
-    it('ignores getErrorScreen when error has not occured', function () {
+    it('ignores getErrorScreen when error has not occurred', function () {
       this.instance.state = {
         directory: new TaskDirectory({items: [{nlink: 1, path: '/stdout'}]})
       };

--- a/src/js/pages/universe/__tests__/PackageDetailTab-test.js
+++ b/src/js/pages/universe/__tests__/PackageDetailTab-test.js
@@ -184,7 +184,7 @@ describe('PackageDetailTab', function () {
 
   describe('#render', function () {
 
-    it('should call getErrorScreen when error occured', function () {
+    it('should call getErrorScreen when error occurred', function () {
       this.instance.state.hasError = true;
       this.instance.getErrorScreen = jasmine.createSpy('getErrorScreen');
 
@@ -192,7 +192,7 @@ describe('PackageDetailTab', function () {
       expect(this.instance.getErrorScreen).toHaveBeenCalled();
     });
 
-    it('ignores getErrorScreen when error has not occured', function () {
+    it('ignores getErrorScreen when error has not occurred', function () {
       this.instance.state.hasError = false;
       this.instance.getErrorScreen = jasmine.createSpy('getErrorScreen');
 
@@ -216,7 +216,7 @@ describe('PackageDetailTab', function () {
       expect(this.instance.getLoadingScreen).not.toHaveBeenCalled();
     });
 
-    it('ignores getLoadingScreen when error has occured', function () {
+    it('ignores getLoadingScreen when error has occurred', function () {
       this.instance.state.hasError = true;
       this.instance.state.isLoading = true;
       this.instance.getLoadingScreen = jasmine.createSpy('getLoadingScreen');

--- a/tests/pages/universe/packages/PackagesTab-cy.js
+++ b/tests/pages/universe/packages/PackagesTab-cy.js
@@ -79,7 +79,7 @@ describe('Packages Tab', function () {
 
     cy
       .get('.page-content .h3.text-align-center')
-      .should('contain', 'An Error Occured');
+      .should('contain', 'An Error Occurred');
   });
 
   context('searching', function () {


### PR DESCRIPTION
Spelling error in the Cosmos error modal, thanks to @ssk2 for the report. 

I also fixed up the same error in some of the tests while I was at it. 