### PR TITLE
DCOS-8081: Add Link to status documentation to the status column header

### DIFF
--- a/src/js/components/ServicesTable.js
+++ b/src/js/components/ServicesTable.js
@@ -7,6 +7,7 @@ import {StoreMixin} from 'mesosphere-shared-reactjs';
 import EventTypes from '../constants/EventTypes';
 import HealthBar from './HealthBar';
 import Icon from './Icon';
+import Links from '../constants/Links';
 import MarathonStore from '../stores/MarathonStore';
 import NestedServiceLinks from '../components/NestedServiceLinks';
 import ResourceTableUtil from '../utils/ResourceTableUtil';
@@ -415,7 +416,15 @@ var ServicesTable = React.createClass({
         className,
         headerClassName: className,
         prop: 'status',
-        helpText: 'At-a-glance overview of the global application or group state',
+        helpText: (
+            <span>
+              {'At-a-glance overview of the global application or group state '}
+              <a
+                href={Links.statusHelpLink} target="_blank">
+                Read Me
+              </a>
+            </span>
+        ),
         render: this.renderStatus,
         sortable: true,
         sortFunction: ServiceTableUtil.propCompareFunctionFactory,

--- a/src/js/constants/Links.js
+++ b/src/js/constants/Links.js
@@ -1,0 +1,4 @@
+export default {
+  statusHelpLink:'https://mesosphere.github.io/marathon/docs/marathon-ui' +
+    '.html#application-status-reference'
+};

--- a/src/js/constants/Links.js
+++ b/src/js/constants/Links.js
@@ -1,4 +1,6 @@
+import Config from '../config/Config';
+
 export default {
-  statusHelpLink:'https://mesosphere.github.io/marathon/docs/marathon-ui' +
+  statusHelpLink:`${Config.marathonDocsURI}marathon-ui` +
     '.html#application-status-reference'
 };

--- a/src/js/utils/ResourceTableUtil.js
+++ b/src/js/utils/ResourceTableUtil.js
@@ -113,6 +113,7 @@ var ResourceTableUtil = {
           <Tooltip
             content={this.helpText}
             wrapText={true}
+            interactive={true}
             wrapperClassName="tooltip-wrapper text-align-center table-header-help-icon">
             <Icon id="ring-question" size="mini" family="mini" color="grey" />
           </Tooltip>


### PR DESCRIPTION
This adds a link to the marathon docs which explains the status column in more detail.

![image](https://cloud.githubusercontent.com/assets/156010/17971277/7c862654-6ada-11e6-8a43-5a491ff4a23d.png)
