### PR TITLE
[Pods] DCOS-10183: Fix network labels destructuring

### DIFF
--- a/src/js/components/PodNetworkSpecView.js
+++ b/src/js/components/PodNetworkSpecView.js
@@ -22,7 +22,7 @@ class PodNetworkSpecView extends React.Component {
   }
 
   getLabelSection() {
-    let {network: labels} = this.props;
+    let {network: {labels}} = this.props;
     if (!labels || !Object.keys(labels).length) {
       return null;
     }


### PR DESCRIPTION
This PR addresses the issue of using `network` as `labels` because of a bug in destructuring.