### PR TITLE
Standardize modal headings

### DIFF
--- a/plugins/services/src/js/components/modals/KillPodInstanceModal.js
+++ b/plugins/services/src/js/components/modals/KillPodInstanceModal.js
@@ -3,6 +3,7 @@ import React, {PropTypes} from 'react';
 import PureRender from 'react-addons-pure-render-mixin';
 
 import AppLockedMessage from './AppLockedMessage';
+import ModalHeading from '../../../../../../src/js/components/modals/ModalHeading';
 import Pod from '../../structs/Pod';
 import StringUtil from '../../../../../../src/js/utils/StringUtil';
 
@@ -89,10 +90,7 @@ class KillPodInstanceModal extends React.Component {
     let instanceCountContent = `${selectedItemsLength} ${StringUtil.pluralize('Instance', selectedItemsLength)}`;
 
     return (
-      <div className="container container-pod container-pod-short-top text-align-center flush-bottom">
-        <h2 className="text-danger text-align-center flush-top">
-          {action} {StringUtil.pluralize('Instance', selectedItemsLength)}
-        </h2>
+      <div className="text-align-center">
         <p>
           You are about to {action.toLowerCase()} {instanceCountContent}.
           <br />
@@ -128,17 +126,25 @@ class KillPodInstanceModal extends React.Component {
       this.shouldForceUpdate()
     );
 
+    let header = (
+      <ModalHeading className="text-danger">
+        {ACTION_DISPLAY_NAMES[action]} {StringUtil.pluralize('Instance', selectedItems.length)}
+      </ModalHeading>
+    );
+
     return (
       <Confirm
         closeByBackdropClick={true}
         disabled={isPending}
+        header={header}
         open={open}
         onClose={onClose}
         leftButtonText="Close"
         leftButtonCallback={onClose}
         rightButtonText={buttonText}
         rightButtonClassName="button button-danger"
-        rightButtonCallback={killAction}>
+        rightButtonCallback={killAction}
+        showHeader={true}>
         {this.getModalContents()}
       </Confirm>
     );

--- a/plugins/services/src/js/components/modals/KillTaskModal.js
+++ b/plugins/services/src/js/components/modals/KillTaskModal.js
@@ -3,6 +3,7 @@ import React, {PropTypes} from 'react';
 import PureRender from 'react-addons-pure-render-mixin';
 
 import AppLockedMessage from './AppLockedMessage';
+import ModalHeading from '../../../../../../src/js/components/modals/ModalHeading';
 import StringUtil from '../../../../../../src/js/utils/StringUtil';
 
 const ACTION_DISPLAY_NAMES = {
@@ -88,10 +89,7 @@ class KillTaskModal extends React.Component {
     let taskCountContent = `${selectedItemsLength} ${StringUtil.pluralize('Task', selectedItemsLength)}`;
 
     return (
-      <div className={'pod pod-short flush-right flush-bottom flush-left text-align-center'}>
-        <h2 className="text-danger text-align-center flush-top">
-          {action} {StringUtil.pluralize('Task', selectedItemsLength)}
-        </h2>
+      <div className="text-align-center">
         <p>
           You are about to {action.toLowerCase()} {taskCountContent}.
           <br />
@@ -124,17 +122,25 @@ class KillTaskModal extends React.Component {
       this.shouldForceUpdate()
     );
 
+    let header = (
+      <ModalHeading className="text-danger">
+        {ACTION_DISPLAY_NAMES[action]} {StringUtil.pluralize('Task', selectedItems.length)}
+      </ModalHeading>
+    );
+
     return (
       <Confirm
         closeByBackdropClick={true}
         disabled={isPending}
+        header={header}
         open={open}
         onClose={onClose}
         leftButtonText="Close"
         leftButtonCallback={onClose}
         rightButtonText={buttonText}
         rightButtonClassName="button button-danger"
-        rightButtonCallback={killTasksAction}>
+        rightButtonCallback={killTasksAction}
+        showHeader={true}>
         {this.getModalContents()}
       </Confirm>
     );

--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -2,6 +2,7 @@ import {Confirm} from 'reactjs-components';
 import React, {PropTypes} from 'react';
 import PureRender from 'react-addons-pure-render-mixin';
 
+import ModalHeading from '../../../../../../src/js/components/modals/ModalHeading';
 import Pod from '../../structs/Pod';
 import Service from '../../structs/Service';
 import ServiceTree from '../../structs/ServiceTree';
@@ -60,23 +61,28 @@ class ServiceDestroyModal extends React.Component {
       serviceName = service.getId();
     }
 
+    let heading = (
+      <ModalHeading className="text-danger">
+        Destroy {itemText}
+      </ModalHeading>
+    );
+
     return (
       <Confirm
         disabled={isPending}
+        header={heading}
         open={open}
         onClose={onClose}
         leftButtonText="Cancel"
         leftButtonCallback={onClose}
         rightButtonText={`Destroy ${itemText}`}
         rightButtonClassName="button button-danger"
-        rightButtonCallback={deleteItem}>
-        <div className="container-pod flush-top container-pod-short-bottom">
-          <h2 className="text-danger text-align-center flush-top">
-            Destroy {itemText}
-          </h2>
-          <p>Destroying <span className="emphasize">{serviceName}</span> is irreversible. Are you sure you want to continue?</p>
-          {this.getErrorMessage()}
-        </div>
+        rightButtonCallback={deleteItem}
+        showHeader={true}>
+        <p>
+          Destroying <span className="emphasize">{serviceName}</span> is irreversible. Are you sure you want to continue?
+        </p>
+        {this.getErrorMessage()}
       </Confirm>
     );
   }

--- a/plugins/services/src/js/components/modals/ServiceFormModal.js
+++ b/plugins/services/src/js/components/modals/ServiceFormModal.js
@@ -11,6 +11,7 @@ import 'brace/ext/language_tools';
 
 import Config from '../../../../../../src/js/config/Config';
 import Icon from '../../../../../../src/js/components/Icon';
+import ModalHeading from '../../../../../../src/js/components/modals/ModalHeading';
 import PodSpec from '../../structs/PodSpec';
 import Service from '../../structs/Service';
 import ServiceForm from '../ServiceForm';
@@ -517,12 +518,12 @@ class ServiceFormModal extends React.Component {
     }
 
     let header = (
-      <div className="modal-header-title">
+      <div>
         <div className="header-flex">
           <div className="header-left">
-            <span className="h4 flush-top flush-bottom text-color-neutral">
+            <ModalHeading align="left" level={4}>
               {headerText}
-            </span>
+            </ModalHeading>
           </div>
           <div className="header-right">
             {this.getToggleButton()}

--- a/plugins/services/src/js/components/modals/ServiceGroupFormModal.js
+++ b/plugins/services/src/js/components/modals/ServiceGroupFormModal.js
@@ -2,6 +2,7 @@ import React, {PropTypes} from 'react';
 import PureRender from 'react-addons-pure-render-mixin';
 
 import FormModal from '../../../../../../src/js/components/FormModal';
+import ModalHeading from '../../../../../../src/js/components/modals/ModalHeading';
 import ServiceValidatorUtil from '../../utils/ServiceValidatorUtil';
 
 const METHODS_TO_BIND = [
@@ -93,14 +94,15 @@ class ServiceGroupFormModal extends React.Component {
         ref="form"
         buttonDefinition={buttonDefinition}
         disabled={isPending}
+        modalProps={{
+          header: <ModalHeading>Create Group</ModalHeading>,
+          showHeader: true
+        }}
         onClose={onClose}
         onSubmit={this.handleNewGroupSubmit}
         onChange={clearError}
         open={open}
         definition={this.getNewGroupFormDefinition()}>
-        <h2 className="modal-header-title text-align-center flush-top">
-          Create Group
-        </h2>
         <p className="text-align-center flush-top">
           {'Enter a path for the new group under '}
           <span className="emphasize">{parentGroupId}</span>

--- a/plugins/services/src/js/components/modals/ServiceRestartModal.js
+++ b/plugins/services/src/js/components/modals/ServiceRestartModal.js
@@ -3,6 +3,7 @@ import React, {PropTypes} from 'react';
 import PureRender from 'react-addons-pure-render-mixin';
 
 import AppLockedMessage from './AppLockedMessage';
+import ModalHeading from '../../../../../../src/js/components/modals/ModalHeading';
 import Service from '../../structs/Service';
 import ServiceTree from '../../structs/ServiceTree';
 
@@ -53,6 +54,11 @@ class ServiceRestartModal extends React.Component {
       restartService
     } = this.props;
 
+    let heading = (
+      <ModalHeading>
+        Restart Service
+      </ModalHeading>
+    );
     let serviceName = '';
 
     if (service) {
@@ -62,15 +68,14 @@ class ServiceRestartModal extends React.Component {
     return (
       <Confirm
         disabled={isPending}
+        header={heading}
         open={open}
         onClose={onClose}
         leftButtonCallback={onClose}
         rightButtonText="Restart Service"
         rightButtonClassName="button button-danger"
-        rightButtonCallback={() => restartService(service, this.shouldForceUpdate())}>
-        <h2 className="text-align-center flush-top">
-          Restart Service
-        </h2>
+        rightButtonCallback={() => restartService(service, this.shouldForceUpdate())}
+        showHeader={true}>
         <p>
           Are you sure you want to restart <span className="emphasize">{serviceName}</span>?
         </p>

--- a/plugins/services/src/js/components/modals/ServiceScaleFormModal.js
+++ b/plugins/services/src/js/components/modals/ServiceScaleFormModal.js
@@ -2,6 +2,7 @@ import React, {PropTypes} from 'react';
 import PureRender from 'react-addons-pure-render-mixin';
 
 import FormModal from '../../../../../../src/js/components/FormModal';
+import ModalHeading from '../../../../../../src/js/components/modals/ModalHeading';
 import Pod from '../../structs/Pod';
 import Service from '../../structs/Service';
 import ServiceTree from '../../structs/ServiceTree';
@@ -113,9 +114,7 @@ class ServiceScaleFormModal extends React.Component {
     }
 
     return (
-      <h2 className="modal-header-title text-align-center flush-top">
-        Scale {headerText}
-      </h2>
+      <ModalHeading>Scale {headerText}</ModalHeading>
     );
   }
 
@@ -162,12 +161,15 @@ class ServiceScaleFormModal extends React.Component {
       <FormModal
         buttonDefinition={buttonDefinition}
         definition={this.getScaleFormDefinition()}
+        modalProps={{
+          header: this.getHeader(),
+          showHeader: true
+        }}
         disabled={isPending}
         onClose={onClose}
         onSubmit={onSubmit}
         onChange={clearError}
         open={open} >
-        {this.getHeader()}
         {this.getBodyText()}
         {this.getErrorMessage()}
       </FormModal>

--- a/plugins/services/src/js/components/modals/ServiceSuspendModal.js
+++ b/plugins/services/src/js/components/modals/ServiceSuspendModal.js
@@ -3,6 +3,7 @@ import React, {PropTypes} from 'react';
 import PureRender from 'react-addons-pure-render-mixin';
 
 import AppLockedMessage from './AppLockedMessage';
+import ModalHeading from '../../../../../../src/js/components/modals/ModalHeading';
 import Pod from '../../structs/Pod';
 import Service from '../../structs/Service';
 import ServiceTree from '../../structs/ServiceTree';
@@ -97,17 +98,22 @@ class ServiceSuspendModal extends React.Component {
       serviceName = service.getId();
     }
 
+    let heading = (
+      <ModalHeading>
+        Suspend {itemText}
+      </ModalHeading>
+    );
+
     return (
       <Confirm
         disabled={isPending}
+        header={heading}
         open={open}
         onClose={onClose}
         leftButtonCallback={onClose}
         rightButtonText={`Suspend ${itemText}`}
-        rightButtonCallback={() => suspendItem(this.shouldForceUpdate())}>
-        <h2 className="text-align-center flush-top">
-          Suspend {itemText}
-        </h2>
+        rightButtonCallback={() => suspendItem(this.shouldForceUpdate())}
+        showHeader={true}>
         <p>
           Are you sure you want to suspend <span className="emphasize">{serviceName}</span> by scaling to 0 instances?
         </p>

--- a/plugins/services/src/js/pages/services/DeploymentsTab.js
+++ b/plugins/services/src/js/pages/services/DeploymentsTab.js
@@ -14,6 +14,7 @@ import defaultServiceImage from '../../../img/icon-service-default-small@2x.png'
 import Loader from '../../../../../../src/js/components/Loader';
 import Icon from '../../../../../../src/js/components/Icon';
 import MarathonActions from '../../events/MarathonActions';
+import ModalHeading from '../../../../../../src/js/components/modals/ModalHeading';
 import NestedServiceLinks from '../../../../../../src/js/components/NestedServiceLinks';
 import StatusBar from '../../../../../../src/js/components/StatusBar';
 import StringUtil from '../../../../../../src/js/utils/StringUtil';
@@ -342,19 +343,26 @@ class DeploymentsTab extends mixin(StoreMixin) {
       deploymentRollbackError
     } = this.state;
 
+    let heading = (
+      <ModalHeading>
+        You're About To Rollback The Deployment
+      </ModalHeading>
+    );
+
     if (deploymentToRollback != null) {
       return (
         <Confirm
           closeByBackdropClick={true}
           disabled={!!awaitingRevertDeploymentResponse}
+          header={heading}
           onClose={this.handleRollbackCancel}
           leftButtonCallback={this.handleRollbackCancel}
           leftButtonText="Cancel"
           rightButtonClassName="button button-danger"
           rightButtonCallback={this.handleRollbackConfirm}
-          rightButtonText="Continue Rollback">
+          rightButtonText="Continue Rollback"
+          showHeader={true}>
           <div className="text-align-center">
-            <h3 className="flush-top">You're About To Rollback The Deployment</h3>
             <p>{this.getRollbackModalText(deploymentToRollback)}</p>
             {this.renderRollbackError(deploymentRollbackError)}
           </div>

--- a/src/js/components/FormModal.js
+++ b/src/js/components/FormModal.js
@@ -133,8 +133,7 @@ class FormModal extends React.Component {
         showHeader={false}
         showFooter={true}
         footer={this.getFooter()}
-        titleClass="modal-header-title text-align-center flush-top
-          flush-bottom"
+        titleClass="text-align-center flush"
         {...this.props.modalProps}>
         {this.getContent()}
       </Modal>

--- a/src/js/components/RepositoriesTable.js
+++ b/src/js/components/RepositoriesTable.js
@@ -11,6 +11,7 @@ import CollapsingString from './CollapsingString';
 import Config from '../config/Config';
 import CosmosPackagesStore from '../stores/CosmosPackagesStore';
 import List from '../structs/List';
+import ModalHeading from './modals/ModalHeading';
 import RepositoriesTableHeaderLabels from '../constants/RepositoriesTableHeaderLabels';
 import TableUtil from '../utils/TableUtil';
 
@@ -193,7 +194,6 @@ class RepositoriesTable extends mixin(StoreMixin) {
 
     return (
       <div className="text-align-center">
-        <h3 className="flush-top">Are you sure?</h3>
         <p>
           {`Repository (${repositoryLabel}) will be removed from ${Config.productName}. You will not be able to install any packages belonging to that repository anymore.`}
         </p>
@@ -204,6 +204,11 @@ class RepositoriesTable extends mixin(StoreMixin) {
 
   render() {
     let {props, state} = this;
+    let heading = (
+      <ModalHeading>
+        Are you sure?
+      </ModalHeading>
+    );
 
     return (
       <div>
@@ -216,12 +221,14 @@ class RepositoriesTable extends mixin(StoreMixin) {
         <Confirm
           closeByBackdropClick={true}
           disabled={state.pendingRequest}
+          header={heading}
           open={!!state.repositoryToRemove}
           onClose={this.handleDeleteCancel}
           leftButtonCallback={this.handleDeleteCancel}
           rightButtonCallback={this.handleDeleteRepository}
           rightButtonClassName="button button-danger"
-          rightButtonText="Remove Repository">
+          rightButtonText="Remove Repository"
+          showHeader={true}>
           {this.getRemoveModalContent()}
         </Confirm>
       </div>

--- a/src/js/components/ServerErrorModal.js
+++ b/src/js/components/ServerErrorModal.js
@@ -8,6 +8,8 @@ import {StoreMixin} from 'mesosphere-shared-reactjs';
 
 import {Hooks} from 'PluginSDK';
 
+import ModalHeading from './modals/ModalHeading';
+
 const METHODS_TO_BIND = ['handleModalClose', 'handleServerError'];
 
 function getEventsFromStoreListeners(storeListeners) {
@@ -106,9 +108,9 @@ module.exports = class ServerErrorModal extends mixin(StoreMixin) {
 
   render() {
     let header = (
-      <h5 className="modal-header-title text-align-center flush">
+      <ModalHeading level={5}>
         An error has occurred
-      </h5>
+      </ModalHeading>
     );
 
     return (

--- a/src/js/components/__tests__/ServerErrorModal-test.js
+++ b/src/js/components/__tests__/ServerErrorModal-test.js
@@ -1,4 +1,5 @@
 jest.dontMock('../ServerErrorModal');
+jest.dontMock('../modals/ModalHeading');
 
 const PluginTestUtils = require('PluginTestUtils');
 

--- a/src/js/components/modals/ActionsModal.js
+++ b/src/js/components/modals/ActionsModal.js
@@ -3,6 +3,7 @@ import mixin from 'reactjs-mixin';
 import React from 'react';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
+import ModalHeading from './ModalHeading';
 import StringUtil from '../../utils/StringUtil';
 import Util from '../../utils/Util';
 
@@ -96,12 +97,11 @@ class ActionsModal extends mixin(StoreMixin) {
   }
 
   getActionsModalContents() {
-    let {actionText, itemType} = this.props;
+    let {itemType} = this.props;
     let {requestErrors, validationError} = this.state;
 
     return (
       <div className="text-align-center">
-        <h3 className="flush-top">{actionText.title}</h3>
         <p>{this.getActionsModalContentsText()}</p>
         {this.getDropdown(itemType)}
         {this.getErrorMessage(validationError)}
@@ -208,14 +208,22 @@ class ActionsModal extends mixin(StoreMixin) {
       return null;
     }
 
+    let heading = (
+      <ModalHeading>
+        {this.props.actionText.title}
+      </ModalHeading>
+    );
+
     return (
       <Confirm
         disabled={this.state.pendingRequest}
+        header={heading}
         open={!!action}
         onClose={this.handleButtonCancel}
         leftButtonCallback={this.handleButtonCancel}
         rightButtonCallback={this.handleButtonConfirm}
         rightButtonText={StringUtil.capitalize(action)}
+        showHeader={true}
         useGemini={false}
         {...props}>
         {this.getActionsModalContents()}

--- a/src/js/components/modals/AddRepositoryFormModal.js
+++ b/src/js/components/modals/AddRepositoryFormModal.js
@@ -1,4 +1,3 @@
-import classNames from 'classnames';
 import mixin from 'reactjs-mixin';
 /* eslint-disable no-unused-vars */
 import React from 'react';
@@ -7,6 +6,7 @@ import {StoreMixin} from 'mesosphere-shared-reactjs';
 
 import CosmosPackagesStore from '../../stores/CosmosPackagesStore';
 import FormModal from '../FormModal';
+import ModalHeading from '../modals/ModalHeading';
 import ValidatorUtil from '../../utils/ValidatorUtil';
 
 const METHODS_TO_BIND = [
@@ -137,23 +137,21 @@ class AddRepositoryFormModal extends mixin(StoreMixin) {
   render() {
     let {props, state} = this;
 
-    let headerClasses = classNames(
-      'modal-header-title text-align-center flush-top',
-      {'short-bottom': this.state.errorMsg}
-    );
-
     return (
       <FormModal
         definition={this.getAddRepositoryFormDefinition()}
         disabled={state.disableButtons}
         buttonDefinition={this.getButtonDefinition()}
+        modalProps={{
+          header: (
+            <ModalHeading>Add Repository</ModalHeading>
+          ),
+          showHeader: true
+        }}
         onChange={this.resetState}
         onClose={props.onClose}
         onSubmit={this.handleAddRepository}
         open={props.open}>
-        <h2 className={headerClasses}>
-          Add Repository?
-        </h2>
         {this.getErrorMessage()}
       </FormModal>
     );

--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -6,6 +6,7 @@ import React from 'react';
 import ClickToSelect from '../ClickToSelect';
 import Icon from '../Icon';
 import MetadataStore from '../../stores/MetadataStore';
+import ModalHeading from '../modals/ModalHeading';
 
 const METHODS_TO_BIND = ['onClose'];
 const osTypes = {
@@ -156,28 +157,19 @@ class CliInstallModal extends React.Component {
   }
 
   render() {
-    let {footer, open, showFooter, subHeaderContent, title} = this.props;
-    let isWindows = (this.state.selectedOS === 'Windows');
-    let titleClass = classNames({
-      'modal-header-title': true,
-      'text-align-center': true,
-      'flush-top': !isWindows,
-      'flush': isWindows,
-      'flush-bottom': !subHeaderContent
-    });
-
-    let header = <h5 className={titleClass}>{title}</h5>;
+    let {footer, open, showFooter, title} = this.props;
+    let header = <ModalHeading align="left" level={5}>{title}</ModalHeading>;
 
     return (
       <Modal
+        header={header}
         footer={footer}
         modalClass="modal"
         onClose={this.onClose}
         open={open}
         showHeader={true}
         showFooter={showFooter}
-        subHeader={this.getSubHeader()}
-        header={header}>
+        subHeader={this.getSubHeader()}>
         {this.getContent()}
       </Modal>
     );

--- a/src/js/components/modals/ErrorModal.js
+++ b/src/js/components/modals/ErrorModal.js
@@ -2,6 +2,8 @@ import React from 'react';
 
 import {Modal} from 'reactjs-components';
 
+import ModalHeading from '../modals/ModalHeading';
+
 var ErrorModal = React.createClass({
 
   displayName: 'ErrorModal',
@@ -17,9 +19,9 @@ var ErrorModal = React.createClass({
 
   render() {
     let header = (
-      <h5 className="modal-header-title text-align-center flush-top flush-bottom">
+      <ModalHeading>
         Looks Like Something is Wrong
-      </h5>
+      </ModalHeading>
     );
 
     return (

--- a/src/js/components/modals/IdentifyModal.js
+++ b/src/js/components/modals/IdentifyModal.js
@@ -4,6 +4,7 @@ import React from 'react';
 
 import Config from '../../config/Config';
 import InternalStorageMixin from '../../mixins/InternalStorageMixin';
+import ModalHeading from '../modals/ModalHeading';
 import ValidatorUtil from '../../utils/ValidatorUtil';
 
 var IdentifyModal = React.createClass({
@@ -55,9 +56,9 @@ var IdentifyModal = React.createClass({
 
   getHeader() {
     return (
-      <h5 className="modal-header-title text-align-center flush-top">
+      <ModalHeading level={5}>
         {Config.productName}
-      </h5>
+      </ModalHeading>
     );
   },
 

--- a/src/js/components/modals/JobFormModal.js
+++ b/src/js/components/modals/JobFormModal.js
@@ -16,6 +16,7 @@ import JobForm from '../JobForm';
 import JobUtil from '../../utils/JobUtil';
 import JobSchema from '../../schemas/JobSchema';
 import MetronomeStore from '../../stores/MetronomeStore';
+import ModalHeading from '../modals/ModalHeading';
 import SchemaUtil from '../../utils/SchemaUtil';
 import ToggleButton from '../ToggleButton';
 
@@ -419,9 +420,9 @@ class JobFormModal extends mixin(StoreMixin) {
       <div>
         <div className="header-flex">
           <div className="header-left">
-            <span className="h4 flush-top flush-bottom text-color-neutral">
+            <ModalHeading align="left" level={4}>
               {heading}
-            </span>
+            </ModalHeading>
           </div>
           <div className="header-right">
             <ToggleButton

--- a/src/js/components/modals/JobStopRunModal.js
+++ b/src/js/components/modals/JobStopRunModal.js
@@ -4,6 +4,7 @@ import React from 'react';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
 import MetronomeStore from '../../stores/MetronomeStore';
+import ModalHeading from '../modals/ModalHeading';
 
 const METHODS_TO_BIND = [
   'handleButtonConfirm'
@@ -55,9 +56,9 @@ class JobStopRunModal extends mixin(StoreMixin) {
     }
 
     return (
-      <h2 className="flush-top text-align-center" key="confirmHeader">
+      <ModalHeading key="confirmHeader">
         {`Are you sure you want to stop ${headerContent}?`}
-      </h2>
+      </ModalHeading>
     );
   }
 
@@ -83,7 +84,6 @@ class JobStopRunModal extends mixin(StoreMixin) {
 
     return (
       <div className="text-align-center">
-        {this.getContentHeader(selectedItems, selectedItemsLength)}
         {this.getConfirmTextBody(selectedItems, selectedItemsLength)}
       </div>
     );
@@ -92,6 +92,7 @@ class JobStopRunModal extends mixin(StoreMixin) {
   render() {
     let {onClose, open, selectedItems} = this.props;
     let rightButtonText = 'Stop Job Run';
+    let selectedItemsLength = selectedItems.length;
 
     if (selectedItems.length > 1) {
       rightButtonText = 'Stop Job Runs';
@@ -101,13 +102,15 @@ class JobStopRunModal extends mixin(StoreMixin) {
       <Confirm
         closeByBackdropClick={true}
         disabled={this.state.pendingRequest}
+        header={this.getContentHeader(selectedItems, selectedItemsLength)}
         open={open}
         onClose={onClose}
         leftButtonText="Close"
         leftButtonCallback={onClose}
         rightButtonText={rightButtonText}
         rightButtonClassName="button button-danger"
-        rightButtonCallback={this.handleButtonConfirm}>
+        rightButtonCallback={this.handleButtonConfirm}
+        showHeader={true}>
         {this.getModalContents()}
       </Confirm>
     );

--- a/src/js/components/modals/ModalHeading.js
+++ b/src/js/components/modals/ModalHeading.js
@@ -1,0 +1,40 @@
+import classNames from 'classnames';
+import React from 'react';
+
+const ModalHeading = (props) => {
+  let {align, children, className, flush, level} = props;
+
+  return React.createElement(
+    `h${level}`,
+    {
+      className: classNames(
+        `text-align-${align}`,
+        {
+          'flush': flush
+        },
+        className
+      )
+    },
+    children
+  );
+};
+
+ModalHeading.defaultProps = {
+  align: 'center',
+  flush: true,
+  level: 2
+};
+
+ModalHeading.propTypes = {
+  align: React.PropTypes.oneOf(['left', 'right', 'center']),
+  children: React.PropTypes.node.isRequired,
+  className: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ]),
+  flush: React.PropTypes.bool,
+  level: React.PropTypes.oneOf([1, 2, 3, 4, 5, 6])
+};
+
+module.exports = ModalHeading;

--- a/src/js/components/modals/UserFormModal.js
+++ b/src/js/components/modals/UserFormModal.js
@@ -6,8 +6,9 @@ import React from 'react';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
 import AuthStore from '../../stores/AuthStore';
-import UserStore from '../../stores/UserStore';
 import FormModal from '../FormModal';
+import ModalHeading from '../modals/ModalHeading';
+import UserStore from '../../stores/UserStore';
 
 const TELEMETRY_NOTIFICATION = 'Because telemetry is disabled you must manually notify users of ACL changes.';
 
@@ -101,9 +102,9 @@ class UserFormModal extends mixin(StoreMixin) {
 
   getHeader() {
     return Hooks.applyFilter('userFormModalHeader', (
-      <h2 className="modal-header-title text-align-center flush-top">
+      <ModalHeading>
         Add User to Cluster
-      </h2>
+      </ModalHeading>
     ));
   }
 
@@ -119,11 +120,14 @@ class UserFormModal extends mixin(StoreMixin) {
         buttonDefinition={this.getButtonDefinition()}
         definition={this.getNewUserFormDefinition()}
         disabled={this.state.disableNewUser}
+        modalProps={{
+          header: this.getHeader(),
+          showHeader: true
+        }}
         onClose={this.props.onClose}
         onSubmit={this.handleNewUserSubmit}
         open={this.props.open}
         contentFooter={this.getFooter()}>
-        {this.getHeader()}
       </FormModal>
     );
   }

--- a/src/js/components/modals/VersionsModal.js
+++ b/src/js/components/modals/VersionsModal.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 import ClickToSelect from '../ClickToSelect';
 import Config from '../../config/Config';
+import ModalHeading from '../modals/ModalHeading';
 
 var VersionsModal = React.createClass({
 
@@ -28,9 +29,9 @@ var VersionsModal = React.createClass({
 
   render() {
     let header = (
-      <h5 configlassName="modal-header-title text-align-center flush-top flush-bottom">
+      <ModalHeading>
         {Config.productName} Info
-      </h5>
+      </ModalHeading>
     );
 
     return (

--- a/src/js/components/modals/__tests__/VersionsModal-test.js
+++ b/src/js/components/modals/__tests__/VersionsModal-test.js
@@ -1,5 +1,6 @@
 jest.dontMock('../../../utils/DOMUtils');
 jest.dontMock('../../../utils/JestUtil');
+jest.dontMock('.././ModalHeading');
 jest.dontMock('../VersionsModal');
 /* eslint-disable no-unused-vars */
 const React = require('react');

--- a/src/js/plugin-bridge/PluginModules.js
+++ b/src/js/plugin-bridge/PluginModules.js
@@ -66,6 +66,7 @@ module.exports = {
     Icon: 'Icon',
     Loader: 'Loader',
     MesosphereLogo: 'icons/MesosphereLogo',
+    ModalHeading: 'modals/ModalHeading',
     NestedServiceLinks: 'NestedServiceLinks',
     Page: 'Page',
     RequestErrorMsg: 'RequestErrorMsg',

--- a/src/styles/components/multiple-form/styles.less
+++ b/src/styles/components/multiple-form/styles.less
@@ -11,7 +11,12 @@
    */
 
   .form-element-inline {
-    display: inline-block;
+
+    // This is necessary to override CNVS specificity.
+    &,
+    label& {
+      display: inline-block;
+    }
 
     & + .form-element-inline {
       margin-left: @base-spacing-unit;
@@ -272,12 +277,6 @@
       .header-full-width {
         margin: @modal-header-padding-top -@modal-header-padding-right -@modal-header-padding-bottom -@modal-header-padding-left;
       }
-    }
-
-    .modal-header-title {
-      color: @heading-h3-color;
-      font-size: @label-font-size;
-      line-height: @label-line-height;
     }
 
     .modal-form-title-label {


### PR DESCRIPTION
This PR aims to standardize modal headings, by doing the following:
* Implements a `ModalHeading` component with the most common defaults
* Moves the headings to actual `header` prop of the `Modal` component, wherever possible (this was not possible for some of the modals, like the `InstallPackage` modals, due to the way their content changes)
* Removes `.modal-header-title` styling which served little purpose