### PR TITLE
DCOS-11060: Adjust the DCOSStore data received flags

### DIFF
--- a/src/js/pages/DashboardPage.js
+++ b/src/js/pages/DashboardPage.js
@@ -203,7 +203,7 @@ var DashboardPage = React.createClass({
               heading={this.getHeading('Services Health')}
               headingClass="panel-header panel-header-bottom-border inverse short-top short-bottom">
               <ServiceList
-                healthProcessed={DCOSStore.dataProcessed}
+                healthProcessed={DCOSStore.serviceDataReceived}
                 services={this.getServicesList()} />
               {this.getViewAllServicesBtn()}
             </Panel>

--- a/src/js/pages/__tests__/DeploymentsTab-test.js
+++ b/src/js/pages/__tests__/DeploymentsTab-test.js
@@ -41,7 +41,7 @@ describe('DeploymentsTab', function () {
         }
       ]
     });
-    DCOSStore.dataProcessed = true;
+    DCOSStore.serviceDataReceived = true;
     DCOSStore.deploymentsList = deployments;
     this.container = document.createElement('div');
     this.instance = ReactDOM.render(

--- a/src/js/pages/__tests__/JobsTab-test.js
+++ b/src/js/pages/__tests__/JobsTab-test.js
@@ -26,7 +26,7 @@ describe('JobsTab', function () {
     DCOSStore.jobTree = new JobTree(MetronomeUtil.parseJobs([{
       id: '/test'
     }]));
-    DCOSStore.dataProcessed = true;
+    DCOSStore.jobDataReceived = true;
     this.container = document.createElement('div');
   });
 
@@ -81,7 +81,7 @@ describe('JobsTab', function () {
     });
 
     it('renders loading screen', function () {
-      DCOSStore.dataProcessed = false;
+      DCOSStore.jobDataReceived = false;
       var instance = ReactDOM.render(
         JestUtil.stubRouterContext(JobsTab, {params: {id: '/'}}),
         this.container

--- a/src/js/pages/__tests__/ServicesTab-test.js
+++ b/src/js/pages/__tests__/ServicesTab-test.js
@@ -29,7 +29,7 @@ describe('ServicesTab', function () {
         id: '/alpha'
       }]
     });
-    DCOSStore.dataProcessed = true;
+    DCOSStore.serviceDataReceived = true;
     this.container = document.createElement('div');
   });
 
@@ -138,7 +138,7 @@ describe('ServicesTab', function () {
     });
 
     it('renders loading screen', function () {
-      DCOSStore.dataProcessed = false;
+      DCOSStore.serviceDataReceived = false;
       var instance = ReactDOM.render(
         JestUtil.stubRouterContext(ServicesTab, {params: {id: '/'}}, {
           getCurrentRoutes() {

--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -176,7 +176,7 @@ class JobsTab extends mixin(StoreMixin, QueryParamsMixin, SaveStateMixin) {
 
   getContents(item) {
     // Render loading screen
-    if (!DCOSStore.dataProcessed) {
+    if (!DCOSStore.jobDataReceived) {
       return (
         <div className="container container-fluid container-pod">
           <Loader className="inverse" />

--- a/src/js/pages/services/DeploymentsTab.js
+++ b/src/js/pages/services/DeploymentsTab.js
@@ -406,7 +406,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
 
   render() {
     let deployments = DCOSStore.deploymentsList.getItems();
-    let loading = !DCOSStore.dataProcessed;
+    let loading = !DCOSStore.serviceDataReceived;
 
     if (loading) {
       return this.renderLoading();

--- a/src/js/pages/services/ServicesTab.js
+++ b/src/js/pages/services/ServicesTab.js
@@ -207,7 +207,7 @@ var ServicesTab = React.createClass({
     }
 
     // Render loading screen
-    if (!DCOSStore.dataProcessed) {
+    if (!DCOSStore.serviceDataReceived) {
       return (
         <div className="container container-fluid container-pod">
           <Loader className="inverse" />

--- a/src/js/stores/DCOSStore.js
+++ b/src/js/stores/DCOSStore.js
@@ -57,11 +57,14 @@ class DCOSStore extends EventEmitter {
         serviceTree: new ServiceTree(),
         queue: new Map(),
         deploymentsList: new DeploymentsList(),
-        versions: new Map()
+        versions: new Map(),
+        dataReceived: false
       },
-      metronome: new JobTree(),
-      mesos: new SummaryList(),
-      dataProcessed: false
+      metronome: {
+        jobTree: new JobTree(),
+        dataReceived: false
+      },
+      mesos: new SummaryList()
     };
   }
 
@@ -135,7 +138,7 @@ class DCOSStore extends EventEmitter {
   }
 
   onMarathonDeploymentsChange() {
-    if (!this.data.dataProcessed) {
+    if (!this.data.marathon.dataReceived) {
       return;
     }
     let deploymentsList = MarathonStore.get('deployments');
@@ -183,8 +186,11 @@ class DCOSStore extends EventEmitter {
       return;
     }
 
-    this.data.marathon.serviceTree = serviceTree;
-    this.data.dataProcessed = true;
+    let {marathon} = this.data;
+
+    // Update service tree and data received flag
+    marathon.serviceTree = serviceTree;
+    marathon.dataReceived = true;
 
     // Populate deployments with services data immediately
     this.onMarathonDeploymentsChange();
@@ -251,7 +257,12 @@ class DCOSStore extends EventEmitter {
   }
 
   onMetronomeChange() {
-    this.data.metronome = MetronomeStore.jobTree;
+    let {metronome} = this.data;
+
+    // Update job tree and data received flag
+    metronome.jobTree = MetronomeStore.jobTree;
+    metronome.dataReceived = true;
+
     this.emit(DCOS_CHANGE);
   }
 
@@ -312,7 +323,7 @@ class DCOSStore extends EventEmitter {
    * @type {JobTree}
    */
   get jobTree() {
-    return this.data.metronome;
+    return this.data.metronome.jobTree;
   }
 
   /**
@@ -367,8 +378,12 @@ class DCOSStore extends EventEmitter {
 
   }
 
-  get dataProcessed() {
-    return this.data.dataProcessed;
+  get jobDataReceived() {
+    return this.data.metronome.dataReceived;
+  }
+
+  get serviceDataReceived() {
+    return this.data.marathon.dataReceived;
   }
 
   get storeID() {

--- a/src/js/stores/__tests__/DCOSStore-test.js
+++ b/src/js/stores/__tests__/DCOSStore-test.js
@@ -59,7 +59,7 @@ describe('DCOSStore', function () {
       ]}));
       spyOn(NotificationStore, 'addNotification');
       // DCOSStore is a singleton, need to reset it manually
-      DCOSStore.data.dataProcessed = false;
+      DCOSStore.data.marathon.dataReceived = false;
     });
 
     describe('when the groups endpoint is not populated', function () {


### PR DESCRIPTION
---
⚠️  *This fix probably also needs to land in 1.9*

---

Rename the `dataProcessed` to `serviceDataReceived` to reflect it's meaning and introduce a new job specific data received getter to entangle the Job and Service behavior.  This changes will make sure that we don't block the Job table rendering in case we didn't get any Service data, which in some cases resulted in an unusable UI.

Closes DCOS-11060