### PR TITLE
DCOS-9883 (1.8): Fix service form port handling

### DIFF
--- a/src/js/schemas/service-schema/Networking.js
+++ b/src/js/schemas/service-schema/Networking.js
@@ -79,6 +79,8 @@ const Networking = {
           return {
             lbPort: portMapping.port || portMapping.containerPort,
             name: portMapping.name,
+            hostPort: portMapping.hostPort,
+            servicePort: portMapping.servicePort,
             protocol: portMapping.protocol,
             loadBalanced: portMapping.labels &&
               Object.keys(portMapping.labels).length > 0,
@@ -157,19 +159,30 @@ const Networking = {
 
               return false;
             },
-            formElementClass: {'column-3': false}
+            formElementClass: {'column-2': false}
           },
           name: {
             title: 'Name',
             type: 'string',
-            formElementClass: {'column-3': true}
+            formElementClass: {'column-2': false, 'column-3': true}
           },
           protocol: {
             title: 'Protocol',
             type: 'string',
             fieldType: 'select',
             default: 'tcp',
-            options: ['tcp', 'udp', 'udp,tcp']
+            options: ['tcp', 'udp', 'udp,tcp'],
+            formElementClass: {'column-2': false, 'column-3': true}
+          },
+          hostPort: {
+            title: 'Host Port',
+            type: 'number',
+            formElementClass: {'hidden': true}
+          },
+          servicePort: {
+            title: 'Service Port',
+            type: 'number',
+            formElementClass: {'hidden': true}
           },
           loadBalanced: {
             label: 'Load Balanced',
@@ -177,7 +190,7 @@ const Networking = {
             title: 'Load Balanced',
             type: 'boolean',
             className: 'form-row-element-mixed-label-presence',
-            formElementClass: {'column-3': false}
+            formElementClass: {'column-2': false}
           }
         }
       }

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -350,6 +350,11 @@ const ServiceUtil = {
               let lbPort = parseInt(port.lbPort || 0, 10);
               portMapping.containerPort = lbPort;
 
+              if (networkType === 'bridge') {
+                portMapping.hostPort = port.hostPort;
+                portMapping.servicePort = port.servicePort;
+              }
+
               if (port.loadBalanced === true) {
 
                 if (networkType !== 'bridge') {

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -154,15 +154,17 @@ describe('ServiceUtil', function () {
 
       describe('host mode', function () {
 
-        it('should not add a portDefinitions field if no ports were passed in', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
-            networking: {
-              networkType: 'host',
-              ports: []
+        it('should not add a portDefinitions field if no ports were passed in',
+            function () {
+              let service = ServiceUtil.createServiceFromFormModel({
+                networking: {
+                  networkType: 'host',
+                  ports: []
+                }
+              });
+              expect(service.portDefinitions).not.toBeDefined();
             }
-          });
-          expect(service.portDefinitions).not.toBeDefined();
-        });
+        );
 
         it('should convert the supplied network fields', function () {
           let service = ServiceUtil.createServiceFromFormModel({
@@ -195,7 +197,8 @@ describe('ServiceUtil', function () {
               }
             });
             expect(service.portDefinitions[0].port).toEqual(1234);
-          });
+          }
+        );
 
         it('should default the port to 0 when loadBalanced is on', function () {
           let service = ServiceUtil.createServiceFromFormModel({
@@ -235,15 +238,15 @@ describe('ServiceUtil', function () {
         });
 
         it('should not add any port definitions if ports is empty',
-          function () {
-            let service = ServiceUtil.createServiceFromFormModel({
-              networking: {
-                networkType: 'host',
-                ports: [{}]
-              }
-            });
-            expect(service.portDefinitions).not.toBeDefined();
-          }
+            function () {
+              let service = ServiceUtil.createServiceFromFormModel({
+                networking: {
+                  networkType: 'host',
+                  ports: [{}]
+                }
+              });
+              expect(service.portDefinitions).not.toBeDefined();
+            }
         );
 
       });
@@ -263,9 +266,12 @@ describe('ServiceUtil', function () {
           expect(this.service.portDefinitions).toBeDefined();
         });
 
-        it('should not add a portMappings field to the docker definition', function () {
-          expect(this.service.container.docker.portMappings).not.toBeDefined();
-        });
+        it('should not add a portMappings field to the docker definition',
+            function () {
+              expect(this.service.container.docker.portMappings)
+                  .not.toBeDefined();
+            }
+        );
 
         it('sets the docker network property correctly', function () {
           expect(this.service.container.docker.network).toEqual('HOST');
@@ -285,19 +291,23 @@ describe('ServiceUtil', function () {
           });
         });
 
-        it('should not add a portMappings field if no ports were passed in', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
-            containerSettings: {image: 'redis'},
-            networking: {networkType: 'bridge'}
-          });
-          expect(Object.keys(service.container.docker))
-            .not.toContain('portMappings');
-        });
+        it('should not add a portMappings field if no ports were passed in',
+            function () {
+              let service = ServiceUtil.createServiceFromFormModel({
+                containerSettings: {image: 'redis'},
+                networking: {networkType: 'bridge'}
+              });
+              expect(Object.keys(service.container.docker))
+                  .not.toContain('portMappings');
+            }
+        );
 
-        it('should not add a portDefinitions field to the app config', function () {
-          expect(Object.keys(this.serviceEmptyPorts))
-            .not.toContain('portDefinitions');
-        });
+        it('should not add a portDefinitions field to the app config',
+            function () {
+              expect(Object.keys(this.serviceEmptyPorts))
+                  .not.toContain('portDefinitions');
+            }
+        );
 
         it('should convert the supplied string fields', function () {
           let service = ServiceUtil.createServiceFromFormModel({
@@ -413,17 +423,19 @@ describe('ServiceUtil', function () {
             .toEqual(1234);
         });
 
-        it('should not add a servicePort when loadBalanced is off', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
-            containerSettings: {image: 'redis'},
-            networking: {
-              networkType: 'user',
-              ports: [{lbPort: 1234}]
+        it('should not add a servicePort when loadBalanced is off',
+            function () {
+              let service = ServiceUtil.createServiceFromFormModel({
+                containerSettings: {image: 'redis'},
+                networking: {
+                  networkType: 'user',
+                  ports: [{lbPort: 1234}]
+                }
+              });
+              expect(Object.keys(service.container.docker.portMappings[0]))
+                  .not.toContain('servicePort');
             }
-          });
-          expect(Object.keys(service.container.docker.portMappings[0]))
-            .not.toContain('servicePort');
-        });
+        );
 
         it('should add a servicePort when loadBalanced is on', function () {
           let service = ServiceUtil.createServiceFromFormModel({
@@ -449,18 +461,20 @@ describe('ServiceUtil', function () {
             .not.toContain('labels');
         });
 
-        it('should add the appropriate VIP label when loadBalanced is on', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
-            containerSettings: {image: 'redis'},
-            general: {id: '/foo/bar'},
-            networking: {
-              networkType: 'user',
-              ports: [{lbPort: 1234, loadBalanced: true}]
+        it('should add the appropriate VIP label when loadBalanced is on',
+            function () {
+              let service = ServiceUtil.createServiceFromFormModel({
+                containerSettings: {image: 'redis'},
+                general: {id: '/foo/bar'},
+                networking: {
+                  networkType: 'user',
+                  ports: [{lbPort: 1234, loadBalanced: true}]
+                }
+              });
+              expect(service.container.docker.portMappings[0].labels)
+                  .toEqual({VIP_0: '/foo/bar:1234'});
             }
-          });
-          expect(service.container.docker.portMappings[0].labels)
-            .toEqual({VIP_0: '/foo/bar:1234'});
-        });
+        );
 
         it('should not add any port definitions if ports is emoty',
           function () {
@@ -647,8 +661,10 @@ describe('ServiceUtil', function () {
       });
 
       it('should convert parameters to an array of objects', function () {
-        expect(this.service.container.docker.parameters[0].key).toEqual('key-a');
-        expect(this.service.container.docker.parameters[0].value).toEqual('value-a');
+        expect(this.service.container.docker.parameters[0].key)
+            .toEqual('key-a');
+        expect(this.service.container.docker.parameters[0].value)
+            .toEqual('value-a');
       });
     });
   });

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -1,9 +1,11 @@
 jest.dontMock('../ServiceUtil');
 jest.dontMock('../../structs/Service');
+jest.dontMock('../../schemas/ServiceSchema');
 jest.dontMock('../../constants/VolumeConstants');
 
 const Service = require('../../structs/Service');
 const ServiceUtil = require('../ServiceUtil');
+const ServiceSchema = require('../../schemas/ServiceSchema');
 
 describe('ServiceUtil', function () {
   describe('#createServiceFromFormModel', function () {
@@ -334,16 +336,93 @@ describe('ServiceUtil', function () {
             .toEqual(1234);
         });
 
-        it('should not add a hostPort when loadBalanced is off', function () {
-          let service = ServiceUtil.createServiceFromFormModel({
-            containerSettings: {image: 'redis'},
+        it('should not remove host port', function () {
+          const definition = {
+            container: {
+              docker: {
+                image: 'docker/image',
+                portMappings: [
+                  {
+                    containerPort: 514,
+                    servicePort: 10000,
+                    hostPort: 5514
+                  }
+                ],
+                network: 'BRIDGE'
+              }
+            }
+          };
+
+          const model = {
+            containerSettings:{
+              forcePullImage: true,
+              image: 'docker/image',
+              parameters: null,
+              privileged: undefined
+            },
             networking: {
               networkType: 'bridge',
-              ports: [{lbPort: 1234}]
+              ports: [{
+                expose: true,
+                lbPort: 514,
+                hostPort: 5514,
+                loadBalanced: undefined,
+                name: undefined,
+                protocol: undefined
+              }]
             }
-          });
-          expect(Object.keys(service.container.docker.portMappings[0]))
-            .not.toContain('hostPort');
+          };
+
+          let service = ServiceUtil.createServiceFromFormModel(model,
+              ServiceSchema, false, definition);
+
+          expect(service.getContainer().docker.portMappings[0].hostPort)
+              .toEqual(5514);
+        });
+
+        it('should not remove service port', function () {
+          const definition = {
+            container: {
+              docker: {
+                image: 'docker/image',
+                portMappings: [
+                  {
+                    containerPort: 514,
+                    servicePort: 10000,
+                    hostPort: 5514
+                  }
+                ],
+                network: 'BRIDGE'
+              }
+            }
+          };
+
+          const model = {
+            containerSettings:{
+              forcePullImage: true,
+              image: 'docker/image',
+              parameters: null,
+              privileged: undefined
+            },
+            networking: {
+              networkType: 'bridge',
+              ports: [{
+                expose: true,
+                lbPort: 514,
+                hostPort: 5514,
+                servicePort: 10000,
+                loadBalanced: undefined,
+                name: undefined,
+                protocol: undefined
+              }]
+            }
+          };
+
+          let service = ServiceUtil.createServiceFromFormModel(model,
+              ServiceSchema, false, definition);
+
+          expect(service.getContainer().docker.portMappings[0].servicePort)
+              .toEqual(10000);
         });
 
         it('should add a VIP label when loadBalanced is on', function () {

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -234,7 +234,7 @@ describe('ServiceUtil', function () {
             .toEqual({VIP_1: '/foo/bar:4321'});
         });
 
-        it('should not add any port definitions if ports is emoty',
+        it('should not add any port definitions if ports is empty',
           function () {
             let service = ServiceUtil.createServiceFromFormModel({
               networking: {

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -437,6 +437,18 @@ describe('ServiceUtil', function () {
             }
         );
 
+        it('should not add a hostPort when loadBalanced is off', function () {
+          let service = ServiceUtil.createServiceFromFormModel({
+            containerSettings: {image: 'redis'},
+            networking: {
+              networkType: 'user',
+              ports: [{lbPort: 1234}]
+            }
+          });
+          expect(Object.keys(service.container.docker.portMappings[0]))
+              .not.toContain('hostPort');
+        });
+
         it('should add a servicePort when loadBalanced is on', function () {
           let service = ServiceUtil.createServiceFromFormModel({
             containerSettings: {image: 'redis'},


### PR DESCRIPTION
--- 
ℹ️ This fix is for 1.8 only as the respective components have changed drastically. Please see #1134 for the respective `master` fix.
⚠️ Don't merge this PR until the network team has verified that this behavior is correct!

---
![port-handling](https://cloud.githubusercontent.com/assets/647035/18796287/7cba071a-81c0-11e6-831b-2e04bc0a6631.gif)

Add a hidden host and service port field to the service network schema and adjusted the service util to keep the host and service port data from the JSON definition for bridged networks.

Fixes DCOS-9937