### PR TITLE
[Pods] Add quick link to logs to task rows

### DIFF
--- a/src/js/components/PodInstancesTable.js
+++ b/src/js/components/PodInstancesTable.js
@@ -6,6 +6,7 @@ import {Table} from 'reactjs-components';
 import CollapsingString from './CollapsingString';
 import EventTypes from '../constants/EventTypes';
 import ExpandingTable from './ExpandingTable';
+import Icon from './Icon';
 import MesosStateStore from '../stores/MesosStateStore';
 import Pod from '../structs/Pod';
 import PodInstanceList from '../structs/PodInstanceList';
@@ -22,6 +23,7 @@ const METHODS_TO_BIND = [
   'handleMesosStateChange',
   'renderColumnAddress',
   'renderColumnID',
+  'renderColumnLogs',
   'renderColumnResource',
   'renderColumnStatus',
   'renderColumnUpdated',
@@ -76,6 +78,7 @@ class PodInstancesTable extends React.Component {
         <col style={{width: '120px'}} />
         <col style={{width: '64px'}} />
         <col style={{width: '86px'}} />
+        <col style={{width: '86px'}} />
         <col style={{width: '160px'}} />
         <col style={{width: '160px'}} />
       </colgroup>
@@ -129,6 +132,13 @@ class PodInstancesTable extends React.Component {
         prop: 'status',
         render: this.renderColumnStatus,
         sortable: true
+      },
+      {
+        className: this.getColumnClassName,
+        heading: this.getColumnHeading,
+        prop: 'logs',
+        render: this.renderColumnLogs,
+        sortable: false
       },
       {
         className: this.getColumnClassName,
@@ -278,6 +288,32 @@ class PodInstancesTable extends React.Component {
       rowOptions,
       (<CollapsingString string={row.id} />),
       classes
+    );
+  }
+
+  renderColumnLogs(prop, row, rowOptions = {}) {
+    if (rowOptions.isParent) {
+      // Because elements are just stacked we need a spacer
+      return <span>&nbsp;</span>;
+    }
+
+    let {name, id} = row;
+
+    return (
+      <Link
+        className="emphasize clickable text-overflow"
+        to="services-task-details-logs"
+        params={{
+          id: encodeURIComponent(this.props.pod.getId()),
+          taskID: id
+        }}
+        title={name}>
+        <Icon
+          color="grey"
+          id="page"
+          size="mini"
+          family="mini" />
+      </Link>
     );
   }
 

--- a/src/styles/components/pod-instances-table.less
+++ b/src/styles/components/pod-instances-table.less
@@ -1,3 +1,7 @@
 .pod-instances-table td {
   vertical-align: top;
 }
+
+.pod-instances-table .column-logs {
+  padding-left: 0;
+}


### PR DESCRIPTION
This PR adds a link to a task's logs.

ℹ️  when testing it please note that Logs view seems not to be working in general. So you don't see any logs under the Log tab.

https://mesosphere.atlassian.net/browse/DCOS-9894

![screen shot 2016-09-28 at 12 18 03](https://cloud.githubusercontent.com/assets/186223/18909906/d382c65a-8575-11e6-9627-795ce1a9d857.png)

/cc @leemunroe 