### PR TITLE
[CNVS Upgrade] Add flex properties for .page-body's scroll container

### DIFF
--- a/src/styles/components/scrollbar/styles.less
+++ b/src/styles/components/scrollbar/styles.less
@@ -55,24 +55,6 @@
 
   .gm-scrollbar-container {
 
-    &.gm-scrollbar-container-flex {
-
-      position: relative;
-
-      .gm-scroll-view {
-
-        position: absolute;
-
-        & > * {
-
-          position: relative;
-
-        }
-
-      }
-
-    }
-
     &.inverse {
 
       .gm-scrollbar {
@@ -97,6 +79,24 @@
           }
 
         }
+
+      }
+
+    }
+
+  }
+
+  .gm-scrollbar-container-flex {
+
+    position: relative;
+
+    .gm-scroll-view {
+
+      position: absolute;
+
+      & > * {
+
+        position: relative;
 
       }
 

--- a/src/styles/layout/page/styles.less
+++ b/src/styles/layout/page/styles.less
@@ -1,16 +1,5 @@
 .page {
   overflow: hidden;
-
-  .page-body {
-
-    & > .gm-scroll-view {
-      display: flex;
-      flex: 1 0 auto;
-      flex-direction: column;
-    }
-
-  }
-
 }
 
 & when (@layout-screen-small-enabled) {

--- a/src/styles/layout/page/styles.less
+++ b/src/styles/layout/page/styles.less
@@ -1,6 +1,15 @@
 .page {
-
   overflow: hidden;
+
+  .page-body {
+
+    & > .gm-scroll-view {
+      display: flex;
+      flex: 1 0 auto;
+      flex-direction: column;
+    }
+
+  }
 
 }
 
@@ -36,6 +45,7 @@
 
 }
 
+// TODO: Audit the following styles.
 // @page-navigation-font-size: @body-text-font-size * 1.4;
 //
 // .page {


### PR DESCRIPTION
This fixes the Gemini Scrollbar content when native overlay scrollbars are enabled. The rest of `page/styles.less` still needs to be audited, but I'd like to wait until more of the components have been audited.