### PR TITLE
DCOS-10490: ServiceSuspendModal: Properly handling error responses

### DIFF
--- a/src/js/components/modals/ServiceRestartModal.js
+++ b/src/js/components/modals/ServiceRestartModal.js
@@ -21,8 +21,24 @@ class ServiceRestartModal extends ServiceActionModal {
       }
     ];
 
-    this.onMarathonStoreServiceRestartError = this.onError;
     this.onMarathonStoreServiceRestartSuccess = this.closeDialog;
+  }
+
+  onMarathonStoreServiceRestartError({message:errorMsg = '', details}) {
+    let hasDetails = details && details.length !== 0;
+
+    if (hasDetails) {
+      this.setState({
+        errorMsg: details.reduce(function (memo, error) {
+
+          return `${memo} ${error.errors.join(' ')}`;
+        }, '')
+      });
+
+      return;
+    }
+
+    this.onError(errorMsg);
   }
 
   handleConfirmClick() {

--- a/src/js/components/modals/ServiceRestartModal.js
+++ b/src/js/components/modals/ServiceRestartModal.js
@@ -30,8 +30,9 @@ class ServiceRestartModal extends ServiceActionModal {
     if (hasDetails) {
       this.setState({
         errorMsg: details.reduce(function (memo, error) {
-
-          return `${memo} ${error.errors.join(' ')}`;
+          if (error != null && Array.isArray(error.errors)) {
+            return `${memo} ${error.errors.join(' ')}`;
+          }
         }, '')
       });
 

--- a/src/js/components/modals/ServiceSuspendModal.js
+++ b/src/js/components/modals/ServiceSuspendModal.js
@@ -44,8 +44,9 @@ class ServiceSuspendModal extends ServiceActionModal {
     if (hasDetails) {
       this.setState({
         errorMsg: details.reduce(function (memo, error) {
-
-          return `${memo} ${error.errors.join(' ')}`;
+          if (error != null && Array.isArray(error.errors)) {
+            return `${memo} ${error.errors.join(' ')}`;
+          }
         }, '')
       });
 

--- a/src/js/components/modals/ServiceSuspendModal.js
+++ b/src/js/components/modals/ServiceSuspendModal.js
@@ -26,11 +26,33 @@ class ServiceSuspendModal extends ServiceActionModal {
       }
     ];
 
-    this.onMarathonStoreServiceEditError = this.onError;
     this.onMarathonStoreServiceEditSuccess = this.closeDialog;
-    this.onMarathonStoreGroupEditError = this.onError;
-    this.onMarathonStoreGroupEditSuccess =
-      this.onMarathonStoreServiceEditSuccess;
+    this.onMarathonStoreGroupEditSuccess = this.closeDialog;
+  }
+
+  onMarathonStoreServiceEditError() {
+    this.onMarathonStoreServiceOrGroupEditError.apply(this, arguments);
+  }
+
+  onMarathonStoreGroupEditError() {
+    this.onMarathonStoreServiceOrGroupEditError.apply(this, arguments);
+  }
+
+  onMarathonStoreServiceOrGroupEditError({message:errorMsg = '', details}) {
+    let hasDetails = details && details.length !== 0;
+
+    if (hasDetails) {
+      this.setState({
+        errorMsg: details.reduce(function (memo, error) {
+
+          return `${memo} ${error.errors.join(' ')}`;
+        }, '')
+      });
+
+      return;
+    }
+
+    this.onError(errorMsg);
   }
 
   handleConfirmClick() {


### PR DESCRIPTION
This PR fixes the error handling on the `ServiceSuspendModal`. Previously, when a service/pod was in a deploying state and a user clicks `Suspend`, the UI was just greying-out.

_Taking the opportunity to fix the same issue with the `ServiceRestartModal` on the services_
