### PR TITLE
[CNVS Upgrade] Introduce new PageHeader components

### DIFF
--- a/src/js/components/NewPage.js
+++ b/src/js/components/NewPage.js
@@ -1,0 +1,26 @@
+import classNames from 'classnames/dedupe';
+import React from 'react';
+
+class Page extends React.Component {
+  render() {
+    let {props} = this;
+    let classes = classNames('page', props.className);
+
+    return (
+      <div className={classes}>
+        {props.children}
+      </div>
+    );
+  }
+}
+
+Page.propTypes = {
+  children: React.PropTypes.node,
+  className: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ])
+};
+
+module.exports = Page;

--- a/src/js/components/NewPageBody.js
+++ b/src/js/components/NewPageBody.js
@@ -1,0 +1,39 @@
+import classNames from 'classnames/dedupe';
+import GeminiScrollbar from 'react-gemini-scrollbar';
+import React from 'react';
+
+class PageHeader extends React.Component {
+  render() {
+    let {props} = this;
+
+    let contentClasses = classNames('pod', props.contentClassName);
+    let scrollbarClasses = classNames(
+      'page-body gm-scrollbar-container-flex',
+      props.scrollbarClassName
+    );
+
+    return (
+      <GeminiScrollbar className={scrollbarClasses}>
+        <div className={contentClasses}>
+          {props.children}
+        </div>
+      </GeminiScrollbar>
+    );
+  }
+}
+
+PageHeader.propTypes = {
+  children: React.PropTypes.node,
+  contentClassName: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ]),
+  scrollbarClassName: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ])
+};
+
+module.exports = PageHeader;

--- a/src/js/components/NewPageHeader.js
+++ b/src/js/components/NewPageHeader.js
@@ -1,0 +1,85 @@
+import classNames from 'classnames/dedupe';
+import React from 'react';
+
+import NewPageHeaderActions from './NewPageHeaderActions';
+import NewPageHeaderBreadcrumbs from './NewPageHeaderBreadcrumbs';
+import NewPageHeaderTabs from './NewPageHeaderTabs';
+
+class PageHeader extends React.Component {
+  render() {
+    let {
+      props: {
+        actions,
+        breadcrumbs,
+        className,
+        innerClassName,
+        primaryContentClassName,
+        secondaryContentDetail,
+        secondaryContentClassName,
+        tabs
+      }
+    } = this;
+
+    let classes = classNames('page-header', className);
+    let innerClasses = classNames(
+      'page-header-inner pod pod-short',
+      innerClassName
+    );
+    let primaryContentClasses = classNames(
+      'page-header-content-section',
+      primaryContentClassName
+    );
+    let secondaryContentClasses = classNames(
+      'page-header-content-section page-header-content-section-secondary',
+      secondaryContentClassName
+    );
+    let secondaryContentDetailElement = null;
+
+    if (secondaryContentDetail) {
+      secondaryContentDetailElement = (
+        <div className="page-header-content-section-secondary-detail">
+          {secondaryContentDetail}
+        </div>
+      );
+    }
+
+    return (
+      <div className={classes}>
+        <div className={innerClasses}>
+          <div className={primaryContentClasses}>
+            <NewPageHeaderBreadcrumbs breadcrumbs={breadcrumbs} />
+            <NewPageHeaderActions actions={actions} />
+          </div>
+          <div className={secondaryContentClasses}>
+            <NewPageHeaderTabs tabs={tabs} />
+            {secondaryContentDetailElement}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+const classProps = React.PropTypes.oneOfType([
+  React.PropTypes.array,
+  React.PropTypes.object,
+  React.PropTypes.string
+]);
+
+PageHeader.defaultProps = {
+  actions: [],
+  tabs: []
+};
+
+PageHeader.propTypes = {
+  actions: React.PropTypes.array,
+  breadcrumbs: React.PropTypes.array.isRequired,
+  className: classProps,
+  innerClassName: classProps,
+  primaryContentClassName: classProps,
+  secondaryContentClassName: classProps,
+  secondaryContentDetail: React.PropTypes.node,
+  tabs: React.PropTypes.array
+};
+
+module.exports = PageHeader;

--- a/src/js/components/NewPageHeaderActions.js
+++ b/src/js/components/NewPageHeaderActions.js
@@ -1,0 +1,50 @@
+import classNames from 'classnames/dedupe';
+import React from 'react';
+
+class PageHeaderActions extends React.Component {
+  render() {
+    let {props: {actions}} = this;
+
+    let actionElements = actions.map(function (action, index) {
+      if (action.node) {
+        return action.node;
+      }
+
+      let classes = classNames('button button-rounded', action.className);
+
+      return (
+        <button className={classes} key={index} onClick={action.clickHandler}>
+          {action.label}
+        </button>
+      );
+    });
+
+    return (
+      <div className="page-header-actions button-collection flush-bottom">
+        {actionElements}
+      </div>
+    );
+  }
+}
+
+PageHeaderActions.defaultProps = {
+  actions: []
+};
+
+const classProps = React.PropTypes.oneOfType([
+  React.PropTypes.array,
+  React.PropTypes.object,
+  React.PropTypes.string
+]);
+
+PageHeaderActions.propTypes = {
+  actions: React.PropTypes.arrayOf(
+    React.PropTypes.shape({
+      className: classProps,
+      clickHandler: React.PropTypes.func,
+      label: React.PropTypes.node
+    })
+  )
+};
+
+module.exports = PageHeaderActions;

--- a/src/js/components/NewPageHeaderBreadcrumbs.js
+++ b/src/js/components/NewPageHeaderBreadcrumbs.js
@@ -1,0 +1,127 @@
+import {Dropdown} from 'reactjs-components';
+import React from 'react';
+
+import Icon from './Icon';
+
+class PageHeaderBreadcrumbs extends React.Component {
+  getBreadcrumbSubMenuItem(menuItem) {
+    let {iconID, label, routeName} = menuItem;
+
+    if (iconID) {
+      return {
+        className: 'hidden',
+        id: 'default',
+        selectedHtml: (
+          <h3 className="flush">
+            <Icon color="purple" family="small" id={iconID} size="small" />
+            {label}
+          </h3>
+        ),
+        routeName
+      };
+    }
+
+    return {id: routeName, html: label, routeName};
+  }
+
+  getCaret(index) {
+    return (
+      <li className="page-header-breadcrumb-caret flush-top flush-left"
+        key={`caret-${index}`}>
+        <Icon color="light-grey" family="mini" id="caret-right" size="mini" />
+      </li>
+    );
+  }
+
+  getPrimaryBreadcrumb(breadcrumb) {
+    let breadcrumbContent = null;
+
+    if (breadcrumb.submenu) {
+      let dropdownItems = breadcrumb.submenu.map(this.getBreadcrumbSubMenuItem);
+
+      breadcrumbContent = (
+        <Dropdown
+          buttonClassName="button dropdown-toggle"
+          dropdownMenuClassName="dropdown-menu"
+          dropdownMenuListClassName="dropdown-menu-list"
+          dropdownMenuListItemClassName="clickable"
+          wrapperClassName="dropdown"
+          items={dropdownItems}
+          onItemSelection={this.handleBreadcrumbSubmenuItemSelect}
+          persistentID="default"
+          transition={true}
+          transitionName="dropdown-menu" />
+      );
+    } else {
+      breadcrumbContent = breadcrumb.label;
+    }
+
+    return (
+      <li className="page-header-breadcrumb-primary h3 flush-top flush-left"
+        key="primary-breadcrumb">
+        {breadcrumbContent}
+      </li>
+    );
+  }
+
+  getSecondaryBreadcrumb(breadcrumb, index) {
+    let {label = null, prefix = null, suffix = null} = breadcrumb;
+
+    return (
+      <li className="page-header-breadcrumb-secondary h3 flush-top flush-left"
+        key={index}>
+        {prefix}
+        {label}
+        {suffix}
+      </li>
+    );
+  }
+
+  handleBreadcrumbSubmenuItemSelect(menuItem) {
+    console.log(menuItem);
+  }
+
+  render() {
+    let {props: {breadcrumbs}} = this;
+
+    let breadcrumbElements = breadcrumbs.reduce((memo, breadcrumb, index) => {
+      if (index === 0) {
+        memo.push(this.getPrimaryBreadcrumb(breadcrumb));
+      } else {
+        memo.push(this.getSecondaryBreadcrumb(breadcrumb, index));
+      }
+
+      if (index !== breadcrumbs.length - 1) {
+        memo.push(this.getCaret(index));
+      }
+
+      return memo;
+    }, []);
+
+    return (
+      <ul className="page-header-breadcrumbs list list-unstyled list-inline flush">
+        {breadcrumbElements}
+      </ul>
+    );
+  }
+}
+
+PageHeaderBreadcrumbs.propTypes = {
+  breadcrumbs: React.PropTypes.arrayOf(
+    React.PropTypes.shape({
+      iconID: React.PropTypes.string,
+      label: React.PropTypes.node.isRequired,
+      prefix: React.PropTypes.node,
+      submenu: React.PropTypes.arrayOf(
+        React.PropTypes.shape({
+          iconID: React.PropTypes.string,
+          label: React.PropTypes.node.isRequired,
+          routeName: React.PropTypes.string.isRequired
+        })
+      ),
+      suffix: React.PropTypes.node
+    })
+  ).isRequired
+};
+
+module.exports = PageHeaderBreadcrumbs;

--- a/src/js/components/NewPageHeaderTabs.js
+++ b/src/js/components/NewPageHeaderTabs.js
@@ -1,0 +1,47 @@
+import classNames from 'classnames/dedupe';
+import {Link} from 'react-router';
+import React from 'react';
+
+class PageHeaderTabs extends React.Component {
+  render() {
+    let {props: {tabs}} = this;
+
+    let tabElements = tabs.map(function (tab, index) {
+      let {isActive} = tab;
+      let classes = classNames('tab-item', {active: isActive});
+      let linkClasses = classNames('tab-item-label', {active: isActive});
+
+      return (
+        <li className={classes} key={index}>
+          <Link className={linkClasses} to={tab.routeName}>
+            <span className="tab-item-label-text">
+              {tab.label}
+            </span>
+          </Link>
+        </li>
+      );
+    });
+
+    return (
+      <ul className="menu-tabbed flush-bottom">
+        {tabElements}
+      </ul>
+    );
+  }
+}
+
+PageHeaderTabs.defaultProps = {
+  tabs: []
+};
+
+PageHeaderTabs.propTypes = {
+  tabs: React.PropTypes.arrayOf(
+    React.PropTypes.shape({
+      isActive: React.PropTypes.bool,
+      label: React.PropTypes.node.isRequired,
+      routeName: React.PropTypes.string.isRequired
+    })
+  )
+};
+
+module.exports = PageHeaderTabs;

--- a/src/styles/components/icons/styles.less
+++ b/src/styles/components/icons/styles.less
@@ -86,6 +86,10 @@
       }
     }
 
+    &.icon-light-grey {
+      color: color-lighten(@neutral, 60%);
+    }
+
     .button &,
     button & {
       flex: 0 0 auto;

--- a/src/styles/components/list/styles.less
+++ b/src/styles/components/list/styles.less
@@ -25,7 +25,7 @@
 
     &.list-inline {
 
-      li {
+      & > li {
         display: inline-block;
         float: none;
         vertical-align: baseline;

--- a/src/styles/components/page-header/styles.less
+++ b/src/styles/components/page-header/styles.less
@@ -3,7 +3,7 @@
 & when (@page-header-enabled) {
 
   .page-header {
-    .clearfix();
+    flex: 0 1 auto;
     position: relative;
 
     &:before {
@@ -16,64 +16,21 @@
       position: absolute;
       width: 100%;
     }
-
-    .page-header-subheadline {
-
-      a {
-        text-decoration: none;
-      }
-    }
   }
 
+  // TODO: Remove this if we aren't going to use it.
   .page-navigation-sidebar-toggle {
     display: none;
   }
 
-  .page-header-heading {
+  .page-header-content-section {
     align-items: center;
     display: flex;
-    flex-wrap: wrap;
   }
 
-  .page-header-breadcrumbs {
-    flex: 1 1 0;
-    white-space: nowrap;
-
-    & > li {
-      // Overriding specificity from CNVS. :(
-      display: inline-block !important;
-      float: none !important;
-      margin-right: @base-spacing-unit * 1/4;
-      vertical-align: middle;
-
-      &:last-child {
-        margin-right: 0;
-      }
-    }
-  }
-
-  .page-header-breadcrumb-primary {
-
-    .icon {
-      margin-right: @base-spacing-unit * 1/8;
-    }
-
-    .dropdown {
-
-      .button {
-        background: none;
-        border: 0;
-        border-radius: 0;
-        padding: 0;
-      }
-    }
-  }
-
-  .page-header-actions {
-    flex: 0 0 auto;
-  }
-
-  .page-header-navigation {
+  .page-header-content-section-secondary {
+    align-items: flex-start;
+    display: flex;
 
     & when not (@pod-margin-bottom = null) {
 
@@ -92,27 +49,80 @@
       margin-bottom: 0;
     }
   }
+
+  .page-header-content-section-secondary-detail {
+    margin-left: auto;
+  }
+
+  .page-header-breadcrumbs {
+    align-items: center;
+    display: flex;
+    flex: 1 1 auto;
+    min-width: 0;
+
+    // This extra classname is necessary to override specificity from CNVS.
+    &.list-inline {
+
+      & > li {
+        display: inline-block;
+        float: none;
+        line-height: 2rem;
+        margin-right: @base-spacing-unit * 1/4;
+        vertical-align: middle;
+
+        &:last-child {
+          margin-right: 0;
+        }
+      }
+    }
+  }
+
+  .page-header-breadcrumb-primary {
+    flex: 0 0 auto;
+
+    .icon {
+      margin-right: @base-spacing-unit * 1/8;
+    }
+
+    .dropdown {
+
+      .button {
+        background: none;
+        border: 0;
+        border-radius: 0;
+        padding: 0;
+      }
+    }
+  }
+
+  .page-header-breadcrumb-secondary {
+    flex: 0 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    &:last-child {
+      flex: 0 0 auto;
+      min-width: auto;
+      overflow: visible;
+    }
+  }
+
+  .page-header-breadcrumb-caret {
+    flex: 0 0 auto;
+  }
+
+  .page-header-actions {
+    flex: 0 0 auto;
+  }
 }
 
 & when (@page-header-enabled) and (@layout-screen-small-enabled) {
 
   @media (min-width: @layout-screen-small-min-width) {
 
-    .page-header-breadcrumbs {
-
-      & > li {
-        margin-right: @base-spacing-unit-screen-small * 1/4;
-      }
-    }
-
-    .page-header-breadcrumb-primary {
-
-      .icon {
-        margin-right: @base-spacing-unit-screen-small * 1/8;
-      }
-    }
-
-    .page-header-navigation {
+    .page-header-content-section-secondary {
 
       & when not (@pod-margin-bottom-screen-small = null) {
 
@@ -127,6 +137,23 @@
         }
       }
     }
+
+    .page-header-breadcrumbs {
+
+      &.list-inline {
+
+        & > li {
+          margin-right: @base-spacing-unit-screen-small * 1/4;
+        }
+      }
+    }
+
+    .page-header-breadcrumb-primary {
+
+      .icon {
+        margin-right: @base-spacing-unit-screen-small * 1/8;
+      }
+    }
   }
 }
 
@@ -134,21 +161,7 @@
 
   @media (min-width: @layout-screen-medium-min-width) {
 
-    .page-header-breadcrumbs {
-
-      & > li {
-        margin-right: @base-spacing-unit-screen-medium * 1/4;
-      }
-    }
-
-    .page-header-breadcrumb-primary {
-
-      .icon {
-        margin-right: @base-spacing-unit-screen-medium * 1/8;
-      }
-    }
-
-    .page-header-navigation {
+    .page-header-content-section-secondary {
 
       & when not (@pod-margin-bottom-screen-medium = null) {
 
@@ -163,6 +176,23 @@
         }
       }
     }
+
+    .page-header-breadcrumbs {
+
+      &.list-inline {
+
+        & > li {
+          margin-right: @base-spacing-unit-screen-medium * 1/4;
+        }
+      }
+    }
+
+    .page-header-breadcrumb-primary {
+
+      .icon {
+        margin-right: @base-spacing-unit-screen-medium * 1/8;
+      }
+    }
   }
 }
 
@@ -170,21 +200,7 @@
 
   @media (min-width: @layout-screen-large-min-width) {
 
-    .page-header-breadcrumbs {
-
-      & > li {
-        margin-right: @base-spacing-unit-screen-large * 1/4;
-      }
-    }
-
-    .page-header-breadcrumb-primary {
-
-      .icon {
-        margin-right: @base-spacing-unit-screen-large * 1/8;
-      }
-    }
-
-    .page-header-navigation {
+    .page-header-content-section-secondary {
 
       & when not (@pod-margin-bottom-screen-large = null) {
 
@@ -199,6 +215,23 @@
         }
       }
     }
+
+    .page-header-breadcrumbs {
+
+      &.list-inline {
+
+        & > li {
+          margin-right: @base-spacing-unit-screen-large * 1/4;
+        }
+      }
+    }
+
+    .page-header-breadcrumb-primary {
+
+      .icon {
+        margin-right: @base-spacing-unit-screen-large * 1/8;
+      }
+    }
   }
 }
 
@@ -206,21 +239,7 @@
 
   @media (min-width: @layout-screen-jumbo-min-width) {
 
-    .page-header-breadcrumbs {
-
-      & > li {
-        margin-right: @base-spacing-unit-screen-jumbo * 1/4;
-      }
-    }
-
-    .page-header-breadcrumb-primary {
-
-      .icon {
-        margin-right: @base-spacing-unit-screen-jumbo * 1/8;
-      }
-    }
-
-    .page-header-navigation {
+    .page-header-content-section-secondary {
 
       & when not (@pod-margin-bottom-screen-jumbo = null) {
 
@@ -233,6 +252,23 @@
           margin-bottom: -@pod-margin-bottom-screen-jumbo * @pod-short-margin-top-scale;
           padding-top: @pod-margin-bottom-screen-jumbo * @pod-short-margin-top-scale;
         }
+      }
+    }
+
+    .page-header-breadcrumbs {
+
+      &.list-inline {
+
+        & > li {
+          margin-right: @base-spacing-unit-screen-jumbo * 1/4;
+        }
+      }
+    }
+
+    .page-header-breadcrumb-primary {
+
+      .icon {
+        margin-right: @base-spacing-unit-screen-jumbo * 1/8;
       }
     }
   }

--- a/src/styles/layout/page-body/styles.less
+++ b/src/styles/layout/page-body/styles.less
@@ -1,8 +1,5 @@
 .page-body {
-  position: relative;
-}
-
-.page-body-content {
-  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
   position: relative;
 }

--- a/src/styles/layout/page-header/styles.less
+++ b/src/styles/layout/page-header/styles.less
@@ -2,29 +2,6 @@
 
 .page-header {
   .clearfix();
-  position: relative;
-
-  &:before {
-    background-color: color-lighten(@neutral, 80);
-    bottom: 0;
-    content: '';
-    display: block;
-    height: 1px;
-    left: 0;
-    position: absolute;
-    width: 100%;
-  }
-
-  .page-header-subheadline {
-
-    a {
-      text-decoration: none;
-    }
-  }
-}
-
-.page-navigation-sidebar-toggle {
-  display: none;
 }
 
 .page-header-navigation {
@@ -40,10 +17,6 @@
       margin-bottom: -@pod-margin-bottom * @pod-short-margin-top-scale;
       padding-top: @pod-margin-bottom * @pod-short-margin-top-scale;
     }
-  }
-
-  .menu-tabbed {
-    margin-bottom: 0;
   }
 }
 

--- a/src/styles/layout/page/styles.less
+++ b/src/styles/layout/page/styles.less
@@ -1,3 +1,6 @@
 .page {
+  display: flex;
+  flex: 1 1 100%;
+  flex-direction: column;
   overflow: hidden;
 }


### PR DESCRIPTION
This PR introduces the `NewPage*` components (to be renamed to ~~`New`~~`Page*` later).

In the new modularized UI, the `container` components will determine which data is available to each `PageHeader` component. Until then, this will not be implemented to avoid unnecessarily reworking our previous components.

Here's how I'm proposing `PageHeader`'s API will look:
```jsx
<PageHeader
  actions={[
    {
      className: 'button-primary',
      clickHandler: () => console.log('hi'),
      label: 'Open Service'
    },
    {
      className: 'button-stroke',
      clickHandler: () => console.log('hello'),
      label: 'Scale'
    }
  ]}
  breadcrumbs={[
    {
      iconID: 'services',
      label: 'Services',
      submenu: [
        {
          iconID: 'services',
          label: 'Services',
          routeName: 'services-overview'
        },
        {
          label: 'Deployments',
          routeName: 'services-deployments'
        }
      ]
    },
    {
      label: 'Cassandra',
      suffix: <span className="text-muted"> (Running)</span>
    },
    {
      label: 'Something Else!'
    }
  ]}
  tabs={[
    {
      label: 'Services',
      isActive: true,
      routeName: 'services-overview'
    },
    {
      label: 'Deployments',
      isActive: false,
      routeName: 'services-deployments'
    }  
  ]} />
```

Which produces the following:
![](https://d3vv6lp55qjaqc.cloudfront.net/items/2K1v2v0u0u2F3e0R2a2x/Screen%20Shot%202016-09-27%20at%204.43.41%20PM.png?X-CloudApp-Visitor-Id=1972842&v=e1a133c7)