### PR TITLE
Bug fix: using unique name and indexed key in schema forms, ref. DCOS-9699

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5426,9 +5426,9 @@
       "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz"
     },
     "reactjs-components": {
-      "version": "0.15.0-beta.3",
-      "from": "reactjs-components@0.15.0-beta.3",
-      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.15.0-beta.3.tgz"
+      "version": "0.15.0-beta.4",
+      "from": "reactjs-components@0.15.0-beta.4",
+      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.15.0-beta.4.tgz"
     },
     "reactjs-mixin": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-gemini-scrollbar": "2.1.0",
     "react-redux": "4.4.0",
     "react-router": "0.13.5",
-    "reactjs-components": "0.15.0-beta.3",
+    "reactjs-components": "0.15.0-beta.4",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
     "tv4": "1.2.7",

--- a/src/js/schemas/job-schema/Labels.js
+++ b/src/js/schemas/job-schema/Labels.js
@@ -1,6 +1,7 @@
 const Labels = {
   type: 'object',
   title: 'Labels',
+  description: 'Attach metadata to jobs to expose additional information to other jobs.',
   properties: {
     items: {
       type: 'array',

--- a/src/js/utils/FormUtil.js
+++ b/src/js/utils/FormUtil.js
@@ -11,16 +11,16 @@ function containsMultipleProp(prop, fieldColumn, id) {
   if (id) {
     return !!(
       fieldColumn &&
-      fieldColumn.id &&
-      fieldColumn.id.includes(`${prop}[${id}]`)
+      fieldColumn.name &&
+      fieldColumn.name.includes(`${prop}[${id}]`)
     );
   }
 
   return !!(
     fieldColumn &&
-    fieldColumn.id &&
-    fieldColumn.id.startsWith(`${prop}[`) &&
-    fieldColumn.id.includes(']')
+    fieldColumn.name &&
+    fieldColumn.name.startsWith(`${prop}[`) &&
+    fieldColumn.name.includes(']')
   );
 }
 
@@ -38,10 +38,10 @@ const FormUtil = {
   getMultipleFieldDefinition(prop, id, definition, model, index = 0) {
     return definition.map(function (definitionField) {
       definitionField = Util.deepCopy(definitionField);
-      // Use index for key (aka. name), so we can reuse same key for same field,
+      // Use index for key, so we can reuse same key for same field,
       // to not make react think it is a completely new field
-      definitionField.id = `${prop}[${id}].${definitionField.name}`;
-      definitionField.name = `${prop}[${index}].${definitionField.name}`;
+      definitionField.key = `${prop}[${index}].${definitionField.name}`;
+      definitionField.name = `${prop}[${id}].${definitionField.name}`;
 
       let propKey = FormUtil.getPropKey(definitionField.name);
       if (model && Object.prototype.hasOwnProperty.call(model, propKey)) {

--- a/src/js/utils/JobUtil.js
+++ b/src/js/utils/JobUtil.js
@@ -53,9 +53,15 @@ const JobUtil = {
     spec.id = general.id;
     spec.description = general.description;
 
-    if (Array.isArray(labels.items)) {
+    if (labels != null && labels.items != null) {
       spec.labels = labels.items.reduce(function (memo, {key, value}) {
-        memo[key] = value || null;
+        if (key == null) {
+          return memo;
+        }
+
+        // The 'undefined' value is not rendered by the JSON.stringify,
+        // so make sure empty environment variables are not left unrendered
+        memo[key] = value || '';
 
         return memo;
       }, {});

--- a/src/js/utils/__tests__/FormUtil-test.js
+++ b/src/js/utils/__tests__/FormUtil-test.js
@@ -21,25 +21,21 @@ describe('FormUtil', function () {
       let result = FormUtil.getMultipleFieldDefinition(
         'variable',
         1,
-        this.definition,
-        null,
-        2
+        this.definition
       );
 
-      expect(result[0].name).toEqual('variable[2].key');
-      expect(result[1].name).toEqual('variable[2].value');
+      expect(result[0].name).toEqual('variable[1].key');
+      expect(result[1].name).toEqual('variable[1].value');
     });
 
     it('does not modify the definition', function () {
       let result = FormUtil.getMultipleFieldDefinition(
         'variable',
         1,
-        this.definition,
-        null,
-        2
+        this.definition
       );
 
-      expect(result[0].name).toEqual('variable[2].key');
+      expect(result[0].name).toEqual('variable[1].key');
       expect(this.definition[0].name).toEqual('key');
     });
 
@@ -51,8 +47,7 @@ describe('FormUtil', function () {
         {
           key: 'kenny',
           value: 'tran'
-        },
-        2
+        }
       );
 
       expect(result[0].value).toEqual('kenny');
@@ -94,8 +89,8 @@ describe('FormUtil', function () {
   describe('#isFieldInstanceOfProp', function () {
     it('should return true if field is instance of prop', function () {
       let fields = [
-        {id: 'variable[2].key', value: 'kenny'},
-        {id: 'variable[2].value', value: 'tran'}
+        {name: 'variable[2].key', value: 'kenny'},
+        {name: 'variable[2].value', value: 'tran'}
       ];
       let result = FormUtil.isFieldInstanceOfProp('variable', fields, 2);
       expect(result).toEqual(true);
@@ -103,15 +98,15 @@ describe('FormUtil', function () {
 
     it('should return false if field is not instance of prop', function () {
       let fields = [
-        {id: 'variable[1].key', value: 'kenny'},
-        {id: 'variable[1].value', value: 'tran'}
+        {name: 'variable[1].key', value: 'kenny'},
+        {name: 'variable[1].value', value: 'tran'}
       ];
       let result = FormUtil.isFieldInstanceOfProp('variable', fields, 2);
       expect(result).toEqual(false);
     });
 
     it('should work on a single definition', function () {
-      let field = {id: 'variable[1].key', value: 'kenny'};
+      let field = {name: 'variable[1].key', value: 'kenny'};
       let result = FormUtil.isFieldInstanceOfProp('variable', field, 1);
       expect(result).toEqual(true);
     });
@@ -120,19 +115,19 @@ describe('FormUtil', function () {
   describe('#removePropID', function () {
     it('should remove the fields with that property', function () {
       let definition = [
-        {id: 'password', value: 'secret'},
-        {id: 'variable[1].key', value: 'kenny'},
-        {id: 'variable[1].value', value: 'tran'},
-        {id: 'variable[2].key', value: 'mat'},
-        {id: 'variable[2].value', value: 'app'}
+        {name: 'password', value: 'secret'},
+        {name: 'variable[1].key', value: 'kenny'},
+        {name: 'variable[1].value', value: 'tran'},
+        {name: 'variable[2].key', value: 'mat'},
+        {name: 'variable[2].value', value: 'app'}
       ];
 
       FormUtil.removePropID(definition, 'variable', 1);
 
       let expectedResult = [
-        {id: 'password', value: 'secret'},
-        {id: 'variable[2].key', value: 'mat'},
-        {id: 'variable[2].value', value: 'app'}
+        {name: 'password', value: 'secret'},
+        {name: 'variable[2].key', value: 'mat'},
+        {name: 'variable[2].value', value: 'app'}
       ];
 
       expect(definition).toEqual(expectedResult);


### PR DESCRIPTION
---
ℹ️ Related to this PR (for history): https://github.com/dcos/dcos-ui/pull/916
~~⚠️ Dependent on this PR: https://github.com/mesosphere/reactjs-components/pull/348~~
---

This PR fixes a bug where the model generation would not know which field was which (due to name/key mixup).
It makes use of the key option in Forms introduced in this PR https://github.com/mesosphere/reactjs-components/pull/348 to assign a separate key to duplicable (label) definitions, but keeping the name unique, so the add/remove functionality still works.

Before:
![](https://d3vv6lp55qjaqc.cloudfront.net/items/0h2X0j302y2P2z2V1p38/Screen%20Recording%202016-09-09%20at%2012.21%20PM.gif)

After:
![](https://cl.ly/291z1k0s3h3e/Screen%20Recording%202016-09-13%20at%2014.50.gif)

This PR includes a reactjs-components update. The only change added since last release was this PR: https://github.com/mesosphere/reactjs-components/pull/348