### PR TITLE
[Pods] DCOS-10100: Getting resource details from spec when available

### DIFF
--- a/src/js/components/PodInstancesTable.js
+++ b/src/js/components/PodInstancesTable.js
@@ -168,6 +168,8 @@ class PodInstancesTable extends React.Component {
 
     let children = containers.map(function (container) {
       let containerResources = container.getResources();
+
+      // TODO: Remove the following 4 lines when DCOS-10098 is addressed
       let containerSpec = podSpec.getContainerSpec(container.name);
       if (containerSpec) {
         containerResources = containerSpec.resources;

--- a/src/js/components/PodInstancesTable.js
+++ b/src/js/components/PodInstancesTable.js
@@ -167,9 +167,14 @@ class PodInstancesTable extends React.Component {
     };
 
     let children = containers.map(function (container) {
+      let containerResources = container.getResources();
       let containerSpec = podSpec.getContainerSpec(container.name);
-      Object.keys(containerSpec.resources).forEach(function (key) {
-        resourcesSum[key] += containerSpec.resources[key];
+      if (containerSpec) {
+        containerResources = containerSpec.resources;
+      }
+
+      Object.keys(containerResources).forEach(function (key) {
+        resourcesSum[key] += containerResources[key];
       });
 
       let addressComponents = container.endpoints.map(function (endpoint, i) {
@@ -189,8 +194,8 @@ class PodInstancesTable extends React.Component {
         name: container.getName(),
         status: container.getContainerStatus(),
         address: addressComponents,
-        cpus: containerSpec.resources.cpus,
-        mem: containerSpec.resources.mem,
+        cpus: containerResources.cpus,
+        mem: containerResources.mem,
         updated: container.getLastUpdated(),
         version: ''
       };

--- a/src/js/structs/PodContainer.js
+++ b/src/js/structs/PodContainer.js
@@ -58,6 +58,16 @@ module.exports = class PodContainer extends Item {
     return this.get('name') || '';
   }
 
+  getResources() {
+    let resources = this.get('resources') || {};
+    return Object.assign({
+      cpus: 0,
+      mem: 0,
+      gpus: 0,
+      disk: 0
+    }, resources);
+  }
+
   hasHealthChecks() {
     // According to RAML specs:
     //

--- a/src/js/structs/PodContainer.js
+++ b/src/js/structs/PodContainer.js
@@ -59,13 +59,12 @@ module.exports = class PodContainer extends Item {
   }
 
   getResources() {
-    let resources = this.get('resources') || {};
     return Object.assign({
       cpus: 0,
       mem: 0,
       gpus: 0,
       disk: 0
-    }, resources);
+    }, this.get('resources'));
   }
 
   hasHealthChecks() {

--- a/src/js/structs/__tests__/PodContainer-test.js
+++ b/src/js/structs/__tests__/PodContainer-test.js
@@ -211,6 +211,27 @@ describe('PodContainer', function () {
 
   });
 
+  describe('#getResources', function () {
+
+    it('should return the correct value', function () {
+      let podContainer = new PodContainer({
+        resources: { cpus: 0.5, mem: 64 }
+      });
+
+      expect(podContainer.getResources()).toEqual({
+        cpus: 0.5, mem: 64, disk: 0, gpus: 0
+      });
+    });
+
+    it('should return the correct default value', function () {
+      let podContainer = new PodContainer();
+      expect(podContainer.getResources()).toEqual({
+        cpus: 0, mem: 0, disk: 0, gpus: 0
+      });
+    });
+
+  });
+
   describe('#hasHealthChecks', function () {
 
     it('should return false if no health checks defined', function () {


### PR DESCRIPTION
This PR is a temporary solution until https://mesosphere.atlassian.net/browse/DCOS-10098 is addressed. It will automatically switch on using the new data when they become available.

In detail: We encountered a case were a pod contains a container not part of the `spec` (ex. you edit the spec and remove a container, but it is still present in the instances for some time). Therefore, we were not able to get the resource information from the spec and the UI was failing. This PR uses by default the `resources` information from the container itself and for the transient period until the issue is addressed it will also use the information from the spec if available.