### PR TITLE
Improve ConfigurationMap styling

### DIFF
--- a/src/js/components/ConfigurationMapHeading.js
+++ b/src/js/components/ConfigurationMapHeading.js
@@ -10,7 +10,8 @@ const ConfigurationMapHeading = (props) => {
       className: classNames(
         'configuration-map-heading short-bottom',
         {
-          'configuration-map-heading-primary': level === 1
+          'configuration-map-heading-primary': level === 1,
+          'short-top': level === 2
         },
         className
       )

--- a/src/styles/components/configuration-map/styles.less
+++ b/src/styles/components/configuration-map/styles.less
@@ -25,11 +25,13 @@
     }
 
     &-row {
-      border-bottom: 1px solid @configuration-map-border-color;
       display: flex;
 
-      &:last-child {
-        border-bottom: none;
+      & + .configuration-map {
+
+        &-row {
+          border-top: 1px solid @configuration-map-border-color;
+        }
       }
     }
 
@@ -39,7 +41,8 @@
     }
 
     &-label {
-      flex: 0 0 @base-spacing-unit * 8;
+      color: @neutral;
+      flex: 0 0 @configuration-map-label-width;
       font-weight: 700;
       text-transform: uppercase;
     }
@@ -63,6 +66,13 @@
         }
       }
     }
+
+    &-table {
+
+      &-label {
+        width: @configuration-map-label-width;
+      }
+    }
   }
 }
 
@@ -84,7 +94,14 @@
       }
 
       &-label {
-        flex-basis: @base-spacing-unit-screen-small * 8;
+        flex-basis: @configuration-map-label-width-screen-small;
+      }
+
+      &-table {
+
+        &-label {
+          width: @configuration-map-label-width-screen-small;
+        }
       }
     }
   }
@@ -108,7 +125,14 @@
       }
 
       &-label {
-        flex-basis: @base-spacing-unit-screen-medium * 8;
+        flex-basis: @configuration-map-label-width-screen-medium;
+      }
+
+      &-table {
+
+        &-label {
+          width: @configuration-map-label-width-screen-medium;
+        }
       }
     }
   }
@@ -132,7 +156,14 @@
       }
 
       &-label {
-        flex-basis: @base-spacing-unit-screen-large * 8;
+        flex-basis: @configuration-map-label-width-screen-large;
+      }
+
+      &-table {
+
+        &-label {
+          width: @configuration-map-label-width-screen-large;
+        }
       }
     }
   }
@@ -156,7 +187,14 @@
       }
 
       &-label {
-        flex-basis: @base-spacing-unit-screen-jumbo * 8;
+        flex-basis: @configuration-map-label-width-screen-jumbo;
+      }
+
+      &-table {
+
+        &-label {
+          width: @configuration-map-label-width-screen-jumbo;
+        }
       }
     }
   }

--- a/src/styles/components/configuration-map/variables.less
+++ b/src/styles/components/configuration-map/variables.less
@@ -7,3 +7,9 @@
 @configuration-map-section-margin-bottom-screen-medium: @pod-margin-bottom-screen-medium;
 @configuration-map-section-margin-bottom-screen-large: @pod-margin-bottom-screen-large;
 @configuration-map-section-margin-bottom-screen-jumbo: @pod-margin-bottom-screen-jumbo;
+
+@configuration-map-label-width: @base-spacing-unit * 8;
+@configuration-map-label-width-screen-small: @base-spacing-unit-screen-small * 8;
+@configuration-map-label-width-screen-medium: @base-spacing-unit-screen-medium * 8;
+@configuration-map-label-width-screen-large: @base-spacing-unit-screen-large * 8;
+@configuration-map-label-width-screen-jumbo: @base-spacing-unit-screen-jumbo * 8;


### PR DESCRIPTION
This PR:
* applies the `short-top` class to all `ConfigurationMapHeading` components where `level === 2`
* applies the `@neutral` color to each `ConfigurationMapLabel` element
* assigns the width for the `ConfigurationMapLabel` elements to a variable for re-use in the neighboring tables