### PR TITLE
[Pods] DCOS-10594: Fixing killPodInstance endpoint

### DIFF
--- a/src/js/events/MarathonActions.js
+++ b/src/js/events/MarathonActions.js
@@ -492,8 +492,12 @@ var MarathonActions = {
   },
 
   killPodInstances(pod, instanceIDs, force) {
-    let podID = pod.getId().substr(1);
+    let podID = pod.getId();
     let params = '';
+
+    if (podID[0] === '/') {
+      podID = podID.substr(1);
+    }
 
     if (force) {
       params = '?force=true';

--- a/src/js/events/MarathonActions.js
+++ b/src/js/events/MarathonActions.js
@@ -492,7 +492,7 @@ var MarathonActions = {
   },
 
   killPodInstances(pod, instanceIDs, force) {
-    let podID = encodeURIComponent(pod.getId());
+    let podID = pod.getId().substr(1);
     let params = '';
 
     if (force) {
@@ -500,7 +500,7 @@ var MarathonActions = {
     }
 
     RequestUtil.json({
-      url: buildURI(`/pods/${podID}::instances${params}`),
+      url: buildURI(`/pods/${podID}::instance${params}`),
       data: instanceIDs,
       method: 'DELETE',
       success() {

--- a/src/js/events/MarathonActions.js
+++ b/src/js/events/MarathonActions.js
@@ -500,7 +500,7 @@ var MarathonActions = {
     }
 
     RequestUtil.json({
-      url: buildURI(`/pods/${podID}::instance${params}`),
+      url: buildURI(`/pods/${podID}::instances${params}`),
       data: instanceIDs,
       method: 'DELETE',
       success() {

--- a/src/js/events/MarathonActions.js
+++ b/src/js/events/MarathonActions.js
@@ -492,12 +492,8 @@ var MarathonActions = {
   },
 
   killPodInstances(pod, instanceIDs, force) {
-    let podID = pod.getId();
+    let podID = pod.getId().replace(/^\//, '');
     let params = '';
-
-    if (podID[0] === '/') {
-      podID = podID.substr(1);
-    }
 
     if (force) {
       params = '?force=true';


### PR DESCRIPTION
Fixing a bug with the `Kill` pod instance button. Apparently:

* ~~The pod spec is wrong, the correct endpoint is `/{id}::instance` (without tailing `s`)~~ fixed in marathon 1.4.0-snap16
* The pod `id` is actually a full path, without the heading slash. It should be injected as a URL component, without escaping

__Hold merge:__ Until marathon fixes the endpoint to `::instances` again.
