### PR TITLE
[CNVS Upgrade] Fix expanding table styling

### DIFF
--- a/src/styles/components/expanding-table/styles.less
+++ b/src/styles/components/expanding-table/styles.less
@@ -2,8 +2,9 @@
 
   .expanding-table {
 
-    tbody {
+    td {
       line-height: 1.8rem;
+      white-space: nowrap;
     }
   }
 
@@ -61,10 +62,6 @@
       height: 1px;
       top: 50%;
       width: @base-spacing-unit * 3/10;
-    }
-
-    a {
-      display: inline-block;
     }
   }
 


### PR DESCRIPTION
The expanding table relies on consistent `line-height` to render these items in "rows." Thus we need to enforce `white-space: nowrap` and apply a specific `line-height` until a better solution exists (ie. the `ExpandingTable` actually renders additional rows when a row is expanded).

The `inline-block` on the `a` tags resulted in extra whitespace being rendered around the element, whereas the default (`inline`) does not result in the extra whitespace. This change doesn't seem to cause any problems wth either instance of `ExpandingTable`, so I just removed it.

#1261 needs to merge before you'll be able to expand any elements in the PodInstances table.

Before:
![](https://cl.ly/0G3s0S1M180p/Screen%20Shot%202016-10-19%20at%203.32.55%20PM.png)

After:
![](https://cl.ly/3j222n3d3L2z/Screen%20Shot%202016-10-19%20at%203.32.09%20PM.png)