### PR TITLE
DCOS-8360: deeper nesting styles of schema forms

### DIFF
--- a/src/js/components/SchemaForm.js
+++ b/src/js/components/SchemaForm.js
@@ -297,7 +297,8 @@ class SchemaForm extends mixin(StoreMixin, InternalStorageMixin) {
 
     let subheaderClasses = classNames({
       h3: levelsDeep === 0,
-      h5: levelsDeep !== 0
+      h4: levelsDeep === 1,
+      h5: levelsDeep >= 2
     }, 'form-header form-row-element flush-bottom flush-top');
 
     return (

--- a/src/js/components/modals/__tests__/InstallPackageModal-test.js
+++ b/src/js/components/modals/__tests__/InstallPackageModal-test.js
@@ -68,7 +68,7 @@ describe('InstallPackageModal', function () {
         this.instance.getModalContents(),
         this.container
       ));
-      var result = node.querySelectorAll('p')[5];
+      var result = node.querySelectorAll('p')[6];
       expect(result.textContent).toEqual('0.11.1');
     });
 

--- a/src/js/components/modals/__tests__/InstallPackageModal-test.js
+++ b/src/js/components/modals/__tests__/InstallPackageModal-test.js
@@ -68,7 +68,7 @@ describe('InstallPackageModal', function () {
         this.instance.getModalContents(),
         this.container
       ));
-      var result = node.querySelectorAll('p')[4];
+      var result = node.querySelectorAll('p')[5];
       expect(result.textContent).toEqual('0.11.1');
     });
 

--- a/tests/_fixtures/cosmos/package-describe.json
+++ b/tests/_fixtures/cosmos/package-describe.json
@@ -347,6 +347,70 @@
           "master"
         ],
         "type": "object"
+      },
+      "nested-properties": {
+        "description": "This is how nested properties looks. We can even have a title!",
+        "title": "Nested Properties",
+        "type": "object",
+        "properties": {
+          "level0": {
+            "description": "This is a top level property. levelsDeep === 0",
+            "title": "Configuration at Level 0",
+            "type": "object",
+            "properties": {
+              "level1": {
+                "description": "Many options, levelsDeep === 1",
+                "title": "Next Level Deep",
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "string",
+                    "default": "hello",
+                    "title": "Yes"
+                  },
+                  "level2": {
+                    "description": "levelsDeep === 2",
+                    "type": "object",
+                    "properties": {
+                      "potato": {
+                        "description": "Yet another level, levelsDeep === 3",
+                        "title": "Grammatical freedom",
+                        "type": "string",
+                        "properties": {
+                          "heavy-potato": {
+                            "description": "Yet another level, levelsDeep === 4",
+                            "title": "Heavy Potato",
+                            "default": "very heavy",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "authentication": {
+                "description": "Mesos scheduler dcos-oauth configuration. levelsDeep === 1",
+                "type": "object",
+                "properties": {
+                  "secret-name": {
+                    "description": "Path to a service-account credential in the secret store. levelsDeep === 2",
+                    "title": "Secret Name!",
+                    "type": "string",
+                    "properties": {
+                      "many-options": {
+                        "default": "semicolon",
+                        "description": "Yet another level, levelsDeep === 3",
+                        "title": "Grammatical freedom",
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "required": [


### PR DESCRIPTION
We are styling the nested schema form configs in the following way:

```
Tier 1 (which is currently the nav and the page header) should be an H2
Tier 2 an H3
Tier 3 an H4
Tier 4 an H5
```
Before:
![](https://cl.ly/3Q0K41253M1G/Image%202016-08-30%20at%203.58.39%20PM.png)

After:
![](https://cl.ly/2W0X0x052z0Z/Image%202016-08-30%20at%203.57.07%20PM.png)