### PR TITLE
[Pods] DCOS-9613: 1/2 Separating Application to ApplicationSpec

### DIFF
--- a/src/js/components/ServiceDetailConfigurationTab.js
+++ b/src/js/components/ServiceDetailConfigurationTab.js
@@ -5,6 +5,7 @@ import ConfigurationView from './ConfigurationView';
 import DCOSStore from '../stores/DCOSStore';
 import MarathonStore from '../stores/MarathonStore';
 import Service from '../structs/Service';
+import ApplicationSpec from '../structs/ApplicationSpec';
 import ServiceFormModal from './modals/ServiceFormModal';
 import ServiceUtil from '../utils/ServiceUtil';
 
@@ -56,8 +57,8 @@ class ServiceDetailConfigurationTab extends React.Component {
       this.props.service.getVersions().get(this.state.selectedVersionID);
 
     MarathonStore.editService(
-      ServiceUtil.getAppDefinitionFromService(
-        new Service(serviceConfiguration)
+      ServiceUtil.getDefinitionFromSpec(
+        new ApplicationSpec(serviceConfiguration)
       )
     );
   }

--- a/src/js/structs/Application.js
+++ b/src/js/structs/Application.js
@@ -1,5 +1,4 @@
 import ApplicationSpec from './ApplicationSpec';
-import {cleanServiceJSON} from '../utils/CleanJSONUtil';
 import Config from '../config/Config';
 import FrameworkUtil from '../utils/FrameworkUtil';
 import HealthStatus from '../constants/HealthStatus';
@@ -9,11 +8,6 @@ import TaskStats from './TaskStats';
 import VolumeList from './VolumeList';
 
 module.exports = class Application extends Service {
-
-  // getContainer() {
-  //   return this.get('container');
-  // }
-
   getDeployments() {
     return this.get('deployments');
   }
@@ -22,7 +16,7 @@ module.exports = class Application extends Service {
    * @override
    */
   getSpec() {
-    return new ApplicationSpec(cleanServiceJSON(this.get()));
+    return new ApplicationSpec(this.get());
   }
 
   /**

--- a/src/js/structs/Application.js
+++ b/src/js/structs/Application.js
@@ -1,3 +1,5 @@
+import ApplicationSpec from './ApplicationSpec';
+import {cleanServiceJSON} from '../utils/CleanJSONUtil';
 import Config from '../config/Config';
 import FrameworkUtil from '../utils/FrameworkUtil';
 import HealthStatus from '../constants/HealthStatus';
@@ -7,57 +9,28 @@ import TaskStats from './TaskStats';
 import VolumeList from './VolumeList';
 
 module.exports = class Application extends Service {
-  getAcceptedResourceRoles() {
-    return this.get('acceptedResourceRoles');
-  }
 
-  getArguments() {
-    return this.get('args');
-  }
-
-  getCommand() {
-    return this.get('cmd');
-  }
-
-  getContainerSettings() {
-    return this.get('container');
-  }
-
-  getCpus() {
-    return this.get('cpus');
-  }
-
-  getContainer() {
-    return this.get('container');
-  }
-
-  getConstraints() {
-    return this.get('constraints');
-  }
+  // getContainer() {
+  //   return this.get('container');
+  // }
 
   getDeployments() {
     return this.get('deployments');
   }
 
-  getDisk() {
-    return this.get('disk');
-  }
-
-  getEnvironmentVariables() {
-    return this.get('env');
-  }
-
-  getExecutor() {
-    return this.get('executor');
-  }
-
+  /**
+   * @override
+   */
   getSpec() {
-    // DCOS-9613: This should be properly implemented
-    return this;
+    return new ApplicationSpec(cleanServiceJSON(this.get()));
   }
 
+  /**
+   * @override
+   */
   getHealth() {
     let {tasksHealthy, tasksUnhealthy, tasksRunning} = this.getTasksSummary();
+    let healthChecks = this.getSpec().getHealthChecks();
 
     if (tasksUnhealthy > 0) {
       return HealthStatus.UNHEALTHY;
@@ -67,31 +40,32 @@ module.exports = class Application extends Service {
       return HealthStatus.HEALTHY;
     }
 
-    if (this.getHealthChecks() && tasksRunning === 0) {
+    if (healthChecks && tasksRunning === 0) {
       return HealthStatus.IDLE;
     }
 
     return HealthStatus.NA;
   }
 
-  getHealthChecks() {
-    return this.get('healthChecks');
-  }
-
+  /**
+   * @override
+   */
   getImages() {
     return FrameworkUtil.getServiceImages(this.getMetadata().images);
   }
 
+  /**
+   * @override
+   */
   getInstancesCount() {
     return this.get('instances');
   }
 
-  getIpAddress() {
-    return this.get('ipAddress');
-  }
-
+  /**
+   * @override
+   */
   getLabels() {
-    return this.get('labels');
+    return this.getSpec().getLabels();
   }
 
   getLastConfigChange() {
@@ -106,10 +80,6 @@ module.exports = class Application extends Service {
     return this.get('lastTaskFailure');
   }
 
-  getMem() {
-    return this.get('mem');
-  }
-
   getMetadata() {
     return FrameworkUtil.getMetadataFromLabels(this.getLabels());
   }
@@ -122,10 +92,9 @@ module.exports = class Application extends Service {
     return this.get('ports');
   }
 
-  getPortDefinitions() {
-    return this.get('portDefinitions');
-  }
-
+  /**
+   * @override
+   */
   getResources() {
     return {
       cpus: this.get('cpus'),
@@ -147,6 +116,9 @@ module.exports = class Application extends Service {
     return status.displayName;
   }
 
+  /**
+   * @override
+   */
   getServiceStatus() {
     let {tasksRunning} = this.getTasksSummary();
     let deployments = this.getDeployments();
@@ -178,6 +150,9 @@ module.exports = class Application extends Service {
     return ServiceStatus.NA;
   }
 
+  /**
+   * @override
+   */
   getTasksSummary() {
     let healthData = {
       tasksHealthy: this.get('tasksHealthy'),
@@ -202,20 +177,8 @@ module.exports = class Application extends Service {
     return new TaskStats(this.get('taskStats'));
   }
 
-  getFetch() {
-    return this.get('fetch');
-  }
-
   getQueue() {
     return this.get('queue');
-  }
-
-  getUpdateStrategy() {
-    return this.get('updateStrategy');
-  }
-
-  getUser() {
-    return this.get('user');
   }
 
   getVersion() {
@@ -233,10 +196,16 @@ module.exports = class Application extends Service {
     return {lastConfigChangeAt, lastScalingAt, currentVersionID};
   }
 
+  /**
+   * @override
+   */
   getVolumes() {
     return new VolumeList({items: this.get('volumes') || []});
   }
 
+  /**
+   * @override
+   */
   getWebURL() {
     let {
       DCOS_SERVICE_NAME,

--- a/src/js/structs/Application.js
+++ b/src/js/structs/Application.js
@@ -114,6 +114,10 @@ module.exports = class Application extends Service {
     return FrameworkUtil.getMetadataFromLabels(this.getLabels());
   }
 
+  getName() {
+    return this.getId().split('/').pop();
+  }
+
   getPorts() {
     return this.get('ports');
   }
@@ -132,6 +136,15 @@ module.exports = class Application extends Service {
 
   getResidency() {
     return this.get('residency');
+  }
+
+  getStatus() {
+    const status = this.getServiceStatus();
+    if (status.displayName == null) {
+      return null;
+    }
+
+    return status.displayName;
   }
 
   getServiceStatus() {

--- a/src/js/structs/ApplicationSpec.js
+++ b/src/js/structs/ApplicationSpec.js
@@ -1,7 +1,12 @@
+import {cleanServiceJSON} from '../utils/CleanJSONUtil';
 import ServiceSpec from './ServiceSpec';
 import VolumeConstants from '../constants/VolumeConstants';
 
 module.exports = class ApplicationSpec extends ServiceSpec {
+  constructor(spec) {
+    super(cleanServiceJSON(spec));
+  }
+
   getAcceptedResourceRoles() {
     return this.get('acceptedResourceRoles');
   }

--- a/src/js/structs/ApplicationSpec.js
+++ b/src/js/structs/ApplicationSpec.js
@@ -1,8 +1,99 @@
-import Application from './Application';
+import ServiceSpec from './ServiceSpec';
+import VolumeConstants from '../constants/VolumeConstants';
 
-module.exports = class ApplicationSpec extends Application {
+module.exports = class ApplicationSpec extends ServiceSpec {
+  getAcceptedResourceRoles() {
+    return this.get('acceptedResourceRoles');
+  }
 
-    // DCOS-9613: Should be properly implemented instead of
-    //            just extending application
+  getArguments() {
+    return this.get('args');
+  }
+
+  getCommand() {
+    return this.get('cmd');
+  }
+
+  getContainerSettings() {
+    return this.get('container');
+  }
+
+  getConstraints() {
+    return this.get('constraints');
+  }
+
+  getCpus() {
+    return this.get('cpus');
+  }
+
+  getDisk() {
+    return this.get('disk');
+  }
+
+  getEnvironmentVariables() {
+    return this.get('env');
+  }
+
+  getExecutor() {
+    return this.get('executor');
+  }
+
+  getFetch() {
+    return this.get('fetch');
+  }
+
+  getHealthChecks() {
+    return this.get('healthChecks');
+  }
+
+  getInstancesCount() {
+    return this.get('instances');
+  }
+
+  getIpAddress() {
+    return this.get('ipAddress');
+  }
+
+  getLabels() {
+    return this.get('labels');
+  }
+
+  getMem() {
+    return this.get('mem');
+  }
+
+  getPortDefinitions() {
+    return this.get('portDefinitions');
+  }
+
+  getResidency() {
+    return this.get('residency');
+  }
+
+  getUpdateStrategy() {
+    return this.get('updateStrategy');
+  }
+
+  getUser() {
+    return this.get('user');
+  }
+
+  toJSON() {
+    let data = Object.assign({}, super.toJSON());
+    let containerSettings = this.getContainerSettings();
+
+    // Remove container.docker if we have MESOS containerizer
+    if (containerSettings &&
+      ((containerSettings.docker && containerSettings.docker.image) ||
+      containerSettings.type === VolumeConstants.type.MESOS)
+    ) {
+
+      if (data.container.type === VolumeConstants.type.MESOS) {
+        delete(data.container.docker);
+      }
+    }
+
+    return data;
+  }
 
 };

--- a/src/js/structs/Framework.js
+++ b/src/js/structs/Framework.js
@@ -3,6 +3,8 @@ import {
   FRAMEWORK_ID_VALID_CHARACTERS
 } from '../constants/FrameworkConstants';
 import Application from './Application';
+import {cleanServiceJSON} from '../utils/CleanJSONUtil';
+import FrameworkSpec from './FrameworkSpec';
 
 module.exports = class Framework extends Application {
   getInstancesCount() {
@@ -29,8 +31,7 @@ module.exports = class Framework extends Application {
   }
 
   getSpec() {
-    // DCOS-9613: This should be properly implemented
-    return this;
+    return new FrameworkSpec(cleanServiceJSON(this.get()));
   }
 
   getTasksSummary() {

--- a/src/js/structs/FrameworkSpec.js
+++ b/src/js/structs/FrameworkSpec.js
@@ -1,8 +1,5 @@
-import Framework from './Framework';
+import ApplicationSpec from './ApplicationSpec';
 
-module.exports = class FrameworkSpec extends Framework {
-
-    // DCOS-9613: Should be properly implemented instead of
-    //            just extending framework
+module.exports = class FrameworkSpec extends ApplicationSpec {
 
 };

--- a/src/js/structs/__tests__/Application-test.js
+++ b/src/js/structs/__tests__/Application-test.js
@@ -7,76 +7,6 @@ const VolumeList = require('../VolumeList');
 
 describe('Service', function () {
 
-  describe('#getArguments', function () {
-
-    it('returns array', function () {
-      let service = new Application({
-        args: []
-      });
-
-      expect(Array.isArray(service.getArguments())).toBeTruthy();
-    });
-
-    it('returns correct arguments', function () {
-      let service = new Application({
-        args: [
-          '--name \'etcd0\'',
-          '--advertise-client-urls \'http://192.168.33.10:2379\''
-        ]
-      });
-
-      expect(service.getArguments()).toEqual([
-        '--name \'etcd0\'',
-        '--advertise-client-urls \'http://192.168.33.10:2379\''
-      ]);
-    });
-
-  });
-
-  describe('#getCommand', function () {
-
-    it('returns correct command', function () {
-      let service = new Application({
-        cmd: 'sleep 999'
-      });
-
-      expect(service.getCommand()).toEqual('sleep 999');
-    });
-
-  });
-
-  describe('#getContainer', function () {
-
-    it('returns correct container data', function () {
-      let service = new Application({
-        container: {
-          type: 'DOCKER',
-          volumes: [],
-          docker: {
-            image: 'mesosphere/marathon:latest',
-            network: 'HOST',
-            privileged: false,
-            parameters: [],
-            forcePullImage: false
-          }
-        }
-      });
-
-      expect(service.getContainer()).toEqual({
-        type: 'DOCKER',
-        volumes: [],
-        docker: {
-          image: 'mesosphere/marathon:latest',
-          network: 'HOST',
-          privileged: false,
-          parameters: [],
-          forcePullImage: false
-        }
-      });
-    });
-
-  });
-
   describe('#getDeployments', function () {
     it('should return an empty array', function () {
       let service = new Application({
@@ -97,30 +27,6 @@ describe('Service', function () {
         {id: '4d08fc0d-d450-4a3e-9c85-464ffd7565f7'}
       ]);
     });
-  });
-
-  describe('#getEnvironmentVariables', function () {
-
-    it('returns correct command', function () {
-      let service = new Application({
-        env: {secretName: 'test'}
-      });
-
-      expect(service.getEnvironmentVariables()).toEqual({secretName: 'test'});
-    });
-
-  });
-
-  describe('#getExecuter', function () {
-
-    it('returns correct command', function () {
-      let service = new Application({
-        executor: '//cmd'
-      });
-
-      expect(service.getExecutor()).toEqual('//cmd');
-    });
-
   });
 
   describe('#getHealth', function () {
@@ -191,18 +97,6 @@ describe('Service', function () {
 
         expect(service.getHealth()).toEqual(HealthStatus.NA);
       });
-  });
-
-  describe('#getHealthChecks', function () {
-
-    it('returns correct health check data', function () {
-      let service = new Application({
-        healthChecks: [{path: '', protocol: 'HTTP'}]
-      });
-
-      expect(service.getHealthChecks()).toEqual([{path: '', protocol: 'HTTP'}]);
-    });
-
   });
 
   describe('#getId', function () {
@@ -548,100 +442,6 @@ describe('Service', function () {
 
   });
 
-  describe('#getFetch', function () {
-
-    beforeEach(function () {
-      this.instance = new Application({
-        fetch: [{
-          uri: 'http://resource/uri',
-          extract: true,
-          executable: false,
-          cache: false
-        }]
-      });
-    });
-
-    it('returns array', function () {
-      expect(Array.isArray(this.instance.getFetch())).toBeTruthy();
-    });
-
-    it('returns correct uris', function () {
-      expect(this.instance.getFetch()).toEqual([{
-        uri: 'http://resource/uri',
-        extract: true,
-        executable: false,
-        cache: false
-      }]);
-    });
-
-  });
-
-  describe('#getConstraints', function () {
-
-    beforeEach(function () {
-      this.instance = new Application({
-        'constraints': [
-          [
-            'hostname',
-            'LIKE',
-            'test'
-          ],
-          [
-            'hostname',
-            'UNLIKE',
-            'no-test'
-          ]
-        ]
-      });
-    });
-
-    it('returns array', function () {
-      expect(Array.isArray(this.instance.getConstraints())).toBeTruthy();
-    });
-
-    it('returns correct constraints', function () {
-      expect(this.instance.getConstraints()).toEqual([
-        [
-          'hostname',
-          'LIKE',
-          'test'
-        ],
-        [
-          'hostname',
-          'UNLIKE',
-          'no-test'
-        ]
-      ]);
-    });
-
-  });
-
-  describe('#getUser', function () {
-
-    it('returns correct user', function () {
-      let service = new Application({
-        user: 'sudo'
-      });
-
-      expect(service.getUser()).toEqual('sudo');
-    });
-
-  });
-
-  describe('#getAcceptedResourceRoles', function () {
-
-    it('returns correct user', function () {
-      let service = new Application({
-        acceptedResourceRoles: [
-          'public_slave'
-        ]
-      });
-
-      expect(service.getAcceptedResourceRoles()).toEqual(['public_slave']);
-    });
-
-  });
-
   describe('#getVersion', function () {
 
     it('returns correct version', function () {
@@ -688,36 +488,6 @@ describe('Service', function () {
 
   });
 
-  describe('#getCpus', function () {
-    it('returns the correct cpus', function () {
-      let service = new Application({
-        cpus: 0.5
-      });
-
-      expect(service.getCpus()).toEqual(0.5);
-    });
-  });
-
-  describe('#getDisk', function () {
-    it('returns the correct disk', function () {
-      let service = new Application({
-        disk: 125
-      });
-
-      expect(service.getDisk()).toEqual(125);
-    });
-  });
-
-  describe('#getMem', function () {
-    it('returns the correct mem', function () {
-      let service = new Application({
-        mem: 49
-      });
-
-      expect(service.getMem()).toEqual(49);
-    });
-  });
-
   describe('#getVolumes', function () {
 
     it('returns volume list', function () {
@@ -742,46 +512,6 @@ describe('Service', function () {
       expect(service.getVolumes().getItems().length).toEqual(0);
     });
 
-  });
-
-  describe('#getResidency', function () {
-    it('should return the right residency value', function () {
-      let service = new Application({
-        residency: {
-          relaunchEscalationTimeoutSeconds: 10,
-          taskLostBehavior: 'WAIT_FOREVER'
-        }
-      });
-
-      expect(service.getResidency()).toEqual({
-        relaunchEscalationTimeoutSeconds: 10,
-        taskLostBehavior: 'WAIT_FOREVER'
-      });
-    });
-  });
-
-  describe('#getUpdateStrategy', function () {
-    it('should return the right updateStrategy value', function () {
-      let service = new Application({
-        updateStrategy: {
-          maximunOverCapacity: 0,
-          minimumHealthCapacity: 0
-        }
-      });
-
-      expect(service.getUpdateStrategy()).toEqual({
-        maximunOverCapacity: 0,
-        minimumHealthCapacity: 0
-      });
-    });
-  });
-
-  describe('#getIpAddress', function () {
-    it('should return the right ipAddress value', function () {
-      let service = new Application({ipAddress:{networkName: 'd-overlay-1'}});
-
-      expect(service.getIpAddress()).toEqual({networkName: 'd-overlay-1'});
-    });
   });
 
   describe('#getWebURL', function () {

--- a/src/js/structs/__tests__/Application-test.js
+++ b/src/js/structs/__tests__/Application-test.js
@@ -5,7 +5,7 @@ const ServiceStatus = require('../../constants/ServiceStatus');
 const TaskStats = require('../TaskStats');
 const VolumeList = require('../VolumeList');
 
-describe('Application', function () {
+describe('Service', function () {
 
   describe('#getArguments', function () {
 

--- a/src/js/structs/__tests__/ApplicationSpec-test.js
+++ b/src/js/structs/__tests__/ApplicationSpec-test.js
@@ -1,0 +1,321 @@
+const ApplicationSpec = require('../ApplicationSpec');
+
+describe('ApplicationSpec', function () {
+
+  describe('#getAcceptedResourceRoles', function () {
+
+    it('returns correct user', function () {
+      let service = new ApplicationSpec({
+        acceptedResourceRoles: [
+          'public_slave'
+        ]
+      });
+
+      expect(service.getAcceptedResourceRoles()).toEqual(['public_slave']);
+    });
+
+  });
+
+  describe('#getArguments', function () {
+
+    it('returns array', function () {
+      let service = new ApplicationSpec({
+        args: []
+      });
+
+      expect(Array.isArray(service.getArguments())).toBeTruthy();
+    });
+
+    it('returns correct arguments', function () {
+      let service = new ApplicationSpec({
+        args: [
+          '--name \'etcd0\'',
+          '--advertise-client-urls \'http://192.168.33.10:2379\''
+        ]
+      });
+
+      expect(service.getArguments()).toEqual([
+        '--name \'etcd0\'',
+        '--advertise-client-urls \'http://192.168.33.10:2379\''
+      ]);
+    });
+
+  });
+
+  describe('#getCommand', function () {
+
+    it('returns correct command', function () {
+      let service = new ApplicationSpec({
+        cmd: 'sleep 999'
+      });
+
+      expect(service.getCommand()).toEqual('sleep 999');
+    });
+
+  });
+
+  describe('#getContainerSettings', function () {
+
+    it('returns correct container data', function () {
+      let service = new ApplicationSpec({
+        container: {
+          type: 'DOCKER',
+          volumes: [],
+          docker: {
+            image: 'mesosphere/marathon:latest',
+            network: 'HOST',
+            privileged: false,
+            parameters: [],
+            forcePullImage: false
+          }
+        }
+      });
+
+      expect(service.getContainerSettings()).toEqual({
+        type: 'DOCKER',
+        volumes: [],
+        docker: {
+          image: 'mesosphere/marathon:latest',
+          network: 'HOST',
+          privileged: false,
+          parameters: [],
+          forcePullImage: false
+        }
+      });
+    });
+
+  });
+
+  describe('#getConstraints', function () {
+
+    beforeEach(function () {
+      this.instance = new ApplicationSpec({
+        'constraints': [
+          [
+            'hostname',
+            'LIKE',
+            'test'
+          ],
+          [
+            'hostname',
+            'UNLIKE',
+            'no-test'
+          ]
+        ]
+      });
+    });
+
+    it('returns array', function () {
+      expect(Array.isArray(this.instance.getConstraints())).toBeTruthy();
+    });
+
+    it('returns correct constraints', function () {
+      expect(this.instance.getConstraints()).toEqual([
+        [
+          'hostname',
+          'LIKE',
+          'test'
+        ],
+        [
+          'hostname',
+          'UNLIKE',
+          'no-test'
+        ]
+      ]);
+    });
+
+  });
+
+  describe('#getCpus', function () {
+    it('returns the correct cpus', function () {
+      let service = new ApplicationSpec({
+        cpus: 0.5
+      });
+
+      expect(service.getCpus()).toEqual(0.5);
+    });
+  });
+
+  describe('#getDisk', function () {
+    it('returns the correct disk', function () {
+      let service = new ApplicationSpec({
+        disk: 125
+      });
+
+      expect(service.getDisk()).toEqual(125);
+    });
+  });
+
+  describe('#getEnvironmentVariables', function () {
+
+    it('returns correct command', function () {
+      let service = new ApplicationSpec({
+        env: {secretName: 'test'}
+      });
+
+      expect(service.getEnvironmentVariables()).toEqual({secretName: 'test'});
+    });
+
+  });
+
+  describe('#getExecutor', function () {
+
+    it('returns correct command', function () {
+      let service = new ApplicationSpec({
+        executor: '//cmd'
+      });
+
+      expect(service.getExecutor()).toEqual('//cmd');
+    });
+
+  });
+
+  describe('#getFetch', function () {
+
+    beforeEach(function () {
+      this.instance = new ApplicationSpec({
+        fetch: [{
+          uri: 'http://resource/uri',
+          extract: true,
+          executable: false,
+          cache: false
+        }]
+      });
+    });
+
+    it('returns array', function () {
+      expect(Array.isArray(this.instance.getFetch())).toBeTruthy();
+    });
+
+    it('returns correct uris', function () {
+      expect(this.instance.getFetch()).toEqual([{
+        uri: 'http://resource/uri',
+        extract: true,
+        executable: false,
+        cache: false
+      }]);
+    });
+
+  });
+
+  describe('#getHealthChecks', function () {
+
+    it('returns correct health check data', function () {
+      let service = new ApplicationSpec({
+        healthChecks: [{path: '', protocol: 'HTTP'}]
+      });
+
+      expect(service.getHealthChecks()).toEqual([{path: '', protocol: 'HTTP'}]);
+    });
+
+  });
+
+  describe('#getInstancesCount', function () {
+
+    it('returns correct instances', function () {
+      let service = new ApplicationSpec({
+        instances: 1
+      });
+
+      expect(service.getInstancesCount()).toEqual(1);
+    });
+
+  });
+
+  describe('#getIpAddress', function () {
+    it('should return the right ipAddress value', function () {
+      let service = new ApplicationSpec({ipAddress:{networkName: 'd-overlay-1'}});
+
+      expect(service.getIpAddress()).toEqual({networkName: 'd-overlay-1'});
+    });
+  });
+
+  describe('#getLabels', function () {
+
+    it('returns correct labels', function () {
+      let service = new ApplicationSpec({
+        labels: {
+          label_1: '1',
+          label_2: '2'
+        }
+      });
+
+      expect(service.getLabels()).toEqual({
+        label_1: '1',
+        label_2: '2'
+      });
+    });
+
+  });
+
+  describe('#getMem', function () {
+    it('returns the correct mem', function () {
+      let service = new ApplicationSpec({
+        mem: 49
+      });
+
+      expect(service.getMem()).toEqual(49);
+    });
+  });
+
+  describe('#getPortDefinitions', function () {
+    it('returns the correct port definitions', function () {
+      let service = new ApplicationSpec({
+        portDefinitions: [
+          {port: 1234, labels: {}, name: 'test', protocol: 'tcp'},
+          {port: 5678, labels: {}, name: 'test', protocol: 'udp'}
+        ]
+      });
+
+      expect(service.getPortDefinitions()).toEqual([
+        {port: 1234, labels: {}, name: 'test', protocol: 'tcp'},
+        {port: 5678, labels: {}, name: 'test', protocol: 'udp'}
+      ]);
+    });
+  });
+
+  describe('#getResidency', function () {
+    it('should return the right residency value', function () {
+      let service = new ApplicationSpec({
+        residency: {
+          relaunchEscalationTimeoutSeconds: 10,
+          taskLostBehavior: 'WAIT_FOREVER'
+        }
+      });
+
+      expect(service.getResidency()).toEqual({
+        relaunchEscalationTimeoutSeconds: 10,
+        taskLostBehavior: 'WAIT_FOREVER'
+      });
+    });
+  });
+
+  describe('#getUpdateStrategy', function () {
+    it('should return the right updateStrategy value', function () {
+      let service = new ApplicationSpec({
+        updateStrategy: {
+          maximunOverCapacity: 0,
+          minimumHealthCapacity: 0
+        }
+      });
+
+      expect(service.getUpdateStrategy()).toEqual({
+        maximunOverCapacity: 0,
+        minimumHealthCapacity: 0
+      });
+    });
+  });
+
+  describe('#getUser', function () {
+
+    it('returns correct user', function () {
+      let service = new ApplicationSpec({
+        user: 'sudo'
+      });
+
+      expect(service.getUser()).toEqual('sudo');
+    });
+
+  });
+
+});

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -455,14 +455,10 @@ const ServiceUtil = {
     let definition = spec.toJSON();
 
     if (spec instanceof ApplicationSpec) {
-
-      // TODO: It looks that this hook operates over Application (Service)
-      //       instances, therefore we are creating an Application instance
-      //       but perhaps it's OK to pass the ApplicationSpec?
       Hooks.applyFilter(
         'serviceToAppDefinition',
         definition,
-        new Application(definition)
+        spec
       );
 
     }

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -3,6 +3,7 @@ jest.dontMock('../../structs/Service');
 jest.dontMock('../../constants/VolumeConstants');
 
 const Application = require('../../structs/Application');
+const ApplicationSpec = require('../../structs/ApplicationSpec');
 const Framework = require('../../structs/Framework');
 const Pod = require('../../structs/Pod');
 const ServiceUtil = require('../ServiceUtil');
@@ -51,7 +52,7 @@ describe('ServiceUtil', function () {
     });
   });
 
-  describe('#createServiceFromFormModel', function () {
+  describe('#createSpecFromFormModel', function () {
     it('should convert to the correct Service', function () {
       let model = {
         general: {
@@ -69,7 +70,7 @@ describe('ServiceUtil', function () {
         instances: null
       });
 
-      expect(ServiceUtil.createServiceFromFormModel(model))
+      expect(ServiceUtil.createSpecFromFormModel(model))
         .toEqual(expectedService);
     });
 
@@ -78,7 +79,7 @@ describe('ServiceUtil', function () {
 
       let expectedService = new Application({});
 
-      expect(ServiceUtil.createServiceFromFormModel(model))
+      expect(ServiceUtil.createSpecFromFormModel(model))
         .toEqual(expectedService);
     });
 
@@ -87,14 +88,14 @@ describe('ServiceUtil', function () {
 
       let expectedService = new Application({});
 
-      expect(ServiceUtil.createServiceFromFormModel(model))
+      expect(ServiceUtil.createSpecFromFormModel(model))
         .toEqual(expectedService);
     });
 
     describe('environmentVariables', function () {
 
       it('should keep undefined values as ""', function () {
-        let service = ServiceUtil.createServiceFromFormModel({
+        let service = ServiceUtil.createSpecFromFormModel({
           environmentVariables: {
             environmentVariables: [
               { key: 'a', value: 'correct' },
@@ -109,7 +110,7 @@ describe('ServiceUtil', function () {
       });
 
       it('should not set items with no key', function () {
-        let service = ServiceUtil.createServiceFromFormModel(
+        let service = ServiceUtil.createSpecFromFormModel(
           {
             environmentVariables: {
               environmentVariables: [
@@ -127,7 +128,7 @@ describe('ServiceUtil', function () {
       });
 
       it('should keep null values as ""', function () {
-        let service = ServiceUtil.createServiceFromFormModel({
+        let service = ServiceUtil.createSpecFromFormModel({
           environmentVariables: {
             environmentVariables: [
               { key: 'A', value: 'correct' },
@@ -146,7 +147,7 @@ describe('ServiceUtil', function () {
     describe('labels', function () {
 
       it('should keep undefined values as ""', function () {
-        let service = ServiceUtil.createServiceFromFormModel({
+        let service = ServiceUtil.createSpecFromFormModel({
           labels: {
             labels: [
               { key: 'a', value: 'correct' },
@@ -161,7 +162,7 @@ describe('ServiceUtil', function () {
       });
 
       it('should not set items with no key', function () {
-        let service = ServiceUtil.createServiceFromFormModel(
+        let service = ServiceUtil.createSpecFromFormModel(
           {
             labels: {
               labels: [
@@ -179,7 +180,7 @@ describe('ServiceUtil', function () {
       });
 
       it('should keep null values as ""', function () {
-        let service = ServiceUtil.createServiceFromFormModel({
+        let service = ServiceUtil.createSpecFromFormModel({
           labels: {
             labels: [
               { key: 'a', value: 'correct' },
@@ -200,7 +201,7 @@ describe('ServiceUtil', function () {
       describe('host mode', function () {
 
         it('should not add a portDefinitions field if no ports were passed in', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             networking: {
               networkType: 'host',
               ports: []
@@ -210,7 +211,7 @@ describe('ServiceUtil', function () {
         });
 
         it('should convert the supplied network fields', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             networking: {
               networkType: 'host',
               ports: [{protocol: 'udp', name: 'foo'}]
@@ -222,7 +223,7 @@ describe('ServiceUtil', function () {
         });
 
         it('should enforce the port when loadBalanced is on', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             networking: {
               networkType: 'host',
               ports: [{lbPort: 1234, loadBalanced: true}]
@@ -233,7 +234,7 @@ describe('ServiceUtil', function () {
 
         it('should not override the port to 0 when loadBalanced is off',
           function () {
-            let service = ServiceUtil.createServiceFromFormModel({
+            let service = ServiceUtil.createSpecFromFormModel({
               networking: {
                 networkType: 'host',
                 ports: [{lbPort: 1234, loadBalanced: false}]
@@ -243,7 +244,7 @@ describe('ServiceUtil', function () {
           });
 
         it('should default the port to 0 when loadBalanced is on', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             networking: {
               networkType: 'host',
               ports: [{loadBalanced: true}]
@@ -253,7 +254,7 @@ describe('ServiceUtil', function () {
         });
 
         it('should add a VIP label when loadBalanced is on', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             general: {id: '/foo/bar'},
             networking: {
               networkType: 'host',
@@ -265,7 +266,7 @@ describe('ServiceUtil', function () {
         });
 
         it('increments the VIP index', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             general: {id: '/foo/bar'},
             networking: {
               networkType: 'host',
@@ -281,7 +282,7 @@ describe('ServiceUtil', function () {
 
         it('should not add any port definitions if ports is emoty',
           function () {
-            let service = ServiceUtil.createServiceFromFormModel({
+            let service = ServiceUtil.createSpecFromFormModel({
               networking: {
                 networkType: 'host',
                 ports: [{}]
@@ -295,7 +296,7 @@ describe('ServiceUtil', function () {
 
       describe('host mode (with docker)', function () {
         beforeEach(function () {
-          this.service = ServiceUtil.createServiceFromFormModel({
+          this.service = ServiceUtil.createSpecFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {
               networkType: 'host',
@@ -321,7 +322,7 @@ describe('ServiceUtil', function () {
       describe('bridge mode (with docker)', function () {
 
         beforeEach(function () {
-          this.serviceEmptyPorts = ServiceUtil.createServiceFromFormModel({
+          this.serviceEmptyPorts = ServiceUtil.createSpecFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {
               networkType: 'bridge',
@@ -331,7 +332,7 @@ describe('ServiceUtil', function () {
         });
 
         it('should not add a portMappings field if no ports were passed in', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {networkType: 'bridge'}
           });
@@ -345,7 +346,7 @@ describe('ServiceUtil', function () {
         });
 
         it('should convert the supplied string fields', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {
               networkType: 'bridge',
@@ -358,7 +359,7 @@ describe('ServiceUtil', function () {
         });
 
         it('should add the specified containerPort', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {
               networkType: 'bridge',
@@ -370,7 +371,7 @@ describe('ServiceUtil', function () {
         });
 
         it('should not add a hostPort when loadBalanced is off', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {
               networkType: 'bridge',
@@ -382,7 +383,7 @@ describe('ServiceUtil', function () {
         });
 
         it('should add a VIP label when loadBalanced is on', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             general: {id: '/foo/bar'},
             containerSettings: {image: 'redis'},
             networking: {
@@ -395,7 +396,7 @@ describe('ServiceUtil', function () {
         });
 
         it('sets the docker network property correctly', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {networkType: 'bridge'}
           });
@@ -404,7 +405,7 @@ describe('ServiceUtil', function () {
 
         it('should not add any port definitions if ports is emoty',
           function () {
-            let service = ServiceUtil.createServiceFromFormModel({
+            let service = ServiceUtil.createSpecFromFormModel({
               networking: {
                 networkType: 'host',
                 ports: [{}]
@@ -418,7 +419,7 @@ describe('ServiceUtil', function () {
 
       describe('user mode', function () {
         it('sets the docker network property correctly', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {networkType: 'prod'}
           });
@@ -426,7 +427,7 @@ describe('ServiceUtil', function () {
         });
 
         it('adds the networkName field to the service', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {networkType: 'prod', ports: [{}]}
           });
@@ -434,7 +435,7 @@ describe('ServiceUtil', function () {
         });
 
         it('should convert the supplied string fields', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {
               networkType: 'user',
@@ -447,7 +448,7 @@ describe('ServiceUtil', function () {
         });
 
         it('should add the specified containerPort', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {
               networkType: 'user',
@@ -459,7 +460,7 @@ describe('ServiceUtil', function () {
         });
 
         it('should not add a servicePort when loadBalanced is off', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {
               networkType: 'user',
@@ -471,7 +472,7 @@ describe('ServiceUtil', function () {
         });
 
         it('should add a servicePort when loadBalanced is on', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {
               networkType: 'user',
@@ -483,7 +484,7 @@ describe('ServiceUtil', function () {
         });
 
         it('should not add a VIP label when loadBalanced is off', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             containerSettings: {image: 'redis'},
             networking: {
               networkType: 'user',
@@ -495,7 +496,7 @@ describe('ServiceUtil', function () {
         });
 
         it('should add the appropriate VIP label when loadBalanced is on', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
+          let service = ServiceUtil.createSpecFromFormModel({
             containerSettings: {image: 'redis'},
             general: {id: '/foo/bar'},
             networking: {
@@ -509,7 +510,7 @@ describe('ServiceUtil', function () {
 
         it('should not add any port definitions if ports is emoty',
           function () {
-            let service = ServiceUtil.createServiceFromFormModel({
+            let service = ServiceUtil.createSpecFromFormModel({
               containerSettings: {image: 'redis'},
               networking: {
                 networkType: 'user',
@@ -552,7 +553,7 @@ describe('ServiceUtil', function () {
           }
         });
 
-        expect(ServiceUtil.createServiceFromFormModel(model))
+        expect(ServiceUtil.createSpecFromFormModel(model))
           .toEqual(expectedService);
       });
 
@@ -602,7 +603,7 @@ describe('ServiceUtil', function () {
           }
         });
 
-        expect(ServiceUtil.createServiceFromFormModel(model))
+        expect(ServiceUtil.createSpecFromFormModel(model))
           .toEqual(expectedService);
       });
 
@@ -636,7 +637,7 @@ describe('ServiceUtil', function () {
           }
         });
 
-        expect(ServiceUtil.createServiceFromFormModel(model))
+        expect(ServiceUtil.createSpecFromFormModel(model))
           .toEqual(expectedService);
       });
 
@@ -670,14 +671,14 @@ describe('ServiceUtil', function () {
           updateStrategy: {maximumOverCapacity: 0, minimumHealthCapacity: 0}
         });
 
-        expect(ServiceUtil.createServiceFromFormModel(model))
+        expect(ServiceUtil.createSpecFromFormModel(model))
           .toEqual(expectedService);
       });
     });
 
     describe('container settings', function () {
       beforeEach(function () {
-        this.service = ServiceUtil.createServiceFromFormModel({
+        this.service = ServiceUtil.createSpecFromFormModel({
           containerSettings: {
             image: 'redis',
             parameters: [
@@ -723,7 +724,7 @@ describe('ServiceUtil', function () {
                 type: 'string',
                 multiLine: true,
                 getter(service) {
-                  return service.getCommand();
+                  return service.getSpec().getCommand();
                 }
               }
             }
@@ -748,14 +749,14 @@ describe('ServiceUtil', function () {
     });
   });
 
-  describe('#getAppDefinitionFromService', function () {
-    it('should create the correct appDefinition', function () {
-      let service = new Application({
+  describe('#getDefinitionFromSpec', function () {
+    it('should create the correct definition for ApplicationSpec', function () {
+      let service = new ApplicationSpec({
         id: '/test',
         cmd: 'sleep 1000;'
       });
 
-      expect(ServiceUtil.getAppDefinitionFromService(service)).toEqual({
+      expect(ServiceUtil.getDefinitionFromSpec(service)).toEqual({
         id: '/test',
         cmd: 'sleep 1000;'
       });


### PR DESCRIPTION
This PR separates `Application` struct to `Application` + `ApplicationSpec`.

The first is used when we need to inspect the *status of a running instance*, while the latter is used when we *create or edit* an application.
