### PR TITLE
ObjectUtil: Adding walkObjectsByPath function

### DIFF
--- a/src/js/utils/ObjectUtil.js
+++ b/src/js/utils/ObjectUtil.js
@@ -1,4 +1,18 @@
-module.exports = {
+/**
+ * Return a new array or a new object, if the key given is a number or string.
+ *
+ * @param {String} forKey - The key to create a new object/array for
+ * @returns {Object|Array} Returns an object or array, according to type
+ */
+function newTypeFor(forKey) {
+  if (isNaN(forKey)) {
+    return {};
+  } else {
+    return [];
+  }
+}
+
+var ObjectUtil = {
 
   /**
    * This function adds the given mark to the provided object.
@@ -26,6 +40,106 @@ module.exports = {
    */
   objectHasMark(obj, mark) {
     return obj.___object_mark___ === mark;
+  },
+
+  /**
+   * A function that can be used as a `walkFn` on a `walkSpec` in the
+   * `walkObjectsByPath` function (see below) for creating missing object paths.
+   *
+   * @param {Object} object - The current object being walked
+   * @param {String} key - The name of the immediate children to return
+   * @param {String} nextKey - The next key in the path (used for type detection)
+   * @returns {Object} Returns the child item
+   */
+  walkCreateMissing(object, key, nextKey) {
+    if (object[key] === undefined) {
+      object[key] = newTypeFor(nextKey);
+    }
+    return object[key];
+  },
+
+  /**
+   * A function that can be used as a `walkFn` on a `walkSpec` in the
+   * `walkObjectsByPath` function (see below) for skipping missing paths.
+   *
+   * If a path is missing this function will return `undefined`.
+   *
+   * @param {Object} object - The current object being walked
+   * @param {String} key - The name of the immediate children to return
+   * @returns {Object|undefined} Returns the child item or undefined if a path was missing
+   */
+  walkSkipMissing(object, key) {
+    if (object === undefined) {
+      return undefined;
+    }
+    return object[key];
+  },
+
+  /**
+   * Walk on one or more objects in parallel following the path given and return
+   * the final result of the walk operation.
+   *
+   * WARNING: We assume the `opFn` will eventually *MUTATE* the object. That's
+   *          intentional, since this function can be used to delete items in
+   *          the object. If you don't want this behaviour, *YOU* are
+   *          responsible for passing object copies.
+   *
+   * Each `walkSpec` is an object with the following syntax:
+   *
+   * {
+   *   object: {}                   // The object to walk
+   *   walkFn(object, key, nextKey) // The walking function
+   * }
+   *
+   * @param {Array} path - The path components as an array of strings
+   * @param {Array} walkSpec - One or more objects to walk concurrently (see above)
+   * @param {Function} opFn - The operation to perform at the end of the walk
+   *
+   * @returns {Array} Returns an array with the objects as mutated by the walk op
+   *
+   */
+  walkObjectsByPath(path, walkSpec, opFn) {
+    let branchKeys = path.slice(0, -1);
+    let leafKey = path[path.length-1];
+
+    // Extract the objects from all
+    let objects = walkSpec.map(function (spec) {
+      return spec.object;
+    });
+
+    // Walk all object paths in parallel
+    let leafObjects = branchKeys.reduce(function (objects, key, keyIdx) {
+      return objects.map(function (object, specIdx) {
+        return (walkSpec[specIdx].walkFn || ObjectUtil.walkCreateMissing)(
+          object, key, path[keyIdx+1]
+        );
+      });
+    }, objects);
+
+    // Call the operator function & return the objects root
+    opFn(leafObjects, leafKey);
+    return objects;
+  },
+
+  /**
+   * Shorthand for walkObjectsByPath for one object
+   *
+   * @param {Array} path - The path components as an array of strings
+   * @param {Object} object - The object to walk
+   * @param {Function} opFn - The operation to perform at the end of the walk
+   * @param {Function} walkFn - The function to use for walking the path
+   *
+   * @returns {Object} Returns the mutated object by the walk op
+   */
+  walkObjectByPath(path, object, opFn, walkFn=ObjectUtil.walkCreateMissing) {
+    return ObjectUtil.walkObjectsByPath(path,
+      [{object, walkFn}],
+      function (objects, key) {
+        return [opFn(objects[0], key)];
+      }
+    )[0];
   }
 
 };
+
+module.exports = ObjectUtil;

--- a/src/js/utils/__tests__/ObjectUtil-test.js
+++ b/src/js/utils/__tests__/ObjectUtil-test.js
@@ -61,4 +61,186 @@ describe('ObjectUtil', function () {
 
   });
 
+  describe('#walkObjectsByPath', function () {
+
+    it('should call the walking function for every but last path item', function () {
+      var walkObj = {a: {b: {c: 0}}};
+
+      var mockWalkFn = jest.fn();
+      mockWalkFn
+        .mockReturnValueOnce(walkObj.a)
+        .mockReturnValueOnce(walkObj.a.b)
+        .mockReturnValue({});
+
+      ObjectUtil.walkObjectsByPath(
+        ['a', 'b', 'c'],
+        [{
+          object: walkObj,
+          walkFn: mockWalkFn
+        }],
+        function () { }
+      );
+
+      expect(mockWalkFn.mock.calls).toEqual([
+        [walkObj, 'a', 'b'],
+        [walkObj.a, 'b', 'c']
+      ]);
+
+    });
+
+    it('should not call any walk function if path has length 1', function () {
+      var walkObj = {a: {b: {c: 0}}};
+      var mockWalkFn = jest.fn();
+
+      ObjectUtil.walkObjectsByPath(
+        ['a'],
+        [{
+          object: walkObj,
+          walkFn: mockWalkFn
+        }],
+        function () { }
+      );
+
+      expect(mockWalkFn).not.toBeCalled();
+
+    });
+
+    it('should correctly call the op function', function () {
+      var walkObj = {a: {b: {c: 0}}};
+      var mockOpFn = jest.fn();
+
+      ObjectUtil.walkObjectsByPath(
+        ['a', 'b', 'c'],
+        [{
+          object: walkObj
+        }],
+        mockOpFn
+      );
+
+      expect(mockOpFn.mock.calls).toEqual([
+        [[walkObj.a.b], 'c']
+      ]);
+
+    });
+
+    it('should call the correct walk functions', function () {
+      var walkObj1 = {a: {b: {c: 0}}};
+      var walkObj2 = {a: {b: {c: 0}}};
+
+      var mockWalkFn1 = jest.fn();
+      mockWalkFn1
+        .mockReturnValueOnce(walkObj1.a)
+        .mockReturnValueOnce(walkObj1.a.b)
+        .mockReturnValue({});
+
+      var mockWalkFn2 = jest.fn();
+      mockWalkFn2
+        .mockReturnValueOnce(walkObj2.a)
+        .mockReturnValueOnce(walkObj2.a.b)
+        .mockReturnValue({});
+
+      ObjectUtil.walkObjectsByPath(
+        ['a', 'b', 'c'],
+        [
+          {
+            object: walkObj1,
+            walkFn: mockWalkFn1
+          },
+          {
+            object: walkObj2,
+            walkFn: mockWalkFn2
+          }
+        ],
+        function () { }
+      );
+
+      expect(mockWalkFn1.mock.calls).toEqual([
+        [walkObj1, 'a', 'b'],
+        [walkObj1.a, 'b', 'c']
+      ]);
+      expect(mockWalkFn2.mock.calls).toEqual([
+        [walkObj2, 'a', 'b'],
+        [walkObj2.a, 'b', 'c']
+      ]);
+
+    });
+
+    it('should by default add missing object path components', function () {
+      var walkObj = {a: {b: {c: 0}}};
+
+      ObjectUtil.walkObjectsByPath(
+        ['a', 'b', 'd', 'e'],
+        [{
+          object: walkObj
+        }],
+        function () { }
+      );
+
+      expect(walkObj).toEqual({
+        a: {
+          b: {
+            c: 0,
+            d: { }
+          }
+        }
+      });
+
+    });
+
+    it('should by default add missing array path components', function () {
+      var walkObj = {a: {b: {c: 0}}};
+
+      ObjectUtil.walkObjectsByPath(
+        ['a', 'b', 'd', '0'],
+        [{
+          object: walkObj
+        }],
+        function () { }
+      );
+
+      expect(walkObj).toEqual({
+        a: {
+          b: {
+            c: 0,
+            d: []
+          }
+        }
+      });
+
+    });
+
+    it('should not modify the object if `walkSkipMissing` used', function () {
+      var walkObj = {a: {b: {c: 0}}};
+
+      ObjectUtil.walkObjectsByPath(
+        ['a', 'b', 'd', 'e'],
+        [{
+          object: walkObj,
+          walkFn: ObjectUtil.walkSkipMissing
+        }],
+        function () { }
+      );
+
+      expect(walkObj).toEqual({a: {b: {c: 0}}});
+    });
+
+    it('should allow opFn to mutate the object', function () {
+      var walkObj = {a: {b: {c: 0}}};
+
+      ObjectUtil.walkObjectsByPath(
+        ['a', 'b', 'c'],
+        [{
+          object: walkObj,
+          walkFn: ObjectUtil.walkSkipMissing
+        }],
+        function (objects, key) {
+          delete objects[0][key];
+        }
+      );
+
+      expect(walkObj).toEqual({a: {b: {}}});
+    });
+
+  });
+
 });


### PR DESCRIPTION
This PR introduces the `walkObjectsByPath` function that can now be used for performing arbitrary operations on objects, based on array paths. I found myself repeating a couple of times, working on the new data validator, so I thought of separating the core functionality as a utility function.

The idea is quite simple:
* Use a `resolution` function to walk every path component and resolve the appropriate nested child
* Use an `operation` function that performs the decided operation on the children of the final leaf

This separation simplifies the way we handle missing object keys, since the `resolution` function is responsible for this (check [walkCreateMissing](https://github.com/dcos/dcos-ui/pull/1337/files#diff-a5ea432b2de66adf76cd2f82b8072e65R54) or  [walkSkipMissing](https://github.com/dcos/dcos-ui/pull/1337/files#diff-a5ea432b2de66adf76cd2f82b8072e65R71)).

This makes the `operation` to always operate on a flat object, allowing any kind of operations to be cleanly applied.

## Example

For example, you can create a utility that assigns values to an object by path like so:
Ps. [`walkObjectByPath`](https://github.com/dcos/dcos-ui/pull/1337/files#diff-a5ea432b2de66adf76cd2f82b8072e65R134) is a shorthand for `walkObjectsByPath` for only one object.

```js
function setByPath(object, path, value) {
  ObjectUtil.walkObjectByPath(path, object, function(leafObject, leafKey) {
    leafObject[leafKey] = value;
  });
}

var object = {};
setByPath(object, ['a', 'b'], 1);

// object = {'a': {'b': 1}};
```
