### PR TITLE
DCOS-11363: Add secondary level navigation filter

### DIFF
--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -138,7 +138,14 @@ var Sidebar = React.createClass({
     let isChildActive = false;
 
     if (isParentActive) {
-      let menuItems = childRoutes.reduce(function (childRoutes, currentChild) {
+      const childRoutesPaths = childRoutes.map(({path}) => path);
+      const childRoutesMap = Hooks
+        .applyFilter('secondaryNavigation', path, childRoutesPaths)
+        .reduce((routesMap, path) => routesMap.set(path, true), new Map());
+      const filteredChildRoutes =
+        childRoutes.filter(({path}) => childRoutesMap.has(path));
+
+      let menuItems = filteredChildRoutes.reduce(function (childRoutes, currentChild) {
         if (currentChild.isInSidebar) {
           let routeLabel = currentChild.path;
           let isActive = false;


### PR DESCRIPTION
⚠️  Depends on https://github.com/mesosphere/dcos-ui-plugins-private/pull/457

---

This PR utilizes a new hook to filter secondary navigation in the sidebar