### PR TITLE
Show task health state in detail page

### DIFF
--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -215,7 +215,7 @@ class TaskTable extends React.Component {
         <col style={{width: '40px'}} />
         <col />
         <col style={{width: '15%'}} className="hidden-mini" />
-        <col style={{width: '105px'}} />
+        <col style={{width: '115px'}} />
         <col style={{width: '40px'}} className="hidden-medium hidden-small hidden-mini" />
         <col style={{width: '85px'}} className="hidden-mini" />
         <col style={{width: '85px'}} className="hidden-mini" />

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -79,12 +79,18 @@ class TaskTable extends React.Component {
     if (task.statuses == null) {
       return null;
     }
-    const healths = task.statuses.map((status) => status.healthy);
+    const healths = task.statuses.map(function (status) {
+      return status.healthy;
+    });
     const healthDataExists = healths.length > 0 && healths.every(
-      (health) => typeof health !== 'undefined'
+      function (health) {
+        return typeof health !== 'undefined';
+      }
     );
     if (healthDataExists) {
-      return healths.some((health) => health);
+      return healths.some(function (health) {
+        return health;
+      });
     }
 
     return null;

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -39,6 +39,14 @@ class TaskTable extends React.Component {
   }
 
   getStatusValue(task) {
+    let taskHealth = this.getTaskHealth(task);
+    if (taskHealth === true) {
+      return 'Healthy';
+    }
+    if (taskHealth === false) {
+      return 'Unhealthy';
+    }
+
     return TaskStates[task.state].displayName;
   }
 
@@ -70,6 +78,9 @@ class TaskTable extends React.Component {
   }
 
   getTaskHealthFromMesos(task) {
+    if (task.statuses == null) {
+      return null;
+    }
     const healths = task.statuses.map((status) => status.healthy);
     const healthDataExists = healths.length > 0 && healths.every(
       (health) => typeof health !== 'undefined'
@@ -128,7 +139,7 @@ class TaskTable extends React.Component {
       {
         cacheCell: true,
         className,
-        getValue: this.getStatusValue,
+        getValue: this.getStatusValue.bind(this),
         headerClassName: className,
         heading,
         prop: 'status',

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -55,12 +55,8 @@ class TaskTable extends React.Component {
     if (mesosTaskHealth !== null) {
       return mesosTaskHealth;
     }
-    let marathonTaskHealth = this.getTaskHealthFromMarathon(task);
-    if (marathonTaskHealth !== null) {
-      return marathonTaskHealth;
-    }
 
-    return null;
+    return this.getTaskHealthFromMarathon(task);
   }
 
   getTaskHealthFromMarathon(task) {

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -61,7 +61,7 @@ class TaskTable extends React.Component {
   }
 
   getTaskHealthFromMarathon(task) {
-    const marathonTask = MarathonStore.getTaskFromTaskID(task.id);
+    const marathonTask = DCOSStore.serviceTree.getTaskFromTaskID(task.id);
     if (marathonTask != null) {
       const {healthCheckResults} = marathonTask;
       if (healthCheckResults != null && healthCheckResults.length > 0) {

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -41,6 +41,7 @@ class TaskTable extends React.Component {
 
   getStatusValue(task) {
     let taskHealth = this.getTaskHealth(task);
+    // task status should only reflect health if taskHealth is defined
     if (taskHealth === true) {
       return 'Healthy';
     }

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -15,6 +15,7 @@ import TableUtil from '../utils/TableUtil';
 import Units from '../utils/Units';
 
 const METHODS_TO_BIND = [
+  'getStatusValue',
   'renderHeadline',
   'renderHost',
   'renderLog',
@@ -135,7 +136,7 @@ class TaskTable extends React.Component {
       {
         cacheCell: true,
         className,
-        getValue: this.getStatusValue.bind(this),
+        getValue: this.getStatusValue,
         headerClassName: className,
         heading,
         prop: 'status',

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -289,26 +289,21 @@ class TaskTable extends React.Component {
     let {state} = task;
 
     let dangerState = TaskStates[state].stateTypes.includes('failure');
-
-    let healthy = this.getTaskHealth(task);
-    let unknown = task.statuses.length === 0 || task.statuses.some(function (status) {
-      return status.healthy == null;
-    });
-
     let activeState = TaskStates[state].stateTypes.includes('active');
 
-    let running = ['TASK_RUNNING', 'TASK_STARTING'].includes(state) && unknown;
-    let success = healthy && state === 'TASK_RUNNING';
-    let danger = (dangerState && !activeState &&
-      ['TASK_ERROR', 'TASK_FAILED'].includes(state)) ||
-      (healthy === false && task.statuses.length !== 0);
+    let healthy = this.getTaskHealth(task);
+    let unhealthy = (healthy === false);
+    let unknown = (healthy === null);
+
+    let failing = ['TASK_ERROR', 'TASK_FAILED'].includes(state);
+    let running = ['TASK_RUNNING', 'TASK_STARTING'].includes(state);
 
     let statusClass = classNames({
       'dot': true,
       'inactive': !activeState,
-      'success': success,
-      'running': running,
-      'danger': danger
+      'success': healthy && running,
+      'running': unknown && running,
+      'danger': dangerState || unhealthy || failing
     });
 
     return (

--- a/src/js/components/__tests__/TaskTable-test.js
+++ b/src/js/components/__tests__/TaskTable-test.js
@@ -12,13 +12,16 @@ const React = require('react');
 const ReactDOM = require('react-dom');
 const JestUtil = require('../../utils/JestUtil');
 
-const MarathonStore = require('../../stores/MarathonStore');
+const DCOSStore = require('../../stores/DCOSStore');
 const MesosStateStore = require('../../stores/MesosStateStore');
 const TaskTable = require('../TaskTable');
 const Tasks = require('./fixtures/MockTasks.json').tasks;
 
 describe('TaskTable', function () {
   beforeEach(function () {
+    DCOSStore.serviceTree = {
+      getTaskFromTaskID: jest.fn()
+    };
     this.parentRouter = {
       getCurrentRoutes() {
         return [{name: 'home'}, {name: 'dashboard'}, {name: 'service-detail'}];
@@ -49,16 +52,16 @@ describe('TaskTable', function () {
     });
 
     it('interrogates the task status', function () {
-      spyOn(MarathonStore, 'getTaskFromTaskID');
+      spyOn(DCOSStore.serviceTree, 'getTaskFromTaskID');
       var health = this.taskTable.getTaskHealth({
         statuses: [{healthy: true}]
       });
       expect(health).toEqual(true);
-      expect(MarathonStore.getTaskFromTaskID).not.toHaveBeenCalled();
+      expect(DCOSStore.serviceTree.getTaskFromTaskID).not.toHaveBeenCalled();
     });
 
-    it('falls back on the MarathonStore task\'s health checks', function () {
-      MarathonStore.getTaskFromTaskID.mockReturnValueOnce({
+    it('falls back on the DCOSStore.serviceTree task\'s health checks', function () {
+      DCOSStore.serviceTree.getTaskFromTaskID.mockReturnValueOnce({
         healthCheckResults: [{alive: true}]
       });
       var health = this.taskTable.getTaskHealth({statuses: []});
@@ -67,7 +70,7 @@ describe('TaskTable', function () {
 
     it('returns null if neither status nor Marathon have task health data',
         function () {
-          MarathonStore.getTaskFromTaskID.mockReturnValueOnce({
+          DCOSStore.serviceTree.getTaskFromTaskID.mockReturnValueOnce({
             healthCheckResults: []
           });
       var health = this.taskTable.getTaskHealth({statuses: []});
@@ -118,7 +121,7 @@ describe('TaskTable', function () {
     });
 
     it('returns true if all health checks pass', function () {
-      MarathonStore.getTaskFromTaskID.mockReturnValueOnce({
+      DCOSStore.serviceTree.getTaskFromTaskID.mockReturnValueOnce({
         healthCheckResults: [{alive: true}, {alive: true}]
       });
       var health = this.taskTable.getTaskHealthFromMarathon({id:'foo'});
@@ -126,7 +129,7 @@ describe('TaskTable', function () {
     });
 
     it('returns false if one health check fails', function () {
-      MarathonStore.getTaskFromTaskID.mockReturnValueOnce({
+      DCOSStore.serviceTree.getTaskFromTaskID.mockReturnValueOnce({
         healthCheckResults: [{alive: true}, {alive: false}, {alive: true}]
       });
       var health = this.taskTable.getTaskHealthFromMarathon({id:'foo'});

--- a/src/js/components/__tests__/TaskTable-test.js
+++ b/src/js/components/__tests__/TaskTable-test.js
@@ -2,6 +2,7 @@ jest.dontMock('../CollapsingString');
 jest.dontMock('./fixtures/MockTasks.json');
 jest.dontMock('../../utils/ResourceTableUtil');
 jest.dontMock('../../stores/MesosStateStore');
+jest.dontMock('../../constants/TaskStates');
 jest.dontMock('../TaskTable');
 jest.dontMock('moment');
 
@@ -135,6 +136,29 @@ describe('TaskTable', function () {
     it('returns null if no health checks are present', function () {
       var health = this.taskTable.getTaskHealthFromMarathon({id:'foo'});
       expect(health).toBeNull();
+    });
+
+  });
+
+  describe('#getStatusValue', function () {
+
+    beforeEach(function () {
+      this.taskTable = new TaskTable();
+    });
+
+    it('returns \'Healthy\' if task is healthy', function () {
+      var value = this.taskTable.getStatusValue({statuses: [{healthy:true}]});
+      expect(value).toEqual('Healthy');
+    });
+
+    it('returns \'Unhealthy\' if task is unhealthy', function () {
+      var value = this.taskTable.getStatusValue({statuses: [{healthy:false}]});
+      expect(value).toEqual('Unhealthy');
+    });
+
+    it('falls back to TaskStates if task has no health data', function () {
+      var value = this.taskTable.getStatusValue({state: 'TASK_KILLING'});
+      expect(value).toEqual('Killing');
     });
 
   });

--- a/src/js/components/__tests__/TaskTable-test.js
+++ b/src/js/components/__tests__/TaskTable-test.js
@@ -11,6 +11,7 @@ const React = require('react');
 const ReactDOM = require('react-dom');
 const JestUtil = require('../../utils/JestUtil');
 
+const MarathonStore = require('../../stores/MarathonStore');
 const MesosStateStore = require('../../stores/MesosStateStore');
 const TaskTable = require('../TaskTable');
 const Tasks = require('./fixtures/MockTasks.json').tasks;
@@ -37,6 +38,104 @@ describe('TaskTable', function () {
       ),
       this.container
     );
+
+  });
+
+  describe('#getTaskHealth', function () {
+
+    beforeEach(function () {
+      this.taskTable = new TaskTable();
+    });
+
+    it('interrogates the task status', function () {
+      spyOn(MarathonStore, 'getTaskFromTaskID');
+      var health = this.taskTable.getTaskHealth({
+        statuses: [{healthy: true}]
+      });
+      expect(health).toEqual(true);
+      expect(MarathonStore.getTaskFromTaskID).not.toHaveBeenCalled();
+    });
+
+    it('falls back on the MarathonStore task\'s health checks', function () {
+      MarathonStore.getTaskFromTaskID.mockReturnValueOnce({
+        healthCheckResults: [{alive: true}]
+      });
+      var health = this.taskTable.getTaskHealth({statuses: []});
+      expect(health).toEqual(true);
+    });
+
+    it('returns null if neither status nor Marathon have task health data',
+        function () {
+          MarathonStore.getTaskFromTaskID.mockReturnValueOnce({
+            healthCheckResults: []
+          });
+      var health = this.taskTable.getTaskHealth({statuses: []});
+      expect(health).toBeNull();
+    });
+  });
+
+  describe('#getTaskHealthFromMesos', function () {
+
+    beforeEach(function () {
+      this.taskTable = new TaskTable();
+    });
+
+    it('returns true if at least one status is healthy', function () {
+      var health = this.taskTable.getTaskHealthFromMesos({
+        statuses: [{healthy: true}, {healthy: false}]
+      });
+      expect(health).toEqual(true);
+    });
+
+    it('returns null if no statuses have health data', function () {
+      var health = this.taskTable.getTaskHealthFromMesos({
+        statuses: [{}, {}, {}]
+      });
+      expect(health).toBeNull();
+    });
+
+    it('returns null if no statuses are present', function () {
+      var health = this.taskTable.getTaskHealthFromMesos({
+        statuses: []
+      });
+      expect(health).toBeNull();
+    });
+
+    it('returns false if all statuses are unhealthy', function () {
+      var health = this.taskTable.getTaskHealthFromMesos({
+        statuses: [{healthy: false}, {healthy: false}]
+      });
+      expect(health).toEqual(false);
+    });
+
+  });
+
+  describe('#getTaskHealthFromMarathon', function () {
+
+    beforeEach(function () {
+      this.taskTable = new TaskTable();
+    });
+
+    it('returns true if all health checks pass', function () {
+      MarathonStore.getTaskFromTaskID.mockReturnValueOnce({
+        healthCheckResults: [{alive: true}, {alive: true}]
+      });
+      var health = this.taskTable.getTaskHealthFromMarathon({id:'foo'});
+      expect(health).toEqual(true);
+    });
+
+    it('returns false if one health check fails', function () {
+      MarathonStore.getTaskFromTaskID.mockReturnValueOnce({
+        healthCheckResults: [{alive: true}, {alive: false}, {alive: true}]
+      });
+      var health = this.taskTable.getTaskHealthFromMarathon({id:'foo'});
+      expect(health).toEqual(false);
+    });
+
+    it('returns null if no health checks are present', function () {
+      var health = this.taskTable.getTaskHealthFromMarathon({id:'foo'});
+      expect(health).toBeNull();
+    });
 
   });
 

--- a/src/js/components/__tests__/TaskTable-test.js
+++ b/src/js/components/__tests__/TaskTable-test.js
@@ -68,11 +68,10 @@ describe('TaskTable', function () {
       expect(health).toEqual(true);
     });
 
-    it('returns null if neither status nor Marathon have task health data',
-        function () {
-          DCOSStore.serviceTree.getTaskFromTaskID.mockReturnValueOnce({
-            healthCheckResults: []
-          });
+    it('returns null if neither status nor Marathon have task health data', function () {
+      DCOSStore.serviceTree.getTaskFromTaskID.mockReturnValueOnce({
+        healthCheckResults: []
+      });
       var health = this.taskTable.getTaskHealth({statuses: []});
       expect(health).toBeNull();
     });


### PR DESCRIPTION
Previously, task health status was being inferred from the presence of the Mesos state.json endpoint in `frameworks[].tasks[].statuses[].healthy`. This is not guaranteed to be present. Separately, task health and running status were being conflated such that where a task was in an unhealthy state (eg Killing) the Running state was being shown. 

This PR:
 - introduces a fallback on the Marathon health checks where the Mesos task healthy property is not present
 - adds a 'Healthy' and 'Unhealthy' label to the status column
 - cleans up the state badges classes so that running and unhealthy do not conflict

This PR resolves https://dcosjira.atlassian.net/browse/DCOS-290

Before:
![screen shot 2016-08-10 at 4 44 25 pm](https://cloud.githubusercontent.com/assets/2989362/17574919/e5d4d5b4-5f19-11e6-8856-6d33b861630f.png)

After:
![screen shot 2016-08-10 at 4 45 09 pm](https://cloud.githubusercontent.com/assets/2989362/17574921/e953f49a-5f19-11e6-83da-f91d3b67d8f9.png)

_NB a separate bug is present in these screenshots where over-capacity tasks are counted twice. This is outside the scope of this PR_
