### PR TITLE
Add help block to cron job field

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5426,9 +5426,9 @@
       "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz"
     },
     "reactjs-components": {
-      "version": "0.15.1-0",
-      "from": "reactjs-components@0.15.1-0",
-      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.15.1-0.tgz"
+      "version": "0.15.0-beta.1",
+      "from": "reactjs-components@0.15.0-beta.1",
+      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.15.0-beta.1.tgz"
     },
     "reactjs-mixin": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-gemini-scrollbar": "2.1.0",
     "react-redux": "4.4.0",
     "react-router": "0.13.5",
-    "reactjs-components": "0.15.1-0",
+    "reactjs-components": "0.15.0-beta.1",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
     "tv4": "1.2.7",

--- a/src/js/schemas/job-schema/Schedule.js
+++ b/src/js/schemas/job-schema/Schedule.js
@@ -24,9 +24,9 @@ const Schedule = {
     },
     cron: {
       title: 'CRON Schedule',
-      description: (
+      helpBlock: (
         <span>
-          Use cron format to set your schedule, e.g. <i>0 0 20 * * *</i><br/><a href={MetadataStore.buildDocsURI('/usage/jobs/getting-started')} target="_blank">View documentation</a>.
+          Use cron format to set your schedule, e.g. <i>0 0 20 * * *</i>. <a href={MetadataStore.buildDocsURI('/usage/jobs/getting-started')} target="_blank">View documentation</a>.
         </span>
       ),
       type: 'string',

--- a/src/js/schemas/job-schema/Schedule.js
+++ b/src/js/schemas/job-schema/Schedule.js
@@ -51,7 +51,11 @@ const Schedule = {
     },
     timezone: {
       title: 'Time Zone',
-      description: 'Enter time zone in TZ format, e.g. America/New_York',
+      description: (
+        <span>
+          Enter time zone in <a href="http://www.timezoneconverter.com/cgi-bin/zonehelp" target="_blank">TZ format</a>, e.g. America/New_York.
+        </span>
+      ),
       type: 'string',
       getter(job) {
         let [schedule = {}] = job.getSchedules();

--- a/src/js/utils/SchemaUtil.js
+++ b/src/js/utils/SchemaUtil.js
@@ -87,6 +87,10 @@ function schemaToFieldDefinition(options) {
     definition.options = fieldProps.options;
   }
 
+  if (fieldProps.helpBlock) {
+    definition.helpBlock = fieldProps.helpBlock;
+  }
+
   if (fieldProps.type === 'boolean') {
     definition.fieldType = 'checkbox';
     definition.checked = fieldProps.default || false;


### PR DESCRIPTION
---
~~⚠️ Is dependent on this reactjs-components feature: https://github.com/mesosphere/reactjs-components/pull/335~~ Merged. This PR is now updated with the new reactjs-components version 0.15.0-beta.1

---

This PR adds a help block for the cron input field