### PR TITLE
[Pods][Testing] Normalising capitalisation of 'status' property

### DIFF
--- a/src/js/structs/Pod.js
+++ b/src/js/structs/Pod.js
@@ -47,7 +47,7 @@ module.exports = class Pod extends Service {
    * @override
    */
   getHealth() {
-    switch (this.get('status')) {
+    switch (this.getStatusString()) {
       // DEGRADED - The number of STABLE pod instances is less than the number
       // of desired instances.
       case 'DEGRADED':
@@ -136,6 +136,10 @@ module.exports = class Pod extends Service {
    */
   getSpec() {
     return this._spec;
+  }
+
+  getStatusString() {
+    return (this.get('status') || '').toUpperCase();
   }
 
   /**

--- a/src/js/structs/PodContainer.js
+++ b/src/js/structs/PodContainer.js
@@ -4,7 +4,7 @@ import StringUtil from '../utils/StringUtil';
 
 module.exports = class PodContainer extends Item {
   getContainerStatus() {
-    switch (this.get('status')) {
+    switch (this.getStatusString()) {
       case 'RUNNING':
         if (this.hasHealthChecks()) {
           if (this.isHealthy()) {
@@ -30,7 +30,7 @@ module.exports = class PodContainer extends Item {
 
       default:
         return Object.assign(Object.create(PodContainerStatus.NA), {
-          displayName: StringUtil.capitalize(this.get('status').toLowerCase())
+          displayName: StringUtil.capitalize(this.getStatusString().toLowerCase())
         });
     }
   }
@@ -53,6 +53,10 @@ module.exports = class PodContainer extends Item {
 
   getName() {
     return this.get('name') || '';
+  }
+
+  getStatusString() {
+    return (this.get('status') || '').toUpperCase();
   }
 
   hasHealthChecks() {

--- a/src/js/structs/PodInstance.js
+++ b/src/js/structs/PodInstance.js
@@ -24,7 +24,7 @@ module.exports = class PodInstance extends Item {
   }
 
   getInstanceStatus() {
-    switch (this.get('status')) {
+    switch (this.getStatusString()) {
       case 'PENDING':
         return PodInstanceStatus.STAGED;
 
@@ -50,7 +50,7 @@ module.exports = class PodInstance extends Item {
 
       default:
         return Object.assign(Object.create(PodInstanceStatus.NA), {
-          displayName: StringUtil.capitalize(this.get('status').toLowerCase())
+          displayName: StringUtil.capitalize(this.getStatusString().toLowerCase())
         });
     }
   }
@@ -61,6 +61,10 @@ module.exports = class PodInstance extends Item {
 
   getLastUpdated() {
     return new Date(this.get('lastUpdated'));
+  }
+
+  getStatusString() {
+    return (this.get('status') || '').toUpperCase();
   }
 
   hasHealthChecks() {
@@ -84,7 +88,7 @@ module.exports = class PodInstance extends Item {
   }
 
   isHealthy() {
-    if (this.get('status') !== 'STABLE') {
+    if (this.getStatusString() !== 'STABLE') {
       return false;
     }
     return this.getContainers().every(function (container) {
@@ -93,16 +97,16 @@ module.exports = class PodInstance extends Item {
   }
 
   isRunning() {
-    let status = this.get('status');
+    let status = this.getStatusString();
     return (status === 'STABLE') || (status === 'DEGRADED');
   }
 
   isStaging() {
-    let status = this.get('status');
+    let status = this.getStatusString();
     return (status === 'PENDING') || (status === 'STAGING');
   }
 
   isTerminating() {
-    return this.get('status') === 'TERMINAL';
+    return this.getStatusString() === 'TERMINAL';
   }
 };

--- a/src/js/structs/__tests__/Pod-test.js
+++ b/src/js/structs/__tests__/Pod-test.js
@@ -115,6 +115,21 @@ describe('Pod', function () {
 
   });
 
+  describe('#getStatusString', function () {
+
+    it('should return the normalized status string', function () {
+      let pod = new Pod({ status: 'rUnNiNG' });
+
+      expect(pod.getStatusString()).toEqual('RUNNING');
+    });
+
+    it('should return the correct default value', function () {
+      let pod = new Pod();
+      expect(pod.getStatusString()).toEqual('');
+    });
+
+  });
+
   describe('#getServiceStatus', function () {
 
     it('should properly detect SUSPENDED', function () {

--- a/src/js/structs/__tests__/PodContainer-test.js
+++ b/src/js/structs/__tests__/PodContainer-test.js
@@ -201,6 +201,21 @@ describe('PodContainer', function () {
 
   });
 
+  describe('#getStatusString', function () {
+
+    it('should return the normalized status string', function () {
+      let podContainer = new PodContainer({ status: 'rUnNiNG' });
+
+      expect(podContainer.getStatusString()).toEqual('RUNNING');
+    });
+
+    it('should return the correct default value', function () {
+      let podContainer = new PodContainer();
+      expect(podContainer.getStatusString()).toEqual('');
+    });
+
+  });
+
   describe('#hasHealthChecks', function () {
 
     it('should return false if no health checks defined', function () {

--- a/src/js/structs/__tests__/PodInstance-test.js
+++ b/src/js/structs/__tests__/PodInstance-test.js
@@ -63,6 +63,21 @@ describe('PodInstance', function () {
 
   });
 
+  describe('#getStatusString', function () {
+
+    it('should return the normalized status string', function () {
+      let podInstance = new PodInstance({ status: 'sTaBlE' });
+
+      expect(podInstance.getStatusString()).toEqual('STABLE');
+    });
+
+    it('should return the correct default value', function () {
+      let podInstance = new PodInstance();
+      expect(podInstance.getStatusString()).toEqual('');
+    });
+
+  });
+
   describe('#getInstanceStatus', function () {
 
     it('should correctly detect container in PENDING state', function () {


### PR DESCRIPTION
In the spec, status string was supposed to be capitalised (https://github.com/mesosphere/marathon/blob/feature/pods/docs/docs/rest-api/public/api/v2/types/podStatus.raml#L100), but on the API it looks like it's not:

![image](https://cloud.githubusercontent.com/assets/883486/18670880/2c6b6770-7f42-11e6-9e50-9ca068c54d75.png)

So, as a precaution I am normalising the status everywhere.