### PR TITLE
[CNVS Upgrade] Update stylelint config to v0.0.2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6715,9 +6715,9 @@
       }
     },
     "stylelint-config-dcos": {
-      "version": "0.0.1",
+      "version": "0.0.2",
       "from": "stylelint-config-dcos@latest",
-      "resolved": "https://registry.npmjs.org/stylelint-config-dcos/-/stylelint-config-dcos-0.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/stylelint-config-dcos/-/stylelint-config-dcos-0.0.2.tgz"
     },
     "stylelint-config-standard": {
       "version": "13.0.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "source-map-loader": "0.1.5",
     "string-replace-webpack-plugin": "0.0.3",
     "style-loader": "0.13.1",
-    "stylelint-config-dcos": "0.0.1",
+    "stylelint-config-dcos": "0.0.2",
     "stylelint-config-standard": "13.0.0",
     "stylelint-webpack-plugin": "0.3.1",
     "svg-sprite": "1.3.1",


### PR DESCRIPTION
The update to `stylelint-config-dcos` fixes a dependency that was erroneously marked as a `devDependency`.