### PR TITLE
[CNVS Upgrade] Service Create modal touchup

### DIFF
--- a/plugins/services/src/js/schemas/service-schema/Networking.js
+++ b/plugins/services/src/js/schemas/service-schema/Networking.js
@@ -159,12 +159,12 @@ const Networking = {
 
               return false;
             },
-            formElementClass: {'column-2': false}
+            formElementClass: {'column-2': false, 'column-3': true, 'form-control-force-narrow': true}
           },
           name: {
             title: 'Name',
             type: 'string',
-            formElementClass: {'column-2': false, 'column-3': true}
+            formElementClass: {'column-2': false, 'column-3': true, 'form-control-force-narrow': true}
           },
           protocol: {
             title: 'Protocol',
@@ -172,7 +172,7 @@ const Networking = {
             fieldType: 'select',
             default: 'tcp',
             options: ['tcp', 'udp', 'udp,tcp'],
-            formElementClass: {'column-2': false, 'column-3': true}
+            formElementClass: {'column-2': false, 'column-3': true, 'form-control-force-narrow': true}
           },
           hostPort: {
             title: 'Host Port',

--- a/src/js/components/SchemaForm.js
+++ b/src/js/components/SchemaForm.js
@@ -191,7 +191,7 @@ class SchemaForm extends mixin(StoreMixin, InternalStorageMixin) {
     let deleteButton = (
       <div key={`${prop}${id}-remove`} className="form-row-element form-row-remove-button form-row-element-mixed-label-presence">
         <button
-          className="button button-link"
+          className="button button-narrow button-link"
           onClick={this.handleRemoveRow.bind(this, generalDefinition, prop, id)}>
           <Icon id="close" size="mini" family="mini" />
         </button>

--- a/src/styles/components/form-elements/styles.less
+++ b/src/styles/components/form-elements/styles.less
@@ -18,4 +18,14 @@
       vertical-align: middle;
     }
   }
+
+  // TODO: Remove this when the full screen Create Service is implemented.
+  .form-control-force-narrow {
+
+    .form-control,
+    .button {
+      padding-left: 0.5rem;
+      padding-right: 0.5rem;
+    }
+  }
 }

--- a/src/styles/components/multiple-form/styles.less
+++ b/src/styles/components/multiple-form/styles.less
@@ -327,7 +327,7 @@
           flex-direction: row;
 
           .multiple-form-left-column {
-            border-right: 1px solid color-lighten(@neutral, 80);
+            box-shadow: inset -1px 0 @default-border-color;
             // Take up full height of container to
             height: 100%;
             max-height: 100%;


### PR DESCRIPTION
This PR fixes some of cosmetic issues with the new Service Create modal.
* Introduce temporary hacks to reduce the padding on these input fields and make them usable. Between the larger padding on input fields, the checkbox label being all caps, and larger padding on the modal itself, some of the input fields were too narrow.
* Applies `button-narrow` to the delete button for these duplicable rows.
* Moves the border of the tabs to an inset box-shadow so that the right edge of the active indicator on the tabs renders on top of the border.

Before:
![](https://cl.ly/3T0K1L1x1U25/Screen%20Shot%202016-10-25%20at%2011.07.23%20AM.png)

After:
![](https://cl.ly/2r3U3x3Y2D0Z/Screen%20Shot%202016-10-25%20at%2011.30.15%20AM.png)