### PR TITLE
Decrease frequency of calls to forceUpdate

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4417,9 +4417,9 @@
       }
     },
     "mesosphere-shared-reactjs": {
-      "version": "0.0.20",
-      "from": "mesosphere-shared-reactjs@0.0.20",
-      "resolved": "https://registry.npmjs.org/mesosphere-shared-reactjs/-/mesosphere-shared-reactjs-0.0.20.tgz"
+      "version": "0.0.21",
+      "from": "mesosphere-shared-reactjs@0.0.21",
+      "resolved": "https://registry.npmjs.org/mesosphere-shared-reactjs/-/mesosphere-shared-reactjs-0.0.21.tgz"
     },
     "method-override": {
       "version": "2.3.5",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "less-color-lighten": "0.0.1",
     "md5": "2.1.0",
     "mesosphere-react-typeahead": "0.8.3",
-    "mesosphere-shared-reactjs": "0.0.20",
+    "mesosphere-shared-reactjs": "0.0.21",
     "moment": "2.13.0",
     "prettycron": "0.10.0",
     "query-string": "4.1.0",

--- a/src/js/components/BreadcrumbSegment.js
+++ b/src/js/components/BreadcrumbSegment.js
@@ -1,16 +1,10 @@
-import mixin from 'reactjs-mixin';
-/* eslint-disable no-unused-vars */
 import React, {PropTypes} from 'react';
-/* eslint-enable no-unused-vars */
-import {StoreMixin} from 'mesosphere-shared-reactjs';
 
 import BreadcrumbSegmentLink from './BreadcrumbSegmentLink';
 
-class BreadcrumbSegment extends mixin(StoreMixin) {
+class BreadcrumbSegment extends React.Component {
   constructor() {
     super(...arguments);
-
-    this.store_listeners = [];
 
     this.state = {
       isLoadingCrumb: true

--- a/src/js/components/RepositoriesTable.js
+++ b/src/js/components/RepositoriesTable.js
@@ -36,9 +36,6 @@ class RepositoriesTable extends mixin(StoreMixin) {
     this.store_listeners = [{
       name: 'cosmosPackages',
       events: ['repositoryDeleteError', 'repositoryDeleteSuccess'],
-      unmountWhen() {
-        return true;
-      },
       listenAlways: true
     }];
 

--- a/src/js/components/ServerErrorModal.js
+++ b/src/js/components/ServerErrorModal.js
@@ -32,7 +32,11 @@ module.exports = class ServerErrorModal extends mixin(StoreMixin) {
     };
 
     this.store_listeners = Hooks.applyFilter('serverErrorModalListeners', [
-      {name: 'marathon', events: ['taskKillError', 'serviceDeleteError']}
+      {
+        name: 'marathon',
+        events: ['taskKillError', 'serviceDeleteError'],
+        suppressUpdate: false
+      }
     ]);
 
     METHODS_TO_BIND.forEach((method) => {

--- a/src/js/components/ServicesTable.js
+++ b/src/js/components/ServicesTable.js
@@ -62,7 +62,8 @@ var ServicesTable = React.createClass({
         events: [
           'serviceRestartError',
           'serviceRestartSuccess'
-        ]
+        ],
+        suppressUpdate: true
       }
     ];
   },

--- a/src/js/components/ServicesTable.js
+++ b/src/js/components/ServicesTable.js
@@ -4,11 +4,9 @@ import {Link} from 'react-router';
 import React from 'react';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
-import EventTypes from '../constants/EventTypes';
 import HealthBar from './HealthBar';
 import Icon from './Icon';
 import Links from '../constants/Links';
-import MarathonStore from '../stores/MarathonStore';
 import NestedServiceLinks from '../components/NestedServiceLinks';
 import ResourceTableUtil from '../utils/ResourceTableUtil';
 import Service from '../structs/Service';
@@ -68,20 +66,6 @@ var ServicesTable = React.createClass({
     ];
   },
 
-  componentDidMount() {
-    MarathonStore.addChangeListener(
-      EventTypes.MARATHON_APPS_CHANGE,
-      this.onMarathonAppsChange
-    );
-  },
-
-  componentWillUnmount() {
-    MarathonStore.removeChangeListener(
-      EventTypes.MARATHON_APPS_CHANGE,
-      this.onMarathonAppsChange
-    );
-  },
-
   onServiceDestroyModalClose() {
     this.closeDialog();
     this.context.router.transitionTo('services-page');
@@ -122,10 +106,6 @@ var ServicesTable = React.createClass({
           size="mini" />
       </a>
     );
-  },
-
-  onMarathonAppsChange() {
-    this.forceUpdate();
   },
 
   onActionsItemSelection(service, actionItem) {

--- a/src/js/components/charts/Chart.js
+++ b/src/js/components/charts/Chart.js
@@ -27,7 +27,8 @@ var Chart = React.createClass({
     this.store_listeners = [
       {
         name: 'sidebar',
-        events: ['widthChange']
+        events: ['widthChange'],
+        suppressUpdate: false
       }
     ];
 

--- a/src/js/components/modals/ActionsModal.js
+++ b/src/js/components/modals/ActionsModal.js
@@ -1,9 +1,5 @@
 import {Confirm, Dropdown} from 'reactjs-components';
-import mixin from 'reactjs-mixin';
-/* eslint-disable no-unused-vars */
 import React from 'react';
-/* eslint-enable no-unused-vars */
-import {StoreMixin} from 'mesosphere-shared-reactjs';
 
 import StringUtil from '../../utils/StringUtil';
 import Util from '../../utils/Util';
@@ -19,7 +15,7 @@ const METHODS_TO_BIND = [
 const DEFAULT_ID = 'DEFAULT';
 const ITEMS_DISPLAYED = 3;
 
-class ActionsModal extends mixin(StoreMixin) {
+class ActionsModal extends React.Component {
   constructor() {
     super(...arguments);
 

--- a/src/js/components/modals/ServiceGroupFormModal.js
+++ b/src/js/components/modals/ServiceGroupFormModal.js
@@ -40,7 +40,8 @@ class ServiceGroupFormModal extends mixin(StoreMixin) {
     this.store_listeners = [
       {
         name: 'marathon',
-        events: ['groupCreateSuccess', 'groupCreateError']
+        events: ['groupCreateSuccess', 'groupCreateError'],
+        suppressUpdate: true
       }
     ];
 

--- a/src/js/components/modals/ServiceScaleFormModal.js
+++ b/src/js/components/modals/ServiceScaleFormModal.js
@@ -42,7 +42,8 @@ class ServiceScaleFormModal extends mixin(StoreMixin) {
           'serviceEditError',
           'serviceEditSuccess',
           'groupEditError'
-        ]
+        ],
+        suppressUpdate: true
       }
     ];
 

--- a/src/js/components/modals/UninstallPackageModal.js
+++ b/src/js/components/modals/UninstallPackageModal.js
@@ -30,9 +30,6 @@ class UninstallPackageModal extends mixin(StoreMixin) {
       {
         name: 'cosmosPackages',
         events: ['uninstallError', 'uninstallSuccess'],
-        unmountWhen() {
-          return true;
-        },
         listenAlways: true
       }
     ];

--- a/src/js/pages/DashboardPage.js
+++ b/src/js/pages/DashboardPage.js
@@ -68,9 +68,9 @@ var DashboardPage = React.createClass({
 
   componentWillMount() {
     this.store_listeners = [
-      {name: 'dcos', events: ['change']},
-      {name: 'summary', events: ['success', 'error']},
-      {name: 'unitHealth', events: ['success', 'error']}
+      {name: 'dcos', events: ['change'], suppressUpdate: true },
+      {name: 'summary', events: ['success', 'error'], suppressUpdate: false},
+      {name: 'unitHealth', events: ['success', 'error'], suppressUpdate: false}
     ];
 
     this.internalStorage_set({

--- a/src/js/pages/ServicesPage.js
+++ b/src/js/pages/ServicesPage.js
@@ -33,7 +33,7 @@ var ServicesPage = React.createClass({
 
   componentWillMount() {
     this.store_listeners = [
-      {name: 'notification', events: ['change']}
+      {name: 'notification', events: ['change'], suppressUpdate: false}
     ];
     this.tabs_tabs = {
       'services-page': 'Services',

--- a/src/js/pages/jobs/JobDetailPage.js
+++ b/src/js/pages/jobs/JobDetailPage.js
@@ -55,7 +55,8 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
         'jobRunSuccess',
         'jobScheduleUpdateError',
         'jobScheduleUpdateSuccess'
-      ]
+      ],
+      suppressUpdate: false
     }];
 
     this.tabs_tabs = {

--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -45,8 +45,12 @@ class JobsTab extends mixin(StoreMixin, QueryParamsMixin, SaveStateMixin) {
     this.saveState_properties = saveState_properties;
 
     this.store_listeners = [
-      {name: 'dcos', events: ['change']},
-      {name: 'metronome', events: ['change', 'jobCreateSuccess']}
+      {name: 'dcos', events: ['change'], suppressUpdate: false},
+      {
+        name: 'metronome',
+        events: ['change', 'jobCreateSuccess'],
+        suppressUpdate: false
+      }
     ];
 
     METHODS_TO_BIND.forEach((method) => {

--- a/src/js/pages/network/VirtualNetworksTab.js
+++ b/src/js/pages/network/VirtualNetworksTab.js
@@ -34,7 +34,8 @@ class VirtualNetworksTabContent extends mixin(StoreMixin) {
     this.store_listeners = [
       {
         name: 'virtualNetworks',
-        events: ['success', 'error']
+        events: ['success', 'error'],
+        suppressUpdate: true
       }
     ];
 

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
@@ -32,7 +32,8 @@ class VirtualNetworkDetail extends mixin(StoreMixin, TabsMixin) {
     this.store_listeners = [
       {
         name: 'virtualNetworks',
-        events: ['success', 'error']
+        events: ['success', 'error'],
+        suppressUpdate: true
       }
     ];
 

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
@@ -45,7 +45,8 @@ class VirtualNetworkTaskTab extends mixin(StoreMixin) {
 
     this.store_listeners = [{
       name: 'state',
-      events: ['success', 'error']
+      events: ['success', 'error'],
+      suppressUpdate: true
     }];
 
     METHODS_TO_BIND.forEach((method) => {

--- a/src/js/pages/nodes/NodeDetailPage.js
+++ b/src/js/pages/nodes/NodeDetailPage.js
@@ -27,9 +27,13 @@ class NodeDetailPage extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) 
     super(...arguments);
 
     this.store_listeners = [
-      {name: 'summary', events: ['success']},
-      {name: 'state', events: ['success']},
-      {name: 'nodeHealth', events: ['nodeSuccess', 'nodeError', 'unitsSuccess', 'unitsError']}
+      {name: 'summary', events: ['success'], suppressUpdate: false},
+      {name: 'state', events: ['success'], suppressUpdate: false},
+      {
+        name: 'nodeHealth',
+        events: ['nodeSuccess', 'nodeError', 'unitsSuccess', 'unitsError'],
+        suppressUpdate: false
+      }
     ];
 
     this.tabs_tabs = {

--- a/src/js/pages/nodes/breadcrumbs/TaskDetailBreadcrumb.js
+++ b/src/js/pages/nodes/breadcrumbs/TaskDetailBreadcrumb.js
@@ -11,12 +11,10 @@ class TaskDetailBreadcrumb extends BreadcrumbSegment {
   }
 
   componentDidMount() {
-    super.componentDidMount();
     this.updateCrumbStatus();
   }
 
   componentWillReceiveProps() {
-    super.componentWillReceiveProps(...arguments);
     this.updateCrumbStatus();
   }
 

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -58,10 +58,11 @@ class DeploymentsTab extends mixin(StoreMixin) {
 
     this.state = {};
     this.store_listeners = [
-      {name: 'dcos', events: ['change']},
+      {name: 'dcos', events: ['change'], suppressUpdate: false},
       {
         name: 'marathon',
-        events: ['deploymentRollbackSuccess', 'deploymentRollbackError']
+        events: ['deploymentRollbackSuccess', 'deploymentRollbackError'],
+        suppressUpdate: true
       }
     ];
 

--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -71,8 +71,15 @@ var ServicesTab = React.createClass({
 
   componentWillMount() {
     this.store_listeners = [
-      {name: 'dcos', events: ['change']},
-      {name: 'marathon', events: ['groupsSuccess', 'groupsError']}
+      {
+        name: 'dcos', events: ['change'],
+        suppressUpdate: false
+      },
+      {
+        name: 'marathon',
+        events: ['groupsSuccess', 'groupsError'],
+        suppressUpdate: true
+      }
     ];
   },
 

--- a/src/js/pages/system/RepositoriesTab.js
+++ b/src/js/pages/system/RepositoriesTab.js
@@ -32,6 +32,7 @@ class RepositoriesTab extends mixin(StoreMixin) {
       {
         name: 'cosmosPackages',
         events: ['repositoriesSuccess', 'repositoriesError'],
+        suppressUpdate: true
       }
     ];
 

--- a/src/js/pages/system/RepositoriesTab.js
+++ b/src/js/pages/system/RepositoriesTab.js
@@ -32,10 +32,6 @@ class RepositoriesTab extends mixin(StoreMixin) {
       {
         name: 'cosmosPackages',
         events: ['repositoriesSuccess', 'repositoriesError'],
-        unmountWhen() {
-          return true;
-        },
-        listenAlways: true
       }
     ];
 

--- a/src/js/pages/system/UnitsHealthDetail.js
+++ b/src/js/pages/system/UnitsHealthDetail.js
@@ -28,7 +28,8 @@ class UnitsHealthDetail extends mixin(StoreMixin) {
     this.store_listeners = [
       {
         name: 'unitHealth',
-        events: ['unitSuccess', 'unitError', 'nodesSuccess', 'nodesError']
+        events: ['unitSuccess', 'unitError', 'nodesSuccess', 'nodesError'],
+        suppressUpdate: true
       }
     ];
 

--- a/src/js/pages/system/UnitsHealthNodeDetail.js
+++ b/src/js/pages/system/UnitsHealthNodeDetail.js
@@ -25,7 +25,8 @@ class UnitsHealthNodeDetail extends mixin(StoreMixin) {
     this.store_listeners = [
       {
         name: 'unitHealth',
-        events: ['unitSuccess', 'unitError', 'nodeSuccess', 'nodeError']
+        events: ['unitSuccess', 'unitError', 'nodeSuccess', 'nodeError'],
+        suppressUpdate: true
       }
     ];
   }

--- a/src/js/pages/system/UnitsHealthTab.js
+++ b/src/js/pages/system/UnitsHealthTab.js
@@ -33,7 +33,8 @@ class UnitsHealthTab extends mixin(StoreMixin) {
     this.store_listeners = [
       {
         name: 'unitHealth',
-        events: ['success', 'error']
+        events: ['success', 'error'],
+        suppressUpdate: false
       }
     ];
 

--- a/src/js/pages/system/UsersTab.js
+++ b/src/js/pages/system/UsersTab.js
@@ -27,7 +27,6 @@ class UsersTab extends mixin(StoreMixin) {
     super(...arguments);
 
     this.store_listeners = Hooks.applyFilter('usersTabStoreListeners', [
-      {name: 'marathon', events: ['appsSuccess']},
       {
         name: 'user',
         events: ['createSuccess', 'deleteSuccess'],

--- a/src/js/pages/task-details/TaskDetail.js
+++ b/src/js/pages/task-details/TaskDetail.js
@@ -38,7 +38,11 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
       {name: 'marathon', events: ['appsSuccess'], listenAlways: false},
       {name: 'state', events: ['success'], listenAlways: false},
       {name: 'summary', events: ['success'], listenAlways: false},
-      {name: 'taskDirectory', events: ['error', 'success']}
+      {
+        name: 'taskDirectory',
+        events: ['error', 'success'],
+        suppressUpdate: true
+      }
     ];
 
     METHODS_TO_BIND.forEach((method) => {

--- a/src/js/pages/universe/InstalledPackagesTab.js
+++ b/src/js/pages/universe/InstalledPackagesTab.js
@@ -27,10 +27,6 @@ class InstalledPackagesTab extends mixin(StoreMixin) {
       {
         name: 'cosmosPackages',
         events: ['installedError', 'installedSuccess'],
-        unmountWhen() {
-          return true;
-        },
-        listenAlways: true
       }
     ];
 

--- a/src/js/pages/universe/InstalledPackagesTab.js
+++ b/src/js/pages/universe/InstalledPackagesTab.js
@@ -27,6 +27,7 @@ class InstalledPackagesTab extends mixin(StoreMixin) {
       {
         name: 'cosmosPackages',
         events: ['installedError', 'installedSuccess'],
+        suppressUpdate: true
       }
     ];
 

--- a/src/js/pages/universe/PackageDetailTab.js
+++ b/src/js/pages/universe/PackageDetailTab.js
@@ -36,7 +36,8 @@ class PackageDetailTab extends mixin(StoreMixin) {
           return !!CosmosPackagesStore.get('packageDetails');
         }
       },
-      listenAlways: false
+      listenAlways: false,
+      suppressUpdate: true
     }];
 
     METHODS_TO_BIND.forEach((method) => {

--- a/src/js/pages/universe/PackagesTab.js
+++ b/src/js/pages/universe/PackagesTab.js
@@ -31,7 +31,11 @@ class PackagesTab extends mixin(StoreMixin) {
     };
 
     this.store_listeners = [
-      {name: 'cosmosPackages', events: ['availableError', 'availableSuccess']}
+      {
+        name: 'cosmosPackages',
+        events: ['availableError', 'availableSuccess'],
+        suppressUpdate: true
+      }
     ];
 
     METHODS_TO_BIND.forEach((method) => {


### PR DESCRIPTION
Please test using dcos/mesosphere-shared-reactjs#17

This is the first major chunk of work on improving the performance of dcos-ui by decreasing the number of times a component is rendered. Using the changes to the `StoreMixin` in the above PR, we specify whether or not a component should unmount after its first render, and whether a render should be forced by the mixin, or whether the component should handle its own updates via `state`. 

In [some cases](https://github.com/dcos/dcos-ui/blob/d2f674a4f40299ab6e189c5c918eab662f15457c/src/js/components/BreadcrumbSegment.js) it was possible to remove the store mixin altogether, and in [others](https://github.com/dcos/dcos-ui/commit/d2f674a4f40299ab6e189c5c918eab662f15457c) to remove specific store events which were unused. 

Where `suppressUpdate` has been added and is true, a component is able to render itself instead of being force-updated. Where `suppressUpdate` has been added and is false, the component still requires force-updating and should be refactored to avoid this (see especially the JobsPage and NetworkTab for instances of this). 