### PR TITLE
[Pods][Testing] Adding embed=group.pods

### DIFF
--- a/src/js/events/MarathonActions.js
+++ b/src/js/events/MarathonActions.js
@@ -280,6 +280,7 @@ var MarathonActions = {
           const embed = [
             {name: 'embed', value: 'group.groups'},
             {name: 'embed', value: 'group.apps'},
+            {name: 'embed', value: 'group.pods'},
             {name: 'embed', value: 'group.apps.deployments'},
             {name: 'embed', value: 'group.apps.counts'},
             {name: 'embed', value: 'group.apps.tasks'},


### PR DESCRIPTION
Adding `embed=group.pods` on the `MarathonActions` in order to fetch pod-related details.