### PR TITLE
DCOS-9248: Remove overcapacity from bar

### DIFF
--- a/src/js/components/HealthBar.js
+++ b/src/js/components/HealthBar.js
@@ -60,10 +60,10 @@ class HealthBar extends React.Component {
 
     // This filters overCapacity ou
     tasksSummary = Object.keys(tasksSummary)
-      .filter(function(key) {
+      .filter(function (key) {
         return key !== 'tasksOverCapacity';
       })
-      .reduce(function(memo, key) {
+      .reduce(function (memo, key) {
         memo[key] = tasksSummary[key];
         return memo;
       }, {});

--- a/src/js/components/HealthBar.js
+++ b/src/js/components/HealthBar.js
@@ -55,7 +55,7 @@ class HealthBar extends React.Component {
   }
 
   render() {
-    let {tasksSummary, instancesCount, disableToolTip} = this.props;
+    let {tasksSummary, instancesCount, isDeploying} = this.props;
 
     if (tasksSummary == null) {
       return null;
@@ -71,12 +71,10 @@ class HealthBar extends React.Component {
         return memo;
       }, {});
 
-    if (disableToolTip) {
-      return (
-        <StatusBar
-          data={this.getMappedTasksSummary(tasksSummary)}
-          scale={instancesCount}/>
-      );
+    if (isDeploying) {
+      tasksSummary = {
+        tasksStaged: instancesCount
+      };
     }
 
     return (
@@ -90,12 +88,12 @@ class HealthBar extends React.Component {
 }
 
 HealthBar.defaultProps = {
-  disableToolTip: false,
+  isDeploying: false,
   instancesCount: null
 };
 
 HealthBar.propTypes = {
-  disableToolTip: React.PropTypes.bool,
+  isDeploying: React.PropTypes.bool,
   instancesCount: React.PropTypes.number,
   tasksSummary: React.PropTypes.shape({
     tasksRunning: React.PropTypes.number,

--- a/src/js/components/HealthBar.js
+++ b/src/js/components/HealthBar.js
@@ -58,6 +58,16 @@ class HealthBar extends React.Component {
       return null;
     }
 
+    // This filters overCapacity ou
+    tasksSummary = Object.keys(tasksSummary)
+      .filter(function(key) {
+        return key !== 'tasksOverCapacity';
+      })
+      .reduce(function(memo, key) {
+        memo[key] = tasksSummary[key];
+        return memo;
+      }, {});
+
     return (
       <Tooltip interactive={true} content={this.renderToolTip()}>
         <StatusBar

--- a/src/js/components/HealthBar.js
+++ b/src/js/components/HealthBar.js
@@ -42,7 +42,10 @@ class HealthBar extends React.Component {
   renderToolTip() {
     let {tasksSummary, instancesCount} = this.props;
 
-    tasksSummary = this.getTaskList(tasksSummary, instancesCount);
+    tasksSummary = this.getTaskList(
+      tasksSummary,
+      Math.max(tasksSummary.tasksRunning, instancesCount)
+    );
 
     if (tasksSummary.length === 0) {
       return 'No Running Tasks';

--- a/src/js/components/HealthBar.js
+++ b/src/js/components/HealthBar.js
@@ -55,7 +55,7 @@ class HealthBar extends React.Component {
   }
 
   render() {
-    let {tasksSummary, instancesCount} = this.props;
+    let {tasksSummary, instancesCount, disableToolTip} = this.props;
 
     if (tasksSummary == null) {
       return null;
@@ -71,6 +71,14 @@ class HealthBar extends React.Component {
         return memo;
       }, {});
 
+    if (disableToolTip) {
+      return (
+        <StatusBar
+          data={this.getMappedTasksSummary(tasksSummary)}
+          scale={instancesCount}/>
+      );
+    }
+
     return (
       <Tooltip interactive={true} content={this.renderToolTip()}>
         <StatusBar
@@ -82,10 +90,12 @@ class HealthBar extends React.Component {
 }
 
 HealthBar.defaultProps = {
+  disableToolTip: false,
   instancesCount: null
 };
 
 HealthBar.propTypes = {
+  disableToolTip: React.PropTypes.bool,
   instancesCount: React.PropTypes.number,
   tasksSummary: React.PropTypes.shape({
     tasksRunning: React.PropTypes.number,

--- a/src/js/components/ServiceInfo.js
+++ b/src/js/components/ServiceInfo.js
@@ -93,6 +93,13 @@ class ServiceInfo extends React.Component {
     let runningTasksCount = tasksSummary.tasksRunning;
     let instancesCount = service.getInstancesCount();
     let runningTasksSubHeader = StringUtil.pluralize('Task', runningTasksCount);
+    let overCapacity = '';
+
+    if (tasksSummary.tasksOverCapacity !== 0) {
+      overCapacity =
+          ` (over capacity by ${tasksSummary.tasksOverCapacity} tasks)`;
+    }
+
     let subHeaderItems = [
       {
         classes: `media-object-item ${serviceStatusClassSet}`,
@@ -101,7 +108,7 @@ class ServiceInfo extends React.Component {
       },
       {
         classes: 'media-object-item',
-        label: `${runningTasksCount} ${runningTasksSubHeader}`,
+        label: `${runningTasksCount} ${runningTasksSubHeader}` + overCapacity,
         shouldShow: runningTasksCount != null && runningTasksSubHeader != null
       },
       {

--- a/src/js/components/ServiceInfo.js
+++ b/src/js/components/ServiceInfo.js
@@ -94,10 +94,18 @@ class ServiceInfo extends React.Component {
     let instancesCount = service.getInstancesCount();
     let runningTasksSubHeader = StringUtil.pluralize('Task', runningTasksCount);
     let overCapacity = '';
+    let disableToolTip = serviceStatus === 'Deploying';
 
     if (tasksSummary.tasksOverCapacity !== 0) {
       overCapacity =
           ` (over capacity by ${tasksSummary.tasksOverCapacity} tasks)`;
+    }
+
+    if (disableToolTip) {
+      tasksSummary = {
+        tasksStaged: instancesCount,
+        tasksRunning: 0
+      };
     }
 
     let subHeaderItems = [
@@ -114,8 +122,9 @@ class ServiceInfo extends React.Component {
       {
         label: (
           <HealthBar
+            disableToolTip={disableToolTip}
             tasksSummary={tasksSummary}
-            instancesCount={instancesCount} />
+            instancesCount={instancesCount}/>
         ),
         shouldShow: true
       }

--- a/src/js/components/ServiceInfo.js
+++ b/src/js/components/ServiceInfo.js
@@ -94,18 +94,11 @@ class ServiceInfo extends React.Component {
     let instancesCount = service.getInstancesCount();
     let runningTasksSubHeader = StringUtil.pluralize('Task', runningTasksCount);
     let overCapacity = '';
-    let disableToolTip = serviceStatus === 'Deploying';
+    let isDeploying = serviceStatus === 'Deploying';
 
     if (tasksSummary.tasksOverCapacity !== 0) {
       overCapacity =
           ` (over capacity by ${tasksSummary.tasksOverCapacity} tasks)`;
-    }
-
-    if (disableToolTip) {
-      tasksSummary = {
-        tasksStaged: instancesCount,
-        tasksRunning: 0
-      };
     }
 
     let subHeaderItems = [
@@ -122,7 +115,7 @@ class ServiceInfo extends React.Component {
       {
         label: (
           <HealthBar
-            disableToolTip={disableToolTip}
+            isDeploying={isDeploying}
             tasksSummary={tasksSummary}
             instancesCount={instancesCount}/>
         ),

--- a/src/js/components/ServiceInfo.js
+++ b/src/js/components/ServiceInfo.js
@@ -96,7 +96,7 @@ class ServiceInfo extends React.Component {
     let overCapacity = '';
     let isDeploying = serviceStatus === 'Deploying';
 
-    if (tasksSummary.tasksOverCapacity !== 0) {
+    if (tasksSummary.tasksOverCapacity > 0) {
       overCapacity =
           ` (over capacity by ${tasksSummary.tasksOverCapacity} tasks)`;
     }

--- a/src/js/components/ServicesTable.js
+++ b/src/js/components/ServicesTable.js
@@ -289,26 +289,36 @@ var ServicesTable = React.createClass({
   },
 
   renderStatus(prop, service) {
-    let instanceCount = service.getInstancesCount();
+    let instancesCount = service.getInstancesCount();
     let serviceId = service.getId();
     let serviceStatus = service.getStatus();
     let serviceStatusClassSet = StatusMapping[serviceStatus] || '';
-    let taskSummary = service.getTasksSummary();
-    let {tasksRunning} = taskSummary;
+    let tasksSummary = service.getTasksSummary();
+    let {tasksRunning} = tasksSummary;
 
-    let conciseOverview = ` (${tasksRunning}/${instanceCount})`;
+    let disableToolTip = serviceStatus === 'Deploying';
+
+    let conciseOverview = ` (${tasksRunning}/${instancesCount})`;
     let verboseOverview = ` (${tasksRunning} ${StringUtil.pluralize('Task', tasksRunning)})`;
-    if (tasksRunning !== instanceCount) {
-      verboseOverview = ` (${tasksRunning} of ${instanceCount} Tasks)`;
+    if (tasksRunning !== instancesCount) {
+      verboseOverview = ` (${tasksRunning} of ${instancesCount} Tasks)`;
+    }
+
+    if (disableToolTip) {
+      tasksSummary = {
+        tasksStaged: instancesCount,
+        tasksRunning: 0
+      };
     }
 
     return (
       <div className="status-bar-wrapper">
         <span className="status-bar-indicator">
           <HealthBar
+            disableToolTip={disableToolTip}
             key={serviceId}
-            tasksSummary={taskSummary}
-            instancesCount={instanceCount} />
+            tasksSummary={tasksSummary}
+            instancesCount={instancesCount} />
         </span>
         <span className="status-bar-text">
           <span className={serviceStatusClassSet}>{serviceStatus}</span>

--- a/src/js/components/ServicesTable.js
+++ b/src/js/components/ServicesTable.js
@@ -296,7 +296,7 @@ var ServicesTable = React.createClass({
     let tasksSummary = service.getTasksSummary();
     let {tasksRunning} = tasksSummary;
 
-    let disableToolTip = serviceStatus === 'Deploying';
+    let isDeploying = serviceStatus === 'Deploying';
 
     let conciseOverview = ` (${tasksRunning}/${instancesCount})`;
     let verboseOverview = ` (${tasksRunning} ${StringUtil.pluralize('Task', tasksRunning)})`;
@@ -304,18 +304,11 @@ var ServicesTable = React.createClass({
       verboseOverview = ` (${tasksRunning} of ${instancesCount} Tasks)`;
     }
 
-    if (disableToolTip) {
-      tasksSummary = {
-        tasksStaged: instancesCount,
-        tasksRunning: 0
-      };
-    }
-
     return (
       <div className="status-bar-wrapper">
         <span className="status-bar-indicator">
           <HealthBar
-            disableToolTip={disableToolTip}
+            isDeploying={isDeploying}
             key={serviceId}
             tasksSummary={tasksSummary}
             instancesCount={instancesCount} />

--- a/src/js/components/__tests__/ServiceInfo-test.js
+++ b/src/js/components/__tests__/ServiceInfo-test.js
@@ -23,6 +23,7 @@ describe('ServiceInfo', function () {
     tasksRunning: 2,
     tasksHealthy: 2,
     tasksUnhealthy: 0,
+    instances: 2,
     labels: {
       'DCOS_PACKAGE_METADATA': 'eyJpbWFnZXMiOiB7ICJpY29uLXNtYWxsIjogImZvby1zbWFsbC5wbmciLCAiaWNvbi1tZWRpdW0iOiAiZm9vLW1lZGl1bS5wbmciLCAiaWNvbi1sYXJnZSI6ICJmb28tbGFyZ2UucG5nIn19'
     }


### PR DESCRIPTION
This PR does remove over capacity from the statusbar because the number was not clear to the user. There is now a text added next to the total task count if a service is over capacity.

Also the over capacity line is still in the tooltip.

over capacity:
![image](https://cloud.githubusercontent.com/assets/156010/18130591/dbd6c3c0-6f8f-11e6-9613-ec0d1e4aab6e.png)

within capacity:
![image](https://cloud.githubusercontent.com/assets/156010/18130618/fa08bd80-6f8f-11e6-8721-3e3e408e54ff.png)

/cc @leemunroe @silverem2