### PR TITLE
DCOS-9054: Service icons not displaying

### DIFF
--- a/src/js/components/__tests__/ServiceInfo-test.js
+++ b/src/js/components/__tests__/ServiceInfo-test.js
@@ -23,8 +23,8 @@ describe('ServiceInfo', function () {
     tasksRunning: 2,
     tasksHealthy: 2,
     tasksUnhealthy: 0,
-    images: {
-      'icon-large': 'foo.png'
+    labels: {
+      'DCOS_PACKAGE_METADATA': 'eyJpbWFnZXMiOiB7ICJpY29uLXNtYWxsIjogImZvby1zbWFsbC5wbmciLCAiaWNvbi1tZWRpdW0iOiAiZm9vLW1lZGl1bS5wbmciLCAiaWNvbi1sYXJnZSI6ICJmb28tbGFyZ2UucG5nIn19'
     }
   });
 
@@ -49,7 +49,7 @@ describe('ServiceInfo', function () {
     it('renders image', function () {
       expect(
         this.node.querySelector('.icon img').src
-      ).toEqual('foo.png');
+      ).toEqual('foo-large.png');
     });
 
     it('renders app status, not health state', function () {

--- a/src/js/structs/Framework.js
+++ b/src/js/structs/Framework.js
@@ -3,17 +3,8 @@ import {
   FRAMEWORK_ID_VALID_CHARACTERS
 } from '../constants/FrameworkConstants';
 import Service from './Service';
-import FrameworkUtil from '../utils/FrameworkUtil';
 
 module.exports = class Framework extends Service {
-  getImages() {
-    return FrameworkUtil.getServiceImages(this.getMetadata().images);
-  }
-
-  getMetadata() {
-    return FrameworkUtil.getMetadataFromLabels(this.getLabels());
-  }
-
   getNodeIDs() {
     return this.get('slave_ids');
   }

--- a/src/js/structs/Service.js
+++ b/src/js/structs/Service.js
@@ -1,7 +1,7 @@
 import Config from '../config/Config';
+import ServiceUtil from '../utils/ServiceUtil';
 import HealthStatus from '../constants/HealthStatus';
 import Item from './Item';
-import ServiceImages from '../constants/ServiceImages';
 import ServiceStatus from '../constants/ServiceStatus';
 import TaskStats from './TaskStats';
 import VolumeList from './VolumeList';
@@ -78,7 +78,7 @@ module.exports = class Service extends Item {
   }
 
   getImages() {
-    return this.get('images') || ServiceImages.NA_IMAGES;
+    return ServiceUtil.getServiceImages(this.getMetadata().images);
   }
 
   getInstancesCount() {
@@ -107,6 +107,10 @@ module.exports = class Service extends Item {
 
   getMem() {
     return this.get('mem');
+  }
+
+  getMetadata() {
+    return ServiceUtil.getMetadataFromLabels(this.getLabels());
   }
 
   getName() {

--- a/src/js/structs/Service.js
+++ b/src/js/structs/Service.js
@@ -1,5 +1,5 @@
 import Config from '../config/Config';
-import ServiceUtil from '../utils/ServiceUtil';
+import FrameworkUtil from '../utils/FrameworkUtil';
 import HealthStatus from '../constants/HealthStatus';
 import Item from './Item';
 import ServiceStatus from '../constants/ServiceStatus';
@@ -78,7 +78,7 @@ module.exports = class Service extends Item {
   }
 
   getImages() {
-    return ServiceUtil.getServiceImages(this.getMetadata().images);
+    return FrameworkUtil.getServiceImages(this.getMetadata().images);
   }
 
   getInstancesCount() {
@@ -110,7 +110,7 @@ module.exports = class Service extends Item {
   }
 
   getMetadata() {
-    return ServiceUtil.getMetadataFromLabels(this.getLabels());
+    return FrameworkUtil.getMetadataFromLabels(this.getLabels());
   }
 
   getName() {

--- a/src/js/structs/__tests__/Service-test.js
+++ b/src/js/structs/__tests__/Service-test.js
@@ -227,17 +227,15 @@ describe('Service', function () {
 
     it('returns correct images', function () {
       let service = new Service({
-        images: {
-          'icon-small': 'icon-small@2x.png',
-          'icon-medium': 'icon-medium@2x.png',
-          'icon-large': 'icon-large@2x.png'
+        labels: {
+          'DCOS_PACKAGE_METADATA': 'eyJpbWFnZXMiOiB7ICJpY29uLXNtYWxsIjogImZvby1zbWFsbC5wbmciLCAiaWNvbi1tZWRpdW0iOiAiZm9vLW1lZGl1bS5wbmciLCAiaWNvbi1sYXJnZSI6ICJmb28tbGFyZ2UucG5nIn19'
         }
       });
 
       expect(service.getImages()).toEqual({
-        'icon-small': 'icon-small@2x.png',
-        'icon-medium': 'icon-medium@2x.png',
-        'icon-large': 'icon-large@2x.png'
+        'icon-small': 'foo-small.png',
+        'icon-medium': 'foo-medium.png',
+        'icon-large': 'foo-large.png'
       });
     });
 

--- a/src/js/utils/FrameworkUtil.js
+++ b/src/js/utils/FrameworkUtil.js
@@ -1,6 +1,8 @@
 import ServiceImages from '../constants/ServiceImages';
 import Util from '../utils/Util';
 
+// You might be tempted to merge FrameworkUtil into ServiceUtil, but that will
+// cause a circular dependency with ServiceUtil and struct/Service.
 const FrameworkUtil = {
   getImageSizeFromImagesObject(images, size) {
     if (images == null ||


### PR DESCRIPTION
Some service icons were missing. It turns out that some Applications carry their icons in their `DCOS_PACKAGE_METADATA` label even though they are not a Framework. And so we will generalise the Service struct (from which both Framework and Application inherit) to check for a metadata label when rendering an icon.

Original PR: https://github.com/dcos/dcos-ui/pull/949 caused a circular dependency, this PM avoids that problem.