### PR TITLE
Properly set the expose network checkbox prop ID

### DIFF
--- a/src/js/components/ServiceForm.js
+++ b/src/js/components/ServiceForm.js
@@ -415,11 +415,13 @@ class ServiceForm extends SchemaForm {
           return;
         }
 
-        let propID = FormUtil.getPropIndex(portDefinition[0].name);
+        const propID = FormUtil.getPropIndex(portDefinition[0].id);
+        const propName = FormUtil.getPropIndex(portDefinition[0].name);
 
         definitionGroup.push({
           fieldType: 'checkbox',
-          name: `ports[${propID}].expose`,
+          id: `ports[${propID}].expose`,
+          name: `ports[${propName}].expose`,
           placeholder: '',
           required: false,
           showError: false,


### PR DESCRIPTION
Adjust `getExposeNetworkingCheckboxes` method to define a  checkbox prop
ID. Without this ID the`FormUtil.removePropID` method (used by the remove row button)  fails to remove the respective fields.
This change fixes an issue where it was impossible to remove endpoints
in the networking tab.