### PR TITLE
DCOS-9498: Remove ipAddress on network switch to HOST

### DIFF
--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -380,8 +380,10 @@ const ServiceUtil = {
         if (isContainerApp) {
           if (networkType === 'host') {
             definition.container.docker.network = 'HOST';
+            delete(definition.ipAddress);
           } else if (networkType === 'bridge') {
             definition.container.docker.network = 'BRIDGE';
+            delete(definition.ipAddress);
           } else {
             definition.container.docker.network = 'USER';
             definition.ipAddress = {networkName: networkType};


### PR DESCRIPTION
This PR will make sure that the ipAddress field in the config is removed if the user selects a different option from the dropdown.