### PR TITLE
[CNVS Upgrade] Update DescriptionList flex classname

### DIFF
--- a/src/js/components/DescriptionList.js
+++ b/src/js/components/DescriptionList.js
@@ -45,7 +45,7 @@ class DescriptionList extends React.Component {
       }
 
       return (
-        <dl key={index} className="flex-box row">
+        <dl key={index} className="flex row">
           <dt className={dtClassName}>{key}</dt>
           <dd className={ddClassName}>{value}</dd>
         </dl>


### PR DESCRIPTION
This fixes the `DescriptionList` classname discrepancy, but there's an `!important` in CNVS that will cause these to look misaligned still. I submitted a PR to CNVS to fix that here: https://github.com/mesosphere/canvas/pull/27