### PR TITLE
Adding missing import for cleanJobJSON

### DIFF
--- a/src/js/components/modals/JobFormModal.js
+++ b/src/js/components/modals/JobFormModal.js
@@ -9,6 +9,7 @@ import 'brace/theme/monokai';
 import 'brace/ext/language_tools';
 
 import CollapsibleErrorMessage from '../CollapsibleErrorMessage';
+import {cleanJobJSON} from '../../utils/CleanJSONUtil';
 import FormUtil from '../../utils/FormUtil';
 import Job from '../../structs/Job';
 import JobForm from '../JobForm';


### PR DESCRIPTION
This PR fixes a missing import in the JobFormModal file ~~from this PR: https://github.com/dcos/dcos-ui/pull/950~~

~~Specific commit: https://github.com/dcos/dcos-ui/pull/950/commits/4df93a7d81ace2262f486f34c258368ebc38e064~~

Apparently what happened is that the import was removed here: https://github.com/dcos/dcos-ui/commit/d0bab83745ce2346f5485219b195b913e8f07887 in the `feature/pods` branch, and then in master some more entries using the same function was added here: https://github.com/dcos/dcos-ui/pull/907

So when the `feature/pods` branch was rebased by me it added new uses of the function without having the import.