### PR TITLE
DCOS-9995: Adding support for force=true on destroy

### DIFF
--- a/src/js/components/ServerErrorModal.js
+++ b/src/js/components/ServerErrorModal.js
@@ -56,7 +56,7 @@ module.exports = class ServerErrorModal extends mixin(StoreMixin) {
     });
   }
 
-  handleServerError({message:errorMessage}) {
+  handleServerError(errorMessage) {
     if (!errorMessage) {
       throw 'No error message defined!';
     }

--- a/src/js/components/ServerErrorModal.js
+++ b/src/js/components/ServerErrorModal.js
@@ -56,7 +56,7 @@ module.exports = class ServerErrorModal extends mixin(StoreMixin) {
     });
   }
 
-  handleServerError(errorMessage) {
+  handleServerError({message:errorMessage}) {
     if (!errorMessage) {
       throw 'No error message defined!';
     }

--- a/src/js/components/modals/ServiceActionModal.js
+++ b/src/js/components/modals/ServiceActionModal.js
@@ -66,8 +66,8 @@ class ServiceActionModal extends mixin(StoreMixin) {
     if (this.shouldForceUpdate(errorMsg)) {
       return (
         <h4 className="text-align-center text-danger flush-top">
-          App is currently locked by one or more deployments. Press the button
-          again to forcefully change and deploy the new configuration.
+          Resource currently locked by one or more deployments. Press the button
+          again to force this action.
         </h4>
       );
     }

--- a/src/js/components/modals/ServiceActionModal.js
+++ b/src/js/components/modals/ServiceActionModal.js
@@ -32,7 +32,7 @@ class ServiceActionModal extends mixin(StoreMixin) {
     });
   }
 
-  onError({message:errorMsg}) {
+  onError(errorMsg) {
     this.setState({
       disabled: false,
       errorMsg

--- a/src/js/components/modals/ServiceDestroyModal.js
+++ b/src/js/components/modals/ServiceDestroyModal.js
@@ -39,9 +39,11 @@ class ServiceDestroyModal extends ServiceActionModal {
     let isGroup = service instanceof ServiceTree;
 
     if (isGroup) {
-      MarathonStore.deleteGroup(service.getId());
+      MarathonStore.deleteGroup(service.getId(),
+        this.shouldForceUpdate(this.state.errorMsg));
     } else {
-      MarathonStore.deleteService(service);
+      MarathonStore.deleteService(service,
+        this.shouldForceUpdate(this.state.errorMsg));
     }
   }
 

--- a/src/js/events/MarathonActions.js
+++ b/src/js/events/MarathonActions.js
@@ -87,7 +87,7 @@ var MarathonActions = {
       error(xhr) {
         AppDispatcher.handleServerAction({
           type: REQUEST_MARATHON_GROUP_DELETE_ERROR,
-          data: RequestUtil.parseResponseBody(xhr),
+          data: RequestUtil.getErrorFromXHR(xhr),
           xhr
         });
       }
@@ -192,7 +192,7 @@ var MarathonActions = {
       error(xhr) {
         AppDispatcher.handleServerAction({
           type: REQUEST_MARATHON_SERVICE_DELETE_ERROR,
-          data: RequestUtil.parseResponseBody(xhr),
+          data: RequestUtil.getErrorFromXHR(xhr),
           xhr
         });
       }

--- a/src/js/events/MarathonActions.js
+++ b/src/js/events/MarathonActions.js
@@ -68,10 +68,16 @@ var MarathonActions = {
     });
   },
 
-  deleteGroup(groupId) {
+  deleteGroup(groupId, force) {
     groupId = encodeURIComponent(groupId);
+    let url = buildURI(`/groups/${groupId}`);
+
+    if (force === true) {
+      url += '?force=true';
+    }
+
     RequestUtil.json({
-      url: buildURI(`/groups/${groupId}`),
+      url,
       method: 'DELETE',
       success() {
         AppDispatcher.handleServerAction({
@@ -154,8 +160,9 @@ var MarathonActions = {
    * Delete a service (app, framework, or pod)
    *
    * @param {Service} service - the service you want to delete
+   * @param {Boolean} force - force delete even if deploying
    */
-  deleteService(service) {
+  deleteService(service, force) {
     if (!(service instanceof Service)) {
       if (process.env.NODE_ENV !== 'production') {
         throw new TypeError('service is not an instance of Service');
@@ -168,6 +175,10 @@ var MarathonActions = {
 
     if (service instanceof Pod) {
       url = buildURI(`/pods/${service.getId()}`);
+    }
+
+    if (force === true) {
+      url += '?force=true';
     }
 
     RequestUtil.json({

--- a/src/js/stores/MarathonStore.js
+++ b/src/js/stores/MarathonStore.js
@@ -41,6 +41,7 @@ import DeploymentsList from '../structs/DeploymentsList';
 import GetSetBaseStore from './GetSetBaseStore';
 import HealthStatus from '../constants/HealthStatus';
 import MarathonActions from '../events/MarathonActions';
+import Util from '../utils/Util';
 import {
   MARATHON_APPS_CHANGE,
   MARATHON_APPS_ERROR,
@@ -160,6 +161,8 @@ class MarathonStore extends GetSetBaseStore {
       }
 
       var action = payload.action;
+      var data;
+
       switch (action.type) {
         case REQUEST_MARATHON_INSTANCE_INFO_ERROR:
           this.emit(MARATHON_INSTANCE_INFO_ERROR, action.data);
@@ -174,11 +177,15 @@ class MarathonStore extends GetSetBaseStore {
           this.emit(MARATHON_GROUP_CREATE_SUCCESS);
           break;
         case REQUEST_MARATHON_GROUP_DELETE_ERROR:
-          let groupErrorMessage = action.data;
-          if (!Object.keys(groupErrorMessage).length) {
-            groupErrorMessage = 'Error destroying group';
+          data = action.data;
+          if (!data || (Util.isObject(data) && !data.message)) {
+            data.message = 'Error destroying group';
+          } else if (typeof data === 'string') {
+            data = {
+              message: data
+            };
           }
-          this.emit(MARATHON_GROUP_DELETE_ERROR, groupErrorMessage);
+          this.emit(MARATHON_GROUP_DELETE_ERROR, data);
           break;
         case REQUEST_MARATHON_GROUP_DELETE_SUCCESS:
           this.emit(MARATHON_GROUP_DELETE_SUCCESS);
@@ -196,11 +203,15 @@ class MarathonStore extends GetSetBaseStore {
           this.emit(MARATHON_SERVICE_CREATE_SUCCESS);
           break;
         case REQUEST_MARATHON_SERVICE_DELETE_ERROR:
-          let message = action.data;
-          if (!Object.keys(message).length) {
-            message = 'Error destroying service';
+          data = action.data;
+          if (!data || (Util.isObject(data) && !data.message)) {
+            data.message = 'Error destroying service';
+          } else if (typeof data === 'string') {
+            data = {
+              message: data
+            };
           }
-          this.emit(MARATHON_SERVICE_DELETE_ERROR, message);
+          this.emit(MARATHON_SERVICE_DELETE_ERROR, data);
           break;
         case REQUEST_MARATHON_SERVICE_DELETE_SUCCESS:
           this.emit(MARATHON_SERVICE_DELETE_SUCCESS);

--- a/src/js/stores/MarathonStore.js
+++ b/src/js/stores/MarathonStore.js
@@ -41,7 +41,6 @@ import DeploymentsList from '../structs/DeploymentsList';
 import GetSetBaseStore from './GetSetBaseStore';
 import HealthStatus from '../constants/HealthStatus';
 import MarathonActions from '../events/MarathonActions';
-import Util from '../utils/Util';
 import {
   MARATHON_APPS_CHANGE,
   MARATHON_APPS_ERROR,
@@ -161,7 +160,6 @@ class MarathonStore extends GetSetBaseStore {
       }
 
       var action = payload.action;
-      var data;
 
       switch (action.type) {
         case REQUEST_MARATHON_INSTANCE_INFO_ERROR:
@@ -177,15 +175,7 @@ class MarathonStore extends GetSetBaseStore {
           this.emit(MARATHON_GROUP_CREATE_SUCCESS);
           break;
         case REQUEST_MARATHON_GROUP_DELETE_ERROR:
-          data = action.data;
-          if (!data || (Util.isObject(data) && !data.message)) {
-            data.message = 'Error destroying group';
-          } else if (typeof data === 'string') {
-            data = {
-              message: data
-            };
-          }
-          this.emit(MARATHON_GROUP_DELETE_ERROR, data);
+          this.emit(MARATHON_GROUP_DELETE_ERROR, action.data);
           break;
         case REQUEST_MARATHON_GROUP_DELETE_SUCCESS:
           this.emit(MARATHON_GROUP_DELETE_SUCCESS);
@@ -203,15 +193,7 @@ class MarathonStore extends GetSetBaseStore {
           this.emit(MARATHON_SERVICE_CREATE_SUCCESS);
           break;
         case REQUEST_MARATHON_SERVICE_DELETE_ERROR:
-          data = action.data;
-          if (!data || (Util.isObject(data) && !data.message)) {
-            data.message = 'Error destroying service';
-          } else if (typeof data === 'string') {
-            data = {
-              message: data
-            };
-          }
-          this.emit(MARATHON_SERVICE_DELETE_ERROR, data);
+          this.emit(MARATHON_SERVICE_DELETE_ERROR, action.data);
           break;
         case REQUEST_MARATHON_SERVICE_DELETE_SUCCESS:
           this.emit(MARATHON_SERVICE_DELETE_SUCCESS);


### PR DESCRIPTION
It looks like when destroying a service, we never properly checked for errors in order to prompt for force-destroy. This PR:

* Introduces the `force` option to `destroyGroup` and `destroyService`.
* Makes the error message a bit more generic
