### PR TITLE
[Pods] DCOS-9984:  Adjust task directory path handling to support pods

### DIFF
--- a/src/js/events/TaskDirectoryActions.js
+++ b/src/js/events/TaskDirectoryActions.js
@@ -5,27 +5,6 @@ import AppDispatcher from './AppDispatcher';
 import Config from '../config/Config';
 import MesosStateUtil from '../utils/MesosStateUtil';
 
-function findWithID(stateObject, listProps, id) {
-  let searchItem;
-  let length = listProps.length;
-
-  for (let i = 0; i < length; i++) {
-    let array = stateObject[listProps[i]];
-
-    if (array) {
-      searchItem = array.find(function (element) {
-        return element.id === id;
-      });
-
-      if (searchItem) {
-        return searchItem;
-      }
-    }
-  }
-
-  return null;
-}
-
 var TaskDirectoryActions = {
   getDownloadURL(nodeID, path) {
     return `${Config.rootUrl}/agent/${nodeID}/files/download?` +
@@ -44,34 +23,6 @@ var TaskDirectoryActions = {
     }
 
     return `${Config.rootUrl}/agent/${task.slave_id}/${nodePID}/state`;
-  },
-
-  getInnerPath(nodeState, task, innerPath) {
-    innerPath = innerPath || '';
-
-    // Search frameworks
-    let framework = findWithID(
-      nodeState,
-      ['frameworks', 'completed_frameworks'],
-      task.framework_id
-    );
-
-    if (!framework) {
-      return null;
-    }
-
-    // Search executors
-    let executor = findWithID(
-      framework,
-      ['executors', 'completed_executors'],
-      task.executor_id || task.id // Fallback to task id, if no executor id
-    );
-
-    if (!executor) {
-      return null;
-    }
-
-    return `${executor.directory}/${innerPath}`;
   },
 
   fetchNodeState: RequestUtil.debounceOnError(

--- a/src/js/events/TaskDirectoryActions.js
+++ b/src/js/events/TaskDirectoryActions.js
@@ -3,6 +3,7 @@ import {RequestUtil} from 'mesosphere-shared-reactjs';
 import ActionTypes from '../constants/ActionTypes';
 import AppDispatcher from './AppDispatcher';
 import Config from '../config/Config';
+import MesosStateUtil from '../utils/MesosStateUtil';
 
 function findWithID(stateObject, listProps, id) {
   let searchItem;
@@ -104,7 +105,7 @@ var TaskDirectoryActions = {
   ),
 
   fetchDirectory(task, innerPath, nodeState) {
-    let path = TaskDirectoryActions.getInnerPath(nodeState, task, innerPath);
+    let path = MesosStateUtil.getTaskPath(nodeState, task, innerPath);
     if (path == null) {
       AppDispatcher.handleServerAction({
         type: ActionTypes.REQUEST_TASK_DIRECTORY_ERROR

--- a/src/js/events/__tests__/TaskDirectoryActions-test.js
+++ b/src/js/events/__tests__/TaskDirectoryActions-test.js
@@ -29,64 +29,6 @@ describe('TaskDirectoryActions', function () {
     Config.useFixtures = this.configUseFixtures;
   });
 
-  describe('#getInnerPath', function () {
-
-    it('finds path of a running task', function () {
-      var result = TaskDirectoryActions.getInnerPath(
-        {frameworks: [{id: 'foo', executors: [{id: 'bar'}]}]},
-        {framework_id: 'foo', id: 'bar'}
-      );
-
-      expect(result).toBeTruthy();
-    });
-
-    it('finds path of a completed task', function () {
-      var result = TaskDirectoryActions.getInnerPath(
-        {completed_frameworks: [{id: 'foo', completed_executors: [{id: 'bar'}]}]},
-        {framework_id: 'foo', id: 'bar'}
-      );
-
-      expect(result).toBeTruthy();
-    });
-
-    it('finds path of a task in completed executors', function () {
-      var result = TaskDirectoryActions.getInnerPath(
-        {frameworks: [{id: 'foo', completed_executors: [{id: 'bar'}]}]},
-        {framework_id: 'foo', id: 'bar'}
-      );
-
-      expect(result).toBeTruthy();
-    });
-
-    it('finds path of a task in completed frameworks', function () {
-      var result = TaskDirectoryActions.getInnerPath(
-        {completed_frameworks: [{id: 'foo', executors: [{id: 'bar'}]}]},
-        {framework_id: 'foo', id: 'bar'}
-      );
-
-      expect(result).toBeTruthy();
-    });
-
-    it('finds path of a completed task', function () {
-      var result = TaskDirectoryActions.getInnerPath(
-        {completed_frameworks: [{id: 'foo', completed_executors: [{id: 'bar'}]}]},
-        {framework_id: 'foo', id: 'bar'}
-      );
-
-      expect(result).toBeTruthy();
-    });
-
-    it('finds path of a completed task with executor id', function () {
-      var result = TaskDirectoryActions.getInnerPath(
-        {completed_frameworks: [{id: 'foo', completed_executors: [{id: 'bar'}]}]},
-        {framework_id: 'foo', executor_id: 'bar'}
-      );
-
-      expect(result).toBeTruthy();
-    });
-
-  });
-
   describe('#fetchDirectory', function () {
 
     beforeEach(function () {

--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -33,9 +33,9 @@ const MesosStateUtil = {
   getFramework(state, frameworkID) {
     const {frameworks, completed_frameworks} = state;
     return [].concat(frameworks, completed_frameworks).find(
-        function (framework) {
-          return framework != null && framework.id === frameworkID;
-        });
+      function (framework) {
+        return framework != null && framework.id === frameworkID;
+      });
   },
 
   /**
@@ -118,17 +118,17 @@ const MesosStateUtil = {
 
           // Find pod task and executor
           return [].concat(executor.tasks, executor.completed_tasks)
-              .every(function (task) {
-                if (task != null && task.id === taskID) {
-                  // For a detail documentation on how to construct the path
-                  // please see: https://reviews.apache.org/r/52376/
-                  taskPath =
-                      `${executor.directory}/tasks/${task.id}/${path}`;
-                  return false;
-                }
+            .every(function (task) {
+              if (task != null && task.id === taskID) {
+                // For a detail documentation on how to construct the path
+                // please see: https://reviews.apache.org/r/52376/
+                taskPath =
+                    `${executor.directory}/tasks/${task.id}/${path}`;
+                return false;
+              }
 
-                return true;
-              });
+              return true;
+            });
         });
 
     return taskPath;

--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -34,7 +34,7 @@ const MesosStateUtil = {
     const {frameworks, completed_frameworks} = state;
     return [].concat(frameworks, completed_frameworks).find(
         function (framework) {
-          return framework.id === frameworkID;
+          return framework != null && framework.id === frameworkID;
         });
   },
 

--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -26,6 +26,19 @@ const MesosStateUtil = {
   },
 
   /**
+   * @param {{frameworks:array,completed_frameworks:array}} state
+   * @param {string} frameworkID
+   * @returns {{executors:Array, completed_executors:Array}|null} framework
+   */
+  getFramework(state, frameworkID) {
+    const {frameworks, completed_frameworks} = state;
+    return [].concat(frameworks, completed_frameworks).find(
+        function (framework) {
+          return framework.id === frameworkID;
+        });
+  },
+
+  /**
    * @param  {Object} state A document of mesos state
    * @param  {Array} filter Allows us to filter by framework id
    *   All other frameworks will be put into an 'other' category

--- a/src/js/utils/__tests__/MesosStateUtil-test.js
+++ b/src/js/utils/__tests__/MesosStateUtil-test.js
@@ -131,4 +131,134 @@ describe('MesosStateUtil', function () {
 
   });
 
+  describe('#getTaskPath', function () {
+
+    describe('app/framework tasks', function () {
+      const state = {
+        frameworks: [
+          {
+            id: 'framework-123',
+            name: 'test-1',
+            executors: [
+              {
+                id: 'executor-foo',
+                directory: 'foo'
+              }
+            ],
+            completed_executors: [{
+              id: 'executor-bar',
+              directory: 'bar'
+            }]
+          }
+        ]
+      };
+
+      it('gets the task path for a running task', function () {
+        const task = {
+          id: 'executor-foo',
+          framework_id: 'framework-123',
+          executor_id: 'executor-bar'
+        };
+
+        expect(MesosStateUtil.getTaskPath(state, task)).toEqual('foo/');
+      });
+
+      it('gets the task path form a completed task', function () {
+        const task = {
+          id: 'executor-bar',
+          framework_id: 'framework-123',
+          executor_id: 'executor-bar'
+        };
+
+        expect(MesosStateUtil.getTaskPath(state, task)).toEqual('bar/');
+      });
+
+      it('gets the task path for a task with unknown executor id', function () {
+        const task = {
+          id: 'executor-bar',
+          framework_id: 'framework-123'
+        };
+
+        expect(MesosStateUtil.getTaskPath(state, task)).toEqual('bar/');
+      });
+
+      it('appends provided path', function () {
+        const task = {
+          id: 'executor-bar',
+          framework_id: 'framework-123'
+        };
+
+        expect(MesosStateUtil.getTaskPath(state, task, 'test'))
+            .toEqual('bar/test');
+      });
+
+    });
+
+    describe('pod tasks', function () {
+      const state = {
+        frameworks: [
+          {
+            id: 'framework-123',
+            name: 'test-1',
+            executors: [
+              {
+                id: 'executor-foo',
+                directory: 'foo',
+                completed_tasks: [{id: 'task-foo-completed'}],
+                tasks: [{id: 'task-foo-running'}]
+              }
+            ],
+            completed_executors: [{
+              id: 'executor-bar',
+              directory: 'bar',
+              completed_tasks: [{id: 'task-bar-completed'}]
+            }]
+          }
+        ]
+      };
+
+      it('gets the task path for a running task', function () {
+        const task = {
+          id: 'task-foo-running',
+          framework_id: 'framework-123'
+        };
+
+        expect(MesosStateUtil.getTaskPath(state, task))
+            .toEqual('foo/tasks/task-foo-running/');
+      });
+
+      it('gets the task path form a completed task', function () {
+        const task = {
+          id: 'task-foo-completed',
+          framework_id: 'framework-123'
+        };
+
+        expect(MesosStateUtil.getTaskPath(state, task))
+            .toEqual('foo/tasks/task-foo-completed/');
+      });
+
+      it('gets the task path form a completed executor', function () {
+        const task = {
+          id: 'task-bar-completed',
+          framework_id: 'framework-123'
+        };
+
+        expect(MesosStateUtil.getTaskPath(state, task))
+            .toEqual('bar/tasks/task-bar-completed/');
+      });
+
+      it('appends provided path', function () {
+        const task = {
+          id: 'task-foo-running',
+          framework_id: 'framework-123'
+        };
+
+        expect(MesosStateUtil.getTaskPath(state, task, 'test'))
+            .toEqual('foo/tasks/task-foo-running/test');
+      });
+
+    });
+
+  });
+
 });

--- a/src/js/utils/__tests__/MesosStateUtil-test.js
+++ b/src/js/utils/__tests__/MesosStateUtil-test.js
@@ -53,6 +53,38 @@ describe('MesosStateUtil', function () {
 
   });
 
+  describe('#getFramework', function () {
+    const state = {
+      frameworks: [
+        {
+          id: 'framework-123',
+          name: 'test-1'
+        }
+      ],
+      completed_frameworks: [
+        {
+          id: 'framework-abc',
+          name: 'test-2'
+        }
+      ]
+    };
+
+    it('should return the matching framework', function () {
+      expect(MesosStateUtil.getFramework(state, 'framework-123').name)
+          .toEqual('test-1');
+    });
+
+    it('should return the matching "completed" framework', function () {
+      expect(MesosStateUtil.getFramework(state, 'framework-abc').name)
+          .toEqual('test-2');
+    });
+
+    it('should return nothing if no matching framework was found', function () {
+      expect(MesosStateUtil.getFramework(state, 'unknown')).not.toBeDefined();
+    });
+
+  });
+
   describe('#getTasksFromVirtualNetworkName', function () {
 
     beforeEach(function () {


### PR DESCRIPTION
Introduce and integrate a new util to get the task directory from Mesos state which is capable of handling nested task groups (pods).

Closes DCOS-9984