### PR TITLE
Updating innerPath as soon as we start polling for a new directory

### DIFF
--- a/src/js/pages/task-details/TaskDetail.js
+++ b/src/js/pages/task-details/TaskDetail.js
@@ -110,23 +110,22 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
       return;
     }
 
-    this.setState({
-      directory: TaskDirectoryStore.get('directory'),
-      taskDirectoryErrorCount: 0
-    });
+    let directory = TaskDirectoryStore.get('directory');
+    this.setState({directory, taskDirectoryErrorCount: 0});
   }
 
   handleFetchDirectory() {
     let {params} = this.props;
     let task = MesosStateStore.getTaskFromTaskID(params.taskID);
-    // Declare undefined to not override default values in getDirectory
+    // Declare undefined to not override default values in fetchDirectory
     let innerPath;
 
     if (params.innerPath != null) {
       innerPath = decodeURIComponent(params.innerPath);
     }
 
-    TaskDirectoryStore.getDirectory(task, innerPath);
+    TaskDirectoryStore.fetchDirectory(task, innerPath);
+    this.setState({directory: null});
   }
 
   getErrorScreen() {

--- a/src/js/pages/task-details/__tests__/TaskDetail-test.js
+++ b/src/js/pages/task-details/__tests__/TaskDetail-test.js
@@ -43,7 +43,7 @@ describe('TaskDetail', function () {
     this.instance.setState = jasmine.createSpy('setState');
     this.instance.getErrorScreen = jasmine.createSpy('getErrorScreen');
     // Store original versions
-    this.storeGetDirectory = TaskDirectoryStore.getDirectory;
+    this.storeGetDirectory = TaskDirectoryStore.fetchDirectory;
     this.storeGet = MesosStateStore.get;
     this.storeChangeListener = MesosStateStore.addChangeListener;
     // Create mock functions
@@ -60,14 +60,14 @@ describe('TaskDetail', function () {
       });
     };
 
-    TaskDirectoryStore.getDirectory = jasmine.createSpy('getDirectory');
+    TaskDirectoryStore.fetchDirectory = jasmine.createSpy('getDirectory');
   });
 
   afterEach(function () {
     // Restore original functions
     MesosStateStore.get = this.storeGet;
     MesosStateStore.addChangeListener = this.storeChangeListener;
-    TaskDirectoryStore.getDirectory = this.storeGetDirectory;
+    TaskDirectoryStore.fetchDirectory = this.storeGetDirectory;
 
     ReactDOM.unmountComponentAtNode(this.container);
   });
@@ -76,7 +76,7 @@ describe('TaskDetail', function () {
 
     it('should call getDirectory after onStateStoreSuccess is called', function () {
       this.instance.onStateStoreSuccess();
-      expect(TaskDirectoryStore.getDirectory).toHaveBeenCalled();
+      expect(TaskDirectoryStore.fetchDirectory).toHaveBeenCalled();
     });
 
   });

--- a/src/js/stores/TaskDirectoryStore.js
+++ b/src/js/stores/TaskDirectoryStore.js
@@ -113,7 +113,7 @@ class TaskDirectoryStore extends GetSetBaseStore {
     this.set({directory: null});
     // Make sure to update innerPath if different before fetching
     if (this.get('innerPath') !== innerPath) {
-      this.set({innerPath: innerPath});
+      this.set({innerPath});
     }
 
     this.emit(TASK_DIRECTORY_CHANGE, task.id);

--- a/src/js/stores/TaskDirectoryStore.js
+++ b/src/js/stores/TaskDirectoryStore.js
@@ -18,24 +18,24 @@ import TaskDirectoryActions from '../events/TaskDirectoryActions';
 var requestInterval = null;
 var activeXHR = null;
 
-function fetchState(task, deeperPath) {
+function fetchState(task, innerPath) {
   let node = MesosStateStore.getNodeFromID(task.slave_id);
   activeXHR = TaskDirectoryActions.fetchNodeState(
     task,
     node,
     function (response) {
       activeXHR = TaskDirectoryActions
-        .fetchDirectory(task, deeperPath, response);
+        .fetchDirectory(task, innerPath, response);
     }
   );
 }
 
-function startPolling(task, deeperPath) {
+function startPolling(task, innerPath) {
   if (requestInterval == null) {
-    fetchState(task, deeperPath);
+    fetchState(task, innerPath);
 
     requestInterval = setInterval(
-      fetchState.bind(this, task, deeperPath), Config.getRefreshRate()
+      fetchState.bind(this, task, innerPath), Config.getRefreshRate()
     );
   }
 }
@@ -107,23 +107,27 @@ class TaskDirectoryStore extends GetSetBaseStore {
     }
   }
 
-  // Default deeperPath to empty string so it matches with default innerPath
-  getDirectory(task, deeperPath = '') {
+  // Default innerPath to empty string so it matches with default innerPath
+  fetchDirectory(task, innerPath = '') {
     this.resetRequests();
     this.set({directory: null});
-    this.emit(TASK_DIRECTORY_CHANGE, task.id);
+    // Make sure to update innerPath if different before fetching
+    if (this.get('innerPath') !== innerPath) {
+      this.set({innerPath: innerPath});
+    }
 
-    startPolling(task, deeperPath);
+    this.emit(TASK_DIRECTORY_CHANGE, task.id);
+    startPolling(task, innerPath);
   }
 
   addPath(task, path) {
     this.set({innerPath: this.get('innerPath') + '/' + path});
-    this.getDirectory(task, this.get('innerPath'));
+    this.fetchDirectory(task, this.get('innerPath'));
   }
 
   setPath(task, path) {
     this.set({innerPath: path});
-    this.getDirectory(task, path);
+    this.fetchDirectory(task, path);
   }
 
   processStateError(taskID) {


### PR DESCRIPTION
This PR fixes a problem where the log for a file in a nested folder would never load.
This was due to the path not being updated when requesting a directory in a different path. This would in turn not emit events as the path stored vs. returned would be different