### PR TITLE
Add Parser Util

### DIFF
--- a/src/js/structs/Transaction.js
+++ b/src/js/structs/Transaction.js
@@ -11,15 +11,18 @@ class Transaction {
     Object.defineProperties(this, {
       path: {
         value: path,
-        writable: false
+        writable: false,
+        enumerable: true
       },
       value: {
         value,
-        writable: false
+        writable: false,
+        enumerable: true
       },
       type: {
         value: type,
-        writable: false
+        writable: false,
+        enumerable: true
       }
     });
   }

--- a/src/js/utils/ParserUtil.js
+++ b/src/js/utils/ParserUtil.js
@@ -1,0 +1,29 @@
+module.exports = {
+  combineParsers(parsers = []) {
+    parsers = parsers.filter(
+      function (parser) {
+        return typeof parser === 'function';
+      }
+    ).reverse();
+
+    return function (state = {}) {
+      let index = parsers.length;
+
+      const transactionLog = [];
+
+      while (--index >= 0) {
+        let parser = parsers[index];
+
+        let transaction = parser(state);
+
+        if (transaction instanceof Array) {
+          transactionLog.push(...transaction);
+        } else {
+          transactionLog.push(transaction);
+        }
+      }
+
+      return transactionLog;
+    };
+  }
+};

--- a/src/js/utils/__tests__/ParserUtil-test.js
+++ b/src/js/utils/__tests__/ParserUtil-test.js
@@ -1,0 +1,108 @@
+let ParserUtil = require('../ParserUtil');
+
+const SET = 'SET';
+
+describe('ParserUtil', function () {
+  describe('#combinePasers', function () {
+    function idParser(state) {
+      return {
+        type: SET,
+        path: 'id',
+        value: state.id
+      };
+    }
+
+    it('should return a function', function () {
+      expect(typeof ParserUtil.combineParsers()).toBe('function');
+    });
+
+    it('should return the right TransactionLog', function () {
+      let parsers = ParserUtil.combineParsers(
+        [
+          idParser
+        ]
+      );
+      expect(parsers({id: 'test'})).toEqual([
+        {
+          type: SET,
+          path: 'id',
+          value: 'test'
+        }
+      ]);
+    });
+
+    it('should have the right ordered TransactionLog with multiple parsers',
+      function () {
+        const parser = ParserUtil.combineParsers([
+          idParser,
+          function (state) {
+            return {
+              type: SET,
+              path: 'cmd',
+              value: state.cmd
+            };
+          }
+        ]);
+        const appDefinition = {
+          id: 'test',
+          cmd: 'sleep 100;'
+        };
+        expect(parser(appDefinition)).toEqual([
+          {
+            type: SET,
+            path: 'id',
+            value: 'test'
+          },
+          {
+            type: SET,
+            path: 'cmd',
+            value: 'sleep 100;'
+          }
+        ]);
+      });
+    it('should have the right order for nested parsers', function () {
+      const containerParser = function (state) {
+        if (state.container != null && state.container.docker != null) {
+          return ParserUtil.combineParsers([
+            function (state) {
+              return {
+                type: SET,
+                path: 'container.docker.image',
+                value: state.container.docker.image
+              };
+            }
+          ])(state);
+        }
+        return [];
+      };
+
+      let parser = ParserUtil.combineParsers([
+        idParser,
+        containerParser
+      ]);
+
+      let state = {
+        id: 'docker',
+        container: {
+          docker: {
+            image: 'nginx'
+          }
+        }
+      };
+
+      expect(parser(state)).toEqual([
+        {
+          type: SET,
+          path: 'id',
+          value: 'docker'
+        },
+        {
+          type: SET,
+          path: 'container.docker.image',
+          value: 'nginx'
+        }
+      ]);
+    });
+
+  });
+});


### PR DESCRIPTION
This adds a ParserUtil which contains a function named combineParsers with this function it is possible to create a composable set of parsers which will return a flat list of items. In our use case this will be a set of transactions.

The util can be used like this:

```JS
const parser = ParserUtil.combineParsers([
  function (state) {
    return {
      type: SET,
      path: 'id',
      value: state.id
  },
  function (state) {
    return {
      type: SET,
      path: 'cmd',
      value: state.cmd
    };
  }
]);

const appDefinition = {
  id: 'test',
  cmd: 'sleep 100;'
};

console.log(parser(appDefinition));

// Will resolve into: 
// [
//   {
//     type: SET,
//     path: 'id',
//     value: 'test'
//   },
//   {
//     type: SET,
//     path: 'cmd',
//     value: 'sleep 100;'
//   }
// ]);

```

A more complex example with some nesting is also possible:

```JS
const containerParser = function (state) {
  if (state.container != null && state.container.docker != null) {
    return ParserUtil.combineParsers([
      function (state) {
        return {
          type: SET,
          path: 'container.docker.image',
          value: state.container.docker.image
        };
      }
    ])(state);
  }
  return [];
};

let parser = ParserUtil.combineParsers([
  function (state) {
    return {
      type: SET,
      path: 'id',
      value: state.id
    } 
  },
  containerParser
]);

let state = {
  id: 'docker',
  container: {
    docker: {
      image: 'nginx'
    }
  }
};

console.log(parser(state));

// Will result into:
// [
//   {
//     type: SET,
//     path: 'id',
//     value: 'docker'
//   },
//   {
//     type: SET,
//     path: 'container.docker.image',
//     value: 'nginx'
//   }
// ]
```

This will enable us to have a tree structure of parsers based on conditions. But the result will always be a flat list.