### PR TITLE
[CNVS Upgrade] Fix broken unit tests

### DIFF
--- a/src/js/components/Panel.js
+++ b/src/js/components/Panel.js
@@ -1,6 +1,8 @@
 import classNames from 'classnames/dedupe';
 import React from 'react';
 
+import Util from '../utils/Util';
+
 const defaultClasses = {
   panel: 'panel',
   content: 'panel-content panel-cell panel-cell-narrow panel-cell-short panel-cell-borderless',
@@ -48,7 +50,8 @@ var Panel = React.createClass({
     let panelClasses = classNames(defaultClasses.panel, props.className);
 
     return (
-      <div className={panelClasses}>
+      <div className={panelClasses}
+        {...Util.omit(props, ['children', 'className', 'heading', 'footer'])}>
         {this.getNode('heading')}
         <div className={contentClasses}>
           {props.children}

--- a/src/js/components/Panel.js
+++ b/src/js/components/Panel.js
@@ -21,7 +21,8 @@ var Panel = React.createClass({
     // classes
     contentClass: React.PropTypes.string,
     headingClass: React.PropTypes.string,
-    footerClass: React.PropTypes.string
+    footerClass: React.PropTypes.string,
+    onClick: React.PropTypes.func
   },
 
   getNode(nodeName) {
@@ -50,8 +51,7 @@ var Panel = React.createClass({
     let panelClasses = classNames(defaultClasses.panel, props.className);
 
     return (
-      <div className={panelClasses}
-        {...Util.omit(props, ['children', 'className', 'heading', 'footer'])}>
+      <div className={panelClasses} onClick={this.props.onClick}>
         {this.getNode('heading')}
         <div className={contentClasses}>
           {props.children}

--- a/src/js/components/__tests__/Panel-test.js
+++ b/src/js/components/__tests__/Panel-test.js
@@ -41,7 +41,7 @@ describe('Panel', function () {
       var panel =
         TestUtils.findRenderedComponentWithType(this.instance, Panel);
       var node = ReactDOM.findDOMNode(panel);
-      expect(node.className).toBe('foo');
+      expect(node.className).toContain('foo');
     });
 
     it('should override className to content node', function () {
@@ -50,7 +50,7 @@ describe('Panel', function () {
         'bar'
       );
       var node = ReactDOM.findDOMNode(content);
-      expect(node.className).toBe('bar');
+      expect(node.className).toContain('bar');
     });
 
     it('should use default className to content node', function () {
@@ -59,7 +59,7 @@ describe('Panel', function () {
         'panel-content'
       );
       var node = ReactDOM.findDOMNode(content);
-      expect(node.className).toBe('panel-content');
+      expect(node.className).toContain('panel-content');
     });
 
     it('should override className to footer node', function () {
@@ -68,7 +68,7 @@ describe('Panel', function () {
         'bar'
       );
       var node = ReactDOM.findDOMNode(footer);
-      expect(node.className).toBe('bar');
+      expect(node.className).toContain('bar');
     });
 
     it('should use default className to footer node', function () {
@@ -77,7 +77,7 @@ describe('Panel', function () {
         'panel-footer'
       );
       var node = ReactDOM.findDOMNode(footer);
-      expect(node.className).toBe('panel-footer');
+      expect(node.className).toContain('panel-footer');
     });
 
     it('should not render footer when none is given', function () {
@@ -94,7 +94,7 @@ describe('Panel', function () {
         'bar'
       );
       var node = ReactDOM.findDOMNode(heading);
-      expect(node.className).toBe('bar');
+      expect(node.className).toContain('bar');
     });
 
     it('should use default className to heading node', function () {
@@ -103,7 +103,7 @@ describe('Panel', function () {
         'panel-header'
       );
       var node = ReactDOM.findDOMNode(heading);
-      expect(node.className).toBe('panel-header');
+      expect(node.className).toContain('panel-header');
     });
 
     it('should not render heading when none is given', function () {


### PR DESCRIPTION
Velocity won't properly report the status of the unit tests because this still relies on the `cnvs-upgrade/master` branch of both `reactjs-components` and the plugins repository, but you can see them passing locally:
![](https://cl.ly/2O1l242p3b32/Screen%20Shot%202016-09-14%20at%2011.46.18%20AM.png)