### PR TITLE
[Pods] Adding pod actions to pod-specific views

### DIFF
--- a/src/js/components/PodDetail.js
+++ b/src/js/components/PodDetail.js
@@ -4,10 +4,12 @@ import React from 'react';
 import Breadcrumbs from './Breadcrumbs';
 import Pod from '../structs/Pod';
 import PodInstancesView from './PodInstancesView';
+import PodActionItem from '../constants/PodActionItem';
 import PodHeader from './PodHeader';
 import TabsMixin from '../mixins/TabsMixin';
 
 const METHODS_TO_BIND = [
+  'handleAction'
 ];
 
 class PodDetail extends mixin(TabsMixin) {
@@ -27,6 +29,22 @@ class PodDetail extends mixin(TabsMixin) {
     METHODS_TO_BIND.forEach((method) => {
       this[method] = this[method].bind(this);
     });
+  }
+
+  handleAction(action) {
+    switch (action.id) {
+      case PodActionItem.SCALE:
+        console.debug('Scale');
+        break;
+
+      case PodActionItem.EDIT:
+        console.debug('Edit');
+        break;
+
+      case PodActionItem.DESTROY:
+        console.debug('Destroy');
+        break;
+    }
   }
 
   renderConfigurationTabView() {
@@ -62,7 +80,7 @@ class PodDetail extends mixin(TabsMixin) {
         <div className="container-pod container-pod-divider-bottom-align-right container-pod-short-top flush-bottom flush-top media-object-spacing-wrapper media-object-spacing-narrow">
           <Breadcrumbs />
           <PodHeader
-            onDeploy={this.onActionDeploy}
+            onAction={this.handleAction}
             pod={pod}
             tabs={this.tabs_getUnroutedTabs()} />
           {this.tabs_getTabView()}

--- a/src/js/components/PodDetail.js
+++ b/src/js/components/PodDetail.js
@@ -2,6 +2,10 @@ import mixin from 'reactjs-mixin';
 import React from 'react';
 
 import Breadcrumbs from './Breadcrumbs';
+import ServiceDestroyModal from './modals/ServiceDestroyModal';
+import ServiceFormModal from './modals/ServiceFormModal';
+import ServiceScaleFormModal from './modals/ServiceScaleFormModal';
+import ServiceSuspendModal from './modals/ServiceSuspendModal';
 import Pod from '../structs/Pod';
 import PodInstancesView from './PodInstancesView';
 import PodActionItem from '../constants/PodActionItem';
@@ -9,7 +13,8 @@ import PodHeader from './PodHeader';
 import TabsMixin from '../mixins/TabsMixin';
 
 const METHODS_TO_BIND = [
-  'handleAction'
+  'handleAction',
+  'handleCloseDialog'
 ];
 
 class PodDetail extends mixin(TabsMixin) {
@@ -23,7 +28,8 @@ class PodDetail extends mixin(TabsMixin) {
     };
 
     this.state = {
-      currentTab: Object.keys(this.tabs_tabs).shift()
+      currentTab: Object.keys(this.tabs_tabs).shift(),
+      activeActionDialog: null
     };
 
     METHODS_TO_BIND.forEach((method) => {
@@ -33,18 +39,28 @@ class PodDetail extends mixin(TabsMixin) {
 
   handleAction(action) {
     switch (action.id) {
-      case PodActionItem.SCALE:
-        console.debug('Scale');
-        break;
-
-      case PodActionItem.EDIT:
-        console.debug('Edit');
-        break;
-
       case PodActionItem.DESTROY:
-        console.debug('Destroy');
+      case PodActionItem.EDIT:
+      case PodActionItem.SCALE:
+      case PodActionItem.SUSPEND:
+
+        this.setState({
+          activeActionDialog: action.id
+        });
         break;
+
+      default:
+        if (process.env.NODE_ENV !== 'production') {
+          throw new TypeError('Trying to handle an unknown action:', action.id);
+        }
+
     }
+  }
+
+  handleCloseDialog() {
+    this.setState({
+      activeActionDialog: null
+    });
   }
 
   renderConfigurationTabView() {
@@ -74,6 +90,7 @@ class PodDetail extends mixin(TabsMixin) {
 
   render() {
     const {pod} = this.props;
+    const {activeActionDialog} = this.state;
 
     return (
       <div className="flex-container-col">
@@ -85,6 +102,24 @@ class PodDetail extends mixin(TabsMixin) {
             tabs={this.tabs_getUnroutedTabs()} />
           {this.tabs_getTabView()}
         </div>
+
+        <ServiceScaleFormModal
+          onClose={this.handleCloseDialog}
+          open={activeActionDialog === PodActionItem.SCALE}
+          service={pod} />
+        <ServiceDestroyModal
+          onClose={this.handleCloseDialog}
+          open={activeActionDialog === PodActionItem.DESTROY}
+          service={pod} />
+        <ServiceSuspendModal
+          onClose={this.handleCloseDialog}
+          open={activeActionDialog === PodActionItem.SUSPEND}
+          service={pod} />
+        <ServiceFormModal
+          onClose={this.handleCloseDialog}
+          open={activeActionDialog === PodActionItem.EDIT}
+          service={pod} />
+
       </div>
 
     );

--- a/src/js/components/PodHeader.js
+++ b/src/js/components/PodHeader.js
@@ -1,3 +1,4 @@
+import classNames from 'classnames/dedupe';
 import {Dropdown} from 'reactjs-components';
 import React from 'react';
 
@@ -14,6 +15,8 @@ class PodInfo extends React.Component {
   }
 
   getActionButtons() {
+    var {pod} = this.props;
+
     const dropdownItems = [
       // This item is used as a label to the dropdown
       {
@@ -21,6 +24,13 @@ class PodInfo extends React.Component {
         id: '__MORE__',
         html: '',
         selectedHtml: 'More'
+      },
+      {
+        className: classNames({
+          hidden: pod.getInstancesCount() === 0
+        }),
+        id: PodActionItem.SUSPEND,
+        html: 'Suspend'
       },
       {
         id: PodActionItem.DESTROY,

--- a/src/js/components/PodHeader.js
+++ b/src/js/components/PodHeader.js
@@ -1,9 +1,11 @@
+import {Dropdown} from 'reactjs-components';
 import React from 'react';
 
 import HealthBar from './HealthBar';
 import PageHeader from './PageHeader';
 import Pod from '../structs/Pod';
 import StatusMapping from '../constants/StatusMapping';
+import PodActionItem from '../constants/PodActionItem';
 import StringUtil from '../utils/StringUtil';
 
 class PodInfo extends React.Component {
@@ -12,11 +14,46 @@ class PodInfo extends React.Component {
   }
 
   getActionButtons() {
+    const dropdownItems = [
+      // This item is used as a label to the dropdown
+      {
+        className: 'hidden',
+        id: '__MORE__',
+        html: '',
+        selectedHtml: 'More'
+      },
+      {
+        id: PodActionItem.DESTROY,
+        html: <span className="text-danger">Destroy</span>
+      }
+    ];
+
     let actionButtons = [
+      <button className="button flush-bottom  button-primary"
+        key="action-button-scale"
+        onClick={() =>
+          this.props.onAction({id: PodActionItem.SCALE})}>
+        Scale
+      </button>,
       <button className="button flush-bottom button-stroke button-inverse"
-        key="action-button-edit">
-        Placeholder
-      </button>
+        key="action-button-edit"
+        onClick={() =>
+          this.props.onAction({id: PodActionItem.EDIT})}>
+        Edit
+      </button>,
+      <Dropdown
+        key="actions-dropdown"
+        anchorRight={true}
+        buttonClassName="button button-stroke button-inverse dropdown-toggle"
+        dropdownMenuClassName="dropdown-menu"
+        dropdownMenuListClassName="dropdown-menu-list"
+        dropdownMenuListItemClassName="clickable"
+        wrapperClassName="dropdown flush-bottom"
+        items={dropdownItems}
+        persistentID="__MORE__"
+        onItemSelection={this.props.onAction}
+        transition={true}
+        transitionName="dropdown-menu" />
     ];
 
     return actionButtons;
@@ -93,7 +130,14 @@ class PodInfo extends React.Component {
   }
 }
 
+PodInfo.defaultProps = {
+  onAction() { },
+  pod: null,
+  tabs: []
+};
+
 PodInfo.propTypes = {
+  onAction: React.PropTypes.func,
   pod: React.PropTypes.instanceOf(Pod).isRequired,
   tabs: React.PropTypes.array
 };

--- a/src/js/components/modals/ServiceDestroyModal.js
+++ b/src/js/components/modals/ServiceDestroyModal.js
@@ -4,6 +4,7 @@ import React from 'react';
 /* eslint-enable no-unused-vars */
 
 import MarathonStore from '../../stores/MarathonStore';
+import Pod from '../../structs/Pod';
 import ServiceTree from '../../structs/ServiceTree';
 import ServiceActionModal from './ServiceActionModal';
 
@@ -48,6 +49,10 @@ class ServiceDestroyModal extends ServiceActionModal {
     const {open, service} = this.props;
     let itemText = 'Service';
     let serviceName = '';
+
+    if (service instanceof Pod) {
+      itemText = 'Pod';
+    }
 
     if (service instanceof ServiceTree) {
       itemText = 'Group';

--- a/src/js/components/modals/ServiceScaleFormModal.js
+++ b/src/js/components/modals/ServiceScaleFormModal.js
@@ -6,6 +6,7 @@ import {StoreMixin} from 'mesosphere-shared-reactjs';
 
 import FormModal from '../FormModal';
 import MarathonStore from '../../stores/MarathonStore';
+import Pod from '../../structs/Pod';
 import ServiceTree from '../../structs/ServiceTree';
 
 const METHODS_TO_BIND = [
@@ -159,6 +160,10 @@ class ServiceScaleFormModal extends mixin(StoreMixin) {
   getHeader() {
     let headerText = 'Service';
 
+    if (this.props.service instanceof Pod) {
+      headerText = 'Pod';
+    }
+
     if (this.props.service instanceof ServiceTree) {
       headerText = 'Group';
     }
@@ -188,14 +193,13 @@ class ServiceScaleFormModal extends mixin(StoreMixin) {
 
     return (
       <FormModal
-        ref="form"
         buttonDefinition={buttonDefinition}
+        definition={this.getScaleFormDefinition()}
         disabled={state.disableForm}
         onClose={props.onClose}
         onSubmit={this.handleScaleSubmit}
         onChange={this.resetState}
-        open={props.open}
-        definition={this.getScaleFormDefinition()}>
+        open={props.open} >
         {this.getHeader()}
         {this.getBodyText()}
         {this.getErrorMessage()}

--- a/src/js/components/modals/ServiceSuspendModal.js
+++ b/src/js/components/modals/ServiceSuspendModal.js
@@ -4,6 +4,7 @@ import React from 'react';
 /* eslint-enable no-unused-vars */
 
 import MarathonStore from '../../stores/MarathonStore';
+import Pod from '../../structs/Pod';
 import ServiceTree from '../../structs/ServiceTree';
 import ServiceActionModal from './ServiceActionModal';
 
@@ -50,6 +51,10 @@ class ServiceSuspendModal extends ServiceActionModal {
     const {open, service} = this.props;
     let itemText = 'Service';
     let serviceName = '';
+
+    if (service instanceof Pod) {
+      itemText = 'Pod';
+    }
 
     if (service instanceof ServiceTree) {
       itemText = 'Group';

--- a/src/js/constants/PodActionItem.js
+++ b/src/js/constants/PodActionItem.js
@@ -1,0 +1,7 @@
+const PodActionItem = {
+  EDIT: 'edit',
+  DESTROY: 'destroy',
+  SCALE: 'scale'
+};
+
+module.exports = PodActionItem;

--- a/src/js/constants/PodActionItem.js
+++ b/src/js/constants/PodActionItem.js
@@ -2,7 +2,7 @@ const PodActionItem = {
   EDIT: 'edit',
   DESTROY: 'destroy',
   SCALE: 'scale',
-  SUSPED: 'suspend'
+  SUSPEND: 'suspend'
 };
 
 module.exports = PodActionItem;

--- a/src/js/constants/PodActionItem.js
+++ b/src/js/constants/PodActionItem.js
@@ -1,7 +1,8 @@
 const PodActionItem = {
   EDIT: 'edit',
   DESTROY: 'destroy',
-  SCALE: 'scale'
+  SCALE: 'scale',
+  SUSPED: 'suspend'
 };
 
 module.exports = PodActionItem;


### PR DESCRIPTION
---
~~⚠️  Depends on #1071~~
~~⚠️  Depends on #1070~~

---

This PR introduces the action buttons and links them to the appropriate pod-specific store actions.

_WIP: Using this PR as a base in order to integrate the `ServiceFormModal` in a separate PR_