### PR TITLE
Provide foundation packages via PluginSDK

### DIFF
--- a/src/js/plugin-bridge/Loader.js
+++ b/src/js/plugin-bridge/Loader.js
@@ -14,6 +14,10 @@ const requireComponents = require.context('../components', false);
 const requireCharts = require.context('../components/charts', false);
 const requireIcons = require.context('../components/icons', false);
 const requireModals = require.context('../components/modals', false);
+// Foundation
+const requireAuth = require.context('../../../foundation-ui/auth', false);
+const requireMount = require.context('../../../foundation-ui/mount', false);
+
 let requireExternalPlugin = function () {
   return {};
 };
@@ -86,6 +90,8 @@ function pluckComponent(path) {
 function requireModule(dir, name) {
   let path = './' + name;
   switch (dir) {
+    case 'auth':
+      return requireAuth(path);
     case 'config':
       return requireConfig(path);
     case 'constants':
@@ -102,6 +108,8 @@ function requireModule(dir, name) {
       return requireUtils(path);
     case 'mixins':
       return requireMixins(path);
+    case 'mount':
+      return requireMount(path);
     case 'components':
       return pluckComponent(path);
     case 'externalPlugin':

--- a/src/js/plugin-bridge/PluginModules.js
+++ b/src/js/plugin-bridge/PluginModules.js
@@ -1,5 +1,14 @@
 // Modules to paths
 module.exports = {
+  auth: {
+    Auth: 'Auth',
+    Authorizer: 'Authorizer',
+    AuthService: 'AuthService'
+  },
+  mount: {
+    Mount: 'Mount',
+    MountService: 'MountService'
+  },
   constants: {
     EventTypes: 'EventTypes',
     HTTPStatusCodes: 'HTTPStatusCodes'

--- a/src/js/plugin-bridge/__mocks__/Loader.js
+++ b/src/js/plugin-bridge/__mocks__/Loader.js
@@ -54,12 +54,14 @@ function __requireModule(dir, name) {
     return Mocks[name];
   }
 
-  if (dir === 'internalPlugin') {
-    return require(path.resolve(pluginsDir, name));
-  }
-
-  if (dir === 'externalPlugin') {
-    return require(path.resolve(externalPluginsDir, name));
+  switch (dir) {
+    case 'auth':
+    case 'mount':
+      return require(path.resolve('./foundation-ui', `${dir}/${name}`));
+    case 'externalPlugin':
+      return require(path.resolve(externalPluginsDir, name));
+    case 'internalPlugin':
+      return require(path.resolve(pluginsDir, name));
   }
 
   return require(path.resolve('./src/js', `${dir}/${name}`));


### PR DESCRIPTION
---
⚠️ This PR depends on changes that will get introduced with #1362 

---

Adjust the plugin loader and module configuration to provide the respective packages via the PluginSDK interface. This a temporary solution which will be replaced once we have a proper process to build and integrate packages.