### PR TITLE
DCOS-9948 (1.8): Fix host port handling for `user` network

### DIFF
--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -368,7 +368,7 @@ const ServiceUtil = {
               if (!['host', 'bridge'].includes(networkType)) {
 
                 if (port.expose) {
-                  portMapping.hostPort = 0;
+                  portMapping.hostPort = port.hostPort || 0;
                 }
                 definition.container.docker.portMappings.push(portMapping);
                 // TODO - Add portDefinition to loadBalanced field

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -425,6 +425,56 @@ describe('ServiceUtil', function () {
             .not.toContain('servicePort');
         });
 
+        it('should not overwrite host port', function () {
+          const model = {
+            containerSettings:{
+              forcePullImage: true,
+              image: 'docker/image',
+              parameters: null,
+              privileged: undefined
+            },
+            networking: {
+              networkType: 'user',
+              ports: [{
+                expose: true,
+                lbPort: 514,
+                hostPort: 5514,
+                loadBalanced: true
+              }]
+            }
+          };
+
+          let service = ServiceUtil.createServiceFromFormModel(model);
+
+          expect(service.getContainer().docker.portMappings[0].hostPort)
+              .toEqual(5514);
+        });
+
+        it('should default host port to `0` (zero)', function () {
+          const model = {
+            containerSettings:{
+              forcePullImage: true,
+              image: 'docker/image',
+              parameters: null,
+              privileged: undefined
+            },
+            networking: {
+              networkType: 'user',
+              ports: [{
+                expose: true,
+                lbPort: 514,
+                hostPort: undefined,
+                loadBalanced: true
+              }]
+            }
+          };
+
+          let service = ServiceUtil.createServiceFromFormModel(model);
+
+          expect(service.getContainer().docker.portMappings[0].hostPort)
+              .toEqual(0);
+        });
+
         it('should add a servicePort when loadBalanced is on', function () {
           let service = ServiceUtil.createServiceFromFormModel({
             containerSettings: {image: 'redis'},


### PR DESCRIPTION
---
ℹ️ This fix is for 1.8 only as the respective components have changed drastically. Please see #1136 for the respective master fix.

---

Adjust the service util to use the provided host port data from the JSON definition for `user` networks.

Fixes DCOS-9948