### PR TITLE
DCOS-9921: Fix service form JSON toggle spec handling

### DIFF
--- a/src/js/components/modals/ServiceFormModal.js
+++ b/src/js/components/modals/ServiceFormModal.js
@@ -230,7 +230,7 @@ class ServiceFormModal extends mixin(StoreMixin) {
         model,
         ServiceSchema,
         this.props.isEdit,
-        this.props.service.getSpec().get() // Work on the original service spec
+        serviceSpec.get()
       );
     }
 


### PR DESCRIPTION
Adjust the service form JSON toggle handler method to use the current service  spec instead of the original one as we otherwise lose changes from the JSON editor.

/closes DCOS-9921