### PR TITLE
[Pods] DCOS-10180: Recursively showing pods in groups

### DIFF
--- a/src/js/structs/ServiceTree.js
+++ b/src/js/structs/ServiceTree.js
@@ -218,6 +218,12 @@ module.exports = class ServiceTree extends Tree {
             }
 
             if (parseInt(otherKey, 10) === ServiceOther.PODS.key) {
+              if (service instanceof ServiceTree) {
+                memo = memo.concat(
+                  service.filterItemsByFilter({other: [otherKey]}).getItems()
+                );
+              }
+
               if (service instanceof Pod) {
                 memo.push(service);
               }


### PR DESCRIPTION
This bug addresses an issue were pods inside groups were not visible when the `Pods` filter was active on the services list.