### PR TITLE
[CNVS Upgrade] Fix ServicesTable hover icons

### DIFF
--- a/src/js/components/ServicesTable.js
+++ b/src/js/components/ServicesTable.js
@@ -94,7 +94,7 @@ var ServicesTable = React.createClass({
     }
 
     return (
-      <a className="table-display-on-row-hover"
+      <a className="table-cell-icon table-display-on-row-hover"
         href={service.getWebURL()}
         target="_blank"
         title="Open in a new window">
@@ -192,7 +192,7 @@ var ServicesTable = React.createClass({
           params={{id}}>
           {this.getImage(service)}
         </Link>
-        <span className="table-cell-value">
+        <span className="table-cell-value table-cell-flex-box">
           {this.getServiceLink(service)}
           {this.getOpenInNewWindowLink(service)}
         </span>

--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -68,6 +68,7 @@
     // property. http://stackoverflow.com/questions/9789723/css-text-overflow-in-a-table-cell
     min-width: 0;
     overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   // TODO: Is there a better way to handle this?


### PR DESCRIPTION
This PR fixes the icons in the `ServicesTable`. It should look something like this when the icon color PR and `table-cell-flex-box` PRs get merged...
![](https://cl.ly/243m2j3p0G1f/Screen%20Recording%202016-10-06%20at%2003.18%20PM.gif)