### PR TITLE
Use single classname for ConfigurationMapSection

### DIFF
--- a/src/js/components/ConfigurationMapSection.js
+++ b/src/js/components/ConfigurationMapSection.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const ConfigurationMapSection = (props) => {
   return (
-    <div className="configuration-map-section pod flush-top flush-right flush-left">
+    <div className="configuration-map-section">
       {props.children}
     </div>
   );

--- a/src/styles/components/configuration-map/styles.less
+++ b/src/styles/components/configuration-map/styles.less
@@ -3,6 +3,7 @@
   .configuration-map {
 
     &-section {
+      margin-bottom: @configuration-map-section-margin-bottom;
 
       .configuration-map {
 
@@ -71,6 +72,10 @@
 
     .configuration-map {
 
+      &-section {
+        margin-bottom: @configuration-map-section-margin-bottom-screen-small;
+      }
+
       &-heading {
 
         &-primary {
@@ -90,6 +95,10 @@
   @media (min-width: @layout-screen-medium-min-width) {
 
     .configuration-map {
+
+      &-section {
+        margin-bottom: @configuration-map-section-margin-bottom-screen-medium;
+      }
 
       &-heading {
 
@@ -111,6 +120,10 @@
 
     .configuration-map {
 
+      &-section {
+        margin-bottom: @configuration-map-section-margin-bottom-screen-large;
+      }
+
       &-heading {
 
         &-primary {
@@ -130,6 +143,10 @@
   @media (min-width: @layout-screen-jumbo-min-width) {
 
     .configuration-map {
+
+      &-section {
+        margin-bottom: @configuration-map-section-margin-bottom-screen-jumbo;
+      }
 
       &-heading {
 

--- a/src/styles/components/configuration-map/variables.less
+++ b/src/styles/components/configuration-map/variables.less
@@ -1,3 +1,9 @@
 @configuration-map-enabled: true;
 
 @configuration-map-border-color: color-lighten(@neutral, 90);
+
+@configuration-map-section-margin-bottom: @pod-margin-bottom;
+@configuration-map-section-margin-bottom-screen-small: @pod-margin-bottom-screen-small;
+@configuration-map-section-margin-bottom-screen-medium: @pod-margin-bottom-screen-medium;
+@configuration-map-section-margin-bottom-screen-large: @pod-margin-bottom-screen-large;
+@configuration-map-section-margin-bottom-screen-jumbo: @pod-margin-bottom-screen-jumbo;


### PR DESCRIPTION
This PR removes the utility classes for `ConfigurationMapSection` based on @MatApple's suggestion here: https://github.com/dcos/dcos-ui/pull/1304/files/a040845dba717d9022639c8f91bb3d594e5b9a2c#r85980690