### PR TITLE
DCOS-8479: Adding over-capacity animation to the dot

### DIFF
--- a/src/styles/components/badges.less
+++ b/src/styles/components/badges.less
@@ -94,7 +94,13 @@ Badge
 
   &.over-capacity {
 
-    color: @blue;
+    animation: candy-stripe 1s linear infinite;
+    background-size: 16px 16px;
+    background-image: linear-gradient(-45deg, color-lighten(@green, -30) 0,
+    color-lighten(@green, -30) 25%, color-lighten(@green, -50) 25%,
+    color-lighten(@green, -50) 50%, color-lighten(@green, -30) 50%,
+    color-lighten(@green, -30) 75%, color-lighten(@green, -50) 75%,
+    color-lighten(@green, -50) 100%);
 
   }
 


### PR DESCRIPTION
Related to #890 , adds the over-capacity animation to the legend dot too.