### PR TITLE
DCOS-8898: Change history embed with historySummary embed on jobs request

### DIFF
--- a/src/js/events/MetronomeActions.js
+++ b/src/js/events/MetronomeActions.js
@@ -54,7 +54,7 @@ const MetronomeActions = {
           data: [
             {name: 'embed', value: 'activeRuns'},
             {name: 'embed', value: 'schedules'},
-            {name: 'embed', value: 'history'}
+            {name: 'embed', value: 'historySummary'}
           ],
           success(response) {
             try {

--- a/src/js/structs/Job.js
+++ b/src/js/structs/Job.js
@@ -62,9 +62,8 @@ module.exports = class Job extends Item {
     return mem;
   }
 
-  // TODO DCOS-8898 only get history summary
   getLastRunsSummary() {
-    return this.get('history') || {};
+    return this.get('historySummary') || {};
   }
 
   getLastRunStatus() {

--- a/src/js/structs/__tests__/Job-test.js
+++ b/src/js/structs/__tests__/Job-test.js
@@ -230,7 +230,7 @@ describe('Job', function () {
     it('returns an object with the time in ms', function () {
       let job = new Job({
         id: 'test.job',
-        history: {
+        historySummary: {
           lastSuccessAt: '1990-04-30T00:00:00Z',
           lastFailureAt: '1985-04-30T00:00:00Z'
         }
@@ -242,7 +242,7 @@ describe('Job', function () {
     it('returns the most recent status', function () {
       let job = new Job({
         id: 'test.job',
-        history: {
+        historySummary: {
           lastSuccessAt: '1990-04-30T00:00:00Z',
           lastFailureAt: '1985-04-30T00:00:00Z'
         }
@@ -254,7 +254,7 @@ describe('Job', function () {
     it('returns the most recent status', function () {
       let job = new Job({
         id: 'test.job',
-        history: {
+        historySummary: {
           lastSuccessAt: '1985-04-30T00:00:00Z',
           lastFailureAt: '1990-04-30T00:00:00Z'
         }
@@ -266,7 +266,7 @@ describe('Job', function () {
     it('returns N/A status if both are undefiend', function () {
       let job = new Job({
         id: 'test.job',
-        history: {}
+        historySummary: {}
       });
 
       expect(job.getLastRunStatus().status).toEqual('N/A');
@@ -276,7 +276,7 @@ describe('Job', function () {
     it('returns success if lastFailureAt is undefiend', function () {
       let job = new Job({
         id: 'test.job',
-        history: {
+        historySummary: {
           lastSuccessAt: '1990-04-30T00:00:00Z'
         }
       });
@@ -287,7 +287,7 @@ describe('Job', function () {
     it('returns success if lastSuccessAt is undefiend', function () {
       let job = new Job({
         id: 'test.job',
-        history: {
+        historySummary: {
           lastFailureAt: '1990-04-30T00:00:00Z'
         }
       });


### PR DESCRIPTION
This changes the emebed parameter for the jobs request and we only request the history
summary from metronome now. This will remove a lot of overhead in request size for
clusters which are using a lot of jobs.