### PR TITLE
Revert "DCOS-9285: Disable checkboxes for non-marathon tasks"

### DIFF
--- a/src/js/components/CheckboxTable.js
+++ b/src/js/components/CheckboxTable.js
@@ -52,9 +52,7 @@ class CheckboxTable extends React.Component {
 
   bulkCheck(isChecked) {
     let checkedIDs = [];
-    let {data, onCheckboxChange, uniqueProperty, disabledItemsMap} = this.props;
-
-    data = data.filter((datum) => !disabledItemsMap[datum[uniqueProperty]]);
+    let {data, onCheckboxChange, uniqueProperty} = this.props;
 
     if (isChecked) {
       data.forEach(function (datum) {
@@ -77,14 +75,13 @@ class CheckboxTable extends React.Component {
   renderHeadingCheckbox() {
     let checked = false;
     let indeterminate = false;
-    let {allowMultipleSelect, checkedItemsMap, disabledItemsMap, data} = this.props;
+    let {allowMultipleSelect, checkedItemsMap, data} = this.props;
 
     if (!allowMultipleSelect) {
       return null;
     }
 
     let checkedItemsCount = Object.keys(checkedItemsMap).length;
-    let disabledItemsCount = Object.keys(disabledItemsMap).length;
 
     if (checkedItemsCount > 0) {
       indeterminate = true;
@@ -92,7 +89,7 @@ class CheckboxTable extends React.Component {
       checked = false;
     }
 
-    if (checkedItemsCount + disabledItemsCount === data.length && checkedItemsCount !== 0) {
+    if (checkedItemsCount === data.length && checkedItemsCount !== 0) {
       checked = true;
       indeterminate = false;
     }

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -228,15 +228,6 @@ class TaskTable extends React.Component {
     );
   }
 
-  getDisabledItemsMap(tasks) {
-    return tasks
-      .filter((task) => task.scheduler !== 'marathon')
-      .reduce((acc, task) => {
-        acc[task.id] = true;
-        return acc;
-      }, {});
-  }
-
   renderHeadline(prop, task) {
     let title = task.id;
     let params = this.props.parentRouter.getCurrentParams();
@@ -374,7 +365,6 @@ class TaskTable extends React.Component {
         className={className}
         columns={this.getColumns()}
         data={tasks.slice()}
-        disabledItemsMap={this.getDisabledItemsMap(tasks)}
         getColGroup={this.getColGroup}
         onCheckboxChange={onCheckboxChange}
         sortBy={{prop: 'updated', order: 'desc'}}

--- a/src/js/components/__tests__/TaskTable-test.js
+++ b/src/js/components/__tests__/TaskTable-test.js
@@ -45,17 +45,6 @@ describe('TaskTable', function () {
 
   });
 
-  describe('#getDisabledItemsMap', function () {
-    beforeEach(function () {
-      this.taskTable = new TaskTable();
-    });
-
-    it('returns a map of disabled items', function () {
-      var tasks = [{id: '1', scheduler: 'marathon'}, {id: '2'}];
-      expect(this.taskTable.getDisabledItemsMap(tasks)).toEqual({'2': true});
-    });
-  });
-
   describe('#getTaskHealth', function () {
 
     beforeEach(function () {

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -255,21 +255,17 @@ class MesosStateStore extends GetSetBaseStore {
     // the scheduler tasks or a list of Marathon application tasks.
     return frameworks.reduce(function (serviceTasks, framework) {
       let {tasks = [], completed_tasks = {}, name} = framework;
-
-      let allTasks = tasks.concat(completed_tasks).map(function (task) {
-        task.scheduler = name;
-        return task;
-      });
-
       // Include tasks from framework match, if service is a Framework
       if (service instanceof Framework && name === serviceName) {
-        return serviceTasks.concat(allTasks);
+        return serviceTasks.concat(tasks, completed_tasks);
       }
+
       // Filter marathon tasks by service name
       if (name === 'marathon') {
-        return allTasks
-          .filter(({name}) => name === mesosTaskName)
-          .concat(serviceTasks);
+        return tasks.concat(completed_tasks)
+          .filter(function ({name}) {
+            return name === mesosTaskName;
+          }).concat(serviceTasks);
       }
 
       return serviceTasks;

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -46,19 +46,11 @@ describe('MesosStateStore', function () {
               tasks: [
                 {name: 'spark', id: 'spark.1'},
                 {name: 'alpha', id: 'alpha.1'},
-                {name: 'alpha', id: 'alpha.2'},
-                {name: 'beta', id: 'beta.1'}
+                {name: 'alpha', id: 'alpha.2'}
               ],
               completed_tasks: [
                 {name: 'alpha', id: 'alpha.3'}
               ]
-            },
-            {
-              name: 'beta',
-              tasks: [
-                {name: '1'}
-              ],
-              completed_tasks: []
             },
             {
               name: 'spark',
@@ -79,27 +71,16 @@ describe('MesosStateStore', function () {
       MesosStateStore.get = this.get;
     });
 
-    it('should flag tasks started with marathon', function () {
-      var tasks = MesosStateStore.getTasksByService(
-        new Framework({id: '/beta', labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'beta'}})
-      );
-
-      expect(tasks).toEqual([
-        {name: 'beta', id: 'beta.1', scheduler: 'marathon'},
-        {name: '1', scheduler: 'beta'}
-      ]);
-    });
-
     it('should return matching framework tasks including scheduler tasks',
       function () {
         var tasks = MesosStateStore.getTasksByService(
           new Framework({id: '/spark', labels: {DCOS_PACKAGE_FRAMEWORK_NAME: 'spark'}})
         );
         expect(tasks).toEqual([
-          {name: 'spark', id: 'spark.1', scheduler: 'marathon'},
-          {name: '1', scheduler: 'spark'},
-          {name: '2', scheduler: 'spark'},
-          {name: '3', scheduler: 'spark'}
+          {name: 'spark', id: 'spark.1'},
+          {name: '1'},
+          {name: '2'},
+          {name: '3'}
         ]);
       }
     );
@@ -109,9 +90,9 @@ describe('MesosStateStore', function () {
         new Service({id: '/alpha'})
       );
       expect(tasks).toEqual([
-        {name: 'alpha', id: 'alpha.1', scheduler: 'marathon'},
-        {name: 'alpha', id: 'alpha.2', scheduler: 'marathon'},
-        {name: 'alpha', id: 'alpha.3', scheduler: 'marathon'}
+        {name: 'alpha', id: 'alpha.1'},
+        {name: 'alpha', id: 'alpha.2'},
+        {name: 'alpha', id: 'alpha.3'}
       ]);
     });
 


### PR DESCRIPTION
Reverts dcos/dcos-ui#1021

Hey guys - This PR needs to be reverted as it's mutating data and it doesn't work when viewing the tasks table through the Nodes page. We need to rethink this solution so that we use a method on the struct or a Util to determine if the task was started through Marathon.
We'll likely reuse some of this code. Anyone feel free to give this another stab.