### PR TITLE
[Pods proposal] Visual separation of networks and containers

### DIFF
--- a/src/js/components/PodContainerSpecView.js
+++ b/src/js/components/PodContainerSpecView.js
@@ -3,6 +3,7 @@ import React from 'react';
 import DescriptionList from './DescriptionList';
 import EnvironmentList from './EnvironmentList';
 import ServiceConfigUtil from '../utils/ServiceConfigUtil';
+import Icon from './Icon';
 import Util from '../utils/Util';
 
 class PodContainerSpecView extends React.Component {
@@ -153,13 +154,21 @@ class PodContainerSpecView extends React.Component {
     return (
       <div className="pod-config-container">
         <h5 className="inverse flush-top">
+          <Icon
+            className="icon-margin-right"
+            color="white"
+            family="mini"
+            id="gears"
+            size="mini" />
           {name}
         </h5>
-        {this.getGeneralDetails()}
-        {this.getEnvironmentSection()}
-        {this.getArtifactsSection()}
-        {this.getVolumesSection()}
-        {this.getEndpointsSection()}
+        <div className="pod-config-resource-group">
+          {this.getGeneralDetails()}
+          {this.getEnvironmentSection()}
+          {this.getArtifactsSection()}
+          {this.getVolumesSection()}
+          {this.getEndpointsSection()}
+        </div>
       </div>
     );
   }

--- a/src/js/components/PodNetworkSpecView.js
+++ b/src/js/components/PodNetworkSpecView.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import DescriptionList from './DescriptionList';
+import Icon from './Icon';
 
 class PodNetworkSpecView extends React.Component {
   getGeneralDetails() {
@@ -43,9 +44,15 @@ class PodNetworkSpecView extends React.Component {
     return (
       <div className="pod-config-network">
         <h5 className="inverse flush-top">
+          <Icon
+            className="icon-margin-right"
+            color="white"
+            family="mini"
+            id="network"
+            size="mini" />
           {name}
         </h5>
-        <div>
+        <div className="pod-config-resource-group">
           {this.getGeneralDetails()}
           {this.getLabelSection()}
         </div>

--- a/src/styles/components/pod-configuration-tab.less
+++ b/src/styles/components/pod-configuration-tab.less
@@ -1,0 +1,6 @@
+
+.pod-config-resource-group {
+    margin-left: 8px;
+    border-left: solid 2px #3c4457;
+    padding-left: 12px;
+}

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -154,6 +154,7 @@ Components
 @import "components/nested-service-links.less";
 @import "components/nodes-grid-view.less";
 @import "components/page-header.less";
+@import "components/pod-configuration-tab.less";
 @import "components/pod-instances-table.less";
 @import "components/scrollbar.less";
 @import "components/secret-value.less";


### PR DESCRIPTION
This is a proposal of a visual improvement for pods configuration tab. As Containers and Networks are large it’d be nice to have a visual separation.

<img width="810" alt="screen shot 2016-09-23 at 17 35 24" src="https://cloud.githubusercontent.com/assets/186223/18791735/2e805fb0-81b4-11e6-93f4-37682af05e89.png">
