### PR TITLE
[Pods] Extract MarathonConfigUtil from ConfigurationView

### DIFF
--- a/src/js/components/ConfigurationView.js
+++ b/src/js/components/ConfigurationView.js
@@ -7,7 +7,7 @@ import DescriptionList from './DescriptionList';
 import Loader from './Loader';
 import Service from '../structs/Service';
 import StringUtil from '../utils/StringUtil';
-import MarathonConfigUtil from '../utils/MarathonConfigUtil';
+import ServiceConfigUtil from '../utils/ServiceConfigUtil';
 
 const sectionClassName = 'container-fluid container-pod container-pod-super-short flush flush-bottom';
 
@@ -99,7 +99,7 @@ class ConfigurationView extends mixin(StoreMixin) {
       return null;
     }
 
-    let portConfigurations = MarathonConfigUtil.getPortDefinitionGroups(
+    let portConfigurations = ServiceConfigUtil.getPortDefinitionGroups(
         id, portDefinitions, function (content, linkTo) {
           return <a href={linkTo} target="_blank">{content}</a>;
         }

--- a/src/js/utils/MarathonConfigUtil.js
+++ b/src/js/utils/MarathonConfigUtil.js
@@ -1,0 +1,73 @@
+import HostUtil from '../utils/HostUtil';
+import Networking from '../constants/Networking';
+
+const serviceAddressKey = 'Service Address';
+
+function buildHostName(id, port) {
+  let hostname = HostUtil.stringToHostname(id);
+  return `${hostname}${Networking.L4LB_ADDRESS}:${port}`;
+}
+
+function defaultCreateLink(contents) {
+  return contents;
+}
+
+var MarathonConfigUtil = {
+
+  getCommandString(container) {
+
+    // Pre-pods approach
+    if (container.cmd) {
+      return container.cmd;
+    }
+
+    // Pods approach
+    // https://github.com/mesosphere/marathon/blob/feature/pods/docs/docs/rest-api/public/api/v2/types/podContainer.raml#L61
+    if (container.exec && container.exec.command) {
+      let {command} = container.exec;
+      if (command.shell) {
+        return command.shell;
+      }
+      if (command.argv) {
+        return command.argv.join(' ');
+      }
+    }
+
+    return null;
+  },
+
+  getPortDefinitionGroups(id, portDefinitions, createLink = defaultCreateLink) {
+    return portDefinitions.map(function (portDefinition, index) {
+      let headline = `Port Definition ${index + 1}`;
+
+      if (portDefinition.name) {
+        headline += ` (${portDefinition.name})`;
+      }
+
+      let headerValueMapping = Object.assign(
+        {[serviceAddressKey]: null},
+        portDefinition
+      );
+
+      // Check if this port is load balanced
+      let hasVIPLabel = portDefinition.labels &&
+        Object.keys(portDefinition.labels).find(function (key) {
+          return /^VIP_[0-9]+$/.test(key);
+        });
+      if (hasVIPLabel) {
+        let link = buildHostName(id, portDefinition.port);
+        headerValueMapping[serviceAddressKey] = createLink(link, link);
+      } else {
+        delete headerValueMapping[serviceAddressKey];
+      }
+
+      return {
+        hash: headerValueMapping,
+        headline
+      };
+    });
+  }
+
+};
+
+module.exports = MarathonConfigUtil;

--- a/src/js/utils/ServiceConfigUtil.js
+++ b/src/js/utils/ServiceConfigUtil.js
@@ -12,7 +12,7 @@ function defaultCreateLink(contents) {
   return contents;
 }
 
-var MarathonConfigUtil = {
+var ServiceConfigUtil = {
 
   getCommandString(container) {
 
@@ -70,4 +70,4 @@ var MarathonConfigUtil = {
 
 };
 
-module.exports = MarathonConfigUtil;
+module.exports = ServiceConfigUtil;

--- a/src/js/utils/ServiceConfigUtil.js
+++ b/src/js/utils/ServiceConfigUtil.js
@@ -28,14 +28,14 @@ var ServiceConfigUtil = {
 
     // Pods approach
     // https://github.com/mesosphere/marathon/blob/feature/pods/docs/docs/rest-api/public/api/v2/types/podContainer.raml#L61
-    if (container.exec && container.exec.command) {
-      let {command} = container.exec;
-      if (command.shell) {
-        return command.shell;
-      }
-      if (command.argv) {
-        return command.argv.join(' ');
-      }
+    let {shell, argv} =
+      Util.findNestedPropertyInObject(container, 'exec.command') || {};
+
+    if (shell) {
+      return shell;
+    }
+    if (Array.isArray(argv)) {
+      return argv.join(' ');
     }
 
     return null;

--- a/src/js/utils/ServiceConfigUtil.js
+++ b/src/js/utils/ServiceConfigUtil.js
@@ -20,9 +20,7 @@ function hasVIPLabel(portDefinition) {
 }
 
 var ServiceConfigUtil = {
-
   getCommandString(container) {
-
     // Pre-pods approach
     if (container.cmd) {
       return container.cmd;

--- a/src/js/utils/ServiceConfigUtil.js
+++ b/src/js/utils/ServiceConfigUtil.js
@@ -21,12 +21,12 @@ function hasVIPLabel(labels={}) {
 
 var ServiceConfigUtil = {
   getCommandString(container) {
-    // Pre-pods approach
+    // Generic Service
     if (container.cmd) {
       return container.cmd;
     }
 
-    // Pods approach
+    // Pod
     // https://github.com/mesosphere/marathon/blob/feature/pods/docs/docs/rest-api/public/api/v2/types/podContainer.raml#L61
     let {shell, argv} =
       Util.findNestedPropertyInObject(container, 'exec.command') || {};

--- a/src/js/utils/ServiceConfigUtil.js
+++ b/src/js/utils/ServiceConfigUtil.js
@@ -1,5 +1,6 @@
 import HostUtil from '../utils/HostUtil';
 import Networking from '../constants/Networking';
+import Util from '../utils/Util';
 
 const serviceAddressKey = 'Service Address';
 
@@ -12,11 +13,10 @@ function defaultCreateLink(contents) {
   return contents;
 }
 
-function hasVIPLabel(portDefinition) {
-  return portDefinition.labels &&
-    Object.keys(portDefinition.labels).find(function (key) {
-      return /^VIP_[0-9]+$/.test(key);
-    });
+function hasVIPLabel(labels={}) {
+  return Object.keys(labels).find(function (key) {
+    return /^VIP_[0-9]+$/.test(key);
+  });
 }
 
 var ServiceConfigUtil = {
@@ -51,7 +51,7 @@ var ServiceConfigUtil = {
       }
 
       // Check if this port is load balanced
-      if (hasVIPLabel(portDefinition)) {
+      if (hasVIPLabel(portDefinition.labels)) {
         let link = buildHostName(id, portDefinition.port);
         hash[serviceAddressKey] = createLink(link, link);
       }

--- a/src/js/utils/__tests__/ServiceConfigUtil-test.js
+++ b/src/js/utils/__tests__/ServiceConfigUtil-test.js
@@ -1,0 +1,50 @@
+jest.dontMock('../ServiceConfigUtil');
+
+const ServiceConfigUtil = require('../ServiceConfigUtil');
+
+describe('ServiceConfigUtil', function () {
+  describe('#getCommandString', function () {
+    describe('pre-pods approach', function () {
+      it('returns container command', function () {
+        const container = {
+          cmd: 'sleep 10'
+        };
+
+        expect(ServiceConfigUtil.getCommandString(container)).toEqual('sleep 10');
+      });
+    });
+
+    describe('pods approach', function () {
+      describe('shell command', function () {
+        it('returns container command', function () {
+          const container = {
+            exec: {
+              command: {
+                shell: 'sleep 10'
+              }
+            }
+          };
+          expect(ServiceConfigUtil.getCommandString(container)).toEqual('sleep 10');
+        });
+
+      });
+
+      describe('argv command', function () {
+        it('returns container command', function () {
+          const container = {
+            exec: {
+              command: {
+                argv: ['sleep', '10']
+              }
+            }
+          };
+          expect(ServiceConfigUtil.getCommandString(container)).toEqual('sleep 10');
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/src/js/utils/__tests__/ServiceConfigUtil-test.js
+++ b/src/js/utils/__tests__/ServiceConfigUtil-test.js
@@ -47,4 +47,64 @@ describe('ServiceConfigUtil', function () {
 
   });
 
+  describe('#getPortDefinitionGroups', function () {
+    describe('port definitions with no name', function () {
+      it('creates index-based headline', function () {
+        const portDefinitions = [{}];
+        const {headline} =
+          ServiceConfigUtil.getPortDefinitionGroups(1, portDefinitions)[0];
+
+        expect(headline).toEqual('Port Definition 1');
+      });
+
+    });
+
+    describe('named port definitions', function () {
+      it('adds the name to the headline', function () {
+        const portDefinitions = [{
+          name: 'portName'
+        }];
+        const {headline} =
+          ServiceConfigUtil.getPortDefinitionGroups('1234', portDefinitions)[0];
+
+        expect(headline).toEqual('Port Definition 1 (portName)');
+      });
+
+    });
+
+    describe('load-balanced ports', function () {
+      it('adds a service address to the definition', function () {
+        const portDefinitions = [{
+          port: 80,
+          labels: {
+            'VIP_0': '1.2.3.4:80'
+          }
+        }];
+        const {hash} =
+          ServiceConfigUtil.getPortDefinitionGroups('1234', portDefinitions)[0];
+
+        expect(hash['Service Address'])
+          .toEqual('1234.marathon.l4lb.thisdcos.directory:80');
+      });
+
+    });
+
+    describe('generic ports', function () {
+      it('doesn\'t add a service address to the definition', function () {
+        const portDefinitions = [{
+          port: 80,
+          labels: {
+            'SOME': 'LABEL'
+          }
+        }];
+        const {hash} =
+          ServiceConfigUtil.getPortDefinitionGroups('1234', portDefinitions)[0];
+
+        expect(hash['Service Address']).toBeUndefined();
+      });
+
+    });
+
+  });
+
 });


### PR DESCRIPTION
Extracting utility functions from ConfigurationView to MarathonConfigUtil. To slim down the component and improve code reusability. MarathonConfigUtil is going to be used in Pods configuration view as well. 

Refactoring has been done by @wavesoft had to split some commits in order to slice #1111 in smaller yet meaningful chunks.

Part of the ticket: https://mesosphere.atlassian.net/browse/DCOS-9823