### PR TITLE
Use inline cheap source maps for development mode

### DIFF
--- a/webpack/webpack.dev.babel.js
+++ b/webpack/webpack.dev.babel.js
@@ -36,7 +36,7 @@ let entry = [
 
 if (environment === 'development') {
   entry.push('webpack/hot/only-dev-server');
-  devtool = '#eval-source-map';
+  devtool = '#inline-eval-cheap-source-map';
 } else if (environment === 'testing') {
   // Cypress constantly saves fixture files, which causes webpack to detect
   // a filechange and rebuild the application. The problem with this is that


### PR DESCRIPTION
https://github.com/erikras/react-redux-universal-hot-example/issues/616#issuecomment-159953813

Before:
<pre>
delta:dcos-ui ml (master)$ npm start

...

content is served from /Users/ml/Mesosphere/dcos-ui/build
<b>Time: 68228ms</b>
chunk    {0} index.js (main) 9.86 MB [rendered]
Child html-webpack-plugin for "index.html":
    chunk    {0} index.html 200 kB [rendered]
webpack: bundle is now VALID.
webpack: bundle is now INVALID.
<b>Time: 9482ms</b>
chunk    {0} index.js, 0.17c12013250a06570382.hot-update.js (main) 9.86 MB [rendered]
Child html-webpack-plugin for "index.html":
    chunk    {0} index.html 200 kB
webpack: bundle is now VALID.
webpack: bundle is now INVALID.
<b>Time: 3639ms</b>
chunk    {0} index.js, 0.6e5a4047e21c3640a600.hot-update.js (main) 9.86 MB [rendered]
Child html-webpack-plugin for "index.html":
    chunk    {0} index.html 200 kB
webpack: bundle is now VALID.
webpack: bundle is now INVALID.
<b>Time: 3597ms</b>
chunk    {0} index.js, 0.ec9b2d9825ecdff0f341.hot-update.js (main) 9.86 MB [rendered]
Child html-webpack-plugin for "index.html":
    chunk    {0} index.html 200 kB
webpack: bundle is now VALID.
webpack: bundle is now INVALID.
<b>Time: 2902ms</b>
chunk    {0} index.js, 0.bfddbe22805b35cff948.hot-update.js (main) 9.86 MB [rendered]
Child html-webpack-plugin for "index.html":
    chunk    {0} index.html 200 kB
webpack: bundle is now VALID.
</pre>
=> Reloads between 3-4s

After:
<pre>
delta:dcos-ui ml (master)$ npm start

...

content is served from /Users/ml/Mesosphere/dcos-ui/build
<b>Time: 59161ms</b>
chunk    {0} index.js (main) 9.86 MB [rendered]
Child html-webpack-plugin for "index.html":
    chunk    {0} index.html 200 kB [rendered]
webpack: bundle is now VALID.
webpack: bundle is now INVALID.
<b>Time: 5313ms</b>         
chunk    {0} index.js, 0.17c12013250a06570382.hot-update.js (main) 9.86 MB [rendered]
Child html-webpack-plugin for "index.html":
    chunk    {0} index.html 200 kB
webpack: bundle is now VALID.
webpack: bundle is now INVALID.
<b>Time: 2542ms</b>
chunk    {0} index.js, 0.6e5a4047e21c3640a600.hot-update.js (main) 9.86 MB [rendered]
Child html-webpack-plugin for "index.html":
    chunk    {0} index.html 200 kB
webpack: bundle is now VALID.
webpack: bundle is now INVALID.
<b>Time: 2688ms</b>
chunk    {0} index.js, 0.ec9b2d9825ecdff0f341.hot-update.js (main) 9.86 MB [rendered]
Child html-webpack-plugin for "index.html":
    chunk    {0} index.html 200 kB
webpack: bundle is now VALID.
webpack: bundle is now INVALID.
<b>Time: 2902ms</b>
chunk    {0} index.js, 0.bfddbe22805b35cff948.hot-update.js (main) 9.86 MB [rendered]
Child html-webpack-plugin for "index.html":
    chunk    {0} index.html 200 kB
webpack: bundle is now VALID.
</pre>
=> Reloads between 2.5-3s