### PR TITLE
[CNVS Upgrade] Fix Status Dot border radius

### DIFF
--- a/src/styles/components/status-dots/styles.less
+++ b/src/styles/components/status-dots/styles.less
@@ -3,8 +3,8 @@
   .dot {
     background-color: @neutral;
     border-radius: 100%;
-    height: 0.75rem;
-    width: 0.75rem;
+    height: 8px;
+    width: 8px;
 
     &.danger {
       background-color: @danger-color;
@@ -59,8 +59,8 @@
   @media (min-width: @layout-screen-small-min-width) {
 
     .dot {
-      .property-variant(body, width, font-size, null, screen-small);
-      .property-variant(body, line-height, screen-small);
+      height: 9px;
+      width: 9px;
 
       .table & {
         margin-right: @base-spacing-unit-screen-small * 0.25;
@@ -77,8 +77,8 @@
   @media (min-width: @layout-screen-medium-min-width) {
 
     .dot {
-      .property-variant(body, width, font-size, null, screen-medium);
-      .property-variant(body, line-height, screen-medium);
+      height: 10px;
+      width: 10px;
 
       .table & {
         margin-right: @base-spacing-unit-screen-medium * 0.25;
@@ -95,8 +95,8 @@
   @media (min-width: @layout-screen-large-min-width) {
 
     .dot {
-      .property-variant(body, width, font-size, null, screen-large);
-      .property-variant(body, line-height, screen-large);
+      height: 11px;
+      width: 11px;
 
       .table & {
         margin-right: @base-spacing-unit-screen-large * 0.25;
@@ -113,8 +113,8 @@
   @media (min-width: @layout-screen-jumbo-min-width) {
 
     .dot {
-      .property-variant(body, width, font-size, null, screen-jumbo);
-      .property-variant(body, line-height, screen-jumbo);
+      height: 12px;
+      width: 12px;
 
       .table & {
         margin-right: @base-spacing-unit-screen-jumbo * 0.25;


### PR DESCRIPTION
Defining a status dot's size based on the `font-size` and `line-height` meant using decimal values for heights and widths. This resulted in oval-ish shaped status dots, because `border-radius` doesn't play nicely with decimal values. This PR defines static integer dimensions for all screen sizes.

Before:
![](https://cl.ly/0Z0G0G251e0E/Screen%20Shot%202016-08-30%20at%203.49.19%20PM.png)

After:
![](https://cl.ly/2X3S1Y1T1m1N/Screen%20Shot%202016-08-30%20at%203.49.46%20PM.png)