### PR TITLE
DCOS-9918: Improve containers port mapping

### DIFF
--- a/src/js/components/ConfigurationView.js
+++ b/src/js/components/ConfigurationView.js
@@ -92,10 +92,9 @@ class ConfigurationView extends mixin(StoreMixin) {
   }
 
   getPortDefinitionsSection(config) {
-    let {id, container, portDefinitions} = config;
+    let {id, portDefinitions} = config;
 
-    if (portDefinitions == null || !(container == null || container.docker == null
-        || container.docker.portMappings == null)) {
+    if (portDefinitions == null) {
       return null;
     }
 

--- a/src/js/components/ConfigurationView.js
+++ b/src/js/components/ConfigurationView.js
@@ -8,6 +8,7 @@ import Loader from './Loader';
 import Service from '../structs/Service';
 import StringUtil from '../utils/StringUtil';
 import ServiceConfigUtil from '../utils/ServiceConfigUtil';
+import Util from '../utils/Util';
 
 const sectionClassName = 'container-fluid container-pod container-pod-super-short flush flush-bottom';
 
@@ -66,23 +67,23 @@ class ConfigurationView extends mixin(StoreMixin) {
       return `${key} : ${value}`;
     });
 
-    let networkNameKey = 'Network Name';
+    let portMappings = docker.portMappings || [];
+    portMappings = portMappings.reduce(function (memo, mapping, index) {
+      memo[`Port mapping ${index + 1}`] = mapping;
+      return memo;
+    }, {});
+
     let headerValueMapping = {
       'Force Pull Image': docker.forcePullImage,
       'Image': docker.image,
       'Network': docker.network,
-      [networkNameKey]: null,
-      'Parameters': StringUtil.arrayToJoinedString(
-        parameters
-      ),
+      'Network Name': ipAddress && ipAddress.networkName,
+      'Parameters': StringUtil.arrayToJoinedString(parameters),
+      'Port Mappings': portMappings,
       'Privileged': docker.privileged
     };
 
-    if (ipAddress) {
-      headerValueMapping[networkNameKey] = ipAddress.networkName;
-    } else {
-      delete headerValueMapping[networkNameKey];
-    }
+    headerValueMapping = Util.filterEmptyValues(headerValueMapping);
 
     return (
       <DescriptionList className={sectionClassName}

--- a/src/js/components/ConfigurationView.js
+++ b/src/js/components/ConfigurationView.js
@@ -109,7 +109,7 @@ class ConfigurationView extends mixin(StoreMixin) {
             hash={hash}
             headline={headline}
             key={index} />
-          );
+        );
       });
 
     return (

--- a/src/js/utils/Util.js
+++ b/src/js/utils/Util.js
@@ -1,3 +1,5 @@
+import ValidatorUtil from './ValidatorUtil';
+
 let uniqueIDMap = {};
 
 const Util = {
@@ -178,6 +180,21 @@ const Util = {
     }
 
     return copy;
+  },
+
+  /**
+   * Removes keys with empty values from an Object
+   *
+   * @param {Object} obj Object to filter
+   * @return {Object} Copy of a filtered obj
+   */
+  filterEmptyValues(obj) {
+    return Object.keys(obj).filter(function (key) {
+      return !ValidatorUtil.isEmpty(obj[key]);
+    }).reduce(function (memo, key) {
+      memo[key] = obj[key];
+      return memo;
+    }, {});
   }
 };
 

--- a/src/js/utils/__tests__/Util-test.js
+++ b/src/js/utils/__tests__/Util-test.js
@@ -372,4 +372,32 @@ describe('Util', function () {
 
   });
 
+  describe('#filterEmptyValues', function () {
+    it('filters empty values from an Object', function () {
+      let expectedObject = {
+        ooleanFalse: false,
+        booleanTrue: true,
+        string: 'string',
+        array: [1, 2, 3],
+        object: {a: 1},
+        number: 123
+      };
+
+      expect(Util.filterEmptyValues({
+        booleanFalse: false,
+        booleanTrue: true,
+        emptyString: '',
+        string: 'string',
+        emptyArray: [],
+        array: [1, 2, 3],
+        emptyObject: {},
+        object: {a: 1},
+        number: 123,
+        nullValue: null,
+        undefinedValue: undefined
+      }), expectedObject);
+    });
+
+  });
+
 });

--- a/src/js/utils/__tests__/Util-test.js
+++ b/src/js/utils/__tests__/Util-test.js
@@ -395,7 +395,7 @@ describe('Util', function () {
         number: 123,
         nullValue: null,
         undefinedValue: undefined
-      }), expectedObject);
+      })).toEqual(expectedObject);
     });
 
   });

--- a/src/js/utils/__tests__/Util-test.js
+++ b/src/js/utils/__tests__/Util-test.js
@@ -375,7 +375,7 @@ describe('Util', function () {
   describe('#filterEmptyValues', function () {
     it('filters empty values from an Object', function () {
       let expectedObject = {
-        ooleanFalse: false,
+        booleanFalse: false,
         booleanTrue: true,
         string: 'string',
         array: [1, 2, 3],


### PR DESCRIPTION
With this PR we will be displaying a docker container port mappings like this:

<img width="775" alt="screen shot 2016-09-30 at 13 09 16" src="https://cloud.githubusercontent.com/assets/186223/18989960/3c1f4518-870f-11e6-94b1-9a8ea4cf3530.png">

⚠️  new `Util.filterEmptyValues` has been added. That function removes keys with empty values from an Object using `ValidatorUtil.isEmpty`. All the usages will be migrated in a separate PR.