### PR TITLE
JestUtil: Trimming mapTextContent result

### DIFF
--- a/src/js/utils/JestUtil.js
+++ b/src/js/utils/JestUtil.js
@@ -101,7 +101,7 @@ const JestUtil = {
    * @returns {string} The text content
    */
   mapTextContent(element) {
-    return element.textContent;
+    return element.textContent.trim();
   },
 
   /**


### PR DESCRIPTION
This PR trims the output of `JestUtil.Trimming`, since on tests we don't really care about heading/tailing spaces.