### PR TITLE
[CNVS Upgrade] Fix input element height

### DIFF
--- a/src/styles/vendor/cnvs/components/form/form-control/variables.less
+++ b/src/styles/vendor/cnvs/components/form/form-control/variables.less
@@ -1,0 +1,5 @@
+@form-control-height:                                                           @button-height;
+@form-control-height-screen-small:                                              @button-height-screen-small;
+@form-control-height-screen-medium:                                             @button-height-screen-medium;
+@form-control-height-screen-large:                                              @button-height-screen-large;
+@form-control-height-screen-jumbo:                                              @button-height-screen-jumbo;

--- a/src/styles/vendor/cnvs/styles.less
+++ b/src/styles/vendor/cnvs/styles.less
@@ -122,7 +122,7 @@
 
 /* Form Control */
 
-// @import 'components/form/form-control/variables.less';
+@import 'components/form/form-control/variables.less';
 
 // Form Control Shapes
 


### PR DESCRIPTION
This PR assigns default CNVS `form-control-height-*` variables to the `button-height-*` variables.