### PR TITLE
[CNVS Upgrade] Fix bottom-margin on tabs

### DIFF
--- a/src/styles/components/menu-tabbed/styles.less
+++ b/src/styles/components/menu-tabbed/styles.less
@@ -44,7 +44,6 @@
 
     .menu-tabbed-item {
       display: block;
-      margin-bottom: 0;
       margin-right: 0;
 
       &:last-child {
@@ -77,6 +76,7 @@
 
   .menu-tabbed-item {
     display: inline-block;
+    margin-bottom: 0;
     margin-right: @menu-tabbed-horizontal-item-margin-right;
     padding: 0;
 


### PR DESCRIPTION
This PR fixes a bug I introduced with my vertical tabs. Both vertical and horizontal tabbed menus need their children to have a bottom margin of 0.