### PR TITLE
Validation of batch types

### DIFF
--- a/src/js/constants/TransactionTypes.js
+++ b/src/js/constants/TransactionTypes.js
@@ -1,0 +1,4 @@
+module.exports = {
+  SET: Symbol('SET'),
+  DEL: Symbol('DEL')
+};

--- a/src/js/structs/Transaction.js
+++ b/src/js/structs/Transaction.js
@@ -1,9 +1,9 @@
-import FormActionTypes from '../constants/TransactionTypes';
+import TransactionTypes from '../constants/TransactionTypes';
 
-const validTypes = Object.values(FormActionTypes);
+const validTypes = Object.values(TransactionTypes);
 
 class Transaction {
-  constructor(path, value, type = FormActionTypes.SET) {
+  constructor(path, value, type = TransactionTypes.SET) {
     if (!validTypes.includes(type)) {
       throw new TypeError(`Only the following types are allowed: ${validTypes}`);
     }

--- a/src/js/structs/Transaction.js
+++ b/src/js/structs/Transaction.js
@@ -1,5 +1,12 @@
+import FormActionTypes from '../constants/TransactionTypes';
+
+const validTypes = Object.values(FormActionTypes);
+
 class Transaction {
-  constructor(path, value, type = 'SET') {
+  constructor(path, value, type = FormActionTypes.SET) {
+    if (!validTypes.includes(type)) {
+      throw new TypeError(`Only the following types are allowed: ${validTypes}`);
+    }
     Object.defineProperties(this, {
       path: {
         value: path,

--- a/src/js/structs/Transaction.js
+++ b/src/js/structs/Transaction.js
@@ -1,11 +1,12 @@
 import TransactionTypes from '../constants/TransactionTypes';
 
 const validTypes = Object.values(TransactionTypes);
+const validKeys = Object.keys(TransactionTypes);
 
 class Transaction {
   constructor(path, value, type = TransactionTypes.SET) {
     if (!validTypes.includes(type)) {
-      throw new TypeError(`Only the following types are allowed: ${validTypes}`);
+      throw new TypeError(`Only the following types are allowed: ${validKeys}`);
     }
     Object.defineProperties(this, {
       path: {
@@ -22,7 +23,6 @@ class Transaction {
       }
     });
   }
-
 }
 
 module.exports = Transaction;

--- a/src/js/structs/__tests__/Transaction-test.js
+++ b/src/js/structs/__tests__/Transaction-test.js
@@ -13,6 +13,10 @@ describe('Transaction', function () {
       expect(()=>new Transaction(0, 0, 'DEL')).toThrowError(TypeError);
     });
 
+    it('should accept SET constant', function () {
+      expect(()=>new Transaction(0, 0, TransactionTypes.SET)).not.toThrowError();
+    });
+
     it('type should not be writeable', function () {
       const transaction = new Transaction(0, 0);
       expect(() => transaction.type = 'EVIL DELETE').toThrowError();

--- a/src/js/structs/__tests__/Transaction-test.js
+++ b/src/js/structs/__tests__/Transaction-test.js
@@ -1,15 +1,16 @@
+const TransactionTypes = require('../../constants/TransactionTypes');
+
 const Transaction = require('../Transaction');
 
 describe('Transaction', function () {
   describe('#constructor', function () {
     it('should have the type SET', function () {
       const transaction = new Transaction(0, 0);
-      expect(transaction.type).toEqual('SET');
+      expect(transaction.type).toEqual(TransactionTypes.SET);
     });
 
-    it('should have the type DEL', function () {
-      const transaction = new Transaction(0, 0, 'DEL');
-      expect(transaction.type).toEqual('DEL');
+    it('should throw a Error for random type', function () {
+      expect(()=>new Transaction(0, 0, 'DEL')).toThrowError(TypeError);
     });
 
     it('type should not be writeable', function () {

--- a/src/js/structs/__tests__/Transaction-test.js
+++ b/src/js/structs/__tests__/Transaction-test.js
@@ -10,11 +10,12 @@ describe('Transaction', function () {
     });
 
     it('should throw a Error for random type', function () {
-      expect(()=>new Transaction(0, 0, 'DEL')).toThrowError(TypeError);
+      expect(() => new Transaction(0, 0, 'DEL')).toThrowError(TypeError);
     });
 
     it('should accept SET constant', function () {
-      expect(()=>new Transaction(0, 0, TransactionTypes.SET)).not.toThrowError();
+      expect(() => new Transaction(0, 0, TransactionTypes.SET))
+        .not.toThrowError();
     });
 
     it('type should not be writeable', function () {


### PR DESCRIPTION
This is adding the support of type validation in the `Transaction`s 

I choose to use `Symbols` as values over `Strings` since they are unique and can not produce bugs because we just pass in Strings. 

If a invalid type is added a TypeError will be thrown, which should give enough information.

About the `DEL` type, this type is currently just in there for testing purposes it might be that this will be removed/replaced at a later time. 