### PR TITLE
DCOS-9285: Move scheduler name assignment to MesosStateActions

### DIFF
--- a/src/js/components/CheckboxTable.js
+++ b/src/js/components/CheckboxTable.js
@@ -52,7 +52,9 @@ class CheckboxTable extends React.Component {
 
   bulkCheck(isChecked) {
     let checkedIDs = [];
-    let {data, onCheckboxChange, uniqueProperty} = this.props;
+    let {data, onCheckboxChange, uniqueProperty, disabledItemsMap} = this.props;
+
+    data = data.filter((datum) => !disabledItemsMap[datum[uniqueProperty]]);
 
     if (isChecked) {
       data.forEach(function (datum) {
@@ -75,13 +77,14 @@ class CheckboxTable extends React.Component {
   renderHeadingCheckbox() {
     let checked = false;
     let indeterminate = false;
-    let {allowMultipleSelect, checkedItemsMap, data} = this.props;
+    let {allowMultipleSelect, checkedItemsMap, disabledItemsMap, data} = this.props;
 
     if (!allowMultipleSelect) {
       return null;
     }
 
     let checkedItemsCount = Object.keys(checkedItemsMap).length;
+    let disabledItemsCount = Object.keys(disabledItemsMap).length;
 
     if (checkedItemsCount > 0) {
       indeterminate = true;
@@ -89,7 +92,7 @@ class CheckboxTable extends React.Component {
       checked = false;
     }
 
-    if (checkedItemsCount === data.length && checkedItemsCount !== 0) {
+    if (checkedItemsCount + disabledItemsCount >= data.length && checkedItemsCount !== 0) {
       checked = true;
       indeterminate = false;
     }

--- a/src/js/components/CheckboxTable.js
+++ b/src/js/components/CheckboxTable.js
@@ -92,7 +92,7 @@ class CheckboxTable extends React.Component {
       checked = false;
     }
 
-    if (checkedItemsCount + disabledItemsCount >= data.length && checkedItemsCount !== 0) {
+    if (checkedItemsCount + disabledItemsCount === data.length && checkedItemsCount !== 0) {
       checked = true;
       indeterminate = false;
     }

--- a/src/js/components/CheckboxTable.js
+++ b/src/js/components/CheckboxTable.js
@@ -54,7 +54,9 @@ class CheckboxTable extends React.Component {
     let checkedIDs = [];
     let {data, onCheckboxChange, uniqueProperty, disabledItemsMap} = this.props;
 
-    data = data.filter((datum) => !disabledItemsMap[datum[uniqueProperty]]);
+    data = data.filter(function (datum) {
+      return !disabledItemsMap[datum[uniqueProperty]];
+    });
 
     if (isChecked) {
       data.forEach(function (datum) {

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -242,7 +242,7 @@ class TaskTable extends React.Component {
   getDisabledItemsMap(tasks) {
     return tasks
       .filter(function (task) {
-        return task.scheduler !== 'marathon';
+        return !task.isStartedByMarathon;
       })
       .reduce(function (acc, task) {
         acc[task.id] = true;

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -239,6 +239,15 @@ class TaskTable extends React.Component {
     );
   }
 
+  getDisabledItemsMap(tasks) {
+    return tasks
+      .filter((task) => task.scheduler !== 'marathon')
+      .reduce((acc, task) => {
+        acc[task.id] = true;
+        return acc;
+      }, {});
+  }
+
   renderHeadline(prop, task) {
     let title = task[prop];
     let params = this.props.parentRouter.getCurrentParams();
@@ -376,6 +385,7 @@ class TaskTable extends React.Component {
         className={className}
         columns={this.getColumns()}
         data={tasks.slice()}
+        disabledItemsMap={this.getDisabledItemsMap(tasks)}
         getColGroup={this.getColGroup}
         onCheckboxChange={onCheckboxChange}
         sortBy={{prop: 'updated', order: 'desc'}}

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -241,8 +241,10 @@ class TaskTable extends React.Component {
 
   getDisabledItemsMap(tasks) {
     return tasks
-      .filter((task) => task.scheduler !== 'marathon')
-      .reduce((acc, task) => {
+      .filter(function (task) {
+        return task.scheduler !== 'marathon';
+      })
+      .reduce(function (acc, task) {
         acc[task.id] = true;
         return acc;
       }, {});

--- a/src/js/components/__tests__/TaskTable-test.js
+++ b/src/js/components/__tests__/TaskTable-test.js
@@ -51,7 +51,7 @@ describe('TaskTable', function () {
     });
 
     it('returns a map of disabled items', function () {
-      var tasks = [{id: '1', scheduler: 'marathon'}, {id: '2'}];
+      var tasks = [{id: '1', isStartedByMarathon: true}, {id: '2'}];
       expect(this.taskTable.getDisabledItemsMap(tasks)).toEqual({'2': true});
     });
   });

--- a/src/js/components/__tests__/TaskTable-test.js
+++ b/src/js/components/__tests__/TaskTable-test.js
@@ -45,6 +45,17 @@ describe('TaskTable', function () {
 
   });
 
+  describe('#getDisabledItemsMap', function () {
+    beforeEach(function () {
+      this.taskTable = new TaskTable();
+    });
+
+    it('returns a map of disabled items', function () {
+      var tasks = [{id: '1', scheduler: 'marathon'}, {id: '2'}];
+      expect(this.taskTable.getDisabledItemsMap(tasks)).toEqual({'2': true});
+    });
+  });
+
   describe('#getTaskHealth', function () {
 
     beforeEach(function () {

--- a/src/js/events/MesosStateActions.js
+++ b/src/js/events/MesosStateActions.js
@@ -3,6 +3,7 @@ import {RequestUtil} from 'mesosphere-shared-reactjs';
 import ActionTypes from '../constants/ActionTypes';
 import AppDispatcher from './AppDispatcher';
 import Config from '../config/Config';
+import MesosStateUtil from '../utils/MesosStateUtil';
 
 var MesosStateActions = {
 
@@ -15,7 +16,7 @@ var MesosStateActions = {
           success(response) {
             AppDispatcher.handleServerAction({
               type: ActionTypes.REQUEST_MESOS_STATE_SUCCESS,
-              data: response
+              data: MesosStateUtil.assignSchedulerNameToTasks(response)
             });
             resolve();
           },

--- a/src/js/events/MesosStateActions.js
+++ b/src/js/events/MesosStateActions.js
@@ -16,7 +16,7 @@ var MesosStateActions = {
           success(response) {
             AppDispatcher.handleServerAction({
               type: ActionTypes.REQUEST_MESOS_STATE_SUCCESS,
-              data: MesosStateUtil.assignSchedulerNameToTasks(response)
+              data: MesosStateUtil.flagMarathonTasks(response)
             });
             resolve();
           },

--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -2,29 +2,24 @@ import Util from './Util';
 
 const RESOURCE_KEYS = ['cpus', 'disk', 'mem'];
 
-function setSchedulerName(name, tasks) {
+function setIsStartedByMarathonFlag(name, tasks) {
   return tasks.map(function (task) {
-    let newTask = Object.assign({}, task);
-
-    newTask.scheduler = name;
-
-    return newTask;
+    return Object.assign({isStartedByMarathon: name === 'marathon'}, task);
   });
 }
 
 const MesosStateUtil = {
 
-  assignSchedulerNameToTasks(state) {
+  flagMarathonTasks(state) {
     let newState = Object.assign({}, state);
 
     newState.frameworks = state.frameworks.map(function (framework) {
-      let newFramework = Object.assign({}, framework);
       let {tasks = [], completed_tasks = [], name} = framework;
 
-      newFramework.tasks = setSchedulerName(name, tasks);
-      newFramework.completed_tasks = setSchedulerName(name, completed_tasks);
-
-      return newFramework;
+      return Object.assign({}, framework, {
+        tasks: setIsStartedByMarathonFlag(name, tasks),
+        completed_tasks: setIsStartedByMarathonFlag(name, completed_tasks)
+      });
     });
 
     return newState;

--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -2,7 +2,33 @@ import Util from './Util';
 
 const RESOURCE_KEYS = ['cpus', 'disk', 'mem'];
 
+function setSchedulerName(name, tasks) {
+  return tasks.map(function (task) {
+    let newTask = Object.assign({}, task);
+
+    newTask.scheduler = name;
+
+    return newTask;
+  });
+}
+
 const MesosStateUtil = {
+
+  assignSchedulerNameToTasks(state) {
+    let newState = Object.assign({}, state);
+
+    newState.frameworks = state.frameworks.map(function (framework) {
+      let newFramework = Object.assign({}, framework);
+      let {tasks = [], completed_tasks = [], name} = framework;
+
+      newFramework.tasks = setSchedulerName(name, tasks);
+      newFramework.completed_tasks = setSchedulerName(name, completed_tasks);
+
+      return newFramework;
+    });
+
+    return newState;
+  },
 
   /**
    * @param  {Object} state A document of mesos state

--- a/src/js/utils/__tests__/MesosStateUtil-test.js
+++ b/src/js/utils/__tests__/MesosStateUtil-test.js
@@ -10,7 +10,7 @@ describe('MesosStateUtil', function () {
             name: 'marathon',
             tasks: [
               {name: 'spark', id: 'spark.1'},
-              {name: 'alpha', id: 'alpha.1'},
+              {name: 'alpha', id: 'alpha.1'}
             ],
             completed_tasks: [
               {name: 'alpha', id: 'alpha.2'}

--- a/src/js/utils/__tests__/MesosStateUtil-test.js
+++ b/src/js/utils/__tests__/MesosStateUtil-test.js
@@ -2,6 +2,57 @@ const MesosStateUtil = require('../MesosStateUtil');
 
 describe('MesosStateUtil', function () {
 
+  describe('#assignSchedulerNameToTasks', function () {
+    it('should assign a scheduler name to all tasks', function () {
+      const state = {
+        frameworks: [
+          {
+            name: 'marathon',
+            tasks: [
+              {name: 'spark', id: 'spark.1'},
+              {name: 'alpha', id: 'alpha.1'},
+            ],
+            completed_tasks: [
+              {name: 'alpha', id: 'alpha.2'}
+            ]
+          },
+          {
+            name: 'spark',
+            tasks: [
+              {name: '1'}
+            ],
+            completed_tasks: [
+              {name: '2'}
+            ]
+          }
+        ]
+      };
+
+      expect(MesosStateUtil.assignSchedulerNameToTasks(state)).toEqual({frameworks: [
+        {
+          name: 'marathon',
+          tasks: [
+            {name: 'spark', id: 'spark.1', scheduler: 'marathon'},
+            {name: 'alpha', id: 'alpha.1', scheduler: 'marathon'}
+          ],
+          completed_tasks: [
+            {name: 'alpha', id: 'alpha.2', scheduler: 'marathon'}
+          ]
+        },
+        {
+          name: 'spark',
+          tasks: [
+            {name: '1', scheduler: 'spark'}
+          ],
+          completed_tasks: [
+            {name: '2', scheduler: 'spark'}
+          ]
+        }
+      ]});
+    });
+
+  });
+
   describe('#getTasksFromVirtualNetworkName', function () {
 
     beforeEach(function () {

--- a/src/js/utils/__tests__/MesosStateUtil-test.js
+++ b/src/js/utils/__tests__/MesosStateUtil-test.js
@@ -3,7 +3,7 @@ const MesosStateUtil = require('../MesosStateUtil');
 describe('MesosStateUtil', function () {
 
   describe('#assignSchedulerNameToTasks', function () {
-    it('should assign a scheduler name to all tasks', function () {
+    it('should assign a isStartedByMarathon flag to all tasks', function () {
       const state = {
         frameworks: [
           {
@@ -28,24 +28,24 @@ describe('MesosStateUtil', function () {
         ]
       };
 
-      expect(MesosStateUtil.assignSchedulerNameToTasks(state)).toEqual({frameworks: [
+      expect(MesosStateUtil.flagMarathonTasks(state)).toEqual({frameworks: [
         {
           name: 'marathon',
           tasks: [
-            {name: 'spark', id: 'spark.1', scheduler: 'marathon'},
-            {name: 'alpha', id: 'alpha.1', scheduler: 'marathon'}
+            {name: 'spark', id: 'spark.1', isStartedByMarathon: true},
+            {name: 'alpha', id: 'alpha.1', isStartedByMarathon: true}
           ],
           completed_tasks: [
-            {name: 'alpha', id: 'alpha.2', scheduler: 'marathon'}
+            {name: 'alpha', id: 'alpha.2', isStartedByMarathon: true}
           ]
         },
         {
           name: 'spark',
           tasks: [
-            {name: '1', scheduler: 'spark'}
+            {name: '1', isStartedByMarathon: false}
           ],
           completed_tasks: [
-            {name: '2', scheduler: 'spark'}
+            {name: '2', isStartedByMarathon: false}
           ]
         }
       ]});


### PR DESCRIPTION
In this PR I implemented the after merge comments from @mlunoe https://github.com/dcos/dcos-ui/pull/1021 regarding the place of the scheduler name assigning logic. So the logic has been moved to the `MesosStateActions` as a central place, where the data comes in into the app, therefore the data will be consistent across the whole app.

Works on the Services page and on the Nodes page as pointed out by @rcorral in https://github.com/dcos/dcos-ui/pull/1066

I also moved the CheckboxTable fix as well.

![screen shot 2016-09-16 at 13 16 38](https://cloud.githubusercontent.com/assets/186223/18584273/eb773116-7c0f-11e6-8433-f5db3a0ba822.png)

![screen shot 2016-09-16 at 13 15 46](https://cloud.githubusercontent.com/assets/186223/18584282/f323c410-7c0f-11e6-88e9-5b2bc040565f.png)
