### PR TITLE
DCOS-10394 (master): Adjust util to use the provided service port

### DIFF
--- a/src/js/utils/ServiceUtil.js
+++ b/src/js/utils/ServiceUtil.js
@@ -390,16 +390,17 @@ const ServiceUtil = {
               let lbPort = parseInt(port.lbPort || 0, 10);
               portMapping.containerPort = lbPort;
 
-              if (networkType === 'bridge') {
+              if (ValidatorUtil.isDefined(port.hostPort)) {
                 portMapping.hostPort = port.hostPort;
+              }
+
+              if (ValidatorUtil.isDefined(port.servicePort)) {
                 portMapping.servicePort = port.servicePort;
+              } else if (port.loadBalanced === true && networkType !== 'bridge') {
+                portMapping.servicePort = lbPort;
               }
 
               if (port.loadBalanced === true) {
-
-                if (networkType !== 'bridge') {
-                  portMapping.servicePort = lbPort;
-                }
                 portMapping.labels = {};
                 if (general != null) {
                   portMapping.labels[`VIP_${index}`] = `${general.id}:${lbPort}`;

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -562,6 +562,33 @@ describe('ServiceUtil', function () {
           }
         );
 
+        it('should not overwrite service port',
+          function () {
+            const model = {
+              containerSettings: {
+                forcePullImage: true,
+                image: 'docker/image',
+                parameters: null,
+                privileged: undefined
+              },
+              networking: {
+                networkType: 'user',
+                ports: [{
+                  expose: true,
+                  lbPort: 514,
+                  servicePort: 5514,
+                  loadBalanced: true
+                }]
+              }
+            };
+
+            let service = ServiceUtil.createSpecFromFormModel(model);
+
+            expect(service.getContainerSettings().docker.portMappings[0].servicePort)
+                .toEqual(5514);
+          }
+        );
+
         it('should not add a hostPort when loadBalanced is off', function () {
           let service = ServiceUtil.createSpecFromFormModel({
             containerSettings: {image: 'redis'},


### PR DESCRIPTION
---
ℹ️ This fix is for master only see #1212 for the respective 1.8 fix.

---

Adjust the service util to always use the provided service port data from the JSON definition.

Fixes DCOS-10394