### PR TITLE
[Pods] DCOS-10108 [1/3]: Adding support for onSelectionChange on the instances table

### DIFF
--- a/src/js/components/PodInstancesTable.js
+++ b/src/js/components/PodInstancesTable.js
@@ -68,12 +68,11 @@ class PodInstancesTable extends React.Component {
 
     // When the `instances` property is changed and we have selected
     // items, re-trigger selection change in order to remove checked
-    // entries that are no longer preset.
+    // entries that are no longer present.
 
-    if (!deepEqual(prevInstances, nextInstances)) {
-      if (Object.keys(checkedItems).length) {
-        this.triggerSelectionChange(checkedItems, nextProps.instances);
-      }
+    if (Object.keys(checkedItems).length &&
+       !deepEqual(prevInstances, nextInstances)) {
+      this.triggerSelectionChange(checkedItems, nextProps.instances);
     }
   }
 
@@ -83,7 +82,7 @@ class PodInstancesTable extends React.Component {
         return checkedItems[item.getId()];
       }
     );
-    this.props.onSelectionChange( checkedItemInstances );
+    this.props.onSelectionChange(checkedItemInstances);
   }
 
   handleItemCheck(idsChecked) {

--- a/src/js/components/PodInstancesTable.js
+++ b/src/js/components/PodInstancesTable.js
@@ -2,8 +2,8 @@ import classNames from 'classnames';
 import deepEqual from 'deep-equal';
 import React from 'react';
 import {Link} from 'react-router';
-import {Table} from 'reactjs-components';
 
+import CheckboxTable from './CheckboxTable';
 import CollapsingString from './CollapsingString';
 import EventTypes from '../constants/EventTypes';
 import ExpandingTable from './ExpandingTable';
@@ -14,7 +14,6 @@ import PodInstanceList from '../structs/PodInstanceList';
 import PodInstanceStatus from '../constants/PodInstanceStatus';
 import PodTableHeaderLabels from '../constants/PodTableHeaderLabels';
 import PodUtil from '../utils/PodUtil';
-import TableUtil from '../utils/TableUtil';
 import TimeAgo from './TimeAgo';
 import Units from '../utils/Units';
 
@@ -102,6 +101,7 @@ class PodInstancesTable extends React.Component {
   getColGroup() {
     return (
       <colgroup>
+        <col style={{width: '40px'}} />
         <col />
         <col style={{width: '120px'}} />
         <col style={{width: '120px'}} />
@@ -429,10 +429,9 @@ class PodInstancesTable extends React.Component {
         data={this.getTableDataFor(instances, filterText)}
         expandAll={!!filterText}
         getColGroup={this.getColGroup}
-        itemHeight={TableUtil.getRowHeight()}
         onCheckboxChange={this.handleItemCheck}
         sortBy={{prop: 'name', order: 'asc'}}
-        tableComponent={Table}
+        tableComponent={CheckboxTable}
         uniqueProperty="id" />
     );
   }

--- a/src/js/components/PodInstancesTable.js
+++ b/src/js/components/PodInstancesTable.js
@@ -66,7 +66,10 @@ class PodInstancesTable extends React.Component {
     let {checkedItems} = this.state;
     let prevInstances = this.props.instances.getItems();
     let nextInstances = nextProps.instances.getItems();
-    let shouldUpdate = false;
+
+    // When the `instances` property is changed and we have selected
+    // items, re-trigger selection change in order to remove checked
+    // entries that are no longer preset.
 
     if (!deepEqual(prevInstances, nextInstances)) {
       if (Object.keys(checkedItems).length) {

--- a/src/js/components/PodInstancesTable.js
+++ b/src/js/components/PodInstancesTable.js
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import deepEqual from 'deep-equal';
 import React from 'react';
 import {Link} from 'react-router';
 import {Table} from 'reactjs-components';
@@ -61,6 +62,29 @@ class PodInstancesTable extends React.Component {
     this.forceUpdate();
   }
 
+  componentWillReceiveProps(nextProps) {
+    let {checkedItems} = this.state;
+    let prevInstances = this.props.instances.getItems();
+    let nextInstances = nextProps.instances.getItems();
+    let shouldUpdate = false;
+
+    if (!deepEqual(prevInstances, nextInstances)) {
+      if (Object.keys(checkedItems).length) {
+        this.triggerSelectionChange(checkedItems, nextProps.instances);
+      }
+    }
+  }
+
+  triggerSelectionChange(checkedItems, instances) {
+    let checkedItemInstances = instances.getItems().filter(
+      function (item) {
+        return checkedItems[item.getId()];
+      }
+    );
+    console.log(checkedItemInstances);
+    this.props.onSelectionChange( checkedItemInstances );
+  }
+
   handleItemCheck(idsChecked) {
     let checkedItems = {};
 
@@ -68,6 +92,8 @@ class PodInstancesTable extends React.Component {
       checkedItems[id] = true;
     });
     this.setState({checkedItems});
+
+    this.triggerSelectionChange(checkedItems, this.props.instances);
   }
 
   getColGroup() {
@@ -391,7 +417,7 @@ class PodInstancesTable extends React.Component {
 
     return (
       <ExpandingTable
-        allowMultipleSelect={false}
+        allowMultipleSelect={true}
         className="pod-instances-table expanding-table table table-hover inverse table-borderless-outer table-borderless-inner-columns flush-bottom"
         childRowClassName="expanding-table-child"
         checkedItemsMap={checkedItems}
@@ -414,6 +440,7 @@ PodInstancesTable.defaultProps = {
   filterText: '',
   instances: null,
   inverseStyle: false,
+  onSelectionChange() { },
   pod: null
 };
 
@@ -421,6 +448,7 @@ PodInstancesTable.propTypes = {
   filterText: React.PropTypes.string,
   instances: React.PropTypes.instanceOf(PodInstanceList),
   inverseStyle: React.PropTypes.bool,
+  onSelectionChange: React.PropTypes.func,
   pod: React.PropTypes.instanceOf(Pod).isRequired
 };
 

--- a/src/js/components/PodInstancesTable.js
+++ b/src/js/components/PodInstancesTable.js
@@ -83,7 +83,6 @@ class PodInstancesTable extends React.Component {
         return checkedItems[item.getId()];
       }
     );
-    console.log(checkedItemInstances);
     this.props.onSelectionChange( checkedItemInstances );
   }
 

--- a/src/js/components/PodInstancesView.js
+++ b/src/js/components/PodInstancesView.js
@@ -9,7 +9,10 @@ import PodViewFilter from './PodViewFilter';
 
 const METHODS_TO_BIND = [
   'handleFilterChange',
-  'handleFilterReset'
+  'handleFilterReset',
+  'handleSelectionChange',
+  'handleKillClick',
+  'handleKillAndScaleClick'
 ];
 
 class PodInstancesView extends React.Component {
@@ -20,7 +23,8 @@ class PodInstancesView extends React.Component {
       filter: {
         text: '',
         status: 'active'
-      }
+      },
+      selectedItems: []
     };
 
     METHODS_TO_BIND.forEach(function (method) {
@@ -47,6 +51,27 @@ class PodInstancesView extends React.Component {
     }
   }
 
+  getKillButtons() {
+    if (!this.state.selectedItems.length) {
+      return null;
+    }
+
+    return (
+      <div className="button-collection flush-bottom">
+        <div
+          className="button button-stroke button-danger"
+          onClick={this.handleKillAndScaleClick}>
+          Kill and Scale
+        </div>
+        <div
+          className="button button-stroke button-danger"
+          onClick={this.handleKillClick}>
+          Kill
+        </div>
+      </div>
+    );
+  }
+
   handleFilterChange(filter) {
     this.setState({filter});
   }
@@ -58,6 +83,18 @@ class PodInstancesView extends React.Component {
         status: 'all'
       }
     });
+  }
+
+  handleKillClick() {
+
+  }
+
+  handleKillAndScaleClick() {
+
+  }
+
+  handleSelectionChange(selectedItems) {
+    this.setState({selectedItems});
   }
 
   render() {
@@ -96,11 +133,14 @@ class PodInstancesView extends React.Component {
           items={filteredTextItems.getItems()}
           onFilterChange={this.handleFilterChange}
           statusChoices={['all', 'active', 'completed']}
-          statusMapper={this.getInstanceFilterStatus} />
+          statusMapper={this.getInstanceFilterStatus}>
+          {this.getKillButtons()}
+        </PodViewFilter>
         <PodInstancesTable
           filterText={filter.text}
           instances={filteredItems}
           inverseStyle={true}
+          onSelectionChange={this.handleSelectionChange}
           pod={this.props.pod} />
       </div>
     );

--- a/src/js/components/PodViewFilter.js
+++ b/src/js/components/PodViewFilter.js
@@ -60,10 +60,7 @@ class PodViewFilter extends React.Component {
 
   render() {
     let {children, filter, inverseStyle} = this.props;
-    let childrenCount = 0;
-    if (Array.isArray(children)) {
-      childrenCount = children.length;
-    }
+    let childrenCount = React.Children.count(children);
 
     return (
       <FilterBar rightAlignLastNChildren={childrenCount}>

--- a/src/js/components/__tests__/PodInstancesTable-test.js
+++ b/src/js/components/__tests__/PodInstancesTable-test.js
@@ -155,11 +155,9 @@ describe('PodInstancesTable', function () {
           {pod}, {service: pod});
         this.instance = TestUtils.renderIntoDocument(component);
 
-        // 2 clicks on the header (ascending), becaue
-        // we are sorting by name by default.
+        // 1 click on the header (ascending)
         let columnHeader = TestUtils.scryRenderedDOMComponentsWithClass(
             this.instance, 'column-name')[0];
-        TestUtils.Simulate.click(columnHeader);
         TestUtils.Simulate.click(columnHeader);
       });
 
@@ -185,9 +183,10 @@ describe('PodInstancesTable', function () {
           {pod}, {service: pod});
         this.instance = TestUtils.renderIntoDocument(component);
 
-        // 1 click on the header (descending)
+        // 2 clicks on the header (descending)
         let columnHeader = TestUtils.scryRenderedDOMComponentsWithClass(
             this.instance, 'column-name')[0];
+        TestUtils.Simulate.click(columnHeader);
         TestUtils.Simulate.click(columnHeader);
       });
 


### PR DESCRIPTION
This PR re-enables the checkboxes on the `PodInstanceTable` and it also properly handles the event to show the `Kill` and `Kill and Scale` buttons.

(Note that the `scale` option will be available soon: https://mesosphere.atlassian.net/browse/DCOS-10110 )

![image](https://cloud.githubusercontent.com/assets/883486/18962888/da15020a-8672-11e6-86a8-ed511e981e05.png)
