### PR TITLE
[Pods] DCOS-10321: Including completed pod instances on summary view

### DIFF
--- a/src/js/components/PodInstancesTable.js
+++ b/src/js/components/PodInstancesTable.js
@@ -219,7 +219,7 @@ class PodInstancesTable extends React.Component {
         containerResources = containerSpec.resources;
       }
 
-      let addressComponents = container.endpoints.map(function (endpoint, i) {
+      let addressComponents = container.getEndpoints().map(function (endpoint, i) {
         return (
           <a className="text-muted"
             href={`http://${agentAddress}:${endpoint.allocatedHostPort}`}

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -262,7 +262,7 @@ class MesosStateStore extends GetSetBaseStore {
     let serviceName = service.getName();
 
     // Convert serviceId to Mesos task name
-    let mesosTaskName = service.getId().split('/').slice(1).reverse().join('.');
+    let mesosTaskName = service.getMesosId();
 
     if (!serviceName || !mesosTaskName || !frameworks) {
       return [];

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -133,6 +133,12 @@ class MesosStateStore extends GetSetBaseStore {
     );
   }
 
+  getPodHistoricalInstances(pod) {
+    return MesosStateUtil.getPodHistoricalInstances(
+      this.get('lastMesosState'), pod
+    );
+  }
+
   getServiceFromName(name) {
     let services = this.get('lastMesosState').frameworks;
 

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -1,9 +1,13 @@
 jest.dontMock('../MesosStateStore');
 
+const Application = require('../../structs/Application');
 const Framework = require('../../structs/Framework');
 const MesosStateStore = require('../MesosStateStore');
-const Application = require('../../structs/Application');
+const MesosStateUtil = require('../../utils/MesosStateUtil');
+const Pod = require('../../structs/Pod');
 const Task = require('../../structs/Task');
+
+const MESOS_STATE_WITH_HISTORY = require('../../utils/__tests__/fixtures/MesosStateWithHistory');
 
 describe('MesosStateStore', function () {
 
@@ -204,6 +208,26 @@ describe('MesosStateStore', function () {
     it('shouldn\'t find a task', function () {
       var result = MesosStateStore.getSchedulerTaskFromServiceName('bar');
       expect(result).toEqual(undefined);
+    });
+  });
+
+  describe('#getPodHistoricalInstances', function () {
+    beforeEach(function () {
+      this.get = MesosStateStore.get;
+      MesosStateStore.get = () => {
+        return MESOS_STATE_WITH_HISTORY;
+      };
+    });
+
+    afterEach(function () {
+      MesosStateStore.get = this.get;
+    });
+
+    it('should pass-through to MesosStateUtil.getPodHistoricalInstances', function () {
+      var pod = new Pod({id: '/pod-p0'});
+      var result = MesosStateStore.getPodHistoricalInstances(pod);
+      var expected = MesosStateUtil.getPodHistoricalInstances(MESOS_STATE_WITH_HISTORY, pod);
+      expect(result).toEqual(expected);
     });
   });
 });

--- a/src/js/structs/Pod.js
+++ b/src/js/structs/Pod.js
@@ -48,6 +48,7 @@ module.exports = class Pod extends Service {
    * Return the normalized pod ID, used as a prefix in the marathon framework
    * state, as fetched from Mesos state.
    *
+   * @override
    * @returns {String} The normalized mesos ID
    */
   getMesosId() {

--- a/src/js/structs/Pod.js
+++ b/src/js/structs/Pod.js
@@ -45,6 +45,17 @@ module.exports = class Pod extends Service {
   }
 
   /**
+   * Return the normalized pod ID, used as a prefix in the marathon framework
+   * state, as fetched from Mesos state.
+   *
+   * @returns {String} The normalized mesos ID
+   */
+  getMesosId() {
+    let id = this.getId().substr(1);
+    return id.replace(/\//g, '_');
+  }
+
+  /**
    * @override
    */
   getHealth() {

--- a/src/js/structs/Service.js
+++ b/src/js/structs/Service.js
@@ -11,6 +11,10 @@ module.exports = class Service extends Item {
     return this.get('id') || '';
   }
 
+  getMesosId() {
+    return this.getId().split('/').slice(1).reverse().join('.');
+  }
+
   getName() {
     return this.getId().split('/').pop();
   }

--- a/src/js/structs/__tests__/Pod-test.js
+++ b/src/js/structs/__tests__/Pod-test.js
@@ -106,6 +106,18 @@ describe('Pod', function () {
 
   });
 
+  describe('#getMesosId', function () {
+
+    it('returns correct id', function () {
+      let pod = new Pod({
+        id: '/test/cmd'
+      });
+
+      expect(pod.getMesosId()).toEqual('test_cmd');
+    });
+
+  });
+
   describe('#getResources', function () {
 
     it('should pass-through from specs', function () {

--- a/src/js/structs/__tests__/Service-test.js
+++ b/src/js/structs/__tests__/Service-test.js
@@ -14,6 +14,18 @@ describe('Service', function () {
 
   });
 
+  describe('#getMesosId', function () {
+
+    it('returns correct id', function () {
+      let service = new Service({
+        id: '/test/cmd'
+      });
+
+      expect(service.getMesosId()).toEqual('cmd.test');
+    });
+
+  });
+
   describe('#toJSON', function () {
 
     it('returns a object with the values in _itemData', function () {

--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -136,10 +136,9 @@ const MesosStateUtil = {
               //
               // NOTE: We are creating a Date object from this value, so we
               //       should be OK with the timestamp
-              // TODO: What happens to the timezone?
               //
-              lastChanged: lastStatus.timestamp,
-              lastUpdated: lastStatus.timestamp
+              lastChanged: lastStatus.timestamp * 1000,
+              lastUpdated: lastStatus.timestamp * 1000
             }, task));
           }
         }

--- a/src/js/utils/PodUtil.js
+++ b/src/js/utils/PodUtil.js
@@ -66,18 +66,21 @@ var PodUtil = {
       return memo;
     }, {});
 
-    historicalInstances.forEach(function (instance) {
-      let podInstance = podInstancesMap[instance.id];
+    // Then merge historical instance information in the pod instance map
+    podInstancesMap = historicalInstances.reduce(function (memo, instance) {
+      let podInstance = memo[instance.id];
       if (podInstance === undefined) {
-        podInstancesMap[instance.id] = instance;
-        return;
+        memo[instance.id] = instance;
+        return memo;
       }
 
       podInstance.containers = [].concat(
           podInstance.containers,
           instance.containers
         );
-    });
+
+      return memo;
+    }, podInstancesMap);
 
     // Re-compose PodInstances from plain objects
     let instances = Object.values(podInstancesMap).map(function (instance) {

--- a/src/js/utils/PodUtil.js
+++ b/src/js/utils/PodUtil.js
@@ -55,6 +55,9 @@ var PodUtil = {
    * @returns {PodInstanceList} The new array of PodInstance objects
    */
   mergeHistoricalInstanceList(podInstances, historicalInstances) {
+    if (!historicalInstances) {
+      return podInstances;
+    }
 
     // De-compose PodInstances into plain objects, so we always operate
     // with plain objects

--- a/src/js/utils/PodUtil.js
+++ b/src/js/utils/PodUtil.js
@@ -1,3 +1,6 @@
+import PodInstance from '../structs/PodInstance';
+import PodInstanceList from '../structs/PodInstanceList';
+
 var PodUtil = {
 
   /**
@@ -36,7 +39,50 @@ var PodUtil = {
     return instance.getContainers().some(function (container) {
       return PodUtil.isContainerMatchingText(container, text);
     });
+  },
+
+  /**
+   * This function merges the output of MesosStateUtil.getPodHistoricalInstances
+   * with the array of currently known instances returned from the
+   * Pod.getInstances() function.
+   *
+   * NOTE: podInstances is an array of PodInstance objects, but the
+   *       historicalInstances is an array of plain objects, with a structure
+   *       that can be used to construct a PodInstance!
+   *
+   * @param {PodInstanceList} podInstances - An array of PodInstance objects
+   * @param {Array} historicalInstances - The output of getPodHistoricalInstances
+   * @returns {PodInstanceList} The new array of PodInstance objects
+   */
+  mergeHistoricalInstanceList(podInstances, historicalInstances) {
+
+    // De-compose PodInstances into plain objects, so we always operate
+    // with plain objects
+    let podInstancesMap = podInstances.reduceItems(function (memo, instance) {
+      memo[instance.getId()] = instance.get();
+      return memo;
+    }, {});
+
+    historicalInstances.forEach(function (instance) {
+      let podInstance = podInstancesMap[instance.id];
+      if (podInstance === undefined) {
+        podInstancesMap[instance.id] = instance;
+        return;
+      }
+
+      podInstance.containers = [].concat(
+          podInstance.containers,
+          instance.containers
+        );
+    });
+
+    // Re-compose PodInstances from plain objects
+    let instances = Object.values(podInstancesMap).map(function (instance) {
+      return new PodInstance(instance);
+    });
+    return new PodInstanceList({items: instances});
   }
+
 };
 
 module.exports = PodUtil;

--- a/src/js/utils/__tests__/MesosStateUtil-test.js
+++ b/src/js/utils/__tests__/MesosStateUtil-test.js
@@ -331,4 +331,45 @@ describe('MesosStateUtil', function () {
 
   });
 
+  describe('#isPodTaskId', function () {
+
+    it('should correctly match pod (PodDefinition) task ID', function () {
+      expect(MesosStateUtil
+        .isPodTaskId('podname.instance-instancename.taskname')).toBeTruthy();
+    });
+
+    it('should not match marathon (AppDefinition) task ID', function () {
+      expect(MesosStateUtil
+        .isPodTaskId('podname.marathon-instancename.taskname')).toBeFalsy();
+    });
+
+    it('should not match anything else that looks close', function () {
+      expect(MesosStateUtil
+        .isPodTaskId('podname.marathon-instancename')).toBeFalsy();
+      expect(MesosStateUtil
+        .isPodTaskId('marathon-instancename.taskname')).toBeFalsy();
+      expect(MesosStateUtil
+        .isPodTaskId('podname.marathon-instancename.taskname.junk'))
+        .toBeFalsy();
+      expect(MesosStateUtil
+        .isPodTaskId('junk.podname.marathon-instancename.taskname'))
+        .toBeFalsy();
+    });
+
+  });
+
+  describe('#decomposePodTaskId', function () {
+
+    it('should correctly de-compose', function () {
+      expect(MesosStateUtil
+        .decomposePodTaskId('podname.instance-instancename.taskname'))
+        .toEqual({
+          podID: 'podname',
+          instanceID: 'instancename',
+          taskName: 'taskname'
+        });
+    });
+
+  });
+
 });

--- a/src/js/utils/__tests__/PodUtil-test.js
+++ b/src/js/utils/__tests__/PodUtil-test.js
@@ -60,4 +60,49 @@ describe('PodUtil', function () {
         .toBeFalsy();
     });
   });
+
+  describe('#mergeHistoricalInstanceList', function () {
+    it('should properly append new instances', function () {
+      let instances = this.pod.getInstanceList();
+      let historicalInstances = [
+        {
+          'id': 'pod-a2',
+          'containers': [
+            {
+              'name': 'container-c1'
+            }
+          ]
+        }
+      ];
+
+      instances = PodUtil.mergeHistoricalInstanceList(instances,
+        historicalInstances);
+
+      expect(instances.getItems().length).toEqual(2);
+      expect(instances.getItems()[1].get()).toEqual(historicalInstances[0]);
+    });
+
+    it('should properly append new containers on existing items', function () {
+      let instances = this.pod.getInstanceList();
+      let historicalInstances = [
+        {
+          'id': 'pod-a1',
+          'containers': [
+            {
+              'name': 'container-c3'
+            }
+          ]
+        }
+      ];
+
+      instances = PodUtil.mergeHistoricalInstanceList(instances,
+        historicalInstances);
+
+      expect(instances.getItems().length).toEqual(1);
+      expect(instances.getItems()[0].getContainers().length).toEqual(3);
+      expect(instances.getItems()[0].getContainers()[2].get())
+        .toEqual(historicalInstances[0].containers[0]);
+    });
+  });
+
 });

--- a/src/js/utils/__tests__/fixtures/MesosStateWithHistory.js
+++ b/src/js/utils/__tests__/fixtures/MesosStateWithHistory.js
@@ -1,0 +1,90 @@
+const timestamp01 = 1001;
+const timestamp02 = 1002;
+const timestamp03 = 1003;
+const timestamp04 = 1004;
+const timestamp05 = 1005;
+const timestamp06 = 1006;
+const timestamp07 = 1007;
+const timestamp08 = 1008;
+
+module.exports = {
+  frameworks: [
+    {
+      name: 'marathon',
+      completed_tasks: [
+        {
+          id: 'pod-p0.instance-inst-a1.container-c1',
+          name: 'c1',
+          state: 'TASK_RUNNING',
+          resources: {cpus:0.1, mem:16, disk:16},
+          statuses: [
+            {
+              state: 'TASK_STAGING',
+              timestamp: timestamp01
+            },
+            {
+              state: 'TASK_RUNNING',
+              timestamp: timestamp02
+            }
+          ]
+        },
+        {
+          id: 'pod-p0.instance-inst-a1.container-c2',
+          name: 'c2',
+          state: 'TASK_RUNNING',
+          resources: {cpus:0.1, mem:16, disk:0},
+          statuses: [
+            {
+              state: 'TASK_STAGING',
+              timestamp: timestamp03
+            },
+            {
+              state: 'TASK_RUNNING',
+              timestamp: timestamp04
+            }
+          ]
+        },
+        {
+          id: 'pod-p0.instance-inst-a1.container-c3',
+          name: 'c3',
+          state: 'TASK_RUNNING',
+          resources: {cpus:0.2, mem:16, disk:0},
+          statuses: [
+            {
+              state: 'TASK_STAGING',
+              timestamp: timestamp05
+            },
+            {
+              state: 'TASK_RUNNING',
+              timestamp: timestamp06
+            }
+          ]
+        },
+        {
+          id: 'pod-p0.instance-inst-a2.container-c4',
+          name: 'c4',
+          state: 'TASK_RUNNING',
+          resources: {cpus:0.1, mem:16, gpus:1},
+          statuses: [
+            {
+              state: 'TASK_RUNNING',
+              timestamp: timestamp07
+            }
+          ]
+        },
+        {
+          id: 'pod-p1.instance-inst-a1.container-c1',
+          name: 'c1',
+          state: 'TASK_RUNNING',
+          resources: {cpus:0.1, mem:16, disk:0},
+          statuses: [
+            {
+              state: 'TASK_RUNNING',
+              timestamp: timestamp08
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};


### PR DESCRIPTION
This PR uses the mesos state endpoint to extend the list of instances in the `PodInstancesView` to include completed instances.

![image](https://cloud.githubusercontent.com/assets/883486/19157065/5ab6a8c0-8be4-11e6-92ac-97602f1a0903.png)
