### PR TITLE
Tying new service create edit flow together

### DIFF
--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -13,6 +13,7 @@ import Util from '../../../../../../src/js/utils/Util';
 
 const METHODS_TO_BIND = [
   'handleGoBack',
+  'handleClose',
   'handleJSONToggle',
   'handleServiceSelection',
   'handleServiceReview',
@@ -23,18 +24,7 @@ class NewServiceFormModal extends Component {
   constructor() {
     super(...arguments);
 
-    this.state = {
-      isJSONModeActive: false,
-      serviceFormActive: false,
-      servicePickerActive: true,
-      serviceReviewConfig: null
-    };
-
-    // Switch directly to form if edit
-    if (this.props.isEdit) {
-      this.state.servicePickerActive = false;
-      this.state.serviceFormActive = true;
-    }
+    this.state = this.getResetState();
 
     METHODS_TO_BIND.forEach((method) => {
       this[method] = this[method].bind(this);
@@ -46,7 +36,7 @@ class NewServiceFormModal extends Component {
     const shouldClose = requestCompleted && !nextProps.errors;
 
     if (shouldClose) {
-      this.props.onClose();
+      this.handleClose();
     }
   }
 
@@ -59,7 +49,7 @@ class NewServiceFormModal extends Component {
 
     // Close if clicker is open, or if editing a service in the form
     if (servicePickerActive || (serviceFormActive && this.props.isEdit)) {
-      this.props.onClose();
+      this.handleClose();
       return;
     }
 
@@ -81,8 +71,30 @@ class NewServiceFormModal extends Component {
     }
   }
 
+  handleClose() {
+    this.props.onClose();
+    this.setState(this.getResetState());
+  }
+
   handleJSONToggle() {
     this.setState({isJSONModeActive: !this.state.isJSONModeActive});
+  }
+
+  getResetState(nextProps = this.props) {
+    let newState = {
+      isJSONModeActive: false,
+      serviceFormActive: false,
+      servicePickerActive: true,
+      serviceReviewConfig: null
+    };
+
+    // Switch directly to form if edit
+    if (nextProps.isEdit) {
+      newState.servicePickerActive = false;
+      newState.serviceFormActive = true;
+    }
+
+    return newState;
   }
 
   handleServiceSelection() {
@@ -242,6 +254,7 @@ class NewServiceFormModal extends Component {
     return (
       <FullScreenModal
         header={this.getHeader()}
+        onClose={this.handleClose}
         {...Util.omit(props, Object.keys(NewServiceFormModal.propTypes))}>
         {this.getModalContent()}
       </FullScreenModal>

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -47,7 +47,7 @@ class NewServiceFormModal extends Component {
       serviceReviewConfig
     } = this.state;
 
-    // Close if clicker is open, or if editing a service in the form
+    // Close if picker is open, or if editing a service in the form
     if (servicePickerActive || (serviceFormActive && this.props.isEdit)) {
       this.handleClose();
       return;

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Component, PropTypes} from 'react';
 
 import FullScreenModal from '../../../../../../src/js/components/modals/FullScreenModal';
 import FullScreenModalHeader from '../../../../../../src/js/components/modals/FullScreenModalHeader';
@@ -6,24 +6,79 @@ import FullScreenModalHeaderActions from '../../../../../../src/js/components/mo
 import FullScreenModalHeaderTitle from '../../../../../../src/js/components/modals/FullScreenModalHeaderTitle';
 import NewCreateServiceModalServicePicker from './NewCreateServiceModalServicePicker';
 import NewCreateServiceModalForm from './NewCreateServiceModalForm';
+import Service from '../../structs/Service';
+import ServiceConfigDisplay from '../../service-configuration/ServiceConfigDisplay';
 import ToggleButton from '../../../../../../src/js/components/ToggleButton';
 import Util from '../../../../../../src/js/utils/Util';
 
-const METHODS_TO_BIND = ['handleJSONToggle', 'handleServiceSelection'];
+const METHODS_TO_BIND = [
+  'handleGoBack',
+  'handleJSONToggle',
+  'handleServiceSelection',
+  'handleServiceReview',
+  'handleServiceRun'
+];
 
-class NewServiceFormModal extends React.Component {
+class NewServiceFormModal extends Component {
   constructor() {
     super(...arguments);
 
     this.state = {
       isJSONModeActive: false,
+      serviceFormActive: false,
       servicePickerActive: true,
-      serviceFormActive: false
+      serviceReviewConfig: null
     };
+
+    // Switch directly to form if edit
+    if (this.props.isEdit) {
+      this.state.servicePickerActive = false;
+      this.state.serviceFormActive = true;
+    }
 
     METHODS_TO_BIND.forEach((method) => {
       this[method] = this[method].bind(this);
     });
+  }
+
+  componentWillUpdate(nextProps) {
+    const requestCompleted = this.props.isPending && !nextProps.isPending;
+    const shouldClose = requestCompleted && !nextProps.errors;
+
+    if (shouldClose) {
+      this.props.onClose();
+    }
+  }
+
+  handleGoBack() {
+    let {
+      serviceFormActive,
+      servicePickerActive,
+      serviceReviewConfig
+    } = this.state;
+
+    // Close if clicker is open, or if editing a service in the form
+    if (servicePickerActive || (serviceFormActive && this.props.isEdit)) {
+      this.props.onClose();
+      return;
+    }
+
+    if (serviceFormActive) {
+      this.setState({
+        servicePickerActive: true,
+        serviceFormActive: false,
+        serviceReviewConfig: null
+      });
+      return;
+    }
+
+    if (serviceReviewConfig) {
+      this.setState({
+        servicePickerActive: false,
+        serviceFormActive: true,
+        serviceReviewConfig: null
+      });
+    }
   }
 
   handleJSONToggle() {
@@ -33,19 +88,67 @@ class NewServiceFormModal extends React.Component {
   handleServiceSelection() {
     this.setState({
       servicePickerActive: false,
-      serviceFormActive: true
+      serviceFormActive: true,
+      serviceReviewConfig: null
     });
   }
 
+  handleServiceReview() {
+    this.setState({
+      servicePickerActive: false,
+      serviceFormActive: false,
+      serviceReviewConfig: this.serviceModalForm.getAppConfig()
+    });
+  }
+
+  handleServiceRun() {
+    let {marathonAction, service} = this.props;
+    marathonAction(
+      service,
+      this.state.serviceReviewConfig
+    );
+  }
+
   getHeader() {
+    if (this.state.serviceReviewConfig) {
+      return (
+        <FullScreenModalHeader>
+          <FullScreenModalHeaderActions
+            actions={this.getSecondaryActions()}
+            type="secondary" />
+          <FullScreenModalHeaderTitle>
+            Review & Run Service
+          </FullScreenModalHeaderTitle>
+          <FullScreenModalHeaderActions
+            actions={this.getPrimaryActions()}
+            type="primary" />
+        </FullScreenModalHeader>
+      );
+    }
+
+    let title = 'Run a Service';
+    let {isEdit, service} = this.props;
+    let serviceName = service.getName() || 'Service';
+    if (serviceName) {
+      serviceName = `"${serviceName}"`;
+    } else {
+      serviceName = 'Service';
+    }
+
+    if (isEdit) {
+      title = `Edit ${serviceName}`;
+    }
+
     return (
       <FullScreenModalHeader>
-        <FullScreenModalHeaderActions actions={this.getSecondaryActions()}
+        <FullScreenModalHeaderActions
+          actions={this.getSecondaryActions()}
           type="secondary" />
         <FullScreenModalHeaderTitle>
-          Run a Service
+          {title}
         </FullScreenModalHeaderTitle>
-        <FullScreenModalHeaderActions actions={this.getPrimaryActions()}
+        <FullScreenModalHeaderActions
+          actions={this.getPrimaryActions()}
           type="primary" />
       </FullScreenModalHeader>
     );
@@ -59,56 +162,76 @@ class NewServiceFormModal extends React.Component {
       );
     }
 
+    if (this.state.serviceReviewConfig) {
+      return (
+        <ServiceConfigDisplay appConfig={this.state.serviceReviewConfig} />
+      );
+    }
+
     return (
       <NewCreateServiceModalForm
-        isJSONModeActive={this.state.isJSONModeActive} />
+        isJSONModeActive={this.state.isJSONModeActive}
+        service={this.props.service}
+        ref={(ref) => { this.serviceModalForm = ref; }} />
     );
   }
 
   getPrimaryActions() {
-    if (this.state.servicePickerActive) {
+    let {
+      serviceFormActive,
+      servicePickerActive,
+      serviceReviewConfig
+    } = this.state;
+
+    if (servicePickerActive) {
       return null;
     }
 
-    return [
-      {
-        node: (
-          <ToggleButton
-            className="flush"
-            checkboxClassName="toggle-button"
-            checked={this.state.isJSONModeActive}
-            onChange={this.handleJSONToggle}
-            key="json-editor">
-            JSON Editor
-          </ToggleButton>
-        )
-      },
-      {
-        className: 'button-primary flush-vertical',
-        clickHandler: () => console.log('Review...'),
-        label: 'Review & Run'
-      }
-    ];
+    if (serviceFormActive) {
+      return [
+        {
+          node: (
+            <ToggleButton
+              className="flush"
+              checkboxClassName="toggle-button"
+              checked={this.state.isJSONModeActive}
+              onChange={this.handleJSONToggle}
+              key="json-editor">
+              JSON Editor
+            </ToggleButton>
+          )
+        },
+        {
+          className: 'button-primary flush-vertical',
+          clickHandler: this.handleServiceReview,
+          label: 'Review & Run'
+        }
+      ];
+    }
+
+    if (serviceReviewConfig) {
+      return [
+        {
+          className: 'button-primary flush-vertical',
+          clickHandler: this.handleServiceRun,
+          label: 'Run Service'
+        }
+      ];
+    }
   }
 
   getSecondaryActions() {
-    if (this.state.servicePickerActive) {
-      return [
-        {
-          className: 'button-stroke',
-          clickHandler: () => this.props.onClose(),
-          label: 'Cancel'
-        }
-      ];
+    let {servicePickerActive, serviceFormActive} = this.state;
+    let label = 'Back';
+    if (servicePickerActive || (serviceFormActive && this.props.isEdit)) {
+      label = 'Cancel';
     }
 
     return [
       {
         className: 'button-stroke',
-        clickHandler: () => {
-          this.setState({servicePickerActive: true, serviceFormActive: false});
-        },
-        label: 'Back'
+        clickHandler: this.handleGoBack,
+        label
       }
     ];
   }
@@ -119,7 +242,6 @@ class NewServiceFormModal extends React.Component {
     return (
       <FullScreenModal
         header={this.getHeader()}
-        title="Run a Service"
         {...Util.omit(props, Object.keys(NewServiceFormModal.propTypes))}>
         {this.getModalContent()}
       </FullScreenModal>
@@ -128,7 +250,15 @@ class NewServiceFormModal extends React.Component {
 }
 
 NewServiceFormModal.propTypes = {
-  children: React.PropTypes.node
+  errors: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.string
+  ]),
+  isEdit: PropTypes.bool,
+  isPending: PropTypes.bool.isRequired,
+  marathonAction: PropTypes.func.isRequired,
+  onClose: PropTypes.func,
+  service: PropTypes.instanceOf(Service).isRequired
 };
 
 module.exports = NewServiceFormModal;

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -140,7 +140,7 @@ class NewServiceFormModal extends Component {
 
     let title = 'Run a Service';
     let {isEdit, service} = this.props;
-    let serviceName = service.getName() || 'Service';
+    let serviceName = service.getName();
     if (serviceName) {
       serviceName = `"${serviceName}"`;
     } else {

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -1,6 +1,6 @@
 import Ace from 'react-ace';
 import classNames from 'classnames';
-import React from 'react';
+import React, {PropTypes, Component} from 'react';
 
 import AppValidators from '../../../../../../src/resources/raml/marathon/v2/types/app.raml';
 import Batch from '../../../../../../src/js/structs/Batch';
@@ -11,6 +11,7 @@ import EnvironmentFormSection from '../forms/EnvironmentFormSection';
 import GeneralServiceFormSection from '../forms/GeneralServiceFormSection';
 import JSONConfigReducers from '../../reducers/JSONConfigReducers';
 import JSONParserReducers from '../../reducers/JSONParserReducers';
+import Service from '../../structs/Service';
 import TabButton from '../../../../../../src/js/components/TabButton';
 import TabButtonList from '../../../../../../src/js/components/TabButtonList';
 import Tabs from '../../../../../../src/js/components/Tabs';
@@ -41,11 +42,18 @@ const inputConfigReducers = combineReducers(
   Object.assign({}, ...SECTIONS.map((item) => item.configReducers))
 );
 
-class NewCreateServiceModalForm extends React.Component {
+class NewCreateServiceModalForm extends Component {
   constructor() {
     super(...arguments);
 
     let batch = new Batch();
+
+    // Turn service configuration into Batch Transactions
+    if (this.props.service) {
+      jsonParserReducers(this.props.service.toJSON()).forEach((item) => {
+        batch.add(item);
+      });
+    }
 
     this.state = {
       appConfig: {},
@@ -241,7 +249,8 @@ NewCreateServiceModalForm.defaultProps = {
 };
 
 NewCreateServiceModalForm.propTypes = {
-  onChange: React.PropTypes.func
+  onChange: PropTypes.func,
+  service: PropTypes.instanceOf(Service)
 };
 
 module.exports = NewCreateServiceModalForm;

--- a/plugins/services/src/js/service-configuration/NetworkingServiceConfigSection.js
+++ b/plugins/services/src/js/service-configuration/NetworkingServiceConfigSection.js
@@ -46,16 +46,18 @@ module.exports = {
           protocol: 'protocol'
         };
 
-        if ((portDefinitions == null || portDefinitions.length === 0)) {
-          let containerPortMappings = Util.findNestedPropertyInObject(
-            appDefinition, 'container.docker.portMappings'
-          );
+        let containerPortMappings = Util.findNestedPropertyInObject(
+          appDefinition, 'container.docker.portMappings'
+        );
+        if ((portDefinitions == null || portDefinitions.length === 0) &&
+          containerPortMappings != null && containerPortMappings.length !== 0) {
+          portDefinitions = containerPortMappings;
+          keys.port = 'containerPort';
+        }
 
-          if (containerPortMappings != null
-            && containerPortMappings.length !== 0) {
-            portDefinitions = containerPortMappings;
-            keys.port = 'containerPort';
-          }
+        // Make sure to have something to render, even if there is no data
+        if (!portDefinitions) {
+          portDefinitions = [];
         }
 
         const columns = [


### PR DESCRIPTION
This PR ties current efforts on the create/edit flow for services together, see it in action here:
![](https://cl.ly/2H3Z1m2z3L3Y/Screen%20Recording%202016-11-14%20at%2017.03.gif)

Here is the changes you need to make to `ServiceModals` to activate the new flow:
```
- import ServiceFormModal from './ServiceFormModal';
+ import NewCreateServiceModal from './NewCreateServiceModal';
@@ -65,7 +65,7 @@ class ServiceModals extends React.Component {
    };

    return (
-      <ServiceFormModal
+      <NewCreateServiceModal
@@ -102,10 +102,10 @@ class ServiceModals extends React.Component {
    }

    return (
-      <ServiceFormModal
+      <NewCreateServiceModal
-        isEdit={false}
+        isEdit={true}
```
![](https://cl.ly/2B3W120L153R/Image%202016-11-14%20at%2017.07.00.png)