### PR TITLE
[Pods] DCOS-10099: Getting total resources from instance information

### DIFF
--- a/src/js/components/PodInstancesTable.js
+++ b/src/js/components/PodInstancesTable.js
@@ -229,14 +229,14 @@ class PodInstancesTable extends React.Component {
       let children = this.getContainersWithResources(
         podSpec, containers, instance.getAgentAddress()
       );
-      let resourcesSum = instance.getResources();
+      let {cpus, mem} = instance.getResources();
 
       return {
         id: instance.getId(),
         name: instance.getName(),
         address: instance.getAgentAddress(),
-        cpus: resourcesSum.cpus,
-        mem: resourcesSum.mem,
+        cpus,
+        mem,
         updated: instance.getLastUpdated(),
         status: instance.getInstanceStatus(),
         version: podSpec.getVersion(),

--- a/src/js/components/PodInstancesTable.js
+++ b/src/js/components/PodInstancesTable.js
@@ -183,10 +183,6 @@ class PodInstancesTable extends React.Component {
   }
 
   getContainersWithResources(podSpec, containers, agentAddress) {
-    let resourcesSum = {
-      cpus: 0, mem: 0, disk: 0, gpus: 0
-    };
-
     let children = containers.map(function (container) {
       let containerResources = container.getResources();
 
@@ -195,10 +191,6 @@ class PodInstancesTable extends React.Component {
       if (containerSpec) {
         containerResources = containerSpec.resources;
       }
-
-      Object.keys(containerResources).forEach(function (key) {
-        resourcesSum[key] += containerResources[key];
-      });
 
       let addressComponents = container.endpoints.map(function (endpoint, i) {
         return (
@@ -224,7 +216,7 @@ class PodInstancesTable extends React.Component {
       };
     });
 
-    return {children, resourcesSum};
+    return children;
   }
 
   getTableDataFor(instances, filterText) {
@@ -234,9 +226,10 @@ class PodInstancesTable extends React.Component {
       let containers = instance.getContainers().filter(function (container) {
         return PodUtil.isContainerMatchingText(container, filterText);
       });
-      let {children, resourcesSum} = this.getContainersWithResources(
+      let children = this.getContainersWithResources(
         podSpec, containers, instance.getAgentAddress()
       );
+      let resourcesSum = instance.getResources();
 
       return {
         id: instance.getId(),

--- a/src/js/components/__tests__/PodInstancesView-test.js
+++ b/src/js/components/__tests__/PodInstancesView-test.js
@@ -110,6 +110,21 @@ describe('PodInstancesView', function () {
           'container-1'
         ]);
       });
+
+      it('should always show instance total resources', function () {
+        var mem = TestUtils.scryRenderedDOMComponentsWithClass(
+            this.instance, 'column-mem')
+            .filter(JestUtil.filterByTagName('TD'))
+            .reduce(JestUtil.reduceTextContentOfSelector(
+              'span'), []);
+
+        expect(mem).toEqual([
+          '128 MiB',
+          '64 MiB',
+          '128 MiB',
+          '64 MiB'
+        ]);
+      });
     });
 
     describe('show all', function () {

--- a/src/js/structs/PodInstance.js
+++ b/src/js/structs/PodInstance.js
@@ -66,6 +66,7 @@ module.exports = class PodInstance extends Item {
 
   getResources() {
     let resources = this.get('resources') || {};
+
     return Object.assign({
       cpus: 0,
       mem: 0,

--- a/src/js/structs/PodInstance.js
+++ b/src/js/structs/PodInstance.js
@@ -64,6 +64,16 @@ module.exports = class PodInstance extends Item {
     return new Date(this.get('lastUpdated'));
   }
 
+  getResources() {
+    let resources = this.get('resources') || {};
+    return Object.assign({
+      cpus: 0,
+      mem: 0,
+      gpus: 0,
+      disk: 0
+    }, resources);
+  }
+
   hasHealthChecks() {
     // If for any reason any of the containers has at least 1 health
     // check that is failing, assume that we have leath checks

--- a/src/js/structs/__tests__/PodInstance-test.js
+++ b/src/js/structs/__tests__/PodInstance-test.js
@@ -179,6 +179,27 @@ describe('PodInstance', function () {
 
   });
 
+  describe('#getResources', function () {
+
+    it('should return the correct value', function () {
+      let podInstance = new PodInstance({
+        resources: { cpus: 0.5, mem: 64 }
+      });
+
+      expect(podInstance.getResources()).toEqual({
+        cpus: 0.5, mem: 64, disk: 0, gpus: 0
+      });
+    });
+
+    it('should return the correct default value', function () {
+      let podInstance = new PodInstance();
+      expect(podInstance.getResources()).toEqual({
+        cpus: 0, mem: 0, disk: 0, gpus: 0
+      });
+    });
+
+  });
+
   describe('#hasHealthChecks', function () {
 
     it('should return true if all container have health checks', function () {


### PR DESCRIPTION
Making sure we always show the total count of resources, as received from marathon (instead of summing-up the current values of the view, ex. when a filter is applied).