### PR TITLE
DCOS-10443: Deactivate task log cell caching

### DIFF
--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -161,7 +161,7 @@ class TaskTable extends React.Component {
         sortFunction
       },
       {
-        cacheCell: true,
+        cacheCell: false,
         className,
         headerClassName: className,
         heading,


### PR DESCRIPTION
Don't cache the task log cells as otherwise the links will all point to the same task detail.

Closes DCOS-10443