### PR TITLE
Remove obsolete `system-organization-tabs` filter

### DIFF
--- a/plugins/oauth/hooks.js
+++ b/plugins/oauth/hooks.js
@@ -48,7 +48,6 @@ module.exports = Object.assign({}, StoreMixin, {
     'delayApplicationLoad',
     'organizationRoutes',
     'sidebarFooter',
-    'system-organization-tabs',
     'serverErrorModalListeners'
   ],
 
@@ -189,15 +188,6 @@ module.exports = Object.assign({}, StoreMixin, {
     };
 
     return routeDefinition;
-  },
-
-  'system-organization-tabs': function (tabs) {
-    return Object.assign({}, tabs, {
-      '/organization/users': {
-        content: 'Users',
-        priority: 50
-      }
-    });
   },
 
   userLoginSuccess() {


### PR DESCRIPTION
Since we've split system page into several pages and it doesn't exist anymore we don't need this filter. 