### PR TITLE
Fix ServiceScaleFormModal textbox

### DIFF
--- a/plugins/services/src/js/components/modals/ServiceScaleFormModal.js
+++ b/plugins/services/src/js/components/modals/ServiceScaleFormModal.js
@@ -89,7 +89,6 @@ class ServiceScaleFormModal extends React.Component {
     return [
       {
         fieldType: 'number',
-        formGroupClass: 'column-2',
         formElementClass: 'horizontal-center',
         min: 0,
         name: 'instances',


### PR DESCRIPTION
This PR fixes the width of the input field in the `ServiceScaleFormModal`. The `column-2` class was constraining the width of the element which was already inside a `column-12` element.

Before:
![](https://cl.ly/3C0H0j1f1q32/Screen%20Shot%202016-11-16%20at%202.20.20%20PM.png)

After:
![](https://cl.ly/2H2z0D3m4014/Screen%20Shot%202016-11-16%20at%202.20.08%20PM.png)