### PR TITLE
Hide ServiceSidebarFilters at larger screen sizes

### DIFF
--- a/plugins/services/src/js/services/ServiceSidebarFilters.js
+++ b/plugins/services/src/js/services/ServiceSidebarFilters.js
@@ -16,7 +16,7 @@ class ServiceSidebarFilters extends React.Component {
     const {countByValue, filters} = props;
 
     return (
-      <div className="services-sidebar hidden-medium-down pod flush-top flush-bottom flush-left">
+      <div className="services-sidebar hidden-large-down pod flush-top flush-bottom flush-left">
         <SidebarFilter
           countByValue={countByValue.filterHealth}
           filters={filters}


### PR DESCRIPTION
This prevents the `name` column from being completely illegible at some viewports.
