### PR TITLE
Affirm Universe Package config `title`s are utilised with tests and fixtures

### DIFF
--- a/src/js/utils/__tests__/SchemaUtil-test.js
+++ b/src/js/utils/__tests__/SchemaUtil-test.js
@@ -14,7 +14,8 @@ describe('SchemaUtil', function () {
                 id: {
                   type: 'string'
                 }
-              }
+              },
+              title: "Application"
             }
           }
         };
@@ -27,15 +28,11 @@ describe('SchemaUtil', function () {
       });
 
       it('sets the title of the definition', function () {
-        expect(this.result.application.title).toEqual('application');
+        expect(this.result.application.title).toEqual('Application');
       });
 
       it('creates a field for the property', function () {
         expect(this.result.application).not.toEqual(undefined);
-      });
-
-      it('sets the title correctly', function () {
-        expect(this.result.application.title).toEqual('application');
       });
 
       it('turns a schema to a definition', function () {

--- a/src/js/utils/__tests__/SchemaUtil-test.js
+++ b/src/js/utils/__tests__/SchemaUtil-test.js
@@ -15,7 +15,7 @@ describe('SchemaUtil', function () {
                   type: 'string'
                 }
               },
-              title: "Application"
+              title: 'Application'
             }
           }
         };

--- a/tests/_fixtures/cosmos/package-describe.json
+++ b/tests/_fixtures/cosmos/package-describe.json
@@ -28,9 +28,11 @@
         "properties": {
           "name": {
             "default": "marathon-user",
+            "title": "Name",
             "type": "string"
           }
-        }
+        },
+        "title": "Service"
       },
       "marathon": {
         "additionalProperties": false,
@@ -279,7 +281,7 @@
           },
           "uris": {
             "default": [
-              
+
             ],
             "description": "List of URIs that will be download and made available in the current working directory of Marathon. For example this can be used to download a Java keystore file for SSL configuration.",
             "items": {


### PR DESCRIPTION
We are already using the `title` attribute in Universe Package configs, this PR is to affirm this to fixtures and tests.