### PR TITLE
Exclude null reducer values from state

### DIFF
--- a/src/js/utils/ReducerUtil.js
+++ b/src/js/utils/ReducerUtil.js
@@ -56,7 +56,11 @@ module.exports = {
         // reducer.bind(context.get(reducer))(state[key], action);
         // but it will not copy the function, which in this case is a huge
         // increase in performance.
-        localState[key] = reducer.call(context.get(reducer), localState[key], action);
+        let value = reducer.call(context.get(reducer), localState[key], action);
+
+        if (value != null) {
+          localState[key] = value;
+        }
       }
 
       return localState;


### PR DESCRIPTION
This PR will exclude null values from state in `#combineReducers`.

For the networking configuration, in some instances we want to remove keys from the root of the configuration and move them elsewhere (e.g. `portMappings` exists at the root in some situations and other times it exists at `container.docker`).

@Poltergeist Could you please review this and see if this is reasonable? If it is not reasonable, do you have other ideas for how we could exclude some keys from the app config?