### PR TITLE
Improve task table performance

### DIFF
--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -107,7 +107,10 @@ var ServicesTab = React.createClass({
   },
 
   onMarathonStoreGroupsSuccess() {
-    this.setState({marathonErrorCount: 0});
+    // Updating state on every success is costly
+    if (this.state.marathonErrorCount !== 0) {
+      this.setState({marathonErrorCount: 0});
+    }
   },
 
   handleCloseServiceFormModal() {


### PR DESCRIPTION
Avoids costly re-render of services tab when marathon store updates.

Before:
<img width="995" alt="screen shot 2016-08-22 at 12 36 39 am" src="https://cloud.githubusercontent.com/assets/2989362/17847166/6d6ab5a8-6801-11e6-9b13-76e300fefd28.png">

After:
<img width="981" alt="screen shot 2016-08-22 at 12 37 18 am" src="https://cloud.githubusercontent.com/assets/2989362/17847169/70d865dc-6801-11e6-912f-d8a2c0e6297f.png">
