### PR TITLE
[Pods] DCOS-9893: Align pod instances table cells at the top

### DIFF
--- a/src/styles/components/pod-instances-table.less
+++ b/src/styles/components/pod-instances-table.less
@@ -1,0 +1,3 @@
+.pod-instances-table td {
+  vertical-align: top;
+}

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -154,6 +154,7 @@ Components
 @import "components/nested-service-links.less";
 @import "components/nodes-grid-view.less";
 @import "components/page-header.less";
+@import "components/pod-instances-table.less";
 @import "components/scrollbar.less";
 @import "components/secret-value.less";
 @import "components/service-sidebar.less";


### PR DESCRIPTION
This PR adds `vertical-align: top` to the pod-instances-table cells. I decided to go with having `td` in `.less` over adding a default class like `columns-select` to `ResourceTableUtil` because `ResourceTableUtil` is being used like everywhere.

https://mesosphere.atlassian.net/browse/DCOS-9893

*Before* checkbox and version are vertically aligned in the middle:
![screen shot 2016-09-26 at 14 41 49](https://cloud.githubusercontent.com/assets/186223/18834649/743c015e-83f7-11e6-8587-0ba92130824a.png)

*After* checkbox and version are vertically aligned at the top:
![screen shot 2016-09-26 at 14 41 34](https://cloud.githubusercontent.com/assets/186223/18834687/a2cdfdce-83f7-11e6-821a-de77f98d5137.png)
