### PR TITLE
Removing id property from ServiceFormModal

### DIFF
--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -11,6 +11,7 @@ import 'brace/mode/json';
 import 'brace/theme/monokai';
 import 'brace/ext/language_tools';
 
+import Application from '../../structs/Application';
 import Config from '../../config/Config';
 import CollapsibleErrorMessage from '../CollapsibleErrorMessage';
 import Icon from '../Icon';
@@ -160,21 +161,21 @@ class ServiceFormModal extends mixin(StoreMixin) {
   }
 
   resetState(props = this.props) {
-    let model = ServiceUtil.createFormModelFromSchema(ServiceSchema);
-    if (props.id) {
-      model.general.id = props.id;
-    }
-    let service = ServiceUtil.createServiceFromFormModel(
-      model,
-      ServiceSchema,
-      this.props.isEdit
-    );
+    let service;
     if (props.service) {
       service = props.service;
+    } else {
+      service = ServiceUtil.createServiceFromFormModel(
+        model,
+        ServiceSchema,
+        this.props.isEdit
+      );
     }
 
+    let model = ServiceUtil.createFormModelFromSchema(ServiceSchema, service);
     let warningMessage = null;
     let jsonMode = false;
+
     if (this.shouldDisableForm(service)) {
       warningMessage = {
         message: 'Your config contains attributes we currently only support ' +
@@ -208,7 +209,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
     let {service} = this.state;
 
     try {
-      service = new Service(JSON.parse(jsonDefinition));
+      service = new Application(JSON.parse(jsonDefinition));
     } catch (e) {
 
     }
@@ -621,12 +622,10 @@ ServiceFormModal.defaultProps = {
   isEdit: false,
   onClose() {},
   open: false,
-  id: null,
   service: null
 };
 
 ServiceFormModal.propTypes = {
-  id: React.PropTypes.string,
   isEdit: React.PropTypes.bool,
   open: React.PropTypes.bool,
   onClose: React.PropTypes.func,

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -160,15 +160,12 @@ class ServiceFormModal extends mixin(StoreMixin) {
       didMessageChange(state.warningMessage, nextState.warningMessage);
   }
 
-  resetState(props = this.props) {
-    let service;
-    if (props.service) {
-      service = props.service;
-    } else {
+  resetState({service, isEdit} = this.props) {
+    if (!service) {
       service = ServiceUtil.createServiceFromFormModel(
         model,
         ServiceSchema,
-        this.props.isEdit
+        isEdit
       );
     }
 

--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {Link, RouteHandler} from 'react-router';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
+import Application from '../../structs/Application';
 import AlertPanel from '../../components/AlertPanel';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import DCOSStore from '../../stores/DCOSStore';
@@ -377,7 +378,7 @@ var ServicesTab = React.createClass({
           parentGroupId={item.getId()}
           onClose={this.handleCloseGroupFormModal}/>
         <ServiceFormModal open={state.isServiceFormModalShown}
-          id={serviceId}
+          service={new Application({id: serviceId})}
           onClose={this.handleCloseServiceFormModal}/>
       </div>
     );


### PR DESCRIPTION
_Not addressing pod-only problem, but is needed for a feature on the pods UI._

The `id=` property was causing some troubles on some new implementation that I am working on and it didn't look good eitherwise. Suggested a modification.