### PR TITLE
Fix loading indicators! 🕸 

### DIFF
--- a/plugins/nodes/src/js/components/NodesGridView.js
+++ b/plugins/nodes/src/js/components/NodesGridView.js
@@ -49,7 +49,7 @@ var NodesGridView = React.createClass({
     }
 
     var loadingClassSet = classNames({
-      'hidden': hasLoadingError
+      hidden: hasLoadingError
     });
 
     return (

--- a/plugins/nodes/src/js/components/NodesTable.js
+++ b/plugins/nodes/src/js/components/NodesTable.js
@@ -64,11 +64,7 @@ var NodesTable = React.createClass({
     let requestReceived = this.props.receivedNodeHealthResponse;
 
     if (!requestReceived) {
-      return (
-        <Loader
-          innerClassName="loader-small"
-          type="ballBeat" />
-      );
+      return <Loader innerClassName="loader-small" type="ballBeat" />;
     }
 
     let health = node.getHealth();

--- a/plugins/nodes/src/js/components/NodesTable.js
+++ b/plugins/nodes/src/js/components/NodesTable.js
@@ -64,7 +64,7 @@ var NodesTable = React.createClass({
     let requestReceived = this.props.receivedNodeHealthResponse;
 
     if (!requestReceived) {
-      return <Loader innerClassName="loader-small" type="ballBeat" />;
+      return <Loader size="small" type="ballBeat" />;
     }
 
     let health = node.getHealth();

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailPage.js
@@ -95,11 +95,7 @@ class NodeDetailPage extends mixin(TabsMixin, StoreMixin) {
   }
 
   getLoadingScreen() {
-    return (
-      <div className="pod">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
 
   getNotFound(nodeID) {

--- a/plugins/services/src/js/components/MesosLogView.js
+++ b/plugins/services/src/js/components/MesosLogView.js
@@ -338,7 +338,7 @@ class MesosLogView extends mixin(StoreMixin) {
     return (
       <Loader
         className="pod pod-tall-bottom flush-right flush-left"
-        innerClassName="loader-small"
+        size="small"
         type="ballSpinFadeLoader" />
     );
   }

--- a/plugins/services/src/js/components/MesosLogView.js
+++ b/plugins/services/src/js/components/MesosLogView.js
@@ -336,11 +336,10 @@ class MesosLogView extends mixin(StoreMixin) {
 
     // Show loader since we will start a request for more logs
     return (
-      <div className="pod flush-top">
-        <Loader
-          innerClassName="loader-small"
-          type="ballSpinFadeLoader" />
-      </div>
+      <Loader
+        className="pod pod-tall-bottom flush-right flush-left"
+        innerClassName="loader-small"
+        type="ballSpinFadeLoader" />
     );
   }
 

--- a/plugins/services/src/js/components/ServiceList.js
+++ b/plugins/services/src/js/components/ServiceList.js
@@ -72,11 +72,7 @@ let ServiceList = React.createClass({
 
       let healthLabel = HealthLabels[state.key];
       if (!healthProcessed) {
-        healthLabel = (
-          <Loader
-            innerClassName="loader-small"
-            type="ballBeat" />
-        );
+        healthLabel = <Loader size="small" type="ballBeat" />;
       }
 
       let classSet = classNames('tooltip-wrapper', state.classNames);

--- a/plugins/services/src/js/pages/services/DeploymentsTab.js
+++ b/plugins/services/src/js/pages/services/DeploymentsTab.js
@@ -313,11 +313,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
   }
 
   renderLoading() {
-    return (
-      <div className="pod">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
 
   renderPopulated(deploymentsItems) {

--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -157,11 +157,7 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
   }
 
   getLoadingScreen() {
-    return (
-      <div className="pod">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
 
   getService() {

--- a/plugins/services/src/js/service-configuration/ServiceSpecView.js
+++ b/plugins/services/src/js/service-configuration/ServiceSpecView.js
@@ -218,11 +218,7 @@ class ServiceSpecView extends mixin(StoreMixin) {
 
     // Render loading screen
     if (config == null) {
-      return (
-        <div className="pod">
-          <Loader />
-        </div>
-      );
+      return <Loader />;
     }
 
     return (

--- a/src/js/components/Loader.js
+++ b/src/js/components/Loader.js
@@ -50,14 +50,20 @@ class Loader extends React.Component {
   }
 
   render() {
-    let {className, innerClassName, type} = this.props;
+    let {className, innerClassName, size, type} = this.props;
     let config = typeMap[type] || typeMap.ballScale;
     let classes = classNames(
       'loader horizontal-center',
       className
     );
 
-    let innerClasses = classNames(config.className, innerClassName);
+    let innerClasses = classNames(
+      config.className,
+      {
+        'loader-small': size === 'small'
+      },
+      innerClassName
+    );
 
     return (
       <div className={classes}>
@@ -84,6 +90,7 @@ let classPropType = React.PropTypes.oneOfType([
 Loader.propTypes = {
   className: classPropType,
   innerClassName: classPropType,
+  size: React.PropTypes.oneOf(['small']),
   type: React.PropTypes.oneOf(['ballBeat', 'ballScale', 'ballSpinFadeLoader'])
 };
 

--- a/src/js/components/Loader.js
+++ b/src/js/components/Loader.js
@@ -45,7 +45,7 @@ let typeMap = {
 class Loader extends React.Component {
   getDivs(length) {
     return Array.from({length}).map(function (_, index) {
-      return <div key={index} />;
+      return <div className="loader-element" key={index} />;
     });
   }
 
@@ -53,7 +53,7 @@ class Loader extends React.Component {
     let {className, innerClassName, type} = this.props;
     let config = typeMap[type] || typeMap.ballScale;
     let classes = classNames(
-      'loader horizontal-center vertical-center',
+      'loader horizontal-center',
       className
     );
 

--- a/src/js/components/modals/InstallPackageModal.js
+++ b/src/js/components/modals/InstallPackageModal.js
@@ -239,7 +239,7 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
 
   getLoadingScreen() {
     return (
-      <div className="modal-content-loading-indicator">
+      <div className="modal-content-loading-indicator vertical-center">
         <Loader />
       </div>
     );

--- a/src/js/pages/NetworkPage.js
+++ b/src/js/pages/NetworkPage.js
@@ -81,11 +81,7 @@ class NetworkPage extends mixin(TabsMixin) {
   }
 
   getLoadingScreen() {
-    return (
-      <div className="pod">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
 
   getRoutedItem(tab) {

--- a/src/js/pages/jobs/JobDetailPage.js
+++ b/src/js/pages/jobs/JobDetailPage.js
@@ -261,11 +261,7 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
   }
 
   getLoadingScreen() {
-    return (
-      <div className="pod">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
 
   getNavigationTabs() {

--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -176,11 +176,7 @@ class JobsTab extends mixin(StoreMixin, QueryParamsMixin, SaveStateMixin) {
   getContents(item) {
     // Render loading screen
     if (!DCOSStore.dataProcessed) {
-      return (
-        <div className="pod">
-          <Loader />
-        </div>
-      );
+      return <Loader />;
     }
 
     if (item instanceof JobTree && item.getItems().length > 0) {

--- a/src/js/pages/network/VirtualNetworksTab.js
+++ b/src/js/pages/network/VirtualNetworksTab.js
@@ -94,11 +94,7 @@ class VirtualNetworksTabContent extends mixin(StoreMixin) {
   }
 
   getLoadingScreen() {
-    return (
-      <div className="pod">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
 
   getContent() {

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
@@ -102,11 +102,7 @@ class VirtualNetworkDetail extends mixin(StoreMixin, TabsMixin) {
   }
 
   getLoadingScreen() {
-    return (
-      <div className="pod">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
 
   render() {

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
@@ -141,11 +141,7 @@ class VirtualNetworkTaskTab extends mixin(StoreMixin) {
   }
 
   getLoadingScreen() {
-    return (
-      <div className="pod">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
 
   getTaskLink(taskID, value, title, hierarchy = {}) {

--- a/src/js/pages/system/OverviewDetailTab.js
+++ b/src/js/pages/system/OverviewDetailTab.js
@@ -37,11 +37,7 @@ class OverviewDetailTab extends mixin(StoreMixin) {
   }
 
   getLoading() {
-    return (
-      <Loader
-        innerClassName="loader-small"
-        type="ballBeat" />
-    );
+    return <Loader size="small" type="ballBeat" />;
   }
 
   getClusterDetailsHash() {

--- a/src/js/pages/system/RepositoriesTab.js
+++ b/src/js/pages/system/RepositoriesTab.js
@@ -72,11 +72,7 @@ class RepositoriesTab extends mixin(StoreMixin) {
   }
 
   getLoadingScreen() {
-    return (
-      <div className="pod">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
 
   render() {

--- a/src/js/pages/system/UnitsHealthDetail.js
+++ b/src/js/pages/system/UnitsHealthDetail.js
@@ -87,11 +87,7 @@ class UnitsHealthDetail extends mixin(StoreMixin) {
   }
 
   getLoadingScreen() {
-    return (
-      <div className="pod">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
 
   getNodesTable(unit, visibleData) {

--- a/src/js/pages/system/UnitsHealthNodeDetail.js
+++ b/src/js/pages/system/UnitsHealthNodeDetail.js
@@ -63,11 +63,7 @@ class UnitsHealthNodeDetail extends mixin(StoreMixin) {
   }
 
   getLoadingScreen() {
-    return (
-      <div className="pod">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
 
   render() {

--- a/src/js/pages/system/UsersTab.js
+++ b/src/js/pages/system/UsersTab.js
@@ -89,11 +89,7 @@ class UsersTab extends mixin(StoreMixin) {
   }
 
   getLoadingScreen() {
-    return (
-      <div className="pod">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
 
   getContents() {

--- a/src/js/pages/universe/InstalledPackagesTab.js
+++ b/src/js/pages/universe/InstalledPackagesTab.js
@@ -59,11 +59,7 @@ class InstalledPackagesTab extends mixin(StoreMixin) {
   }
 
   getLoadingScreen() {
-    return (
-      <div className="pod">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
 
   render() {

--- a/src/js/pages/universe/PackageDetailTab.js
+++ b/src/js/pages/universe/PackageDetailTab.js
@@ -118,11 +118,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
   }
 
   getLoadingScreen() {
-    return (
-      <div className="pod">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
 
   getSubItem(label, value, key) {

--- a/src/js/pages/universe/PackagesTab.js
+++ b/src/js/pages/universe/PackagesTab.js
@@ -110,11 +110,7 @@ class PackagesTab extends mixin(StoreMixin) {
   }
 
   getLoadingScreen() {
-    return (
-      <div className="pod">
-        <Loader />
-      </div>
-    );
+    return <Loader />;
   }
 
   getSelectedPackages(packages) {

--- a/src/styles/components/loaders/styles.less
+++ b/src/styles/components/loaders/styles.less
@@ -1,7 +1,14 @@
 .loader {
 
-  &.inverse .ball-scale > div {
-    background-color: @muted-color;
+  .loader-element {
+    background: @loaders-elements-backgroud;
+  }
+
+  .inverse {
+
+    .loader-element {
+      background: @loaders-elements-backgroud-inverse;
+    }
   }
 
   .ball-scale {

--- a/src/styles/components/loaders/variables.less
+++ b/src/styles/components/loaders/variables.less
@@ -4,4 +4,5 @@
  * Styling
  */
 
-@loaders-ball-scale-background: color-lighten(@neutral, 60);
+@loaders-elements-backgroud: fade(@neutral, 50%);
+@loaders-elements-backgroud-inverse: fade(@white, 50%);


### PR DESCRIPTION
This PR removes the wrapping `div` that we used in conjunction with the `Loader` component almost everywhere. We don't need it because it adds extra margin where it shouldn't in 99% of the cases.

In the future, if we do decide to add margin or padding, we can do so in the `Loader` component itself and it'll just work everywhere :)
