### PR TITLE
DCOS-8945 Allow excluding certain items from being selected in checkbox table

### DIFF
--- a/src/js/components/CheckboxTable.js
+++ b/src/js/components/CheckboxTable.js
@@ -113,8 +113,13 @@ class CheckboxTable extends React.Component {
   }
 
   renderCheckbox(prop, row) {
-    let {checkedItemsMap, uniqueProperty} = this.props;
+    let {checkedItemsMap, disabledItemsMap, uniqueProperty} = this.props;
     let rowID = row[uniqueProperty];
+
+    if (disabledItemsMap[rowID]) {
+      return null;
+    }
+
     let checked = false;
 
     if (checkedItemsMap[rowID]) {
@@ -192,6 +197,7 @@ CheckboxTable.propTypes = {
   ]),
   columns: PropTypes.array,
   data: PropTypes.array,
+  disabledItemsMap: PropTypes.object,
   getColGroup: PropTypes.func,
   labelClass: PropTypes.oneOfType([
     PropTypes.string,
@@ -208,6 +214,7 @@ CheckboxTable.defaultProps = {
   checkedItemsMap: {},
   columns: [],
   data: [],
+  disabledItemsMap: {},
   getColGroup: function () {},
   labelClass: {},
   onCheckboxChange: function () {},

--- a/src/js/pages/jobs/JobRunHistoryTable.js
+++ b/src/js/pages/jobs/JobRunHistoryTable.js
@@ -169,6 +169,14 @@ class JobRunHistoryTable extends React.Component {
     });
   }
 
+  getDisabledItemsMap(job) {
+    return job.getJobRuns().getItems().reduce(function (memo, jobRun) {
+      let isDisabled = ['ACTIVE', 'INITIAL', 'STARTING'].indexOf(jobRun.getStatus()) < 0;
+      memo[jobRun.get('id')] = isDisabled;
+      return memo;
+    }, {});
+  }
+
   getStopButton(hasCheckedTasks) {
     if (!hasCheckedTasks) {
       return null;
@@ -325,6 +333,7 @@ class JobRunHistoryTable extends React.Component {
           getColGroup={this.getColGroup}
           uniqueProperty="id"
           checkedItemsMap={this.state.checkedItems}
+          disabledItemsMap={this.getDisabledItemsMap(job)}
           onCheckboxChange={this.handleItemCheck}
           sortBy={{prop: 'startedAt', order: 'desc'}}
           tableComponent={CheckboxTable} />

--- a/src/js/pages/jobs/JobRunHistoryTable.js
+++ b/src/js/pages/jobs/JobRunHistoryTable.js
@@ -305,9 +305,20 @@ class JobRunHistoryTable extends React.Component {
   render() {
     let {job} = this.props;
     let {checkedItems} = this.state;
+    let disabledItems = this.getDisabledItemsMap(job);
     let totalRunCount = job.getJobRuns().getItems().length;
     let rightAlignLastNChildren = 0;
-    let hasCheckedTasks = Object.keys(checkedItems).length !== 0;
+    let hasCheckedTasks = false;
+
+    // Remove all disabled items from the checkedItems.
+    checkedItems = Object.keys(checkedItems).reduce(function (filteredItems, key) {
+      if (!disabledItems[key]) {
+        filteredItems[key] = checkedItems[key];
+        hasCheckedTasks = true;
+      }
+      return filteredItems;
+    }, {});
+
     if (hasCheckedTasks) {
       rightAlignLastNChildren = 1;
     }
@@ -333,7 +344,7 @@ class JobRunHistoryTable extends React.Component {
           getColGroup={this.getColGroup}
           uniqueProperty="id"
           checkedItemsMap={this.state.checkedItems}
-          disabledItemsMap={this.getDisabledItemsMap(job)}
+          disabledItemsMap={disabledItems}
           onCheckboxChange={this.handleItemCheck}
           sortBy={{prop: 'startedAt', order: 'desc'}}
           tableComponent={CheckboxTable} />


### PR DESCRIPTION
Exclude the non-running `jobRuns` from being selected and stopped, which would produce a 404 error.

![disable](https://cloud.githubusercontent.com/assets/1078545/17485644/829f2dc8-5d8e-11e6-8dac-e1c9a123a53c.gif)
