### PR TITLE
Improve table styling

### DIFF
--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -39,6 +39,7 @@
       // This property is necessary for table cells to respect the text-overflow
       // property. http://stackoverflow.com/questions/9789723/css-text-overflow-in-a-table-cell
       max-width: 0;
+      vertical-align: top;
     }
 
     .table-header-title {
@@ -124,5 +125,9 @@
         }
       }
     }
+  }
+
+  .table-break-word {
+    word-break: break-all;
   }
 }

--- a/src/styles/content/tables/table-simple/styles.less
+++ b/src/styles/content/tables/table-simple/styles.less
@@ -1,0 +1,37 @@
+& when (@table-simple-enabled) {
+
+  .table-simple {
+    &:extend(.table-borderless-outer all);
+    &:extend(.table-borderless-inner-columns all);
+
+    // The extra specificity is needed to override CNVS defaults.
+    thead {
+
+      th {
+        background: none;
+        color: @neutral;
+        font-size: @table-font-size;
+
+        &.active {
+          background: none;
+        }
+      }
+    }
+
+    th,
+    td {
+
+      &:first-child {
+        padding-left: 0;
+      }
+
+      &:last-child {
+        padding-right: 0;
+      }
+
+      &.active {
+        background: none;
+      }
+    }
+  }
+}

--- a/src/styles/content/tables/table-simple/variables.less
+++ b/src/styles/content/tables/table-simple/variables.less
@@ -1,0 +1,1 @@
+@table-simple-enabled: true;

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -89,6 +89,11 @@
 @import 'content/tables/variables.less';
 @import 'content/tables/styles.less';
 
+// Tables: Simple Variant
+
+@import 'content/tables/table-simple/variables.less';
+@import 'content/tables/table-simple/styles.less';
+
 /*
  * Components
  */


### PR DESCRIPTION
This PR:
* sets `vertical-align: top` for all `table` elements (as far as I can tell, all tables that rely on `vertical-align: middle` have explicitly declared this)
* adds a `table-break-word` class
* adds a `table-simple` style variant which looks like this:
![](https://cl.ly/0M022q2r2E3t/Screen%20Shot%202016-11-07%20at%201.56.19%20PM.png)