### PR TITLE
Fixes color for disk.

### DIFF
--- a/src/styles/components/progressbar.less
+++ b/src/styles/components/progressbar.less
@@ -40,7 +40,11 @@
       background-color: @pink;
     }
 
-    &.color-3, &.over-capacity {
+    &.color-3 {
+      background-color: @blue;
+    }
+
+    &.over-capacity {
       animation: candy-stripe 1s linear infinite;
       background-size: 16px 16px;
       background-image: linear-gradient(-45deg, color-lighten(@green, -30) 0,


### PR DESCRIPTION
Philip(p)s! I need your help...will this be a problem with the progressbars in the services page?
I'm fixing this because it was causing the disk progressbars in the Nodes page to look like the overcapacity ones.
See:
![img](https://cl.ly/3k143D3L341h/Image%202016-08-08%20at%203.23.57%20PM.png)