### PR TITLE
[Pods] Fleshing out PodDebugTabView

### DIFF
--- a/src/js/components/PodContainerTerminationTable.js
+++ b/src/js/components/PodContainerTerminationTable.js
@@ -1,0 +1,136 @@
+import classNames from 'classnames';
+import React from 'react';
+import {Table} from 'reactjs-components';
+
+import ResourceTableUtil from '../utils/ResourceTableUtil';
+import TableUtil from '../utils/TableUtil';
+
+const METHODS_TO_BIND = [
+  'getColumnHeading',
+  'renderColumnID',
+  'renderColumnState',
+  'renderColumnTerminationCode',
+  'renderColumnTerminationMessage'
+];
+
+class PodContainerTerminationTable extends React.Component {
+  constructor() {
+    super(...arguments);
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  getColumns() {
+    let {getClassName} = ResourceTableUtil;
+
+    return [
+      {
+        className: getClassName,
+        headerClassName: getClassName,
+        prop: 'ID',
+        heading: this.getColumnHeading,
+        render: this.renderColumnID
+      },
+      {
+        className: getClassName,
+        headerClassName: getClassName,
+        prop: 'Last State',
+        heading: this.getColumnHeading,
+        render: this.renderColumnState
+      },
+      {
+        className: getClassName,
+        headerClassName: getClassName,
+        prop: 'Code',
+        heading: this.getColumnHeading,
+        render: this.renderColumnTerminationCode
+      },
+      {
+        className: getClassName,
+        headerClassName: getClassName,
+        prop: 'Message',
+        heading: this.getColumnHeading,
+        render: this.renderColumnTerminationMessage
+      }
+    ];
+  }
+
+  getColGroup() {
+    return (
+      <colgroup>
+        <col />
+        <col style={{width: '160px'}} />
+        <col style={{width: '80px'}} />
+        <col style={{width: '160px'}} />
+      </colgroup>
+    );
+  }
+
+  getColumnHeading(prop, order, sortBy) {
+    let caretClassNames = classNames(
+      'caret',
+      {
+        [`caret--${order}`]: order != null,
+        'caret--visible': prop === sortBy.prop
+      }
+    );
+
+    return (
+      <span>
+        {prop}
+        <span className={caretClassNames}></span>
+      </span>
+    );
+  }
+
+  renderColumnID(prop, row) {
+    return (
+      <span>{row.getId()}</span>
+    );
+  }
+
+  renderColumnState(prop, row) {
+    return (
+      <span>{row.getLastKnownState()}</span>
+    );
+  }
+
+  renderColumnTerminationCode(prop, row) {
+    return (
+      <span>{row.getTermination().exitCode || 0}</span>
+    );
+  }
+
+  renderColumnTerminationMessage(prop, row) {
+    return (
+      <span>{row.getTermination().message || '-'}</span>
+    );
+  }
+
+  render() {
+    return (
+        <Table
+          className={this.props.className}
+          columns={this.getColumns()}
+          colGroup={this.getColGroup()}
+          data={this.props.containers}
+          itemHeight={TableUtil.getRowHeight()}
+          sortBy={{prop: 'ID', order: 'desc'}}
+          />
+      );
+  };
+};
+
+PodContainerTerminationTable.defaultProps = {
+  className: 'inverse table table-borderless-outer table-borderless-inner-columns flush-bottom',
+  containers: []
+};
+
+PodContainerTerminationTable.propTypes = {
+  className: React.PropTypes.string,
+  containers: React.PropTypes.array.isRequired
+};
+
+module.exports = PodContainerTerminationTable;

--- a/src/js/components/PodContainerTerminationTable.js
+++ b/src/js/components/PodContainerTerminationTable.js
@@ -29,7 +29,7 @@ class PodContainerTerminationTable extends React.Component {
       {
         className: getClassName,
         headerClassName: getClassName,
-        prop: 'ID',
+        prop: 'Container ID',
         heading: this.getColumnHeading,
         render: this.renderColumnID
       },

--- a/src/js/components/PodContainerTerminationTable.js
+++ b/src/js/components/PodContainerTerminationTable.js
@@ -111,15 +111,14 @@ class PodContainerTerminationTable extends React.Component {
 
   render() {
     return (
-        <Table
-          className={this.props.className}
-          columns={this.getColumns()}
-          colGroup={this.getColGroup()}
-          data={this.props.containers}
-          itemHeight={TableUtil.getRowHeight()}
-          sortBy={{prop: 'ID', order: 'desc'}}
-          />
-      );
+      <Table
+        className={this.props.className}
+        columns={this.getColumns()}
+        colGroup={this.getColGroup()}
+        data={this.props.containers}
+        itemHeight={TableUtil.getRowHeight()}
+        sortBy={{prop: 'ID', order: 'desc'}} />
+    );
   };
 };
 

--- a/src/js/components/PodDebugTabView.js
+++ b/src/js/components/PodDebugTabView.js
@@ -24,18 +24,19 @@ class PodDebugTabView extends React.Component {
           <span>
             {startedAt.toString()} (<TimeAgo time={startedAt} />)
           </span>
-        ),
-        'Containers': (
-          <PodContainerTerminationTable containers={item.getContainers()} />
         )
       };
 
       return (
         <div key={index}>
-          <h6>
+          <h5 className="inverse flush-top">
             Terminated at {terminatedAt.toString()} (<TimeAgo time={terminatedAt} />)
-          </h6>
+          </h5>
           <DescriptionList hash={terminationValueMapping} />
+          <h5 className="inverse flush-top">
+            Containers
+          </h5>
+          <PodContainerTerminationTable containers={item.getContainers()} />
         </div>
       );
     });
@@ -59,13 +60,13 @@ class PodDebugTabView extends React.Component {
   render() {
     return (
       <div>
-        <h5 className="inverse flush-top">
+        <h4 className="inverse flush-top">
           Last Changes
-        </h5>
+        </h4>
         {this.getLastVersionChange()}
-        <h5 className="inverse flush-top">
+        <h4 className="inverse flush-top">
           Last Terminations
-        </h5>
+        </h4>
         {this.getTerminationHistory()}
       </div>
     );

--- a/src/js/components/PodDebugTabView.js
+++ b/src/js/components/PodDebugTabView.js
@@ -10,11 +10,17 @@ class PodDebugTabView extends React.Component {
     let history = this.props.pod.getTerminationHistoryList().getItems();
     if (!history.length) {
       return (
-        <div>(No data)</div>
+        <div>
+          <h4 className="inverse flush-top">
+            Last Terminations
+          </h4>
+          <p>(No data)</p>
+        </div>
       );
     }
 
     return history.map(function (item, index) {
+      let headline;
       let startedAt = item.getStartedAt();
       let terminatedAt = item.getTerminatedAt();
       let terminationValueMapping = {
@@ -27,11 +33,23 @@ class PodDebugTabView extends React.Component {
         )
       };
 
+      if (index === 0) {
+        headline = (
+          <h4 className="inverse flush-top">
+            Last Termination (<TimeAgo time={terminatedAt} />)
+          </h4>
+          );
+      } else {
+        headline = (
+          <h4 className="inverse flush-top">
+            Terminated at {terminatedAt.toString()} (<TimeAgo time={terminatedAt} />)
+          </h4>
+          );
+      }
+
       return (
         <div key={index}>
-          <h5 className="inverse flush-top">
-            Terminated at {terminatedAt.toString()} (<TimeAgo time={terminatedAt} />)
-          </h5>
+          {headline}
           <DescriptionList hash={terminationValueMapping} />
           <h5 className="inverse flush-top">
             Containers
@@ -64,9 +82,6 @@ class PodDebugTabView extends React.Component {
           Last Changes
         </h4>
         {this.getLastVersionChange()}
-        <h4 className="inverse flush-top">
-          Last Terminations
-        </h4>
         {this.getTerminationHistory()}
       </div>
     );

--- a/src/js/components/PodDebugTabView.js
+++ b/src/js/components/PodDebugTabView.js
@@ -10,8 +10,8 @@ class PodDebugTabView extends React.Component {
     let history = this.props.pod.getTerminationHistoryList().getItems();
     if (!history.length) {
       return (
-          <div>(No data)</div>
-        );
+        <div>(No data)</div>
+      );
     }
 
     return history.map(function (item, index) {

--- a/src/js/components/PodDebugTabView.js
+++ b/src/js/components/PodDebugTabView.js
@@ -1,0 +1,83 @@
+import React from 'react';
+
+import DescriptionList from './DescriptionList';
+import Pod from '../structs/Pod';
+import PodContainerTerminationTable from './PodContainerTerminationTable';
+import TimeAgo from './TimeAgo';
+
+class PodDebugTabView extends React.Component {
+  getTerminationHistory() {
+    let history = this.props.pod.getTerminationHistoryList().getItems();
+    if (!history.length) {
+      return (
+          <div>(No data)</div>
+        );
+    }
+
+    return history.map(function (item, index) {
+      let startedAt = item.getStartedAt();
+      let terminatedAt = item.getTerminatedAt();
+      let terminationValueMapping = {
+        'Instance ID': item.getId(),
+        'Message': item.getMessage(),
+        'Started At': (
+          <span>
+            {startedAt.toString()} (<TimeAgo time={startedAt} />)
+          </span>
+        ),
+        'Containers': (
+          <PodContainerTerminationTable containers={item.getContainers()} />
+        )
+      };
+
+      return (
+        <div key={index}>
+          <h6>
+            Terminated at {terminatedAt.toString()} (<TimeAgo time={terminatedAt} />)
+          </h6>
+          <DescriptionList hash={terminationValueMapping} />
+        </div>
+      );
+    });
+  }
+
+  getLastVersionChange() {
+    let {pod} = this.props;
+    let lastChanged = pod.getLastChanged();
+
+    let LastVersionChangeValueMapping = {
+      'Configuration': (
+        <span>
+          {lastChanged.toString()} (<TimeAgo time={lastChanged} />)
+        </span>
+      )
+    };
+
+    return <DescriptionList hash={LastVersionChangeValueMapping} />;
+  }
+
+  render() {
+    return (
+      <div>
+        <h5 className="inverse flush-top">
+          Last Changes
+        </h5>
+        {this.getLastVersionChange()}
+        <h5 className="inverse flush-top">
+          Last Terminations
+        </h5>
+        {this.getTerminationHistory()}
+      </div>
+    );
+  }
+}
+
+PodDebugTabView.contextTypes = {
+  router: React.PropTypes.func
+};
+
+PodDebugTabView.propTypes = {
+  pod: React.PropTypes.instanceOf(Pod)
+};
+
+module.exports = PodDebugTabView;

--- a/src/js/components/PodDebugTabView.js
+++ b/src/js/components/PodDebugTabView.js
@@ -38,13 +38,13 @@ class PodDebugTabView extends React.Component {
           <h4 className="inverse flush-top">
             Last Termination (<TimeAgo time={terminatedAt} />)
           </h4>
-          );
+        );
       } else {
         headline = (
           <h4 className="inverse flush-top">
             Terminated at {terminatedAt.toString()} (<TimeAgo time={terminatedAt} />)
           </h4>
-          );
+        );
       }
 
       return (

--- a/src/js/components/PodDetail.js
+++ b/src/js/components/PodDetail.js
@@ -69,16 +69,15 @@ class PodDetail extends mixin(TabsMixin) {
 
     return (
       <pre>
-      &lt;PodConfigurationView pod={pod.getId()} /&gt;
+        &lt;PodConfigurationView pod={pod.getId()} /&gt;
       </pre>
     );
   }
 
   renderDebugTabView() {
     let {pod} = this.props;
-    return (
-      <PodDebugTabView pod={pod} />
-    );
+
+    return <PodDebugTabView pod={pod} />
   }
 
   renderInstancesTabView() {
@@ -120,7 +119,6 @@ class PodDetail extends mixin(TabsMixin) {
           service={pod} />
 
       </div>
-
     );
   }
 }

--- a/src/js/components/PodDetail.js
+++ b/src/js/components/PodDetail.js
@@ -7,9 +7,10 @@ import ServiceFormModal from './modals/ServiceFormModal';
 import ServiceScaleFormModal from './modals/ServiceScaleFormModal';
 import ServiceSuspendModal from './modals/ServiceSuspendModal';
 import Pod from '../structs/Pod';
-import PodInstancesView from './PodInstancesView';
 import PodActionItem from '../constants/PodActionItem';
+import PodDebugTabView from './PodDebugTabView';
 import PodHeader from './PodHeader';
+import PodInstancesView from './PodInstancesView';
 import TabsMixin from '../mixins/TabsMixin';
 
 const METHODS_TO_BIND = [
@@ -65,6 +66,7 @@ class PodDetail extends mixin(TabsMixin) {
 
   renderConfigurationTabView() {
     let {pod} = this.props;
+
     return (
       <pre>
       &lt;PodConfigurationView pod={pod.getId()} /&gt;
@@ -75,17 +77,14 @@ class PodDetail extends mixin(TabsMixin) {
   renderDebugTabView() {
     let {pod} = this.props;
     return (
-      <pre>
-      &lt;PodDebugTabView pod={pod.getId()} /&gt;
-      </pre>
+      <PodDebugTabView pod={pod} />
     );
   }
 
   renderInstancesTabView() {
     let {pod} = this.props;
-    return (
-        <PodInstancesView pod={pod} />
-      );
+
+    return <PodInstancesView pod={pod} />
   }
 
   render() {

--- a/src/js/components/PodDetail.js
+++ b/src/js/components/PodDetail.js
@@ -77,13 +77,13 @@ class PodDetail extends mixin(TabsMixin) {
   renderDebugTabView() {
     let {pod} = this.props;
 
-    return <PodDebugTabView pod={pod} />
+    return (<PodDebugTabView pod={pod} />);
   }
 
   renderInstancesTabView() {
     let {pod} = this.props;
 
-    return <PodInstancesView pod={pod} />
+    return (<PodInstancesView pod={pod} />);
   }
 
   render() {

--- a/src/js/structs/Pod.js
+++ b/src/js/structs/Pod.js
@@ -1,6 +1,7 @@
 import HealthStatus from '../constants/HealthStatus';
 import PodInstanceList from './PodInstanceList';
 import PodSpec from './PodSpec';
+import PodTerminationHistoryList from './PodTerminationHistoryList';
 import Service from './Service';
 import ServiceStatus from '../constants/ServiceStatus';
 import ServiceImages from '../constants/ServiceImages';
@@ -92,6 +93,14 @@ module.exports = class Pod extends Service {
     return this.getSpec().getLabels();
   }
 
+  getLastChanged() {
+    return new Date(this.get('lastChanged'));
+  }
+
+  getLastUpdated() {
+    return new Date(this.get('lastUpdated'));
+  }
+
   /**
    * @override
    */
@@ -169,4 +178,11 @@ module.exports = class Pod extends Service {
 
     return taskSummary;
   }
+
+  getTerminationHistoryList() {
+    return new PodTerminationHistoryList({
+      items: this.get('terminationHistory') || []
+    });
+  }
+
 };

--- a/src/js/structs/PodContainerTerminationHistory.js
+++ b/src/js/structs/PodContainerTerminationHistory.js
@@ -1,0 +1,18 @@
+import Item from './Item';
+
+module.exports = class PodContainerTerminationHistory extends Item {
+  getId() {
+    return this.get('containerId');
+  }
+
+  getLastKnownState() {
+    return this.get('lastKnownState') || 'unknown';
+  }
+
+  getTermination() {
+    return this.get('termination') || {
+      exitCode: 0,
+      message: ''
+    };
+  }
+};

--- a/src/js/structs/PodTerminationHistory.js
+++ b/src/js/structs/PodTerminationHistory.js
@@ -1,0 +1,27 @@
+import Item from './Item';
+import PodContainerTerminationHistory from './PodContainerTerminationHistory';
+
+module.exports = class PodTerminationHistory extends Item {
+  getContainers() {
+    let containers = this.get('containers') || [];
+    return containers.map(function (container) {
+      return new PodContainerTerminationHistory(container);
+    });
+  }
+
+  getId() {
+    return this.get('instanceID');
+  }
+
+  getMessage() {
+    return this.get('message') || 'Pod terminated';
+  }
+
+  getStartedAt() {
+    return new Date(this.get('startedAt'));
+  }
+
+  getTerminatedAt() {
+    return new Date(this.get('terminatedAt'));
+  }
+};

--- a/src/js/structs/PodTerminationHistoryList.js
+++ b/src/js/structs/PodTerminationHistoryList.js
@@ -1,0 +1,8 @@
+import List from './List';
+import PodTerminationHistory from './PodTerminationHistory';
+
+class PodTerminationHistoryList extends List {};
+
+PodTerminationHistoryList.type = PodTerminationHistory;
+
+module.exports = PodTerminationHistoryList;

--- a/tests/_fixtures/marathon-pods/groups.json
+++ b/tests/_fixtures/marathon-pods/groups.json
@@ -268,6 +268,23 @@
               }
             ]
           }
+        ],
+        "terminationHistory": [
+          {
+            "instanceID": "pod-34590238602947",
+            "startedAt": "2016-08-31T01:01:01.001",
+            "terminatedAt": "2016-08-31T01:01:01.001",
+            "containers": [
+                {
+                  "containerId": "podtask-3490824906824564563455",
+                  "lastKnownState": "RUNNING",
+                  "termination": {
+                    "exitCode": 2,
+                    "message": "I/O Error"
+                  }
+                }
+            ]
+          }
         ]
       }
   ],


### PR DESCRIPTION
---
~~⚠️ Requires #1071 to be merged~~ Merged!

---

This PR implements the DebugTab view. It shows the time of the last change, and it also extracts last termination information according to this spec: https://github.com/mesosphere/marathon/blob/feature/pods/docs/docs/rest-api/public/api/v2/types/podStatus.raml#L217

![image](https://cloud.githubusercontent.com/assets/883486/18479679/2f85c6a6-79d6-11e6-8277-db3b34a1b65b.png)
