### PR TITLE
[CNVS Upgrade] Fix dropdown menu z-index

### DIFF
--- a/src/styles/components/dropdown-menus/styles.less
+++ b/src/styles/components/dropdown-menus/styles.less
@@ -2,13 +2,6 @@
 
   .dropdown {
 
-    &.open {
-
-      .dropdown-menu {
-        z-index: @z-index-dropdown;
-      }
-    }
-
     &.dropdown-wide {
 
       &,
@@ -100,6 +93,7 @@
     // Overrides default Canvas styles.
     float: initial;
     left: initial;
+    z-index: @z-index-dropdown;
   }
 
   .dropdown-menu-list {

--- a/src/styles/variables/variables-z-index.less
+++ b/src/styles/variables/variables-z-index.less
@@ -1,6 +1,6 @@
 // TODO: Audit these variables and all z-index proeprties, some are not being
 // used properly.
-@z-index-dropdown:                                                              @z-index-side-panel-container + 1;
+@z-index-dropdown:                                                              @z-index-modal-container + 1;
 @z-index-dropdown-chart-details:                                                @z-index-side-panel + 20;
 @z-index-dygraph-chart:                                                         @z-index-side-panel + 10;
 @z-index-dygraph-hover-label:                                                   100;


### PR DESCRIPTION
This PR ensures that the z-index of the dropdown is above the modal.

This is in anticipation of this change to reactjs-components: https://github.com/mesosphere/reactjs-components/pull/367