### PR TITLE
[CNVS Upgrade] Fix services sidebar active test

### DIFF
--- a/plugins/services/src/js/services/ServicesContainer.js
+++ b/plugins/services/src/js/services/ServicesContainer.js
@@ -634,7 +634,7 @@ ServicesContainer.contextTypes = {
 ServicesContainer.routeConfig = {
   label: 'Services',
   icon: <Icon id="services-inverse" size="small" family="small" />,
-  matches: /^\/services/
+  matches: /^\/services\/overview/
 };
 
 module.exports = ServicesContainer;


### PR DESCRIPTION
This PR fixes the regex for the Services sidebar sub-menu item.

Before (when Deployments was active, Services also appeared active):
![](https://cl.ly/2E220E0e3X3p/Screen%20Shot%202016-10-24%20at%206.30.24%20PM.png)

After:
![](https://cl.ly/36243v2Y2X3O/Screen%20Shot%202016-10-24%20at%206.29.50%20PM.png)