### PR TITLE
Add checks for node environment variables for use with symlinked reactjs-components

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,5 +3,5 @@
 To develop ReactJS Components and see the implications immediately in DC/OS UI, it is helpful to use [npm link](https://docs.npmjs.com/cli/link).
 1. Run `npm link` in your `reactjs-components` directory.
 2. Run `npm link reactjs-components` in your `dcos-ui` directory.
-3. Run `npm run start-reactjs-components-local` to start the Webpack dev server.
+3. Run `REACTJS_COMPONENTS_LOCAL=true npm start` to start the Webpack dev server with the proper configuration variable.
 4. After any changes are made to `reactjs-components`, run `npm run dist-src` in the `reactjs-components` directory.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,5 +3,5 @@
 To develop ReactJS Components and see the implications immediately in DC/OS UI, it is helpful to use [npm link](https://docs.npmjs.com/cli/link).
 1. Run `npm link` in your `reactjs-components` directory.
 2. Run `npm link reactjs-components` in your `dcos-ui` directory.
-3. Run `REACTJS_COMPONENTS_LOCAL=true npm start` to start the Webpack dev server with the proper configuration variable.
+3. Run `REACTJS_COMPONENTS_LOCAL=true; npm start` to start the Webpack dev server with the proper configuration variable.
 4. After any changes are made to `reactjs-components`, run `npm run dist-src` in the `reactjs-components` directory.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+### Working with ReactJS Components
+
+To develop ReactJS Components and see the implications immediately in DC/OS UI, it is helpful to use [npm link](https://docs.npmjs.com/cli/link).
+1. Run `npm link` in your `reactjs-components` directory.
+2. Run `npm link reactjs-components` in your `dcos-ui` directory.
+3. Run `npm run start-reactjs-components-local` to start the Webpack dev server.
+4. After any changes are made to `reactjs-components`, run `npm run dist-src` in the `reactjs-components` directory.

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "serve-notify": "export NOTIFY=true && npm run serve",
     "scaffold": "./node_modules/.bin/gulp ensureConfig && ./node_modules/.bin/gulp ensureDevProxy",
     "start": "NODE_ENV=development webpack-dev-server --config ./webpack/webpack.dev.babel.js --hot --progress --colors --content-base ./build --host 0.0.0.0 --port $npm_package_config_port",
+    "start-reactjs-components-local": "REACTJS_COMPONENTS_LOCAL=true npm start",
     "test": "node jest/gen-config.js && NODE_PATH=node_modules jest --config=jest/config.json --no-cache",
     "testing": "NODE_ENV=testing webpack-dev-server --config ./webpack/webpack.dev.babel.js --progress --colors --content-base ./build --port $npm_package_config_port"
   },

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "serve-notify": "export NOTIFY=true && npm run serve",
     "scaffold": "./node_modules/.bin/gulp ensureConfig && ./node_modules/.bin/gulp ensureDevProxy",
     "start": "NODE_ENV=development webpack-dev-server --config ./webpack/webpack.dev.babel.js --hot --progress --colors --content-base ./build --host 0.0.0.0 --port $npm_package_config_port",
-    "start-reactjs-components-local": "REACTJS_COMPONENTS_LOCAL=true npm start",
     "test": "node jest/gen-config.js && NODE_PATH=node_modules jest --config=jest/config.json --no-cache",
     "testing": "NODE_ENV=testing webpack-dev-server --config ./webpack/webpack.dev.babel.js --progress --colors --content-base ./build --port $npm_package_config_port"
   },

--- a/webpack/webpack.config.babel.js
+++ b/webpack/webpack.config.babel.js
@@ -71,6 +71,12 @@ let svgSpriter = new SVGSprite({
   }
 });
 
+let eslintExclusion = /node_modules/;
+
+if (process.env.REACTJS_COMPONENTS_LOCAL) {
+  eslintExclusion = /node_modules|reactjs-components/;
+}
+
 module.exports = {
   lessLoader: {
     lessPlugins: [
@@ -132,7 +138,7 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'eslint-loader',
-        exclude: /node_modules/
+        exclude: eslintExclusion
       },
       {
         test: /\.js$/,

--- a/webpack/webpack.dev.babel.js
+++ b/webpack/webpack.dev.babel.js
@@ -50,6 +50,12 @@ if (environment === 'development') {
   };
 }
 
+let reactHotLoader = 'react-hot!';
+
+if (process.env.REACTJS_COMPONENTS_LOCAL) {
+  reactHotLoader = '';
+}
+
 module.exports = Object.assign({}, webpackConfig, {
   entry,
   devtool,
@@ -76,7 +82,7 @@ module.exports = Object.assign({}, webpackConfig, {
         test: /\.js$/,
         // Exclude all node_modules except dcos-dygraphs
         exclude: /(?=\/node_modules\/)(?!\/node_modules\/dcos-dygraphs\/)/,
-        loader: 'react-hot!babel?' + JSON.stringify({
+        loader: reactHotLoader + 'babel?' + JSON.stringify({
           cacheDirectory: true,
           // Map through resolve to fix preset loading problem
           presets: [


### PR DESCRIPTION
This PR introduces a script which disables eslint and `react-hot-loader`. This is necessary when using `npm link` with a local copy of `reactjs-components`.

Disabling eslint prevents linting the transpiled source, and disabling `react-hot-loader` is necessary due to our use of getters in `reactjs-components`. Read more about it here: https://github.com/gaearon/react-hot-loader/issues/131