### PR TITLE
Fix breadcrumb route to universe package.

### DIFF
--- a/src/js/components/BreadcrumbSegmentLink.js
+++ b/src/js/components/BreadcrumbSegmentLink.js
@@ -10,8 +10,7 @@ class BreadcrumbSegmentLink extends React.Component {
       return (
         <Link
           className={props.className}
-          to={props.route.to}
-          params={props.route.params}
+          {...props.route}
           title={content}>
           {content}
         </Link>

--- a/src/js/pages/universe/PackageDetailTab.js
+++ b/src/js/pages/universe/PackageDetailTab.js
@@ -47,9 +47,10 @@ class PackageDetailTab extends mixin(StoreMixin) {
   componentDidMount() {
     super.componentDidMount(...arguments);
 
-    let {packageName, packageVersion} = this.props.params;
+    let {packageName} = this.props.params;
+    let {version} = this.props.query;
     // Fetch package description
-    CosmosPackagesStore.fetchPackageDescription(packageName, packageVersion);
+    CosmosPackagesStore.fetchPackageDescription(packageName, version);
   }
 
   onCosmosPackagesStoreDescriptionError() {

--- a/src/js/pages/universe/__tests__/PackageDetailTab-test.js
+++ b/src/js/pages/universe/__tests__/PackageDetailTab-test.js
@@ -25,7 +25,9 @@ describe('PackageDetailTab', function () {
   beforeEach(function () {
     this.container = document.createElement('div');
     this.instance = ReactDOM.render(
-      <PackageDetailTab params={{packageName: 'marathon'}} />,
+      <PackageDetailTab
+        params={{packageName: 'marathon'}}
+        query={{version: 1}} />,
       this.container
     );
   });

--- a/src/js/routes/universe.js
+++ b/src/js/routes/universe.js
@@ -32,16 +32,23 @@ let universeRoutes = {
     {
       type: Route,
       name: 'universe-packages-detail',
-      path: 'packages/:packageName?:packageVersion?',
+      path: 'packages/:packageName?',
       handler: PackageDetailTab,
       hideHeaderNavigation: true,
       buildBreadCrumb: function () {
         return {
           parentCrumb: 'universe-packages',
           getCrumbs: function (router) {
+            let params = router.getCurrentParams();
+
             return [
               {
-                label: router.getCurrentParams().packageName
+                label: params.packageName,
+                route: {
+                  to: 'universe-packages-detail',
+                  params: params,
+                  query: router.getCurrentQuery()
+                }
               }
             ];
           }


### PR DESCRIPTION
This PR fixes a few things:
* Fix breadcrumb route to universe package.
* Allows passing any additional parameter to BreadcrumbSegmentLink through `this.props.route`
* Fixes request to fetch package description, the version was being accessed incorrectly.