### PR TITLE
[CNVS Upgrade] Fix link styles in PodInstancesTable

### DIFF
--- a/plugins/services/src/js/components/PodInstancesTable.js
+++ b/plugins/services/src/js/components/PodInstancesTable.js
@@ -316,7 +316,7 @@ class PodInstancesTable extends React.Component {
       return (
         <div className="expanding-table-primary-cell-heading text-overflow">
           <Link
-            className="emphasize clickable text-overflow"
+            className="table-cell-link-secondary text-overflow"
             to="/services/overview/:id/tasks/:taskID"
             params={{
               id: encodeURIComponent(this.props.pod.getId()),
@@ -350,7 +350,6 @@ class PodInstancesTable extends React.Component {
 
     return (
       <Link
-        className="emphasize clickable text-overflow"
         to="/services/overview/tasks/:taskID/view"
         params={{
           id: encodeURIComponent(this.props.pod.getId()),
@@ -379,7 +378,7 @@ class PodInstancesTable extends React.Component {
 
       return this.renderWithClickHandler(rowOptions, (
           <Link
-            className="emphasize clickable text-overflow"
+            className="table-cell-link-secondary text-overflow"
             to="/nodes/:nodeID"
             params={{nodeID: agent.id}}
             title={address}>


### PR DESCRIPTION
This PR removes unnecessary classes in the `Link` elements and adds the proper classes for the desired styling.

Before:
![](https://cl.ly/2W0y0q470t1F/Screen%20Shot%202016-10-19%20at%204.10.23%20PM.png)

After:
![](https://cl.ly/3O2A103a0U2Z/Screen%20Shot%202016-10-19%20at%204.07.27%20PM.png)