### PR TITLE
[Nodes Page] Nodes detail page

### DIFF
--- a/plugins/nodes/src/js/components/HealthTab.js
+++ b/plugins/nodes/src/js/components/HealthTab.js
@@ -1,3 +1,4 @@
+import PureRenderMixin from 'react-addons-pure-render-mixin';
 import React from 'react';
 import {ResourceTableUtil} from 'foundation-ui';
 import {Table} from 'reactjs-components';
@@ -22,6 +23,7 @@ class HealthTab extends React.Component {
   constructor() {
     super(...arguments);
 
+    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate;
     this.state = {
       healthFilter: 'all',
       searchString: ''

--- a/plugins/nodes/src/js/components/HealthTab.js
+++ b/plugins/nodes/src/js/components/HealthTab.js
@@ -140,12 +140,12 @@ class HealthTab extends React.Component {
         <FilterBar>
           <FilterInputText
             className="flush-bottom"
-            searchString={searchString}
-            handleFilterChange={this.handleSearchStringChange} />
+            handleFilterChange={this.handleSearchStringChange}
+            searchString={searchString} />
           <UnitHealthDropdown
-            initialID="all"
             className="button dropdown-toggle text-align-left"
             dropdownMenuClassName="dropdown-menu"
+            initialID="all"
             onHealthSelection={this.handleHealthSelection}
             ref={(ref) => this.healthFilter = ref} />
         </FilterBar>

--- a/src/js/components/FilterBar.js
+++ b/src/js/components/FilterBar.js
@@ -1,6 +1,12 @@
+import PureRenderMixin from 'react-addons-pure-render-mixin';
 import React from 'react';
 
 class FilterBar extends React.Component {
+
+  constructor() {
+    super(...arguments);
+    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate;
+  }
 
   getFilterBarLeft(filterItems, rightAlignCount) {
     if (filterItems.length === rightAlignCount) {

--- a/src/js/components/FilterHeadline.js
+++ b/src/js/components/FilterHeadline.js
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import PureRenderMixin from 'react-addons-pure-render-mixin';
 import React, {PropTypes} from 'react';
 
 import StringUtil from '../utils/StringUtil';
@@ -10,6 +11,7 @@ const METHODS_TO_BIND = [
 class FilterHeadline extends React.Component {
   constructor() {
     super(...arguments);
+    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate;
 
     METHODS_TO_BIND.forEach((method) => {
       this[method] = this[method].bind(this);

--- a/src/js/components/UnitHealthDropdown.js
+++ b/src/js/components/UnitHealthDropdown.js
@@ -1,8 +1,7 @@
 import {Dropdown} from 'reactjs-components';
-import mixin from 'reactjs-mixin';
+import PureRenderMixin from 'react-addons-pure-render-mixin';
 import React from 'react';
 
-import InternalStorageMixin from '../mixins/InternalStorageMixin';
 import UnitHealthStatus from '../constants/UnitHealthStatus';
 
 const DEFAULT_ITEM = {
@@ -11,9 +10,11 @@ const DEFAULT_ITEM = {
   selectedHtml: 'All Health Checks'
 };
 
-class UnitHealthDropdown extends mixin(InternalStorageMixin) {
-  componentWillMount() {
-    this.internalStorage_set({dropdownItems: this.getDropdownItems()});
+class UnitHealthDropdown extends React.Component {
+  constructor() {
+    super(...arguments);
+    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate;
+    this.state = {dropdownItems: this.getDropdownItems()};
   }
 
   getDropdownItems() {
@@ -41,6 +42,7 @@ class UnitHealthDropdown extends mixin(InternalStorageMixin) {
 
   render() {
     let {className, dropdownMenuClassName, initialID, onHealthSelection} = this.props;
+    let {dropdownItems} = this.state;
 
     return (
       <Dropdown
@@ -48,7 +50,7 @@ class UnitHealthDropdown extends mixin(InternalStorageMixin) {
         dropdownMenuClassName={dropdownMenuClassName}
         dropdownMenuListClassName="dropdown-menu-list"
         initialID={initialID}
-        items={this.internalStorage_get().dropdownItems}
+        items={dropdownItems}
         onItemSelection={onHealthSelection}
         ref={(ref) => this.dropdown = ref}
         scrollContainer=".gm-scroll-view"

--- a/src/js/pages/system/UnitsHealthNodeDetail.js
+++ b/src/js/pages/system/UnitsHealthNodeDetail.js
@@ -4,13 +4,11 @@ import React from 'react';
 /* eslint-enable no-unused-vars */
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
-import Breadcrumbs from '../../components/Breadcrumbs';
-import DetailViewHeader from '../../components/DetailViewHeader';
-import {documentationURI} from '../../config/Config';
-import Icon from '../../components/Icon';
 import Loader from '../../components/Loader';
 import RequestErrorMsg from '../../components/RequestErrorMsg';
 import UnitHealthStore from '../../stores/UnitHealthStore';
+import UnitsHealthNodeDetailPanel from
+  './units-health-node-detail/UnitsHealthNodeDetailPanel';
 import UnitSummaries from '../../constants/UnitSummaries';
 
 class UnitsHealthNodeDetail extends mixin(StoreMixin) {
@@ -33,8 +31,7 @@ class UnitsHealthNodeDetail extends mixin(StoreMixin) {
   }
 
   componentDidMount() {
-    super.componentDidMount();
-
+    super.componentDidMount(...arguments);
     let {unitID, unitNodeID} = this.props.params;
 
     UnitHealthStore.fetchUnit(unitID);
@@ -57,23 +54,6 @@ class UnitsHealthNodeDetail extends mixin(StoreMixin) {
     this.setState({hasError: true});
   }
 
-  getSubTitle(unit, node) {
-    let healthStatus = node.getHealth();
-
-    return (
-      <ul className="list-inline flush-bottom">
-        <li>
-          <span className={healthStatus.classNames}>
-            {healthStatus.title}
-          </span>
-        </li>
-        <li>
-          {node.get('host_ip')}
-        </li>
-      </ul>
-    );
-  }
-
   getErrorNotice() {
     return (
       <div className="pod">
@@ -86,34 +66,6 @@ class UnitsHealthNodeDetail extends mixin(StoreMixin) {
     return (
       <div className="pod">
         <Loader />
-      </div>
-    );
-  }
-
-  getNodeInfo(node, unit) {
-    let unitSummary = UnitSummaries[unit.get('id')] || {};
-    let unitDocsURL = unitSummary.getDocumentationURI &&
-      unitSummary.getDocumentationURI();
-
-    if (!unitDocsURL) {
-      unitDocsURL = documentationURI;
-    }
-
-    return (
-      <div className="flex-container-col flex-grow">
-        <span className="h4 flush-top">Summary</span>
-        <p>
-          {unitSummary.summary}
-        </p>
-        <p>
-          <a href={unitDocsURL} target="_blank">
-            View Documentation
-          </a>
-        </p>
-        <span className="h4">Output</span>
-        <pre className="flex-grow flush-bottom">
-          {node.getOutput()}
-        </pre>
       </div>
     );
   }
@@ -133,19 +85,22 @@ class UnitsHealthNodeDetail extends mixin(StoreMixin) {
     let node = UnitHealthStore.getNode(unitNodeID);
     let unit = UnitHealthStore.getUnit(unitID);
 
+    let healthStatus = node.getHealth();
+
+    let unitSummary = UnitSummaries[unit.get('id')] || {};
+    let unitDocsURL = unitSummary.getDocumentationURI &&
+        unitSummary.getDocumentationURI();
+
     return (
-      <div className="flex-container-col">
-        <Breadcrumbs />
-        <DetailViewHeader
-          icon={<Icon color="neutral" id="heart-pulse" size="large" />}
-          subTitle={this.getSubTitle(unit, node)}
-          title={`${unit.getTitle()} Health Check`} />
-        <div className="flex-container-col flex-grow no-overflow">
-          {this.getNodeInfo(node, unit)}
-        </div>
-      </div>
+      <UnitsHealthNodeDetailPanel
+        docsURL={unitDocsURL}
+        healthStatus={healthStatus.title}
+        healthStatusClassNames={healthStatus.classNames}
+        hostIP={node.get('host_ip')}
+        pageHeaderTitle={`${unit.getTitle()} Health Check`}
+        output={node.getOutput()}
+        summary={unitSummary.summary} />
     );
   }
-};
-
+}
 module.exports = UnitsHealthNodeDetail;

--- a/src/js/pages/system/units-health-node-detail/NodeInfoPanel.js
+++ b/src/js/pages/system/units-health-node-detail/NodeInfoPanel.js
@@ -1,0 +1,47 @@
+import PureRenderMixin from 'react-addons-pure-render-mixin';
+import React from 'react';
+
+import {documentationURI} from '../../../config/Config';
+
+class NodeInfoPanel extends React.Component {
+
+  constructor() {
+    super(...arguments);
+    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate;
+  }
+
+  render() {
+    const {summary, docsURL, output} = this.props;
+
+    return (
+      <div className="flex-container-col flex-grow">
+        <span className="h4 inverse flush-top">Summary</span>
+        <p className="inverse">
+          {summary}
+        </p>
+        <p className="inverse">
+          <a href={docsURL} target="_blank">
+            View Documentation
+          </a>
+        </p>
+        <span className="h4 inverse">Output</span>
+        <pre className="flex-grow flush-bottom">
+          {output}
+        </pre>
+      </div>
+    );
+  }
+
+}
+
+NodeInfoPanel.propTypes = {
+  docsURL: React.PropTypes.string,
+  output: React.PropTypes.string,
+  summary: React.PropTypes.string
+};
+
+NodeInfoPanel.defaultProps = {
+  docsURL: documentationURI
+};
+
+module.exports = NodeInfoPanel;

--- a/src/js/pages/system/units-health-node-detail/UnitsHealthNodeDetailPanel.js
+++ b/src/js/pages/system/units-health-node-detail/UnitsHealthNodeDetailPanel.js
@@ -1,0 +1,64 @@
+import PureRenderMixin from 'react-addons-pure-render-mixin';
+import React from 'react';
+
+import Breadcrumbs from '../../../components/Breadcrumbs';
+import DetailViewHeader from '../../../../../src/js/components/DetailViewHeader';
+import Icon from '../../../components/Icon';
+import NodeInfoPanel from './NodeInfoPanel';
+
+class UnitsHealthNodeDetailPanel extends React.Component {
+
+  constructor() {
+    super(...arguments);
+    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate;
+  }
+
+  renderSubTitle() {
+    const {healthStatus, healthStatusClassNames, hostIP} = this.props;
+
+    return (
+      <ul className="list-inline flush-bottom">
+        <li>
+          <span className={healthStatusClassNames}>
+            {healthStatus}
+          </span>
+        </li>
+        <li>
+          {hostIP}
+        </li>
+      </ul>
+    );
+  }
+
+  render() {
+    const {pageHeaderTitle, summary, docsURL, output} = this.props;
+
+    return (
+      <div className="flex-container-col">
+        <Breadcrumbs />
+        <DetailViewHeader
+          icon={<Icon color="neutral" id="heart-pulse" size="large" />}
+          subTitle={this.renderSubTitle()}
+          title={pageHeaderTitle} />
+        <div className="flex-container-col flex-grow no-overflow">
+          <NodeInfoPanel
+            docsURL={docsURL}
+            output={output}
+            summary={summary} />
+        </div>
+      </div>
+    );
+  }
+}
+
+UnitsHealthNodeDetailPanel.propTypes = {
+  docsURL: React.PropTypes.string,
+  healthStatus: React.PropTypes.string,
+  healthStatusClassNames: React.PropTypes.string,
+  hostIP: React.PropTypes.string,
+  pageHeaderTitle: React.PropTypes.string,
+  output: React.PropTypes.string,
+  summary: React.PropTypes.string
+};
+
+module.exports = UnitsHealthNodeDetailPanel;


### PR DESCRIPTION
⚠️ This PR depends on #1218

This PR separates the tabs in the nodes detail page into container and component. 

~~Testing this PR will require the `cnvs-upgrade` branch in `reactjs-components` checked out and linked locally, and use of the `REACT_JS_COMPONENTS_LOCAL=true` EV.~~