### PR TITLE
Adjust the Mesos task path util

### DIFF
--- a/src/js/constants/ExecutorTypes.js
+++ b/src/js/constants/ExecutorTypes.js
@@ -1,0 +1,5 @@
+const ExecutorTypes = {
+  DEFAULT: 'DEFAULT'
+};
+
+module.exports = ExecutorTypes;

--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -1,3 +1,4 @@
+import ExecutorTypes from '../constants/ExecutorTypes';
 import PodInstanceState from '../constants/PodInstanceState';
 import Util from './Util';
 
@@ -230,7 +231,7 @@ const MesosStateUtil = {
             // Use the executor task path construct if it's a "pod" / TaskGroup
             // executor (type: DEFAULT), otherwise fallback to the default
             // app/framework behavior.
-            if (executor.type === 'DEFAULT') {
+            if (executor.type === ExecutorTypes.DEFAULT) {
               // For a detail documentation on how to construct the task path
               // please see: https://reviews.apache.org/r/52376/
               taskPath = `${executor.directory}/tasks/${taskID}/${path}`;

--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -225,26 +225,25 @@ const MesosStateUtil = {
     // Find matching executor or task to construct the task path
     [].concat(framework.executors, framework.completed_executors)
         .every(function (executor) {
-          // Find app/framework executor
-          if (executor != null &&
-              (executor.id === executorID || executor.id === taskID)) {
+          if (executor.id === executorID || executor.id === taskID) {
+
+            // Use the executor task path construct if it's a "pod" / TaskGroup
+            // executor (type: DEFAULT), otherwise fallback to the default
+            // app/framework behavior.
+            if (executor.type === 'DEFAULT') {
+              // For a detail documentation on how to construct the task path
+              // please see: https://reviews.apache.org/r/52376/
+              taskPath = `${executor.directory}/tasks/${taskID}/${path}`;
+              return false;
+            }
+
+            // Simply use the executors directory for "apps" and "frameworks",
+            // as well as any other executor
             taskPath = `${executor.directory}/${path}`;
             return false;
           }
 
-          // Find pod task and executor
-          return [].concat(executor.tasks, executor.completed_tasks)
-            .every(function (task) {
-              if (task != null && task.id === taskID) {
-                // For a detail documentation on how to construct the path
-                // please see: https://reviews.apache.org/r/52376/
-                taskPath =
-                    `${executor.directory}/tasks/${task.id}/${path}`;
-                return false;
-              }
-
-              return true;
-            });
+          return true;
         });
 
     return taskPath;

--- a/src/js/utils/__tests__/MesosStateUtil-test.js
+++ b/src/js/utils/__tests__/MesosStateUtil-test.js
@@ -208,13 +208,15 @@ describe('MesosStateUtil', function () {
                 id: 'executor-foo',
                 directory: 'foo',
                 completed_tasks: [{id: 'task-foo-completed'}],
-                tasks: [{id: 'task-foo-running'}]
+                tasks: [{id: 'task-foo-running'}],
+                type: 'DEFAULT'
               }
             ],
             completed_executors: [{
               id: 'executor-bar',
               directory: 'bar',
-              completed_tasks: [{id: 'task-bar-completed'}]
+              completed_tasks: [{id: 'task-bar-completed'}],
+              type: 'DEFAULT'
             }]
           }
         ]
@@ -223,6 +225,7 @@ describe('MesosStateUtil', function () {
       it('gets the task path for a running task', function () {
         const task = {
           id: 'task-foo-running',
+          executor_id: 'executor-foo',
           framework_id: 'framework-123'
         };
 
@@ -233,6 +236,7 @@ describe('MesosStateUtil', function () {
       it('gets the task path form a completed task', function () {
         const task = {
           id: 'task-foo-completed',
+          executor_id: 'executor-foo',
           framework_id: 'framework-123'
         };
 
@@ -243,6 +247,7 @@ describe('MesosStateUtil', function () {
       it('gets the task path form a completed executor', function () {
         const task = {
           id: 'task-bar-completed',
+          executor_id: 'executor-bar',
           framework_id: 'framework-123'
         };
 
@@ -253,6 +258,7 @@ describe('MesosStateUtil', function () {
       it('appends provided path', function () {
         const task = {
           id: 'task-foo-running',
+          executor_id: 'executor-foo',
           framework_id: 'framework-123'
         };
 


### PR DESCRIPTION
Align the util with the latest Mesos API advancements as the "pod" task data changed which resulted in wrong paths. It also no longer necessary to iterate over the list of tasks as we already have all the bits to construct the paths.

Closes DCOS-10807