### PR TITLE
[Pods] DCOS-9895: Have Pod and task tables use up available space before truncating

### DIFF
--- a/src/js/components/PodInstancesTable.js
+++ b/src/js/components/PodInstancesTable.js
@@ -74,7 +74,7 @@ class PodInstancesTable extends React.Component {
     return (
       <colgroup>
         <col />
-        <col />
+        <col className="hidden-mini" />
         <col className="hidden-mini" />
         <col className="hidden-mini" />
         <col className="hidden-mini" />
@@ -103,10 +103,21 @@ class PodInstancesTable extends React.Component {
   }
 
   getColumnClassName(prop, sortBy, row) {
+    let hiddenMiniCols = [
+      'address',
+      'status',
+      'logs',
+      'cpus',
+      'mem',
+      'version'
+    ];
+
     return classNames(`column-${prop}`, {
       'highlight': prop === sortBy.prop,
       'clickable': row == null,
-      'table-cell-task-dot': prop === 'status'
+      'table-cell-task-dot': prop === 'status',
+      'hidden-medium hidden-small': prop === 'version',
+      'hidden-mini': hiddenMiniCols.includes(prop)
     });
   }
 

--- a/src/js/components/PodInstancesTable.js
+++ b/src/js/components/PodInstancesTable.js
@@ -74,13 +74,13 @@ class PodInstancesTable extends React.Component {
     return (
       <colgroup>
         <col />
-        <col style={{width: '120px'}} />
-        <col style={{width: '120px'}} />
-        <col style={{width: '64px'}} />
-        <col style={{width: '86px'}} />
-        <col style={{width: '86px'}} />
-        <col style={{width: '160px'}} />
-        <col style={{width: '160px'}} />
+        <col />
+        <col className="hidden-mini" />
+        <col className="hidden-mini" />
+        <col className="hidden-mini" />
+        <col className="hidden-mini" />
+        <col />
+        <col className="hidden-medium hidden-small hidden-mini" />
       </colgroup>
     );
   }

--- a/src/styles/components/pod-instances-table.less
+++ b/src/styles/components/pod-instances-table.less
@@ -5,3 +5,35 @@
 .pod-instances-table .column-logs {
   padding-left: 0;
 }
+
+.pod-instances-table .column-checkbox {
+  width: 40px;
+}
+
+.pod-instances-table .column-name {
+  width: 100%;
+  min-width: 150px;
+}
+
+.pod-instances-table .column-address {
+  min-width: 120px;
+  max-width: 300px;
+}
+
+.pod-instances-table .column-status {
+  width: 120px;
+  min-width: 120px;
+}
+
+.table.pod-instances-table .table-cell-task-dot {
+  max-width: none;
+}
+
+.pod-instances-table .column-cpus {
+  width: 64px;
+}
+
+.pod-instances-table .column-version {
+  min-width: 160px;
+  max-width: 300px;
+}


### PR DESCRIPTION
With this PR less important columns in the pod's instances table will be hidden on the smaller screens as we do for the regular app tasks table. In addition to that I introduced min-/max-width to make use of the empty space as stated in the ticket.

![screen shot 2016-09-29 at 13 54 33](https://cloud.githubusercontent.com/assets/186223/18953328/32f65772-864e-11e6-8a54-f97272795ec7.png)
![sep-29-2016 13-51-35](https://cloud.githubusercontent.com/assets/186223/18953333/35b576dc-864e-11e6-907d-beff86ec4aaa.gif)
