### PR TITLE
DCOS-9034: Renaming VIPs when changing service

### DIFF
--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -146,14 +146,6 @@ class ServiceFormModal extends mixin(StoreMixin) {
       this[method] = this[method].bind(this);
     });
 
-    this.sourceService = null;
-
-  }
-
-  componentDidMount() {
-    if (this.props.service) {
-      this.sourceService = JSON.parse(this.props.service.toJSON());
-    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -340,10 +332,9 @@ class ServiceFormModal extends mixin(StoreMixin) {
       );
 
       // Handle service rename if this action renamed a field
-      if (this.props.isEdit && this.sourceService) {
-        let sourceName = this.sourceService['id'].split('/').pop();
-        if (service.getName() !== sourceName) {
-          service.handleRename( sourceName, service.getName() );
+      if (this.props.isEdit && this.props.service && this.props.service.getName()) {
+        if (service.getName() !== this.props.service.getName()) {
+          service.handleRename( this.props.service.getName(), service.getName() );
         }
       }
 

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -308,6 +308,14 @@ class ServiceFormModal extends mixin(StoreMixin) {
     }
 
     if (this.state.jsonMode) {
+
+      // Handle service rename if this action renamed a field
+      if (this.props.isEdit && this.props.service && this.props.service.getId()) {
+        if (this.state.service.getId() !== this.props.service.getId()) {
+          this.state.service.handleRename( this.props.service.getId(), this.state.service.getId() );
+        }
+      }
+
       let jsonDefinition = JSON.parse(this.state.service.toJSON());
       jsonDefinition = cleanJSONdefinition(jsonDefinition);
       marathonAction(jsonDefinition, this.state.force);
@@ -332,9 +340,9 @@ class ServiceFormModal extends mixin(StoreMixin) {
       );
 
       // Handle service rename if this action renamed a field
-      if (this.props.isEdit && this.props.service && this.props.service.getName()) {
-        if (service.getName() !== this.props.service.getName()) {
-          service.handleRename( this.props.service.getName(), service.getName() );
+      if (this.props.isEdit && this.props.service && this.props.service.getId()) {
+        if (service.getId() !== this.props.service.getId()) {
+          service.handleRename( this.props.service.getId(), service.getId() );
         }
       }
 

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -145,6 +145,15 @@ class ServiceFormModal extends mixin(StoreMixin) {
     METHODS_TO_BIND.forEach((method) => {
       this[method] = this[method].bind(this);
     });
+
+    this.sourceService = null;
+
+  }
+
+  componentDidMount() {
+    if (this.props.service) {
+      this.sourceService = JSON.parse(this.props.service.toJSON());
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -329,6 +338,15 @@ class ServiceFormModal extends mixin(StoreMixin) {
         this.props.isEdit,
         JSON.parse(this.state.service.toJSON())
       );
+
+      // Handle service rename if this action renamed a field
+      if (this.props.isEdit && this.sourceService) {
+        let sourceName = this.sourceService['id'].split('/').pop();
+        if (service.getName() !== sourceName) {
+          service.handleRename( sourceName, service.getName() );
+        }
+      }
+
       this.setState({
         errorMessage: null,
         model,

--- a/src/js/structs/Service.js
+++ b/src/js/structs/Service.js
@@ -6,6 +6,21 @@ import ServiceStatus from '../constants/ServiceStatus';
 import TaskStats from './TaskStats';
 import VolumeList from './VolumeList';
 
+function renamePortDefinition(fromName, toName, portDef) {
+  if (portDef.labels) {
+    Object.keys(portDef.labels).forEach(function (labelName) {
+      if (labelName.substr(0, 4) === 'VIP_') {
+        let labelValue = portDef.labels[labelName];
+        let labelParts = labelValue.split(':');
+        if (labelParts[0] === fromName) {
+          portDef.labels[labelName] = toName + ':' + labelParts[1];
+          return;
+        }
+      }
+    });
+  }
+}
+
 module.exports = class Service extends Item {
   getArguments() {
     return this.get('args');
@@ -249,24 +264,17 @@ module.exports = class Service extends Item {
 
   }
 
-  handleRename( fromName, toName ) {
-    let portDefinitions = this.getPortDefinitions();
+  handleRename(fromName, toName) {
 
     // Rename VIPs on portDefinitions
-    portDefinitions.forEach(function (portDef) {
-      if (portDef.labels) {
-        Object.keys(portDef.labels).forEach(function (labelName) {
-          if (labelName.substr(0, 4) === 'VIP_') {
-            let labelValue = portDef.labels[labelName];
-            let labelParts = labelValue.split(':');
-            if (labelParts[0] === fromName) {
-              portDef.labels[labelName] = toName + ':' + labelParts[1];
-              return;
-            }
-          }
-        });
-      }
-    });
+    let portDefinitions = this.getPortDefinitions();
+    portDefinitions.forEach(renamePortDefinition.bind(this, fromName, toName));
+
+    // Rename VIPs on portMappings in a docker container
+    let container = this.getContainer();
+    if (container.docker && container.docker.portMappings) {
+      container.docker.portMappings.forEach(renamePortDefinition.bind(this, fromName, toName));
+    }
 
   }
 

--- a/src/js/structs/Service.js
+++ b/src/js/structs/Service.js
@@ -249,6 +249,27 @@ module.exports = class Service extends Item {
 
   }
 
+  handleRename( fromName, toName ) {
+    let portDefinitions = this.getPortDefinitions();
+
+    // Rename VIPs on portDefinitions
+    portDefinitions.forEach(function (portDef) {
+      if (portDef.labels) {
+        Object.keys(portDef.labels).forEach(function (labelName) {
+          if (labelName.substr(0, 4) === 'VIP_') {
+            let labelValue = portDef.labels[labelName];
+            let labelParts = labelValue.split(':');
+            if (labelParts[0] === fromName) {
+              portDef.labels[labelName] = toName + ':' + labelParts[1];
+              return;
+            }
+          }
+        });
+      }
+    });
+
+  }
+
   toJSON() {
     return JSON.stringify(this.get());
   }


### PR DESCRIPTION
Adding support for renaming service VIPs when committing service changes.

_NOTE: That's a tech debt. It might be a better idea to add `diff` support on service edit_