### PR TITLE
DCOS-10421: Adjust the Spec health check getter

### DIFF
--- a/src/js/structs/ApplicationSpec.js
+++ b/src/js/structs/ApplicationSpec.js
@@ -48,7 +48,13 @@ module.exports = class ApplicationSpec extends ServiceSpec {
   }
 
   getHealthChecks() {
-    return this.get('healthChecks');
+    let healthChecks = this.get('healthChecks') || [];
+
+    // "Clone" health checks to ensure that no one is accidentally altering the
+    // properties.
+    return healthChecks.map(function (healthCheck) {
+      return Object.assign({}, healthCheck);
+    });
   }
 
   getInstancesCount() {

--- a/src/js/structs/__tests__/ApplicationSpec-test.js
+++ b/src/js/structs/__tests__/ApplicationSpec-test.js
@@ -208,6 +208,21 @@ describe('ApplicationSpec', function () {
       expect(service.getHealthChecks()).toEqual([{path: '', protocol: 'HTTP'}]);
     });
 
+    it('returns "cloned" objects, so that no one is accidentally mutating them',
+      function () {
+        let service = new ApplicationSpec({
+          healthChecks: [{command: {value:'exit 0;'}, protocol: 'COMMAND'}]
+        });
+
+        service.getHealthChecks()[0].command = undefined;
+
+        expect(service.getHealthChecks()).toEqual([{
+          command: {value: 'exit 0;'},
+          protocol: 'COMMAND'
+        }]);
+      }
+    );
+
   });
 
   describe('#getInstancesCount', function () {


### PR DESCRIPTION
Make sure that the `ApplicationSpec` health check getter returns "cloned" objects so that no one is accidentally mutating them. This change resolves an issue where the service form cancel button isn't working due to unwanted mutations.

Closes DCOS-10421