### PR TITLE
DCOS-10975: Form validation based on RAML spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tmp/
 .external_plugins/
 jest/config.json
 webpack/proxy.dev.js
+src/resources/raml

--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     "stylelint": "bash -c 'opts=$@ ; set -f; if [[ $# -lt 1 ]]; then opts=\"{src/styles,plugins,foundation-ui}/**/*.less\"; fi ; stylelint ${opts}' 0",
     "lint-plugins": "PLUGINS=$npm_config_externalplugins; npm run eslint -- \"$PLUGINS/**/*.js\" && npm run stylelint -- \"$PLUGINS/**/*.less\"",
     "prebuild": "./scripts/validate-tests",
-    "raml-update": "(TARGET=`pwd`/src/resources/raml; TMP_DIR=`mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'`; cd $TMP_DIR; wget https://github.com/mesosphere/marathon/archive/master.tar.gz && tar -zxf master.tar.gz && cp -rv marathon-master/docs/docs/rest-api/public/api/v2 $TARGET; cd $TARGET && rm -rf $TMP_DIR)",
     "serve": "npm run build-assets && ./node_modules/.bin/gulp serve",
     "serve-notify": "export NOTIFY=true && npm run serve",
     "scaffold": "./node_modules/.bin/gulp ensureConfig && ./node_modules/.bin/gulp ensureDevProxy",

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "stylelint": "bash -c 'opts=$@ ; set -f; if [[ $# -lt 1 ]]; then opts=\"{src/styles,plugins,foundation-ui}/**/*.less\"; fi ; stylelint ${opts}' 0",
     "lint-plugins": "PLUGINS=$npm_config_externalplugins; npm run eslint -- \"$PLUGINS/**/*.js\" && npm run stylelint -- \"$PLUGINS/**/*.less\"",
     "prebuild": "./scripts/validate-tests",
+    "raml-update": "(TARGET=`pwd`/src/resources/raml; TMP_DIR=`mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'`; cd $TMP_DIR; wget https://github.com/mesosphere/marathon/archive/master.tar.gz && tar -zxf master.tar.gz && cp -rv marathon-master/docs/docs/rest-api/public/api/v2 $TARGET; cd $TARGET && rm -rf $TMP_DIR)",
     "serve": "npm run build-assets && ./node_modules/.bin/gulp serve",
     "serve-notify": "export NOTIFY=true && npm run serve",
     "scaffold": "./node_modules/.bin/gulp ensureConfig && ./node_modules/.bin/gulp ensureDevProxy",

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -2,6 +2,7 @@ import Ace from 'react-ace';
 import classNames from 'classnames';
 import React from 'react';
 
+import AppValidators from '../../../../../../src/resources/raml/v2/types/app.raml';
 import Batch from '../../../../../../src/js/structs/Batch';
 import {combineParsers} from '../../../../../../src/js/utils/ParserUtil';
 import {combineReducers} from '../../../../../../src/js/utils/ReducerUtil';
@@ -17,6 +18,7 @@ import TabViewList from '../../../../../../src/js/components/TabViewList';
 import Transaction from '../../../../../../src/js/structs/Transaction';
 import TransactionTypes from '../../../../../../src/js/constants/TransactionTypes';
 import Util from '../../../../../../src/js/utils/Util';
+import DataValidatorUtil from '../../../../../../src/js/utils/DataValidatorUtil';
 
 const METHODS_TO_BIND = [
   'handleFormChange',
@@ -121,9 +123,15 @@ class NewCreateServiceModalForm extends React.Component {
     let appConfig = this.getAppConfig();
 
     // Run validation reducers on appConfig
-    let errors = Util.filterEmptyValues(
-      new Batch().reduce(validationReducers, appConfig)
-    );
+    let errorList = DataValidatorUtil.validate(appConfig, [
+      AppValidators.App
+    ]);
+
+    errorList.forEach(function (error) {
+      console.error('on /' + error.path.join('/') + ': ' + error.message);
+    });
+
+    let errors = DataValidatorUtil.errorArrayToMap( errorList );
 
     // Create new jsonValue
     let jsonValue = JSON.stringify(appConfig, null, 2);

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -17,7 +17,6 @@ import TabView from '../../../../../../src/js/components/TabView';
 import TabViewList from '../../../../../../src/js/components/TabViewList';
 import Transaction from '../../../../../../src/js/structs/Transaction';
 import TransactionTypes from '../../../../../../src/js/constants/TransactionTypes';
-import Util from '../../../../../../src/js/utils/Util';
 import DataValidatorUtil from '../../../../../../src/js/utils/DataValidatorUtil';
 
 const METHODS_TO_BIND = [
@@ -38,9 +37,6 @@ const jsonParserReducers = combineParsers(JSONParserReducers);
 const jsonConfigReducers = combineReducers(JSONConfigReducers);
 const inputConfigReducers = combineReducers(
   Object.assign({}, ...SECTIONS.map((item) => item.configReducers))
-);
-const validationReducers = combineReducers(
-  Object.assign({}, ...SECTIONS.map((item) => item.validationReducers))
 );
 
 class NewCreateServiceModalForm extends React.Component {
@@ -79,10 +75,12 @@ class NewCreateServiceModalForm extends React.Component {
       // Flush batch
       let batch = new Batch();
 
-      // Run validation reducers
-      let errors = Util.filterEmptyValues(
-        batch.reduce(validationReducers, appConfig)
-      );
+      // Run data validation on the raw data
+      let errorList = DataValidatorUtil.validate(appConfig, [
+        AppValidators.App
+      ]);
+
+      let errors = DataValidatorUtil.errorArrayToMap( errorList );
 
       // Translate appConfig to batch transactions
       jsonParserReducers(appConfig).forEach((item) => {
@@ -122,14 +120,10 @@ class NewCreateServiceModalForm extends React.Component {
     // Create temporary finalized appConfig
     let appConfig = this.getAppConfig();
 
-    // Run validation reducers on appConfig
+    // Run data validation on the raw data
     let errorList = DataValidatorUtil.validate(appConfig, [
       AppValidators.App
     ]);
-
-    errorList.forEach(function (error) {
-      console.error('on /' + error.path.join('/') + ': ' + error.message);
-    });
 
     let errors = DataValidatorUtil.errorArrayToMap( errorList );
 

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -2,7 +2,7 @@ import Ace from 'react-ace';
 import classNames from 'classnames';
 import React from 'react';
 
-import AppValidators from '../../../../../../src/resources/raml/v2/types/app.raml';
+import AppValidators from '../../../../../../src/resources/raml/marathon/v2/types/app.raml';
 import Batch from '../../../../../../src/js/structs/Batch';
 import {combineParsers} from '../../../../../../src/js/utils/ParserUtil';
 import {combineReducers} from '../../../../../../src/js/utils/ReducerUtil';

--- a/scripts/pre-install
+++ b/scripts/pre-install
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
+MARATHON_TAG="1.4.0-snap25"
 
 # Import utils
 source ${SCRIPT_PATH}/utils/git
+source ${SCRIPT_PATH}/utils/marathon
 
 # Validate node and npm version and install git hooks
-${SCRIPT_PATH}/validate-engine-versions && install_hooks "pre-commit"
+${SCRIPT_PATH}/validate-engine-versions && install_hooks "pre-commit" && \
+  install_marathon_raml "$MARATHON_TAG"
 
 exit 0

--- a/scripts/utils/marathon
+++ b/scripts/utils/marathon
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+SCRIPT_PATH="${PROJECT_ROOT}/scripts"
+
+# Import utils
+source ${SCRIPT_PATH}/utils/message
+
+# Make sure that we have the RAML files for the specified marathon version
+function install_marathon_raml() {
+  local TARGET_DIR="${PROJECT_ROOT}/src/resources/raml/marathon/v2"
+  local TAG=$1
+  [ -z "$TAG" ] && TAG="master"
+
+  title "Ensuring we have the RAML specs for marathon v${TAG}"
+
+  # Check if the installer version matches the requested
+  local INSTALLED_VERSION=$(cat ${TARGET_DIR}/.marathon-version 2>/dev/null)
+  if [ "$INSTALLED_VERSION" == "$TAG" ]; then
+    info "Local files are up to date"
+    return
+  fi
+
+  # Download and expand on-the-fly the marathon tarball into a temporary folder
+  header "Downloading marathon v${TAG} archive"
+  local URL="https://github.com/mesosphere/marathon/archive/v${TAG}.tar.gz"
+  local TMP_DIR=`mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'`
+  curl -L ${URL} | tar -zx -C $TMP_DIR
+
+  # Empty the target raml directory
+  [ -d $TARGET_DIR ] && rm -rf $TARGET_DIR
+  mkdir -p $TARGET_DIR
+
+  # Copy only relevant parts in the RAML directory
+  header "Installing raml files"
+  cp -r $TMP_DIR/marathon-${TAG}/docs/docs/rest-api/public/api/v2/{schema,types,*.raml} $TARGET_DIR \
+    && echo $TAG > "${TARGET_DIR}/.marathon-version"
+
+  # Cleanup
+  rm -rf $TMP_DIR
+
+  info "Updated RAML in src/resources/raml/marathon-v2"
+}

--- a/src/js/utils/DataValidatorUtil.js
+++ b/src/js/utils/DataValidatorUtil.js
@@ -1,0 +1,65 @@
+/**
+ * Return a new array or a new object, if the key given is a number or string.
+ *
+ * @param {String} forKey - The key to create a new object/array for
+ * @returns {Object|Array} Returns an object or array, according to type
+ */
+function newTypeFor(forKey) {
+  if (isNaN(forKey)) {
+    return {};
+  } else {
+    return [];
+  }
+}
+
+module.exports = {
+
+  /**
+   * This is a shorthand function to collect a list of validation errors for
+   * the given input data, passed through an array of validation functions.
+   *
+   * @param {any} inputData - The data to pass to the validator(s)
+   * @param {array|function} validatorFn - The validation function(s)
+   * @returns {[{path, message}]} Returns an array with the errors
+   */
+  validate(inputData, validatorFn) {
+    if (!Array.isArray(validatorFn)) {
+      validatorFn = [validatorFn];
+    }
+
+    return validatorFn.reduce(function (errors, validator) {
+      return errors.concat(
+        validator(inputData)
+      );
+    }, []);
+  },
+
+  /**
+   * This function converts an array of errors returned from `validate`
+   * and creates an object with the errors in the correct location.
+   *
+   * @param {[{path, message}]} errors - The array of errors
+   * @returns {Object} Returns an object with the errors in the correct paths
+   */
+  errorArrayToMap(errors) {
+    return errors.reduce(function (errorMap, error) {
+      let parent = error.path.slice(0, -1).reduce(function (object, key, i) {
+        if (object[key] === undefined) {
+          object[key] = newTypeFor(error.path[i+1]);
+        }
+
+        return object[key];
+      }, errorMap);
+
+      let key = error.path[error.path.length - 1];
+      if (parent[key] === undefined) {
+        parent[key] = error.message;
+      } else {
+        parent[key] += `, ${error.message}`;
+      }
+
+      return errorMap;
+    }, {});
+  }
+
+};

--- a/src/js/utils/__tests__/DataValidatorUtil-test.js
+++ b/src/js/utils/__tests__/DataValidatorUtil-test.js
@@ -1,0 +1,44 @@
+jest.dontMock('../DataValidatorUtil');
+
+const DataValidatorUtil = require('../DataValidatorUtil');
+
+describe('DataValidatorUtil', function () {
+
+  describe('#errorArrayToMap', function () {
+
+    it('should correctly return an object', function () {
+      var obj = DataValidatorUtil.errorArrayToMap([
+        {path: ['a', 'b'], message: 'Foo'}
+      ]);
+      expect(obj).toEqual({a: {b: 'Foo'}});
+    });
+
+    it('should correctly merge paths that share the same base', function () {
+      var obj = DataValidatorUtil.errorArrayToMap([
+        {path: ['a', 'b'], message: 'Foo'},
+        {path: ['a', 'c'], message: 'Bar'}
+      ]);
+      expect(obj).toEqual({a: {b: 'Foo', c: 'Bar'}});
+    });
+
+    it('should correctly create arrays when numbers in path', function () {
+      var obj = DataValidatorUtil.errorArrayToMap([
+        {path: ['a', 0, 'b'], message: 'Foo'},
+        {path: ['a', 5, 'b'], message: 'Bar'}
+      ]);
+      expect(obj).toEqual({a: [
+        {b: 'Foo'}, undefined, undefined, undefined, undefined, {b: 'Bar'}
+      ]});
+    });
+
+    it('should correctly merge errors in the same path', function () {
+      var obj = DataValidatorUtil.errorArrayToMap([
+        {path: ['a', 'b'], message: 'Foo'},
+        {path: ['a', 'b'], message: 'Bar'}
+      ]);
+      expect(obj).toEqual({a: {b: 'Foo, Bar'}});
+    });
+
+  });
+
+});

--- a/src/resources/raml/README.md
+++ b/src/resources/raml/README.md
@@ -1,0 +1,7 @@
+# Marathon RAML Files
+
+To download and place the latest marathon RAML files in this directory type:
+
+```
+npm run update-raml
+```


### PR DESCRIPTION
This PR uses the `raml-validator-loader` webpack loader to translate RAML documents to javascript validation functions and then uses them to validate the form contents.

To test:

```
npm run raml-update
```

_NOTE: I have embedded the `raml-validator-loader` project with the 528b2ab commit. Ideally it should be moved on a separate project and that commit should be removed, but until we have settled with the management stuff it will stay here_

**To check only the interesting changes check [this diff here](https://github.com/dcos/dcos-ui/compare/master...862cc88d104073a6207b843fc0496586a3d1c478)**

![validation mov](https://cloud.githubusercontent.com/assets/883486/20062913/a862468a-a505-11e6-885f-3ddda2b30360.gif)
