### PR TITLE
Fixes visibility store so that it doesn't set isInactive as false when it is active.

### DIFF
--- a/src/js/stores/VisibilityStore.js
+++ b/src/js/stores/VisibilityStore.js
@@ -88,14 +88,16 @@ class VisibilityStore extends GetSetBaseStore {
       }, Config.setInactiveAfter || 0);
     }
 
-    if (this.get('isInactive') && isTabVisible) {
+    if (isTabVisible) {
       if (this.timeOut) {
         clearTimeout(this.timeOut);
         this.timeOut = null;
       }
 
-      this.set({isInactive: false});
-      this.emit(VISIBILITY_CHANGE);
+      if (this.get('isInactive')) {
+        this.set({isInactive: false});
+        this.emit(VISIBILITY_CHANGE);
+      }
     }
   }
 


### PR DESCRIPTION
The problem was that if you switched between dcos tab and another tab in your browser and back to dcos, we wouldn't clear the timeout and after 30 seconds `isInactive` would be set to false, halting all ajax requests.

ps. this was fun to debug.

cc/ @MatApple 