### PR TITLE
Properly checking if error/warning messages have changed

### DIFF
--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -1,5 +1,6 @@
 import Ace from 'react-ace';
 import classNames from 'classnames';
+import deepEqual from 'deep-equal';
 import {Hooks} from 'PluginSDK';
 import mixin from 'reactjs-mixin';
 import {Modal, Tooltip} from 'reactjs-components';
@@ -146,10 +147,25 @@ class ServiceFormModal extends mixin(StoreMixin) {
 
   shouldComponentUpdate(nextProps, nextState) {
     let {state, props} = this;
+
+    if ((typeof state.errorMessage !== typeof nextState.errorMessage) ||
+       ((typeof state.errorMessage === 'object') && !deepEqual(
+          state.errorMessage,
+          nextState.errorMessage)
+       )) {
+      return true;
+    }
+
+    if ((typeof state.warningMessage !== typeof nextState.warningMessage) ||
+       ((typeof state.warningMessage === 'object') && !deepEqual(
+          state.warningMessage,
+          nextState.warningMessage)
+       )) {
+      return true;
+    }
+
     return props.open !== nextProps.open ||
       state.jsonMode !== nextState.jsonMode ||
-      state.errorMessage !== nextState.errorMessage ||
-      state.warningMessage !== nextState.warningMessage ||
       state.pendingRequest !== nextState.pendingRequest;
   }
 

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -105,7 +105,7 @@ const responseAttributePathToFieldIdMap = Object.assign({
 }, ErrorPaths);
 
 function didMessageChange(prevMessage, newMessage) {
-  return  (typeof prevMessage !== typeof newMessage) ||
+  return (typeof prevMessage !== typeof newMessage) ||
          ((typeof prevMessage === 'object') &&
           !deepEqual(prevMessage, newMessage));
 }

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -104,6 +104,12 @@ const responseAttributePathToFieldIdMap = Object.assign({
   '/user': 'user'
 }, ErrorPaths);
 
+function didMessageChange(prevMessage, newMessage) {
+  return  (typeof prevMessage !== typeof newMessage) ||
+         ((typeof prevMessage === 'object') &&
+          !deepEqual(prevMessage, newMessage));
+}
+
 class ServiceFormModal extends mixin(StoreMixin) {
   constructor() {
     super(...arguments);
@@ -147,26 +153,11 @@ class ServiceFormModal extends mixin(StoreMixin) {
 
   shouldComponentUpdate(nextProps, nextState) {
     let {state, props} = this;
-
-    if ((typeof state.errorMessage !== typeof nextState.errorMessage) ||
-       ((typeof state.errorMessage === 'object') && !deepEqual(
-          state.errorMessage,
-          nextState.errorMessage)
-       )) {
-      return true;
-    }
-
-    if ((typeof state.warningMessage !== typeof nextState.warningMessage) ||
-       ((typeof state.warningMessage === 'object') && !deepEqual(
-          state.warningMessage,
-          nextState.warningMessage)
-       )) {
-      return true;
-    }
-
     return props.open !== nextProps.open ||
       state.jsonMode !== nextState.jsonMode ||
-      state.pendingRequest !== nextState.pendingRequest;
+      state.pendingRequest !== nextState.pendingRequest ||
+      didMessageChange(state.errorMessage, nextState.errorMessage) ||
+      didMessageChange(state.warningMessage, nextState.warningMessage);
   }
 
   resetState(props = this.props) {


### PR DESCRIPTION
This makes sure `ServiceFormModal` properly checks if the component should update.

This fixes a bug encountered when the form is in JSON edit mode. Previously, when a warning message is visible (ex. the JSON string contains unhanded attributes), the components updates on every character type, making Ace editor replace it's contents on every key press - effectively prohibiting further edit of it's contents.