### PR TITLE
[Pods] Properly composing instance id

### DIFF
--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -133,9 +133,10 @@ const MesosStateUtil = {
         if (MesosStateUtil.isPodTaskId(task.id)) {
           let {podID, instanceID} = MesosStateUtil.decomposePodTaskId(task.id);
           if (podID === pod.getMesosId()) {
-            let containerArray = memo[instanceID];
+            let fullInstanceID = `${podID}.instance-${instanceID}`;
+            let containerArray = memo[fullInstanceID];
             if (containerArray === undefined) {
-              containerArray = memo[instanceID] = [];
+              containerArray = memo[fullInstanceID] = [];
             }
 
             // The last status can give us information about the time the
@@ -169,8 +170,8 @@ const MesosStateUtil = {
     // Try to compose actual PodInstance structures from the information we
     // have so far. Obviously we don't have any details, but we can populate
     // most of the UI-interesting fields by summarising container details
-    return Object.keys(instancesMap).map(function (instanceId) {
-      let containers = instancesMap[instanceId];
+    return Object.keys(instancesMap).map(function (instanceID) {
+      let containers = instancesMap[instanceID];
       let summaryProperties = containers.reduce(function (memo, instance) {
         let {resources={}, lastChanged=0} = instance;
 
@@ -195,7 +196,7 @@ const MesosStateUtil = {
 
       // Compose something as close as possible to what `PodInstance` understand
       return Object.assign({
-        id: instanceId,
+        id: instanceID,
         status: PodInstanceState.TERMINAL,
         containers
       }, summaryProperties);

--- a/src/js/utils/__tests__/MesosStateUtil-test.js
+++ b/src/js/utils/__tests__/MesosStateUtil-test.js
@@ -278,8 +278,8 @@ describe('MesosStateUtil', function () {
       let instances = MesosStateUtil.getPodHistoricalInstances(state, pod);
 
       expect(instances.length).toEqual(2);
-      expect(instances[0].id).toEqual('inst-a1');
-      expect(instances[1].id).toEqual('inst-a2');
+      expect(instances[0].id).toEqual('pod-p0.instance-inst-a1');
+      expect(instances[1].id).toEqual('pod-p0.instance-inst-a2');
     });
 
     it('should add `containerID` property on containers', function () {


### PR DESCRIPTION
This PR makes sure that the pod instances composed from `completed_tasks` have the correct ID.

Previously:
![image](https://cloud.githubusercontent.com/assets/883486/19353244/fa98fe64-9162-11e6-85d6-d607b9133f59.png)


Now:
![image](https://cloud.githubusercontent.com/assets/883486/19353223/e75aa3c0-9162-11e6-9fc5-0a27d3b8c0fd.png)
