### PR TITLE
[Nodes Page] Purify node detail view

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5762,6 +5762,11 @@
       "from": "react-addons-css-transition-group@0.14.7",
       "resolved": "https://registry.npmjs.org/react-addons-css-transition-group/-/react-addons-css-transition-group-0.14.7.tgz"
     },
+    "react-addons-pure-render-mixin": {
+      "version": "0.14.7",
+      "from": "react-addons-pure-render-mixin@0.14.7",
+      "resolved": "https://registry.npmjs.org/react-addons-pure-render-mixin/-/react-addons-pure-render-mixin-0.14.7.tgz"
+    },
     "react-addons-test-utils": {
       "version": "0.14.7",
       "from": "react-addons-test-utils@0.14.7",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react": "0.14.7",
     "react-ace": "3.4.1",
     "react-addons-css-transition-group": "0.14.7",
+    "react-addons-pure-render-mixin": "0.14.7",
     "react-addons-test-utils": "0.14.7",
     "react-dom": "0.14.7",
     "react-gemini-scrollbar": "2.1.0",

--- a/src/js/components/DescriptionList.js
+++ b/src/js/components/DescriptionList.js
@@ -1,6 +1,12 @@
+import PureRenderMixin from 'react-addons-pure-render-mixin';
 import React from 'react';
 
 class DescriptionList extends React.Component {
+  constructor() {
+    super(...arguments);
+    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate;
+  }
+
   getHeadline() {
     let {headline, headlineClassName} = this.props;
     if (!headline) {

--- a/src/js/pages/nodes/NodeDetailTab.js
+++ b/src/js/pages/nodes/NodeDetailTab.js
@@ -1,3 +1,4 @@
+import PureRenderMixin from 'react-addons-pure-render-mixin';
 import React from 'react';
 
 import DateUtil from '../../utils/DateUtil';
@@ -7,6 +8,11 @@ import Node from '../../structs/Node';
 import StringUtil from '../../utils/StringUtil';
 
 class NodeDetailTab extends React.Component {
+  constructor() {
+    super(...arguments);
+    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate;
+  }
+
   render() {
     let {node} = this.props;
 


### PR DESCRIPTION
This PR is simply adds the pure render mixin to the NodeDetailTab and its only child, DescriptionList. 