### PR TITLE
Fix text overflow behavior in services table

### DIFF
--- a/plugins/services/src/js/services/ServicesTable.js
+++ b/plugins/services/src/js/services/ServicesTable.js
@@ -94,11 +94,9 @@ class ServicesTable extends React.Component {
 
     return (
       <Link
-        className="table-cell-link-primary"
+        className="table-cell-link-primary text-overflow"
         to={`/services/overview/${id}`}>
-        <span className="text-overflow">
-          {service.getName()}
-        </span>
+        {service.getName()}
       </Link>
     );
   }


### PR DESCRIPTION
Before:
![](https://cl.ly/3B2h1W0g2U0y/Screen%20Shot%202016-10-28%20at%202.39.18%20PM.png)

After:
![](https://cl.ly/3H202B1l372s/Screen%20Shot%202016-10-28%20at%202.38.42%20PM.png)
