### PR TITLE
DCOS-9604: Add Framework fields to service config blacklist

### DIFF
--- a/src/js/constants/ServiceConfig.js
+++ b/src/js/constants/ServiceConfig.js
@@ -12,7 +12,25 @@ let ServiceConfig = {
     'tasksHealthy',
     'tasksRunning',
     'tasksStaged',
-    'tasksUnhealthy'
+    'tasksUnhealthy',
+    'name',
+    'pid',
+    'used_resources',
+    'offered_resources',
+    'capabilities',
+    'hostname',
+    'webui_url',
+    'active',
+    'TASK_STAGING',
+    'TASK_STARTING',
+    'TASK_RUNNING',
+    'TASK_KILLING',
+    'TASK_FINISHED',
+    'TASK_KILLED',
+    'TASK_FAILED',
+    'TASK_LOST',
+    'TASK_ERROR',
+    'slave_ids'
   ]
 };
 


### PR DESCRIPTION
This adds framework fields from the state summary to the service config blacklist. To remove them from the service json in the service form.