### PR TITLE
[Pods] DCOS-9986: Using Table instead of CheckboxTable on PodInstancesTable

### DIFF
--- a/src/js/components/PodInstancesTable.js
+++ b/src/js/components/PodInstancesTable.js
@@ -70,7 +70,6 @@ class PodInstancesTable extends React.Component {
   getColGroup() {
     return (
       <colgroup>
-        <col style={{width: '40px'}} />
         <col />
         <col style={{width: '120px'}} />
         <col style={{width: '120px'}} />

--- a/src/js/components/PodInstancesTable.js
+++ b/src/js/components/PodInstancesTable.js
@@ -12,6 +12,7 @@ import PodInstanceList from '../structs/PodInstanceList';
 import PodInstanceStatus from '../constants/PodInstanceStatus';
 import PodTableHeaderLabels from '../constants/PodTableHeaderLabels';
 import PodUtil from '../utils/PodUtil';
+import TableUtil from '../utils/TableUtil';
 import TimeAgo from './TimeAgo';
 import Units from '../utils/Units';
 
@@ -356,8 +357,9 @@ class PodInstancesTable extends React.Component {
         data={this.getTableDataFor(instances, filterText)}
         expandAll={!!filterText}
         getColGroup={this.getColGroup}
+        itemHeight={TableUtil.getRowHeight()}
         onCheckboxChange={this.handleItemCheck}
-        sortBy={{prop: 'startedAt', order: 'desc'}}
+        sortBy={{prop: 'name', order: 'asc'}}
         tableComponent={Table}
         uniqueProperty="id" />
     );

--- a/src/js/components/PodInstancesTable.js
+++ b/src/js/components/PodInstancesTable.js
@@ -1,9 +1,9 @@
 import classNames from 'classnames';
 import React from 'react';
 import {Link} from 'react-router';
+import {Table} from 'reactjs-components';
 
 import CollapsingString from './CollapsingString';
-import CheckboxTable from './CheckboxTable';
 import EventTypes from '../constants/EventTypes';
 import ExpandingTable from './ExpandingTable';
 import MesosStateStore from '../stores/MesosStateStore';
@@ -359,7 +359,7 @@ class PodInstancesTable extends React.Component {
         getColGroup={this.getColGroup}
         onCheckboxChange={this.handleItemCheck}
         sortBy={{prop: 'startedAt', order: 'desc'}}
-        tableComponent={CheckboxTable}
+        tableComponent={Table}
         uniqueProperty="id" />
     );
   }

--- a/src/js/components/__tests__/PodInstancesTable-test.js
+++ b/src/js/components/__tests__/PodInstancesTable-test.js
@@ -155,9 +155,11 @@ describe('PodInstancesTable', function () {
           {pod}, {service: pod});
         this.instance = TestUtils.renderIntoDocument(component);
 
-        // 1 click on the header (ascending)
+        // 2 clicks on the header (ascending), becaue
+        // we are sorting by name by default.
         let columnHeader = TestUtils.scryRenderedDOMComponentsWithClass(
             this.instance, 'column-name')[0];
+        TestUtils.Simulate.click(columnHeader);
         TestUtils.Simulate.click(columnHeader);
       });
 
@@ -183,10 +185,9 @@ describe('PodInstancesTable', function () {
           {pod}, {service: pod});
         this.instance = TestUtils.renderIntoDocument(component);
 
-        // 2 clicks on the header (descending)
+        // 1 click on the header (descending)
         let columnHeader = TestUtils.scryRenderedDOMComponentsWithClass(
             this.instance, 'column-name')[0];
-        TestUtils.Simulate.click(columnHeader);
         TestUtils.Simulate.click(columnHeader);
       });
 


### PR DESCRIPTION
Removing checkboxes from `PodInstancesTable`. However I am keeping the logic of the `CheckboxTable` since this is something we will roll-back into when we have the per-instance kill functionality.

![image](https://cloud.githubusercontent.com/assets/883486/18869287/52b29f80-84b4-11e6-8195-21a1f337ee06.png)
