### PR TITLE
DCOS-9148: Improve networking tab usability

### DIFF
--- a/src/js/components/ServiceForm.js
+++ b/src/js/components/ServiceForm.js
@@ -22,7 +22,7 @@ const DUPLICABLE_FIELDS_TO_WATCH = {
     forceUpdate: true
   },
   ports: {
-    fields: ['discovery', 'protocol'],
+    fields: ['loadBalanced', 'protocol'],
     // Watch name to update the virtual network port exposure
     // Watch lbPort to update Service Address port on bridged networks
     blurOnly: ['name', 'lbPort'],

--- a/src/js/schemas/service-schema/Networking.js
+++ b/src/js/schemas/service-schema/Networking.js
@@ -9,7 +9,11 @@ const DISABLED_LB_PORT_FIELD_VALUE = 'Not Enabled';
 const Networking = {
   type: 'object',
   title: 'Network',
-  description: 'Configure the networking for your service.',
+  description: (
+    <span>
+       Configure the networking for your service. We will automatically generate a Service Address to connect to for each of your load balanced endpoints. <a href="https://docs.mesosphere.com/1.8/usage/service-discovery/load-balancing-vips/virtual-ip-addresses/" target="_blank">Read more about load balancing</a>.
+    </span>
+  ),
   properties: {
     networkType: {
       fieldType: 'select',

--- a/src/js/schemas/service-schema/Networking.js
+++ b/src/js/schemas/service-schema/Networking.js
@@ -80,7 +80,7 @@ const Networking = {
             lbPort: portMapping.port || portMapping.containerPort,
             name: portMapping.name,
             protocol: portMapping.protocol,
-            discovery: portMapping.labels &&
+            loadBalanced: portMapping.labels &&
               Object.keys(portMapping.labels).length > 0,
             expose: portMapping.hostPort != null
           };
@@ -122,7 +122,7 @@ const Networking = {
             definition.showLabel = 'LB Port';
 
             // show as input
-            if (service.discovery && definition.value === DISABLED_LB_PORT_FIELD_VALUE) {
+            if (service.loadBalanced && definition.value === DISABLED_LB_PORT_FIELD_VALUE) {
               delete definition.value;
               definition.disabled = false;
               definition.className = 'form-control';
@@ -130,7 +130,7 @@ const Networking = {
             }
 
             // show as disabled
-            if (!service.discovery) {
+            if (!service.loadBalanced) {
               definition.value = disabledLBPortFieldValue;
               definition.disabled = true;
               definition.fieldType = 'text';
@@ -156,11 +156,13 @@ const Networking = {
                 'LB Port  must be a number between 0 and 65535.';
 
               return false;
-            }
+            },
+            formElementClass: {'column-3': false}
           },
           name: {
             title: 'Name',
-            type: 'string'
+            type: 'string',
+            formElementClass: {'column-3': true}
           },
           protocol: {
             title: 'Protocol',
@@ -169,12 +171,13 @@ const Networking = {
             default: 'tcp',
             options: ['tcp', 'udp', 'udp,tcp']
           },
-          discovery: {
-            label: 'Discovery',
+          loadBalanced: {
+            label: 'Load Balanced',
             showLabel: false,
-            title: 'Discovery',
+            title: 'Load Balanced',
             type: 'boolean',
-            className: 'form-row-element-mixed-label-presence'
+            className: 'form-row-element-mixed-label-presence',
+            formElementClass: {'column-3': false}
           }
         }
       }

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -295,7 +295,7 @@ const ServiceUtil = {
 
         if (networking.ports != null) {
           networking.ports = networking.ports.filter(function (port) {
-            return port.name != null || port.lbPort != null || port.discovery;
+            return port.name != null || port.lbPort != null || port.loadBalanced;
           });
         }
 
@@ -311,7 +311,7 @@ const ServiceUtil = {
                 if (networkType === 'host') {
                   portMapping.port = 0;
                 }
-                if (port.discovery === true) {
+                if (port.loadBalanced === true) {
                   if (networkType === 'host') {
                     portMapping.port = lbPort;
                   }
@@ -350,7 +350,7 @@ const ServiceUtil = {
               // if (networkType === 'bridge') {
               //   portMapping.hostPort = lbPort;
               // }
-              if (port.discovery === true) {
+              if (port.loadBalanced === true) {
 
                 if (networkType !== 'bridge') {
                   portMapping.servicePort = lbPort;
@@ -371,7 +371,7 @@ const ServiceUtil = {
                   portMapping.hostPort = 0;
                 }
                 definition.container.docker.portMappings.push(portMapping);
-                // TODO - Add portDefinition to discovery field
+                // TODO - Add portDefinition to loadBalanced field
               }
             });
           }

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -176,43 +176,43 @@ describe('ServiceUtil', function () {
           ]);
         });
 
-        it('should enforce the port when discovery is on', function () {
+        it('should enforce the port when loadBalanced is on', function () {
           let service = ServiceUtil.createServiceFromFormModel({
             networking: {
               networkType: 'host',
-              ports: [{lbPort: 1234, discovery: true}]
+              ports: [{lbPort: 1234, loadBalanced: true}]
             }
           });
           expect(service.portDefinitions[0].port).toEqual(1234);
         });
 
-        it('should not override the port to 0 when discovery is off',
+        it('should not override the port to 0 when loadBalanced is off',
           function () {
             let service = ServiceUtil.createServiceFromFormModel({
               networking: {
                 networkType: 'host',
-                ports: [{lbPort: 1234, discovery: false}]
+                ports: [{lbPort: 1234, loadBalanced: false}]
               }
             });
             expect(service.portDefinitions[0].port).toEqual(1234);
           });
 
-        it('should default the port to 0 when discovery is on', function () {
+        it('should default the port to 0 when loadBalanced is on', function () {
           let service = ServiceUtil.createServiceFromFormModel({
             networking: {
               networkType: 'host',
-              ports: [{discovery: true}]
+              ports: [{loadBalanced: true}]
             }
           });
           expect(service.portDefinitions[0].port).toEqual(0);
         });
 
-        it('should add a VIP label when discovery is on', function () {
+        it('should add a VIP label when loadBalanced is on', function () {
           let service = ServiceUtil.createServiceFromFormModel({
             general: {id: '/foo/bar'},
             networking: {
               networkType: 'host',
-              ports: [{lbPort: 1234, discovery: true}]
+              ports: [{lbPort: 1234, loadBalanced: true}]
             }
           });
           expect(service.portDefinitions[0].labels)
@@ -225,8 +225,8 @@ describe('ServiceUtil', function () {
             networking: {
               networkType: 'host',
               ports: [
-                {lbPort: 1234, discovery: true},
-                {lbPort: 4321, discovery: true}
+                {lbPort: 1234, loadBalanced: true},
+                {lbPort: 4321, loadBalanced: true}
               ]
             }
           });
@@ -324,7 +324,7 @@ describe('ServiceUtil', function () {
             .toEqual(1234);
         });
 
-        it('should not add a hostPort when discovery is off', function () {
+        it('should not add a hostPort when loadBalanced is off', function () {
           let service = ServiceUtil.createServiceFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {
@@ -336,13 +336,13 @@ describe('ServiceUtil', function () {
             .not.toContain('hostPort');
         });
 
-        it('should add a VIP label when discovery is on', function () {
+        it('should add a VIP label when loadBalanced is on', function () {
           let service = ServiceUtil.createServiceFromFormModel({
             general: {id: '/foo/bar'},
             containerSettings: {image: 'redis'},
             networking: {
               networkType: 'bridge',
-              ports: [{lbPort: 1234, discovery: true}]
+              ports: [{lbPort: 1234, loadBalanced: true}]
             }
           });
           expect(service.container.docker.portMappings[0].labels)
@@ -413,7 +413,7 @@ describe('ServiceUtil', function () {
             .toEqual(1234);
         });
 
-        it('should not add a servicePort when discovery is off', function () {
+        it('should not add a servicePort when loadBalanced is off', function () {
           let service = ServiceUtil.createServiceFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {
@@ -425,19 +425,19 @@ describe('ServiceUtil', function () {
             .not.toContain('servicePort');
         });
 
-        it('should add a servicePort when discovery is on', function () {
+        it('should add a servicePort when loadBalanced is on', function () {
           let service = ServiceUtil.createServiceFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {
               networkType: 'user',
-              ports: [{lbPort: 1234, discovery: true}]
+              ports: [{lbPort: 1234, loadBalanced: true}]
             }
           });
           expect(service.container.docker.portMappings[0].servicePort)
             .toEqual(1234);
         });
 
-        it('should not add a VIP label when discovery is off', function () {
+        it('should not add a VIP label when loadBalanced is off', function () {
           let service = ServiceUtil.createServiceFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {
@@ -449,13 +449,13 @@ describe('ServiceUtil', function () {
             .not.toContain('labels');
         });
 
-        it('should add the appropriate VIP label when discovery is on', function () {
+        it('should add the appropriate VIP label when loadBalanced is on', function () {
           let service = ServiceUtil.createServiceFromFormModel({
             containerSettings: {image: 'redis'},
             general: {id: '/foo/bar'},
             networking: {
               networkType: 'user',
-              ports: [{lbPort: 1234, discovery: true}]
+              ports: [{lbPort: 1234, loadBalanced: true}]
             }
           });
           expect(service.container.docker.portMappings[0].labels)


### PR DESCRIPTION
![](https://cloud.githubusercontent.com/assets/647035/18164760/e040f0fe-7041-11e6-8ab8-1ea038a0ee97.png)

* Add service address documentation to the networking tab
* Rename discovery to load balanced 

💜  @jfurrow @mlunoe thanks a bunch for the `formElementClass` pointer

/cc @leemunroe 