### PR TITLE
JSONUtil: Adding `position` attribute on JSON tokens

### DIFF
--- a/src/js/utils/JSONUtil.js
+++ b/src/js/utils/JSONUtil.js
@@ -12,10 +12,6 @@ const TOKENIZER_TOKENS = {
   'null': /null/g,
   'boolean': /(true|false)/g,
   'number': /-?\d+(\.\d+)?([eE]-?\d+)?/g,
-  'maybe-decimal-number': /-?\d+\./g,
-  'maybe-negative-number': /-/g,
-  'maybe-exponential-number': /-?\d+(\.\d+)?([eE])?/g,
-  'maybe-exponential-number-negative': /-?\d+(\.\d+)?([eE]-)?/g,
   'symbol': /\w+/g
 };
 
@@ -124,6 +120,9 @@ module.exports = {
     // This variable keeps track of the current object key. It's used only
     // when in an object { } and is populated only when a colon ':'' is encoutered
     let objectKey = null;
+    // Stack of block tokens, used to keep track of the last opened block
+    // token in order to update the ending position.
+    let blockTokens = [];
 
     // First validate sanity of the JSON source, in order for us
     // to safely asume that this is a legit JSON source
@@ -155,11 +154,15 @@ module.exports = {
         case 'begin-object':
           // Keep track of keyed objects
           if (objectKey) {
-            keyLines.push({
+            let blockToken = {
               path: [].concat(path, objectKey),
               line: lineNo,
-              type: 'object'
-            });
+              type: 'object',
+              pos: [offset, i]
+            };
+
+            keyLines.push(blockToken);
+            blockTokens.push(blockToken);
 
             path.push(objectKey);
             objectKey = null;
@@ -167,11 +170,15 @@ module.exports = {
 
           // Keep track of indexed objects
           if (arrayIndex !== -1) {
-            keyLines.push({
+            let blockToken = {
               path: [].concat(path, arrayIndex),
               line: lineNo,
-              type: 'object'
-            });
+              type: 'object',
+              pos: [offset, i]
+            };
+
+            keyLines.push(blockToken);
+            blockTokens.push(blockToken);
 
             path.push(arrayIndex);
           }
@@ -186,11 +193,15 @@ module.exports = {
         case 'begin-array':
           // Keep track of keyed arrays
           if (objectKey) {
-            keyLines.push({
+            let blockToken = {
               path: [].concat(path, objectKey),
               line: lineNo,
-              type: 'array'
-            });
+              type: 'array',
+              pos: [offset, i]
+            };
+
+            keyLines.push(blockToken);
+            blockTokens.push(blockToken);
 
             path.push(objectKey);
             objectKey = null;
@@ -198,11 +209,15 @@ module.exports = {
 
           // Keep track of indexed arrays
           if (arrayIndex !== -1) {
-            keyLines.push({
+            let blockToken = {
               path: [].concat(path, arrayIndex),
               line: lineNo,
-              type: 'array'
-            });
+              type: 'array',
+              pos: [offset, i]
+            };
+
+            keyLines.push(blockToken);
+            blockTokens.push(blockToken);
 
             path.push(arrayIndex);
           }
@@ -223,6 +238,12 @@ module.exports = {
             arrayIndex = lastValue;
           } else {
             arrayIndex = -1;
+          }
+
+          // Update the ending position of the last block token on stack
+          let lastBlockToken = blockTokens.pop();
+          if (lastBlockToken) {
+            lastBlockToken.pos[1] = i;
           }
           break;
 
@@ -281,7 +302,8 @@ module.exports = {
               path: [].concat(path, objectKey),
               line: lineNo,
               value: match,
-              type: 'literal'
+              type: 'literal',
+              pos: [offset, i]
             });
             objectKey = null;
           }
@@ -292,7 +314,8 @@ module.exports = {
               path: [].concat(path, arrayIndex),
               line: lineNo,
               value: match,
-              type: 'literal'
+              type: 'literal',
+              pos: [offset, i]
             });
           }
           break;

--- a/src/js/utils/JSONUtil.js
+++ b/src/js/utils/JSONUtil.js
@@ -158,7 +158,7 @@ module.exports = {
               path: [].concat(path, objectKey),
               line: lineNo,
               type: 'object',
-              pos: [offset, i]
+              position: [offset, i]
             };
 
             keyLines.push(blockToken);
@@ -174,7 +174,7 @@ module.exports = {
               path: [].concat(path, arrayIndex),
               line: lineNo,
               type: 'object',
-              pos: [offset, i]
+              position: [offset, i]
             };
 
             keyLines.push(blockToken);
@@ -197,7 +197,7 @@ module.exports = {
               path: [].concat(path, objectKey),
               line: lineNo,
               type: 'array',
-              pos: [offset, i]
+              position: [offset, i]
             };
 
             keyLines.push(blockToken);
@@ -213,7 +213,7 @@ module.exports = {
               path: [].concat(path, arrayIndex),
               line: lineNo,
               type: 'array',
-              pos: [offset, i]
+              position: [offset, i]
             };
 
             keyLines.push(blockToken);
@@ -243,7 +243,7 @@ module.exports = {
           // Update the ending position of the last block token on stack
           let lastBlockToken = blockTokens.pop();
           if (lastBlockToken) {
-            lastBlockToken.pos[1] = i;
+            lastBlockToken.position[1] = i;
           }
           break;
 
@@ -303,7 +303,7 @@ module.exports = {
               line: lineNo,
               value: match,
               type: 'literal',
-              pos: [offset, i]
+              position: [offset, i]
             });
             objectKey = null;
           }
@@ -315,7 +315,7 @@ module.exports = {
               line: lineNo,
               value: match,
               type: 'literal',
-              pos: [offset, i]
+              position: [offset, i]
             });
           }
           break;

--- a/src/js/utils/__tests__/JSONUtil-test.js
+++ b/src/js/utils/__tests__/JSONUtil-test.js
@@ -74,7 +74,7 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['name'], line: 2, type: 'literal', value: 'value',
-            pos: [10, 17]}
+            position: [10, 17]}
         ]);
       });
 
@@ -83,7 +83,7 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['name'], line: 2, type: 'literal', value: 1,
-            pos: [10, 11]}
+            position: [10, 11]}
         ]);
       });
 
@@ -92,7 +92,7 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['name'], line: 2, type: 'literal', value: null,
-            pos: [10, 14]}
+            position: [10, 14]}
         ]);
       });
 
@@ -101,7 +101,7 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['name'], line: 2, type: 'literal', value: true,
-            pos: [10, 14]}
+            position: [10, 14]}
         ]);
       });
 
@@ -110,7 +110,7 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['name'], line: 2, type: 'literal', value: false,
-            pos: [10, 15]}
+            position: [10, 15]}
         ]);
       });
 
@@ -123,9 +123,9 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['name'], line: 2, type: 'literal', value: 1,
-            pos: [10, 11]},
+            position: [10, 11]},
           {path: ['name'], line: 3, type: 'literal', value: 2,
-            pos: [21, 22]}
+            position: [21, 22]}
         ]);
       });
 
@@ -134,9 +134,9 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['name'], line: 2, type: 'literal', value: 1,
-            pos: [10, 11]},
+            position: [10, 11]},
           {path: ['nome'], line: 2, type: 'literal', value: 2,
-            pos: [21, 22]}
+            position: [21, 22]}
         ]);
       });
 
@@ -145,9 +145,9 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['name'], line: 2, type: 'literal', value: 1,
-            pos: [10, 11]},
+            position: [10, 11]},
           {path: ['name'], line: 2, type: 'literal', value: 2,
-            pos: [21, 22]}
+            position: [21, 22]}
         ]);
       });
 
@@ -160,9 +160,9 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['name'], line: 2, type: 'object',
-            pos: [10, 26]},
+            position: [10, 26]},
           {path: ['name', 'child'], line: 3, type: 'literal', value: 1,
-            pos: [22, 23]}
+            position: [22, 23]}
         ]);
       });
 
@@ -171,11 +171,11 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['name'], line: 2, type: 'object',
-            pos: [10, 43]},
+            position: [10, 43]},
           {path: ['name', 'child'], line: 3, type: 'object',
-            pos: [22, 40]},
+            position: [22, 40]},
           {path: ['name', 'child', 'value'], line: 4, type: 'literal', value: 1,
-            pos: [35, 36]}
+            position: [35, 36]}
         ]);
       });
 
@@ -184,11 +184,11 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['key1'], line: 2, type: 'literal', value: 1,
-            pos: [10, 11]},
+            position: [10, 11]},
           {path: ['key2'], line: 3, type: 'literal', value: 2,
-            pos: [21, 22]},
+            position: [21, 22]},
           {path: ['key3'], line: 4, type: 'literal', value: 3,
-            pos: [32, 33]}
+            position: [32, 33]}
         ]);
       });
 
@@ -197,15 +197,15 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['key1'], line: 2, type: 'literal', value: 'string',
-            pos: [10, 18]},
+            position: [10, 18]},
           {path: ['key2'], line: 3, type: 'literal', value: 2,
-            pos: [28, 29]},
+            position: [28, 29]},
           {path: ['key3'], line: 4, type: 'literal', value: false,
-            pos: [39, 44]},
+            position: [39, 44]},
           {path: ['key4'], line: 5, type: 'literal', value: true,
-            pos: [54, 58]},
+            position: [54, 58]},
           {path: ['key5'], line: 6, type: 'literal', value: null,
-            pos: [68, 72]}
+            position: [68, 72]}
         ]);
       });
 
@@ -214,23 +214,23 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['obj1'], line: 2, type:'object',
-            pos: [10, 34]},
+            position: [10, 34]},
           {path: ['obj1', 'key1'], line: 3, type: 'literal', value: 1,
-            pos: [20, 21]},
+            position: [20, 21]},
           {path: ['obj1', 'key2'], line: 4, type: 'literal', value: 2,
-            pos: [31, 32]},
+            position: [31, 32]},
           {path: ['obj2'], line: 5, type:'object',
-            pos: [44, 68]},
+            position: [44, 68]},
           {path: ['obj2', 'key3'], line: 6, type: 'literal', value: 1,
-            pos: [54, 55]},
+            position: [54, 55]},
           {path: ['obj2', 'key4'], line: 7, type: 'literal', value: 2,
-            pos: [65, 66]},
+            position: [65, 66]},
           {path: ['obj3'], line: 8, type:'object',
-            pos: [78, 102]},
+            position: [78, 102]},
           {path: ['obj3', 'key5'], line: 9, type: 'literal', value: 1,
-            pos: [88, 89]},
+            position: [88, 89]},
           {path: ['obj3', 'key6'], line: 10, type: 'literal', value: 2,
-            pos: [99, 100]}
+            position: [99, 100]}
         ]);
       });
 
@@ -243,9 +243,9 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['name'], line: 2, type: 'array',
-            pos: [10, 23]},
+            position: [10, 23]},
           {path: ['name', 0], line: 3, type: 'literal', value: 'child',
-            pos: [13, 20]}
+            position: [13, 20]}
         ]);
       });
 
@@ -254,11 +254,11 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['name'], line: 2, type: 'array',
-            pos: [10, 28]},
+            position: [10, 28]},
           {path: ['name', 0], line: 3, type: 'object',
-            pos: [13, 25]},
+            position: [13, 25]},
           {path: ['name', 0, 'child'], line: 3, type: 'literal', value: 1,
-            pos: [23, 24]}
+            position: [23, 24]}
         ]);
       });
 
@@ -267,11 +267,11 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['name'], line: 2, type: 'array',
-            pos: [10, 31]},
+            position: [10, 31]},
           {path: ['name', 0], line: 3, type: 'array',
-            pos: [13, 28]},
+            position: [13, 28]},
           {path: ['name', 0, 0], line: 4, type: 'literal', value: 'child',
-            pos: [17, 24]}
+            position: [17, 24]}
         ]);
       });
 
@@ -280,13 +280,13 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['name'], line: 2, type: 'array',
-            pos: [10, 30]},
+            position: [10, 30]},
           {path: ['name', 0], line: 3, type: 'array',
-            pos: [13, 27]},
+            position: [13, 27]},
           {path: ['name', 0, 0], line: 3, type: 'object',
-            pos: [14, 26]},
+            position: [14, 26]},
           {path: ['name', 0, 0, 'child'], line: 3, type: 'literal', value: 1,
-            pos: [24, 25]}
+            position: [24, 25]}
         ]);
       });
 
@@ -295,13 +295,13 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['name'], line: 2, type: 'array',
-            pos: [10, 33]},
+            position: [10, 33]},
           {path: ['name', 0], line: 3, type: 'array',
-            pos: [13, 30]},
+            position: [13, 30]},
           {path: ['name', 0, 0], line: 4, type: 'array',
-            pos: [17, 26]},
+            position: [17, 26]},
           {path: ['name', 0, 0, 0], line: 4, type: 'literal', value: 'child',
-            pos: [18, 25]}
+            position: [18, 25]}
         ]);
       });
 
@@ -310,15 +310,15 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['name'], line: 2, type: 'array',
-            pos: [10, 38]},
+            position: [10, 38]},
           {path: ['name', 0], line: 3, type: 'array',
-            pos: [13, 35]},
+            position: [13, 35]},
           {path: ['name', 0, 0], line: 4, type: 'array',
-            pos: [17, 31]},
+            position: [17, 31]},
           {path: ['name', 0, 0, 0], line: 4, type: 'object',
-            pos: [18, 30]},
+            position: [18, 30]},
           {path: ['name', 0, 0, 0, 'child'], line: 4, type: 'literal', value: 1,
-            pos: [28, 29]}
+            position: [28, 29]}
         ]);
       });
 
@@ -331,15 +331,15 @@ describe('JSONUtil', function () {
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
           {path: ['name'], line: 2, type: 'array',
-            pos: [10, 53]},
+            position: [10, 53]},
           {path: ['name', 0], line: 3, type: 'object',
-            pos: [13, 50]},
+            position: [13, 50]},
           {path: ['name', 0, 'child'], line: 4, type: 'array',
-            pos: [26, 46]},
+            position: [26, 46]},
           {path: ['name', 0, 'child', 0], line: 5, type: 'object',
-            pos: [31, 42]},
+            position: [31, 42]},
           {path: ['name', 0, 'child', 0, 'value'], line: 5, type: 'literal', value: 1,
-            pos: [40, 41]}
+            position: [40, 41]}
         ]);
       });
 

--- a/src/js/utils/__tests__/JSONUtil-test.js
+++ b/src/js/utils/__tests__/JSONUtil-test.js
@@ -73,7 +73,8 @@ describe('JSONUtil', function () {
         var code = '{\n"name": "value"\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['name'], line: 2, type: 'literal', value: 'value'}
+          {path: ['name'], line: 2, type: 'literal', value: 'value',
+            pos: [10, 17]}
         ]);
       });
 
@@ -81,7 +82,8 @@ describe('JSONUtil', function () {
         var code = '{\n"name": 1\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['name'], line: 2, type: 'literal', value: 1 }
+          {path: ['name'], line: 2, type: 'literal', value: 1,
+            pos: [10, 11]}
         ]);
       });
 
@@ -89,7 +91,8 @@ describe('JSONUtil', function () {
         var code = '{\n"name": null\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['name'], line: 2, type: 'literal', value: null}
+          {path: ['name'], line: 2, type: 'literal', value: null,
+            pos: [10, 14]}
         ]);
       });
 
@@ -97,7 +100,8 @@ describe('JSONUtil', function () {
         var code = '{\n"name": true\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['name'], line: 2, type: 'literal', value: true}
+          {path: ['name'], line: 2, type: 'literal', value: true,
+            pos: [10, 14]}
         ]);
       });
 
@@ -105,7 +109,8 @@ describe('JSONUtil', function () {
         var code = '{\n"name": false\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['name'], line: 2, type: 'literal', value: false}
+          {path: ['name'], line: 2, type: 'literal', value: false,
+            pos: [10, 15]}
         ]);
       });
 
@@ -117,8 +122,10 @@ describe('JSONUtil', function () {
         var code = '{\n"name": 1,\n"name": 2\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['name'], line: 2, type: 'literal', value: 1},
-          {path: ['name'], line: 3, type: 'literal', value: 2}
+          {path: ['name'], line: 2, type: 'literal', value: 1,
+            pos: [10, 11]},
+          {path: ['name'], line: 3, type: 'literal', value: 2,
+            pos: [21, 22]}
         ]);
       });
 
@@ -126,8 +133,10 @@ describe('JSONUtil', function () {
         var code = '{\n"name": 1, "nome": 2\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['name'], line: 2, type: 'literal', value: 1},
-          {path: ['nome'], line: 2, type: 'literal', value: 2}
+          {path: ['name'], line: 2, type: 'literal', value: 1,
+            pos: [10, 11]},
+          {path: ['nome'], line: 2, type: 'literal', value: 2,
+            pos: [21, 22]}
         ]);
       });
 
@@ -135,8 +144,10 @@ describe('JSONUtil', function () {
         var code = '{\n"name": 1, "name": 2\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['name'], line: 2, type: 'literal', value: 1},
-          {path: ['name'], line: 2, type: 'literal', value: 2}
+          {path: ['name'], line: 2, type: 'literal', value: 1,
+            pos: [10, 11]},
+          {path: ['name'], line: 2, type: 'literal', value: 2,
+            pos: [21, 22]}
         ]);
       });
 
@@ -148,8 +159,10 @@ describe('JSONUtil', function () {
         var code = '{\n"name": {\n\t"child": 1\n\t}\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['name'], line: 2, type: 'object'},
-          {path: ['name', 'child'], line: 3, type: 'literal', value: 1}
+          {path: ['name'], line: 2, type: 'object',
+            pos: [10, 26]},
+          {path: ['name', 'child'], line: 3, type: 'literal', value: 1,
+            pos: [22, 23]}
         ]);
       });
 
@@ -157,9 +170,12 @@ describe('JSONUtil', function () {
         var code = '{\n"name": {\n\t"child": {\n\t\t"value": 1\n\t\t}\n\t}\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['name'], line: 2, type: 'object'},
-          {path: ['name', 'child'], line: 3, type: 'object'},
-          {path: ['name', 'child', 'value'], line: 4, type: 'literal', value: 1}
+          {path: ['name'], line: 2, type: 'object',
+            pos: [10, 43]},
+          {path: ['name', 'child'], line: 3, type: 'object',
+            pos: [22, 40]},
+          {path: ['name', 'child', 'value'], line: 4, type: 'literal', value: 1,
+            pos: [35, 36]}
         ]);
       });
 
@@ -167,9 +183,12 @@ describe('JSONUtil', function () {
         var code = '{\n"key1": 1,\n"key2": 2,\n"key3": 3}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['key1'], line: 2, type: 'literal', value: 1},
-          {path: ['key2'], line: 3, type: 'literal', value: 2},
-          {path: ['key3'], line: 4, type: 'literal', value: 3}
+          {path: ['key1'], line: 2, type: 'literal', value: 1,
+            pos: [10, 11]},
+          {path: ['key2'], line: 3, type: 'literal', value: 2,
+            pos: [21, 22]},
+          {path: ['key3'], line: 4, type: 'literal', value: 3,
+            pos: [32, 33]}
         ]);
       });
 
@@ -177,11 +196,16 @@ describe('JSONUtil', function () {
         var code = '{\n"key1": "string",\n"key2": 2,\n"key3": false,\n"key4": true,\n"key5": null\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['key1'], line: 2, type: 'literal', value: 'string'},
-          {path: ['key2'], line: 3, type: 'literal', value: 2},
-          {path: ['key3'], line: 4, type: 'literal', value: false},
-          {path: ['key4'], line: 5, type: 'literal', value: true},
-          {path: ['key5'], line: 6, type: 'literal', value: null}
+          {path: ['key1'], line: 2, type: 'literal', value: 'string',
+            pos: [10, 18]},
+          {path: ['key2'], line: 3, type: 'literal', value: 2,
+            pos: [28, 29]},
+          {path: ['key3'], line: 4, type: 'literal', value: false,
+            pos: [39, 44]},
+          {path: ['key4'], line: 5, type: 'literal', value: true,
+            pos: [54, 58]},
+          {path: ['key5'], line: 6, type: 'literal', value: null,
+            pos: [68, 72]}
         ]);
       });
 
@@ -189,15 +213,24 @@ describe('JSONUtil', function () {
         var code = '{\n"obj1": {\n"key1": 1,\n"key2": 2\n}, "obj2": {\n"key3": 1,\n"key4": 2\n}, "obj3": {\n"key5": 1,\n"key6": 2\n}\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['obj1'], line: 2, type:'object'},
-          {path: ['obj1', 'key1'], line: 3, type: 'literal', value: 1},
-          {path: ['obj1', 'key2'], line: 4, type: 'literal', value: 2},
-          {path: ['obj2'], line: 5, type:'object'},
-          {path: ['obj2', 'key3'], line: 6, type: 'literal', value: 1},
-          {path: ['obj2', 'key4'], line: 7, type: 'literal', value: 2},
-          {path: ['obj3'], line: 8, type:'object'},
-          {path: ['obj3', 'key5'], line: 9, type: 'literal', value: 1},
-          {path: ['obj3', 'key6'], line: 10, type: 'literal', value: 2}
+          {path: ['obj1'], line: 2, type:'object',
+            pos: [10, 34]},
+          {path: ['obj1', 'key1'], line: 3, type: 'literal', value: 1,
+            pos: [20, 21]},
+          {path: ['obj1', 'key2'], line: 4, type: 'literal', value: 2,
+            pos: [31, 32]},
+          {path: ['obj2'], line: 5, type:'object',
+            pos: [44, 68]},
+          {path: ['obj2', 'key3'], line: 6, type: 'literal', value: 1,
+            pos: [54, 55]},
+          {path: ['obj2', 'key4'], line: 7, type: 'literal', value: 2,
+            pos: [65, 66]},
+          {path: ['obj3'], line: 8, type:'object',
+            pos: [78, 102]},
+          {path: ['obj3', 'key5'], line: 9, type: 'literal', value: 1,
+            pos: [88, 89]},
+          {path: ['obj3', 'key6'], line: 10, type: 'literal', value: 2,
+            pos: [99, 100]}
         ]);
       });
 
@@ -209,8 +242,10 @@ describe('JSONUtil', function () {
         var code = '{\n"name": [\n\t"child"\n\t]\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['name'], line: 2, type: 'array'},
-          {path: ['name', 0], line: 3, type: 'literal', value: 'child'}
+          {path: ['name'], line: 2, type: 'array',
+            pos: [10, 23]},
+          {path: ['name', 0], line: 3, type: 'literal', value: 'child',
+            pos: [13, 20]}
         ]);
       });
 
@@ -218,9 +253,12 @@ describe('JSONUtil', function () {
         var code = '{\n"name": [\n\t{"child": 1}\n\t]\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['name'], line: 2, type: 'array'},
-          {path: ['name', 0], line: 3, type: 'object'},
-          {path: ['name', 0, 'child'], line: 3, type: 'literal', value: 1}
+          {path: ['name'], line: 2, type: 'array',
+            pos: [10, 28]},
+          {path: ['name', 0], line: 3, type: 'object',
+            pos: [13, 25]},
+          {path: ['name', 0, 'child'], line: 3, type: 'literal', value: 1,
+            pos: [23, 24]}
         ]);
       });
 
@@ -228,9 +266,12 @@ describe('JSONUtil', function () {
         var code = '{\n"name": [\n\t[\n\t\t"child"\n\t\t]\n\t]\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['name'], line: 2, type: 'array'},
-          {path: ['name', 0], line: 3, type: 'array'},
-          {path: ['name', 0, 0], line: 4, type: 'literal', value: 'child'}
+          {path: ['name'], line: 2, type: 'array',
+            pos: [10, 31]},
+          {path: ['name', 0], line: 3, type: 'array',
+            pos: [13, 28]},
+          {path: ['name', 0, 0], line: 4, type: 'literal', value: 'child',
+            pos: [17, 24]}
         ]);
       });
 
@@ -238,10 +279,14 @@ describe('JSONUtil', function () {
         var code = '{\n"name": [\n\t[{"child": 1}]\n\t]\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['name'], line: 2, type: 'array'},
-          {path: ['name', 0], line: 3, type: 'array'},
-          {path: ['name', 0, 0], line: 3, type: 'object'},
-          {path: ['name', 0, 0, 'child'], line: 3, type: 'literal', value: 1}
+          {path: ['name'], line: 2, type: 'array',
+            pos: [10, 30]},
+          {path: ['name', 0], line: 3, type: 'array',
+            pos: [13, 27]},
+          {path: ['name', 0, 0], line: 3, type: 'object',
+            pos: [14, 26]},
+          {path: ['name', 0, 0, 'child'], line: 3, type: 'literal', value: 1,
+            pos: [24, 25]}
         ]);
       });
 
@@ -249,10 +294,14 @@ describe('JSONUtil', function () {
         var code = '{\n"name": [\n\t[\n\t\t["child"]\n\t\t]\n\t]\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['name'], line: 2, type: 'array'},
-          {path: ['name', 0], line: 3, type: 'array'},
-          {path: ['name', 0, 0], line: 4, type: 'array'},
-          {path: ['name', 0, 0, 0], line: 4, type: 'literal', value: 'child'}
+          {path: ['name'], line: 2, type: 'array',
+            pos: [10, 33]},
+          {path: ['name', 0], line: 3, type: 'array',
+            pos: [13, 30]},
+          {path: ['name', 0, 0], line: 4, type: 'array',
+            pos: [17, 26]},
+          {path: ['name', 0, 0, 0], line: 4, type: 'literal', value: 'child',
+            pos: [18, 25]}
         ]);
       });
 
@@ -260,11 +309,16 @@ describe('JSONUtil', function () {
         var code = '{\n"name": [\n\t[\n\t\t[{"child": 1}]\n\t\t]\n\t]\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['name'], line: 2, type: 'array'},
-          {path: ['name', 0], line: 3, type: 'array'},
-          {path: ['name', 0, 0], line: 4, type: 'array'},
-          {path: ['name', 0, 0, 0], line: 4, type: 'object'},
-          {path: ['name', 0, 0, 0, 'child'], line: 4, type: 'literal', value: 1}
+          {path: ['name'], line: 2, type: 'array',
+            pos: [10, 38]},
+          {path: ['name', 0], line: 3, type: 'array',
+            pos: [13, 35]},
+          {path: ['name', 0, 0], line: 4, type: 'array',
+            pos: [17, 31]},
+          {path: ['name', 0, 0, 0], line: 4, type: 'object',
+            pos: [18, 30]},
+          {path: ['name', 0, 0, 0, 'child'], line: 4, type: 'literal', value: 1,
+            pos: [28, 29]}
         ]);
       });
 
@@ -276,11 +330,16 @@ describe('JSONUtil', function () {
         var code = '{\n"name": [\n\t{\n\t\t"child": [\n\t\t\t{"value":1}\n\t\t]\n\t\t}\n\t]\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
-          {path: ['name'], line: 2, type: 'array'},
-          {path: ['name', 0], line: 3, type: 'object'},
-          {path: ['name', 0, 'child'], line: 4, type: 'array'},
-          {path: ['name', 0, 'child', 0], line: 5, type: 'object'},
-          {path: ['name', 0, 'child', 0, 'value'], line: 5, type: 'literal', value: 1}
+          {path: ['name'], line: 2, type: 'array',
+            pos: [10, 53]},
+          {path: ['name', 0], line: 3, type: 'object',
+            pos: [13, 50]},
+          {path: ['name', 0, 'child'], line: 4, type: 'array',
+            pos: [26, 46]},
+          {path: ['name', 0, 'child', 0], line: 5, type: 'object',
+            pos: [31, 42]},
+          {path: ['name', 0, 'child', 0, 'value'], line: 5, type: 'literal', value: 1,
+            pos: [40, 41]}
         ]);
       });
 


### PR DESCRIPTION
This PR adds a `pos` attribute on the JSON tokens, containing the starting, ending offset of each token in the source string. This is particularly useful on tokens that are on the same line.
