### PR TITLE
DCOS-9356: Sort component health widget by health

### DIFF
--- a/src/js/components/ComponentList.js
+++ b/src/js/components/ComponentList.js
@@ -3,7 +3,7 @@ import {Link} from 'react-router';
 import {List} from 'reactjs-components';
 import React from 'react';
 
-import UnitHealthUtil from '../utils/UnitHealthUtil';
+import HealthTypes from '../constants/HealthTypes';
 
 class ComponentList extends React.Component {
 
@@ -45,9 +45,10 @@ class ComponentList extends React.Component {
   }
 
   getVisibleComponents(units, displayCount) {
-    let sortFunction = UnitHealthUtil.getHealthSortFunction;
-
-    units = units.sort(sortFunction('health'));
+    // HealthTypes gives the sorting weight.
+    units = units.sort(function (a, b) {
+      return HealthTypes[a.getHealth().title.toUpperCase()] - HealthTypes[b.getHealth().title.toUpperCase()];
+    });
 
     if (units.length > displayCount) {
       return units.slice(0, displayCount);

--- a/tests/_fixtures/unit-health/units.json
+++ b/tests/_fixtures/unit-health/units.json
@@ -20,6 +20,11 @@
       "name": "A Signal Service"
     },
     {
+      "id": "log-rotate",
+      "health": 3,
+      "name": "Log Rotate"
+    },
+    {
       "id": "dcos-history-service.service",
       "health": 0,
       "name": "History Service"


### PR DESCRIPTION
Previously, the Component Health widget was sorted in this way:

- Health
- Unhealthy
- Idle
- N/A

We want to expose the Unhealthy components, so now it is sorted:

- Unhealthy
- Healthy
- Idle
- N/A