### PR TITLE
Updating mesosphere-shared-reactjs to version 0.0.23

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4417,9 +4417,9 @@
       }
     },
     "mesosphere-shared-reactjs": {
-      "version": "0.0.22",
-      "from": "mesosphere-shared-reactjs@0.0.22",
-      "resolved": "https://registry.npmjs.org/mesosphere-shared-reactjs/-/mesosphere-shared-reactjs-0.0.22.tgz"
+      "version": "0.0.23",
+      "from": "mesosphere-shared-reactjs@0.0.23",
+      "resolved": "https://registry.npmjs.org/mesosphere-shared-reactjs/-/mesosphere-shared-reactjs-0.0.23.tgz"
     },
     "method-override": {
       "version": "2.3.5",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "less-color-lighten": "0.0.1",
     "md5": "2.1.0",
     "mesosphere-react-typeahead": "0.8.3",
-    "mesosphere-shared-reactjs": "0.0.22",
+    "mesosphere-shared-reactjs": "0.0.23",
     "moment": "2.13.0",
     "prettycron": "0.10.0",
     "query-string": "4.1.0",


### PR DESCRIPTION
---
ℹ️ Related to this PR: https://github.com/dcos/dcos-ui/pull/1073

---

Only change in this release is the removal of GetSetMixin, which is not being used anywhere: https://github.com/dcos/mesosphere-shared-reactjs/pull/20