### PR TITLE
DCOS-9919: Renaming ConfigurationView to ServiceSpecView

### DIFF
--- a/src/js/components/ServiceDetailConfigurationTab.js
+++ b/src/js/components/ServiceDetailConfigurationTab.js
@@ -1,7 +1,7 @@
 import {Dropdown} from 'reactjs-components';
 import React from 'react';
 
-import ConfigurationView from './ConfigurationView';
+import ServiceSpecView from './ServiceSpecView';
 import DCOSStore from '../stores/DCOSStore';
 import MarathonStore from '../stores/MarathonStore';
 import Service from '../structs/Service';
@@ -197,7 +197,7 @@ class ServiceDetailConfigurationTab extends React.Component {
     return (
       <div className="tab">
         {this.getVersionsActions()}
-        <ConfigurationView
+        <ServiceSpecView
           headline={headline}
           service={service}
           versionID={selectedVersionID} />

--- a/src/js/components/ServiceSpecView.js
+++ b/src/js/components/ServiceSpecView.js
@@ -18,7 +18,7 @@ function fetchVersion(service, versionID) {
   }
 }
 
-class ConfigurationView extends mixin(StoreMixin) {
+class ServiceSpecView extends mixin(StoreMixin) {
   constructor() {
     super(...arguments);
 
@@ -240,14 +240,14 @@ class ConfigurationView extends mixin(StoreMixin) {
   }
 }
 
-ConfigurationView.defaultProps = {
+ServiceSpecView.defaultProps = {
   headline: 'Configuration'
 };
 
-ConfigurationView.propTypes = {
+ServiceSpecView.propTypes = {
   headline: React.PropTypes.string,
   service: React.PropTypes.instanceOf(Service).isRequired,
   versionID: React.PropTypes.string.isRequired
 };
 
-module.exports = ConfigurationView;
+module.exports = ServiceSpecView;

--- a/src/js/components/__tests__/ServiceDetailConfigurationTab-test.js
+++ b/src/js/components/__tests__/ServiceDetailConfigurationTab-test.js
@@ -1,5 +1,5 @@
 jest.dontMock('../ServiceDetailConfigurationTab');
-jest.dontMock('../ConfigurationView');
+jest.dontMock('../ServiceSpecView');
 
 /* eslint-disable no-unused-vars */
 const React = require('react');
@@ -9,7 +9,7 @@ const TestUtils = require('react-addons-test-utils');
 
 const Application = require('../../structs/Application');
 const ServiceDetailConfigurationTab = require('../ServiceDetailConfigurationTab');
-const ConfigurationView = require('../ConfigurationView');
+const ServiceSpecView = require('../ServiceSpecView');
 
 describe('ServiceDetailConfigurationTab', function () {
 
@@ -42,10 +42,10 @@ describe('ServiceDetailConfigurationTab', function () {
   describe('#render', function () {
 
     it('renders correct id', function () {
-      var configurationView = TestUtils
-        .findRenderedComponentWithType(this.instance, ConfigurationView);
+      var ServiceSpecView = TestUtils
+        .findRenderedComponentWithType(this.instance, ServiceSpecView);
 
-      expect(configurationView).toBeDefined();
+      expect(ServiceSpecView).toBeDefined();
     });
 
   });

--- a/src/js/components/__tests__/ServiceDetailConfigurationTab-test.js
+++ b/src/js/components/__tests__/ServiceDetailConfigurationTab-test.js
@@ -42,10 +42,10 @@ describe('ServiceDetailConfigurationTab', function () {
   describe('#render', function () {
 
     it('renders correct id', function () {
-      var ServiceSpecView = TestUtils
+      var serviceSpecView = TestUtils
         .findRenderedComponentWithType(this.instance, ServiceSpecView);
 
-      expect(ServiceSpecView).toBeDefined();
+      expect(serviceSpecView).toBeDefined();
     });
 
   });

--- a/src/js/components/__tests__/ServiceSpecView-test.js
+++ b/src/js/components/__tests__/ServiceSpecView-test.js
@@ -1,5 +1,5 @@
 jest.dontMock('../CollapsingString');
-jest.dontMock('../ConfigurationView');
+jest.dontMock('../ServiceSpecView');
 jest.dontMock('../DescriptionList');
 
 /* eslint-disable no-unused-vars */
@@ -10,10 +10,10 @@ const TestUtils = require('react-addons-test-utils');
 
 const Application = require('../../structs/Application');
 const DCOSStore = require('../../stores/DCOSStore');
-const ConfigurationView = require('../ConfigurationView');
+const ServiceSpecView = require('../ServiceSpecView');
 const DescriptionList = require('../DescriptionList');
 
-describe('ConfigurationView', function () {
+describe('ServiceSpecView', function () {
 
   const versionID = '2016-05-02T16:07:32.583Z';
   const service = new Application({
@@ -32,7 +32,7 @@ describe('ConfigurationView', function () {
   beforeEach(function () {
     this.container = document.createElement('div');
     this.instance = ReactDOM.render(
-      <ConfigurationView service={service}
+      <ServiceSpecView service={service}
         versionID={versionID} />,
       this.container
     );
@@ -52,7 +52,7 @@ describe('ConfigurationView', function () {
       let versionID = '2016-05-02T17:07:32.583Z';
 
       this.instance = ReactDOM.render(
-        <ConfigurationView service={service}
+        <ServiceSpecView service={service}
           versionID={versionID} />,
         this.container
       );
@@ -62,7 +62,7 @@ describe('ConfigurationView', function () {
 
     it('should not fetch the version if its already loaded', function () {
       this.instance = ReactDOM.render(
-        <ConfigurationView service={service}
+        <ServiceSpecView service={service}
           versionID={versionID} />,
         this.container
       );


### PR DESCRIPTION
Renaming `ConfigurationView` to `ServiceSpecView` in order to be consistent with the naming used on `PodSpecView`