### PR TITLE
DCOS-11391: Fix Links to Volume Detail

### DIFF
--- a/plugins/nodes/src/js/routes/nodes.js
+++ b/plugins/nodes/src/js/routes/nodes.js
@@ -156,18 +156,18 @@ let nodesRoutes = {
               }
             },
             {
-              type: Route,
-              path: 'volumes(/:volumeID)',
+              component: VolumeTable,
               hideHeaderNavigation: true,
               isTab: true,
-              component: VolumeTable,
+              path: 'volumes',
+              title: 'Volumes',
+              type: Route,
               buildBreadCrumb() {
                 return {
                   parentCrumb: '/nodes/:nodeID/tasks/:taskID',
                   getCrumbs() { return []; }
                 };
-              },
-              title: 'Volumes'
+              }
             }
           ]
         },

--- a/plugins/services/src/js/components/VolumeTable.js
+++ b/plugins/services/src/js/components/VolumeTable.js
@@ -3,6 +3,7 @@ import {Link} from 'react-router';
 import React from 'react';
 import {Table} from 'reactjs-components';
 
+import {reconstructPathFromRoutes} from '../../../../../src/js/utils/RouterUtil';
 import Volume from '../structs/Volume';
 import VolumeStatus from '../constants/VolumeStatus';
 
@@ -131,15 +132,15 @@ class VolumeTable extends React.Component {
   renderIDColumn(prop, row) {
     let id = row[prop];
     let {nodeID, taskID} = this.props.params;
-    let volumeID = global.encodeURIComponent(id);
-    let routes = this.props.routes;
-    let currentroutePath = routes[routes.length - 1].path;
+    let volumeID = encodeURIComponent(id);
+    let serviceID = encodeURIComponent(this.props.params.id);
+    let currentroutePath = reconstructPathFromRoutes(this.props.routes);
     let routePath = null;
 
     if (currentroutePath === '/services/overview/:id') {
-      routePath = `/services/overview/${this.props.params.id}/volumes/${volumeID}`;
+      routePath = `/services/overview/${serviceID}/volumes/${volumeID}`;
     } else if (currentroutePath === '/services/overview/:id/tasks/:taskID/volumes') {
-      routePath = `/services/overview/${this.props.params.id}/tasks/${taskID}/volumes/${volumeID}`;
+      routePath = `/services/overview/${serviceID}/tasks/${taskID}/volumes/${volumeID}`;
     } else if (currentroutePath === '/nodes/:nodeID/tasks/:taskID/volumes') {
       routePath = `/nodes/${nodeID}/tasks/${taskID}/volumes/${volumeID}`;
     }


### PR DESCRIPTION
This PR fixes links to the Volume Detail view from all locations:
- Services
- Service/Volumes
- Nodes/Task/Volumes

PS. I do agree that we should refactor the way we detect current location, I'd rather see HOC pushing this piece of config down to `VolumeTable`

🙇 