### PR TITLE
[Service create form 1 of 2] Introduce fields: input and textarea

### DIFF
--- a/src/js/components/form/FieldError.js
+++ b/src/js/components/form/FieldError.js
@@ -1,0 +1,26 @@
+import classNames from 'classnames/dedupe';
+import React from 'react';
+
+import Util from '../../utils/Util';
+
+const FieldError = (props) => {
+  let {className} = props;
+  let classes = classNames('small text-danger flush-bottom', className);
+
+  return (
+    <p
+      className={classes}
+      {...Util.omit(props, Object.keys(FieldError.propTypes))} />
+  );
+};
+
+FieldError.propTypes = {
+  // Classes
+  className: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ])
+};
+
+module.exports = FieldError;

--- a/src/js/components/form/FieldHelp.js
+++ b/src/js/components/form/FieldHelp.js
@@ -1,0 +1,26 @@
+import classNames from 'classnames/dedupe';
+import React from 'react';
+
+import Util from '../../utils/Util';
+
+const FieldHelp = (props) => {
+  let {className} = props;
+  let classes = classNames('small flush-bottom', className);
+
+  return (
+    <p
+      className={classes}
+      {...Util.omit(props, Object.keys(FieldHelp.propTypes))} />
+  );
+};
+
+FieldHelp.propTypes = {
+  // Classes
+  className: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ])
+};
+
+module.exports = FieldHelp;

--- a/src/js/components/form/FieldInput.js
+++ b/src/js/components/form/FieldInput.js
@@ -55,6 +55,12 @@ class FieldInput extends React.Component {
     );
   }
 
+  getElement(attributes) {
+    return (
+      <input {...attributes} />
+    );
+  }
+
   render() {
     let {
       error,
@@ -70,7 +76,7 @@ class FieldInput extends React.Component {
     return (
       <div className={classes}>
         {this.getLabel()}
-        <input {...attributes} />
+        {this.getElement(attributes)}
         {this.getHelpBlock()}
         {this.getErrorMsg()}
       </div>

--- a/src/js/components/form/FieldInput.js
+++ b/src/js/components/form/FieldInput.js
@@ -1,0 +1,117 @@
+import classNames from 'classnames/dedupe';
+import deepEqual from 'deep-equal';
+import React from 'react';
+
+import Util from '../../utils/Util';
+
+class FieldInput extends React.Component {
+  shouldComponentUpdate(nextProps) {
+    return !deepEqual(this.props, nextProps);
+  }
+
+  getErrorMsg() {
+    let {helpBlockClass, error} = this.props;
+
+    if (!error) {
+      return null;
+    }
+
+    return (
+      <span className={classNames(helpBlockClass)}>
+        {error}
+      </span>
+    );
+  }
+
+  getHelpBlock() {
+    let {helpBlock, helpBlockClass} = this.props;
+
+    if (!helpBlock) {
+      return null;
+    }
+
+    return (
+      <p className={classNames(helpBlockClass)}>
+        {helpBlock}
+      </p>
+    );
+  }
+
+  getLabel() {
+    let {label, labelClass} = this.props;
+
+    if (!label) {
+      return null;
+    }
+
+    if (typeof label !== 'string') {
+      return label;
+    }
+
+    return (
+      <label className={classNames(labelClass)}>
+        {label}
+      </label>
+    );
+  }
+
+  render() {
+    let {
+      error,
+      formGroupClass,
+      formGroupErrorClass
+    } = this.props;
+    let attributes = Util.omit(this.props, Object.keys(FieldInput.propTypes));
+    let classes = classNames(
+      {[formGroupErrorClass]: !!error},
+      formGroupClass
+    );
+
+    return (
+      <div className={classes}>
+        {this.getLabel()}
+        <input {...attributes} />
+        {this.getHelpBlock()}
+        {this.getErrorMsg()}
+      </div>
+    );
+  }
+}
+
+FieldInput.defaultProps = {
+  className: 'form-control',
+  formGroupClass: 'form-group',
+  helpBlockClass: 'small flush-bottom',
+  onChange() {},
+  value: ''
+};
+
+let classPropType = React.PropTypes.oneOfType([
+  React.PropTypes.array,
+  React.PropTypes.object,
+  React.PropTypes.string
+]);
+
+FieldInput.propTypes = {
+  // Optional boolean, string, or react node.
+  // If boolean: true - shows name as label; false - shows nothing.
+  // If string: shows string as label.
+  // If node: returns the node as the label.
+  label: React.PropTypes.oneOfType([
+    React.PropTypes.node,
+    React.PropTypes.string
+  ]),
+  // Optional help block
+  helpBlock: React.PropTypes.node,
+  // Optional error messages node
+  error: React.PropTypes.node,
+
+  // Classes
+  formGroupClass: classPropType,
+  // Class to be toggled, can be overridden by formGroupClass
+  formGroupErrorClass: React.PropTypes.string,
+  helpBlockClass: classPropType,
+  labelClass: classPropType
+};
+
+module.exports = FieldInput;

--- a/src/js/components/form/FieldInput.js
+++ b/src/js/components/form/FieldInput.js
@@ -1,123 +1,35 @@
 import classNames from 'classnames/dedupe';
-import deepEqual from 'deep-equal';
 import React from 'react';
 
 import Util from '../../utils/Util';
 
-class FieldInput extends React.Component {
-  shouldComponentUpdate(nextProps) {
-    return !deepEqual(this.props, nextProps);
-  }
+const FieldInput = (props) => {
+  let {className} = props;
+  let classes = classNames('form-control', className);
 
-  getErrorMsg() {
-    let {helpBlockClass, error} = this.props;
-
-    if (!error) {
-      return null;
-    }
-
-    return (
-      <span className={classNames(helpBlockClass)}>
-        {error}
-      </span>
-    );
-  }
-
-  getHelpBlock() {
-    let {helpBlock, helpBlockClass} = this.props;
-
-    if (!helpBlock) {
-      return null;
-    }
-
-    return (
-      <p className={classNames(helpBlockClass)}>
-        {helpBlock}
-      </p>
-    );
-  }
-
-  getLabel() {
-    let {label, labelClass} = this.props;
-
-    if (!label) {
-      return null;
-    }
-
-    if (typeof label !== 'string') {
-      return label;
-    }
-
-    return (
-      <label className={classNames(labelClass)}>
-        {label}
-      </label>
-    );
-  }
-
-  getElement(attributes) {
-    return (
-      <input {...attributes} />
-    );
-  }
-
-  render() {
-    let {
-      error,
-      formGroupClass,
-      formGroupErrorClass
-    } = this.props;
-    let attributes = Util.omit(this.props, Object.keys(FieldInput.propTypes));
-    let classes = classNames(
-      {[formGroupErrorClass]: !!error},
-      formGroupClass
-    );
-
-    return (
-      <div className={classes}>
-        {this.getLabel()}
-        {this.getElement(attributes)}
-        {this.getHelpBlock()}
-        {this.getErrorMsg()}
-      </div>
-    );
-  }
-}
+  return (
+    <input className={classes} {...Util.omit(props, ['className'])} />
+  );
+};
 
 FieldInput.defaultProps = {
-  className: 'form-control',
-  formGroupClass: 'form-group',
-  helpBlockClass: 'small flush-bottom',
   onChange() {},
   value: ''
 };
 
-let classPropType = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
-]);
-
 FieldInput.propTypes = {
-  // Optional boolean, string, or react node.
-  // If boolean: true - shows name as label; false - shows nothing.
-  // If string: shows string as label.
-  // If node: returns the node as the label.
-  label: React.PropTypes.oneOfType([
-    React.PropTypes.node,
+  onChange: React.PropTypes.func,
+  value: React.PropTypes.oneOfType([
+    React.PropTypes.number,
     React.PropTypes.string
   ]),
-  // Optional help block
-  helpBlock: React.PropTypes.node,
-  // Optional error messages node
-  error: React.PropTypes.node,
 
   // Classes
-  formGroupClass: classPropType,
-  // Class to be toggled, can be overridden by formGroupClass
-  formGroupErrorClass: React.PropTypes.string,
-  helpBlockClass: classPropType,
-  labelClass: classPropType
+  className: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ])
 };
 
 module.exports = FieldInput;

--- a/src/js/components/form/FieldLabel.js
+++ b/src/js/components/form/FieldLabel.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const FieldLabel = (props) => {
+  return (
+    <label {...props} />
+  );
+};
+
+FieldLabel.propTypes = {
+  // Classes
+  className: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ])
+};
+
+module.exports = FieldLabel;

--- a/src/js/components/form/FieldTextarea.js
+++ b/src/js/components/form/FieldTextarea.js
@@ -1,0 +1,120 @@
+import classNames from 'classnames/dedupe';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import FieldInput from './FieldInput';
+import Util from '../../utils/Util';
+
+let throttle = function (func, wait) {
+  let canCall = true;
+
+  let resetCall = function () {
+    canCall = true;
+  };
+
+  return function () {
+    if (canCall) {
+      setTimeout(resetCall, wait);
+      canCall = false;
+      func.apply(this, arguments);
+    }
+  };
+};
+
+const METHODS_TO_BIND = [
+  'handleChange'
+];
+
+class FieldTextarea extends FieldInput {
+  constructor() {
+    super(...arguments);
+
+    this.state = {minHeight: this.props.minHeight};
+    this.updateTextareaHeight = throttle(this.updateTextareaHeight, 100);
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  componentDidMount() {
+    let inputElement = ReactDOM.findDOMNode(this.refs.inputElement);
+    this.updateTextareaHeight(inputElement);
+
+    // React throws a warning if children are specified in an element with
+    // contenteditable="true", so this hack allows us to set a default value
+    // for this form field.
+    if (this.props.value) {
+      inputElement.textContent = this.props.value;
+    }
+  }
+
+  componentDidUpdate() {
+    let inputElement = ReactDOM.findDOMNode(this.refs.inputElement);
+    this.updateTextareaHeight(inputElement);
+  }
+
+  handleChange(event) {
+    this.updateTextareaHeight(event.target);
+
+    this.props.onChange(event);
+  }
+
+  updateTextareaHeight(domElement) {
+    let {minHeight, maxHeight, scrollHeightOffset} = this.props;
+    let newHeight = minHeight;
+    let {scrollHeight} = domElement;
+
+    if (scrollHeight > minHeight && scrollHeight < maxHeight) {
+      newHeight = scrollHeight + scrollHeightOffset;
+    } else if (scrollHeight >= maxHeight) {
+      newHeight = maxHeight;
+    }
+
+    if (newHeight !== this.state.minHeight) {
+      this.setState({minHeight: newHeight});
+    }
+  }
+
+  render() {
+    let {
+      error,
+      formGroupClass,
+      formGroupErrorClass
+    } = this.props;
+    let attributes = Util.omit(this.props, Object.keys(FieldInput.propTypes));
+
+    let classes = classNames(
+      {[formGroupErrorClass]: !!error},
+      formGroupClass
+    );
+
+    return (
+      <div className={classes}>
+        {this.getLabel()}
+        <textarea
+          ref="inputElement"
+          {...attributes}
+          onChange={this.handleChange}
+          style={{minHeight: `${this.state.minHeight}px`}} />
+        {this.getHelpBlock()}
+        {this.getErrorMsg()}
+      </div>
+    );
+  }
+}
+
+FieldTextarea.defaultProps = Object.assign({}, FieldInput.defaultProps, {
+  maxHeight: 400,
+  minHeight: 100,
+  scrollHeightOffset: 2
+});
+
+FieldTextarea.propTypes = Object.assign({}, FieldInput.propTypes, {
+  maxHeight: React.PropTypes.number,
+  minHeight: React.PropTypes.number,
+  onChange: React.PropTypes.func,
+  scrollHeightOffset: React.PropTypes.number
+});
+
+module.exports = FieldTextarea;

--- a/src/js/components/form/FieldTextarea.js
+++ b/src/js/components/form/FieldTextarea.js
@@ -1,81 +1,10 @@
 import classNames from 'classnames/dedupe';
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 import FieldInput from './FieldInput';
 import Util from '../../utils/Util';
 
-let throttle = function (func, wait) {
-  let canCall = true;
-
-  let resetCall = function () {
-    canCall = true;
-  };
-
-  return function () {
-    if (canCall) {
-      setTimeout(resetCall, wait);
-      canCall = false;
-      func.apply(this, arguments);
-    }
-  };
-};
-
-const METHODS_TO_BIND = [
-  'handleChange'
-];
-
 class FieldTextarea extends FieldInput {
-  constructor() {
-    super(...arguments);
-
-    this.state = {minHeight: this.props.minHeight};
-    this.updateTextareaHeight = throttle(this.updateTextareaHeight, 100);
-
-    METHODS_TO_BIND.forEach((method) => {
-      this[method] = this[method].bind(this);
-    });
-  }
-
-  componentDidMount() {
-    let inputElement = ReactDOM.findDOMNode(this.refs.inputElement);
-    this.updateTextareaHeight(inputElement);
-
-    // React throws a warning if children are specified in an element with
-    // contenteditable="true", so this hack allows us to set a default value
-    // for this form field.
-    if (this.props.value) {
-      inputElement.textContent = this.props.value;
-    }
-  }
-
-  componentDidUpdate() {
-    let inputElement = ReactDOM.findDOMNode(this.refs.inputElement);
-    this.updateTextareaHeight(inputElement);
-  }
-
-  handleChange(event) {
-    this.updateTextareaHeight(event.target);
-
-    this.props.onChange(event);
-  }
-
-  updateTextareaHeight(domElement) {
-    let {minHeight, maxHeight, scrollHeightOffset} = this.props;
-    let newHeight = minHeight;
-    let {scrollHeight} = domElement;
-
-    if (scrollHeight > minHeight && scrollHeight < maxHeight) {
-      newHeight = scrollHeight + scrollHeightOffset;
-    } else if (scrollHeight >= maxHeight) {
-      newHeight = maxHeight;
-    }
-
-    if (newHeight !== this.state.minHeight) {
-      this.setState({minHeight: newHeight});
-    }
-  }
-
   render() {
     let {
       error,
@@ -92,11 +21,7 @@ class FieldTextarea extends FieldInput {
     return (
       <div className={classes}>
         {this.getLabel()}
-        <textarea
-          ref="inputElement"
-          {...attributes}
-          onChange={this.handleChange}
-          style={{minHeight: `${this.state.minHeight}px`}} />
+        <textarea {...attributes} />
         {this.getHelpBlock()}
         {this.getErrorMsg()}
       </div>
@@ -104,17 +29,8 @@ class FieldTextarea extends FieldInput {
   }
 }
 
-FieldTextarea.defaultProps = Object.assign({}, FieldInput.defaultProps, {
-  maxHeight: 400,
-  minHeight: 100,
-  scrollHeightOffset: 2
-});
+FieldTextarea.defaultProps = Object.assign({}, FieldInput.defaultProps);
 
-FieldTextarea.propTypes = Object.assign({}, FieldInput.propTypes, {
-  maxHeight: React.PropTypes.number,
-  minHeight: React.PropTypes.number,
-  onChange: React.PropTypes.func,
-  scrollHeightOffset: React.PropTypes.number
-});
+FieldTextarea.propTypes = Object.assign({}, FieldInput.propTypes);
 
 module.exports = FieldTextarea;

--- a/src/js/components/form/FieldTextarea.js
+++ b/src/js/components/form/FieldTextarea.js
@@ -1,30 +1,11 @@
-import classNames from 'classnames/dedupe';
 import React from 'react';
 
 import FieldInput from './FieldInput';
-import Util from '../../utils/Util';
 
 class FieldTextarea extends FieldInput {
-  render() {
-    let {
-      error,
-      formGroupClass,
-      formGroupErrorClass
-    } = this.props;
-    let attributes = Util.omit(this.props, Object.keys(FieldInput.propTypes));
-
-    let classes = classNames(
-      {[formGroupErrorClass]: !!error},
-      formGroupClass
-    );
-
+  getElement(attributes) {
     return (
-      <div className={classes}>
-        {this.getLabel()}
-        <textarea {...attributes} />
-        {this.getHelpBlock()}
-        {this.getErrorMsg()}
-      </div>
+      <textarea {...attributes} />
     );
   }
 }

--- a/src/js/components/form/FieldTextarea.js
+++ b/src/js/components/form/FieldTextarea.js
@@ -1,17 +1,35 @@
+import classNames from 'classnames/dedupe';
 import React from 'react';
 
-import FieldInput from './FieldInput';
+import Util from '../../utils/Util';
 
-class FieldTextarea extends FieldInput {
-  getElement(attributes) {
-    return (
-      <textarea {...attributes} />
-    );
-  }
-}
+const FieldTextarea = (props) => {
+  let {className} = props;
+  let classes = classNames('form-control', className);
 
-FieldTextarea.defaultProps = Object.assign({}, FieldInput.defaultProps);
+  return (
+    <textarea className={classes} {...Util.omit(props, ['className'])} />
+  );
+};
 
-FieldTextarea.propTypes = Object.assign({}, FieldInput.propTypes);
+FieldTextarea.defaultProps = {
+  onChange() {},
+  value: ''
+};
+
+FieldTextarea.propTypes = {
+  onChange: React.PropTypes.func,
+  value: React.PropTypes.oneOfType([
+    React.PropTypes.number,
+    React.PropTypes.string
+  ]),
+
+  // Classes
+  className: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ])
+};
 
 module.exports = FieldTextarea;

--- a/src/js/components/form/FormGroup.js
+++ b/src/js/components/form/FormGroup.js
@@ -1,0 +1,42 @@
+import classNames from 'classnames/dedupe';
+import React from 'react';
+
+import Util from '../../utils/Util';
+
+const FormGroup = (props) => {
+  let {className, errorClassName, hasError} = props;
+
+  let classes = classNames(
+    {[errorClassName]: hasError},
+    'form-group',
+    className
+  );
+
+  return (
+    <div
+      className={classes}
+      {...Util.omit(props, Object.keys(FormGroup.propTypes))} />
+  );
+};
+
+FormGroup.defaultProps = {
+  errorClassName: 'form-group-danger'
+};
+
+let classPropType = React.PropTypes.oneOfType([
+  React.PropTypes.array,
+  React.PropTypes.object,
+  React.PropTypes.string
+]);
+
+FormGroup.propTypes = {
+  // Optional error messages node
+  hasError: React.PropTypes.bool,
+
+  // Classes
+  className: classPropType,
+  // Class to be toggled, can be overridden by className
+  errorClassName: React.PropTypes.string
+};
+
+module.exports = FormGroup;


### PR DESCRIPTION
This PR introduces two fields; FieldInput and FieldTextarea.

They are both fairly simple; they do not hold state and are only concerned with rendering

Example usage:
```js
class ServiceFormSection extends Component {
  getIDHelpBlock() {
    return (
      <span>
        {"Include the path to your service, if applicable. E.g. /dev/tools/my-service. "}
        <a href="https://mesosphere.github.io/marathon/docs/application-groups.html" target="_blank">
          More information
        </a>.
      </span>
    );
  }

  render() {
    let {data, errors} = this.props;

    return (
      <form className="flex row" onChange={this.handleChange}>
        <FormGroup className="column-8">
          <FieldLabel>
            SERVICE NAME <span className="text-danger">*</span>
          </FieldLabel>
          <FieldInput
            name="id"
            type="text"
            value={data.id} />
          <FieldHelp>{this.getIDHelpBlock()}</FieldHelp>
          <FieldError>{errors.id}</FieldError>
        </FormGroup>

        <FormGroup className="column-4">
          <FieldLabel>
            INSTANCES <span className="text-danger">*</span>
          </FieldLabel>
          <FieldInput
            name="instances"
            min={0}
            type="number"
            value={data.instances} />
          <FieldError>{errors.instances}</FieldError>
        </FormGroup>
      </form>
    );
  }
}
```