### PR TITLE
Debounce DCOSStore events

### DIFF
--- a/src/js/components/PodInstancesTable.js
+++ b/src/js/components/PodInstancesTable.js
@@ -246,6 +246,16 @@ class PodInstancesTable extends React.Component {
     return children;
   }
 
+  getDisabledItemsMap(instanceList) {
+    return instanceList.reduceItems(function (memo, instance) {
+      if (!instance.isRunning()) {
+        memo[instance.getId()] = true;
+      }
+
+      return memo;
+    }, {});
+  }
+
   getTableDataFor(instances, filterText) {
     let podSpec = this.props.pod.getSpec();
 
@@ -429,6 +439,7 @@ class PodInstancesTable extends React.Component {
         columns={this.getColumns()}
         colGroup={this.getColGroup()}
         data={this.getTableDataFor(instances, filterText)}
+        disabledItemsMap={this.getDisabledItemsMap(instances)}
         expandAll={!!filterText}
         getColGroup={this.getColGroup}
         onCheckboxChange={this.handleItemCheck}

--- a/src/js/stores/DCOSStore.js
+++ b/src/js/stores/DCOSStore.js
@@ -32,6 +32,8 @@ const METHODS_TO_BIND = [
   'onMesosSummaryChange'
 ];
 
+const EVENT_DEBOUNCE_TIME = 250;
+
 class DCOSStore extends EventEmitter {
   constructor() {
     super(...arguments);
@@ -63,6 +65,8 @@ class DCOSStore extends EventEmitter {
       mesos: new SummaryList(),
       dataProcessed: false
     };
+
+    this.debouncedEvents = new Map();
   }
 
   getProxyListeners() {
@@ -175,6 +179,18 @@ class DCOSStore extends EventEmitter {
       });
 
     this.emit(DCOS_CHANGE);
+  }
+
+  emit(eventType) {
+    // Debounce specified events
+    if ([DCOS_CHANGE].includes(eventType)) {
+      clearTimeout(this.debouncedEvents.get(eventType));
+      this.debouncedEvents.set(eventType,
+          setTimeout(super.emit.bind(this, ...arguments), EVENT_DEBOUNCE_TIME));
+      return;
+    }
+
+    super.emit(eventType);
   }
 
   onMarathonGroupsChange() {


### PR DESCRIPTION
The DCOS change event is fired whenever one of the depended stores (e.g. Marathon) fires a change event; this results in an unnecessarily high amount of change events due to the unregular nature of those updates.

This PR introduces methods to debounce change event calls (max 4x per second), which significantly improves the overall performance.

_Please note that we besides reducing the number of change event calls also need to address the high number of network request as well as the large number of stacked calls._

**Before**
![current](https://cloud.githubusercontent.com/assets/647035/19391477/13f0e1fe-922d-11e6-9a13-2f5b6152dbd4.gif)

**After**
![debounced mov](https://cloud.githubusercontent.com/assets/647035/19391484/1832e35c-922d-11e6-9776-086c2ed10ef3.gif)

