### PR TITLE
Adding timezone-mock package

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "string-replace-webpack-plugin": "0.0.3",
     "style-loader": "0.13.1",
     "svg-sprite": "1.3.1",
+    "timezone-mock": "0.0.0",
     "transform-loader": "0.2.3",
     "vinyl": "1.1.1",
     "webpack": "1.13.0",


### PR DESCRIPTION
This PR adds the `timezone-mock` package in the development dependencies in order for the tests to be able to mock timezone when `Date.toLocaleString()` is used.