### PR TITLE
DCOS-8568: Making inactive filter items fade 50%

### DIFF
--- a/src/js/components/SidebarFilter.js
+++ b/src/js/components/SidebarFilter.js
@@ -153,12 +153,14 @@ class SidebarFilter extends mixin(QueryParamsMixin) {
       .map((filterLabel) => {
         let value = filterValues[filterLabel];
         let checked = selectedNodes.indexOf(value.toString()) > -1;
+        let isActive = this.getCountByValue(filterLabel) > 0;
 
         let labelClassSet = classNames(
           'side-list-item form-row-element form-element-checkbox inverse',
           'row row-flex flex-align-items-center vertical-center flush clickable',
           {
-            'filter-active': this.getCountByValue(filterLabel) > 0,
+            'filter-active': isActive,
+            'filter-inactive': !isActive,
             'filter-checked': checked
           }
         );

--- a/src/styles/components/service-sidebar.less
+++ b/src/styles/components/service-sidebar.less
@@ -4,6 +4,10 @@
       color: color-lighten(@neutral, 75);
     }
 
+    .filter-inactive {
+      opacity: 0.5;
+    }
+
     .filter-checked, &:hover {
       color: @white;
     }


### PR DESCRIPTION
This makes a bit more obvious the fact that a filter without items is disabled.

![image](https://cloud.githubusercontent.com/assets/883486/17597795/c010bb34-5ff7-11e6-8b13-3715107b02d8.png)
