### PR TITLE
Move eslint to dev webpack build

### DIFF
--- a/webpack/webpack.config.babel.js
+++ b/webpack/webpack.config.babel.js
@@ -71,12 +71,6 @@ let svgSpriter = new SVGSprite({
   }
 });
 
-let eslintExclusion = /node_modules/;
-
-if (process.env.REACTJS_COMPONENTS_LOCAL) {
-  eslintExclusion = /node_modules|reactjs-components/;
-}
-
 module.exports = {
   lessLoader: {
     lessPlugins: [
@@ -134,11 +128,6 @@ module.exports = {
             }
           ]
         })
-      },
-      {
-        test: /\.js$/,
-        loader: 'eslint-loader',
-        exclude: eslintExclusion
       },
       {
         test: /\.js$/,

--- a/webpack/webpack.dev.babel.js
+++ b/webpack/webpack.dev.babel.js
@@ -34,6 +34,12 @@ let entry = [
   './src/js/index.js'
 ];
 
+let eslintExclusion = /node_modules/;
+
+if (process.env.REACTJS_COMPONENTS_LOCAL) {
+  eslintExclusion = /node_modules|reactjs-components/;
+}
+
 if (environment === 'development') {
   entry.push('webpack/hot/only-dev-server');
   devtool = '#inline-eval-cheap-source-map';
@@ -56,6 +62,12 @@ if (process.env.REACTJS_COMPONENTS_LOCAL) {
   reactHotLoader = '';
 }
 
+let preLoaders = webpackConfig.module.preLoaders.concat([{
+    test: /\.js$/,
+    loader: 'eslint-loader',
+    exclude: eslintExclusion
+  }]);
+
 module.exports = Object.assign({}, webpackConfig, {
   entry,
   devtool,
@@ -76,7 +88,7 @@ module.exports = Object.assign({}, webpackConfig, {
     new WebpackNotifierPlugin({alwaysNotify: true})
   ],
   module: {
-    preLoaders: webpackConfig.module.preLoaders,
+    preLoaders,
     loaders: webpackConfig.module.loaders.concat([
       {
         test: /\.js$/,


### PR DESCRIPTION
This PR moves the webpack `eslint` loader to `webpack.dev.babel`. In production, `eslint` is run before the assets are compiled via a separate npm script.

@mlunoe and I paired on this.