### PR TITLE
[Nodes Page] modularize the nodes overview page

### DIFF
--- a/plugins/nodes/src/js/components/NodesGridView.js
+++ b/plugins/nodes/src/js/components/NodesGridView.js
@@ -117,8 +117,8 @@ var NodesGridView = React.createClass({
         <div className={classSet}>
           <label className="show-services-label h5 flush-top">
             <input type="checkbox"
-              name="nodes-grid-show-services"
               checked={props.showServices}
+              name="nodes-grid-show-services"
               onChange={props.onShowServices} />
             Show Services by Share
           </label>
@@ -128,9 +128,9 @@ var NodesGridView = React.createClass({
 
         <NodesGridDials
           hosts={props.hosts}
+          resourcesByFramework={props.resourcesByFramework}
           selectedResource={props.selectedResource}
           serviceColors={props.serviceColors}
-          resourcesByFramework={props.resourcesByFramework}
           showServices={props.showServices} />
       </div>
     );

--- a/plugins/nodes/src/js/components/NodesGridView.js
+++ b/plugins/nodes/src/js/components/NodesGridView.js
@@ -19,8 +19,8 @@ var NodesGridView = React.createClass({
     hasLoadingError: React.PropTypes.bool,
     hiddenServices: React.PropTypes.array,
     hosts: React.PropTypes.array.isRequired,
-    lastMesosStateWasEmpty: React.PropTypes.bool,
-    nodeHealthResponseReceived: React.PropTypes.bool,
+    receivedEmptyMesosState: React.PropTypes.bool,
+    receivedNodeHealthResponse: React.PropTypes.bool,
     onShowServices: React.PropTypes.func.isRequired,
     resourcesByFramework: React.PropTypes.object.isRequired,
     selectedResource: React.PropTypes.string.isRequired,
@@ -32,7 +32,7 @@ var NodesGridView = React.createClass({
   defaultProps: {
     hasLoadingError: false,
     hiddenServices: [],
-    nodeHealthResponseReceived: false,
+    receivedNodeHealthResponse: false,
     showServices: false
   },
 
@@ -139,11 +139,11 @@ var NodesGridView = React.createClass({
   render() {
     const {
       hasLoadingError,
-      lastMesosStateWasEmpty,
-      nodeHealthResponseReceived
+      receivedEmptyMesosState,
+      receivedNodeHealthResponse
     } = this.props;
 
-    if (hasLoadingError || lastMesosStateWasEmpty || !nodeHealthResponseReceived) {
+    if (hasLoadingError || receivedEmptyMesosState || !receivedNodeHealthResponse) {
       return this.getLoadingScreen();
     } else {
       return this.getNodesGrid();

--- a/plugins/nodes/src/js/components/NodesTable.js
+++ b/plugins/nodes/src/js/components/NodesTable.js
@@ -1,13 +1,12 @@
 import classNames from 'classnames';
 import {Link} from 'react-router';
+import PureRenderMixin from 'react-addons-pure-render-mixin';
 import React from 'react';
 import {ResourceTableUtil} from 'foundation-ui';
-import {StoreMixin} from 'mesosphere-shared-reactjs';
 import {Table, Tooltip} from 'reactjs-components';
 
 import NodesTableHeaderLabels from '../../../../../src/js/constants/NodesTableHeaderLabels';
 import Icon from '../../../../../src/js/components/Icon';
-import InternalStorageMixin from '../../../../../src/js/mixins/InternalStorageMixin';
 import Loader from '../../../../../src/js/components/Loader';
 import StatusBar from '../../../../../src/js/components/StatusBar';
 import StringUtil from '../../../../../src/js/utils/StringUtil';
@@ -24,7 +23,7 @@ var NodesTable = React.createClass({
 
   displayName: 'NodesTable',
 
-  mixins: [InternalStorageMixin, StoreMixin],
+  mixins: [PureRenderMixin],
 
   propTypes: {
     hosts: React.PropTypes.array.isRequired
@@ -34,27 +33,6 @@ var NodesTable = React.createClass({
     return {
       hosts: []
     };
-  },
-
-  componentWillMount() {
-    this.internalStorage_set({
-      nodeHealthResponseReceived: false
-    });
-
-    this.store_listeners = [
-      {
-        name: 'nodeHealth',
-        events: ['success'],
-        listenAlways: false
-      }
-    ];
-  },
-
-  onNodeHealthStoreSuccess() {
-    this.internalStorage_set({
-      nodeHealthResponseReceived: true
-    });
-    this.forceUpdate();
   },
 
   renderHeadline(prop, node) {
@@ -83,7 +61,7 @@ var NodesTable = React.createClass({
   },
 
   renderHealth(prop, node) {
-    let requestReceived = this.internalStorage_get().nodeHealthResponseReceived;
+    let requestReceived = this.props.nodeHealthResponseReceived;
 
     if (!requestReceived) {
       return (

--- a/plugins/nodes/src/js/components/NodesTable.js
+++ b/plugins/nodes/src/js/components/NodesTable.js
@@ -5,9 +5,9 @@ import React from 'react';
 import {ResourceTableUtil} from 'foundation-ui';
 import {Table, Tooltip} from 'reactjs-components';
 
-import NodesTableHeaderLabels from '../../../../../src/js/constants/NodesTableHeaderLabels';
 import Icon from '../../../../../src/js/components/Icon';
 import Loader from '../../../../../src/js/components/Loader';
+import NodesTableHeaderLabels from '../../../../../src/js/constants/NodesTableHeaderLabels';
 import StatusBar from '../../../../../src/js/components/StatusBar';
 import StringUtil from '../../../../../src/js/utils/StringUtil';
 import TableUtil from '../../../../../src/js/utils/TableUtil';
@@ -42,11 +42,11 @@ var NodesTable = React.createClass({
       headline = (
         <Tooltip anchor="start" content="Connection to node lost">
           <Icon
+            className="icon-alert icon-margin-right"
+            color="neutral"
             family="mini"
             id="yield"
-            size="mini"
-            className="icon-alert icon-margin-right"
-            color="neutral" />
+            size="mini" />
           {headline}
         </Tooltip>
       );
@@ -192,14 +192,14 @@ var NodesTable = React.createClass({
   render() {
     return (
       <Table
+        buildRowOptions={this.getRowAttributes}
         className="node-table table table-borderless-outer table-borderless-inner-columns flush-bottom"
-        columns={this.getColumns()}
         colGroup={this.getColGroup()}
+        columns={this.getColumns()}
         containerSelector=".gm-scroll-view"
         data={this.props.hosts.slice()}
         itemHeight={TableUtil.getRowHeight()}
-        sortBy={{ prop: 'health', order: 'asc' }}
-        buildRowOptions={this.getRowAttributes} />
+        sortBy={{ prop: 'health', order: 'asc' }} />
     );
   }
 });

--- a/plugins/nodes/src/js/components/NodesTable.js
+++ b/plugins/nodes/src/js/components/NodesTable.js
@@ -61,7 +61,7 @@ var NodesTable = React.createClass({
   },
 
   renderHealth(prop, node) {
-    let requestReceived = this.props.nodeHealthResponseReceived;
+    let requestReceived = this.props.receivedNodeHealthResponse;
 
     if (!requestReceived) {
       return (

--- a/plugins/nodes/src/js/pages/NodesOverview.js
+++ b/plugins/nodes/src/js/pages/NodesOverview.js
@@ -12,6 +12,7 @@ import HostsPageContent from './nodes-overview/HostsPageContent';
 import Icon from '../../../../../src/js/components/Icon';
 import InternalStorageMixin from '../../../../../src/js/mixins/InternalStorageMixin';
 import MesosSummaryStore from '../../../../../src/js/stores/MesosSummaryStore';
+import QueryParamsMixin from '../../../../../src/js/mixins/QueryParamsMixin';
 import SidebarActions from '../../../../../src/js/events/SidebarActions';
 import StringUtil from '../../../../../src/js/utils/StringUtil';
 
@@ -52,7 +53,7 @@ var NodesOverview = React.createClass({
 
   displayName: 'NodesOverview',
 
-  mixins: [InternalStorageMixin, StoreMixin],
+  mixins: [InternalStorageMixin, QueryParamsMixin, StoreMixin],
 
   statics: {
     routeConfig: {
@@ -70,7 +71,7 @@ var NodesOverview = React.createClass({
   },
 
   contextTypes: {
-    router: React.PropTypes.func
+    router: React.PropTypes.func.isRequired
   },
 
   getInitialState() {
@@ -138,6 +139,8 @@ var NodesOverview = React.createClass({
 
     this.setState(state);
     this.internalStorage_update(getMesosHosts(state));
+
+    this.resetQueryParams(['searchString', 'filterService', 'filterHealth']);
   },
 
   handleSearchStringChange(searchString = '') {
@@ -147,6 +150,7 @@ var NodesOverview = React.createClass({
 
     this.internalStorage_update(getMesosHosts(stateChanges));
     this.setState({searchString});
+    this.setQueryParam('searchString', searchString);
   },
 
   handleByServiceFilterChange(byServiceFilter) {
@@ -160,11 +164,13 @@ var NodesOverview = React.createClass({
 
     this.internalStorage_update(getMesosHosts(stateChanges));
     this.setState({byServiceFilter});
+    this.setQueryParam('filterService', byServiceFilter);
   },
 
   handleHealthFilterChange(healthFilter) {
     this.internalStorage_update(getMesosHosts({healthFilter}));
     this.setState({healthFilter});
+    this.setQueryParam('filterHealth', healthFilter);
   },
 
   onResourceSelectionChange(selectedResource) {

--- a/plugins/nodes/src/js/pages/NodesOverview.js
+++ b/plugins/nodes/src/js/pages/NodesOverview.js
@@ -35,10 +35,10 @@ function getMesosHosts(state) {
 
   return {
     nodes: filteredNodes,
-    totalNodes: nodes.getItems().length,
     refreshRate: Config.getRefreshRate(),
     services: lastState.getServiceList().getItems(),
     totalHostsResources: states.getResourceStatesForNodeIDs(nodeIDs),
+    totalNodes: nodes.getItems().length,
     totalResources: lastState.getSlaveTotalResources()
   };
 }
@@ -245,34 +245,34 @@ var NodesOverview = React.createClass({
 
     return (
       <HostsPageContent
-        nodeCount={data.nodes.length}
-        totalHostsResources={data.totalHostsResources}
-        totalResources={data.totalResources}
-        refreshRate={data.refreshRate}
-        selectedResource={selectedResource}
-        onResourceSelectionChange={this.onResourceSelectionChange}
-        filteredNodeCount={nodesList.length}
-        isFiltering={isFiltering}
-        onResetFilter={this.resetFilter}
-        totalNodeCount={data.totalNodes}
-        filterInputText={this.getFilterInputText()}
-        filterButtonContent={this.getButtonContent}
-        onFilterChange={this.handleHealthFilterChange}
-        filterItemList={nodesHealth}
-        selectedFilter={healthFilter}
         byServiceFilter={byServiceFilter}
+        filterButtonContent={this.getButtonContent}
+        filterInputText={this.getFilterInputText()}
+        filterItemList={nodesHealth}
+        filteredNodeCount={nodesList.length}
         handleFilterChange={this.handleByServiceFilterChange}
+        hosts={nodesList}
+        isFiltering={isFiltering}
+        nodeCount={data.nodes.length}
+        onFilterChange={this.handleHealthFilterChange}
+        onResetFilter={this.resetFilter}
+        onResourceSelectionChange={this.onResourceSelectionChange}
+        refreshRate={data.refreshRate}
+        selectedFilter={healthFilter}
+        selectedResource={selectedResource}
         services={data.services}
-        viewTypeRadioButtons={this.getViewTypeRadioButtons(this.resetFilter)}
-        hosts={nodesList} />
+        totalHostsResources={data.totalHostsResources}
+        totalNodeCount={data.totalNodes}
+        totalResources={data.totalResources}
+        viewTypeRadioButtons={this.getViewTypeRadioButtons(this.resetFilter)} />
     );
   },
 
   getEmptyHostsPageContent() {
     return (
       <AlertPanel
-        title="Empty Datacenter"
-        icon={<Icon id="servers" color="neutral" size="jumbo" />}>
+        icon={<Icon id="servers" color="neutral" size="jumbo" />}
+        title="Empty Datacenter">
         <p className="flush-bottom">
           Your datacenter is looking pretty empty. We don't see any nodes other than your master.
         </p>

--- a/plugins/nodes/src/js/pages/NodesOverview.js
+++ b/plugins/nodes/src/js/pages/NodesOverview.js
@@ -1,26 +1,21 @@
 import classNames from 'classnames';
 import React from 'react';
-import {HashLocation, Link, RouteHandler} from 'react-router';
+import {HashLocation, Link} from 'react-router';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
 import AlertPanel from '../../../../../src/js/components/AlertPanel';
 import CompositeState from '../../../../../src/js/structs/CompositeState';
 import Config from '../../../../../src/js/config/Config';
 import EventTypes from '../../../../../src/js/constants/EventTypes';
-import FilterButtons from '../../../../../src/js/components/FilterButtons';
-import FilterBar from '../../../../../src/js/components/FilterBar';
-import FilterByService from '../../../../services/src/js/components/FilterByService';
 import FilterInputText from '../../../../../src/js/components/FilterInputText';
-import FilterHeadline from '../../../../../src/js/components/FilterHeadline';
+import HostsPageContent from './nodes-overview/HostsPageContent';
 import Icon from '../../../../../src/js/components/Icon';
 import InternalStorageMixin from '../../../../../src/js/mixins/InternalStorageMixin';
 import MesosSummaryStore from '../../../../../src/js/stores/MesosSummaryStore';
-import ResourceBarChart from '../../../../../src/js/components/charts/ResourceBarChart';
 import SidebarActions from '../../../../../src/js/events/SidebarActions';
 import StringUtil from '../../../../../src/js/utils/StringUtil';
 
 const NODES_DISPLAY_LIMIT = 300;
-const HEALTH_FILTER_BUTTONS = ['all', 'healthy', 'unhealthy'];
 
 function getMesosHosts(state) {
   let states = MesosSummaryStore.get('states');
@@ -143,10 +138,6 @@ var NodesOverview = React.createClass({
 
     this.setState(state);
     this.internalStorage_update(getMesosHosts(state));
-
-    if (this.serviceFilter !== null && this.serviceFilter.dropdown !== null) {
-      this.serviceFilter.setDropdownValue('default');
-    }
   },
 
   handleSearchStringChange(searchString = '') {
@@ -247,45 +238,27 @@ var NodesOverview = React.createClass({
       searchString !== '';
 
     return (
-      <div>
-        <ResourceBarChart
-          itemCount={data.nodes.length}
-          resources={data.totalHostsResources}
-          totalResources={data.totalResources}
-          refreshRate={data.refreshRate}
-          resourceType="Nodes"
-          selectedResource={selectedResource}
-          onResourceSelectionChange={this.onResourceSelectionChange} />
-        <FilterHeadline
-          currentLength={nodesList.length}
-          isFiltering={isFiltering}
-          name="Node"
-          onReset={this.resetFilter}
-          totalLength={data.totalNodes} />
-        <FilterBar rightAlignLastNChildren={1}>
-          {this.getFilterInputText()}
-          <FilterButtons
-            renderButtonContent={this.getButtonContent}
-            filters={HEALTH_FILTER_BUTTONS}
-            filterByKey="title"
-            onFilterChange={this.handleHealthFilterChange}
-            itemList={nodesHealth}
-            selectedFilter={healthFilter} />
-          <div className="form-group flush-bottom">
-            <FilterByService
-              byServiceFilter={byServiceFilter}
-              handleFilterChange={this.handleByServiceFilterChange}
-              ref={(ref) => this.serviceFilter = ref}
-              services={data.services}
-              totalHostsCount={data.totalNodes} />
-          </div>
-          {this.getViewTypeRadioButtons(this.resetFilter)}
-        </FilterBar>
-        <RouteHandler
-          selectedResource={selectedResource}
-          hosts={nodesList}
-          services={data.services} />
-      </div>
+      <HostsPageContent
+        nodeCount={data.nodes.length}
+        totalHostsResources={data.totalHostsResources}
+        totalResources={data.totalResources}
+        refreshRate={data.refreshRate}
+        selectedResource={selectedResource}
+        onResourceSelectionChange={this.onResourceSelectionChange}
+        filteredNodeCount={nodesList.length}
+        isFiltering={isFiltering}
+        onResetFilter={this.resetFilter}
+        totalNodeCount={data.totalNodes}
+        filterInputText={this.getFilterInputText()}
+        filterButtonContent={this.getButtonContent}
+        onFilterChange={this.handleHealthFilterChange}
+        filterItemList={nodesHealth}
+        selectedFilter={healthFilter}
+        byServiceFilter={byServiceFilter}
+        handleFilterChange={this.handleByServiceFilterChange}
+        services={data.services}
+        viewTypeRadioButtons={this.getViewTypeRadioButtons(this.resetFilter)}
+        hosts={nodesList} />
     );
   },
 

--- a/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
+++ b/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
@@ -1,0 +1,123 @@
+import PureRenderMixin from 'react-addons-pure-render-mixin';
+import React from 'react';
+import {RouteHandler} from 'react-router';
+
+import FilterBar from '../../../../../../src/js/components/FilterBar';
+import FilterButtons from '../../../../../../src/js/components/FilterButtons';
+import FilterByService from '../../../../../services/src/js/components/FilterByService';
+import FilterHeadline from '../../../../../../src/js/components/FilterHeadline';
+import ResourceBarChart from '../../../../../../src/js/components/charts/ResourceBarChart';
+
+const HEALTH_FILTER_BUTTONS = ['all', 'healthy', 'unhealthy'];
+
+const METHODS_TO_BIND = ['onResetFilter'];
+
+class HostsPageContent extends React.Component {
+
+  constructor() {
+    super(...arguments);
+    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate;
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  onResetFilter() {
+    this.props.onResetFilter(...arguments);
+
+    if (this.serviceFilter !== null && this.serviceFilter.dropdown !== null) {
+      this.serviceFilter.setDropdownValue('default');
+    }
+  }
+
+  render() {
+    const {
+      nodeCount,
+      totalHostsResources,
+      totalResources,
+      refreshRate,
+      selectedResource,
+      onResourceSelectionChange,
+      filteredNodeCount,
+      isFiltering,
+      totalNodeCount,
+      filterInputText,
+      filterButtonContent,
+      onFilterChange,
+      filterItemList,
+      selectedFilter,
+      byServiceFilter,
+      handleFilterChange,
+      services,
+      viewTypeRadioButtons,
+      hosts
+    } = this.props;
+    return (
+      <div>
+        <ResourceBarChart
+          itemCount={nodeCount}
+          resources={totalHostsResources}
+          totalResources={totalResources}
+          refreshRate={refreshRate}
+          resourceType="Nodes"
+          selectedResource={selectedResource}
+          onResourceSelectionChange={onResourceSelectionChange} />
+        <FilterHeadline
+          currentLength={filteredNodeCount}
+          isFiltering={isFiltering}
+          name="Node"
+          onReset={this.onResetFilter}
+          totalLength={totalNodeCount} />
+        <FilterBar rightAlignLastNChildren={1}>
+          {filterInputText}
+          <FilterButtons
+            renderButtonContent={filterButtonContent}
+            filters={HEALTH_FILTER_BUTTONS}
+            filterByKey="title"
+            onFilterChange={onFilterChange}
+            itemList={filterItemList}
+            selectedFilter={selectedFilter} />
+          <div className="form-group flush-bottom">
+            <FilterByService
+              byServiceFilter={byServiceFilter}
+              handleFilterChange={handleFilterChange}
+              ref={(ref) => this.serviceFilter = ref}
+              services={services}
+              totalHostsCount={totalNodeCount} />
+          </div>
+          {viewTypeRadioButtons}
+        </FilterBar>
+        <RouteHandler
+          selectedResource={selectedResource}
+          hosts={hosts}
+          services={services} />
+      </div>
+    );
+  }
+}
+
+HostsPageContent.propTypes = {
+  nodeCount: React.PropTypes.number.isRequired,
+  totalHostsResources: React.PropTypes.object.isRequired,
+  totalResources: React.PropTypes.object.isRequired,
+  refreshRate: React.PropTypes.number.isRequired,
+  selectedResource: React.PropTypes.string.isRequired,
+  onResourceSelectionChange: React.PropTypes.func.isRequired,
+  filteredNodeCount: React.PropTypes.number.isRequired,
+  isFiltering: React.PropTypes.bool,
+  onResetFilter: React.PropTypes.func.isRequired,
+  totalNodeCount: React.PropTypes.number.isRequired,
+  filterInputText: React.PropTypes.node,
+  filterButtonContent: React.PropTypes.func,
+  onFilterChange: React.PropTypes.func,
+  filterItemList: React.PropTypes.array.isRequired,
+  selectedFilter: React.PropTypes.string,
+  byServiceFilter: React.PropTypes.string,
+  handleFilterChange: React.PropTypes.func.isRequired,
+  services: React.PropTypes.array.isRequired,
+  viewTypeRadioButtons: React.PropTypes.node.isRequired,
+  hosts: React.PropTypes.array.isRequired
+};
+
+module.exports = HostsPageContent;

--- a/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
+++ b/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
@@ -33,36 +33,36 @@ class HostsPageContent extends React.Component {
 
   render() {
     const {
-      nodeCount,
-      totalHostsResources,
-      totalResources,
-      refreshRate,
-      selectedResource,
-      onResourceSelectionChange,
-      filteredNodeCount,
-      isFiltering,
-      totalNodeCount,
-      filterInputText,
-      filterButtonContent,
-      onFilterChange,
-      filterItemList,
-      selectedFilter,
       byServiceFilter,
+      filterButtonContent,
+      filterInputText,
+      filterItemList,
+      filteredNodeCount,
       handleFilterChange,
+      hosts,
+      isFiltering,
+      nodeCount,
+      onFilterChange,
+      onResourceSelectionChange,
+      refreshRate,
+      selectedFilter,
+      selectedResource,
       services,
-      viewTypeRadioButtons,
-      hosts
+      totalHostsResources,
+      totalNodeCount,
+      totalResources,
+      viewTypeRadioButtons
     } = this.props;
     return (
       <div>
         <ResourceBarChart
           itemCount={nodeCount}
-          resources={totalHostsResources}
-          totalResources={totalResources}
+          onResourceSelectionChange={onResourceSelectionChange}
           refreshRate={refreshRate}
           resourceType="Nodes"
+          resources={totalHostsResources}
           selectedResource={selectedResource}
-          onResourceSelectionChange={onResourceSelectionChange} />
+          totalResources={totalResources} />
         <FilterHeadline
           currentLength={filteredNodeCount}
           isFiltering={isFiltering}
@@ -72,11 +72,11 @@ class HostsPageContent extends React.Component {
         <FilterBar rightAlignLastNChildren={1}>
           {filterInputText}
           <FilterButtons
-            renderButtonContent={filterButtonContent}
-            filters={HEALTH_FILTER_BUTTONS}
             filterByKey="title"
-            onFilterChange={onFilterChange}
+            filters={HEALTH_FILTER_BUTTONS}
             itemList={filterItemList}
+            onFilterChange={onFilterChange}
+            renderButtonContent={filterButtonContent}
             selectedFilter={selectedFilter} />
           <div className="form-group flush-bottom">
             <FilterByService
@@ -89,8 +89,8 @@ class HostsPageContent extends React.Component {
           {viewTypeRadioButtons}
         </FilterBar>
         <RouteHandler
-          selectedResource={selectedResource}
           hosts={hosts}
+          selectedResource={selectedResource}
           services={services} />
       </div>
     );
@@ -98,26 +98,26 @@ class HostsPageContent extends React.Component {
 }
 
 HostsPageContent.propTypes = {
-  nodeCount: React.PropTypes.number.isRequired,
-  totalHostsResources: React.PropTypes.object.isRequired,
-  totalResources: React.PropTypes.object.isRequired,
-  refreshRate: React.PropTypes.number.isRequired,
-  selectedResource: React.PropTypes.string.isRequired,
-  onResourceSelectionChange: React.PropTypes.func.isRequired,
-  filteredNodeCount: React.PropTypes.number.isRequired,
-  isFiltering: React.PropTypes.bool,
-  onResetFilter: React.PropTypes.func.isRequired,
-  totalNodeCount: React.PropTypes.number.isRequired,
-  filterInputText: React.PropTypes.node,
-  filterButtonContent: React.PropTypes.func,
-  onFilterChange: React.PropTypes.func,
-  filterItemList: React.PropTypes.array.isRequired,
-  selectedFilter: React.PropTypes.string,
   byServiceFilter: React.PropTypes.string,
+  filterButtonContent: React.PropTypes.func,
+  filterInputText: React.PropTypes.node,
+  filterItemList: React.PropTypes.array.isRequired,
+  filteredNodeCount: React.PropTypes.number.isRequired,
   handleFilterChange: React.PropTypes.func.isRequired,
+  hosts: React.PropTypes.array.isRequired,
+  isFiltering: React.PropTypes.bool,
+  nodeCount: React.PropTypes.number.isRequired,
+  onFilterChange: React.PropTypes.func,
+  onResetFilter: React.PropTypes.func.isRequired,
+  onResourceSelectionChange: React.PropTypes.func.isRequired,
+  refreshRate: React.PropTypes.number.isRequired,
+  selectedFilter: React.PropTypes.string,
+  selectedResource: React.PropTypes.string.isRequired,
   services: React.PropTypes.array.isRequired,
-  viewTypeRadioButtons: React.PropTypes.node.isRequired,
-  hosts: React.PropTypes.array.isRequired
+  totalHostsResources: React.PropTypes.object.isRequired,
+  totalNodeCount: React.PropTypes.number.isRequired,
+  totalResources: React.PropTypes.object.isRequired,
+  viewTypeRadioButtons: React.PropTypes.node.isRequired
 };
 
 module.exports = HostsPageContent;

--- a/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.js
@@ -1,0 +1,169 @@
+import deepEqual from 'deep-equal';
+import mixin from 'reactjs-mixin';
+import React from 'react';
+import {StoreMixin} from 'mesosphere-shared-reactjs';
+
+import CompositeState from '../../../../../../../src/js/structs/CompositeState';
+import MesosStateStore from '../../../../../../../src/js/stores/MesosStateStore';
+import NodesGridView from '../../../components/NodesGridView';
+import QueryParamsMixin from '../../../../../../../src/js/mixins/QueryParamsMixin';
+
+const MAX_SERVICES_TO_SHOW = 32;
+const METHODS_TO_BIND=['handleShowServices'];
+
+class NodesGridContainer extends mixin(StoreMixin, QueryParamsMixin) {
+
+  constructor() {
+    super(...arguments);
+
+    this.state = {
+      filters: {health: 'all', name: '', service: null},
+      filteredNodes: [],
+      hasLoadingError: false,
+      hiddenServices: [],
+      lastMesosStateWasEmpty: true,
+      mesosStateErrorCount: 0,
+      nodeHealthResponseReceived: false,
+      resourcesByFramework: {},
+      serviceColors: {},
+      showServices: false
+    };
+    this.store_listeners = [
+      {
+        name: 'nodeHealth',
+        events: ['success'],
+        listenAlways: false,
+        suppressUpdate: true
+      },
+      {
+        name: 'state',
+        events: ['success', 'error'],
+        suppressUpdate: true
+      }
+    ];
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  componentWillReceiveProps(props) {
+    const {services, query} = props;
+    let ids = services.map(function (service) {
+      return service.id;
+    });
+
+    let {serviceColors} = this.state;
+
+    if (!deepEqual(Object.keys(serviceColors), ids)) {
+      this.computeServiceColors(services);
+      this.computeShownServices(services);
+    }
+
+    const filters = {
+      health: query.filterHealth || 'all',
+      name: query.searchString || '',
+      service: query.filterService || null
+    };
+    this.setFilters(filters);
+  }
+
+  computeServiceColors(services) {
+    var colors = {};
+
+    services.forEach(function (service, index) {
+      // Drop all others into the same 'other' color
+      if (index < MAX_SERVICES_TO_SHOW) {
+        colors[service.id] = index;
+      } else {
+        colors.other = OTHER_SERVICES_COLOR;
+      }
+    });
+
+    this.setState({serviceColors: colors});
+  }
+
+  computeShownServices(services) {
+    var hidden = services.slice(MAX_SERVICES_TO_SHOW).map(function (service) {
+      return service.id;
+    });
+
+    this.setState({hiddenServices: hidden});
+  }
+
+  getFilteredNodes(filters = this.state.filters) {
+    return CompositeState.getNodesList().filter(filters).getItems();
+  }
+
+  setFilters(newFilters, callback) {
+    if (newFilters.service === '') {
+      newFilters.service = null;
+    }
+    const filters = Object.assign({}, this.state.filters, newFilters);
+    const filteredNodes = this.getFilteredNodes(filters);
+
+    this.setState({filters, filteredNodes}, callback);
+  }
+
+  handleShowServices(e) {
+    this.setState({showServices: e.currentTarget.checked});
+  }
+
+  onStateStoreSuccess() {
+    const {hiddenServices} = this.state;
+    const resourcesByFramework = MesosStateStore.getHostResourcesByFramework(hiddenServices);
+    const lastMesosStateWasEmpty = Object.keys(MesosStateStore.get('lastMesosState')).length === 0;
+    this.setState({resourcesByFramework, lastMesosStateWasEmpty});
+  }
+
+  onStateStoreError() {
+    const mesosStateErrorCount = this.state.mesosStateErrorCount + 1;
+    if (mesosStateErrorCount > 3) {
+      this.setState({mesosStateErrorCount, hasLoadingError: true});
+    } else {
+      this.setState({mesosStateErrorCount});
+    }
+  }
+
+  onNodeHealthStoreSuccess() {
+    this.setState({
+      nodeHealthResponseReceived: true,
+      filteredNodes: this.getFilteredNodes()
+    });
+  }
+
+  render() {
+    const {
+      filteredNodes,
+      hasLoadingError,
+      hiddenServices,
+      lastMesosStateWasEmpty,
+      nodeHealthResponseReceived,
+      serviceColors,
+      showServices,
+      resourcesByFramework
+    } = this.state;
+
+    const {services, selectedResource} = this.props;
+    return (
+      <NodesGridView
+        hasLoadingError={hasLoadingError}
+        hiddenServices={hiddenServices}
+        hosts={filteredNodes}
+        lastMesosStateWasEmpty={lastMesosStateWasEmpty}
+        onShowServices={this.handleShowServices}
+        nodeHealthResponseReceived={nodeHealthResponseReceived}
+        resourcesByFramework={resourcesByFramework}
+        selectedResource={selectedResource}
+        serviceColors={serviceColors}
+        services={services}
+        showServices={showServices} />
+    );
+  }
+}
+
+NodesGridContainer.contextTypes = {
+  router: React.PropTypes.func.isRequired,
+  selectedResource: React.PropTypes.string
+};
+
+module.exports = NodesGridContainer;

--- a/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.js
@@ -17,8 +17,8 @@ class NodesGridContainer extends mixin(StoreMixin, QueryParamsMixin) {
     super(...arguments);
 
     this.state = {
-      filters: {health: 'all', name: '', service: null},
       filteredNodes: [],
+      filters: {health: 'all', name: '', service: null},
       hasLoadingError: false,
       hiddenServices: [],
       lastMesosStateWasEmpty: true,
@@ -30,14 +30,14 @@ class NodesGridContainer extends mixin(StoreMixin, QueryParamsMixin) {
     };
     this.store_listeners = [
       {
-        name: 'nodeHealth',
         events: ['success'],
         listenAlways: false,
+        name: 'nodeHealth',
         suppressUpdate: true
       },
       {
-        name: 'state',
         events: ['success', 'error'],
+        name: 'state',
         suppressUpdate: true
       }
     ];
@@ -138,9 +138,9 @@ class NodesGridContainer extends mixin(StoreMixin, QueryParamsMixin) {
       hiddenServices,
       lastMesosStateWasEmpty,
       nodeHealthResponseReceived,
+      resourcesByFramework,
       serviceColors,
-      showServices,
-      resourcesByFramework
+      showServices
     } = this.state;
 
     const {services, selectedResource} = this.props;
@@ -150,8 +150,8 @@ class NodesGridContainer extends mixin(StoreMixin, QueryParamsMixin) {
         hiddenServices={hiddenServices}
         hosts={filteredNodes}
         lastMesosStateWasEmpty={lastMesosStateWasEmpty}
-        onShowServices={this.handleShowServices}
         nodeHealthResponseReceived={nodeHealthResponseReceived}
+        onShowServices={this.handleShowServices}
         resourcesByFramework={resourcesByFramework}
         selectedResource={selectedResource}
         serviceColors={serviceColors}

--- a/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.js
@@ -21,9 +21,9 @@ class NodesGridContainer extends mixin(StoreMixin, QueryParamsMixin) {
       filters: {health: 'all', name: '', service: null},
       hasLoadingError: false,
       hiddenServices: [],
-      lastMesosStateWasEmpty: true,
       mesosStateErrorCount: 0,
-      nodeHealthResponseReceived: false,
+      receivedEmptyMesosState: true,
+      receivedNodeHealthResponse: false,
       resourcesByFramework: {},
       serviceColors: {},
       showServices: false
@@ -111,8 +111,8 @@ class NodesGridContainer extends mixin(StoreMixin, QueryParamsMixin) {
   onStateStoreSuccess() {
     const {hiddenServices} = this.state;
     const resourcesByFramework = MesosStateStore.getHostResourcesByFramework(hiddenServices);
-    const lastMesosStateWasEmpty = Object.keys(MesosStateStore.get('lastMesosState')).length === 0;
-    this.setState({resourcesByFramework, lastMesosStateWasEmpty});
+    const receivedEmptyMesosState = Object.keys(MesosStateStore.get('lastMesosState')).length === 0;
+    this.setState({resourcesByFramework, receivedEmptyMesosState});
   }
 
   onStateStoreError() {
@@ -126,8 +126,8 @@ class NodesGridContainer extends mixin(StoreMixin, QueryParamsMixin) {
 
   onNodeHealthStoreSuccess() {
     this.setState({
-      nodeHealthResponseReceived: true,
-      filteredNodes: this.getFilteredNodes()
+      filteredNodes: this.getFilteredNodes(),
+      receivedNodeHealthResponse: true
     });
   }
 
@@ -136,8 +136,8 @@ class NodesGridContainer extends mixin(StoreMixin, QueryParamsMixin) {
       filteredNodes,
       hasLoadingError,
       hiddenServices,
-      lastMesosStateWasEmpty,
-      nodeHealthResponseReceived,
+      receivedEmptyMesosState,
+      receivedNodeHealthResponse,
       resourcesByFramework,
       serviceColors,
       showServices
@@ -149,8 +149,8 @@ class NodesGridContainer extends mixin(StoreMixin, QueryParamsMixin) {
         hasLoadingError={hasLoadingError}
         hiddenServices={hiddenServices}
         hosts={filteredNodes}
-        lastMesosStateWasEmpty={lastMesosStateWasEmpty}
-        nodeHealthResponseReceived={nodeHealthResponseReceived}
+        receivedEmptyMesosState={receivedEmptyMesosState}
+        receivedNodeHealthResponse={receivedNodeHealthResponse}
         onShowServices={this.handleShowServices}
         resourcesByFramework={resourcesByFramework}
         selectedResource={selectedResource}

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -1,0 +1,76 @@
+import mixin from 'reactjs-mixin';
+import React from 'react';
+import {StoreMixin} from 'mesosphere-shared-reactjs';
+
+import CompositeState from '../../../../../../../src/js/structs/CompositeState';
+import NodesTable from '../../../components/NodesTable';
+import QueryParamsMixin from '../../../../../../../src/js/mixins/QueryParamsMixin';
+
+class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
+
+  constructor() {
+    super(...arguments);
+
+    this.state = {
+      filters: {health: 'all', name: '', service: null},
+      filteredNodes: [],
+      nodeHealthResponseReceived: false
+    };
+    this.store_listeners = [
+      {
+        name: 'nodeHealth',
+        events: ['success'],
+        listenAlways: false,
+        suppressUpdate: true
+      }
+    ];
+  }
+
+  componentWillReceiveProps(router) {
+    let {query} = router;
+
+    const filters = {
+      health: query.filterHealth || 'all',
+      name: query.searchString || '',
+      service: query.filterService || null
+    };
+    this.setFilters(filters);
+  }
+
+  getFilteredNodes(filters = this.state.filters) {
+    return CompositeState.getNodesList().filter(filters).getItems();
+  }
+
+  setFilters(newFilters, callback) {
+    if (newFilters.service === '') {
+      newFilters.service = null;
+    }
+    const filters = Object.assign({}, this.state.filters, newFilters);
+    const filteredNodes = this.getFilteredNodes(filters);
+
+    this.setState({filters, filteredNodes}, callback);
+  }
+
+  onNodeHealthStoreSuccess() {
+    this.setState({
+      nodeHealthResponseReceived: true,
+      filteredNodes: this.getFilteredNodes()
+    });
+  }
+
+  render() {
+    let {nodeHealthResponseReceived, filteredNodes} = this.state;
+
+    return (
+      <NodesTable
+        nodeHealthResponseReceived={nodeHealthResponseReceived}
+        hosts={filteredNodes} />
+    );
+  }
+}
+
+NodesTableContainer.contextTypes = {
+  router: React.PropTypes.func.isRequired
+};
+
+module.exports = NodesTableContainer;

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -12,15 +12,15 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
     super(...arguments);
 
     this.state = {
-      filters: {health: 'all', name: '', service: null},
       filteredNodes: [],
+      filters: {health: 'all', name: '', service: null},
       nodeHealthResponseReceived: false
     };
     this.store_listeners = [
       {
-        name: 'nodeHealth',
         events: ['success'],
         listenAlways: false,
+        name: 'nodeHealth',
         suppressUpdate: true
       }
     ];
@@ -53,8 +53,8 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
 
   onNodeHealthStoreSuccess() {
     this.setState({
-      nodeHealthResponseReceived: true,
-      filteredNodes: this.getFilteredNodes()
+      filteredNodes: this.getFilteredNodes(),
+      nodeHealthResponseReceived: true
     });
   }
 
@@ -63,8 +63,8 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
 
     return (
       <NodesTable
-        nodeHealthResponseReceived={nodeHealthResponseReceived}
-        hosts={filteredNodes} />
+        hosts={filteredNodes}
+        nodeHealthResponseReceived={nodeHealthResponseReceived} />
     );
   }
 }

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -14,7 +14,7 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
     this.state = {
       filteredNodes: [],
       filters: {health: 'all', name: '', service: null},
-      nodeHealthResponseReceived: false
+      receivedNodeHealthResponse: false
     };
     this.store_listeners = [
       {
@@ -54,17 +54,17 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
   onNodeHealthStoreSuccess() {
     this.setState({
       filteredNodes: this.getFilteredNodes(),
-      nodeHealthResponseReceived: true
+      receivedNodeHealthResponse: true
     });
   }
 
   render() {
-    let {nodeHealthResponseReceived, filteredNodes} = this.state;
+    let {receivedNodeHealthResponse, filteredNodes} = this.state;
 
     return (
       <NodesTable
         hosts={filteredNodes}
-        nodeHealthResponseReceived={nodeHealthResponseReceived} />
+        receivedNodeHealthResponse={receivedNodeHealthResponse} />
     );
   }
 }

--- a/plugins/nodes/src/js/routes/nodes.js
+++ b/plugins/nodes/src/js/routes/nodes.js
@@ -3,23 +3,23 @@ import {DefaultRoute, Redirect, Route} from 'react-router';
 import React from 'react';
 /* eslint-enable no-unused-vars */
 
-import NodesTableContainer from '../pages/nodes/nodes-table/NodesTableContainer';
 import NodeDetailBreadcrumb from '../pages/nodes/breadcrumbs/NodeDetailBreadcrumb';
+import NodeDetailHealthTab from '../pages/nodes/NodeDetailHealthTab';
 import NodeDetailPage from '../pages/nodes/NodeDetailPage';
 import NodeDetailTab from '../pages/nodes/NodeDetailTab';
-import NodeDetailHealthTab from '../pages/nodes/NodeDetailHealthTab';
 import NodeDetailTaskTab from '../pages/nodes/NodeDetailTaskTab';
 import NodesGridContainer from '../pages/nodes/nodes-grid/NodesGridContainer';
 import NodesOverview from '../pages/NodesOverview';
 import NodesPage from '../pages/NodesPage';
 
+import NodesTableContainer from '../pages/nodes/nodes-table/NodesTableContainer';
 import TaskDetail from '../../../../services/src/js/pages/task-details/TaskDetail';
 import TaskDetailBreadcrumb from '../../../../services/src/js/pages/nodes/breadcrumbs/TaskDetailBreadcrumb';
 import TaskDetailsTab from '../../../../services/src/js/pages/task-details/TaskDetailsTab';
-import TaskFilesTab from '../../../../services/src/js/pages/task-details/TaskFilesTab';
 import TaskFileViewer from '../../../../services/src/js/pages/task-details/TaskFileViewer';
-import UnitsHealthNodeDetail from '../../../../../src/js/pages/system/UnitsHealthNodeDetail';
+import TaskFilesTab from '../../../../services/src/js/pages/task-details/TaskFilesTab';
 import UnitsHealthDetailBreadcrumb from '../../../../../src/js/pages/system/breadcrumbs/UnitsHealthDetailBreadcrumb';
+import UnitsHealthNodeDetail from '../../../../../src/js/pages/system/UnitsHealthNodeDetail';
 import VolumeDetail from '../../../../services/src/js/components/VolumeDetail';
 import VolumeTable from '../../../../services/src/js/components/VolumeTable';
 

--- a/plugins/nodes/src/js/routes/nodes.js
+++ b/plugins/nodes/src/js/routes/nodes.js
@@ -9,7 +9,7 @@ import NodeDetailPage from '../pages/nodes/NodeDetailPage';
 import NodeDetailTab from '../pages/nodes/NodeDetailTab';
 import NodeDetailHealthTab from '../pages/nodes/NodeDetailHealthTab';
 import NodeDetailTaskTab from '../pages/nodes/NodeDetailTaskTab';
-import NodesGridView from '../components/NodesGridView';
+import NodesGridContainer from '../pages/nodes/nodes-grid/NodesGridContainer';
 import NodesOverview from '../pages/NodesOverview';
 import NodesPage from '../pages/NodesPage';
 
@@ -57,7 +57,7 @@ let nodesRoutes = {
           type: Route,
           name: 'nodes-grid',
           path: 'grid/?',
-          handler: NodesGridView
+          handler: NodesGridContainer
         }
       ]
     },

--- a/plugins/nodes/src/js/routes/nodes.js
+++ b/plugins/nodes/src/js/routes/nodes.js
@@ -3,7 +3,7 @@ import {DefaultRoute, Redirect, Route} from 'react-router';
 import React from 'react';
 /* eslint-enable no-unused-vars */
 
-import NodesTable from '../components/NodesTable';
+import NodesTableContainer from '../pages/nodes/nodes-table/NodesTableContainer';
 import NodeDetailBreadcrumb from '../pages/nodes/breadcrumbs/NodeDetailBreadcrumb';
 import NodeDetailPage from '../pages/nodes/NodeDetailPage';
 import NodeDetailTab from '../pages/nodes/NodeDetailTab';
@@ -51,7 +51,7 @@ let nodesRoutes = {
         {
           type: DefaultRoute,
           name: 'nodes-list',
-          handler: NodesTable
+          handler: NodesTableContainer
         },
         {
           type: Route,

--- a/src/js/mixins/QueryParamsMixin.js
+++ b/src/js/mixins/QueryParamsMixin.js
@@ -37,6 +37,24 @@ var QueryParamsMixin = {
     return router.getCurrentQuery();
   },
 
+  resetQueryParams(params) {
+    const {router} = this.context;
+    if (!router) {
+      return;
+    }
+
+    const queryParams = router.getCurrentQuery();
+    if (params == null) {
+      params = Object.keys(queryParams);
+    }
+
+    params.forEach(function (param) {
+      delete queryParams[param];
+    });
+
+    router.transitionTo(router.getCurrentPathname(), {}, queryParams);
+  },
+
   setQueryParam(paramKey, paramValue) {
     let {router} = this.context;
     let queryParams = router.getCurrentQuery();

--- a/src/js/mixins/__tests__/QueryParamsMixin-test.js
+++ b/src/js/mixins/__tests__/QueryParamsMixin-test.js
@@ -109,4 +109,26 @@ describe('QueryParamsMixin', function () {
     expect(route).toEqual({});
     expect(queryParams).toEqual(queryObject);
   });
+
+  describe('#resetQueryParams', function () {
+
+    it('should reset all params by default', function () {
+      this.instance.resetQueryParams();
+      expect(this.instance.context.router.transitionTo)
+        .toHaveBeenCalledWith('/pathname', {}, {});
+    });
+
+    it('should reset only specified params, when present', function () {
+      this.instance.resetQueryParams(['arrayValue']);
+      expect(this.instance.context.router.transitionTo)
+        .toHaveBeenCalledWith('/pathname', {}, {stringValue: 'string'});
+    });
+
+    it('should exit cleanly when called without a router', function () {
+      expect(this.instance.resetQueryParams.bind({context: {}}))
+          .not.toThrow();
+    });
+
+  });
+
 });


### PR DESCRIPTION
⚠️  This PR depends on #1218

This PR:
 - introduces routing for the nodes page filters
 - separates the node table and node grid views into container and component

~~Testing this PR will require the `cnvs-upgrade` branch in `reactjs-components` checked out and linked locally, and use of the `REACT_JS_COMPONENTS_LOCAL=true` EV.~~