### PR TITLE
Add link to CSS styleguide

### DIFF
--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -116,3 +116,7 @@ this.state = {
 ## API Requests
 
 API Requests should go into an Action file like [this](https://github.com/dcos/dcos-ui/blob/master/src/js/events/CosmosPackagesActions.js)
+
+## CSS
+
+Please review our [CSS styleguide](https://github.com/dcos/dcos-ui-common/tree/master/stylelint-config-dcos).


### PR DESCRIPTION
This PR adds a link to our CSS styleguide in `BEST_PRACTICES.md`.