### PR TITLE
DCOS-11363: Bring ACL menu filter back

### DIFF
--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -16,6 +16,20 @@ import NotificationStore from '../stores/NotificationStore';
 import SaveStateMixin from '../mixins/SaveStateMixin';
 import SidebarActions from '../events/SidebarActions';
 
+let defaultMenuItems = [
+  '/dashboard',
+  '/services',
+  '/jobs',
+  '/universe',
+  '/nodes',
+  '/network',
+  '/security',
+  '/cluster',
+  '/components',
+  '/settings',
+  '/organization'
+];
+
 let {Hooks} = PluginSDK;
 
 var Sidebar = React.createClass({
@@ -88,12 +102,16 @@ var Sidebar = React.createClass({
   },
 
   getNavigationSections() {
-    let indexRoute = this.props.routes
-      .find(function (route) {
-        return route.id === 'index';
-      });
+    const menuItems = Hooks
+      .applyFilter('sidebarNavigation', defaultMenuItems)
+      .reduce((routesMap, path) => routesMap.set(path, true), new Map());
 
-    return this.getMenuGroupsFromChildren(indexRoute.childRoutes)
+    let indexRoute = this.props.routes.find(({id}) => id === 'index');
+
+    const routes = indexRoute.childRoutes
+      .filter((route) => menuItems.has(`/${route.path}`));
+
+    return this.getMenuGroupsFromChildren(routes)
       .map((group, index) => {
         let heading = null;
 


### PR DESCRIPTION
⚠️  merge the plugins first https://github.com/mesosphere/dcos-ui-plugins-private/pull/451

---

This PR re-enables Sidebar ACL filtering as it went missing in this commit https://github.com/dcos/dcos-ui/commit/b559575a39caf39407bca39984bd3045ddd14a82
