### PR TITLE
[CNVS Upgrade] [React router migration] Migrate named routes

### DIFF
--- a/plugins/nodes/src/js/components/HealthTab.js
+++ b/plugins/nodes/src/js/components/HealthTab.js
@@ -117,7 +117,7 @@ class HealthTab extends React.Component {
     return (
       <a
         className="emphasize clickable text-overflow"
-        onClick={() => { this.props.parentRouter.transitionTo('node-detail-health', params); }}
+        onClick={() => { this.props.parentRouter.transitionTo('/nodes/:nodeID/health/:unitNodeID/:unitID', params); }}
         title={healthCheckName}>
         {healthCheckName}
       </a>

--- a/plugins/nodes/src/js/components/NodesGridDials.js
+++ b/plugins/nodes/src/js/components/NodesGridDials.js
@@ -29,7 +29,7 @@ var NodesGridDials = React.createClass({
 
   handleDialClick(nodeID) {
     // Using handler, since Link in arrays cannot get router context
-    this.context.router.transitionTo('node-detail', {nodeID});
+    this.context.router.transitionTo('/nodes/:nodeID', {nodeID});
   },
 
   getServiceSlicesConfig(node) {

--- a/plugins/nodes/src/js/components/NodesTable.js
+++ b/plugins/nodes/src/js/components/NodesTable.js
@@ -54,7 +54,7 @@ var NodesTable = React.createClass({
 
     return (
       <Link className="table-cell-link-primary" params={{nodeID: node.get('id')}}
-        to="node-detail">
+        to="/nodes/:nodeID">
         {headline}
       </Link>
     );

--- a/plugins/nodes/src/js/pages/NodesOverview.js
+++ b/plugins/nodes/src/js/pages/NodesOverview.js
@@ -213,18 +213,20 @@ var NodesOverview = React.createClass({
   },
 
   getViewTypeRadioButtons(resetFilter) {
+    let isGridActive = /\/nodes\/grid\/?/i.test(HashLocation.getCurrentPath());
+
     var listClassSet = classNames('button button-stroke', {
-      'active': /\/nodes\/list\/?/i.test(HashLocation.getCurrentPath())
+      'active': !isGridActive
     });
 
     var gridClassSet = classNames('button button-stroke', {
-      'active': /\/nodes\/grid\/?/i.test(HashLocation.getCurrentPath())
+      'active': isGridActive
     });
 
     return (
       <div className="button-group flush-bottom">
-        <Link className={listClassSet} onClick={resetFilter} to="nodes-list">List</Link>
-        <Link className={gridClassSet} onClick={resetFilter} to="nodes-grid">Grid</Link>
+        <Link className={listClassSet} onClick={resetFilter} to="/nodes">List</Link>
+        <Link className={gridClassSet} onClick={resetFilter} to="/nodes/grid">Grid</Link>
       </div>
     );
   },

--- a/plugins/nodes/src/js/pages/__tests__/NodeDetailPage-test.js
+++ b/plugins/nodes/src/js/pages/__tests__/NodeDetailPage-test.js
@@ -90,7 +90,7 @@ describe('NodeDetailPage', function () {
         NodeDetailPage,
         {params: {nodeID: 'nonExistent', taskID: 'foo'}},
         {getCurrentRoutes() {
-          return [{name: 'node-detail', children: []}];
+          return [{path: '/nodes/:nodeID', children: []}];
         }}
       ),
       this.container
@@ -135,7 +135,7 @@ describe('NodeDetailPage', function () {
           NodeDetailPage,
           {params: {nodeID: 'existingNode'}},
           {getCurrentRoutes() {
-            return [{name: 'node-detail', children: []}];
+            return [{path: '/nodes/:nodeID', children: []}];
           }}
         ),
         this.container

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
@@ -46,16 +46,14 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
     // TODO: DCOS-7871 Refactor the TabsMixin to generalize this solution:
     let routes = this.context.router.getCurrentRoutes();
     let currentRoute = routes.find(function (route) {
-      return route.name === 'node-detail';
+      return route.handler === NodeDetailPage;
     });
 
     if (currentRoute != null) {
-      this.tabs_tabs = currentRoute.children.reduce(function (tabs, {name, title}) {
-        // Only select routes with names that ends with tab
-        if (typeof name === 'string' && name.endsWith('-tab')) {
-          tabs[name] = title || name;
-        }
-
+      this.tabs_tabs = currentRoute.childRoutes.filter(function ({isTab}) {
+        return !!isTab;
+      }).reduce(function (tabs, {path, title}) {
+        tabs[path] = title;
         return tabs;
       }, this.tabs_tabs);
 
@@ -84,7 +82,7 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
 
   updateCurrentTab() {
     let routes = this.context.router.getCurrentRoutes();
-    let currentTab = routes[routes.length - 1].name;
+    let currentTab = routes[routes.length - 1].path;
     if (currentTab != null) {
       this.setState({currentTab});
     }

--- a/plugins/nodes/src/js/routes/nodes.js
+++ b/plugins/nodes/src/js/routes/nodes.js
@@ -1,4 +1,4 @@
-import {DefaultRoute, Redirect, Route} from 'react-router';
+import {DefaultRoute, Route} from 'react-router';
 /* eslint-disable no-unused-vars */
 import React from 'react';
 /* eslint-enable no-unused-vars */
@@ -25,8 +25,7 @@ import VolumeTable from '../../../../services/src/js/components/VolumeTable';
 
 let nodesRoutes = {
   type: Route,
-  name: 'nodes-page',
-  path: '/nodes/?',
+  path: 'nodes',
   handler: NodesPage,
   category: 'resources',
   isInSidebar: true,
@@ -36,7 +35,7 @@ let nodesRoutes = {
         return [
           {
             label: 'Nodes',
-            route: {to: 'nodes-page'}
+            route: {to: '/nodes'}
           }
         ];
       }
@@ -45,61 +44,55 @@ let nodesRoutes = {
   children: [
     {
       type: Route,
-      name: 'nodes-overview',
       handler: NodesOverview,
       children: [
         {
           type: DefaultRoute,
-          name: 'nodes-list',
           handler: NodesTableContainer
         },
         {
           type: Route,
-          name: 'nodes-grid',
-          path: 'grid/?',
+          path: 'grid',
           handler: NodesGridContainer
         }
       ]
     },
     {
       type: Route,
-      name: 'node-detail',
-      path: '/nodes/:nodeID/?',
+      path: ':nodeID',
       handler: NodeDetailPage,
+      buildBreadCrumb() {
+        return {
+          parentCrumb: '/nodes',
+          getCrumbs(router) {
+            return [
+              <NodeDetailBreadcrumb
+                parentRouter={router}
+                routePath="/nodes/:nodeID" />
+            ];
+          }
+        };
+      },
       children: [
         {
-          type: Route,
-          name: 'node-tasks-tab',
+          type: DefaultRoute,
+          isTab: true,
           title: 'Tasks',
-          path: 'tasks/?',
-          handler: NodeDetailTaskTab,
-          buildBreadCrumb() {
-            return {
-              parentCrumb: 'nodes-page',
-              getCrumbs(router) {
-                return [
-                  <NodeDetailBreadcrumb
-                    parentRouter={router}
-                    routeName="node-detail" />
-                ];
-              }
-            };
-          }
+          handler: NodeDetailTaskTab
         },
         {
           type: Route,
-          path: 'tasks/:taskID/?',
-          name: 'nodes-task-details',
+          path: 'tasks/:taskID',
           handler: TaskDetail,
           hideHeaderNavigation: true,
           buildBreadCrumb() {
             return {
-              parentCrumb: 'node-tasks-tab',
+              parentCrumb: '/nodes/:nodeID',
               getCrumbs(router) {
                 return [
                   <TaskDetailBreadcrumb
                     parentRouter={router}
-                    routeName="nodes-task-details" />
+                    routePath="/nodes/:nodeID/tasks/:taskID" />
                 ];
               }
             };
@@ -107,57 +100,55 @@ let nodesRoutes = {
           children: [
             {
               type: DefaultRoute,
-              name: 'nodes-task-details-tab',
               handler: TaskDetailsTab,
-              title:'Details',
+              title: 'Details',
+              isTab: true,
+              hideHeaderNavigation: true,
               buildBreadCrumb() {
                 return {
-                  parentCrumb: 'nodes-task-details',
+                  parentCrumb: '/nodes/:nodeID/tasks/:taskID',
                   getCrumbs() { return []; }
                 };
               }
             },
             {
               type: Route,
-              name: 'nodes-task-details-files',
-              path: 'files/?',
-              title:'Files',
-              children: [
-                {
-                  type: DefaultRoute,
-                  name: 'nodes-task-details-files-directory',
-                  handler: TaskFilesTab,
-                  fileViewerRouteName: 'nodes-task-details-files-viewer',
-                  buildBreadCrumb() {
-                    return {
-                      parentCrumb: 'nodes-task-details',
-                      getCrumbs() { return []; }
-                    };
-                  }
-                },
-                {
-                  type: Route,
-                  name: 'nodes-task-details-files-viewer',
-                  path: 'view/:filePath?/?:innerPath?/?',
-                  handler: TaskFileViewer,
-                  dontScroll: true,
-                  buildBreadCrumb() {
-                    return {
-                      parentCrumb: 'nodes-task-details',
-                      getCrumbs() { return []; }
-                    };
-                  }
-                }
-              ]
+              path: 'files',
+              isTab: true,
+              handler: TaskFilesTab,
+              title: 'Files',
+              hideHeaderNavigation: true,
+              fileViewerRoutePath: '/nodes/:nodeID/tasks/:taskID/view/?:filePath?/?:innerPath?',
+              buildBreadCrumb() {
+                return {
+                  parentCrumb: '/nodes/:nodeID/tasks/:taskID',
+                  getCrumbs() { return []; }
+                };
+              }
             },
             {
               type: Route,
-              name: 'nodes-task-details-volumes',
-              path: 'volumes/:volumeID?',
+              handler: TaskFileViewer,
+              dontScroll: true,
+              title: 'Logs',
+              isTab: true,
+              path: 'view/?:filePath?/?:innerPath?',
+              hideHeaderNavigation: true,
+              buildBreadCrumb() {
+                return {
+                  parentCrumb: '/nodes/:nodeID/tasks/:taskID',
+                  getCrumbs() { return []; }
+                };
+              }
+            },
+            {
+              type: Route,
+              path: 'volumes/?:volumeID?',
+              isTab: true,
               handler: VolumeTable,
               buildBreadCrumb() {
                 return {
-                  parentCrumb: 'nodes-task-details',
+                  parentCrumb: '/nodes/:nodeID/tasks/:taskID',
                   getCrumbs() { return []; }
                 };
               },
@@ -169,19 +160,18 @@ let nodesRoutes = {
         // in the nodes-task-details route.
         {
           type: Route,
-          name: 'item-volume-detail',
-          path: 'tasks/:taskID/volumes/:volumeID/?',
+          path: 'tasks/:taskID/volumes/:volumeID',
           handler: VolumeDetail,
           buildBreadCrumb() {
             return {
-              parentCrumb: 'node-detail',
+              parentCrumb: '/nodes/:nodeID',
               getCrumbs(router) {
                 return [
                   {
                     label: 'Volumes',
                     route: {
                       params: router.getCurrentParams(),
-                      to: 'nodes-task-details-volumes'
+                      to: '/nodes/:nodeID/tasks/:taskID/volumes/:volumeID'
                     }
                   },
                   {
@@ -194,18 +184,18 @@ let nodesRoutes = {
         },
         {
           type: Route,
-          name: 'node-health-tab',
-          path: 'health/?',
+          path: 'health',
           title: 'Health',
+          isTab: true,
           handler: NodeDetailHealthTab,
           buildBreadCrumb() {
             return {
-              parentCrumb: 'nodes-page',
+              parentCrumb: '/nodes',
               getCrumbs(router) {
                 return [
                   <NodeDetailBreadcrumb
                     parentRouter={router}
-                    routeName="node-detail" />
+                    routePath="/nodes/:nodeID" />
                 ];
               }
             };
@@ -213,17 +203,16 @@ let nodesRoutes = {
         },
         {
           type: Route,
-          name: 'node-detail-health',
-          path: 'health/:unitNodeID/:unitID/?',
+          path: 'health/:unitNodeID/:unitID',
           handler: UnitsHealthNodeDetail,
           buildBreadCrumb() {
             return {
-              parentCrumb: 'node-health-tab',
+              parentCrumb: '/nodes/health',
               getCrumbs(router) {
                 return [
                   <UnitsHealthDetailBreadcrumb
                     parentRouter={router}
-                    routeName="node-detail-health" />
+                    routePath="/nodes/:nodeID/health/:unitNodeID/:unitID" />
                 ];
               }
             };
@@ -231,34 +220,24 @@ let nodesRoutes = {
         },
         {
           type: Route,
-          name: 'node-details-tab',
-          path: 'details/?',
+          path: 'details',
           title: 'Details',
+          isTab: true,
           handler: NodeDetailTab,
           buildBreadCrumb() {
             return {
-              parentCrumb: 'nodes-page',
+              parentCrumb: '/nodes',
               getCrumbs(router) {
                 return [
                   <NodeDetailBreadcrumb
                     parentRouter={router}
-                    routeName="node-detail" />
+                    routePath="/nodes/:nodeID" />
                 ];
               }
             };
           }
-        },
-        {
-          type: Redirect,
-          from: '/nodes/:nodeID/?',
-          to: 'node-tasks-tab'
         }
       ]
-    },
-    {
-      type: Redirect,
-      path: '/nodes/?',
-      to: 'nodes-overview'
     }
   ]
 };

--- a/plugins/oauth/hooks.js
+++ b/plugins/oauth/hooks.js
@@ -126,15 +126,13 @@ module.exports = Object.assign({}, StoreMixin, {
     // Add access denied and login pages
     routes[0].children.unshift(
       {
-        type: Route,
-        name: 'access-denied',
-        path: 'access-denied',
-        handler: AccessDeniedPage
+        handler: AccessDeniedPage,
+        path: '/access-denied',
+        type: Route
       },
       {
         handler: LoginPage,
-        name: 'login',
-        path: 'login',
+        path: '/login',
         type: Route
       }
     );
@@ -159,17 +157,16 @@ module.exports = Object.assign({}, StoreMixin, {
   organizationRoutes(routeDefinition = defaultOrganizationRoute) {
     let userRoute = {
       type: Route,
-      name: 'system-organization-users',
-      path: 'users/?',
+      path: 'users',
       handler: UsersTab,
       buildBreadCrumb() {
         return {
-          parentCrumb: 'system-organization',
+          parentCrumb: '/organization',
           getCrumbs() {
             return [
               {
                 label: 'Users',
-                route: {to: 'system-organization-users'}
+                route: {to: '/organization/users'}
               }
             ];
           }
@@ -191,8 +188,8 @@ module.exports = Object.assign({}, StoreMixin, {
 
     routeDefinition.redirect = {
       type: Redirect,
-      from: '/system/organization/?',
-      to: 'system-organization-users'
+      from: '/organization',
+      to: '/organization/users'
     };
 
     return routeDefinition;
@@ -200,7 +197,7 @@ module.exports = Object.assign({}, StoreMixin, {
 
   'system-organization-tabs': function (tabs) {
     return Object.assign({}, tabs, {
-      'system-organization-users': {
+      '/organization/users': {
         content: 'Users',
         priority: 50
       }

--- a/plugins/services/src/js/components/PodInstancesTable.js
+++ b/plugins/services/src/js/components/PodInstancesTable.js
@@ -317,7 +317,7 @@ class PodInstancesTable extends React.Component {
         <div className="expanding-table-primary-cell-heading text-overflow">
           <Link
             className="emphasize clickable text-overflow"
-            to="services-task-details"
+            to="/services/overview/:id/tasks/:taskID"
             params={{
               id: encodeURIComponent(this.props.pod.getId()),
               taskID: row.id
@@ -351,7 +351,7 @@ class PodInstancesTable extends React.Component {
     return (
       <Link
         className="emphasize clickable text-overflow"
-        to="services-task-details-logs"
+        to="/services/overview/tasks/:taskID/view"
         params={{
           id: encodeURIComponent(this.props.pod.getId()),
           taskID: id
@@ -380,7 +380,7 @@ class PodInstancesTable extends React.Component {
       return this.renderWithClickHandler(rowOptions, (
           <Link
             className="emphasize clickable text-overflow"
-            to="node-tasks-tab"
+            to="/nodes/:nodeID"
             params={{nodeID: agent.id}}
             title={address}>
             <CollapsingString string={address} />

--- a/plugins/services/src/js/components/ServiceList.js
+++ b/plugins/services/src/js/components/ServiceList.js
@@ -45,7 +45,7 @@ let ServiceList = React.createClass({
     // Modifier key not pressed or service didn't have a web URL, open detail
     event.preventDefault();
     this.context.router.transitionTo(
-      'services-detail',
+      '/services/overview/:id',
       {id: encodeURIComponent(service.getId())}
     );
   },

--- a/plugins/services/src/js/components/VolumeDetail.js
+++ b/plugins/services/src/js/components/VolumeDetail.js
@@ -32,7 +32,7 @@ class VolumeDetail extends React.Component {
     let service = null;
     let volume = null;
 
-    if (currentRoute.name === 'service-volume-details') {
+    if (currentRoute.path === '/services/overview/:id/volumes/:volumeID') {
       let id = decodeURIComponent(params.id);
       service = serviceTree.findItemById(id);
     } else {

--- a/plugins/services/src/js/components/VolumeTable.js
+++ b/plugins/services/src/js/components/VolumeTable.js
@@ -132,24 +132,23 @@ class VolumeTable extends React.Component {
     let id = row[prop];
     let params = {volumeID: global.encodeURIComponent(id)};
     let routes = this.context.router.getCurrentRoutes();
-    let routeParams = this.context.router.getCurrentParams();
-    let currentRouteName = routes[routes.length - 1].name;
-    let routeName = null;
+    let currentRoutePath = routes[routes.length - 1].path;
+    let routePath = null;
 
-    if (currentRouteName === 'services-detail') {
-      routeName = 'service-volume-details';
-      params.id = routeParams.id;
-    } else if (currentRouteName === 'services-task-details-volumes') {
-      routeName = 'service-task-details-volume-details';
-      params.id = routeParams.id;
-      params.taskID = routeParams.taskID;
-    } else if (currentRouteName === 'nodes-task-details-volumes') {
-      routeName = 'item-volume-detail';
-      params.nodeID = routeParams.nodeID;
-      params.taskID = routeParams.taskID;
+    if (currentRoutePath === '/services/overview/:id') {
+      routePath = '/services/overview/:id/volumes/:volumeID';
+      params.id = this.props.params.id;
+    } else if (currentRoutePath === '/services/overview/:id/tasks/:taskID/volumes') {
+      routePath = '/services/overview/:id/tasks/:taskID/volumes/:volumeID';
+      params.id = this.props.params.id;
+      params.taskID = this.props.params.taskID;
+    } else if (currentRoutePath === '/nodes/:nodeID/tasks/:taskID/volumes') {
+      routePath = '/nodes/:nodeID/tasks/:taskID/volumes/:volumeID';
+      params.nodeID = this.props.params.nodeID;
+      params.taskID = this.props.params.taskID;
     }
 
-    return <Link to={routeName} params={params}>{id}</Link>;
+    return <Link to={routePath} params={params}>{id}</Link>;
   }
 
   renderStatusColumn(prop, row) {

--- a/plugins/services/src/js/pages/ServicesPage.js
+++ b/plugins/services/src/js/pages/ServicesPage.js
@@ -27,7 +27,7 @@ var ServicesPage = React.createClass({
 
   getInitialState() {
     return {
-      currentTab: 'services-page'
+      currentTab: '/services/overview'
     };
   },
 
@@ -36,8 +36,8 @@ var ServicesPage = React.createClass({
       {name: 'notification', events: ['change'], suppressUpdate: false}
     ];
     this.tabs_tabs = {
-      'services-page': 'Services',
-      'services-deployments': 'Deployments'
+      '/services/overview': 'Services',
+      '/services/deployments': 'Deployments'
     };
     this.updateCurrentTab();
   },
@@ -48,10 +48,10 @@ var ServicesPage = React.createClass({
 
   updateCurrentTab() {
     let routes = this.context.router.getCurrentRoutes();
-    let currentTab = routes[routes.length - 1].name;
-    // `services-page` tab also contains routes for 'services-details'
-    if (currentTab === 'services-detail' || currentTab == null) {
-      currentTab = 'services-page';
+    let currentTab = routes[routes.length - 1].path;
+    // `/services/overview` tab also contains routes for '/services/overview/:id'
+    if (currentTab === '/services/overview/:id' || currentTab == null) {
+      currentTab = '/services/overview';
     }
 
     if (this.state.currentTab !== currentTab) {

--- a/plugins/services/src/js/pages/services/DeploymentsTab.js
+++ b/plugins/services/src/js/pages/services/DeploymentsTab.js
@@ -129,7 +129,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
 
       return (
         <dd key={`service_${id}`}>
-          <Link to="services-detail" params={{id}} className="deployment-service-name table-cell-link-primary">
+          <Link to="/services/overview/:id" params={{id}} className="deployment-service-name table-cell-link-primary">
             <span className="icon icon-small icon-image-container icon-app-container deployment-service-icon">
               <img src={image} />
             </span>
@@ -421,4 +421,3 @@ DeploymentsTab.routeConfig = {
 };
 
 module.exports = DeploymentsTab;
-

--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -25,7 +25,7 @@ const METHODS_TO_BIND = [
 ];
 
 const HIDE_BREADCRUMBS = [
-  'services-task-details-tab'
+  '/services/overview/:id/tasks/:taskID'
 ];
 
 class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
@@ -67,10 +67,10 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
     });
 
     if (currentRoute != null) {
-      this.tabs_tabs = currentRoute.children.reduce(function (tabs, {name, title}) {
-        if (name !== null) {
-          tabs[name] = title || name;
-        }
+      this.tabs_tabs = currentRoute.childRoutes.filter(function ({isTab}) {
+        return !!isTab;
+      }).reduce(function (tabs, {path, title}) {
+        tabs[path] = title || path;
 
         return tabs;
       }, this.tabs_tabs);
@@ -92,7 +92,7 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
 
   updateCurrentTab() {
     let routes = this.context.router.getCurrentRoutes();
-    let currentTab = routes[routes.length - 1].name;
+    let currentTab = routes[routes.length - 1].path;
     if (currentTab != null) {
       this.setState({currentTab});
     }
@@ -144,8 +144,8 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
     TaskDirectoryStore.setPath(task, path);
     // Transition to parent route, which uses a default route
     let currentRoutes = router.getCurrentRoutes();
-    let {name} = currentRoutes[currentRoutes.length - 2];
-    router.transitionTo(name, params);
+    let {path: parentPath} = currentRoutes[currentRoutes.length - 2];
+    router.transitionTo(parentPath, params);
   }
 
   getErrorScreen() {
@@ -194,8 +194,8 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
       }
     );
     let currentRoutes = router.getCurrentRoutes();
-    let {fileViewerRouteName} = currentRoutes[currentRoutes.length - 1];
-    router.transitionTo(fileViewerRouteName, params);
+    let {fileViewerRoutePath} = currentRoutes[currentRoutes.length - 1];
+    router.transitionTo(fileViewerRoutePath, params);
   }
 
   getBasicInfo() {
@@ -220,8 +220,8 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
 
     if (!this.hasVolumes(service)) {
       tabsArray = tabsArray.filter(function (tab) {
-        if (tab.key === 'nodes-task-details-volumes'
-          || tab.key === 'services-task-details-volumes') {
+        if (tab.key === '/nodes/:nodeID/tasks/:taskID/volumes/?:volumeID?'
+          || tab.key === '/services/overview/:id/tasks/:taskID/volumes') {
           return false;
         }
 
@@ -242,7 +242,7 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
     return (
       <DetailViewHeader
         icon={taskIcon}
-        iconClassName="icon-app-container icon-image-container"
+        iconClassName="icon-app-container  icon-image-container"
         subTitle={serviceStatus}
         subTitleClassName={serviceStatusClassSet}
         navigationTabs={navigationTabs}
@@ -272,8 +272,8 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
 
   getBreadcrumbs() {
     let routes = this.context.router.getCurrentRoutes();
-    let {name} = routes[routes.length - 1];
-    if (HIDE_BREADCRUMBS.includes(name)) {
+    let {path} = routes[routes.length - 1];
+    if (HIDE_BREADCRUMBS.includes(path)) {
       return null;
     }
 
@@ -317,12 +317,12 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
         <div className="flex flex-item-shrink-0 control-group">
           {this.getBreadcrumbs()}
         </div>
-        <RouteHandler
-          directory={directory}
-          onOpenLogClick={this.handleOpenLogClick.bind(this)}
-          selectedLogFile={selectedLogFile}
-          service={this.getService()}
-          task={task} />
+      <RouteHandler
+        directory={directory}
+        onOpenLogClick={this.handleOpenLogClick.bind(this)}
+        selectedLogFile={selectedLogFile}
+        service={this.getService()}
+        task={task} />
       </div>
     );
   }

--- a/plugins/services/src/js/pages/task-details/TaskFileViewer.js
+++ b/plugins/services/src/js/pages/task-details/TaskFileViewer.js
@@ -108,7 +108,7 @@ class TaskFileViewer extends React.Component {
     let currentRoutes = this.context.router.getCurrentRoutes();
     let lastRoute = currentRoutes.pop();
     this.context.router.transitionTo(
-      lastRoute.name,
+      lastRoute.path,
       Object.assign({}, this.props.params, {filePath: encodeURIComponent(path)})
     );
   }

--- a/plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.js
+++ b/plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.js
@@ -35,7 +35,7 @@ describe('TaskDetail', function () {
       this.container,
       {
         getCurrentRoutes() {
-          return [{name: 'services-task-details-tab'}];
+          return [{path: '/services/overview/:id/tasks/:taskID'}];
         }
       }
     );
@@ -171,7 +171,7 @@ describe('TaskDetail', function () {
         this.container,
         {
           getCurrentRoutes() {
-            return [{name: 'services-task-details-tab'}];
+            return [{path: '/services/overview/:id/tasks/:taskID'}];
           }
         }
       );

--- a/plugins/services/src/js/routes/services.js
+++ b/plugins/services/src/js/routes/services.js
@@ -1,4 +1,4 @@
-import {DefaultRoute, Redirect, Route} from 'react-router';
+import {DefaultRoute, Redirect, Route, RouteHandler} from 'react-router';
 /* eslint-disable no-unused-vars */
 import React from 'react';
 /* eslint-enable no-unused-vars */
@@ -58,6 +58,9 @@ let serviceRoutes = {
         {
           type: Route,
           path: ':id',
+          handler() {
+            return <RouteHandler />;
+          },
           buildBreadCrumb() {
             return {
               parentCrumb: '/services/overview',
@@ -87,6 +90,9 @@ let serviceRoutes = {
             {
               type: Route,
               path: 'tasks',
+              handler() {
+                return <RouteHandler />;
+              },
               children: [
                 {
                   type: Route,

--- a/plugins/services/src/js/routes/services.js
+++ b/plugins/services/src/js/routes/services.js
@@ -25,24 +25,22 @@ function buildServiceCrumbs(router) {
 
     return {
       label: id,
-      route: {to: 'services-detail', params: {id: aggregateIDs}}
+      route: {to: '/services/overview/:id', params: {id: aggregateIDs}}
     };
   });
 }
 
 let serviceRoutes = {
   type: Route,
-  name: 'services-page',
   handler: ServicesPage,
-  path: '/services/?',
+  path: 'services',
   category: 'root',
   isInSidebar: true,
   children: [
     {
       type: Route,
       handler: ServicesContainer,
-      name: 'services-overview',
-      path: 'overview/',
+      path: 'overview',
       isInSidebar: true,
       buildBreadCrumb() {
         return {
@@ -50,7 +48,7 @@ let serviceRoutes = {
             return [
               {
                 label: 'Services',
-                route: {to: 'services-page'}
+                route: {to: '/services'}
               }
             ];
           }
@@ -59,11 +57,10 @@ let serviceRoutes = {
       children: [
         {
           type: Route,
-          name: 'services-detail',
-          path: ':id/?',
+          path: ':id',
           buildBreadCrumb() {
             return {
-              parentCrumb: 'services-overview',
+              parentCrumb: '/services/overview',
               getCrumbs: buildServiceCrumbs
             };
           },
@@ -72,12 +69,11 @@ let serviceRoutes = {
             // rendered in the service-task-details route.
             {
               type: Route,
-              name: 'service-volume-details',
-              path: 'volumes/:volumeID/?',
+              path: 'volumes/:volumeID',
               handler: VolumeDetail,
               buildBreadCrumb() {
                 return {
-                  parentCrumb: 'services-detail',
+                  parentCrumb: '/services/overview',
                   getCrumbs(router) {
                     return [
                       {
@@ -90,105 +86,105 @@ let serviceRoutes = {
             },
             {
               type: Route,
-              name: 'service-task-details-volume-details',
-              path: 'tasks/:taskID/volumes/:volumeID/?',
-              handler: VolumeDetail,
-              buildBreadCrumb() {
-                return {
-                  parentCrumb: 'services-task-details-volumes',
-                  getCrumbs(router) {
-                    return [
-                      {
-                        label: 'Volumes',
-                        route: {
-                          params: router.getCurrentParams(),
-                          to: 'services-task-details-volumes'
-                        }
-                      },
-                      {
-                        label: router.getCurrentParams().volumeID
-                      }
-                    ];
-                  }
-                };
-              }
-            },
-            {
-              type: Route,
-              path: 'tasks/:taskID/?',
-              name: 'services-task-details',
-              handler: TaskDetail,
-              hideHeaderNavigation: true,
-              buildBreadCrumb() {
-                return {
-                  parentCrumb: 'services-detail',
-                  getCrumbs(router) {
-                    return [
-                      <TaskDetailBreadcrumb
-                        parentRouter={router}
-                        routeName="services-task-details" />
-                    ];
-                  }
-                };
-              },
+              path: 'tasks',
               children: [
                 {
-                  type: DefaultRoute,
-                  name: 'services-task-details-tab',
-                  handler: TaskDetailsTab,
+                  type: Route,
+                  path: ':taskID',
+                  handler: TaskDetail,
+                  hideHeaderNavigation: true,
                   buildBreadCrumb() {
                     return {
-                      parentCrumb: 'services-task-details',
-                      getCrumbs() { return []; }
+                      parentCrumb: '/services/overview/:id',
+                      getCrumbs(router) {
+                        return [
+                          <TaskDetailBreadcrumb
+                          parentRouter={router}
+                          routePath="/services/overview/:id/tasks/:taskID" />
+                        ];
+                      }
                     };
                   },
-                  title:'Details'
-                },
-                {
-                  type: Route,
-                  path: 'files/?',
-                  name: 'services-task-details-files',
-                  title:'Files',
                   children: [
                     {
                       type: DefaultRoute,
-                      name: 'services-task-details-files-directory',
-                      handler: TaskFilesTab,
-                      fileViewerRouteName: 'services-task-details-files-viewer',
+                      handler: TaskDetailsTab,
+                      isTab: true,
+                      title:'Details',
                       buildBreadCrumb() {
                         return {
-                          parentCrumb: 'services-task-details',
+                          parentCrumb: '/services/overview/:id/tasks/:taskID',
                           getCrumbs() { return []; }
                         };
                       }
                     },
                     {
                       type: Route,
-                      name: 'services-task-details-files-viewer',
-                      path: 'view/:filePath?/?:innerPath?/?',
-                      handler: TaskFileViewer,
-                      dontScroll: true,
+                      path: 'files',
+                      title:'Files',
+                      handler: TaskFilesTab,
+                      isTab: true,
+                      hideHeaderNavigation: true,
+                      fileViewerRoutePath: '/services/overview/:id/tasks/:taskID/view/?:filePath?/?:innerPath?/?',
                       buildBreadCrumb() {
                         return {
-                          parentCrumb: 'services-task-details',
+                          parentCrumb: '/services/overview/:id/tasks/:taskID',
                           getCrumbs() { return []; }
+                        };
+                      }
+                    },
+                    {
+                      type: Route,
+                      dontScroll: true,
+                      handler: TaskFileViewer,
+                      title:'Logs',
+                      path: 'view/?:filePath?/?:innerPath?/?',
+                      isTab: true,
+                      buildBreadCrumb() {
+                        return {
+                          parentCrumb: '/services/overview/:id/tasks/:taskID',
+                          getCrumbs() { return []; }
+                        };
+                      }
+                    },
+                    {
+                      type: Route,
+                      path: 'volumes',
+                      handler: VolumeTable,
+                      isTab: true,
+                      title:'Volumes',
+                      buildBreadCrumb() {
+                        return {
+                          parentCrumb: '/services/overview/:id/tasks/:taskID',
+                          getCrumbs() { return []; }
+                        };
+                      }
+                    },
+                    {
+                      type: Route,
+                      path: 'volumes/:volumeID',
+                      handler: VolumeDetail,
+                      buildBreadCrumb() {
+                        return {
+                          parentCrumb: '/services/overview/:id/tasks/:taskID/volumes',
+                          getCrumbs(router) {
+                            return [
+                              {
+                                label: 'Volumes',
+                                route: {
+                                  params: router.getCurrentParams(),
+                                  to: '/services/overview/:id/tasks/:taskID/volumes'
+                                }
+                              },
+                              {
+                                label: router.getCurrentParams().volumeID
+                              }
+                            ];
+                          }
                         };
                       }
                     }
                   ]
-                },
-                {
-                  type: Route,
-                  name: 'services-task-details-volumes',
-                  path: 'volumes/?',
-                  handler: VolumeTable,
-                  buildBreadCrumb() {
-                    return {
-                      parentCrumb: 'services-task-details',
-                      getCrumbs() { return []; }
-                    };
-                  },
-                  title:'Volumes'
                 }
               ]
             }
@@ -198,15 +194,14 @@ let serviceRoutes = {
     },
     {
       type: Route,
-      name: 'services-deployments',
-      path: 'deployments/',
+      path: 'deployments',
       handler: DeploymentsTab,
       isInSidebar: true
     },
     {
       type: Redirect,
       from: '/services/?',
-      to: 'services-overview'
+      to: '/services/overview'
     }
   ]
 };

--- a/plugins/services/src/js/services/ServiceItemNotFound.js
+++ b/plugins/services/src/js/services/ServiceItemNotFound.js
@@ -8,7 +8,7 @@ const ServiceItemNotFound = function ({ message }) {
 
   const icon = <Icon id="services" color="white" size="jumbo" />;
   const footer = (
-    <Link to="services-page" className="button button-stroke button-inverse">
+    <Link to="/services" className="button button-stroke button-inverse">
       Go back to Services Page
     </Link>
   );

--- a/plugins/services/src/js/services/ServicesContainer.js
+++ b/plugins/services/src/js/services/ServicesContainer.js
@@ -1,5 +1,6 @@
 import {DCOSStore} from 'foundation-ui';
 import React, {PropTypes} from 'react';
+import {RouteHandler} from 'react-router';
 
 import ActionKeys from '../constants/ActionKeys';
 import MarathonActions from '../events/MarathonActions';
@@ -527,6 +528,11 @@ class ServicesContainer extends React.Component {
   }
 
   render() {
+    // TODO react-router: Temp hack if we are deeper than overview/:id we should render child routes
+    if (Object.keys(this.props.params).length > 1) {
+      return <RouteHandler />;
+    }
+
     const {
       fetchErrors,
       filters,

--- a/plugins/services/src/js/services/ServicesTable.js
+++ b/plugins/services/src/js/services/ServicesTable.js
@@ -93,7 +93,7 @@ class ServicesTable extends React.Component {
     }
 
     return (
-      <Link to="services-detail"
+      <Link to="/services/overview/:id"
         className="table-cell-link-primary"
         params={{id}}>
         <span className="text-overflow">
@@ -131,7 +131,7 @@ class ServicesTable extends React.Component {
     return (
       <div className="service-table-heading flex-box
         flex-box-align-vertical-center table-cell-flex-box">
-        <Link to="services-page"
+        <Link to="/services/overview/:id"
           className="table-cell-icon"
           params={{id}}>
           {this.getImage(service)}
@@ -340,7 +340,7 @@ class ServicesTable extends React.Component {
     return (
       <colgroup>
         <col />
-        <col className="status-bar-column" />
+        <col className="status-bar-column"/>
         <col className="hidden-small-down" style={{width: '65px'}} />
         <col className="hidden-small-down" style={{width: '75px'}} />
         <col className="hidden-small-down" style={{width: '65px'}} />
@@ -350,15 +350,15 @@ class ServicesTable extends React.Component {
 
   render() {
     return (
-      <Table
-        buildRowOptions={this.getRowAttributes}
-        className="table service-table table-borderless-outer table-borderless-inner-columns flush-bottom"
-        columns={this.getColumns()}
-        colGroup={this.getColGroup()}
-        data={this.props.services.slice()}
-        itemHeight={TableUtil.getRowHeight()}
-        containerSelector=".gm-scroll-view"
-        sortBy={{prop: 'name', order: 'asc'}} />
+        <Table
+          buildRowOptions={this.getRowAttributes}
+          className="table service-table table-borderless-outer table-borderless-inner-columns flush-bottom"
+          columns={this.getColumns()}
+          colGroup={this.getColGroup()}
+          data={this.props.services.slice()}
+          itemHeight={TableUtil.getRowHeight()}
+          containerSelector=".gm-scroll-view"
+          sortBy={{prop: 'name', order: 'asc'}} />
     );
   }
 };

--- a/plugins/services/src/js/tasks/TaskTable.js
+++ b/plugins/services/src/js/tasks/TaskTable.js
@@ -201,9 +201,9 @@ class TaskTable extends React.Component {
       let params = this.context.router.getCurrentParams();
       let routeParams = Object.assign({taskID: task.id}, params);
 
-      let linkTo = 'services-task-details';
+      let linkTo = '/services/overview/:id/tasks/:taskID';
       if (params.nodeID != null) {
-        linkTo = 'nodes-task-details';
+        linkTo = '/nodes/:nodeID/tasks/:taskID';
       }
 
       return (
@@ -228,11 +228,10 @@ class TaskTable extends React.Component {
     let params = this.context.router.getCurrentParams();
     let routeParams = Object.assign({taskID: task.id}, params);
 
-    let linkTo = 'services-task-details-files-viewer';
+    let linkTo = '/services/overview/:id/tasks/:taskID/view';
     if (params.nodeID != null) {
-      linkTo = 'nodes-task-details-files-viewer';
+      linkTo = '/nodes/:nodeID/tasks/:taskID/view';
     }
-
     return (
       <Link
         to={linkTo}
@@ -251,7 +250,7 @@ class TaskTable extends React.Component {
     return (
       <Link
         className="table-cell-link-secondary text-overflow"
-        to="node-detail"
+        to="/nodes/:nodeID"
         params={{nodeID: task.slave_id}}
         title={task.hostname}>
         {task.hostname}

--- a/src/js/components/BreadcrumbSegment.js
+++ b/src/js/components/BreadcrumbSegment.js
@@ -23,8 +23,10 @@ class BreadcrumbSegment extends React.Component {
    * @return {String} Crumb label
    */
   getBackupCrumbLabel() {
-    let {parentRouter, routeName} = this.props;
-    let route = parentRouter.namedRoutes[routeName];
+    let {parentRouter, routePath} = this.props;
+    let route = parentRouter.getCurrentRoutes().find(function (eachRoute) {
+      return eachRoute.path === routePath;
+    });
     let lastParam = route.paramNames[route.paramNames.length - 1];
     let currentParamValue = parentRouter.getCurrentParams()[lastParam];
 
@@ -41,7 +43,7 @@ class BreadcrumbSegment extends React.Component {
     }
 
     let route = {
-      to: this.props.routeName,
+      to: this.props.routePath,
       params: this.props.parentRouter.getCurrentParams()
     };
 
@@ -53,7 +55,7 @@ class BreadcrumbSegment extends React.Component {
 
 BreadcrumbSegment.propTypes = {
   parentRouter: PropTypes.func.isRequired,
-  routeName: PropTypes.string.isRequired
+  routePath: PropTypes.string.isRequired
 };
 
 module.exports = BreadcrumbSegment;

--- a/src/js/components/Breadcrumbs.js
+++ b/src/js/components/Breadcrumbs.js
@@ -3,20 +3,19 @@ import React, {PropTypes} from 'react';
 import ManualBreadcrumbs from './ManualBreadcrumbs';
 
 class Breadcrumbs extends React.Component {
-  buildCrumbs(routeName) {
+  buildCrumbs(route) {
     let {router} = this.context;
-    let {namedRoutes} = router;
-    let route = namedRoutes[routeName];
-
-    if (!route || !route.buildBreadCrumb) {
-      return [];
-    }
 
     let crumbConfiguration = route.buildBreadCrumb(router);
     let crumbs = crumbConfiguration.getCrumbs(router);
 
     if (crumbConfiguration.parentCrumb) {
-      crumbs = this.buildCrumbs(crumbConfiguration.parentCrumb).concat(crumbs);
+      let parentCrumb = router.getCurrentRoutes().find(function (eachRoute) {
+        return eachRoute.path === crumbConfiguration.parentCrumb;
+      });
+      if (parentCrumb && parentCrumb.buildBreadCrumb) {
+        crumbs = this.buildCrumbs(parentCrumb).concat(crumbs);
+      }
     }
 
     return crumbs;
@@ -29,7 +28,7 @@ class Breadcrumbs extends React.Component {
     let currentRoute = null;
     loop:
     for (var i = routes.length - 1; i >= 0; i--) {
-      if (routes[i].name) {
+      if (routes[i].buildBreadCrumb) {
         currentRoute = routes[i];
         break loop;
       }
@@ -39,7 +38,7 @@ class Breadcrumbs extends React.Component {
       return [];
     }
 
-    let crumbs = this.buildCrumbs(currentRoute.name);
+    let crumbs = this.buildCrumbs(currentRoute);
 
     return crumbs.slice(this.props.shift);
   }

--- a/src/js/components/ComponentList.js
+++ b/src/js/components/ComponentList.js
@@ -17,7 +17,7 @@ class ComponentList extends React.Component {
           {
             className: 'dashboard-health-list-item-description text-overflow',
             content: (
-              <Link to="components-overview-units-unit-nodes-detail"
+              <Link to="/components/:unitID"
                 params={{unitID: unit.get('id')}}
                 className="dashboard-health-list-item-cell emphasis">
                 {unit.getTitle()}

--- a/src/js/components/NestedServiceLinks.js
+++ b/src/js/components/NestedServiceLinks.js
@@ -12,9 +12,9 @@ class NestedServiceLinks extends React.Component {
         <div className={minorLinkClasses}>
           <Link
             className={minorLinkAnchorClasses}
-            to="services-detail"
-            params={params}
-            title={label}>
+            to="/services/overview/:id"
+              params={params}
+              title={label}>
             {label}
           </Link>
         </div>
@@ -79,7 +79,7 @@ class NestedServiceLinks extends React.Component {
     let label;
     let params;
     let {majorLinkAnchorClassName, serviceID, taskID} = this.props;
-    let routeName;
+    let routePath;
 
     let anchorClasses = classNames(
       'table-cell-link-primary',
@@ -92,17 +92,17 @@ class NestedServiceLinks extends React.Component {
         id: serviceID,
         taskID
       };
-      routeName = 'services-task-details';
+      routePath = '/services/overview/:id/tasks/:taskID';
     } else {
       label = this.getServicePathParts().pop();
       params = {id: encodeURIComponent(serviceID)};
-      routeName = 'services-page';
+      routePath = '/services/overview/:id';
     }
 
     return (
       <Link
         className={anchorClasses}
-        to={routeName}
+        to={routePath}
         params={params}
         title={label}>
         <span className="text-overflow">
@@ -127,7 +127,7 @@ class NestedServiceLinks extends React.Component {
        <div key={key} className="table-cell-value">
         <div className={minorLinkClasses}>
           <Link className={minorLinkAnchorClasses}
-            to="services-page"
+            to="/services"
             title="services">
             Services
           </Link>

--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -95,7 +95,7 @@ var Sidebar = React.createClass({
         return route.id === 'index';
       });
 
-    return this.getMenuGroupsFromChildren(indexRoute.children)
+    return this.getMenuGroupsFromChildren(indexRoute.childRoutes)
       .map((group, index) => {
         let heading = null;
 
@@ -117,14 +117,14 @@ var Sidebar = React.createClass({
       });
   },
 
-  getGroupSubmenu({children = []}, {currentPath, isParentActive}) {
+  getGroupSubmenu({childRoutes = []}, {currentPath, isParentActive}) {
     let submenu = null;
     let isChildActive = false;
 
     if (isParentActive) {
-      let menuItems = children.reduce(function (childRoutes, currentChild) {
+      let menuItems = childRoutes.reduce(function (childRoutes, currentChild) {
         if (currentChild.isInSidebar) {
-          let routeLabel = currentChild.name;
+          let routeLabel = currentChild.path;
           let isActive = false;
 
           // Get the route label defined on the route's handler.
@@ -142,7 +142,7 @@ var Sidebar = React.createClass({
 
           childRoutes.push(
             <li className={menuItemClasses} key={routeLabel}>
-              <Link to={currentChild.name}>{routeLabel}</Link>
+              <Link to={currentChild.path}>{routeLabel}</Link>
             </li>
           );
         }
@@ -189,8 +189,8 @@ var Sidebar = React.createClass({
         route.handler.routeConfig.icon,
         {className: 'sidebar-menu-item-icon icon icon-small'}
       );
-      let hasChildren = route.children && route.children.length !== 0;
-      let notificationCount = NotificationStore.getNotificationCount(route.name);
+      let hasChildren = route.childRoutes && route.childRoutes.length !== 0;
+      let notificationCount = NotificationStore.getNotificationCount(route.path);
       let isParentActive = route.handler.routeConfig.matches.test(currentPath);
       let {isChildActive, submenu} = this.getGroupSubmenu(route, {
         currentPath,
@@ -221,7 +221,7 @@ var Sidebar = React.createClass({
 
       return (
         <li className={itemClassSet} key={index}>
-          <Link to={route.name}>{icon}{sidebarText}</Link>
+          <Link to={route.path}>{icon}{sidebarText}</Link>
           {submenu}
         </li>
       );

--- a/src/js/components/UnitHealthNodesTable.js
+++ b/src/js/components/UnitHealthNodesTable.js
@@ -87,7 +87,7 @@ class UnitHealthNodesTable extends React.Component {
 
     return (
       <Link className="table-cell-link-primary text-overflow" params={params}
-        to="components-overview-units-unit-nodes-node-detail">
+        to="/components/:unitID/nodes/:unitNodeID">
         {linkText}
       </Link>
     );

--- a/src/js/components/__tests__/BreadcrumbSegment-test.js
+++ b/src/js/components/__tests__/BreadcrumbSegment-test.js
@@ -12,10 +12,13 @@ describe('BreadcrumbSegment', function () {
 
   beforeEach(function () {
     function parentRouter() {}
-    parentRouter.namedRoutes = {
-      'foo': {
-        paramNames: ['bar']
-      }
+    parentRouter.getCurrentRoutes = function () {
+      return (
+        [{
+          path:'foo',
+          paramNames: ['bar']
+        }]
+      );
     };
     parentRouter.getCurrentParams = function () {
       return {bar: 'baz'};
@@ -26,7 +29,7 @@ describe('BreadcrumbSegment', function () {
 
   it('renders the label', function () {
     let instance = TestUtils.renderIntoDocument(
-      <BreadcrumbSegment routeName="foo" parentRouter={this.parentRouter} />
+      <BreadcrumbSegment routePath="foo" parentRouter={this.parentRouter} />
     );
 
     expect(instance.getBackupCrumbLabel()).toEqual('baz');
@@ -34,7 +37,7 @@ describe('BreadcrumbSegment', function () {
 
   it('renders the link', function () {
     let instance = TestUtils.renderIntoDocument(
-      <BreadcrumbSegment routeName="foo" parentRouter={this.parentRouter} />
+      <BreadcrumbSegment routePath="foo" parentRouter={this.parentRouter} />
     );
 
     let node = TestUtils.findRenderedComponentWithType(

--- a/src/js/pages/DashboardPage.js
+++ b/src/js/pages/DashboardPage.js
@@ -114,7 +114,7 @@ var DashboardPage = React.createClass({
     var componentCountWord = StringUtil.pluralize('Component', componentCount);
 
     return (
-      <Link to="components-overview-units"
+      <Link to="/components/overview"
         className="button button-rounded button-stroke">
         {`View all ${componentCount} ${componentCountWord}`}
       </Link>
@@ -134,7 +134,7 @@ var DashboardPage = React.createClass({
     textContent += 'Services';
 
     return (
-      <Link to="services-page"
+      <Link to="/services"
         className="button button-rounded button-stroke">
         {textContent}
       </Link>

--- a/src/js/pages/NetworkPage.js
+++ b/src/js/pages/NetworkPage.js
@@ -14,7 +14,7 @@ import TabsUtil from '../utils/TabsUtil';
 import TabsMixin from '../mixins/TabsMixin';
 
 let DEFAULT_NETWORK_TABS = {
-  'virtual-networks-tab': {
+  '/network/virtual-networks': {
     content: 'Virtual Networks',
     priority: 10
   }
@@ -68,7 +68,7 @@ class NetworkPage extends mixin(TabsMixin) {
 
   updateCurrentTab() {
     let routes = this.context.router.getCurrentRoutes();
-    let currentTab = routes[routes.length - 1].name;
+    let currentTab = routes[routes.length - 1].path;
 
     // Get top level Tab
     let topLevelTab = currentTab.split('-').slice(0, 2).join('-');
@@ -102,7 +102,7 @@ class NetworkPage extends mixin(TabsMixin) {
     }
 
     let routes = this.context.router.getCurrentRoutes();
-    let currentRoute = routes[routes.length - 1].name;
+    let currentRoute = routes[routes.length - 1].path;
 
     return (
       <ul className="menu-tabbed">

--- a/src/js/pages/NotFoundPage.js
+++ b/src/js/pages/NotFoundPage.js
@@ -29,7 +29,7 @@ var NotFoundPage = React.createClass({
             The page you’ve requested cannot be found.
             It’s possible you copied the wrong link.
             Check again, or jump back to your&nbsp;
-            <Link to="dashboard">Dashboard</Link>.
+            <Link to="/dashboard">Dashboard</Link>.
           </p>
         </AlertPanel>
       </Page>

--- a/src/js/pages/StylesPage.js
+++ b/src/js/pages/StylesPage.js
@@ -7,36 +7,36 @@ import TabsMixin from '../mixins/TabsMixin';
 import TabsUtil from '../utils/TabsUtil';
 
 const STYLES_TABS = {
-  'styles-layout-tab': 'Layout',
-  'styles-content-tab': 'Content',
-  'styles-components-tab': 'Components'
+  '/styles/layout': 'Layout',
+  '/styles/content': 'Content',
+  '/styles/components': 'Components'
 };
 
 const STYLES_SUB_TABS = {
-  'styles-layout-tab': {
-    'styles-layout-containers': 'Containers',
-    'styles-layout-grid': 'Grid',
-    'styles-layout-pods': 'Pods',
-    'styles-layout-flex': 'Flex',
-    'styles-layout-dividers': 'Dividers',
-    'styles-layout-responsive-utilities': 'Responsive Utilities'
+  '/styles/layout': {
+    '/styles/layout/containers': 'Containers',
+    '/styles/layout/grid': 'Grid',
+    '/styles/layout/pods': 'Pods',
+    '/styles/layout/flex': 'Flex',
+    '/styles/layout/dividers': 'Dividers',
+    '/styles/layout/responsive-utilities': 'Responsive Utilities'
   },
-  'styles-content-tab': {
-    'styles-content-typography': 'Typography',
-    'styles-content-tables': 'Tables',
-    'styles-content-colors': 'Colors',
-    'styles-content-code': 'Code',
-    'styles-content-images': 'Images'
+  '/styles/content': {
+    '/styles/content/typography': 'Typography',
+    '/styles/content/tables': 'Tables',
+    '/styles/content/colors': 'Colors',
+    '/styles/content/code': 'Code',
+    '/styles/content/images': 'Images'
   },
-  'styles-components-tab': {
-    'styles-components-buttons': 'Buttons',
-    'styles-components-button-groups': 'Button Groups',
-    'styles-components-button-collections': 'Button Collections',
-    'styles-components-forms': 'Forms',
-    'styles-components-dropdowns': 'Dropdowns',
-    'styles-components-icons': 'Icons',
-    'styles-components-modals': 'Modals',
-    'styles-components-panels': 'Panels'
+  '/styles/components': {
+    '/styles/components/buttons': 'Buttons',
+    '/styles/components/button-groups': 'Button Groups',
+    '/styles/components/button-collections': 'Button Collections',
+    '/styles/components/forms': 'Forms',
+    '/styles/components/dropdowns': 'Dropdowns',
+    '/styles/components/icons': 'Icons',
+    '/styles/components/modals': 'Modals',
+    '/styles/components/panels': 'Panels'
   }
 };
 
@@ -58,9 +58,9 @@ class StylesPage extends mixin(TabsMixin) {
 
   updateCurrentTab() {
     let routes = this.context.router.getCurrentRoutes();
-    let currentTab = routes[routes.length - 1].name;
+    let currentTab = routes[routes.length - 1].path;
     // Get top level Tab
-    let topLevelTab = currentTab.split('-').slice(0, 2).join('-') + '-tab';
+    let topLevelTab = currentTab.split('/').slice(0, 3).join('/');
 
     this.tabs_tabs = STYLES_SUB_TABS[topLevelTab];
 
@@ -77,7 +77,7 @@ class StylesPage extends mixin(TabsMixin) {
 
   getNavigation() {
     let routes = this.context.router.getCurrentRoutes();
-    let currentRoute = routes[routes.length - 2].name;
+    let currentRoute = routes[routes.length - 2].path;
 
     return (
       <ul className="menu-tabbed">

--- a/src/js/pages/UniversePage.js
+++ b/src/js/pages/UniversePage.js
@@ -28,12 +28,12 @@ class UniversePage extends mixin(TabsMixin) {
 
   updateCurrentTab() {
     let routes = this.context.router.getCurrentRoutes();
-    let currentTab = routes[routes.length - 1].name;
+    let currentTab = routes[routes.length - 1].path;
 
     // Universe Tabs
     this.tabs_tabs = {
-      'universe-packages': 'Packages',
-      'universe-installed-packages': 'Installed'
+      '/universe/packages': 'Packages',
+      '/universe/installed-packages': 'Installed'
     };
 
     this.setState({currentTab});

--- a/src/js/pages/jobs/JobDetailPage.js
+++ b/src/js/pages/jobs/JobDetailPage.js
@@ -104,7 +104,7 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
 
   onMetronomeStoreJobDeleteSuccess() {
     this.closeDialog();
-    this.context.router.transitionTo('jobs-page');
+    this.context.router.transitionTo('/jobs');
   }
 
   onMetronomeStoreJobDetailError() {

--- a/src/js/pages/jobs/JobRunHistoryTable.js
+++ b/src/js/pages/jobs/JobRunHistoryTable.js
@@ -208,7 +208,7 @@ class JobRunHistoryTable extends React.Component {
         <div className="expanding-table-primary-cell-heading text-overflow">
           <Link
             className="table-cell-link-secondary text-overflow"
-            to="jobs-task-details"
+            to="/jobs/:id/tasks/:taskID"
             params={{id, taskID}}
             title={taskID}>
             <CollapsingString endLength={15} string={taskID} />

--- a/src/js/pages/jobs/JobsTable.js
+++ b/src/js/pages/jobs/JobsTable.js
@@ -165,12 +165,12 @@ class JobsTable extends React.Component {
     return (
       <div className="job-table-heading flex-box
         flex-box-align-vertical-center table-cell-flex-box">
-        <Link to="jobs-page-detail"
+        <Link to="/jobs/:id"
           className="table-cell-icon"
           params={{id}}>
           {itemImage}
         </Link>
-        <Link to="jobs-page-detail"
+        <Link to="/jobs/:id"
           className="table-cell-link-primary table-cell-value flex-box flex-box-col"
           params={{id}}>
           <span className="text-overflow">

--- a/src/js/pages/network/VirtualNetworksTable.js
+++ b/src/js/pages/network/VirtualNetworksTable.js
@@ -71,7 +71,7 @@ class VirtualNetworksTable extends React.Component {
         className="table-cell-link-primary"
         params={{overlayName}}
         title={overlayName}
-        to="virtual-networks-tab-detail">
+        to="/network/virtual-networks/:overlayName">
         {overlayName}
       </Link>
     );

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
@@ -55,12 +55,12 @@ class VirtualNetworkDetail extends mixin(StoreMixin, TabsMixin) {
 
   updateCurrentTab() {
     let routes = this.context.router.getCurrentRoutes();
-    let currentTab = routes[routes.length - 1].name;
+    let currentTab = routes[routes.length - 1].path;
 
     // Virtual Network Detail Tabs
     this.tabs_tabs = {
-      'virtual-networks-tab-detail-tasks': 'Tasks',
-      'virtual-networks-tab-detail-details': 'Details'
+      '/network/virtual-networks/:overlayName': 'Tasks',
+      '/network/virtual-networks/:overlayName/details': 'Details'
     };
 
     this.setState({currentTab});

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
@@ -168,7 +168,7 @@ class VirtualNetworkTaskTab extends mixin(StoreMixin) {
         key={value}
         params={{overlayName: this.props.overlay.getName(), taskID}}
         title={title}
-        to="virtual-networks-tab-detail-tasks-detail">
+        to="/network/virtual-networks/:overlayName/tasks/:taskID">
         {value}
       </Link>
     );

--- a/src/js/pages/system/UnitsHealthTab.js
+++ b/src/js/pages/system/UnitsHealthTab.js
@@ -60,7 +60,7 @@ class UnitsHealthTab extends mixin(StoreMixin) {
   renderUnit(prop, unit) {
     return (
       <div className="text-overflow">
-        <Link to="components-overview-units-unit-nodes-detail"
+        <Link to="/components/:unitID"
           params={{unitID: unit.get('id')}}
           className="table-cell-link-primary">
           {unit.getTitle()}

--- a/src/js/pages/universe/PackagesTab.js
+++ b/src/js/pages/universe/PackagesTab.js
@@ -60,7 +60,7 @@ class PackagesTab extends mixin(StoreMixin) {
   handleDetailOpen(cosmosPackage, event) {
     event.stopPropagation();
     this.context.router.transitionTo(
-      'universe-packages-detail',
+      '/universe/packages/:packageName',
       {packageName: cosmosPackage.getName()},
       {version: cosmosPackage.getCurrentVersion()}
     );

--- a/src/js/routes/cluster.js
+++ b/src/js/routes/cluster.js
@@ -5,8 +5,7 @@ import OverviewDetailTab from '../pages/system/OverviewDetailTab';
 
 let clusterRoutes = {
   type: Route,
-  name: 'cluster',
-  path: 'cluster/?',
+  path: 'cluster',
   handler: ClusterPage,
   category: 'system',
   isInSidebar: true,
@@ -14,13 +13,12 @@ let clusterRoutes = {
     {
       type: Route,
       handler: OverviewDetailTab,
-      name: 'cluster-overview',
-      path: 'overview/?'
+      path: 'overview'
     },
     {
       type: Redirect,
-      from: '/cluster/?',
-      to: 'cluster-overview'
+      from: '/cluster',
+      to: '/cluster/overview'
     }
   ]
 };

--- a/src/js/routes/components.js
+++ b/src/js/routes/components.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars */
 import React from 'react';
 /* eslint-enable no-unused-vars */
-import {Route, Redirect} from 'react-router';
+import {Route, DefaultRoute} from 'react-router';
 
 import ComponentsPage from '../pages/ComponentsPage';
 import UnitsHealthDetail from '../pages/system/UnitsHealthDetail';
@@ -12,73 +12,68 @@ import UnitsHealthTab from '../pages/system/UnitsHealthTab';
 
 let componentsRoutes = {
   type: Route,
-  name: 'components',
-  path: 'components/?',
+  path: 'components',
   handler: ComponentsPage,
   category: 'system',
   isInSidebar: true,
+  buildBreadCrumb() {
+    return {
+      getCrumbs() {
+        return [
+          {
+            label: 'System Components',
+            route: {to: '/components'}
+          }
+        ];
+      }
+    };
+  },
   children: [
     {
-      type: Route,
-      name: 'components-overview-units',
-      path: 'overview/?',
-      handler: UnitsHealthTab,
-      buildBreadCrumb() {
-        return {
-          getCrumbs() {
-            return [
-              {
-                label: 'System Components',
-                route: {to: 'components-overview-units'}
-              }
-            ];
-          }
-        };
-      }
+      type: DefaultRoute,
+      handler: UnitsHealthTab
     },
     {
       type: Route,
-      name: 'components-overview-units-unit-nodes-detail',
-      path: 'components/:unitID/?',
-      handler: UnitsHealthDetail,
+      path: ':unitID',
       hideHeaderNavigation: true,
       buildBreadCrumb() {
         return {
-          parentCrumb: 'components-overview-units',
+          parentCrumb: '/components',
           getCrumbs(router) {
             return [
               <UnitsHealthDetailBreadcrumb
-                parentRouter={router}
-                routeName="components-overview-units-unit-nodes-detail" />
+              parentRouter={router}
+              routePath="/components/:unitID" />
             ];
           }
         };
-      }
-    },
-    {
-      type: Route,
-      name: 'components-overview-units-unit-nodes-node-detail',
-      path: 'components/:unitID/nodes/:unitNodeID/?',
-      handler: UnitsHealthNodeDetail,
-      hideHeaderNavigation: true,
-      buildBreadCrumb() {
-        return {
-          parentCrumb: 'components-overview-units-unit-nodes-detail',
-          getCrumbs(router) {
-            return [
-              <UnitsHealthNodeDetailBreadcrumb
-                parentRouter={router}
-                routeName="components-overview-units-unit-nodes-node-detail"
-                />
-            ];
+      },
+      children: [
+        {
+          type: DefaultRoute,
+          handler: UnitsHealthDetail
+        },
+        {
+          type: Route,
+          path: 'nodes/:unitNodeID',
+          handler: UnitsHealthNodeDetail,
+          hideHeaderNavigation: true,
+          buildBreadCrumb() {
+            return {
+              parentCrumb: '/components/:unitID',
+              getCrumbs(router) {
+                return [
+                  <UnitsHealthNodeDetailBreadcrumb
+                  parentRouter={router}
+                  routePath="/components/:unitID/nodes/:unitNodeID"
+                  />
+                ];
+              }
+            };
           }
-        };
-      }
-    },
-    {
-      type: Redirect,
-      from: '/components/?',
-      to: 'components-overview-units'
+        }
+      ]
     }
   ]
 };

--- a/src/js/routes/dashboard.js
+++ b/src/js/routes/dashboard.js
@@ -5,8 +5,7 @@ import DashboardPage from '../pages/DashboardPage';
 let dashboardRoutes = {
   category: 'root',
   type: Route,
-  name: 'dashboard',
-  path: 'dashboard/?',
+  path: 'dashboard',
   handler: DashboardPage,
   isInSidebar: true
 };

--- a/src/js/routes/factories/network.js
+++ b/src/js/routes/factories/network.js
@@ -20,8 +20,7 @@ let RouteFactory = {
     let virtualNetworksRoute = [
       {
         type: Route,
-        name: 'virtual-networks-tab',
-        path: 'virtual-networks/?',
+        path: 'virtual-networks',
         handler: VirtualNetworksTab,
         isInSidebar: true,
         buildBreadCrumb() {
@@ -29,7 +28,7 @@ let RouteFactory = {
             getCrumbs() {
               return [{
                 label: 'Virtual Networks',
-                route: {to: 'virtual-networks-tab'}
+                route: {to: '/network/virtual-networks'}
               }];
             }
           };
@@ -37,25 +36,23 @@ let RouteFactory = {
       },
       {
         type: Route,
-        name: 'virtual-networks-tab-detail',
-        path: 'virtual-networks/:overlayName/?',
+        path: 'virtual-networks/:overlayName',
         handler: VirtualNetworkDetail,
         children: [
           {
             type: DefaultRoute,
-            name: 'virtual-networks-tab-detail-tasks',
             handler: VirtualNetworkTaskTab,
             hideHeaderNavigation: true,
             buildBreadCrumb() {
               return {
-                parentCrumb: 'virtual-networks-tab',
+                parentCrumb: '/network/virtual-networks',
                 getCrumbs(router) {
                   let {overlayName} = router.getCurrentParams();
 
                   return [{
                     label: overlayName,
                     route: {
-                      to: 'virtual-networks-tab-detail-tasks',
+                      to: '/network/virtual-networks/:overlayName',
                       params: {overlayName}
                     }
                   }];
@@ -65,20 +62,19 @@ let RouteFactory = {
           },
           {
             type: Route,
-            name: 'virtual-networks-tab-detail-details',
-            path: 'details/?',
+            path: 'details',
             handler: VirtualNetworkDetailsTab,
             hideHeaderNavigation: true,
             buildBreadCrumb() {
               return {
-                parentCrumb: 'virtual-networks-tab',
+                parentCrumb: '/network/virtual-networks',
                 getCrumbs(router) {
                   let {overlayName} = router.getCurrentParams();
 
                   return [{
                     label: overlayName,
                     route: {
-                      to: 'virtual-networks-tab-detail-details',
+                      to: '/network/virtual-networks/:overlayName',
                       params: {overlayName}
                     }
                   }];
@@ -90,13 +86,12 @@ let RouteFactory = {
       },
       {
         type: Route,
-        path: 'virtual-networks/:overlayName/tasks/:taskID/?',
-        name: 'virtual-networks-tab-detail-tasks-detail',
+        path: 'virtual-networks/:overlayName/tasks/:taskID',
         handler: TaskDetail,
         hideHeaderNavigation: true,
         buildBreadCrumb() {
           return {
-            parentCrumb: 'virtual-networks-tab-detail-tasks',
+            parentCrumb: '/network/virtual-networks/:overlayName/tasks',
             getCrumbs(router) {
               return [{label: router.getCurrentParams().taskID}];
             }
@@ -105,46 +100,42 @@ let RouteFactory = {
         children: [
           {
             type: DefaultRoute,
-            name: 'virtual-networks-tab-detail-tasks-details-tab',
             handler: TaskDetailsTab,
             hideHeaderNavigation: true,
             title:'Details',
             buildBreadCrumb() {
               return {
-                parentCrumb: 'virtual-networks-tab-detail-tasks-detail',
+                parentCrumb: '/network/virtual-networks/:overlayName/tasks/:taskID',
                 getCrumbs() { return []; }
               };
             }
           },
           {
             type: Route,
-            name: 'virtual-networks-tab-detail-tasks-details-files',
-            path: 'files/?',
+            path: 'files',
             title:'Files',
             children: [
               {
                 type: DefaultRoute,
-                name: 'virtual-networks-tab-detail-tasks-details-files-directory',
                 hideHeaderNavigation: true,
                 handler: TaskFilesTab,
-                fileViewerRouteName: 'virtual-networks-tab-detail-tasks-details-file-viewer',
+                fileViewerRoutePath: '/network/virtual-networks/:overlayName/tasks/:taskID/view',
                 buildBreadCrumb() {
                   return {
-                    parentCrumb: 'virtual-networks-tab-detail-tasks-detail',
+                    parentCrumb: '/network/virtual-networks/:overlayName/tasks/:taskID',
                     getCrumbs() { return []; }
                   };
                 }
               },
               {
                 type: Route,
-                path: 'view/:filePath?/?:innerPath?/?',
+                path: 'view/?:filePath?/?:innerPath?',
                 hideHeaderNavigation: true,
-                name: 'virtual-networks-tab-detail-tasks-details-file-viewer',
                 handler: TaskFileViewer,
                 dontScroll: true,
                 buildBreadCrumb() {
                   return {
-                    parentCrumb: 'virtual-networks-tab-detail-tasks-detail',
+                    parentCrumb: '/network/virtual-networks/:overlayName/tasks/:taskID',
                     getCrumbs() { return []; }
                   };
                 }
@@ -162,8 +153,8 @@ let RouteFactory = {
         routes: virtualNetworksRoute,
         redirect: {
           type: Redirect,
-          from: '/network/?',
-          to: 'virtual-networks-tab'
+          from: '/network',
+          to: '/network/virtual-networks'
         }
       })
     );
@@ -179,8 +170,7 @@ let RouteFactory = {
 
     return {
       type: Route,
-      name: 'network',
-      path: 'network/?',
+      path: 'network',
       handler: NetworkPage,
       category: 'resources',
       isInSidebar: true,

--- a/src/js/routes/factories/organization.js
+++ b/src/js/routes/factories/organization.js
@@ -14,19 +14,17 @@ let RouteFactory = {
       Hooks.applyFilter('organizationRoutes', {
         routes: [{
           type: Route,
-          id: 'organization-users',
-          name: 'organization-users',
-          path: 'users/?',
+          path: 'users',
           handler: UsersTab,
           isInSidebar: true,
           buildBreadCrumb() {
             return {
-              parentCrumb: 'system-organization',
+              parentCrumb: '/organization',
               getCrumbs() {
                 return [
                   {
                     label: 'Users',
-                    route: {to: 'organization-users'}
+                    route: {to: '/organization/users'}
                   }
                 ];
               }
@@ -36,8 +34,8 @@ let RouteFactory = {
         }],
         redirect: {
           type: Redirect,
-          from: '/organization/?',
-          to: 'organization-users'
+          from: '/organization',
+          to: '/organization/users'
         }
       })
     );
@@ -53,9 +51,7 @@ let RouteFactory = {
 
     return {
       type: Route,
-      id: 'organization',
-      name: 'organization',
-      path: 'organization/?',
+      path: 'organization',
       handler: OrganizationPage,
       category: 'system',
       isInSidebar: true,
@@ -66,7 +62,7 @@ let RouteFactory = {
             return [
               {
                 label: 'Organization',
-                route: {to: 'organization'}
+                route: {to: '/organization'}
               }
             ];
           }

--- a/src/js/routes/index.js
+++ b/src/js/routes/index.js
@@ -33,7 +33,7 @@ function getApplicationRoutes() {
     {
       type: Redirect,
       from: '/',
-      to: Hooks.applyFilter('applicationRedirectRoute', 'dashboard')
+      to: Hooks.applyFilter('applicationRedirectRoute', '/dashboard')
     },
     {
       type: NotFoundRoute,
@@ -48,7 +48,6 @@ function getApplicationRoutes() {
   return [
     {
       type: Route,
-      name: 'home',
       path: '/',
       children: [
         {

--- a/src/js/routes/jobs.js
+++ b/src/js/routes/jobs.js
@@ -26,16 +26,15 @@ function buildJobCrumbs(router) {
 
     return {
       label: id,
-      route: {to: 'jobs-page-detail', params: {id: aggregateIDs}}
+      route: {to: '/jobs/:id', params: {id: aggregateIDs}}
     };
   });
 }
 
 let jobsRoutes = {
   type: Route,
-  name: 'jobs-page',
   handler: JobsPage,
-  path: '/jobs/?',
+  path: 'jobs',
   category: 'root',
   isInSidebar: true,
   buildBreadCrumb() {
@@ -44,7 +43,7 @@ let jobsRoutes = {
         return [
           {
             label: 'Jobs',
-            route: {to: 'jobs-page'}
+            route: {to: '/jobs'}
           }
         ];
       }
@@ -58,29 +57,27 @@ let jobsRoutes = {
         {
           type: Route,
           handler: JobDetailPage,
-          name: 'jobs-page-detail',
-          path: ':id/?',
+          path: ':id',
           buildBreadCrumb() {
             return {
-              parentCrumb: 'jobs-page',
+              parentCrumb: '/jobs',
               getCrumbs: buildJobCrumbs
             };
           },
-          children: [
+          children:[
             {
               type: Route,
-              path: 'tasks/:taskID/?',
-              name: 'jobs-task-details',
+              path: 'tasks/:taskID',
               handler: TaskDetail,
               hideHeaderNavigation: true,
               buildBreadCrumb() {
                 return {
-                  parentCrumb: 'jobs-page-detail',
+                  parentCrumb: '/jobs/:id',
                   getCrumbs(router) {
                     return [
                       <TaskDetailBreadcrumb
                         parentRouter={router}
-                        routeName="jobs-task-details" />
+                        routePath="/jobs/:id/tasks/:taskID" />
                     ];
                   }
                 };
@@ -88,42 +85,38 @@ let jobsRoutes = {
               children: [
                 {
                   type: DefaultRoute,
-                  name: 'jobs-task-details-tab',
                   handler: TaskDetailsTab,
+                  buildBreadCrumb() {
+                    return {
+                      parentCrumb: '/jobs/:id/tasks/:taskID',
+                      getCrumbs() { return []; }
+                    };
+                  },
                   title:'Details'
                 },
                 {
                   type: Route,
-                  name: 'jobs-task-details-files',
-                  path: 'files/?',
-                  title:'Files',
-                  children: [
-                    {
-                      type: DefaultRoute,
-                      name: 'jobs-task-details-files-directory',
-                      handler: TaskFilesTab,
-                      fileViewerRouteName: 'jobs-task-details-files-viewer',
-                      buildBreadCrumb() {
-                        return {
-                          parentCrumb: 'jobs-task-details',
-                          getCrumbs() { return []; }
-                        };
-                      }
-                    },
-                    {
-                      type: Route,
-                      path: 'view/:filePath?/?:innerPath?/?',
-                      name: 'jobs-task-details-files-viewer',
-                      handler: TaskFileViewer,
-                      dontScroll: true,
-                      buildBreadCrumb() {
-                        return {
-                          parentCrumb: 'jobs-task-details',
-                          getCrumbs() { return []; }
-                        };
-                      }
-                    }
-                  ]
+                  path: 'files',
+                  handler: TaskFilesTab,
+                  fileViewerRoutePath: '/jobs/:id/tasks/:taskID/view/:filePath?/?:innerPath?',
+                  buildBreadCrumb() {
+                    return {
+                      parentCrumb: '/jobs/:id/tasks/:taskID',
+                      getCrumbs() { return []; }
+                    };
+                  }
+                },
+                {
+                  type: Route,
+                  path: 'view/:filePath?/?:innerPath?',
+                  handler: TaskFileViewer,
+                  dontScroll: true,
+                  buildBreadCrumb() {
+                    return {
+                      parentCrumb: '/jobs/:id/tasks/:taskID',
+                      getCrumbs() { return []; }
+                    };
+                  }
                 }
               ]
             }

--- a/src/js/routes/settings.js
+++ b/src/js/routes/settings.js
@@ -5,25 +5,21 @@ import SettingsPage from '../pages/SettingsPage';
 
 let settingsRoutes = {
   type: Route,
-  id: 'settings',
-  name: 'settings',
-  path: 'settings/?',
+  path: 'settings',
   handler: SettingsPage,
   category: 'system',
   isInSidebar: true,
   children: [
     {
       type: Route,
-      id: 'settings-repositories',
-      name: 'settings-repositories',
-      path: 'repositories/?',
+      path: 'repositories',
       handler: RepositoriesTab,
       isInSidebar: true
     },
     {
       type: Redirect,
-      from: '/settings/?',
-      to: 'settings-repositories'
+      from: '/settings',
+      to: '/settings/repositories'
     }
   ]
 };

--- a/src/js/routes/styles.js
+++ b/src/js/routes/styles.js
@@ -26,164 +26,141 @@ import StylesPage from '../pages/StylesPage';
 
 let stylesRoutes = {
   type: Route,
-  name: 'styles',
-  path: 'styles/?',
+  path: 'styles',
   handler: StylesPage,
   children: [
     {
       type: Route,
-      name: 'styles-layout-tab',
-      path: 'layout/?',
+      path: 'layout',
       children: [
         {
           type: Route,
-          name: 'styles-layout-containers',
-          path: 'containers/?',
+          path: 'containers',
           handler: ContainersTabContent
         },
         {
           type: Route,
-          name: 'styles-layout-grid',
-          path: 'grid/?',
+          path: 'grid',
           handler: GridTabContent
         },
         {
           type: Route,
-          name: 'styles-layout-pods',
-          path: 'pods/?',
+          path: 'pods',
           handler: PodsTabContent
         },
         {
           type: Route,
-          name: 'styles-layout-flex',
-          path: 'flex/?',
+          path: 'flex',
           handler: FlexTabContent
         },
         {
           type: Route,
-          name: 'styles-layout-dividers',
-          path: 'dividers/?',
+          path: 'dividers',
           handler: DividersTabContent
         },
         {
           type: Route,
-          name: 'styles-layout-responsive-utilities',
-          path: 'responsive-utilities/?',
+          path: 'responsive-utilities',
           handler: ResponsiveUtilitiesTabContent
         },
         {
           type: Redirect,
           from: '/styles/layout/?',
-          to: 'styles-layout-containers'
+          to: '/styles/layout/containers'
         }
       ]
     },
     {
       type: Route,
-      name: 'styles-content-tab',
-      path: 'content/?',
+      path: 'content',
       children: [
         {
           type: Route,
-          name: 'styles-content-typography',
-          path: 'typography/?',
+          path: 'typography',
           handler: TypographyTabContent
         },
         {
           type: Route,
-          name: 'styles-content-tables',
-          path: 'tables/?',
+          path: 'tables',
           handler: TablesTabContent
         },
         {
           type: Route,
-          name: 'styles-content-colors',
-          path: 'colors/?',
+          path: 'colors',
           handler: ColorsTabContent
         },
         {
           type: Route,
-          name: 'styles-content-code',
-          path: 'code/?',
+          path: 'code',
           handler: CodeTabContent
         },
         {
           type: Route,
-          name: 'styles-content-images',
-          path: 'images/?',
+          path: 'images',
           handler: ImagesTabContent
         },
         {
           type: Redirect,
           from: '/styles/content/?',
-          to: 'styles-content-typography'
+          to: '/styles/content/typography'
         }
       ]
     },
     {
       type: Route,
-      name: 'styles-components-tab',
-      path: 'components/?',
+      path: 'components',
       children: [
         {
           type: Route,
-          name: 'styles-components-buttons',
-          path: 'buttons/?',
+          path: 'buttons',
           handler: ButtonsTabContent
         },
         {
           type: Route,
-          name: 'styles-components-button-collections',
-          path: 'button-collections/?',
+          path: 'button-collections',
           handler: ButtonCollectionsTabContent
         },
         {
           type: Route,
-          name: 'styles-components-button-groups',
-          path: 'button-groups/?',
+          path: 'button-groups',
           handler: ButtonGroupsTabContent
         },
         {
           type: Route,
-          name: 'styles-components-dropdowns',
-          path: 'dropdowns/?',
+          path: 'dropdowns',
           handler: DropdownsTabContent
         },
         {
           type: Route,
-          name: 'styles-components-forms',
-          path: 'forms/?',
+          path: 'forms',
           handler: FormsTabContent
         },
         {
           type: Route,
-          name: 'styles-components-icons',
-          path: 'icons/?',
+          path: 'icons',
           handler: IconsTabContent
         },
         {
           type: Route,
-          name: 'styles-components-modals',
-          path: 'modals/?',
+          path: 'modals',
           handler: ModalsTabContent
         },
         {
           type: Route,
-          name: 'styles-components-panels',
-          path: 'panels/?',
+          path: 'panels',
           handler: PanelsTabContent
         },
         {
           type: Redirect,
           from: '/styles/components/?',
-          to: 'styles-components-buttons'
+          to: '/styles/components/buttons'
         }
       ]
     },
     {
       type: Redirect,
       from: '/styles/?',
-      to: 'styles-layout-tab'
+      to: '/styles/layout'
     }
   ]
 };

--- a/src/js/routes/universe.js
+++ b/src/js/routes/universe.js
@@ -7,16 +7,14 @@ import UniversePage from '../pages/UniversePage';
 
 let universeRoutes = {
   type: Route,
-  name: 'universe',
-  path: 'universe/?',
+  path: 'universe',
   handler: UniversePage,
   category: 'root',
   isInSidebar: true,
   children: [
     {
       type: Route,
-      name: 'universe-packages',
-      path: 'packages/?',
+      path: 'packages',
       handler: PackagesTab,
       isInSidebar: true,
       buildBreadCrumb() {
@@ -25,7 +23,7 @@ let universeRoutes = {
             return [
               {
                 label: 'Packages',
-                route: {to: 'universe-packages'}
+                route: {to: '/universe/packages'}
               }
             ];
           }
@@ -34,13 +32,12 @@ let universeRoutes = {
     },
     {
       type: Route,
-      name: 'universe-packages-detail',
       path: 'packages/:packageName?',
       handler: PackageDetailTab,
       hideHeaderNavigation: true,
       buildBreadCrumb() {
         return {
-          parentCrumb: 'universe-packages',
+          parentCrumb: '/universe/packages',
           getCrumbs(router) {
             let params = router.getCurrentParams();
 
@@ -48,7 +45,7 @@ let universeRoutes = {
               {
                 label: params.packageName,
                 route: {
-                  to: 'universe-packages-detail',
+                  to: '/universe/packages/:packageName',
                   params,
                   query: router.getCurrentQuery()
                 }
@@ -60,15 +57,14 @@ let universeRoutes = {
     },
     {
       type: Route,
-      name: 'universe-installed-packages',
-      path: 'installed-packages/?',
+      path: 'installed-packages',
       handler: InstalledPackagesTab,
       isInSidebar: true
     },
     {
       type: Redirect,
-      from: '/universe/?',
-      to: 'universe-packages'
+      from: '/universe',
+      to: '/universe/packages'
     }
   ]
 };

--- a/src/js/utils/VirtualNetworkUtil.js
+++ b/src/js/utils/VirtualNetworkUtil.js
@@ -14,7 +14,7 @@ const VirtualNetworkUtil = {
         icon={<Icon id="network-hierarchical" color="neutral" size="jumbo" />}>
         <p className="flush">
           {'Could not find the requested virtual network. Go to '}
-          <Link to="virtual-networks-tab">
+          <Link to="/network/virtual-networks">
             Virtual Networks
           </Link> overview to see all virtual networks.
         </p>


### PR DESCRIPTION
This PR is the first part of the react-router migration. It removed all named routes and replaces them with absolute paths. There could still be bugs here and there even though I clicked through the whole thing. Unfortunately I couldn't find a way to deliver this part in smaller parts.

https://mesosphere.atlassian.net/browse/DCOS-10646

⚠️  Remember the plugins ☝️