### PR TITLE
[CNVS Upgrade] Fix hidden-* classes

### DIFF
--- a/plugins/banner/hooks.js
+++ b/plugins/banner/hooks.js
@@ -154,7 +154,7 @@ module.exports = {
     }
 
     return (
-      <span className="content hidden-mini" title={content}>
+      <span className="content hidden-small-down" title={content}>
         {content}
       </span>
     );
@@ -179,7 +179,7 @@ module.exports = {
             {title}
           </span>
           <span
-            className="banner-plugin-info-icon clickable hidden-small hidden-medium hidden-large"
+            className="banner-plugin-info-icon clickable hidden-medium-up"
             onClick={this.toggleFullContent}>
             <Icon
               family="mini"

--- a/src/js/components/NodesTable.js
+++ b/src/js/components/NodesTable.js
@@ -196,9 +196,9 @@ var NodesTable = React.createClass({
         <col />
         <col style={{width: '100px'}} />
         <col style={{width: '110px'}} />
-        <col className="hidden-mini" style={{width: '135px'}} />
-        <col className="hidden-mini" style={{width: '135px'}} />
-        <col className="hidden-mini" style={{width: '135px'}} />
+        <col className="hidden-small-down" style={{width: '135px'}} />
+        <col className="hidden-small-down" style={{width: '135px'}} />
+        <col className="hidden-small-down" style={{width: '135px'}} />
       </colgroup>
     );
   },

--- a/src/js/components/ServicesTable.js
+++ b/src/js/components/ServicesTable.js
@@ -296,8 +296,8 @@ var ServicesTable = React.createClass({
         </span>
         <span className="status-bar-text">
           <span className={serviceStatusClassSet}>{serviceStatus}</span>
-          <span className="visible-x-large-inline">{verboseOverview}</span>
-          <span className="hidden-x-large">{conciseOverview}</span>
+          <span className="hidden-large-down">{verboseOverview}</span>
+          <span className="hidden-jumbo-up">{conciseOverview}</span>
         </span>
       </div>
     );
@@ -318,7 +318,7 @@ var ServicesTable = React.createClass({
   renderStatsHeading(prop, sortBy, row) {
     let isHeader = row == null;
 
-    return classNames('flush-left text-align-right hidden-mini hidden-small', {
+    return classNames('flush-left text-align-right hidden-small-down', {
       'active': prop === sortBy.prop,
       'clickable': isHeader
     });
@@ -397,9 +397,9 @@ var ServicesTable = React.createClass({
       <colgroup>
         <col />
         <col className="status-bar-column"/>
-        <col className="hidden-mini hidden-small" style={{width: '85px'}} />
-        <col className="hidden-mini hidden-small" style={{width: '75px'}} />
-        <col className="hidden-mini hidden-small" style={{width: '85px'}} />
+        <col className="hidden-small-down" style={{width: '85px'}} />
+        <col className="hidden-small-down" style={{width: '75px'}} />
+        <col className="hidden-small-down" style={{width: '85px'}} />
       </colgroup>
     );
   },

--- a/src/js/components/SidebarFilter.js
+++ b/src/js/components/SidebarFilter.js
@@ -210,7 +210,7 @@ class SidebarFilter extends mixin(QueryParamsMixin) {
     let {props} = this;
 
     return (
-      <div className="side-list sidebar-filters hidden-medium hidden-small pod flush-top flush-left">
+      <div className="side-list sidebar-filters pod flush-top flush-left">
         <div className="sidebar-filters-header label">
           {this.getTitle()}
           {this.getClearLinkForFilter(props.filterType)}

--- a/src/js/components/SidebarLabelsFilter.js
+++ b/src/js/components/SidebarLabelsFilter.js
@@ -211,7 +211,7 @@ class SidebarLabelsFilters extends mixin(QueryParamsMixin) {
     }
 
     return (
-      <div className="side-list sidebar-filters hidden-medium hidden-small pod flush-top flush-left">
+      <div className="side-list sidebar-filters pod flush-top flush-left">
         {this.getLabelsDropdown()}
         {this.getSelectedLabels()}
       </div>

--- a/src/js/components/TaskStatsTable.js
+++ b/src/js/components/TaskStatsTable.js
@@ -32,7 +32,7 @@ class TaskStatsTable extends React.Component {
     return classNames({
       'active': prop === sortBy.prop,
       'text-align-right': shouldAlignRight,
-      'hidden-mini': taskStatus.includes(prop)
+      'hidden-small-down': taskStatus.includes(prop)
     });
   }
 
@@ -104,10 +104,10 @@ class TaskStatsTable extends React.Component {
     return (
       <colgroup>
         <col style={{width: '20%'}} />
-        <col style={{width: '95px'}} className="hidden-mini" />
-        <col style={{width: '90px'}} className="hidden-mini" />
-        <col style={{width: '105px'}} className="hidden-mini" />
-        <col style={{width: '90px'}} className="hidden-mini" />
+        <col style={{width: '95px'}} className="hidden-small-down" />
+        <col style={{width: '90px'}} className="hidden-small-down" />
+        <col style={{width: '105px'}} className="hidden-small-down" />
+        <col style={{width: '90px'}} className="hidden-small-down" />
         <col />
       </colgroup>
     );

--- a/src/js/components/TaskTable.js
+++ b/src/js/components/TaskTable.js
@@ -107,10 +107,9 @@ class TaskTable extends React.Component {
   getClassName(prop, sortBy, row) {
     return classNames({
       'text-align-right': RIGHT_ALIGN_PROPS.includes(prop),
-      'hidden-mini': ['name', 'host', 'status', 'cpus', 'mem'].includes(prop),
-      'hidden-small': prop === 'name',
-      'hidden-medium hidden-small hidden-mini':
-        ['version', 'log'].includes(prop),
+      'hidden-small-down': ['host', 'status', 'cpus', 'mem'].includes(prop),
+      'hidden-medium-down': prop === 'name',
+      'hidden-large-down': ['version', 'log'].includes(prop),
       'highlight': prop === sortBy.prop,
       'clickable': row == null // this is a header
     });
@@ -227,14 +226,14 @@ class TaskTable extends React.Component {
       <colgroup>
         <col style={{width: '40px'}} />
         <col />
-        <col style={{width: '10%'}} className="hidden-mini  hidden-small" />
-        <col style={{width: '150px'}} className="hidden-mini" />
-        <col style={{width: '115px'}} />
-        <col style={{width: '40px'}} className="hidden-medium hidden-small hidden-mini" />
-        <col style={{width: '85px'}} className="hidden-mini" />
-        <col style={{width: '85px'}} className="hidden-mini" />
+        <col style={{width: '10%'}} className="hidden-medium-down" />
+        <col style={{width: '150px'}} className="hidden-small-down" />
+        <col style={{width: '115px'}} className="hidden-small-down" />
+        <col style={{width: '40px'}} className="hidden-large-down" />
+        <col style={{width: '85px'}} className="hidden-small-down" />
+        <col style={{width: '85px'}} className="hidden-small-down" />
         <col style={{width: '120px'}} />
-        <col style={{width: '110px'}} className="hidden-medium hidden-small hidden-mini"/>
+        <col style={{width: '110px'}} className="hidden-large-down"/>
       </colgroup>
     );
   }

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -47,7 +47,7 @@ const METHODS_TO_BIND = [
 function columnClassNameGetter(prop, sortBy, row) {
   let classSet = ResourceTableUtil.getClassName(prop, sortBy, row);
   if (COLLAPSING_COLUMNS.includes(prop)) {
-    return classNames(classSet, 'hidden-mini');
+    return classNames(classSet, 'hidden-small-down');
   }
   return classSet;
 }
@@ -295,10 +295,10 @@ class DeploymentsTab extends mixin(StoreMixin) {
     return (
       <colgroup>
         <col style={{width: '300px'}} />
-        <col className="hidden-mini" />
-        <col className="hidden-mini" style={{width: '120px'}} />
+        <col className="hidden-small-down" />
+        <col className="hidden-small-down" style={{width: '120px'}} />
         <col style={{width: '240px'}} />
-        <col className="hidden-mini" style={{width: '160px'}} />
+        <col className="hidden-small-down" style={{width: '160px'}} />
       </colgroup>
     );
   }

--- a/src/js/utils/ResourceTableUtil.js
+++ b/src/js/utils/ResourceTableUtil.js
@@ -36,7 +36,7 @@ var ResourceTableUtil = {
     return classNames({
       'text-align-right': leftAlignCaret(prop)
         || prop === 'TASK_RUNNING' || prop === 'action',
-      'hidden-mini': leftAlignCaret(prop),
+      'hidden-small-down': leftAlignCaret(prop),
       'active': prop === sortBy.prop,
       'clickable': row == null // this is a header
     });

--- a/src/styles/layout/overlay.less
+++ b/src/styles/layout/overlay.less
@@ -1,3 +1,5 @@
+// TODO: Remove this, this isn't being used anywhere.
+
 /*
  * Overlay
  */


### PR DESCRIPTION
These responsive classes are named incorrectly in the published version of CNVS. I submitted two PRs to CNVS to fix them, one of which has already merged. I don't currently have access to publish the NPM module. So if you'd like to test this, you'll need to `npm link` this branch of CNVS: https://github.com/mesosphere/canvas/pull/29

This PR updates all of the `hidden-*` classes. It's not exactly a one-to-one update, due to the following:
1. All screen sizes were renamed in CNVS, so `mini` became `small`, `small` became `medium`, `medium` became `large`, and `large` became `jumbo`.
2. Previously `hidden-small` and `hidden-medium` would hide elements only within the range of that breakpoint.
3. Previously `hidden-mini` hid elements at `mini` and below, and `hidden-large` hid elements at `large` and above.

These responsive classes are now more obvious:
1. `hidden-{breakpoint}` will hide elements only within that breakpoint's range.
2. `hidden-{breakpoint}-up` will hide elements at the breakpoint's min width and up.
3. `hidden-{breakpoint}-down` will hide elements at the breakpoint's max width and down.

Thus, I condensed classes like `hidden-medium hidden-small hidden-mini` into `hidden-large-down`.