### PR TITLE
[CNVS Upgrade] Fix dark status bar & dot backgrounds

### DIFF
--- a/src/styles/components/status-bar/styles.less
+++ b/src/styles/components/status-bar/styles.less
@@ -22,8 +22,9 @@
   }
 
   .status-bar {
-    background-color: @neutral;
+    background-color: color-lighten(@neutral, 90);
     border-radius: 1000px;
+    color: color-lighten(@neutral, 90);
     display: inline-flex;
     height: @base-spacing-unit * 1/6;
     line-height: @base-spacing-unit * 1/6;
@@ -55,14 +56,14 @@
         animation: candy-stripe 1s linear infinite;
         background-image:
           linear-gradient(-45deg,
-          color-lighten(@neutral, 10) 0,
-          color-lighten(@neutral, 10) 25%,
-          color-lighten(@neutral, -10) 25%,
-          color-lighten(@neutral, -10) 50%,
-          color-lighten(@neutral, 10) 50%,
-          color-lighten(@neutral, 10) 75%,
-          color-lighten(@neutral, -10) 75%,
-          color-lighten(@neutral, -10) 100%);
+          color-lighten(@neutral, 90) 0,
+          color-lighten(@neutral, 90) 25%,
+          color-lighten(@neutral, 80) 25%,
+          color-lighten(@neutral, 80) 50%,
+          color-lighten(@neutral, 90) 50%,
+          color-lighten(@neutral, 90) 75%,
+          color-lighten(@neutral, 80) 75%,
+          color-lighten(@neutral, 80) 100%);
         background-size: 16px 16px;
       }
 
@@ -84,14 +85,14 @@
         animation: candy-stripe 1s linear infinite;
         background-image:
           linear-gradient(-45deg,
-          color-lighten(@green, -30) 0,
-          color-lighten(@green, -30) 25%,
-          color-lighten(@green, -50) 25%,
-          color-lighten(@green, -50) 50%,
-          color-lighten(@green, -30) 50%,
-          color-lighten(@green, -30) 75%,
-          color-lighten(@green, -50) 75%,
-          color-lighten(@green, -50) 100%);
+          color-lighten(@green, -20) 0,
+          color-lighten(@green, -20) 25%,
+          @green 25%,
+          @green 50%,
+          color-lighten(@green, -20) 50%,
+          color-lighten(@green, -20) 75%,
+          @green 75%,
+          @green 100%);
         background-size: 16px 16px;
       }
     }

--- a/src/styles/components/status-dots/styles.less
+++ b/src/styles/components/status-dots/styles.less
@@ -1,7 +1,7 @@
 & when (@status-dots-enabled) {
 
   .dot {
-    background-color: @neutral;
+    background-color: color-lighten(@neutral, 90);
     border-radius: 100%;
     height: 8px;
     width: 8px;
@@ -23,14 +23,14 @@
       animation: candy-stripe 1s linear infinite;
       background-image:
         linear-gradient(-45deg,
-        color-lighten(@green, -30) 0,
-        color-lighten(@green, -30) 25%,
-        color-lighten(@green, -50) 25%,
-        color-lighten(@green, -50) 50%,
-        color-lighten(@green, -30) 50%,
-        color-lighten(@green, -30) 75%,
-        color-lighten(@green, -50) 75%,
-        color-lighten(@green, -50) 100%);
+        color-lighten(@green, -20) 0,
+        color-lighten(@green, -20) 25%,
+        @green 25%,
+        @green 50%,
+        color-lighten(@green, -20) 50%,
+        color-lighten(@green, -20) 75%,
+        @green 75%,
+        @green 100%);
       background-size: 16px 16px;
     }
 
@@ -38,14 +38,14 @@
       animation: candy-stripe 1s linear infinite;
       background-image:
         linear-gradient(-45deg,
-        color-lighten(@neutral, -30) 0,
-        color-lighten(@neutral, -30) 25%,
-        color-lighten(@neutral, -50) 25%,
-        color-lighten(@neutral, -50) 50%,
-        color-lighten(@neutral, -30) 50%,
-        color-lighten(@neutral, -30) 75%,
-        color-lighten(@neutral, -50) 75%,
-        color-lighten(@neutral, -50) 100%);
+        color-lighten(@neutral, 90) 0,
+        color-lighten(@neutral, 90) 25%,
+        color-lighten(@neutral, 80) 25%,
+        color-lighten(@neutral, 80) 50%,
+        color-lighten(@neutral, 90) 50%,
+        color-lighten(@neutral, 90) 75%,
+        color-lighten(@neutral, 80) 75%,
+        color-lighten(@neutral, 80) 100%);
       background-size: 16px 16px;
     }
 

--- a/src/styles/components/typography/styles.less
+++ b/src/styles/components/typography/styles.less
@@ -97,7 +97,7 @@
 
   .task-status-running,
   .task-status-starting {
-    color: @white;
+    color: @neutral;
   }
 
   .task-status-staging {


### PR DESCRIPTION
This PR uses light colors for status bars & dots.

Examples (the text may not match the color status in these screenshots):
![](https://cl.ly/0L0M0v0b282F/Screen%20Shot%202016-10-10%20at%201.48.07%20PM.png)

![](https://cl.ly/1T43080u1Z1P/Screen%20Shot%202016-10-10%20at%202.01.43%20PM.png)