### PR TITLE
Break unit health node detail component into stateless/stateful components

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react": "0.14.7",
     "react-ace": "3.4.1",
     "react-addons-css-transition-group": "0.14.7",
+    "react-addons-pure-render-mixin": "0.14.7",
     "react-addons-test-utils": "0.14.7",
     "react-dom": "0.14.7",
     "react-gemini-scrollbar": "2.1.0",

--- a/src/js/pages/system/UnitsHealthNodeDetail.js
+++ b/src/js/pages/system/UnitsHealthNodeDetail.js
@@ -4,13 +4,11 @@ import React from 'react';
 /* eslint-enable no-unused-vars */
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
-import Breadcrumbs from '../../components/Breadcrumbs';
-import {documentationURI} from '../../config/Config';
-import Icon from '../../components/Icon';
 import Loader from '../../components/Loader';
-import PageHeader from '../../components/PageHeader';
 import RequestErrorMsg from '../../components/RequestErrorMsg';
 import UnitHealthStore from '../../stores/UnitHealthStore';
+import UnitsHealthNodeDetailPanel from
+  './units-health-node-detail/UnitsHealthNodeDetailPanel';
 import UnitSummaries from '../../constants/UnitSummaries';
 
 class UnitsHealthNodeDetail extends mixin(StoreMixin) {
@@ -33,8 +31,7 @@ class UnitsHealthNodeDetail extends mixin(StoreMixin) {
   }
 
   componentDidMount() {
-    super.componentDidMount();
-
+    super.componentDidMount(...arguments);
     let {unitID, unitNodeID} = this.props.params;
 
     UnitHealthStore.fetchUnit(unitID);
@@ -57,23 +54,6 @@ class UnitsHealthNodeDetail extends mixin(StoreMixin) {
     this.setState({hasError: true});
   }
 
-  getSubTitle(unit, node) {
-    let healthStatus = node.getHealth();
-
-    return (
-      <ul className="list-inline flush-bottom">
-        <li>
-          <span className={healthStatus.classNames}>
-            {healthStatus.title}
-          </span>
-        </li>
-        <li>
-          {node.get('host_ip')}
-        </li>
-      </ul>
-    );
-  }
-
   getErrorNotice() {
     return (
       <div className="container container-pod">
@@ -86,34 +66,6 @@ class UnitsHealthNodeDetail extends mixin(StoreMixin) {
     return (
       <div className="container container-fluid container-pod">
         <Loader className="inverse" />
-      </div>
-    );
-  }
-
-  getNodeInfo(node, unit) {
-    let unitSummary = UnitSummaries[unit.get('id')] || {};
-    let unitDocsURL = unitSummary.getDocumentationURI &&
-      unitSummary.getDocumentationURI();
-
-    if (!unitDocsURL) {
-      unitDocsURL = documentationURI;
-    }
-
-    return (
-      <div className="flex-container-col flex-grow">
-        <span className="h4 inverse flush-top">Summary</span>
-        <p className="inverse">
-          {unitSummary.summary}
-        </p>
-        <p className="inverse">
-          <a href={unitDocsURL} target="_blank">
-            View Documentation
-          </a>
-        </p>
-        <span className="h4 inverse">Output</span>
-        <pre className="flex-grow flush-bottom">
-          {node.getOutput()}
-        </pre>
       </div>
     );
   }
@@ -133,19 +85,23 @@ class UnitsHealthNodeDetail extends mixin(StoreMixin) {
     let node = UnitHealthStore.getNode(unitNodeID);
     let unit = UnitHealthStore.getUnit(unitID);
 
+    let healthStatus = node.getHealth();
+
+    let unitSummary = UnitSummaries[unit.get('id')] || {};
+    let unitDocsURL = unitSummary.getDocumentationURI &&
+        unitSummary.getDocumentationURI();
+
     return (
-      <div className="flex-container-col">
-        <Breadcrumbs />
-        <PageHeader
-          icon={<Icon color="white" id="heart-pulse" size="large" />}
-          subTitle={this.getSubTitle(unit, node)}
-          title={`${unit.getTitle()} Health Check`} />
-        <div className="flex-container-col flex-grow no-overflow">
-          {this.getNodeInfo(node, unit)}
-        </div>
-      </div>
+      <UnitsHealthNodeDetailPanel
+        docsURL={unitDocsURL}
+        healthStatus={healthStatus.title}
+        healthStatusClassNames={healthStatus.classNames}
+        hostIP={node.get('host_ip')}
+        pageHeaderTitle={`${unit.getTitle()} Health Check`}
+        output={node.getOutput()}
+        summary={unitSummary.summary} />
     );
   }
-};
-
+}
 module.exports = UnitsHealthNodeDetail;
+

--- a/src/js/pages/system/units-health-node-detail/NodeInfoPanel.js
+++ b/src/js/pages/system/units-health-node-detail/NodeInfoPanel.js
@@ -1,0 +1,47 @@
+import PureRenderMixin from 'react-addons-pure-render-mixin';
+import React from 'react';
+
+import {documentationURI} from '../../../config/Config';
+
+class NodeInfoPanel extends React.Component {
+
+  constructor() {
+    super(...arguments);
+    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate;
+  }
+
+  render() {
+    const {summary, docsURL, output} = this.props;
+
+    return (
+      <div className="flex-container-col flex-grow">
+        <span className="h4 inverse flush-top">Summary</span>
+        <p className="inverse">
+          {summary}
+        </p>
+        <p className="inverse">
+          <a href={docsURL} target="_blank">
+            View Documentation
+          </a>
+        </p>
+        <span className="h4 inverse">Output</span>
+        <pre className="flex-grow flush-bottom">
+          {output}
+        </pre>
+      </div>
+    );
+  }
+
+}
+
+NodeInfoPanel.propTypes = {
+  docsURL: React.PropTypes.string,
+  output: React.PropTypes.string,
+  summary: React.PropTypes.string
+};
+
+NodeInfoPanel.defaultProps = {
+  docsURL: documentationURI
+};
+
+module.exports = NodeInfoPanel;

--- a/src/js/pages/system/units-health-node-detail/UnitsHealthNodeDetailPanel.js
+++ b/src/js/pages/system/units-health-node-detail/UnitsHealthNodeDetailPanel.js
@@ -1,0 +1,64 @@
+import PureRenderMixin from 'react-addons-pure-render-mixin';
+import React from 'react';
+
+import Breadcrumbs from '../../../components/Breadcrumbs';
+import Icon from '../../../components/Icon';
+import NodeInfoPanel from './NodeInfoPanel';
+import PageHeader from '../../../components/PageHeader';
+
+class UnitsHealthNodeDetailPanel extends React.Component {
+
+  constructor() {
+    super(...arguments);
+    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate;
+  }
+
+  renderSubTitle() {
+    const {healthStatus, healthStatusClassNames, hostIP} = this.props;
+
+    return (
+      <ul className="list-inline flush-bottom">
+        <li>
+          <span className={healthStatusClassNames}>
+            {healthStatus}
+          </span>
+        </li>
+        <li>
+          {hostIP}
+        </li>
+      </ul>
+    );
+  }
+
+  render() {
+    const {pageHeaderTitle, summary, docsURL, output} = this.props;
+
+    return (
+      <div className="flex-container-col">
+        <Breadcrumbs />
+        <PageHeader
+          icon={<Icon color="white" id="heart-pulse" size="large" />}
+          subTitle={this.renderSubTitle()}
+          title={pageHeaderTitle} />
+        <div className="flex-container-col flex-grow no-overflow">
+          <NodeInfoPanel
+            docsURL={docsURL}
+            output={output}
+            summary={summary} />
+        </div>
+      </div>
+    );
+  }
+
+};
+UnitsHealthNodeDetailPanel.propTypes = {
+  docsURL: React.PropTypes.string,
+  healthStatus: React.PropTypes.string,
+  healthStatusClassNames: React.PropTypes.string,
+  hostIP: React.PropTypes.string,
+  pageHeaderTitle: React.PropTypes.string,
+  output: React.PropTypes.string,
+  summary: React.PropTypes.string
+};
+
+module.exports = UnitsHealthNodeDetailPanel;


### PR DESCRIPTION
⚠️  this PR depends on ~~#1116~~ for routing. 

This is part of the wider nodes modularity/refactoring story. 

This component is used by two routes, `components/:unitID/nodes/:unitNodeID/` and `nodes/:nodeID/health/:unitNodeID/:unitID`. It is current nested in `/system`. 

I'd especially welcome suggestions on improving the directory structure and the naming pattern. 