### PR TITLE
DCOS-9285: Disable checkboxes for non-marathon tasks

### DIFF
--- a/src/js/components/CheckboxTable.js
+++ b/src/js/components/CheckboxTable.js
@@ -77,13 +77,14 @@ class CheckboxTable extends React.Component {
   renderHeadingCheckbox() {
     let checked = false;
     let indeterminate = false;
-    let {allowMultipleSelect, checkedItemsMap, data} = this.props;
+    let {allowMultipleSelect, checkedItemsMap, disabledItemsMap, data} = this.props;
 
     if (!allowMultipleSelect) {
       return null;
     }
 
     let checkedItemsCount = Object.keys(checkedItemsMap).length;
+    let disabledItemsCount = Object.keys(disabledItemsMap).length;
 
     if (checkedItemsCount > 0) {
       indeterminate = true;
@@ -91,7 +92,7 @@ class CheckboxTable extends React.Component {
       checked = false;
     }
 
-    if (checkedItemsCount === data.length && checkedItemsCount !== 0) {
+    if (checkedItemsCount + disabledItemsCount === data.length && checkedItemsCount !== 0) {
       checked = true;
       indeterminate = false;
     }

--- a/src/js/components/CheckboxTable.js
+++ b/src/js/components/CheckboxTable.js
@@ -52,7 +52,9 @@ class CheckboxTable extends React.Component {
 
   bulkCheck(isChecked) {
     let checkedIDs = [];
-    let {data, onCheckboxChange, uniqueProperty} = this.props;
+    let {data, onCheckboxChange, uniqueProperty, disabledItemsMap} = this.props;
+
+    data = data.filter((datum) => !disabledItemsMap[datum[uniqueProperty]]);
 
     if (isChecked) {
       data.forEach(function (datum) {

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -228,6 +228,15 @@ class TaskTable extends React.Component {
     );
   }
 
+  getDisabledItemsMap(tasks) {
+    return tasks
+      .filter((task) => !task.startedByMarathon)
+      .reduce((acc, task) => {
+        acc[task.id] = true;
+        return acc;
+      }, {});
+  }
+
   renderHeadline(prop, task) {
     let title = task.id;
     let params = this.props.parentRouter.getCurrentParams();
@@ -365,6 +374,7 @@ class TaskTable extends React.Component {
         className={className}
         columns={this.getColumns()}
         data={tasks.slice()}
+        disabledItemsMap={this.getDisabledItemsMap(tasks)}
         getColGroup={this.getColGroup}
         onCheckboxChange={onCheckboxChange}
         sortBy={{prop: 'updated', order: 'desc'}}

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -230,7 +230,7 @@ class TaskTable extends React.Component {
 
   getDisabledItemsMap(tasks) {
     return tasks
-      .filter((task) => task.startedBy !== 'marathon')
+      .filter((task) => task.scheduler !== 'marathon')
       .reduce((acc, task) => {
         acc[task.id] = true;
         return acc;

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -230,7 +230,7 @@ class TaskTable extends React.Component {
 
   getDisabledItemsMap(tasks) {
     return tasks
-      .filter((task) => !task.startedByMarathon)
+      .filter((task) => task.startedBy !== 'marathon')
       .reduce((acc, task) => {
         acc[task.id] = true;
         return acc;

--- a/src/js/components/__tests__/TaskTable-test.js
+++ b/src/js/components/__tests__/TaskTable-test.js
@@ -45,6 +45,17 @@ describe('TaskTable', function () {
 
   });
 
+  describe('#getDisabledItemsMap', function () {
+    beforeEach(function () {
+      this.taskTable = new TaskTable();
+    });
+
+    it('returns a map of disabled items', function () {
+      var tasks = [{id: '1', startedByMarathon: true}, {id: '2'}];
+      expect(this.taskTable.getDisabledItemsMap(tasks)).toEqual({'2': true});
+    });
+  });
+
   describe('#getTaskHealth', function () {
 
     beforeEach(function () {

--- a/src/js/components/__tests__/TaskTable-test.js
+++ b/src/js/components/__tests__/TaskTable-test.js
@@ -51,7 +51,7 @@ describe('TaskTable', function () {
     });
 
     it('returns a map of disabled items', function () {
-      var tasks = [{id: '1', startedByMarathon: true}, {id: '2'}];
+      var tasks = [{id: '1', startedBy: 'marathon'}, {id: '2'}];
       expect(this.taskTable.getDisabledItemsMap(tasks)).toEqual({'2': true});
     });
   });

--- a/src/js/components/__tests__/TaskTable-test.js
+++ b/src/js/components/__tests__/TaskTable-test.js
@@ -51,7 +51,7 @@ describe('TaskTable', function () {
     });
 
     it('returns a map of disabled items', function () {
-      var tasks = [{id: '1', startedBy: 'marathon'}, {id: '2'}];
+      var tasks = [{id: '1', scheduler: 'marathon'}, {id: '2'}];
       expect(this.taskTable.getDisabledItemsMap(tasks)).toEqual({'2': true});
     });
   });

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -255,21 +255,20 @@ class MesosStateStore extends GetSetBaseStore {
     // the scheduler tasks or a list of Marathon application tasks.
     return frameworks.reduce(function (serviceTasks, framework) {
       let {tasks = [], completed_tasks = {}, name} = framework;
+
+      let allTasks = tasks.concat(completed_tasks).map(function (task) {
+        task.startedBy = name;
+        return task;
+      });
+
       // Include tasks from framework match, if service is a Framework
       if (service instanceof Framework && name === serviceName) {
-        return serviceTasks.concat(tasks, completed_tasks);
+        return serviceTasks.concat(allTasks);
       }
-
       // Filter marathon tasks by service name
       if (name === 'marathon') {
-        return tasks.concat(completed_tasks)
-          .filter(function ({name}) {
-            return name === mesosTaskName;
-          })
-          .map((task) => {
-            task.startedByMarathon = true;
-            return task;
-          })
+        return allTasks
+          .filter(({name}) => name === mesosTaskName)
           .concat(serviceTasks);
       }
 

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -257,7 +257,7 @@ class MesosStateStore extends GetSetBaseStore {
       let {tasks = [], completed_tasks = {}, name} = framework;
 
       let allTasks = tasks.concat(completed_tasks).map(function (task) {
-        task.startedBy = name;
+        task.scheduler = name;
         return task;
       });
 

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -265,7 +265,12 @@ class MesosStateStore extends GetSetBaseStore {
         return tasks.concat(completed_tasks)
           .filter(function ({name}) {
             return name === mesosTaskName;
-          }).concat(serviceTasks);
+          })
+          .map((task) => {
+            task.startedByMarathon = true;
+            return task;
+          })
+          .concat(serviceTasks);
       }
 
       return serviceTasks;

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -85,8 +85,8 @@ describe('MesosStateStore', function () {
       );
 
       expect(tasks).toEqual([
-        {name: 'beta', id: 'beta.1', startedBy: 'marathon'},
-        {name: '1', startedBy: 'beta'}
+        {name: 'beta', id: 'beta.1', scheduler: 'marathon'},
+        {name: '1', scheduler: 'beta'}
       ]);
     });
 
@@ -96,10 +96,10 @@ describe('MesosStateStore', function () {
           new Framework({id: '/spark', labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'spark'}})
         );
         expect(tasks).toEqual([
-          {name: 'spark', id: 'spark.1', startedBy: 'marathon'},
-          {name: '1', startedBy: 'spark'},
-          {name: '2', startedBy: 'spark'},
-          {name: '3', startedBy: 'spark'}
+          {name: 'spark', id: 'spark.1', scheduler: 'marathon'},
+          {name: '1', scheduler: 'spark'},
+          {name: '2', scheduler: 'spark'},
+          {name: '3', scheduler: 'spark'}
         ]);
       }
     );
@@ -109,9 +109,9 @@ describe('MesosStateStore', function () {
         new Service({id: '/alpha'})
       );
       expect(tasks).toEqual([
-        {name: 'alpha', id: 'alpha.1', startedBy: 'marathon'},
-        {name: 'alpha', id: 'alpha.2', startedBy: 'marathon'},
-        {name: 'alpha', id: 'alpha.3', startedBy: 'marathon'}
+        {name: 'alpha', id: 'alpha.1', scheduler: 'marathon'},
+        {name: 'alpha', id: 'alpha.2', scheduler: 'marathon'},
+        {name: 'alpha', id: 'alpha.3', scheduler: 'marathon'}
       ]);
     });
 

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -46,11 +46,19 @@ describe('MesosStateStore', function () {
               tasks: [
                 {name: 'spark', id: 'spark.1'},
                 {name: 'alpha', id: 'alpha.1'},
-                {name: 'alpha', id: 'alpha.2'}
+                {name: 'alpha', id: 'alpha.2'},
+                {name: 'beta', id: 'beta.1'}
               ],
               completed_tasks: [
                 {name: 'alpha', id: 'alpha.3'}
               ]
+            },
+            {
+              name: 'beta',
+              tasks: [
+                {name: '1'}
+              ],
+              completed_tasks: []
             },
             {
               name: 'spark',
@@ -71,13 +79,24 @@ describe('MesosStateStore', function () {
       MesosStateStore.get = this.get;
     });
 
+    it('should flag tasks started with marathon', function () {
+      var tasks = MesosStateStore.getTasksByService(
+        new Framework({id: '/beta', labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'}})
+      );
+
+      expect(tasks).toEqual([
+        {name: 'beta', id: 'beta.1', startedByMarathon: true},
+        {name: '1'}
+      ]);
+    });
+
     it('should return matching framework tasks including scheduler tasks',
       function () {
         var tasks = MesosStateStore.getTasksByService(
           new Framework({id: '/spark', labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'spark'}})
         );
         expect(tasks).toEqual([
-          {name: 'spark', id: 'spark.1'},
+          {name: 'spark', id: 'spark.1', startedByMarathon: true},
           {name: '1'},
           {name: '2'},
           {name: '3'}
@@ -90,9 +109,9 @@ describe('MesosStateStore', function () {
         new Service({id: '/alpha'})
       );
       expect(tasks).toEqual([
-        {name: 'alpha', id: 'alpha.1'},
-        {name: 'alpha', id: 'alpha.2'},
-        {name: 'alpha', id: 'alpha.3'}
+        {name: 'alpha', id: 'alpha.1', startedByMarathon: true},
+        {name: 'alpha', id: 'alpha.2', startedByMarathon: true},
+        {name: 'alpha', id: 'alpha.3', startedByMarathon: true}
       ]);
     });
 

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -85,8 +85,8 @@ describe('MesosStateStore', function () {
       );
 
       expect(tasks).toEqual([
-        {name: 'beta', id: 'beta.1', startedByMarathon: true},
-        {name: '1'}
+        {name: 'beta', id: 'beta.1', startedBy: 'marathon'},
+        {name: '1', startedBy: 'beta'}
       ]);
     });
 
@@ -96,10 +96,10 @@ describe('MesosStateStore', function () {
           new Framework({id: '/spark', labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'spark'}})
         );
         expect(tasks).toEqual([
-          {name: 'spark', id: 'spark.1', startedByMarathon: true},
-          {name: '1'},
-          {name: '2'},
-          {name: '3'}
+          {name: 'spark', id: 'spark.1', startedBy: 'marathon'},
+          {name: '1', startedBy: 'spark'},
+          {name: '2', startedBy: 'spark'},
+          {name: '3', startedBy: 'spark'}
         ]);
       }
     );
@@ -109,9 +109,9 @@ describe('MesosStateStore', function () {
         new Service({id: '/alpha'})
       );
       expect(tasks).toEqual([
-        {name: 'alpha', id: 'alpha.1', startedByMarathon: true},
-        {name: 'alpha', id: 'alpha.2', startedByMarathon: true},
-        {name: 'alpha', id: 'alpha.3', startedByMarathon: true}
+        {name: 'alpha', id: 'alpha.1', startedBy: 'marathon'},
+        {name: 'alpha', id: 'alpha.2', startedBy: 'marathon'},
+        {name: 'alpha', id: 'alpha.3', startedBy: 'marathon'}
       ]);
     });
 


### PR DESCRIPTION
this PR addresses the issue with a possibility to check and kill tasks that haven't been started by marathon. The issue is resolved by adding additional field `startedBy` with the name of a framework, i.e. `spark` that actually started the task, so we can use that information to filter out non-marathon tasks.

Additionally this PR fixes the way how CheckboxTable component renders the heading checkbox when there are disabled items.

<img width="906" alt="screen shot 2016-08-30 at 14 45 43" src="https://cloud.githubusercontent.com/assets/186223/18089565/daf365e6-6ec0-11e6-95fe-42d30a691f9c.png">
