### PR TITLE
DCOS-8110 Add framework version to service details page

### DIFF
--- a/src/js/components/PageHeader.js
+++ b/src/js/components/PageHeader.js
@@ -140,7 +140,7 @@ PageHeader.propTypes = {
   icon: React.PropTypes.node,
   navigationTabs: React.PropTypes.node,
   subTitle: React.PropTypes.node,
-  title: React.PropTypes.string,
+  title: React.PropTypes.node,
 
   className: classPropType,
   pageHeaderClassNames: classPropType,

--- a/src/js/components/ServiceInfo.js
+++ b/src/js/components/ServiceInfo.js
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import {Dropdown} from 'reactjs-components';
 import React from 'react';
 
+import Framework from '../structs/Framework';
 import HealthBar from './HealthBar';
 import PageHeader from './PageHeader';
 import Service from '../structs/Service';
@@ -127,6 +128,19 @@ class ServiceInfo extends React.Component {
     });
   }
 
+  getHeaderTitle(service) {
+    if (service instanceof Framework) {
+      let {version} = service.getMetadata();
+      version = `v. ${version}`;
+
+      return (
+        <span>{service.getName()}<span className="framework-meta">{version}</span></span>
+      );
+    }
+
+    return service.getName();
+  }
+
   render() {
     let service = this.props.service;
     let serviceIcon = null;
@@ -151,7 +165,7 @@ class ServiceInfo extends React.Component {
         iconClassName="icon-image-container icon-app-container"
         subTitle={this.getSubHeader(service)}
         navigationTabs={tabs}
-        title={service.getName()} />
+        title={this.getHeaderTitle(service)} />
     );
   }
 }

--- a/src/js/components/__tests__/ServiceInfo-test.js
+++ b/src/js/components/__tests__/ServiceInfo-test.js
@@ -7,6 +7,7 @@ var React = require('react');
 /* eslint-enable no-unused-vars */
 var ReactDOM = require('react-dom');
 
+var Framework = require('../../structs/Framework');
 var Service = require('../../structs/Service');
 var ServiceInfo = require('../ServiceInfo');
 
@@ -28,11 +29,25 @@ describe('ServiceInfo', function () {
     }
   });
 
+  const framework = new Framework({
+    id: '/chronos',
+    cpus: 1,
+    labels: {
+      'DCOS_PACKAGE_METADATA': 'eyJsaWNlbnNlcyI6W3sibmFtZSI6IkFwYWNoZSBMaWNlbnNlIFZlcnNpb24gMi4wIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL21lc29zL2Nocm9ub3MvYmxvYi9tYXN0ZXIvTElDRU5TRSJ9XSwibmFtZSI6ImNocm9ub3MiLCJwb3N0SW5zdGFsbE5vdGVzIjoiQ2hyb25vcyBEQ09TIFNlcnZpY2UgaGFzIGJlZW4gc3VjY2Vzc2Z1bGx5IGluc3RhbGxlZCFcblxuXHREb2N1bWVudGF0aW9uOiBodHRwOi8vbWVzb3MuZ2l0aHViLmlvL2Nocm9ub3Ncblx0SXNzdWVzOiBodHRwczovL2dpdGh1Yi5jb20vbWVzb3MvY2hyb25vcy9pc3N1ZXMiLCJzY20iOiJodHRwczovL2dpdGh1Yi5jb20vbWVzb3MvY2hyb25vcy5naXQiLCJkZXNjcmlwdGlvbiI6IkEgZmF1bHQgdG9sZXJhbnQgam9iIHNjaGVkdWxlciBmb3IgTWVzb3Mgd2hpY2ggaGFuZGxlcyBkZXBlbmRlbmNpZXMgYW5kIElTTzg2MDEgYmFzZWQgc2NoZWR1bGVzLiIsInBhY2thZ2luZ1ZlcnNpb24iOiIyLjAiLCJ0YWdzIjpbImNyb24iLCJhbmFseXRpY3MiLCJiYXRjaCJdLCJwb3N0VW5pbnN0YWxsTm90ZXMiOiJUaGUgQ2hyb25vcyBEQ09TIFNlcnZpY2UgaGFzIGJlZW4gdW5pbnN0YWxsZWQgYW5kIHdpbGwgbm8gbG9uZ2VyIHJ1bi5cblBsZWFzZSBmb2xsb3cgdGhlIGluc3RydWN0aW9ucyBhdCBodHRwczovL2RvY3MubWVzb3NwaGVyZS5jb20vdXNhZ2Uvc2VydmljZXMvY2hyb25vcy8jdW5pbnN0YWxsIHRvIGNsZWFuIHVwIGFueSBwZXJzaXN0ZWQgc3RhdGUiLCJtYWludGFpbmVyIjoic3VwcG9ydEBtZXNvc3BoZXJlLmlvIiwic2VsZWN0ZWQiOnRydWUsImZyYW1ld29yayI6dHJ1ZSwidmVyc2lvbiI6IjIuNC4wIiwicHJlSW5zdGFsbE5vdGVzIjoiV2UgcmVjb21tZW5kIGEgbWluaW11bSBvZiBvbmUgbm9kZSB3aXRoIGF0IGxlYXN0IDEgQ1BVIGFuZCAyR0Igb2YgUkFNIGF2YWlsYWJsZSBmb3IgdGhlIENocm9ub3MgU2VydmljZS4iLCJpbWFnZXMiOnsiaWNvbi1zbWFsbCI6Imh0dHBzOi8vZG93bmxvYWRzLm1lc29zcGhlcmUuY29tL3VuaXZlcnNlL2Fzc2V0cy9pY29uLXNlcnZpY2UtY2hyb25vcy1zbWFsbC5wbmciLCJpY29uLW1lZGl1bSI6Imh0dHBzOi8vZG93bmxvYWRzLm1lc29zcGhlcmUuY29tL3VuaXZlcnNlL2Fzc2V0cy9pY29uLXNlcnZpY2UtY2hyb25vcy1tZWRpdW0ucG5nIiwiaWNvbi1sYXJnZSI6Imh0dHBzOi8vZG93bmxvYWRzLm1lc29zcGhlcmUuY29tL3VuaXZlcnNlL2Fzc2V0cy9pY29uLXNlcnZpY2UtY2hyb25vcy1sYXJnZS5wbmciLCJzY3JlZW5zaG90cyI6bnVsbH19',
+    },
+    mem: 2048,
+    disk: 0,
+    tasksStaged: 0,
+    tasksRunning: 1,
+    tasksHealthy: 1,
+    tasksUnhealthy: 0
+  });
+
   describe('#render', function () {
     beforeEach(function () {
       this.container = document.createElement('div');
       this.instance = ReactDOM.render(
-        <ServiceInfo service={service} />,
+        <ServiceInfo onActionsItemSelection={() => {}} service={service} />,
         this.container
       );
       this.node = ReactDOM.findDOMNode(this.instance);
@@ -44,6 +59,17 @@ describe('ServiceInfo', function () {
 
     it('renders name', function () {
       expect(this.node.querySelector('.h1 .collapsing-string-full-string').textContent).toEqual('test');
+    });
+
+    it('renders framework version', function () {
+      this.container = document.createElement('div');
+      this.instance = ReactDOM.render(
+        <ServiceInfo onActionsItemSelection={() => {}} service={framework} />,
+        this.container
+      );
+      this.node = ReactDOM.findDOMNode(this.instance);
+
+      expect(this.node.querySelector('.h1 .collapsing-string-full-string').textContent).toEqual('chronosv. 2.4.0');
     });
 
     it('renders image', function () {

--- a/src/styles/components/services-view.less
+++ b/src/styles/components/services-view.less
@@ -1,0 +1,7 @@
+.framework-meta {
+  color: @body-text-emphasize-color;
+  display: inline-block;
+  font-size: @body-text-font-size;
+  line-height: @body-text-line-height;
+  margin-left: @base-spacing-unit * 0.25;
+}

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -155,6 +155,7 @@ Components
 @import "components/secret-value.less";
 @import "components/service-sidebar.less";
 @import "components/service-table.less";
+@import "components/services-view.less";
 @import "components/side-list.less";
 @import "components/side-tabs.less";
 @import "components/statusbar.less";


### PR DESCRIPTION
 
![image](https://cloud.githubusercontent.com/assets/1078545/17478471/589fd4fe-5d6c-11e6-93e6-8dcdb31878a1.png)


I'd like some thoughts on the following:

1) the `ServiceInfo` uses the `PageHeader` component to render the framework name (`title` prop)
2) the `PageHeader` component passes the `title` down to the `CollapsibleString`
3) the `title` MUST be a string for the `CollapsibleString` magic to work
4) I can’t see a way to make this work by having the framework’s name and version be part of the `title` as seen in the designs

The only option I see here without refactoring anything is to show the version below the framework name, perhaps before the Status bar.

@leemunroe @jfurrow any thoughts?
