### PR TITLE
DCOS-9431: Add support for labels without a value

### DIFF
--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -209,7 +209,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
   }
 
   handleJSONChange(jsonDefinition) {
-    let service = Object.assign({}, this.state.service);
+    let {service} = this.state;
     try {
       service = new Service(JSON.parse(jsonDefinition));
     } catch (e) {

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -216,7 +216,18 @@ const ServiceUtil = {
 
       if (labels != null && labels.labels != null) {
         definition.labels = labels.labels.reduce(function (memo, item) {
-          memo[item.key] = item.value;
+          if (item.key == null) {
+            return memo;
+          }
+
+          // The 'undefined' value is not rendered by the JSON.stringify,
+          // so make sure empty environment variables are not left unrendered
+          let value = item.value;
+          if (value == null) {
+            value = '';
+          }
+
+          memo[item.key] = value;
 
           return memo;
         }, {});

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -98,6 +98,58 @@ describe('ServiceUtil', function () {
 
     });
 
+    describe('labels', function () {
+
+      it('should keep undefined values as ""', function () {
+        let service = ServiceUtil.createServiceFromFormModel({
+          labels: {
+            labels: [
+              { key: 'a', value: 'correct' },
+              { key: 'b', value: undefined }
+            ]
+          }
+        });
+        expect(service.labels).toEqual({
+          a: 'correct',
+          b: ''
+        });
+      });
+
+      it('should not set items with no key', function () {
+        let service = ServiceUtil.createServiceFromFormModel(
+          {
+            labels: {
+              labels: [
+                {key: 'a', value: 'correct'},
+                {value: undefined}
+              ]
+            }
+          }
+        );
+        expect(service.labels).toEqual(
+          {
+            a: 'correct'
+          }
+        );
+      });
+
+      it('should keep null values as ""', function () {
+        let service = ServiceUtil.createServiceFromFormModel({
+          labels: {
+            labels: [
+              { key: 'a', value: 'correct' },
+              { key: 'b', value: null }
+            ]
+          }
+        });
+        expect(service.labels).toEqual({
+          a: 'correct',
+          b: ''
+        });
+      });
+
+    });
+
     describe('networking', function () {
 
       describe('host mode', function () {


### PR DESCRIPTION
The Service Form JSON view seems to remove empty (undefined, null) labels. This PR changes null and undefined values to an empty string `''` which works.