### PR TITLE
DCOS-11291: Fix 'access denied' page when visiting a cluster for the first time

### DIFF
--- a/src/js/routes/index.js
+++ b/src/js/routes/index.js
@@ -21,6 +21,11 @@ let routeFactories = [Organization, Network];
 function getApplicationRoutes() {
   // Statically defined routes
   let routes = [].concat(
+    {
+      type: Redirect,
+      path: '/',
+      to: Hooks.applyFilter('applicationRedirectRoute', '/dashboard')
+    },
     dashboard,
     services,
     jobs,
@@ -47,11 +52,6 @@ function getApplicationRoutes() {
           children: routes
         }
       ]
-    },
-    {
-      type: Redirect,
-      path: '/',
-      to: Hooks.applyFilter('applicationRedirectRoute', '/dashboard')
     },
     {
       type: Route,


### PR DESCRIPTION
This PR fixes a regression that user sees 'access denied' page when visiting a cluster for the first time. The solution is to move the root redirect under the `Authenticated` component so the UI will be able to check on the login status first and then redirect.

🙇 