### PR TITLE
Remove network discovery text when discovery not checked

### DIFF
--- a/src/js/components/ServiceForm.js
+++ b/src/js/components/ServiceForm.js
@@ -147,8 +147,13 @@ class ServiceForm extends SchemaForm {
         let hostNetworkingDefinition = null;
         let {ports} = model.networking;
         let serviceAddressNetworkingDefinition = null;
-
         if (ports == null) {
+          return null;
+        }
+        let hasDiscovery = ports.some(function (port) {
+          return port.discovery;
+        });
+        if (!hasDiscovery) {
           return null;
         }
 


### PR DESCRIPTION
[DCOS-9119](https://mesosphere.atlassian.net/browse/DCOS-9119)

The expected behavior is that when a user checks the "Discovery" box that the blue icon and the information that accompanies it would display.

Currently, it is always being displayed which is not expected. This PR ensures the info is only displayed when a discovery checkbox is checked.