### PR TITLE
DCOS-9906: Disallow completed task selection

### DIFF
--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -242,7 +242,8 @@ class TaskTable extends React.Component {
   getDisabledItemsMap(tasks) {
     return tasks
       .filter(function (task) {
-        return !task.isStartedByMarathon;
+        return TaskStates[task.state].stateTypes.includes('completed')
+          || !task.isStartedByMarathon;
       })
       .reduce(function (acc, task) {
         acc[task.id] = true;

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -4,13 +4,13 @@ import React from 'react';
 
 import CheckboxTable from './CheckboxTable';
 import CompositeState from '../structs/CompositeState';
-import Icon from './Icon';
 import DCOSStore from '../stores/DCOSStore';
+import Icon from './Icon';
 import ResourceTableUtil from '../utils/ResourceTableUtil';
+import TableUtil from '../utils/TableUtil';
 import TaskStates from '../constants/TaskStates';
 import TaskTableHeaderLabels from '../constants/TaskTableHeaderLabels';
 import TaskUtil from '../utils/TaskUtil';
-import TableUtil from '../utils/TableUtil';
 import Units from '../utils/Units';
 
 const METHODS_TO_BIND = [

--- a/src/js/components/__tests__/TaskTable-test.js
+++ b/src/js/components/__tests__/TaskTable-test.js
@@ -50,10 +50,22 @@ describe('TaskTable', function () {
       this.taskTable = new TaskTable();
     });
 
-    it('returns a map of disabled items', function () {
-      var tasks = [{id: '1', isStartedByMarathon: true}, {id: '2'}];
+    it('treats tasks started not by Marathon as disabled', function () {
+      var tasks = [
+        {id: '1', state: 'TASK_STARTING', isStartedByMarathon: true},
+        {id: '2', state: 'TASK_STARTING'}
+      ];
       expect(this.taskTable.getDisabledItemsMap(tasks)).toEqual({'2': true});
     });
+
+    it('it treats completed tasks as disabled', function () {
+      var tasks = [
+        {id: '1', state: 'TASK_STARTING', isStartedByMarathon: true},
+        {id: '2', state: 'TASK_FINISHED', isStartedByMarathon: true}
+      ];
+      expect(this.taskTable.getDisabledItemsMap(tasks)).toEqual({'2': true});
+    });
+
   });
 
   describe('#getTaskHealth', function () {


### PR DESCRIPTION
This PR restricts selection of a completed task in the TasksTable and you can’t kill a task if you can’t select it :)

Ticket: https://mesosphere.atlassian.net/browse/DCOS-9906

<img width="790" alt="screen shot 2016-09-22 at 15 45 14" src="https://cloud.githubusercontent.com/assets/186223/18750485/927f0a0e-80db-11e6-8ec0-b312e7f78fd1.png">
