### PR TITLE
[CNVS Upgrade] Fix up the nodes view

### DIFF
--- a/plugins/nodes/src/js/components/NodesGridView.js
+++ b/plugins/nodes/src/js/components/NodesGridView.js
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import {Form} from 'reactjs-components';
 import PureRender from 'react-addons-pure-render-mixin';
 import React from 'react';
 
@@ -34,6 +35,10 @@ var NodesGridView = React.createClass({
     hiddenServices: [],
     receivedNodeHealthResponse: false,
     showServices: false
+  },
+
+  handleCheckboxChange(model) {
+    this.props.onShowServices(model.showServices);
   },
 
   getLoadingScreen() {
@@ -74,7 +79,7 @@ var NodesGridView = React.createClass({
     // Return view definition
     .map(function (service) {
       var color = props.serviceColors[service.id];
-      var className = `service-legend-color service-color-${color}`;
+      var className = `dot service-color-${color}`;
 
       return (
         <li key={service.id}>
@@ -115,14 +120,17 @@ var NodesGridView = React.createClass({
       <div className="nodes-grid">
 
         <div className={classSet}>
-          <label className="show-services-label h5 flush-top">
-            <input type="checkbox"
-              checked={props.showServices}
-              name="nodes-grid-show-services"
-              onChange={props.onShowServices} />
-            Show Services by Share
+          <label className="show-services-label h5 tall flush-top">
+            <Form
+              definition={[{
+                fieldType: 'checkbox',
+                name: 'showServices',
+                checked: props.showServices,
+                label: 'Show Services by Share',
+                value: props.showServices
+              }]}
+              onChange={this.handleCheckboxChange} />
           </label>
-
           {this.getServicesList(props)}
         </div>
 

--- a/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.js
@@ -104,8 +104,8 @@ class NodesGridContainer extends mixin(StoreMixin, QueryParamsMixin) {
     this.setState({filters, filteredNodes}, callback);
   }
 
-  handleShowServices(e) {
-    this.setState({showServices: e.currentTarget.checked});
+  handleShowServices(value) {
+    this.setState({showServices: value});
   }
 
   onStateStoreSuccess() {

--- a/src/js/components/charts/ResourceBarChart.js
+++ b/src/js/components/charts/ResourceBarChart.js
@@ -115,7 +115,7 @@ let ResourceBarChart = React.createClass({
     return (
       <div className="pod flush-top flush-right flush-left">
         <div className="chart panel">
-          <div className="panel-cell panel-header panel-cell-borderless text-align-center">
+          <div className="panel-cell panel-header panel-cell-borderless flush-bottom text-align-center">
             <div className="panel-options button-group">
               {this.getModeButtons()}
             </div>

--- a/src/styles/components/charts/styles.less
+++ b/src/styles/components/charts/styles.less
@@ -599,8 +599,8 @@
           }
 
           &.path-color-unused {
-            fill: color-lighten(@neutral, 5);
-            stroke: color-lighten(@neutral, 5);
+            fill: color-lighten(@neutral, 80);
+            stroke: color-lighten(@neutral, 80);
           }
         }
 

--- a/src/styles/components/nodes-grid-view/styles.less
+++ b/src/styles/components/nodes-grid-view/styles.less
@@ -1,3 +1,4 @@
+// TODO: Thoroughly audit this.
 & when (@nodes-grid-view-enabled) {
 
   .nodes-grid {
@@ -8,185 +9,171 @@
 
     .nodes-grid-legend {
       display: flex;
-      flex-basis: 225px;
+      flex: 0 0 200px;
       flex-direction: column;
-      flex-shrink: 0;
-      transition: opacity 0.5s;
+      margin-right: @base-spacing-unit * 3/4;
 
-      &.disabled .nodes-grid-service-list {
-        opacity: 0.5;
-      }
+      &.disabled {
 
-      .show-services-label {
-        color: @white;
-        margin-right: @base-spacing-unit;
-        padding-bottom: @base-spacing-unit / 1.5;
-        user-select: none;
-
-        input {
-          margin-right: @base-spacing-unit / 3;
-          outline: none;
+        .nodes-grid-service-list {
+          opacity: 0.5;
         }
       }
 
       .nodes-grid-service-list {
         color: @white;
-        margin-right: @base-spacing-unit;
-        width: 225px;
+        transition: opacity 0.5s;
 
         & > li {
-          line-height: 1.2 * @base-spacing-unit;
-        }
-
-        .service-legend-color {
-          background-color: @white;
-          border-radius: 4px;
-          display: inline-block;
-          height: @base-spacing-unit / 3;
-          margin-right: @base-spacing-unit / 3;
-          width: @base-spacing-unit / 3;
-
-          &.service-color-0 {
-            background-color: @resource-cpu-color;
-          }
-
-          &.service-color-1 {
-            background-color: @yellow;
-          }
-
-          &.service-color-2 {
-            background-color: @red;
-          }
-
-          &.service-color-3 {
-            background-color: @resource-disk-color;
-          }
-
-          &.service-color-4 {
-            background-color: @green;
-          }
-
-          &.service-color-5 {
-            background-color: @orange;
-          }
-
-          &.service-color-6 {
-            background-color: @resource-mem-color;
-          }
-
-          &.service-color-7 {
-            background-color: @cyan;
-          }
-
-          &.service-color-8 {
-            background-color: @unique-color-1;
-          }
-
-          &.service-color-9 {
-            background-color: @unique-color-2;
-          }
-
-          &.service-color-10 {
-            background-color: @unique-color-3;
-          }
-
-          &.service-color-11 {
-            background-color: @unique-color-4;
-          }
-
-          &.service-color-12 {
-            background-color: @unique-color-5;
-          }
-
-          &.service-color-13 {
-            background-color: @unique-color-6;
-          }
-
-          &.service-color-14 {
-            background-color: @unique-color-7;
-          }
-
-          &.service-color-15 {
-            background-color: @unique-color-8;
-          }
-
-          &.service-color-16 {
-            background-color: @unique-color-9;
-          }
-
-          &.service-color-17 {
-            background-color: @unique-color-10;
-          }
-
-          &.service-color-18 {
-            background-color: @unique-color-11;
-          }
-
-          &.service-color-19 {
-            background-color: @unique-color-12;
-          }
-
-          &.service-color-20 {
-            background-color: @unique-color-13;
-          }
-
-          &.service-color-21 {
-            background-color: @unique-color-14;
-          }
-
-          &.service-color-22 {
-            background-color: @unique-color-15;
-          }
-
-          &.service-color-23 {
-            background-color: @unique-color-16;
-          }
-
-          &.service-color-24 {
-            background-color: @unique-color-17;
-          }
-
-          &.service-color-25 {
-            background-color: @unique-color-18;
-          }
-
-          &.service-color-26 {
-            background-color: @unique-color-19;
-          }
-
-          &.service-color-27 {
-            background-color: @unique-color-20;
-          }
-
-          &.service-color-28 {
-            background-color: @unique-color-21;
-          }
-
-          &.service-color-29 {
-            background-color: @unique-color-22;
-          }
-
-          &.service-color-30 {
-            background-color: @unique-color-23;
-          }
-
-          &.service-color-31 {
-            background-color: @unique-color-24;
-          }
-
-          &.service-color-32 {
-            background-color: color-lighten(@neutral, 40);
-          }
-
-          &.service-color-unused {
-            background-color: color-lighten(@neutral, 5);
-          }
-        }
-
-        a {
-          color: @white;
+          line-height: @base-spacing-unit * 3/4;
         }
       }
+
+      .dot {
+        background-color: @neutral;
+        display: inline-block;
+        margin-right: @base-spacing-unit / 3;
+
+        &.service-color-0 {
+          background-color: @resource-cpu-color;
+        }
+
+        &.service-color-1 {
+          background-color: @yellow;
+        }
+
+        &.service-color-2 {
+          background-color: @red;
+        }
+
+        &.service-color-3 {
+          background-color: @resource-disk-color;
+        }
+
+        &.service-color-4 {
+          background-color: @green;
+        }
+
+        &.service-color-5 {
+          background-color: @orange;
+        }
+
+        &.service-color-6 {
+          background-color: @resource-mem-color;
+        }
+
+        &.service-color-7 {
+          background-color: @cyan;
+        }
+
+        &.service-color-8 {
+          background-color: @unique-color-1;
+        }
+
+        &.service-color-9 {
+          background-color: @unique-color-2;
+        }
+
+        &.service-color-10 {
+          background-color: @unique-color-3;
+        }
+
+        &.service-color-11 {
+          background-color: @unique-color-4;
+        }
+
+        &.service-color-12 {
+          background-color: @unique-color-5;
+        }
+
+        &.service-color-13 {
+          background-color: @unique-color-6;
+        }
+
+        &.service-color-14 {
+          background-color: @unique-color-7;
+        }
+
+        &.service-color-15 {
+          background-color: @unique-color-8;
+        }
+
+        &.service-color-16 {
+          background-color: @unique-color-9;
+        }
+
+        &.service-color-17 {
+          background-color: @unique-color-10;
+        }
+
+        &.service-color-18 {
+          background-color: @unique-color-11;
+        }
+
+        &.service-color-19 {
+          background-color: @unique-color-12;
+        }
+
+        &.service-color-20 {
+          background-color: @unique-color-13;
+        }
+
+        &.service-color-21 {
+          background-color: @unique-color-14;
+        }
+
+        &.service-color-22 {
+          background-color: @unique-color-15;
+        }
+
+        &.service-color-23 {
+          background-color: @unique-color-16;
+        }
+
+        &.service-color-24 {
+          background-color: @unique-color-17;
+        }
+
+        &.service-color-25 {
+          background-color: @unique-color-18;
+        }
+
+        &.service-color-26 {
+          background-color: @unique-color-19;
+        }
+
+        &.service-color-27 {
+          background-color: @unique-color-20;
+        }
+
+        &.service-color-28 {
+          background-color: @unique-color-21;
+        }
+
+        &.service-color-29 {
+          background-color: @unique-color-22;
+        }
+
+        &.service-color-30 {
+          background-color: @unique-color-23;
+        }
+
+        &.service-color-31 {
+          background-color: @unique-color-24;
+        }
+
+        &.service-color-32 {
+          background-color: color-lighten(@neutral, 40);
+        }
+
+        &.service-color-unused {
+          background-color: color-lighten(@neutral, 5);
+        }
+      }
+    }
+
+    .nodes-grid-dials {
+      flex: 1 1 auto;
     }
   }
 }
@@ -198,27 +185,12 @@
     .nodes-grid {
 
       .nodes-grid-legend {
-
-        .show-services-label {
-          margin-right: @base-spacing-unit-screen-small;
-          padding-bottom: @base-spacing-unit-screen-small / 1.5;
-
-          input {
-            margin-right: @base-spacing-unit-screen-small / 3;
-          }
-        }
+        margin-right: @base-spacing-unit-screen-small * 3/4;
 
         .nodes-grid-service-list {
-          margin-right: @base-spacing-unit-screen-small;
 
           & > li {
-            line-height: 1.2 * @base-spacing-unit-screen-small;
-          }
-
-          .service-legend-color {
-            height: @base-spacing-unit-screen-small / 3;
-            margin-right: @base-spacing-unit-screen-small / 3;
-            width: @base-spacing-unit-screen-small / 3;
+            line-height: @base-spacing-unit-screen-small * 3/4;
           }
         }
       }
@@ -233,27 +205,12 @@
     .nodes-grid {
 
       .nodes-grid-legend {
-
-        .show-services-label {
-          margin-right: @base-spacing-unit-screen-medium;
-          padding-bottom: @base-spacing-unit-screen-medium / 1.5;
-
-          input {
-            margin-right: @base-spacing-unit-screen-medium / 3;
-          }
-        }
+        margin-right: @base-spacing-unit-screen-medium * 3/4;
 
         .nodes-grid-service-list {
-          margin-right: @base-spacing-unit-screen-medium;
 
           & > li {
-            line-height: 1.2 * @base-spacing-unit-screen-medium;
-          }
-
-          .service-legend-color {
-            height: @base-spacing-unit-screen-medium / 3;
-            margin-right: @base-spacing-unit-screen-medium / 3;
-            width: @base-spacing-unit-screen-medium / 3;
+            line-height: @base-spacing-unit-screen-medium * 3/4;
           }
         }
       }
@@ -268,27 +225,12 @@
     .nodes-grid {
 
       .nodes-grid-legend {
-
-        .show-services-label {
-          margin-right: @base-spacing-unit-screen-large;
-          padding-bottom: @base-spacing-unit-screen-large / 1.5;
-
-          input {
-            margin-right: @base-spacing-unit-screen-large / 3;
-          }
-        }
+        margin-right: @base-spacing-unit-screen-large * 3/4;
 
         .nodes-grid-service-list {
-          margin-right: @base-spacing-unit-screen-large;
 
           & > li {
-            line-height: 1.2 * @base-spacing-unit-screen-large;
-          }
-
-          .service-legend-color {
-            height: @base-spacing-unit-screen-large / 3;
-            margin-right: @base-spacing-unit-screen-large / 3;
-            width: @base-spacing-unit-screen-large / 3;
+            line-height: @base-spacing-unit-screen-large * 3/4;
           }
         }
       }
@@ -303,27 +245,12 @@
     .nodes-grid {
 
       .nodes-grid-legend {
-
-        .show-services-label {
-          margin-right: @base-spacing-unit-screen-jumbo;
-          padding-bottom: @base-spacing-unit-screen-jumbo / 1.5;
-
-          input {
-            margin-right: @base-spacing-unit-screen-jumbo / 3;
-          }
-        }
+        margin-right: @base-spacing-unit-screen-jumbo * 3/4;
 
         .nodes-grid-service-list {
-          margin-right: @base-spacing-unit-screen-jumbo;
 
           & > li {
-            line-height: 1.2 * @base-spacing-unit-screen-jumbo;
-          }
-
-          .service-legend-color {
-            height: @base-spacing-unit-screen-jumbo / 3;
-            margin-right: @base-spacing-unit-screen-jumbo / 3;
-            width: @base-spacing-unit-screen-jumbo / 3;
+            line-height: @base-spacing-unit-screen-jumbo * 3/4;
           }
         }
       }


### PR DESCRIPTION
This PR fixes up the Nodes view:
* I fixed the double padding between the panel header and the panel content in the `ResourceBarChart`
* I fixed the dark graph colors in the nodes grid view
* I moved the width and margin properties of the nodes grid sidebar to the sidebar itself rather than random children (it was confusing)
* I fixed some erroneously defined transition properties, so toggling the task list will transition as intended
* I replaced the old, yucky, native `input` checkbox with the new, yummy, fancy checkbox from reactjs-components.

The `FilterHeadline` margins seem a little tight, but that's everywhere in the app, so I'll address that in a future PR.

![](https://cl.ly/1o1M3S29410m/Screen%20Shot%202016-10-20%20at%205.10.29%20PM.png)