### PR TITLE
DCOS-10470 [DSL 1]: Adding grammar support

### DIFF
--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -1,19 +1,25 @@
 var babel = require('babel-core');
 var jestPreset = require('babel-preset-jest');
+var jison = require('jison');
 var webpackAlias = require('jest-webpack-alias');
 
 module.exports = {
   // Gets called by jest during test prep for every module.
   // src is the raw module content as a String.
   process: function (src, filename) {
+    var isJISON = filename.match(/\.jison$/i);
     // Don't bother doing anything to node_modules
     if (filename.indexOf('node_modules') === -1 || filename.indexOf('node_modules/dcos-dygraphs') > -1) {
       // Don't load image data - it can't be parsed by jest.
       if (filename.match(/\.(jpe?g|png|gif|bmp|svg|less)$/i)) {
         return '';
       }
+      // Use JISON generator for JISON grammar
+      if (isJISON) {
+        src = (new jison.Generator(src)).generate();
+      }
       // Run our modules through Babel before running tests
-      if (babel.util.canCompile(filename)) {
+      if (babel.util.canCompile(filename) || isJISON) {
         src = babel.transform(src, {
           auxiliaryCommentBefore: ' istanbul ignore next ',
           filename,

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "jasmine-reporters": "2.1.1",
     "jest-cli": "16.0.2",
     "jest-webpack-alias": "3.3.0",
-    "jison-loader": "^1.0.0",
+    "jison-loader": "1.0.0",
     "json-loader": "0.5.4",
     "less": "2.6.1",
     "less-loader": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "jasmine-reporters": "2.1.1",
     "jest-cli": "16.0.2",
     "jest-webpack-alias": "3.3.0",
+    "jison-loader": "^1.0.0",
     "json-loader": "0.5.4",
     "less": "2.6.1",
     "less-loader": "2.2.3",

--- a/src/js/constants/DSLCombinerTypes.js
+++ b/src/js/constants/DSLCombinerTypes.js
@@ -1,0 +1,9 @@
+/**
+ * Different types of combiners (operators) in a DSL expression
+ */
+const COMBINER_TYPES = {
+  AND: 1,
+  OR: 2
+};
+
+module.exports = COMBINER_TYPES;

--- a/src/js/constants/DSLFilterTypes.js
+++ b/src/js/constants/DSLFilterTypes.js
@@ -1,0 +1,10 @@
+/**
+ * Different types of filters (operands) in a DSL expression
+ */
+const FILTER_TYPES = {
+  ATTRIB: 1,
+  EXACT: 2,
+  FUZZY: 3
+};
+
+module.exports = FILTER_TYPES;

--- a/src/js/structs/DSLASTNodes.js
+++ b/src/js/structs/DSLASTNodes.js
@@ -2,6 +2,12 @@
  * Base class for AST nodes in DSL, representing a token in the user input
  */
 class ASTNode {
+
+  /**
+   * @param {number} start - The starting point of the token in the input string
+   * @param {number} end - The ending point of the token in the input string
+   * @param {ASTNode[]} children - Child nodes to this node
+   */
   constructor(start, end, children=[]) {
 
     /**
@@ -30,6 +36,12 @@ class ASTNode {
  * Combiner (operator) AST node
  */
 class CombinerNode extends ASTNode {
+
+  /**
+   * @param {DSLCombinerTypes} combinerType - The combiner type (AND, OR)
+   * @param {ASTNode} child1 - The left-side operator
+   * @param {ASTNode} child2 - The right-side operator
+   */
   constructor(combinerType, child1, child2) {
     super(
       child1.position[0][0],
@@ -49,6 +61,13 @@ class CombinerNode extends ASTNode {
  * Filter (operand) AST node
  */
 class FilterNode extends ASTNode {
+
+  /**
+   * @param {number} start - The starting point of the token in the input string
+   * @param {number} end - The ending point of the token in the input string
+   * @param {DSLFilterTypes} filterType - The filter type (ATTRIB, EXACT, FUZZY)
+   * @param {Object} filterParams - Arbitrary parameters to the filter (ex. text)
+   */
   constructor(start, end, filterType, filterParams) {
     super(start, end);
     /**

--- a/src/js/structs/DSLASTNodes.js
+++ b/src/js/structs/DSLASTNodes.js
@@ -1,0 +1,74 @@
+/**
+ * Base class for AST nodes in DSL, representing a token in the user input
+ */
+class ASTNode {
+  constructor(start, end, children=[]) {
+
+    /**
+     * The position array contains an array of tuples, containing the start-end
+     * position of each relevant text portions that composes this token.
+     *
+     * In 99.9% of the cases, this is an array with only 1 tuple. However, when
+     * the `attrib:value1,value2` shorthand is used, this array will contain
+     * 2 tuples, pointing to the `attrib:` and `valueX` parts separately.
+     *
+     * @var {Array}
+     */
+    this.position = [[start, end]];
+
+    /**
+     * Child tokens in this token tree
+     *
+     * @var {Array}
+     */
+    this.children = children;
+
+  }
+}
+
+/**
+ * Combiner (operator) AST node
+ */
+class CombinerNode extends ASTNode {
+  constructor(combinerType, child1, child2) {
+    super(
+      child1.position[0][0],
+      child2.position[child2.position.length-1][1],
+      [child1, child2]
+    );
+
+    /**
+     * The type of the combiner
+     * @var {Number}
+     */
+    this.combinerType = combinerType;
+  }
+}
+
+/**
+ * Filter (operand) AST node
+ */
+class FilterNode extends ASTNode {
+  constructor(start, end, filterType, filterParams) {
+    super(start, end);
+    /**
+     * The type of the filter
+     * @var {Number}
+     */
+    this.filterType = filterType;
+
+    /**
+     * The parameters to the filter
+     * @var {{text, [label]}}
+     */
+    this.filterParams = filterParams;
+  }
+}
+
+/**
+ * Expose the leaf nodes that can be used in more than one place
+ */
+module.exports = {
+  CombinerNode,
+  FilterNode
+};

--- a/src/js/structs/DSLASTNodes.js
+++ b/src/js/structs/DSLASTNodes.js
@@ -33,7 +33,7 @@ class CombinerNode extends ASTNode {
   constructor(combinerType, child1, child2) {
     super(
       child1.position[0][0],
-      child2.position[child2.position.length-1][1],
+      child2.position[child2.position.length - 1][1],
       [child1, child2]
     );
 

--- a/src/js/utils/DSLParserUtil.js
+++ b/src/js/utils/DSLParserUtil.js
@@ -14,7 +14,9 @@ import {FilterNode, CombinerNode} from '../structs/DSLASTNodes';
  * in this context, while the `resultset` is an instance of `List` or `Tree` on
  * which the filers have to be applied.
  *
+ * @private
  * @this CombinerNode
+ *
  * @param {function} [filter1] - The first child filter function (auto-bound)
  * @param {function} [filter2] - The second child filter function (auto-bound)
  * @param {Object} filters - An object containing the valid filters that can be used
@@ -22,7 +24,7 @@ import {FilterNode, CombinerNode} from '../structs/DSLASTNodes';
  *
  * @returns {List} - Returns the filtered resultset
  */
-function combine_fn(filter1, filter2, filters, resultset) {
+function combineTemplateFn(filter1, filter2, filters, resultset) {
   let intermediateResultset;
 
   switch (this.combinerType) {
@@ -57,13 +59,15 @@ function combine_fn(filter1, filter2, filters, resultset) {
  * in this context, while the `resultset` is an instance of `List` or `Tree` on
  * which the filers have to be applied.
  *
+ * @private
  * @this FilterNode
+ *
  * @param {Object} filters - An object containing the valid filters that can be used
  * @param {List} resultset - An instance of List or Tree containing the items to filter
  *
  * @returns {List} - Returns the filtered resultset
  */
-function filter_fn(filters, resultset) {
+function filterTemplateFn(filters, resultset) {
 
   // TODO: Lookup in `filters` object one or more valid filters that can be
   //       applied on the bound token. We can use the `this.filterType` and
@@ -76,99 +80,119 @@ function filter_fn(filters, resultset) {
 /**
  * The following functions are used by the JISON parser in order to parse
  * the expression into a properly nested set of functions and AST nodes.
+ *
+ * @name DSLParserUtil
  */
 module.exports = {
 
   /**
-   * Combines two filter functions using the AND operator
+   * Namespace for the merge operator
    *
-   * @param {Function} f1 - The first operation function
-   * @param {Function} f2 - The second operation function
-   *
-   * @returns {Function} Returns a combined filter function
+   * @namesapce
    */
-  merge_and(f1, f2) {
-    let ast = new CombinerNode(DSLCombinerTypes.AND, f1.ast, f2.ast);
+  Merge: {
 
-    return {
-      filter: combine_fn.bind(ast, f1.filter, f2.filter),
-      ast
-    };
+    /**
+     * Combines two filter functions using the AND operator
+     *
+     * @param {Function} f1 - The first operation function
+     * @param {Function} f2 - The second operation function
+     *
+     * @returns {Function} Returns a combined filter function
+     */
+    and(f1, f2) {
+      let ast = new CombinerNode(DSLCombinerTypes.AND, f1.ast, f2.ast);
+
+      return {
+        filter: combineTemplateFn.bind(ast, f1.filter, f2.filter),
+        ast
+      };
+    },
+
+    /**
+     * Combines two filter functions using the OR operator
+     *
+     * @param {Function} f1 - The first operation function
+     * @param {Function} f2 - The second operation function
+     *
+     * @returns {Function} Returns a combined filter function
+     */
+    or(f1, f2) {
+      let ast = new CombinerNode(DSLCombinerTypes.OR, f1.ast, f2.ast);
+
+      return {
+        filter: combineTemplateFn.bind(ast, f1.filter, f2.filter),
+        ast
+      };
+    }
+
   },
 
   /**
-   * Combines two filter functions using the OR operator
+   * Operator namespace
    *
-   * @param {Function} f1 - The first operation function
-   * @param {Function} f2 - The second operation function
-   *
-   * @returns {Function} Returns a combined filter function
+   * @namesapce
    */
-  merge_or(f1, f2) {
-    let ast = new CombinerNode(DSLCombinerTypes.OR, f1.ast, f2.ast);
+  Operator: {
 
-    return {
-      filter: combine_fn.bind(ast, f1.filter, f2.filter),
-      ast
-    };
-  },
+    /**
+     * Return filter function for an attribute operator
+     *
+     * @param {String} label - The attribute label
+     * @param {String} text - The attribute value
+     * @param {Number} lstart - The starting position of the label token
+     * @param {Number} lend - The ending position of the label token
+     * @param {Number} vstart - The starting position of the value token
+     * @param {Number} vend - The ending position of the value token
+     *
+     * @returns {Function} Returns a filter function
+     */
+    attrib(label, text, lstart, lend, vstart, vend) {
+      let ast = new FilterNode(lstart, lend, DSLFilterTypes.ATTRIB, {text, label});
+      ast.position.push([vstart, vend]);
 
-  /**
-   * Return filter function for an attribute operator
-   *
-   * @param {String} label - The attribute label
-   * @param {String} text - The attribute value
-   * @param {Number} lstart - The starting position of the label token
-   * @param {Number} lend - The ending position of the label token
-   * @param {Number} vstart - The starting position of the value token
-   * @param {Number} vend - The ending position of the value token
-   *
-   * @returns {Function} Returns a filter function
-   */
-  op_attrib(label, text, lstart, lend, vstart, vend) {
-    let ast = new FilterNode(lstart, lend, DSLFilterTypes.ATTRIB, {text, label});
-    ast.position.push([vstart, vend]);
+      return {
+        filter: filterTemplateFn.bind(ast),
+        ast
+      };
+    },
 
-    return {
-      filter: filter_fn.bind(ast),
-      ast
-    };
-  },
+    /**
+     * Return a filter function for exact string matching
+     *
+     * @param {String} text - The fuzzy filter text input
+     * @param {Number} start - The starting position of the filter token
+     * @param {Number} end - The ending position of the filter token
+     *
+     * @returns {Function} Returns a filter function
+     */
+    exact(text, start, end) {
+      let ast = new FilterNode(start, end, DSLFilterTypes.EXACT, {text});
 
-  /**
-   * Return a filter function for exact string matching
-   *
-   * @param {String} text - The fuzzy filter text input
-   * @param {Number} start - The starting position of the filter token
-   * @param {Number} end - The ending position of the filter token
-   *
-   * @returns {Function} Returns a filter function
-   */
-  op_exact(text, start, end) {
-    let ast = new FilterNode(start, end, DSLFilterTypes.EXACT, {text});
+      return {
+        filter: filterTemplateFn.bind(ast),
+        ast
+      };
+    },
 
-    return {
-      filter: filter_fn.bind(ast),
-      ast
-    };
-  },
+    /**
+     * Return a filter function for fuzzy-text matching
+     *
+     * @param {String} text - The fuzzy filter text input
+     * @param {Number} start - The starting position of the filter token
+     * @param {Number} end - The ending position of the filter token
+     *
+     * @returns {Function} Returns a filter function
+     */
+    fuzzy(text, start, end) {
+      let ast = new FilterNode(start, end, DSLFilterTypes.FUZZY, {text});
 
-  /**
-   * Return a filter function for fuzzy-text matching
-   *
-   * @param {String} text - The fuzzy filter text input
-   * @param {Number} start - The starting position of the filter token
-   * @param {Number} end - The ending position of the filter token
-   *
-   * @returns {Function} Returns a filter function
-   */
-  op_fuzzy(text, start, end) {
-    let ast = new FilterNode(start, end, DSLFilterTypes.FUZZY, {text});
+      return {
+        filter: filterTemplateFn.bind(ast),
+        ast
+      };
+    }
 
-    return {
-      filter: filter_fn.bind(ast),
-      ast
-    };
   }
 
 };

--- a/src/js/utils/DSLParserUtil.js
+++ b/src/js/utils/DSLParserUtil.js
@@ -1,0 +1,174 @@
+import DSLFilterTypes from '../constants/DSLFilterTypes';
+import DSLCombinerTypes from '../constants/DSLCombinerTypes';
+import {FilterNode, CombinerNode} from '../structs/DSLASTNodes';
+
+/**
+ * Template function for combining two filters, used by the parser
+ *
+ * When this function is 'instantiated', the first two arguments are bound by
+ * the parser to the child filter functions (see below) and the `this` context
+ * to an instance of a `CombinerNode` representing the token AST node.
+ *
+ * When this function is used, the user has to supply the final two arguments.
+ * The `filters` object is a library with the available filters that can be used
+ * in this context, while the `resultset` is an instance of `List` or `Tree` on
+ * which the filers have to be applied.
+ *
+ * @this CombinerNode
+ * @param {function} [filter1] - The first child filter function (auto-bound)
+ * @param {function} [filter2] - The second child filter function (auto-bound)
+ * @param {Object} filters - An object containing the valid filters that can be used
+ * @param {List} resultset - An instance of List or Tree containing the items to filter
+ *
+ * @returns {List} - Returns the filtered resultset
+ */
+function combine_fn(filter1, filter2, filters, resultset) {
+  let intermediateResultset;
+
+  switch (this.combinerType) {
+    case DSLCombinerTypes.AND:
+      // We are interested in the intersection of the results of the two filters
+      intermediateResultset = filter1(filters, resultset);
+      return filter2(filters, intermediateResultset);
+      break;
+
+    case DSLCombinerTypes.OR:
+      // We are interested in the union of the results of the two filters
+
+      // TODO: Merge the results of `filter1(filters, resultset)` and
+      //       `filter2(filters, resultset)`.
+
+      // TODO: Implement a `List.merge` function that merges two lists,
+      //       discarding duplicate values.
+
+      return resultset;
+      break;
+  }
+}
+
+/**
+ * Template function for filtering a resultset, used by the parser
+ *
+ * When this function is 'instantiated' by the parser, `this` context
+ * is bound to an instance of a `FilterNode` representing the token AST node.
+ *
+ * When this function is used, the user has to supply the final two arguments.
+ * The `filters` object is a library with the available filters that can be used
+ * in this context, while the `resultset` is an instance of `List` or `Tree` on
+ * which the filers have to be applied.
+ *
+ * @this FilterNode
+ * @param {Object} filters - An object containing the valid filters that can be used
+ * @param {List} resultset - An instance of List or Tree containing the items to filter
+ *
+ * @returns {List} - Returns the filtered resultset
+ */
+function filter_fn(filters, resultset) {
+
+  // TODO: Lookup in `filters` object one or more valid filters that can be
+  //       applied on the bound token. We can use the `this.filterType` and
+  //       `this.filterParams` for this purpose. Then apply them on the
+  //       resultset, keeping only the matched results.
+
+  return resultset;
+}
+
+/**
+ * The following functions are used by the JISON parser in order to parse
+ * the expression into a properly nested set of functions and AST nodes.
+ */
+module.exports = {
+
+  /**
+   * Combines two filter functions using the AND operator
+   *
+   * @param {Function} f1 - The first operation function
+   * @param {Function} f2 - The second operation function
+   *
+   * @returns {Function} Returns a combined filter function
+   */
+  merge_and(f1, f2) {
+    let ast = new CombinerNode(DSLCombinerTypes.AND, f1.ast, f2.ast);
+
+    return {
+      filter: combine_fn.bind(ast, f1.filter, f2.filter),
+      ast
+    };
+  },
+
+  /**
+   * Combines two filter functions using the OR operator
+   *
+   * @param {Function} f1 - The first operation function
+   * @param {Function} f2 - The second operation function
+   *
+   * @returns {Function} Returns a combined filter function
+   */
+  merge_or(f1, f2) {
+    let ast = new CombinerNode(DSLCombinerTypes.OR, f1.ast, f2.ast);
+
+    return {
+      filter: combine_fn.bind(ast, f1.filter, f2.filter),
+      ast
+    };
+  },
+
+  /**
+   * Return filter function for an attribute operator
+   *
+   * @param {String} label - The attribute label
+   * @param {String} text - The attribute value
+   * @param {Number} lstart - The starting position of the label token
+   * @param {Number} lend - The ending position of the label token
+   * @param {Number} vstart - The starting position of the value token
+   * @param {Number} vend - The ending position of the value token
+   *
+   * @returns {Function} Returns a filter function
+   */
+  op_attrib(label, text, lstart, lend, vstart, vend) {
+    let ast = new FilterNode(lstart, lend, DSLFilterTypes.ATTRIB, {text, label});
+    ast.position.push([vstart, vend]);
+
+    return {
+      filter: filter_fn.bind(ast),
+      ast
+    };
+  },
+
+  /**
+   * Return a filter function for exact string matching
+   *
+   * @param {String} text - The fuzzy filter text input
+   * @param {Number} start - The starting position of the filter token
+   * @param {Number} end - The ending position of the filter token
+   *
+   * @returns {Function} Returns a filter function
+   */
+  op_exact(text, start, end) {
+    let ast = new FilterNode(start, end, DSLFilterTypes.EXACT, {text});
+
+    return {
+      filter: filter_fn.bind(ast),
+      ast
+    };
+  },
+
+  /**
+   * Return a filter function for fuzzy-text matching
+   *
+   * @param {String} text - The fuzzy filter text input
+   * @param {Number} start - The starting position of the filter token
+   * @param {Number} end - The ending position of the filter token
+   *
+   * @returns {Function} Returns a filter function
+   */
+  op_fuzzy(text, start, end) {
+    let ast = new FilterNode(start, end, DSLFilterTypes.FUZZY, {text});
+
+    return {
+      filter: filter_fn.bind(ast),
+      ast
+    };
+  }
+
+};

--- a/src/resources/grammar/SearchDSL.jison
+++ b/src/resources/grammar/SearchDSL.jison
@@ -1,8 +1,7 @@
 /* description: Parses end executes mathematical expressions. */
 
 %{
-const {merge_and, merge_or, op_fuzzy, op_attrib, op_exact}
-    = require('../../js/utils/DSLParserUtil');
+const {Merge, Operator} = require('../../js/utils/DSLParserUtil');
 %}
 
 /* lexical grammar */
@@ -42,27 +41,27 @@ lv  /* Label value(s) as an array */
 
 e   /* Operators */
     : e WS e
-        {$$ = merge_and($1, $3);}
+        {$$ = Merge.and($1, $3);}
     | e COMMA e
-        {$$ = merge_or($1, $3);}
+        {$$ = Merge.or($1, $3);}
 
     | '(' e ')'
         {$$ = $2;}
 
     /* Simple operands */
     | LITERAL
-        {$$ = op_fuzzy(yytext, @1.first_column, @1.last_column);}
+        {$$ = Operator.fuzzy(yytext, @1.first_column, @1.last_column);}
     | STRING
-        {$$ = op_exact(yytext, @1.first_column, @1.last_column);}
+        {$$ = Operator.exact(yytext, @1.first_column, @1.last_column);}
 
     /* Label operand */
     | LABEL lv
         /* NOTE: We expand the comma-separated list of values as individual
                  label:value tokens, combined with an OR operator */
         {$$ = $2.reduce(function (last_fn, v) {
-            let fn = op_attrib($1, v.text, @1.first_column, @1.last_column, v.start, v.end);
+            let fn = Operator.attrib($1, v.text, @1.first_column, @1.last_column, v.start, v.end);
             if (last_fn) {
-                return merge_or(last_fn, fn);
+                return Merge.or(last_fn, fn);
             } else {
                 return fn;
             }

--- a/src/resources/grammar/SearchDSL.jison
+++ b/src/resources/grammar/SearchDSL.jison
@@ -1,0 +1,74 @@
+/* description: Parses end executes mathematical expressions. */
+
+%{
+const {merge_and, merge_or, op_fuzzy, op_attrib, op_exact}
+    = require('../../js/utils/DSLParserUtil');
+%}
+
+/* lexical grammar */
+%lex
+
+%%
+\s+                                                 return 'WS';
+\s*[,]\s*                                           return 'COMMA';
+[a-z0-9_-]+\:          yytext=yytext.slice(0,-1);   return 'LABEL';
+\"(?:[^\"\\]|\\.)*?\"  yytext=yytext.slice(1,-1);   return 'STRING';
+\'(?:[^\'\\]|\\.)*?\'  yytext=yytext.slice(1,-1);   return 'STRING';
+[^\s\(\)\:,]+                                       return 'LITERAL';
+"("                                                 return '(';
+")"                                                 return ')';
+<<EOF>>                                             return 'EOF';
+
+/lex /* operator associations and precedence */
+
+%left 'COMMA' 'WS'
+%start expressions
+
+%% /* language grammar */
+
+expressions /* Root expression with termination condition */
+    : e EOF
+        {return $1;}
+    ;
+
+lv  /* Label value(s) as an array */
+    : LITERAL
+        {$$ = [{text:yytext, start:@1.first_column, end:@1.last_column}];}
+    | STRING
+        {$$ = [{text:yytext, start:@1.first_column, end:@1.last_column}];}
+    | lv COMMA lv
+        {$$ = [].concat($1, $3);}
+    ;
+
+e   /* Operators */
+    : e WS e
+        {$$ = merge_and($1, $3);}
+    | e COMMA e
+        {$$ = merge_or($1, $3);}
+
+    | '(' e ')'
+        {$$ = $2;}
+
+    /* Simple operands */
+    | LITERAL
+        {$$ = op_fuzzy(yytext, @1.first_column, @1.last_column);}
+    | STRING
+        {$$ = op_exact(yytext, @1.first_column, @1.last_column);}
+
+    /* Label operand */
+    | LABEL lv
+        /* NOTE: We expand the comma-separated list of values as individual
+                 label:value tokens, combined with an OR operator */
+        {$$ = $2.reduce(function (last_fn, v) {
+            let fn = op_attrib($1, v.text, @1.first_column, @1.last_column, v.start, v.end);
+            if (last_fn) {
+                return merge_or(last_fn, fn);
+            } else {
+                return fn;
+            }
+        }, null);}
+
+    /* Label value */
+    | LABEL
+        {$$ = yytext;}
+    ;

--- a/src/resources/grammar/SearchDSL.jison
+++ b/src/resources/grammar/SearchDSL.jison
@@ -60,7 +60,7 @@ e   /* Operators */
         /* NOTE: We expand the comma-separated list of values as individual
                  label:value tokens, combined with an OR operator */
         {$$ = $2.reduce(function (last_fn, v) {
-            let fn = Operator.attrib($1, v.text, @1.first_column, @1.last_column, v.start, v.end);
+            let fn = Operator.attribute($1, v.text, @1.first_column, @1.last_column, v.start, v.end);
             if (last_fn) {
                 return Merge.or(last_fn, fn);
             } else {

--- a/src/resources/grammar/SearchDSL.jison
+++ b/src/resources/grammar/SearchDSL.jison
@@ -1,4 +1,5 @@
-/* description: Parses end executes mathematical expressions. */
+/* Description: Parses and generates AST + Combined Filter Function from a    */
+/*              common filter description language.                           */
 
 %{
 const {Merge, Operator} = require('../../js/utils/DSLParserUtil');

--- a/src/resources/grammar/__tests__/SearchDSL-test.js
+++ b/src/resources/grammar/__tests__/SearchDSL-test.js
@@ -16,11 +16,13 @@ describe('SearchDSL', function () {
         expect(expr.ast.filterType).toEqual(DSLFilterTypes.FUZZY);
         expect(expr.ast.filterParams.text).toEqual('fuzzy');
       });
+
       it('should parse exact text', function () {
         let expr = SearchDSL.parse('"exact string"');
         expect(expr.ast.filterType).toEqual(DSLFilterTypes.EXACT);
         expect(expr.ast.filterParams.text).toEqual('exact string');
       });
+
       it('should parse attributes', function () {
         let expr = SearchDSL.parse('attrib:value');
         expect(expr.ast.filterType).toEqual(DSLFilterTypes.ATTRIB);

--- a/src/resources/grammar/__tests__/SearchDSL-test.js
+++ b/src/resources/grammar/__tests__/SearchDSL-test.js
@@ -1,0 +1,158 @@
+jest.dontMock('../SearchDSL.jison');
+jest.dontMock('../../../js/utils/DSLParserUtil');
+
+const SearchDSL = require('../SearchDSL.jison');
+const DSLFilterTypes = require('../../../js/constants/DSLFilterTypes');
+const DSLCombinerTypes = require('../../../js/constants/DSLCombinerTypes');
+
+describe('SearchDSL', function () {
+
+  describe('Metadata', function () {
+
+    describe('Filters (Operands)', function () {
+
+      it('should parse fuzzy text', function () {
+        let expr = SearchDSL.parse('fuzzy');
+        expect(expr.ast.filterType).toEqual(DSLFilterTypes.FUZZY);
+        expect(expr.ast.filterParams.text).toEqual('fuzzy');
+      });
+      it('should parse exact text', function () {
+        let expr = SearchDSL.parse('"exact string"');
+        expect(expr.ast.filterType).toEqual(DSLFilterTypes.EXACT);
+        expect(expr.ast.filterParams.text).toEqual('exact string');
+      });
+      it('should parse attributes', function () {
+        let expr = SearchDSL.parse('attrib:value');
+        expect(expr.ast.filterType).toEqual(DSLFilterTypes.ATTRIB);
+        expect(expr.ast.filterParams.text).toEqual('value');
+        expect(expr.ast.filterParams.label).toEqual('attrib');
+      });
+
+    });
+
+    describe('Combiners (Operators)', function () {
+
+      it('should use AND operator by default', function () {
+        let expr = SearchDSL.parse('text1 text2');
+        expect(expr.ast.combinerType).toEqual(DSLCombinerTypes.AND);
+      });
+
+      it('should properly use OR operator', function () {
+        let expr = SearchDSL.parse('text1, text2');
+        expect(expr.ast.combinerType).toEqual(DSLCombinerTypes.OR);
+      });
+
+      it('should properly use OR shorthand operator on attrib', function () {
+        // NOTE: attrib:value1,value2 becomes -> attrib:value1, attrib:value2
+        let expr = SearchDSL.parse('attrib:value1,value2');
+        expect(expr.ast.combinerType).toEqual(DSLCombinerTypes.OR);
+        expect(expr.ast.children[0].filterType).toEqual(DSLFilterTypes.ATTRIB);
+        expect(expr.ast.children[0].filterParams.text).toEqual('value1');
+        expect(expr.ast.children[0].filterParams.label).toEqual('attrib');
+        expect(expr.ast.children[1].filterType).toEqual(DSLFilterTypes.ATTRIB);
+        expect(expr.ast.children[1].filterParams.text).toEqual('value2');
+        expect(expr.ast.children[1].filterParams.label).toEqual('attrib');
+      });
+
+      it('should correctly populate children', function () {
+        let expr = SearchDSL.parse('text1 text2');
+        expect(expr.ast.children[0].filterType).toEqual(DSLFilterTypes.FUZZY);
+        expect(expr.ast.children[0].filterParams.text).toEqual('text1');
+        expect(expr.ast.children[1].filterType).toEqual(DSLFilterTypes.FUZZY);
+        expect(expr.ast.children[1].filterParams.text).toEqual('text2');
+      });
+
+    });
+
+    describe('Complex expressions', function () {
+
+      it('should nest operations in correct order', function () {
+        let expr = SearchDSL.parse('text1 text2, (text3 (text4 text5), text6)');
+
+        // .       : [text1 text2] OR [(text3 (text4 text5), text6)]
+        expect(expr.ast.combinerType)
+          .toEqual(DSLCombinerTypes.OR);
+
+        // .0      : [text1] AND [text2]
+        expect(expr.ast.children[0].combinerType)
+          .toEqual(DSLCombinerTypes.AND);
+
+        // .0.0    : text1
+        expect(expr.ast.children[0].children[0].filterType)
+          .toEqual(DSLFilterTypes.FUZZY);
+        expect(expr.ast.children[0].children[0].filterParams.text)
+          .toEqual('text1');
+
+        // .0.1    : text2
+        expect(expr.ast.children[0].children[1].filterType)
+          .toEqual(DSLFilterTypes.FUZZY);
+        expect(expr.ast.children[0].children[1].filterParams.text)
+          .toEqual('text2');
+
+        // .1      : [text3 (text4 text5)] OR [text6]
+        expect(expr.ast.children[1].combinerType)
+          .toEqual(DSLCombinerTypes.OR);
+
+        // .1.0    : [text3] AND [text4 text5]
+        expect(expr.ast.children[1].children[0].combinerType)
+          .toEqual(DSLCombinerTypes.AND);
+
+        // .1.0.0  : text3
+        expect(expr.ast.children[1].children[0].children[0].filterType)
+          .toEqual(DSLFilterTypes.FUZZY);
+        expect(expr.ast.children[1].children[0].children[0].filterParams.text)
+          .toEqual('text3');
+
+        // .1.0.1  : [text4] AND [text5]
+        expect(expr.ast.children[1].children[0].children[1].combinerType)
+          .toEqual(DSLCombinerTypes.AND);
+
+        // .1.0.1.0: text4
+        expect(expr.ast.children[1].children[0].children[1].children[0]
+          .filterType).toEqual(DSLFilterTypes.FUZZY);
+        expect(expr.ast.children[1].children[0].children[1].children[0]
+          .filterParams.text).toEqual('text4');
+
+        // .1.0.1.1: text5
+        expect(expr.ast.children[1].children[0].children[1].children[1]
+          .filterType).toEqual(DSLFilterTypes.FUZZY);
+        expect(expr.ast.children[1].children[0].children[1].children[1]
+          .filterParams.text).toEqual('text5');
+
+        // .1.1    : text6
+        expect(expr.ast.children[1].children[1].filterType)
+          .toEqual(DSLFilterTypes.FUZZY);
+        expect(expr.ast.children[1].children[1].filterParams.text)
+          .toEqual('text6');
+
+      });
+
+    });
+
+    describe('Token positions', function () {
+
+      it('should properly track location of fuzzy text', function () {
+        let expr = SearchDSL.parse('fuzzy');
+        expect(expr.ast.position).toEqual([[0, 5]]);
+      });
+
+      it('should properly track location of exact text', function () {
+        let expr = SearchDSL.parse('"exact string"');
+        expect(expr.ast.position).toEqual([[0, 14]]);
+      });
+
+      it('should properly track location of attrib', function () {
+        let expr = SearchDSL.parse('attrib:value');
+        expect(expr.ast.position).toEqual([[0, 7], [7, 12]]);
+      });
+
+      it('should properly track location of attrib with multi values', function () {
+        let expr = SearchDSL.parse('attrib:value1,value2');
+        expect(expr.ast.children[1].position).toEqual([[0, 7], [14, 20]]);
+      });
+
+    });
+
+  });
+
+});

--- a/webpack/webpack.config.babel.js
+++ b/webpack/webpack.config.babel.js
@@ -145,6 +145,10 @@ module.exports = {
         loader: 'json-loader'
       },
       {
+        test: /\.jison$/,
+        loader: 'jison-loader'
+      },
+      {
         test: /\.(ico|icns)$/,
         loader: 'file?name=./[hash]-[name].[ext]',
       },
@@ -184,6 +188,10 @@ module.exports = {
         })
       }
     ]
+  },
+
+  node: {
+    fs: 'empty'
   },
 
   postcss: [autoprefixer],


### PR DESCRIPTION
This PR introduces the Dynamic Search Language (DSL) grammar and parser based on JISON. More PRs are about to come that will use this base implementation.

### Pending Features
- Pluggable architecture for the search plugins ([placeholder](https://github.com/dcos/dcos-ui/pull/1299/files#diff-e09e16137d96dd9c89e78576433d8e1bR68))
- Adding support for merging 2 lists and de-duplicating their contents ([placeholder](https://github.com/dcos/dcos-ui/pull/1299/files#diff-e09e16137d96dd9c89e78576433d8e1bR41))

### Current Features
- The DSL grammar as a JISON specification
- The `DSLParserUtil` that exposes the functions used by JISON to compose the AST
- Constants and structures shared by the `DSLParserUtil` and the parser users

#### Grammar Operands
1. `text` : Fuzzy text matching
2. `"text"` : Exact string matching
3. `attrib:value` : Attribute-based matching

#### Grammar Operators
1. `<whitespace>` : AND. Example: `fuzzy1 fuzzy2`
2. `,` : OR. Example `fuzzy1, fuzzy2`

#### Grammar expressions
1. Nesting with `( )` : `operator "operator" (attrib:value1 attrib:value2, (fuzzy fuzzy))`
2. Shorthand for multiple values on an attribute `attrib:val1,val2` => `attrib:val1, attrib:val2`
