### PR TITLE
Fix: Adding .raml file loader

### DIFF
--- a/webpack/webpack.config.babel.js
+++ b/webpack/webpack.config.babel.js
@@ -149,6 +149,10 @@ module.exports = {
         loader: 'jison-loader'
       },
       {
+        test: /\.raml$/,
+        loader: 'raml-validator-loader'
+      },
+      {
         test: /\.(ico|icns)$/,
         loader: 'file?name=./[hash]-[name].[ext]'
       },


### PR DESCRIPTION
Forgot to make webpack load `.raml` files with the `raml-validator-loader` by default.