### PR TITLE
Bug fix: Universe error message integration tests

### DIFF
--- a/src/js/components/CollapsibleErrorMessage.js
+++ b/src/js/components/CollapsibleErrorMessage.js
@@ -1,5 +1,5 @@
-import React from 'react';
 import classNames from 'classnames/dedupe';
+import React from 'react';
 
 import Icon from './Icon';
 

--- a/src/js/components/CollapsibleErrorMessage.js
+++ b/src/js/components/CollapsibleErrorMessage.js
@@ -217,7 +217,7 @@ CollapsibleErrorMessage.propTypes = {
   className: React.PropTypes.string,
   details: React.PropTypes.array,
   expanded: React.PropTypes.bool,
-  message: React.PropTypes.string,
+  message: React.PropTypes.node,
   onToggle: React.PropTypes.func
 };
 

--- a/src/js/components/CollapsibleErrorMessage.js
+++ b/src/js/components/CollapsibleErrorMessage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'classnames';
+import classNames from 'classnames/dedupe';
 
 import Icon from './Icon';
 
@@ -90,7 +90,7 @@ class CollapsibleErrorMessage extends React.Component {
     // Render
     return (
         <span
-          className="collapsible-toggle-label  clickable"
+          className="collapsible-toggle-label clickable"
           onClick={this.toggleExpanded} >
           (Show {moreLess})
         </span>
@@ -109,9 +109,7 @@ class CollapsibleErrorMessage extends React.Component {
     return details.map(function (message, i) {
       let msg = message.toString();
 
-      return (
-          <li key={i}>{msg}</li>
-        );
+      return <li key={i}>{msg}</li>;
     });
   }
 
@@ -130,17 +128,17 @@ class CollapsibleErrorMessage extends React.Component {
 
     // Render the fixed part of the message
     return (
-        <div className="collapsible-fixed">
-          <Icon
-            family="mini"
-            id="yield"
-            size="mini"
-            className="icon-alert icon-margin-right"
-            color="red" />
-          {message}
-          {this.getShowDetailsLink()}
-        </div>
-      );
+      <div className="collapsible-fixed">
+        <Icon
+          className="icon-alert icon-margin-right"
+          color="red"
+          family="mini"
+          id="yield"
+          size="mini" />
+        {message}
+        {this.getShowDetailsLink()}
+      </div>
+    );
   }
 
   /**
@@ -160,15 +158,14 @@ class CollapsibleErrorMessage extends React.Component {
     // Render the toggled part of the message
     // (Note: The nested div is used to float the contents when needed)
     return (
-        <div className="collapsible-toggled">
-          <div>
-            <ul>
-            {this.getDetailsListItems()}
-            </ul>
-          </div>
+      <div className="collapsible-toggled">
+        <div>
+          <ul>
+          {this.getDetailsListItems()}
+          </ul>
         </div>
-      );
-
+      </div>
+    );
   }
 
   /**
@@ -186,21 +183,18 @@ class CollapsibleErrorMessage extends React.Component {
 
     // Compile classes
     let className = classNames(
-      this.props.className,
       'collapsible-error-message',
-      {
-        'expanded': this.state.expanded
-      }
+      {'expanded': this.state.expanded},
+      this.props.className
     );
 
     // Render message component
     return (
-        <div className={className}>
-          {this.getFixedMessagePart()}
-          {this.getCollapsibleMessagePart()}
-        </div>
-      );
-
+      <div className={className}>
+        {this.getFixedMessagePart()}
+        {this.getCollapsibleMessagePart()}
+      </div>
+    );
   };
 
 };

--- a/src/js/components/CosmosErrorMessage.js
+++ b/src/js/components/CosmosErrorMessage.js
@@ -30,42 +30,36 @@ class CosmosErrorMessage extends React.Component {
   getMessage() {
     let {type, message} = this.props.error;
 
-    // Append reference to repository page, since repository related errors
-    // can occur at any request to Cosmos
-    if (REPOSITORY_ERRORS.includes(type)) {
-      message = this.appendRepositoryLink(message);
+    if (!REPOSITORY_ERRORS.includes(type)) {
+      // Return message
+      return message;
     }
 
-    // Return message
-    return message;
+    // Append reference to repository page, since repository related errors
+    // can occur at any request to Cosmos
+    return this.appendRepositoryLink(message);
   }
 
   getDetails() {
     let {data} = this.props.error;
-
-    // Check if we should additionally append
-    // the error details as an unordered list
-    if (data && data.errors) {
-
-      // Get an array of array of errors for every individual path
-      let errorsDetails = data.errors.map(function ({path, errors}) {
-        return errors.map(function (error) {
-          return (ErrorPaths[path] || path)+'.'+error;
-        });
-      });
-
-      // Flatten elements in array and return
-      return errorsDetails.reduce(function (a, b) {
-        return a.concat(b);
-      });
-
-    } else {
-
+    if (!data || !data.errors) {
       // No errors
       return null;
-
     }
+    // Check if we should additionally append
+    // the error details as an unordered list
 
+    // Get an array of array of errors for every individual path
+    let errorsDetails = data.errors.map(function ({path, errors}) {
+      return errors.map(function (error) {
+        return (ErrorPaths[path] || path)+'.'+error;
+      });
+    });
+
+    // Flatten elements in array and return
+    return errorsDetails.reduce(function (a, b) {
+      return a.concat(b);
+    });
   }
 
   appendRepositoryLink(message) {

--- a/src/js/components/CosmosErrorMessage.js
+++ b/src/js/components/CosmosErrorMessage.js
@@ -102,7 +102,7 @@ CosmosErrorMessage.defaultProps = {
 CosmosErrorMessage.propTypes = {
   className: React.PropTypes.string,
   error: React.PropTypes.shape({
-    message: React.PropTypes.string,
+    message: React.PropTypes.node,
     type: React.PropTypes.string,
     data: React.PropTypes.object
   }),

--- a/src/js/components/CosmosErrorMessage.js
+++ b/src/js/components/CosmosErrorMessage.js
@@ -79,11 +79,14 @@ class CosmosErrorMessage extends React.Component {
   }
 
   render() {
+    let {className, onResized, wrapperClass} = this.props;
+
     return (
-      <div className={this.props.wrapperClass}>
+      <div className={wrapperClass}>
         {this.getHeader()}
         <CollapsibleErrorMessage
-          onToggle={this.props.onResized}
+          className={className}
+          onToggle={onResized}
           message={this.getMessage()}
           details={this.getDetails()} />
       </div>

--- a/tests/pages/system/overview/components/AddRepositoryFormModal-cy.js
+++ b/tests/pages/system/overview/components/AddRepositoryFormModal-cy.js
@@ -52,11 +52,11 @@ describe('Add Repository Form Modal', function () {
   it('closes modal after add is successful', function () {
     cy
       .get('.modal input')
-      .eq(0).type('Here we go!');
-    cy
+      .eq(0).type('Here we go!')
       .get('.modal input')
-      .eq(1).type('http://there-is-no-stopping.us');
-    cy
+      .eq(1).type('http://there-is-no-stopping.us')
+      .get('.modal input')
+      .eq(2).type('0')
       .get('.modal .modal-footer .button.button-success')
       .contains('Add')
       .click();


### PR DESCRIPTION
Here is the message displaying (as it was before):
![](https://cl.ly/012I0O2u423O/Image%202016-08-23%20at%2015.13.13.png)

However, now it has the appropriate classes on the element 😄 

It also adds a missing required field in the repository modal for an integration test