### PR TITLE
DCOS-9827: Add a new auth package

### DIFF
--- a/foundation-ui/auth/Auth.js
+++ b/foundation-ui/auth/Auth.js
@@ -1,0 +1,83 @@
+import React, {PropTypes} from 'react';
+
+import AuthService from './AuthService';
+import {CHANGE} from './AuthEvent';
+import ReactUtil from '../utils/ReactUtil';
+
+const METHODS_TO_BIND = [
+  'onAuthServiceChange'
+];
+
+/**
+ * A component to show/hide elements based on user permissions. It is using
+ * the `AuthService` to authorize the current user if the required
+ * `permission` was granted.
+ * The component also provides a property (`wrapper`) to configure the wrapping
+ * component as well as the wrapping behavior.
+ *
+ * @example
+ *
+ * <Auth permission="*" wrapper={MyWidgetsWrapper}>
+ *     <span>My Secrets</span>
+ * </Auth>
+ *
+ */
+class Auth extends React.Component {
+  constructor() {
+    super(...arguments);
+
+    // Get components and init state
+    this.state = {
+      authorized: AuthService.authorize(this.props.permission)
+    };
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  componentWillMount() {
+    AuthService.addListener(CHANGE, this.onAuthServiceChange);
+  }
+
+  componentWillReceiveProps({permission}) {
+    if (this.props.permission === permission) {
+      return;
+    }
+
+    this.setState({authorized: AuthService.authorize(permission)});
+  }
+
+  componentWillUnmount() {
+    AuthService.removeListener(CHANGE, this.onAuthServiceChange);
+  }
+
+  onAuthServiceChange() {
+    this.setState({authorized: AuthService.authorize(this.props.permission)});
+  }
+
+  render() {
+    const {alwaysWrap, children, wrapper} = this.props;
+    const {authorized} = this.state;
+
+    if (!authorized) {
+      return null;
+    }
+
+    return ReactUtil.wrapElements(children, wrapper, alwaysWrap);
+  }
+}
+
+Auth.defaultProps = {
+  alwaysWrap: false,
+  wrapper: 'div'
+};
+
+Auth.propTypes = {
+  alwaysWrap: PropTypes.bool,
+  children: PropTypes.element,
+  permission: PropTypes.string.isRequired,
+  wrapper: PropTypes.node
+};
+
+module.exports = Auth;

--- a/foundation-ui/auth/AuthEvent.js
+++ b/foundation-ui/auth/AuthEvent.js
@@ -1,0 +1,4 @@
+module.exports = {
+  CHANGE: Symbol('change')
+};
+

--- a/foundation-ui/auth/AuthService.js
+++ b/foundation-ui/auth/AuthService.js
@@ -30,6 +30,14 @@ class AuthService extends EventEmitter {
       return;
     }
 
+    if (authorizers.includes(authorizer)) {
+      if (global.__DEV__) {
+        throw new Error('Provided authorizer is already registered');
+      }
+
+      return;
+    }
+
     authorizers.push(authorizer);
     this.emit(CHANGE);
   }

--- a/foundation-ui/auth/AuthService.js
+++ b/foundation-ui/auth/AuthService.js
@@ -1,0 +1,8 @@
+import {EventEmitter} from 'events';
+
+/**
+ * AuthService
+ */
+class AuthService extends EventEmitter {}
+
+module.exports = new AuthService();

--- a/foundation-ui/auth/AuthService.js
+++ b/foundation-ui/auth/AuthService.js
@@ -1,5 +1,7 @@
 import {EventEmitter} from 'events';
+
 import Authorizer from './Authorizer';
+import {CHANGE} from './AuthEvent';
 
 /**
  * List of authorizers
@@ -29,6 +31,7 @@ class AuthService extends EventEmitter {
     }
 
     authorizers.push(authorizer);
+    this.emit(CHANGE);
   }
 
   /**
@@ -44,6 +47,8 @@ class AuthService extends EventEmitter {
         break;
       }
     }
+
+    this.emit(CHANGE);
   }
 
   /**

--- a/foundation-ui/auth/AuthService.js
+++ b/foundation-ui/auth/AuthService.js
@@ -31,6 +31,21 @@ class AuthService extends EventEmitter {
     authorizers.push(authorizer);
   }
 
+  /**
+   * Unregisters authorizer
+   *
+   * @param  {Authorizer} authorizer
+   */
+  unregisterAuthorizer(authorizer) {
+    let i = authorizers.length;
+    while (--i >= 0) {
+      if (authorizers[i] === authorizer) {
+        authorizers.splice(i, 1);
+        break;
+      }
+    }
+  }
+
 }
 
 module.exports = new AuthService();

--- a/foundation-ui/auth/AuthService.js
+++ b/foundation-ui/auth/AuthService.js
@@ -23,8 +23,8 @@ class AuthService extends EventEmitter {
   registerAuthorizer(authorizer) {
     if (!authorizer || !(authorizer instanceof Authorizer)) {
       if (global.__DEV__) {
-        throw new TypeError('Provided component must be a ' +
-            'React.Component constructor or a stateless functional component.');
+        throw new TypeError('Provided authorizer must be an ' +
+            'instance of Authorizer');
       }
 
       return;

--- a/foundation-ui/auth/AuthService.js
+++ b/foundation-ui/auth/AuthService.js
@@ -1,8 +1,36 @@
 import {EventEmitter} from 'events';
+import Authorizer from './Authorizer';
+
+/**
+ * List of authorizers
+ *
+ * @type {Array.<Authorizer>}
+ */
+const authorizers = [];
 
 /**
  * AuthService
  */
-class AuthService extends EventEmitter {}
+class AuthService extends EventEmitter {
+
+  /**
+   * Register authorizer
+   *
+   * @param {Authorizer} authorizer
+   */
+  registerAuthorizer(authorizer) {
+    if (!authorizer || !(authorizer instanceof Authorizer)) {
+      if (global.__DEV__) {
+        throw new TypeError('Provided component must be a ' +
+            'React.Component constructor or a stateless functional component.');
+      }
+
+      return;
+    }
+
+    authorizers.push(authorizer);
+  }
+
+}
 
 module.exports = new AuthService();

--- a/foundation-ui/auth/AuthService.js
+++ b/foundation-ui/auth/AuthService.js
@@ -46,6 +46,17 @@ class AuthService extends EventEmitter {
     }
   }
 
+  /**
+   * Authorize current user if required permission was granted
+   *
+   * @param  {string} permission
+   *
+   * @returns {boolean} authorized
+   */
+  authorize(permission = '') {
+    return authorizers.every((authorizer) => authorizer.authorize(permission));
+  }
+
 }
 
 module.exports = new AuthService();

--- a/foundation-ui/auth/Authorizer.js
+++ b/foundation-ui/auth/Authorizer.js
@@ -1,0 +1,17 @@
+class Authorizer {
+  /* eslint-disable no-unused-vars */
+
+  /**
+   * Authorize current user if required permission was granted
+   *
+   * @param  {string} permission
+   *
+   * @returns {boolean} authorized
+   */
+  authorize(permission = '') {
+    return true;
+  }
+
+}
+
+module.exports = Authorizer;

--- a/foundation-ui/auth/__tests__/Auth-test.js
+++ b/foundation-ui/auth/__tests__/Auth-test.js
@@ -1,0 +1,120 @@
+jest.dontMock('../Auth');
+jest.dontMock('../AuthService');
+jest.dontMock('../Authorizer');
+jest.dontMock('../../utils/ReactUtil');
+/* eslint-disable no-unused-vars */
+const React = require('react');
+/* eslint-enable no-unused-vars */
+const TestUtils = require('react-addons-test-utils');
+
+const Auth = require('../Auth');
+const AuthService = require('../AuthService');
+const Authorizer = require('../Authorizer');
+
+describe('Auth', function () {
+  class Authorized extends Authorizer {}
+  class Unauthorized extends Authorizer {
+    /* eslint-disable no-unused-vars */
+    authorize(permission) {
+      return false;
+    }
+    /* eslint-enable no-unused-vars */
+  }
+
+  const authorized = new Authorized();
+  const unauthorized = new Unauthorized();
+
+  beforeEach(function () {
+    AuthService.registerAuthorizer(authorized);
+  });
+
+  afterEach(function () {
+    AuthService.unregisterAuthorizer(authorized);
+    AuthService.unregisterAuthorizer(unauthorized);
+  });
+
+  it('should render the children if user is authorized', function () {
+    const result = TestUtils.renderIntoDocument(
+        <Auth permission="*">
+          <span>foo</span>
+        </Auth>
+    );
+
+    expect(TestUtils.findRenderedDOMComponentWithTag(result, 'span'))
+        .toBeDefined();
+  });
+
+  it('should render null if children is undefined', function () {
+    const renderer = TestUtils.createRenderer();
+    renderer.render(<Auth permission="*"/>);
+
+    expect(renderer.getRenderOutput()).toBe(null);
+  });
+
+  it('should render null if user in unauthorized', function () {
+    const renderer = TestUtils.createRenderer();
+    AuthService.registerAuthorizer(unauthorized);
+    renderer.render(<Auth permission="*"/>);
+
+    expect(renderer.getRenderOutput()).toBe(null);
+  });
+
+  it('should not wrap a single child', function () {
+    const renderer = TestUtils.createRenderer();
+    renderer.render(
+        <Auth permission="*">
+          <span>foo</span>
+        </Auth>
+    );
+
+    expect(TestUtils.isElementOfType(renderer.getRenderOutput(), 'span'))
+        .toBe(true);
+  });
+
+  it('should always wrap elements if configured', function () {
+    const renderer = TestUtils.createRenderer();
+    renderer.render(
+        <Auth permission="*" alwaysWrap={true}>
+          <span>foo</span>
+        </Auth>
+    );
+
+    expect(TestUtils.isElementOfType(renderer.getRenderOutput(), 'div'))
+        .toBe(true);
+  });
+
+  it('should wrap elements with provided wrapper', function () {
+    const renderer = TestUtils.createRenderer();
+    renderer.render(
+        <Auth permission="*" wrapper="p" alwaysWrap={true}>
+          <span>foo</span>
+        </Auth>
+    );
+
+    expect(TestUtils.isElementOfType(renderer.getRenderOutput(), 'p'))
+        .toBe(true);
+  });
+
+  it('should update if new authorizer was registered', function () {
+    const renderer = TestUtils.createRenderer();
+    renderer.render(<Auth permission="*" />);
+    AuthService.registerAuthorizer(unauthorized);
+
+    expect(renderer.getRenderOutput()).toBe(null);
+  });
+
+  it('should update if authorizer was unregistered', function () {
+    AuthService.registerAuthorizer(unauthorized);
+    const result = TestUtils.renderIntoDocument(
+        <Auth permission="*">
+          <span>foo</span>
+        </Auth>
+    );
+
+    AuthService.unregisterAuthorizer(unauthorized);
+
+    expect(TestUtils.findRenderedDOMComponentWithTag(result, 'span'))
+        .toBeDefined();
+  });
+
+});

--- a/foundation-ui/auth/__tests__/Auth-test.js
+++ b/foundation-ui/auth/__tests__/Auth-test.js
@@ -51,7 +51,7 @@ describe('Auth', function () {
     expect(renderer.getRenderOutput()).toBe(null);
   });
 
-  it('should render null if user in unauthorized', function () {
+  it('should render null if user is unauthorized', function () {
     const renderer = TestUtils.createRenderer();
     AuthService.registerAuthorizer(unauthorized);
     renderer.render(<Auth permission="*"/>);

--- a/foundation-ui/auth/__tests__/Auth-test.js
+++ b/foundation-ui/auth/__tests__/Auth-test.js
@@ -54,7 +54,11 @@ describe('Auth', function () {
   it('should render null if user is unauthorized', function () {
     const renderer = TestUtils.createRenderer();
     AuthService.registerAuthorizer(unauthorized);
-    renderer.render(<Auth permission="*"/>);
+    renderer.render(
+        <Auth permission="*">
+          <span>foo</span>
+        </Auth>
+    );
 
     expect(renderer.getRenderOutput()).toBe(null);
   });
@@ -97,7 +101,14 @@ describe('Auth', function () {
 
   it('should update if new authorizer was registered', function () {
     const renderer = TestUtils.createRenderer();
-    renderer.render(<Auth permission="*" />);
+    renderer.render(
+        <Auth permission="*">
+          <span>foo</span>
+        </Auth>
+    );
+
+    expect(renderer.getRenderOutput().type).toBe('span');
+
     AuthService.registerAuthorizer(unauthorized);
 
     expect(renderer.getRenderOutput()).toBe(null);
@@ -105,16 +116,19 @@ describe('Auth', function () {
 
   it('should update if authorizer was unregistered', function () {
     AuthService.registerAuthorizer(unauthorized);
-    const result = TestUtils.renderIntoDocument(
+
+    const renderer = TestUtils.createRenderer();
+    renderer.render(
         <Auth permission="*">
           <span>foo</span>
         </Auth>
     );
 
+    expect(renderer.getRenderOutput()).toBe(null);
+
     AuthService.unregisterAuthorizer(unauthorized);
 
-    expect(TestUtils.findRenderedDOMComponentWithTag(result, 'span'))
-        .toBeDefined();
+    expect(renderer.getRenderOutput().type).toBe('span');
   });
 
 });

--- a/foundation-ui/auth/__tests__/AuthService-test.js
+++ b/foundation-ui/auth/__tests__/AuthService-test.js
@@ -1,17 +1,32 @@
 jest.dontMock('../AuthService');
+jest.dontMock('../Authorizer');
 
 const AuthService = require('../AuthService');
 const Authorizer = require('../Authorizer');
 
 describe('AuthService', function () {
-  const authorizer = new Authorizer();
+  class Authorized extends Authorizer {}
+  class Unauthorized extends Authorizer {
+    /* eslint-disable no-unused-vars */
+    authorize(permission) {
+      return false;
+    }
+    /* eslint-enable no-unused-vars */
+  }
+
+  const authorized = new Authorized();
+  const unauthorized = new Unauthorized();
 
   describe('registerAuthorizer', function () {
+
+    afterEach(function () {
+      AuthService.unregisterAuthorizer(authorized);
+    });
 
     it('should not throw if a instance of Authorizer is provided',
         function () {
           expect(function () {
-            AuthService.registerAuthorizer(authorizer);
+            AuthService.registerAuthorizer(authorized);
           }).not.toThrow();
         }
     );
@@ -41,18 +56,44 @@ describe('AuthService', function () {
   describe('unregisterAuthenticator', function () {
 
     beforeEach(function () {
-      AuthService.registerAuthorizer(authorizer);
+      AuthService.registerAuthorizer(authorized);
     });
 
     afterEach(function () {
-      AuthService.unregisterAuthorizer(authorizer);
+      AuthService.unregisterAuthorizer(authorized);
     });
 
     it('should not throw if a instance of Authorizer is provided',
         function () {
           expect(function () {
-            AuthService.unregisterAuthorizer(authorizer);
+            AuthService.unregisterAuthorizer(authorized);
           }).not.toThrow();
+        }
+    );
+
+  });
+
+  describe('authorize', function () {
+
+    afterEach(function () {
+      AuthService.unregisterAuthorizer(authorized);
+      AuthService.unregisterAuthorizer(unauthorized);
+    });
+
+    it('should return true if every authorizer authorized the request',
+        function () {
+          AuthService.registerAuthorizer(authorized);
+
+          expect(AuthService.authorize()).toBe(true);
+        }
+    );
+
+    it('should return false if one authorizer didn\'t authorized the request',
+        function () {
+          AuthService.registerAuthorizer(authorized);
+          AuthService.registerAuthorizer(unauthorized);
+
+          expect(AuthService.authorize()).toBe(false);
         }
     );
 

--- a/foundation-ui/auth/__tests__/AuthService-test.js
+++ b/foundation-ui/auth/__tests__/AuthService-test.js
@@ -21,6 +21,7 @@ describe('AuthService', function () {
 
     afterEach(function () {
       AuthService.unregisterAuthorizer(authorized);
+      AuthService.unregisterAuthorizer(unauthorized);
     });
 
     it('should not throw if a instance of Authorizer is provided',
@@ -51,16 +52,23 @@ describe('AuthService', function () {
       }).toThrow();
     });
 
+    it('should properly register authorizer', function () {
+      AuthService.registerAuthorizer(unauthorized);
+
+      expect(AuthService.authorize()).toBe(false);
+    });
+
   });
 
   describe('unregisterAuthenticator', function () {
 
     beforeEach(function () {
-      AuthService.registerAuthorizer(authorized);
+      AuthService.registerAuthorizer(unauthorized);
     });
 
     afterEach(function () {
       AuthService.unregisterAuthorizer(authorized);
+      AuthService.unregisterAuthorizer(unauthorized);
     });
 
     it('should not throw if a instance of Authorizer is provided',
@@ -70,6 +78,19 @@ describe('AuthService', function () {
           }).not.toThrow();
         }
     );
+
+    it('should properly remove mathing authorizer', function () {
+      AuthService.unregisterAuthorizer(unauthorized);
+
+      expect(AuthService.authorize()).toBe(true);
+    });
+
+    it('should do nothing if no matching authorizers was found', function () {
+      class Unknown extends Authorizer {}
+
+      AuthService.unregisterAuthorizer(new Unknown());
+      expect(AuthService.authorize()).toBe(false);
+    });
 
   });
 

--- a/foundation-ui/auth/__tests__/AuthService-test.js
+++ b/foundation-ui/auth/__tests__/AuthService-test.js
@@ -1,8 +1,9 @@
 jest.dontMock('../AuthService');
 jest.dontMock('../Authorizer');
 
-const AuthService = require('../AuthService');
 const Authorizer = require('../Authorizer');
+const AuthService = require('../AuthService');
+const AuthEvent = require('../AuthEvent');
 
 describe('AuthService', function () {
   class Authorized extends Authorizer {}
@@ -58,6 +59,15 @@ describe('AuthService', function () {
       expect(AuthService.authorize()).toBe(false);
     });
 
+    it('should emit change event', function () {
+      const changeHandler = jasmine.createSpy();
+
+      AuthService.addListener(AuthEvent.CHANGE, changeHandler);
+      AuthService.registerAuthorizer(unauthorized);
+
+      expect(changeHandler).toHaveBeenCalled();
+    });
+
   });
 
   describe('unregisterAuthenticator', function () {
@@ -90,6 +100,15 @@ describe('AuthService', function () {
 
       AuthService.unregisterAuthorizer(new Unknown());
       expect(AuthService.authorize()).toBe(false);
+    });
+
+    it('should emit change event', function () {
+      const changeHandler = jasmine.createSpy();
+
+      AuthService.addListener(AuthEvent.CHANGE, changeHandler);
+      AuthService.unregisterAuthorizer(unauthorized);
+
+      expect(changeHandler).toHaveBeenCalled();
     });
 
   });

--- a/foundation-ui/auth/__tests__/AuthService-test.js
+++ b/foundation-ui/auth/__tests__/AuthService-test.js
@@ -53,6 +53,16 @@ describe('AuthService', function () {
       }).toThrow();
     });
 
+    it('should throw if the same authorizer instance is already registered',
+        function () {
+          AuthService.registerAuthorizer(authorized);
+
+          expect(function () {
+            AuthService.registerAuthorizer(authorized);
+          }).toThrow();
+        }
+    );
+
     it('should properly register authorizer', function () {
       AuthService.registerAuthorizer(unauthorized);
 

--- a/foundation-ui/auth/__tests__/AuthService-test.js
+++ b/foundation-ui/auth/__tests__/AuthService-test.js
@@ -1,0 +1,5 @@
+describe('AuthService', function () {
+
+  it('init', function () {});
+
+});

--- a/foundation-ui/auth/__tests__/AuthService-test.js
+++ b/foundation-ui/auth/__tests__/AuthService-test.js
@@ -1,5 +1,41 @@
-describe('AuthService', function () {
+jest.dontMock('../AuthService');
 
-  it('init', function () {});
+const AuthService = require('../AuthService');
+const Authorizer = require('../Authorizer');
+
+describe('AuthService', function () {
+  const authorizer = new Authorizer();
+
+  describe('registerAuthorizer', function () {
+
+    it('should not throw if a instance of Authorizer is provided',
+        function () {
+          expect(function () {
+            AuthService.registerAuthorizer(authorizer);
+          }).not.toThrow();
+        }
+    );
+
+    it('should throw if an object instead of a authorizer was provided',
+        function () {
+          expect(function () {
+            AuthService.registerAuthorizer({});
+          }).toThrow();
+        }
+    );
+
+    it('should throw if null instead of a authorizer was provided', function () {
+      expect(function () {
+        AuthService.registerAuthorizer(null);
+      }).toThrow();
+    });
+
+    it('should throw if authorizer is undefined', function () {
+      expect(function () {
+        AuthService.registerAuthorizer(undefined);
+      }).toThrow();
+    });
+
+  });
 
 });

--- a/foundation-ui/auth/__tests__/AuthService-test.js
+++ b/foundation-ui/auth/__tests__/AuthService-test.js
@@ -38,4 +38,24 @@ describe('AuthService', function () {
 
   });
 
+  describe('unregisterAuthenticator', function () {
+
+    beforeEach(function () {
+      AuthService.registerAuthorizer(authorizer);
+    });
+
+    afterEach(function () {
+      AuthService.unregisterAuthorizer(authorizer);
+    });
+
+    it('should not throw if a instance of Authorizer is provided',
+        function () {
+          expect(function () {
+            AuthService.unregisterAuthorizer(authorizer);
+          }).not.toThrow();
+        }
+    );
+
+  });
+
 });

--- a/foundation-ui/auth/index.js
+++ b/foundation-ui/auth/index.js
@@ -1,0 +1,11 @@
+import Auth from './Auth';
+import AuthEvent from './AuthEvent';
+import Authorizer from './Authorizer';
+import AuthService from './AuthService';
+
+module.exports = {
+  Auth,
+  AuthEvent,
+  Authorizer,
+  AuthService
+};


### PR DESCRIPTION
---

⚠️ This PR depends on changes that will get introduced with #1130 

---

Introduce an auth service as well as an auth component.

* The service provides a method to authorize the current user, using the registered `Authorizer`, if the required permission was granted. 
* The component will show and hide elements based on user permissions.

**Example** 

```
// Custom Authorizer 
  class SimpleAuthorizer extends Authorizer {
    authorize(permission) {
      return userPermissions.indexOf(permission) > -1;
    }
  }

// Registration
  AuthService.registerAuthorizer(new SimpleAuthorizer());

// Authorize
  if(AuthService.authorize('some:permission')){
    console.log('authorized')
  };

// Component
  <Auth permission="*">
      ... Some Content
  </Auth>
```