### PR TITLE
Fix max listeners limit.

### DIFF
--- a/src/js/stores/SidebarStore.js
+++ b/src/js/stores/SidebarStore.js
@@ -99,4 +99,7 @@ class SidebarStore extends GetSetBaseStore {
 
 }
 
-module.exports = new SidebarStore();
+const store = new SidebarStore();
+store.setMaxListeners(1000);
+
+module.exports = store;


### PR DESCRIPTION
When rendering many dial chars, the Chart component listens to sidebar width change. If there's many charts, it'll throw a warning.