### PR TITLE
DCOS-9118: Refactor service form modal to only keep service in state

### DIFF
--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -125,7 +125,6 @@ class ServiceFormModal extends mixin(StoreMixin) {
     this.state = {
       defaultTab: '',
       errorMessage: null,
-      jsonDefinition: JSON.stringify({id:'', cmd:''}, null, 2),
       jsonMode: false,
       model,
       pendingRequest: false,
@@ -195,7 +194,6 @@ class ServiceFormModal extends mixin(StoreMixin) {
       warningMessage,
       errorMessage: null,
       force: false,
-      jsonDefinition: service.toJSON(),
       jsonMode,
       model,
       pendingRequest: false,
@@ -221,7 +219,6 @@ class ServiceFormModal extends mixin(StoreMixin) {
     }
     this.setState(
       {
-        jsonDefinition,
         service,
         errorMessage: null,
         warningMessage: null
@@ -242,8 +239,6 @@ class ServiceFormModal extends mixin(StoreMixin) {
       );
       nextState.model = model;
       nextState.service = service;
-      nextState.jsonDefinition = JSON.stringify(ServiceUtil
-        .getAppDefinitionFromService(service), null, 2);
     }
 
     if (this.shouldDisableForm(this.state.service)) {
@@ -307,7 +302,6 @@ class ServiceFormModal extends mixin(StoreMixin) {
     this.props.onClose();
   }
 
-  // TODO (poltergeist): Simplify submit logic.
   handleSubmit() {
     let marathonAction = MarathonStore.createService;
 
@@ -316,15 +310,12 @@ class ServiceFormModal extends mixin(StoreMixin) {
     }
 
     if (this.state.jsonMode) {
-      let jsonDefinition = JSON.parse(this.state.jsonDefinition);
+      let jsonDefinition = JSON.parse(this.state.service.toJSON());
       jsonDefinition = cleanJSONdefinition(jsonDefinition);
       marathonAction(jsonDefinition, this.state.force);
-      jsonDefinition = JSON.stringify(jsonDefinition, null, 2);
       this.setState({
         errorMessage: null,
-        jsonDefinition,
-        pendingRequest: true,
-        service: new Service(jsonDefinition)
+        pendingRequest: true
       });
       return;
     }
@@ -469,10 +460,10 @@ class ServiceFormModal extends mixin(StoreMixin) {
   }
 
   getModalContents() {
-    let {defaultTab, jsonDefinition, jsonMode, service} = this.state;
+    let {defaultTab, jsonMode, service} = this.state;
 
-    jsonDefinition = JSON.stringify(
-      cleanJSONdefinition(JSON.parse(jsonDefinition)),
+    let jsonDefinition = JSON.stringify(
+      cleanJSONdefinition(service.get()),
       null,
       2
     );


### PR DESCRIPTION
This removes the jsonDefinition from the serviceFormModal.