### PR TITLE
Fixes network tab

### DIFF
--- a/src/js/components/ServiceForm.js
+++ b/src/js/components/ServiceForm.js
@@ -149,13 +149,16 @@ class ServiceForm extends SchemaForm {
         let hostNetworkingDefinition = null;
         let {ports} = model.networking;
         let serviceAddressNetworkingDefinition = null;
+
         if (ports == null) {
           return null;
         }
-        let hasDiscovery = ports.some(function (port) {
-          return port.discovery;
+
+        let hasLoadBalanced = ports.some(function (port) {
+          return port.loadBalanced;
         });
-        if (!hasDiscovery) {
+
+        if (!hasLoadBalanced) {
           return null;
         }
 

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -385,6 +385,7 @@ const ServiceUtil = {
           } else {
             definition.container.docker.network = 'USER';
             definition.ipAddress = {networkName: networkType};
+            delete(definition.portDefinitions);
           }
         }
       }


### PR DESCRIPTION
Renames discovery to loadBalanced that was missed and ensures there's no port definitions when setting up a VIP.