### PR TITLE
[Pods] Adjust service actions to support pods

### DIFF
--- a/src/js/components/ServiceDetailConfigurationTab.js
+++ b/src/js/components/ServiceDetailConfigurationTab.js
@@ -53,12 +53,14 @@ class ServiceDetailConfigurationTab extends React.Component {
   }
 
   handleApplyButtonClick() {
-    let serviceConfiguration =
-      this.props.service.getVersions().get(this.state.selectedVersionID);
+    let {service} = this.props;
 
-    MarathonStore.editService(
-      ServiceUtil.getDefinitionFromSpec(
-        new ApplicationSpec(serviceConfiguration)
+    let serviceConfiguration =
+        service.getVersions().get(this.state.selectedVersionID);
+
+    MarathonStore.editService(service,
+      ServiceUtil.getAppDefinitionFromService(
+          new ApplicationSpec(serviceConfiguration)
       )
     );
   }

--- a/src/js/components/modals/ServiceDestroyModal.js
+++ b/src/js/components/modals/ServiceDestroyModal.js
@@ -36,12 +36,11 @@ class ServiceDestroyModal extends ServiceActionModal {
 
     let {service} = this.props;
     let isGroup = service instanceof ServiceTree;
-    let serviceID = service.getId();
 
     if (isGroup) {
-      MarathonStore.deleteGroup(serviceID);
+      MarathonStore.deleteGroup(service.getId());
     } else {
-      MarathonStore.deleteService(serviceID);
+      MarathonStore.deleteService(service);
     }
   }
 

--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -332,14 +332,16 @@ class ServiceFormModal extends mixin(StoreMixin) {
   }
 
   handleSubmit() {
+    const {force, serviceSpec} = this.state;
+    const {isEdit, service} = this.props;
     let marathonAction = MarathonStore.createService;
 
-    if (this.props.isEdit) {
-      marathonAction = MarathonStore.editService;
+    if (isEdit) {
+      marathonAction = MarathonStore.editService.bind(MarathonStore, service);
     }
 
     if (this.state.jsonMode) {
-      marathonAction(this.state.serviceSpec, this.state.force);
+      marathonAction(service, serviceSpec, force);
       this.setState({
         errorMessage: null,
         pendingRequest: true
@@ -360,7 +362,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
         this.props.service.getSpec().get() // Work on the original service spec
       );
       marathonAction(
-        ServiceUtil.getDefinitionFromSpec(serviceSpec),
+        serviceSpec,
         this.state.force
       );
     }

--- a/src/js/components/modals/ServiceRestartModal.js
+++ b/src/js/components/modals/ServiceRestartModal.js
@@ -29,10 +29,9 @@ class ServiceRestartModal extends ServiceActionModal {
     super.handleConfirmClick();
 
     let {service} = this.props;
-    let serviceID = service.getId();
     let forceUpdate = this.shouldForceUpdate(this.state.errorMsg);
 
-    MarathonStore.restartService(serviceID, forceUpdate);
+    MarathonStore.restartService(service, forceUpdate);
   }
 
   render() {

--- a/src/js/components/modals/ServiceScaleFormModal.js
+++ b/src/js/components/modals/ServiceScaleFormModal.js
@@ -106,8 +106,7 @@ class ServiceScaleFormModal extends mixin(StoreMixin) {
           scaleBy: parseInt(instances, 10)
         });
       } else {
-        MarathonStore.editService({
-          id: service.id,
+        MarathonStore.editService(service, {
           instances: parseInt(instances, 10)
         }, this.shouldForceUpdate(this.state.errorMsg));
       }

--- a/src/js/components/modals/ServiceSuspendModal.js
+++ b/src/js/components/modals/ServiceSuspendModal.js
@@ -42,7 +42,7 @@ class ServiceSuspendModal extends ServiceActionModal {
     if (isGroup) {
       MarathonStore.editGroup({id: serviceID, scaleBy: 0}, forceUpdate);
     } else {
-      MarathonStore.editService({id: serviceID, instances: 0}, forceUpdate);
+      MarathonStore.editService(service, {instances: 0}, forceUpdate);
     }
   }
 

--- a/src/js/events/MarathonActions.js
+++ b/src/js/events/MarathonActions.js
@@ -492,6 +492,9 @@ if (Config.useFixtures) {
     editService: {
       event: 'success', success: {response: {}}
     },
+    restartService: {
+      event: 'success', success: {response: {}}
+    },
     fetchGroups: {
       event: 'success', success: {response: groupsFixture}
     }

--- a/src/js/events/MarathonActions.js
+++ b/src/js/events/MarathonActions.js
@@ -234,8 +234,20 @@ var MarathonActions = {
     });
   },
 
-  restartService(serviceId, force = false) {
-    let url = buildURI(`/apps/${serviceId}/restart`);
+  restartService(service, force = false) {
+    if (!(service instanceof Service)) {
+      if (process.env.NODE_ENV !== 'production') {
+        throw new TypeError('service is not an instance of Service');
+      }
+
+      return;
+    }
+
+    let url = buildURI(`/apps/${service.getId()}/restart`);
+
+    if (service instanceof Pod) {
+      url = buildURI(`/pods/${service.getId()}/restart`);
+    }
 
     if (force === true) {
       url += '?force=true';

--- a/src/js/events/MarathonActions.js
+++ b/src/js/events/MarathonActions.js
@@ -39,7 +39,9 @@ import AppDispatcher from './AppDispatcher';
 import Config from '../config/Config';
 import MarathonUtil from '../utils/MarathonUtil';
 import Util from '../utils/Util';
+import Pod from '../structs/Pod';
 import PodSpec from '../structs/PodSpec';
+import Service from '../structs/Service';
 
 function buildURI(path) {
   return `${Config.rootUrl}${Config.marathonAPIPrefix}${path}`;
@@ -148,9 +150,28 @@ var MarathonActions = {
     });
   },
 
-  deleteService(serviceId) {
+  /**
+   * Delete a service (app, framework, or pod)
+   *
+   * @param {Service} service - the service you want to delete
+   */
+  deleteService(service) {
+    if (!(service instanceof Service)) {
+      if (process.env.NODE_ENV !== 'production') {
+        throw new TypeError('service is not an instance of Service');
+      }
+
+      return;
+    }
+
+    let url = buildURI(`/apps/${service.getId()}`);
+
+    if (service instanceof Pod) {
+      url = buildURI(`/pods/${service.getId()}`);
+    }
+
     RequestUtil.json({
-      url: buildURI(`/apps/${serviceId}`),
+      url,
       method: 'DELETE',
       success() {
         AppDispatcher.handleServerAction({

--- a/src/js/events/MarathonActions.js
+++ b/src/js/events/MarathonActions.js
@@ -188,8 +188,28 @@ var MarathonActions = {
     });
   },
 
-  editService(data, force) {
-    let url = buildURI(`/apps/${data.id}`);
+  /**
+   * Edit service (app, framework, or pod)
+   *
+   * @param {Service} service - the service you wish to edit
+   * @param {ServiceSpec} spec - the new service spec
+   * @param {Boolean} force - force deploy change
+   */
+  editService(service, spec, force) {
+    // TODO (DCOS-9621): Only accept instances of ServiceSpec for spec
+    if (!(service instanceof Service)) {
+      if (process.env.NODE_ENV !== 'production') {
+        throw new TypeError('service is not an instance of Service');
+      }
+
+      return;
+    }
+
+    let url = buildURI(`/apps/${service.getId()}`);
+
+    if (service instanceof Pod) {
+      url = buildURI(`/pods/${service.getId()}`);
+    }
 
     if (force === true) {
       url += '?force=true';
@@ -198,7 +218,7 @@ var MarathonActions = {
     RequestUtil.json({
       url,
       method: 'PUT',
-      data,
+      data:spec,
       success() {
         AppDispatcher.handleServerAction({
           type: REQUEST_MARATHON_SERVICE_EDIT_SUCCESS

--- a/src/js/events/MarathonActions.js
+++ b/src/js/events/MarathonActions.js
@@ -427,6 +427,9 @@ if (Config.useFixtures) {
   }
 
   global.actionTypes.MarathonActions = {
+    createService: {
+      event: 'success', success: {response: {}}
+    },
     fetchGroups: {
       event: 'success', success: {response: groupsFixture}
     }

--- a/src/js/events/MarathonActions.js
+++ b/src/js/events/MarathonActions.js
@@ -445,6 +445,9 @@ if (Config.useFixtures) {
     createService: {
       event: 'success', success: {response: {}}
     },
+    deleteService: {
+      event: 'success', success: {response: {}}
+    },
     fetchGroups: {
       event: 'success', success: {response: groupsFixture}
     }

--- a/src/js/events/MarathonActions.js
+++ b/src/js/events/MarathonActions.js
@@ -469,6 +469,9 @@ if (Config.useFixtures) {
     deleteService: {
       event: 'success', success: {response: {}}
     },
+    editService: {
+      event: 'success', success: {response: {}}
+    },
     fetchGroups: {
       event: 'success', success: {response: groupsFixture}
     }

--- a/src/js/events/__tests__/MarathonActions-test.js
+++ b/src/js/events/__tests__/MarathonActions-test.js
@@ -519,56 +519,116 @@ describe('MarathonActions', function () {
   });
 
   describe('#restartService', function () {
-    beforeEach(function () {
-      spyOn(RequestUtil, 'json');
-      MarathonActions.restartService('/foo');
-      this.configuration = RequestUtil.json.calls.mostRecent().args[0];
-    });
 
-    it('calls #json from the RequestUtil', function () {
-      expect(RequestUtil.json).toHaveBeenCalled();
-    });
+    describe('app', function () {
+      const app = new Application({id: '/test'});
 
-    it('sends data to the correct URL', function () {
-      expect(this.configuration.url)
-        .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//foo/restart`);
-    });
-
-    it('sends data to the correct URL with the force=true parameter',
-      function () {
-        MarathonActions.restartService('/foo', true);
+      beforeEach(function () {
+        spyOn(RequestUtil, 'json');
+        MarathonActions.restartService(app);
         this.configuration = RequestUtil.json.calls.mostRecent().args[0];
+      });
 
+      it('calls #json from the RequestUtil', function () {
+        expect(RequestUtil.json).toHaveBeenCalled();
+      });
+
+      it('sends data to the correct URL', function () {
         expect(this.configuration.url)
-          .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//foo/restart?force=true`);
+            .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//test/restart`);
       });
 
-    it('uses POST for the request method', function () {
-      expect(this.configuration.method).toEqual('POST');
-    });
+      it('sends data to the correct URL with the force=true parameter',
+          function () {
+            MarathonActions.restartService(app, true);
+            this.configuration = RequestUtil.json.calls.mostRecent().args[0];
 
-    it('dispatches the correct action when successful', function () {
-      var id = AppDispatcher.register(function (payload) {
-        var action = payload.action;
-        AppDispatcher.unregister(id);
-        expect(action.type)
-          .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_RESTART_SUCCESS);
+            expect(this.configuration.url)
+                .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//test/restart?force=true`);
+          });
+
+      it('uses POST for the request method', function () {
+        expect(this.configuration.method).toEqual('POST');
       });
 
-      this.configuration.success({});
-    });
+      it('dispatches the correct action when successful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.type)
+              .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_RESTART_SUCCESS);
+        });
 
-    it('dispatches the correct action when unsucessful', function () {
-      var id = AppDispatcher.register(function (payload) {
-        var action = payload.action;
-        AppDispatcher.unregister(id);
-        expect(action.type)
-          .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_RESTART_ERROR);
+        this.configuration.success({});
       });
 
-      this.configuration.error({message: 'error', response: '{}'});
+      it('dispatches the correct action when unsucessful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.type)
+              .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_RESTART_ERROR);
+        });
+
+        this.configuration.error({message: 'error', response: '{}'});
+      });
+
     });
 
+    describe('pods', function () {
+      const pod = new Pod({id: '/test'});
+
+      beforeEach(function () {
+        spyOn(RequestUtil, 'json');
+        MarathonActions.restartService(pod);
+        this.configuration = RequestUtil.json.calls.mostRecent().args[0];
+      });
+
+      it('calls #json from the RequestUtil', function () {
+        expect(RequestUtil.json).toHaveBeenCalled();
+      });
+
+      it('sends data to the correct URL', function () {
+        expect(this.configuration.url)
+            .toEqual(`${Config.rootUrl}/service/marathon/v2/pods//test/restart`);
+      });
+
+      it('sends data to the correct URL with the force=true parameter',
+          function () {
+            MarathonActions.restartService(pod, true);
+            this.configuration = RequestUtil.json.calls.mostRecent().args[0];
+
+            expect(this.configuration.url)
+                .toEqual(`${Config.rootUrl}/service/marathon/v2/pods//test/restart?force=true`);
+          });
+
+      it('uses POST for the request method', function () {
+        expect(this.configuration.method).toEqual('POST');
+      });
+
+      it('dispatches the correct action when successful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.type)
+              .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_RESTART_SUCCESS);
+        });
+
+        this.configuration.success({});
+      });
+
+      it('dispatches the correct action when unsucessful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.type)
+              .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_RESTART_ERROR);
+        });
+
+        this.configuration.error({message: 'error', response: '{}'});
+      });
+
+    });
   });
 
   describe('#fetchDeployments', function () {

--- a/src/js/events/__tests__/MarathonActions-test.js
+++ b/src/js/events/__tests__/MarathonActions-test.js
@@ -7,10 +7,12 @@ const Hooks = require('PluginSDK').Hooks;
 const RequestUtil = require('mesosphere-shared-reactjs').RequestUtil;
 
 const ActionTypes = require('../../constants/ActionTypes');
+const Application = require('../../structs/Application');
 const ApplicationSpec = require('../../structs/ApplicationSpec');
 const AppDispatcher = require('../AppDispatcher');
 const Config = require('../../config/Config');
 const MarathonActions = require('../MarathonActions');
+const Pod = require('../../structs/Pod');
 const PodSpec = require('../../structs/PodSpec');
 
 Hooks.addFilter('hasCapability', function () { return true; });
@@ -294,52 +296,101 @@ describe('MarathonActions', function () {
   });
 
   describe('#deleteService', function () {
-    const appDefiniton = {
-      id: '/test'
-    };
 
-    beforeEach(function () {
-      spyOn(RequestUtil, 'json');
-      MarathonActions.deleteService(appDefiniton.id);
-      this.configuration = RequestUtil.json.calls.mostRecent().args[0];
-    });
+    describe('app', function () {
 
-    it('calls #json from the RequestUtil', function () {
-      expect(RequestUtil.json).toHaveBeenCalled();
-    });
-
-    it('sends data to the correct URL', function () {
-      expect(this.configuration.url)
-        .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//test`);
-    });
-
-    it('uses DELETE for the request method', function () {
-      expect(this.configuration.method).toEqual('DELETE');
-    });
-
-    it('dispatches the correct action when successful', function () {
-      var id = AppDispatcher.register(function (payload) {
-        var action = payload.action;
-        AppDispatcher.unregister(id);
-        expect(action.type)
-          .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_DELETE_SUCCESS);
+      beforeEach(function () {
+        spyOn(RequestUtil, 'json');
+        MarathonActions.deleteService(new Application({id: '/test'}));
+        this.configuration = RequestUtil.json.calls.mostRecent().args[0];
       });
 
-      this.configuration.success({
-        'version': '2016-05-13T10:26:55.840Z',
-        'deploymentId': '6119207e-a146-44b4-9c6f-0e4227dc04a5'
+      it('calls #json from the RequestUtil', function () {
+        expect(RequestUtil.json).toHaveBeenCalled();
       });
+
+      it('sends data to the correct URL', function () {
+        expect(this.configuration.url)
+            .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//test`);
+      });
+
+      it('uses DELETE for the request method', function () {
+        expect(this.configuration.method).toEqual('DELETE');
+      });
+
+      it('dispatches the correct action when successful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.type)
+              .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_DELETE_SUCCESS);
+        });
+
+        this.configuration.success({
+          'version': '2016-05-13T10:26:55.840Z',
+          'deploymentId': '6119207e-a146-44b4-9c6f-0e4227dc04a5'
+        });
+      });
+
+      it('dispatches the correct action when unsucessful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.type)
+              .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_DELETE_ERROR);
+        });
+
+        this.configuration.error({message: 'error', response: '{}'});
+      });
+
     });
 
-    it('dispatches the correct action when unsucessful', function () {
-      var id = AppDispatcher.register(function (payload) {
-        var action = payload.action;
-        AppDispatcher.unregister(id);
-        expect(action.type)
-          .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_DELETE_ERROR);
+    describe('pod', function () {
+
+      beforeEach(function () {
+        spyOn(RequestUtil, 'json');
+        MarathonActions.deleteService(new Pod({id: '/test'}));
+        this.configuration = RequestUtil.json.calls.mostRecent().args[0];
       });
 
-      this.configuration.error({message: 'error', response: '{}'});
+      it('calls #json from the RequestUtil', function () {
+        expect(RequestUtil.json).toHaveBeenCalled();
+      });
+
+      it('sends data to the correct URL', function () {
+        expect(this.configuration.url)
+            .toEqual(`${Config.rootUrl}/service/marathon/v2/pods//test`);
+      });
+
+      it('uses DELETE for the request method', function () {
+        expect(this.configuration.method).toEqual('DELETE');
+      });
+
+      it('dispatches the correct action when successful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.type)
+              .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_DELETE_SUCCESS);
+        });
+
+        this.configuration.success({
+          'version': '2016-05-13T10:26:55.840Z',
+          'deploymentId': '6119207e-a146-44b4-9c6f-0e4227dc04a5'
+        });
+      });
+
+      it('dispatches the correct action when unsucessful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.type)
+              .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_DELETE_ERROR);
+        });
+
+        this.configuration.error({message: 'error', response: '{}'});
+      });
+
     });
 
   });

--- a/src/js/events/__tests__/MarathonActions-test.js
+++ b/src/js/events/__tests__/MarathonActions-test.js
@@ -7,9 +7,11 @@ const Hooks = require('PluginSDK').Hooks;
 const RequestUtil = require('mesosphere-shared-reactjs').RequestUtil;
 
 const ActionTypes = require('../../constants/ActionTypes');
+const ApplicationSpec = require('../../structs/ApplicationSpec');
 const AppDispatcher = require('../AppDispatcher');
 const Config = require('../../config/Config');
 const MarathonActions = require('../MarathonActions');
+const PodSpec = require('../../structs/PodSpec');
 
 Hooks.addFilter('hasCapability', function () { return true; });
 
@@ -176,53 +178,117 @@ describe('MarathonActions', function () {
   });
 
   describe('#createService', function () {
-    const appDefiniton = {
-      id: '/test',
-      cmd: 'sleep 100;'
-    };
 
-    beforeEach(function () {
-      spyOn(RequestUtil, 'json');
-      MarathonActions.createService(appDefiniton);
-      this.configuration = RequestUtil.json.calls.mostRecent().args[0];
-    });
+    describe('app', function () {
 
-    it('calls #json from the RequestUtil', function () {
-      expect(RequestUtil.json).toHaveBeenCalled();
-    });
-
-    it('sends data to the correct URL', function () {
-      expect(this.configuration.url)
-        .toEqual(`${Config.rootUrl}/service/marathon/v2/apps`);
-    });
-
-    it('uses POST for the request method', function () {
-      expect(this.configuration.method).toEqual('POST');
-    });
-
-    it('dispatches the correct action when successful', function () {
-      var id = AppDispatcher.register(function (payload) {
-        var action = payload.action;
-        AppDispatcher.unregister(id);
-        expect(action.type)
-          .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_CREATE_SUCCESS);
+      beforeEach(function () {
+        spyOn(RequestUtil, 'json');
+        MarathonActions.createService(new ApplicationSpec({
+          id: '/test',
+          cmd: 'sleep 100;'
+        }));
+        this.configuration = RequestUtil.json.calls.mostRecent().args[0];
       });
 
-      this.configuration.success({
-        'version': '2016-05-13T10:26:55.840Z',
-        'deploymentId': '6119207e-a146-44b4-9c6f-0e4227dc04a5'
+      it('calls #json from the RequestUtil', function () {
+        expect(RequestUtil.json).toHaveBeenCalled();
       });
+
+      it('sends data to the correct URL', function () {
+        expect(this.configuration.url)
+            .toEqual(`${Config.rootUrl}/service/marathon/v2/apps`);
+      });
+
+      it('sends data to the correct URL', function () {
+        expect(this.configuration.url)
+            .toEqual(`${Config.rootUrl}/service/marathon/v2/apps`);
+      });
+
+      it('uses POST for the request method', function () {
+        expect(this.configuration.method).toEqual('POST');
+      });
+
+      it('dispatches the correct action when successful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.type)
+              .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_CREATE_SUCCESS);
+        });
+
+        this.configuration.success({
+          'version': '2016-05-13T10:26:55.840Z',
+          'deploymentId': '6119207e-a146-44b4-9c6f-0e4227dc04a5'
+        });
+      });
+
+      it('dispatches the correct action when unsucessful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.type)
+              .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_CREATE_ERROR);
+        });
+
+        this.configuration.error({message: 'error', response: '{}'});
+      });
+
     });
 
-    it('dispatches the correct action when unsucessful', function () {
-      var id = AppDispatcher.register(function (payload) {
-        var action = payload.action;
-        AppDispatcher.unregister(id);
-        expect(action.type)
-          .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_CREATE_ERROR);
+    describe('pod', function () {
+
+      beforeEach(function () {
+        spyOn(RequestUtil, 'json');
+        MarathonActions.createService(new PodSpec({
+          id: '/test',
+          cmd: 'sleep 100;'
+        }));
+        this.configuration = RequestUtil.json.calls.mostRecent().args[0];
       });
 
-      this.configuration.error({message: 'error', response: '{}'});
+      it('calls #json from the RequestUtil', function () {
+        expect(RequestUtil.json).toHaveBeenCalled();
+      });
+
+      it('sends data to the correct URL', function () {
+        expect(this.configuration.url)
+            .toEqual(`${Config.rootUrl}/service/marathon/v2/pods`);
+      });
+
+      it('sends data to the correct URL', function () {
+        expect(this.configuration.url)
+            .toEqual(`${Config.rootUrl}/service/marathon/v2/pods`);
+      });
+
+      it('uses POST for the request method', function () {
+        expect(this.configuration.method).toEqual('POST');
+      });
+
+      it('dispatches the correct action when successful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.type)
+              .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_CREATE_SUCCESS);
+        });
+
+        this.configuration.success({
+          'version': '2016-05-13T10:26:55.840Z',
+          'deploymentId': '6119207e-a146-44b4-9c6f-0e4227dc04a5'
+        });
+      });
+
+      it('dispatches the correct action when unsucessful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.type)
+              .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_CREATE_ERROR);
+        });
+
+        this.configuration.error({message: 'error', response: '{}'});
+      });
+
     });
 
   });

--- a/src/js/events/__tests__/MarathonActions-test.js
+++ b/src/js/events/__tests__/MarathonActions-test.js
@@ -396,62 +396,124 @@ describe('MarathonActions', function () {
   });
 
   describe('#editService', function () {
-    const appDefiniton = {
-      id: '/test',
-      cmd: 'sleep 100;'
-    };
 
-    beforeEach(function () {
-      spyOn(RequestUtil, 'json');
-      MarathonActions.editService(appDefiniton);
-      this.configuration = RequestUtil.json.calls.mostRecent().args[0];
-    });
+    describe('app', function () {
+      const app = new Application({id: '/test'});
+      const spec = new ApplicationSpec({cmd: 'sleep 100;'});
 
-    it('calls #json from the RequestUtil', function () {
-      expect(RequestUtil.json).toHaveBeenCalled();
-    });
-
-    it('sends data to the correct URL', function () {
-      expect(this.configuration.url)
-        .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//test`);
-    });
-
-    it('sends data to the correct URL with the force=true parameter',
-      function () {
-        MarathonActions.editService(appDefiniton, true);
+      beforeEach(function () {
+        spyOn(RequestUtil, 'json');
+        MarathonActions.editService(app, spec);
         this.configuration = RequestUtil.json.calls.mostRecent().args[0];
+      });
 
+      it('calls #json from the RequestUtil', function () {
+        expect(RequestUtil.json).toHaveBeenCalled();
+      });
+
+      it('sends data to the correct URL', function () {
         expect(this.configuration.url)
-          .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//test?force=true`);
+            .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//test`);
       });
 
-    it('uses PUT for the request method', function () {
-      expect(this.configuration.method).toEqual('PUT');
+      it('sends data to the' +
+          ' correct URL with the force=true parameter',
+          function () {
+            MarathonActions.editService(app, spec, true);
+            this.configuration = RequestUtil.json.calls.mostRecent().args[0];
+
+            expect(this.configuration.url)
+                .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//test?force=true`);
+          });
+
+      it('uses PUT for the request method', function () {
+        expect(this.configuration.method).toEqual('PUT');
+      });
+
+      it('dispatches the correct action when successful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.type)
+              .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_EDIT_SUCCESS);
+        });
+
+        this.configuration.success({
+          'version': '2016-05-13T10:26:55.840Z',
+          'deploymentId': '6119207e-a146-44b4-9c6f-0e4227dc04a5'
+        });
+      });
+
+      it('dispatches the correct action when unsucessful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.type)
+              .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_EDIT_ERROR);
+        });
+
+        this.configuration.error({message: 'error', response: '{}'});
+      });
+
     });
 
-    it('dispatches the correct action when successful', function () {
-      var id = AppDispatcher.register(function (payload) {
-        var action = payload.action;
-        AppDispatcher.unregister(id);
-        expect(action.type)
-          .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_EDIT_SUCCESS);
+    describe('pods', function () {
+      const pod = new Pod({id: '/test'});
+      const spec = new PodSpec({cmd: 'sleep 100;'});
+
+      beforeEach(function () {
+        spyOn(RequestUtil, 'json');
+        MarathonActions.editService(pod, spec);
+        this.configuration = RequestUtil.json.calls.mostRecent().args[0];
       });
 
-      this.configuration.success({
-        'version': '2016-05-13T10:26:55.840Z',
-        'deploymentId': '6119207e-a146-44b4-9c6f-0e4227dc04a5'
-      });
-    });
-
-    it('dispatches the correct action when unsucessful', function () {
-      var id = AppDispatcher.register(function (payload) {
-        var action = payload.action;
-        AppDispatcher.unregister(id);
-        expect(action.type)
-          .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_EDIT_ERROR);
+      it('calls #json from the RequestUtil', function () {
+        expect(RequestUtil.json).toHaveBeenCalled();
       });
 
-      this.configuration.error({message: 'error', response: '{}'});
+      it('sends data to the correct URL', function () {
+        expect(this.configuration.url)
+            .toEqual(`${Config.rootUrl}/service/marathon/v2/pods//test`);
+      });
+
+      it('sends data to the correct URL with the force=true parameter',
+          function () {
+            MarathonActions.editService(pod, spec, true);
+            this.configuration = RequestUtil.json.calls.mostRecent().args[0];
+
+            expect(this.configuration.url)
+                .toEqual(`${Config.rootUrl}/service/marathon/v2/pods//test?force=true`);
+          });
+
+      it('uses PUT for the request method', function () {
+        expect(this.configuration.method).toEqual('PUT');
+      });
+
+      it('dispatches the correct action when successful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.type)
+              .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_EDIT_SUCCESS);
+        });
+
+        this.configuration.success({
+          'version': '2016-05-13T10:26:55.840Z',
+          'deploymentId': '6119207e-a146-44b4-9c6f-0e4227dc04a5'
+        });
+      });
+
+      it('dispatches the correct action when unsucessful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.type)
+              .toEqual(ActionTypes.REQUEST_MARATHON_SERVICE_EDIT_ERROR);
+        });
+
+        this.configuration.error({message: 'error', response: '{}'});
+      });
+
     });
 
   });


### PR DESCRIPTION
Adjust the service actions to support pods. I added mocked versions to enable proper testing.

_Please excuse the rather large number of changes. I figured it might be easier to land this with only one PR instead of a number smaller ones as I'm on vacation and wouldn't be able to do the rebase dance._