### PR TITLE
DCOS-9891: Renaming Tasks to Instances in pods

### DIFF
--- a/src/js/components/PodInstancesView.js
+++ b/src/js/components/PodInstancesView.js
@@ -86,7 +86,7 @@ class PodInstancesView extends React.Component {
           currentLength={filteredItems.getItems().length}
           inverseStyle={true}
           isFiltering={filter.text || (filter.status !== 'all')}
-          name="Pod"
+          name="Instance"
           onReset={this.handleFilterReset}
           totalLength={allItems.getItems().length}
           />

--- a/src/js/components/ServiceDetail.js
+++ b/src/js/components/ServiceDetail.js
@@ -28,7 +28,7 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
     super(...arguments);
 
     this.tabs_tabs = {
-      tasks: 'Tasks',
+      tasks: 'Instances',
       configuration: 'Configuration',
       debug: 'Debug'
     };
@@ -106,7 +106,7 @@ class ServiceDetail extends mixin(InternalStorageMixin, TabsMixin) {
     );
   }
 
-  renderTasksTabView() {
+  renderInstancesTabView() {
     return (
       <ServiceDetailTaskTab service={this.props.service} />
     );

--- a/src/js/components/ServiceDetailTaskTab.js
+++ b/src/js/components/ServiceDetailTaskTab.js
@@ -20,7 +20,10 @@ class ServiceDetailTaskTab extends mixin(StoreMixin) {
     let tasks = MesosStateStore.getTasksByService(this.props.service);
 
     return (
-      <TaskView tasks={tasks} inverseStyle={true} label="Instance"
+      <TaskView
+        tasks={tasks}
+        inverseStyle={true}
+        label="Instance"
         parentRouter={this.context.router} />
     );
   }

--- a/src/js/components/ServiceDetailTaskTab.js
+++ b/src/js/components/ServiceDetailTaskTab.js
@@ -20,7 +20,7 @@ class ServiceDetailTaskTab extends mixin(StoreMixin) {
     let tasks = MesosStateStore.getTasksByService(this.props.service);
 
     return (
-      <TaskView tasks={tasks} inverseStyle={true}
+      <TaskView tasks={tasks} inverseStyle={true} label="Instance"
         parentRouter={this.context.router} />
     );
   }

--- a/src/js/components/ServiceInfo.js
+++ b/src/js/components/ServiceInfo.js
@@ -92,7 +92,7 @@ class ServiceInfo extends React.Component {
     let serviceStatusClassSet = StatusMapping[serviceStatus] || '';
     let runningTasksCount = tasksSummary.tasksRunning;
     let instancesCount = service.getInstancesCount();
-    let runningTasksSubHeader = StringUtil.pluralize('Task', runningTasksCount);
+    let runningTasksSubHeader = StringUtil.pluralize('Instance', runningTasksCount);
     let overCapacity = '';
     let isDeploying = serviceStatus === 'Deploying';
 

--- a/src/js/components/ServicesTable.js
+++ b/src/js/components/ServicesTable.js
@@ -9,7 +9,6 @@ import Icon from './Icon';
 import Links from '../constants/Links';
 import NestedServiceLinks from '../components/NestedServiceLinks';
 import ResourceTableUtil from '../utils/ResourceTableUtil';
-import Pod from '../structs/Pod';
 import Service from '../structs/Service';
 import ServiceActionItem from '../constants/ServiceActionItem';
 import ServiceDestroyModal from './modals/ServiceDestroyModal';
@@ -279,15 +278,11 @@ var ServicesTable = React.createClass({
     let {tasksRunning} = tasksSummary;
 
     let isDeploying = serviceStatus === 'Deploying';
-    let taskString = 'Task';
-    if (service instanceof Pod) {
-      taskString = 'Instance';
-    }
 
     let conciseOverview = ` (${tasksRunning}/${instancesCount})`;
-    let verboseOverview = ` (${tasksRunning} ${StringUtil.pluralize(taskString, tasksRunning)})`;
+    let verboseOverview = ` (${tasksRunning} ${StringUtil.pluralize('Intance', tasksRunning)})`;
     if (tasksRunning !== instancesCount) {
-      verboseOverview = ` (${tasksRunning} of ${instancesCount} ${taskString})`;
+      verboseOverview = ` (${tasksRunning} of ${instancesCount} Instances)`;
     }
 
     return (

--- a/src/js/components/ServicesTable.js
+++ b/src/js/components/ServicesTable.js
@@ -9,6 +9,7 @@ import Icon from './Icon';
 import Links from '../constants/Links';
 import NestedServiceLinks from '../components/NestedServiceLinks';
 import ResourceTableUtil from '../utils/ResourceTableUtil';
+import Pod from '../structs/Pod';
 import Service from '../structs/Service';
 import ServiceActionItem from '../constants/ServiceActionItem';
 import ServiceDestroyModal from './modals/ServiceDestroyModal';
@@ -278,11 +279,15 @@ var ServicesTable = React.createClass({
     let {tasksRunning} = tasksSummary;
 
     let isDeploying = serviceStatus === 'Deploying';
+    let taskString = 'Task';
+    if (service instanceof Pod) {
+      taskString = 'Instance';
+    }
 
     let conciseOverview = ` (${tasksRunning}/${instancesCount})`;
-    let verboseOverview = ` (${tasksRunning} ${StringUtil.pluralize('Task', tasksRunning)})`;
+    let verboseOverview = ` (${tasksRunning} ${StringUtil.pluralize(taskString, tasksRunning)})`;
     if (tasksRunning !== instancesCount) {
-      verboseOverview = ` (${tasksRunning} of ${instancesCount} Tasks)`;
+      verboseOverview = ` (${tasksRunning} of ${instancesCount} ${taskString})`;
     }
 
     return (

--- a/src/js/components/TaskView.js
+++ b/src/js/components/TaskView.js
@@ -221,7 +221,7 @@ class TaskView extends mixin(SaveStateMixin, StoreMixin) {
   }
 
   getContent() {
-    let {inverseStyle, tasks} = this.props;
+    let {inverseStyle, label, tasks} = this.props;
     let {checkedItems, filterByStatus, searchString} = this.state;
     let filteredTasks = this.getFilteredTasks();
 
@@ -248,7 +248,7 @@ class TaskView extends mixin(SaveStateMixin, StoreMixin) {
           inverseStyle={inverseStyle}
           isFiltering={filterByStatus !== 'all' || searchString !== ''}
           onReset={this.resetFilter}
-          name="Task"
+          name={label}
           totalLength={tasks.length} />
         <FilterBar rightAlignLastNChildren={rightAlignLastNChildren}>
           <FilterInputText
@@ -286,12 +286,14 @@ class TaskView extends mixin(SaveStateMixin, StoreMixin) {
 TaskView.defaultProps = {
   inverseStyle: false,
   itemID: '',
+  label: 'Task',
   tasks: []
 };
 
 TaskView.propTypes = {
   inverseStyle: React.PropTypes.bool,
   itemID: React.PropTypes.string,
+  label: React.PropTypes.string,
   parentRouter: React.PropTypes.func,
   tasks: React.PropTypes.array
 };

--- a/src/js/components/__tests__/ServiceDetail-test.js
+++ b/src/js/components/__tests__/ServiceDetail-test.js
@@ -99,19 +99,19 @@ describe('ServiceDetail', function () {
 
   });
 
-  describe('#renderTasksTabView', function () {
+  describe('#renderInstancesTabView', function () {
 
     it('renders task tab', function () {
-      var tasksTabView = ReactDOM.render(
-        this.instance.renderTasksTabView(),
+      var instancesTabView = ReactDOM.render(
+        this.instance.renderInstancesTabView(),
         this.container
       );
-      var serviceDetailTaskTab = TestUtils.findRenderedComponentWithType(
-        tasksTabView,
+      var serviceDetailInstancesTab = TestUtils.findRenderedComponentWithType(
+        instancesTabView,
         ServiceDetailTaskTab
       );
 
-      expect(serviceDetailTaskTab).toBeDefined();
+      expect(serviceDetailInstancesTab).toBeDefined();
 
     });
 

--- a/src/js/components/__tests__/ServiceInfo-test.js
+++ b/src/js/components/__tests__/ServiceInfo-test.js
@@ -62,7 +62,7 @@ describe('ServiceInfo', function () {
     it('renders number of running tasks', function () {
       expect(
         this.node.querySelector('.page-header-sub-heading').children[0].children[1].textContent
-      ).toEqual('2 Tasks');
+      ).toEqual('2 Instances');
     });
 
   });

--- a/src/js/constants/TaskTableHeaderLabels.js
+++ b/src/js/constants/TaskTableHeaderLabels.js
@@ -3,8 +3,8 @@ var TaskTableHeaderLabels = {
   disk: 'DISK',
   host: 'HOST',
   mem: 'MEM',
-  id: 'TASK ID',
-  name: 'TASK NAME',
+  id: 'ID',
+  name: 'NAME',
   status: 'STATUS',
   updated: 'UPDATED',
   version: 'VERSION'


### PR DESCRIPTION
This PR addresses task naming issues:

* On the collection view `Tasks` are now called `Instances` on the pods (I don't have a large enough screen to get a screenshot of this)
* On the pod instance detail view, the filter header shows `Showing X of X Instances` instead of tasks.

![image](https://cloud.githubusercontent.com/assets/883486/18995683/e3c760f4-8735-11e6-8ea3-75436843a5ae.png)
