### PR TITLE
DCOS-9883 (master): Fix service form port handling

### DIFF
--- a/src/js/schemas/service-schema/Networking.js
+++ b/src/js/schemas/service-schema/Networking.js
@@ -79,6 +79,8 @@ const Networking = {
           return {
             lbPort: portMapping.port || portMapping.containerPort,
             name: portMapping.name,
+            hostPort: portMapping.hostPort,
+            servicePort: portMapping.servicePort,
             protocol: portMapping.protocol,
             loadBalanced: portMapping.labels &&
               Object.keys(portMapping.labels).length > 0,
@@ -157,19 +159,30 @@ const Networking = {
 
               return false;
             },
-            formElementClass: {'column-3': false}
+            formElementClass: {'column-2': false}
           },
           name: {
             title: 'Name',
             type: 'string',
-            formElementClass: {'column-3': true}
+            formElementClass: {'column-2': false, 'column-3': true}
           },
           protocol: {
             title: 'Protocol',
             type: 'string',
             fieldType: 'select',
             default: 'tcp',
-            options: ['tcp', 'udp', 'udp,tcp']
+            options: ['tcp', 'udp', 'udp,tcp'],
+            formElementClass: {'column-2': false, 'column-3': true}
+          },
+          hostPort: {
+            title: 'Host Port',
+            type: 'number',
+            formElementClass: {'hidden': true}
+          },
+          servicePort: {
+            title: 'Service Port',
+            type: 'number',
+            formElementClass: {'hidden': true}
           },
           loadBalanced: {
             label: 'Load Balanced',
@@ -177,7 +190,7 @@ const Networking = {
             title: 'Load Balanced',
             type: 'boolean',
             className: 'form-row-element-mixed-label-presence',
-            formElementClass: {'column-3': false}
+            formElementClass: {'column-2': false}
           }
         }
       }

--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -390,6 +390,11 @@ const ServiceUtil = {
               let lbPort = parseInt(port.lbPort || 0, 10);
               portMapping.containerPort = lbPort;
 
+              if (networkType === 'bridge') {
+                portMapping.hostPort = port.hostPort;
+                portMapping.servicePort = port.servicePort;
+              }
+
               if (port.loadBalanced === true) {
 
                 if (networkType !== 'bridge') {

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -200,15 +200,17 @@ describe('ServiceUtil', function () {
 
       describe('host mode', function () {
 
-        it('should not add a portDefinitions field if no ports were passed in', function () {
-          let service = ServiceUtil.createSpecFromFormModel({
-            networking: {
-              networkType: 'host',
-              ports: []
-            }
-          });
-          expect(service.portDefinitions).not.toBeDefined();
-        });
+        it('should not add a portDefinitions field if no ports were passed in',
+          function () {
+            let service = ServiceUtil.createSpecFromFormModel({
+              networking: {
+                networkType: 'host',
+                ports: []
+              }
+            });
+            expect(service.portDefinitions).not.toBeDefined();
+          }
+        );
 
         it('should convert the supplied network fields', function () {
           let service = ServiceUtil.createSpecFromFormModel({
@@ -241,7 +243,8 @@ describe('ServiceUtil', function () {
               }
             });
             expect(service.portDefinitions[0].port).toEqual(1234);
-          });
+          }
+        );
 
         it('should default the port to 0 when loadBalanced is on', function () {
           let service = ServiceUtil.createSpecFromFormModel({
@@ -309,9 +312,12 @@ describe('ServiceUtil', function () {
           expect(this.service.portDefinitions).toBeDefined();
         });
 
-        it('should not add a portMappings field to the docker definition', function () {
-          expect(this.service.container.docker.portMappings).not.toBeDefined();
-        });
+        it('should not add a portMappings field to the docker definition',
+            function () {
+              expect(this.service.container.docker.portMappings)
+                  .not.toBeDefined();
+            }
+        );
 
         it('sets the docker network property correctly', function () {
           expect(this.service.container.docker.network).toEqual('HOST');
@@ -331,19 +337,23 @@ describe('ServiceUtil', function () {
           });
         });
 
-        it('should not add a portMappings field if no ports were passed in', function () {
-          let service = ServiceUtil.createSpecFromFormModel({
-            containerSettings: {image: 'redis'},
-            networking: {networkType: 'bridge'}
-          });
-          expect(Object.keys(service.container.docker))
-            .not.toContain('portMappings');
-        });
+        it('should not add a portMappings field if no ports were passed in',
+          function () {
+            let service = ServiceUtil.createSpecFromFormModel({
+              containerSettings: {image: 'redis'},
+              networking: {networkType: 'bridge'}
+            });
+            expect(Object.keys(service.container.docker))
+                .not.toContain('portMappings');
+          }
+        );
 
-        it('should not add a portDefinitions field to the app config', function () {
-          expect(Object.keys(this.serviceEmptyPorts))
-            .not.toContain('portDefinitions');
-        });
+        it('should not add a portDefinitions field to the app config',
+            function () {
+              expect(Object.keys(this.serviceEmptyPorts))
+                  .not.toContain('portDefinitions');
+            }
+        );
 
         it('should convert the supplied string fields', function () {
           let service = ServiceUtil.createSpecFromFormModel({
@@ -459,17 +469,19 @@ describe('ServiceUtil', function () {
             .toEqual(1234);
         });
 
-        it('should not add a servicePort when loadBalanced is off', function () {
-          let service = ServiceUtil.createSpecFromFormModel({
-            containerSettings: {image: 'redis'},
-            networking: {
-              networkType: 'user',
-              ports: [{lbPort: 1234}]
-            }
-          });
-          expect(Object.keys(service.container.docker.portMappings[0]))
-            .not.toContain('servicePort');
-        });
+        it('should not add a servicePort when loadBalanced is off',
+          function () {
+            let service = ServiceUtil.createSpecFromFormModel({
+              containerSettings: {image: 'redis'},
+              networking: {
+                networkType: 'user',
+                ports: [{lbPort: 1234}]
+              }
+            });
+            expect(Object.keys(service.container.docker.portMappings[0]))
+                .not.toContain('servicePort');
+          }
+        );
 
         it('should add a servicePort when loadBalanced is on', function () {
           let service = ServiceUtil.createSpecFromFormModel({
@@ -495,18 +507,20 @@ describe('ServiceUtil', function () {
             .not.toContain('labels');
         });
 
-        it('should add the appropriate VIP label when loadBalanced is on', function () {
-          let service = ServiceUtil.createSpecFromFormModel({
-            containerSettings: {image: 'redis'},
-            general: {id: '/foo/bar'},
-            networking: {
-              networkType: 'user',
-              ports: [{lbPort: 1234, loadBalanced: true}]
-            }
-          });
-          expect(service.container.docker.portMappings[0].labels)
-            .toEqual({VIP_0: '/foo/bar:1234'});
-        });
+        it('should add the appropriate VIP label when loadBalanced is on',
+          function () {
+            let service = ServiceUtil.createSpecFromFormModel({
+              containerSettings: {image: 'redis'},
+              general: {id: '/foo/bar'},
+              networking: {
+                networkType: 'user',
+                ports: [{lbPort: 1234, loadBalanced: true}]
+              }
+            });
+            expect(service.container.docker.portMappings[0].labels)
+                .toEqual({VIP_0: '/foo/bar:1234'});
+          }
+        );
 
         it('should not add any port definitions if ports is emoty',
           function () {
@@ -693,8 +707,10 @@ describe('ServiceUtil', function () {
       });
 
       it('should convert parameters to an array of objects', function () {
-        expect(this.service.container.docker.parameters[0].key).toEqual('key-a');
-        expect(this.service.container.docker.parameters[0].value).toEqual('value-a');
+        expect(this.service.container.docker.parameters[0].key)
+            .toEqual('key-a');
+        expect(this.service.container.docker.parameters[0].value)
+            .toEqual('value-a');
       });
     });
   });

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -483,6 +483,18 @@ describe('ServiceUtil', function () {
           }
         );
 
+        it('should not add a hostPort when loadBalanced is off', function () {
+          let service = ServiceUtil.createSpecFromFormModel({
+            containerSettings: {image: 'redis'},
+            networking: {
+              networkType: 'user',
+              ports: [{lbPort: 1234}]
+            }
+          });
+          expect(Object.keys(service.container.docker.portMappings[0]))
+              .not.toContain('hostPort');
+        });
+
         it('should add a servicePort when loadBalanced is on', function () {
           let service = ServiceUtil.createSpecFromFormModel({
             containerSettings: {image: 'redis'},

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -280,7 +280,7 @@ describe('ServiceUtil', function () {
             .toEqual({VIP_1: '/foo/bar:4321'});
         });
 
-        it('should not add any port definitions if ports is emoty',
+        it('should not add any port definitions if ports is empty',
           function () {
             let service = ServiceUtil.createSpecFromFormModel({
               networking: {


### PR DESCRIPTION
---
ℹ️ This fix is for `master` only as the respective components have changed drastically. Please see #1133 for the respective 1.8 fix.
⚠️ Don't merge this PR until the network team has verified that this behavior is correct!

---

Add a hidden host and service port field to the service network schema and adjusted the service util to keep the host and service port data from the JSON definition for bridged networks.

Fixes DCOS-9937