### PR TITLE
DCOS-10624: Adjust get service by task id getter

### DIFF
--- a/src/js/structs/ServiceTree.js
+++ b/src/js/structs/ServiceTree.js
@@ -80,14 +80,7 @@ module.exports = class ServiceTree extends Tree {
   }
 
   getServiceFromTaskID(taskID) {
-    let serviceName = ServiceUtil.getServiceNameFromTaskID(taskID);
-    let service = this.findServiceByName(serviceName);
-
-    if (service == null) {
-      return null;
-    }
-
-    return new Service(service.get());
+    return this.findServiceByName(ServiceUtil.getServiceNameFromTaskID(taskID));
   }
 
   getTaskFromTaskID(taskID) {


### PR DESCRIPTION
Return the matching service instance instead of creating a new one using the abstract service struct.

Fixes DCOS-10624