### PR TITLE
DCOS-9104: Add Tasks started by a framework to the taskList

### DIFF
--- a/src/js/schemas/service-schema/General.js
+++ b/src/js/schemas/service-schema/General.js
@@ -96,7 +96,13 @@ let General = {
           type: 'number',
           default: 1,
           getter(service) {
-            return `${service.getInstancesCount() || this.default}`;
+            let taskRunning = service.get('TASK_RUNNING') || 0;
+            let instances = service.getInstancesCount();
+            instances -= taskRunning;
+            if ((instances !== 0 && !instances) || instances < 0) {
+              instances = this.default;
+            }
+            return `${instances}`;
           }
         }
       }

--- a/src/js/structs/Framework.js
+++ b/src/js/structs/Framework.js
@@ -31,6 +31,11 @@ module.exports = class Framework extends Service {
     return tasksSummary;
   }
 
+  getInstancesCount() {
+    let tasksRunning = this.get('TASK_RUNNING') || 0;
+    return super.getInstancesCount() + tasksRunning;
+  }
+
   getName() {
     let labels = this.getLabels();
     if (labels && labels.DCOS_PACKAGE_FRAMEWORK_NAME) {

--- a/src/js/structs/Framework.js
+++ b/src/js/structs/Framework.js
@@ -21,6 +21,16 @@ module.exports = class Framework extends Service {
     return {value};
   }
 
+  getTasksSummary() {
+    let tasksSummary = super.getTasksSummary();
+
+    let tasksRunning = this.get('TASK_RUNNING') || 0;
+    tasksSummary.tasksRunning += tasksRunning;
+    tasksSummary.tasksUnknown += tasksRunning;
+
+    return tasksSummary;
+  }
+
   getName() {
     let labels = this.getLabels();
     if (labels && labels.DCOS_PACKAGE_FRAMEWORK_NAME) {

--- a/src/js/structs/Framework.js
+++ b/src/js/structs/Framework.js
@@ -22,7 +22,7 @@ module.exports = class Framework extends Service {
   }
 
   getTasksSummary() {
-    let tasksSummary = super.getTasksSummary();
+    let tasksSummary = Object.assign({}, super.getTasksSummary());
 
     let tasksRunning = this.get('TASK_RUNNING') || 0;
     tasksSummary.tasksRunning += tasksRunning;

--- a/src/js/structs/__tests__/Framework-test.js
+++ b/src/js/structs/__tests__/Framework-test.js
@@ -64,4 +64,66 @@ describe('Framework', function () {
 
   });
 
+  describe('#getTasksSummary', function () {
+
+    it('returns correct task summary', function () {
+      let service = new Framework({
+        instances: 2,
+        tasksStaged: 0,
+        tasksRunning: 1,
+        tasksHealthy: 1,
+        tasksUnhealthy: 0
+      });
+
+      expect(service.getTasksSummary()).toEqual({
+        tasksStaged: 0,
+        tasksRunning: 1,
+        tasksHealthy: 1,
+        tasksUnhealthy: 0,
+        tasksUnknown: 0,
+        tasksOverCapacity: 0
+      });
+    });
+
+    it('returns correct task summary for overcapcity', function () {
+      let service = new Framework({
+        instances: 2,
+        tasksStaged: 0,
+        tasksRunning: 4,
+        tasksHealthy: 2,
+        tasksUnhealthy: 0
+      });
+
+      expect(service.getTasksSummary()).toEqual({
+        tasksStaged: 0,
+        tasksRunning: 4,
+        tasksHealthy: 2,
+        tasksUnhealthy: 0,
+        tasksUnknown: 2,
+        tasksOverCapacity: 2
+      });
+    });
+
+    it('returns correct task summary with framework data', function () {
+      let service = new Framework({
+        instances: 2,
+        tasksStaged: 0,
+        tasksRunning: 1,
+        tasksHealthy: 1,
+        tasksUnhealthy: 0,
+        TASK_RUNNING: 1
+      });
+
+      expect(service.getTasksSummary()).toEqual({
+        tasksStaged: 0,
+        tasksRunning: 2,
+        tasksHealthy: 1,
+        tasksUnhealthy: 0,
+        tasksUnknown: 1,
+        tasksOverCapacity: 0
+      });
+    });
+
+  });
+
 });

--- a/src/js/structs/__tests__/Framework-test.js
+++ b/src/js/structs/__tests__/Framework-test.js
@@ -126,4 +126,25 @@ describe('Framework', function () {
 
   });
 
+  describe('#getInstancesCount', function () {
+
+    it('returns correct instances', function () {
+      let service = new Framework({
+        instances: 1
+      });
+
+      expect(service.getInstancesCount()).toEqual(1);
+    });
+
+    it('returns correct instances with Framework data', function () {
+      let service = new Framework({
+        instances: 1,
+        TASK_RUNNING: 1
+      });
+
+      expect(service.getInstancesCount()).toEqual(2);
+    });
+
+  });
+
 });


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/156010/18206142/a536d84a-7125-11e6-9009-beb090f4b55a.png)
![image](https://cloud.githubusercontent.com/assets/156010/18206152/af5ca520-7125-11e6-9732-1c2a73c58dee.png)

With this PR we are adding TASKS_RUNNING for frameworks from the mesosSummary to a running Framework. 