### PR TITLE
DCOS-9023: Sidebar icon out of order

### DIFF
--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -23,8 +23,8 @@ let defaultMenuItems = [
   'dashboard',
   'services-page',
   'jobs-page',
-  'nodes-list',
   'network',
+  'nodes-list',
   'universe',
   'system'
 ];


### PR DESCRIPTION
Swap order of DC/OS sidebar icons to match the ordering in Enterprise.