### PR TITLE
[CNVS Upgrade] Fix modal body content flex properties

### DIFF
--- a/src/js/components/modals/FullScreenModal.js
+++ b/src/js/components/modals/FullScreenModal.js
@@ -9,7 +9,6 @@ class FullScreenModal extends React.Component {
 
     return (
       <Modal modalClass="modal modal-full-screen"
-        scrollContainerClass="modal-body flex flex-item-grow-1"
         showHeader={true}
         showFooter={false}
         transitionNameModal="modal-full-screen"

--- a/src/styles/components/modal/full-screen/styles.less
+++ b/src/styles/components/modal/full-screen/styles.less
@@ -14,6 +14,18 @@
       background: color-lighten(@neutral, 95%);
       padding: 0;
     }
+
+    .modal-body-wrapper {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .modal-body {
+      display: flex;
+      flex: 1 0 auto;
+      min-height: 100%;
+      overflow: hidden;
+    }
   }
 
   .modal-full-screen-enter,

--- a/src/styles/components/modal/styles.less
+++ b/src/styles/components/modal/styles.less
@@ -15,10 +15,6 @@
   }
 
   .modal-body-wrapper {
-    display: flex;
-  }
-
-  .modal-body {
     flex: 1 1 auto;
   }
 


### PR DESCRIPTION
This PR fixes a bug I introduced in https://github.com/dcos/dcos-ui/pull/1257 wherein the modals stopped rendering the Gemini scrollbar when appropriate.

By giving the property `display: flex` to all `.modal-body-wrapper` elements, it meant the child of `.modal-body-wrapper` (`.modal-body`) had the same height as its parent. This breaks the modal's logic which compares the height of these two elements to determine when to render Gemini.