### PR TITLE
DCOS-11605: Introducing applyPatch utility function to the form

### DIFF
--- a/plugins/services/src/js/utils/CreateServiceModalFormUtil.js
+++ b/plugins/services/src/js/utils/CreateServiceModalFormUtil.js
@@ -1,5 +1,6 @@
-const CreateServiceModalFormUtil = {
+import ValidatorUtil from '../../../../../src/js/utils/ValidatorUtil';
 
+const CreateServiceModalFormUtil = {
   /**
    * Apply patch data on the given source data, following the principles:
    *
@@ -39,8 +40,8 @@ const CreateServiceModalFormUtil = {
       // If the patch contains an empty value we have to remove the item,
       // with the only exception of the source value having already an empty
       // value in place.
-      if (CreateServiceModalFormUtil.isEmptyValue(patch[key])) {
-        if (!CreateServiceModalFormUtil.isEmptyValue(memo[key])) {
+      if (ValidatorUtil.isEmpty(patch[key])) {
+        if (!ValidatorUtil.isEmpty(memo[key])) {
           delete memo[key];
         }
 
@@ -51,24 +52,7 @@ const CreateServiceModalFormUtil = {
 
       return memo;
     }, Object.assign({}, data));
-  },
-
-  /**
-   * Tests if the given value is "empty". This means:
-   *
-   * - `null` or `undefined`
-   * - Empty string
-   * - Empty object
-   * - Empty array
-   *
-   * @param {*} value - A value to test
-   * @return {Boolean} True if the value is empty
-   */
-  isEmptyValue(value) {
-    return (value == null) || (value === '') ||
-           ((typeof value === 'object') && (Object.keys(value).length === 0));
   }
-
 };
 
 module.exports = CreateServiceModalFormUtil;

--- a/plugins/services/src/js/utils/CreateServiceModalFormUtil.js
+++ b/plugins/services/src/js/utils/CreateServiceModalFormUtil.js
@@ -18,7 +18,7 @@ const CreateServiceModalFormUtil = {
    * @returns {Object} The patched data response
    */
   applyPatch(data, patch) {
-    // If we don't have this in data, prefer patch
+    // If we don't have data, prefer patch
     if (data == null) {
       return patch;
     }
@@ -34,8 +34,7 @@ const CreateServiceModalFormUtil = {
     }
 
     // Walk object types
-    let keys = Object.keys(patch);
-    return keys.reduce(function (memo, key) {
+    return Object.keys(patch).reduce(function (memo, key) {
 
       // If the patch contains an empty value we have to remove the item,
       // with the only exception of the source value having already an empty

--- a/plugins/services/src/js/utils/CreateServiceModalFormUtil.js
+++ b/plugins/services/src/js/utils/CreateServiceModalFormUtil.js
@@ -1,0 +1,74 @@
+const CreateServiceModalFormUtil = {
+
+  /**
+   * Apply patch data on the given source data, following the principles:
+   *
+   * 1. An "empty" value in the patch removes the field.
+   *
+   * 2. The previous statement is not applied when the respective `data` field
+   *    already contains an "empty" value. In that case, the "empty" data value
+   *    is perserved.
+   *
+   * 3. If both `data` and `patch` have a value in a field, but with different
+   *    types, the value from `data` is preferred.
+   *
+   * @param {Object} data - The source data to patch
+   * @param {Object} patch - The patch to apply with
+   * @returns {Object} The patched data response
+   */
+  applyPatch(data, patch) {
+    // If we don't have this in data, prefer patch
+    if (data == null) {
+      return patch;
+    }
+
+    // Prefer `data` type if we have a type clash
+    if (typeof data !== typeof patch) {
+      return data;
+    }
+
+    // Non-object types just pass through
+    if (typeof patch !== 'object') {
+      return patch;
+    }
+
+    // Walk object types
+    let keys = Object.keys(patch);
+    return keys.reduce(function (memo, key) {
+
+      // If the patch contains an empty value we have to remove the item,
+      // with the only exception of the source value having already an empty
+      // value in place.
+      if (CreateServiceModalFormUtil.isEmptyValue(patch[key])) {
+        if (!CreateServiceModalFormUtil.isEmptyValue(memo[key])) {
+          delete memo[key];
+        }
+
+        return memo;
+      }
+
+      memo[key] = CreateServiceModalFormUtil.applyPatch(memo[key], patch[key]);
+
+      return memo;
+    }, Object.assign({}, data));
+  },
+
+  /**
+   * Tests if the given value is "empty". This means:
+   *
+   * - `null` or `undefined`
+   * - Empty string
+   * - Empty object
+   * - Empty array
+   *
+   * @param {*} value - A value to test
+   * @return {Boolean} True if the value is empty
+   */
+  isEmptyValue(value) {
+    return (value == null) || (value === '') ||
+           ((typeof value === 'object') && (Object.keys(value).length === 0));
+  }
+
+};
+
+module.exports = CreateServiceModalFormUtil;

--- a/plugins/services/src/js/utils/__tests__/CreateServiceModalFormUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/CreateServiceModalFormUtil-test.js
@@ -109,51 +109,5 @@ describe('CreateServiceModalFormUtil', function () {
     });
 
   });
-
-  describe('#isEmptyValue', function () {
-    it('should consider `undefined` to be an empty value', function () {
-      expect(CreateServiceModalFormUtil.isEmptyValue(undefined)).toBeTruthy();
-    });
-
-    it('should consider `null` to be an empty value', function () {
-      expect(CreateServiceModalFormUtil.isEmptyValue(null)).toBeTruthy();
-    });
-
-    it('should consider `\'\'` to be an empty value', function () {
-      expect(CreateServiceModalFormUtil.isEmptyValue('')).toBeTruthy();
-    });
-
-    it('should consider `{}` to be an empty value', function () {
-      expect(CreateServiceModalFormUtil.isEmptyValue({})).toBeTruthy();
-    });
-
-    it('should consider `[]` to be an empty value', function () {
-      expect(CreateServiceModalFormUtil.isEmptyValue([])).toBeTruthy();
-    });
-
-    it('should consider `0` not to be an empty value', function () {
-      expect(CreateServiceModalFormUtil.isEmptyValue(0)).toBeFalsy();
-    });
-
-    it('should consider `\'a\'` not to be an empty value', function () {
-      expect(CreateServiceModalFormUtil.isEmptyValue('a')).toBeFalsy();
-    });
-
-    it('should consider `[1]` not to be an empty value', function () {
-      expect(CreateServiceModalFormUtil.isEmptyValue([1])).toBeFalsy();
-    });
-
-    it('should consider `{a: \'foo\'}` not to be an empty value', function () {
-      expect(CreateServiceModalFormUtil.isEmptyValue({a: 'foo'})).toBeFalsy();
-    });
-
-    it('should consider `NaN` not to be an empty value', function () {
-      expect(CreateServiceModalFormUtil.isEmptyValue(NaN)).toBeFalsy();
-    });
-
-    it('should consider `Infinity` not to be an empty value', function () {
-      expect(CreateServiceModalFormUtil.isEmptyValue(Infinity)).toBeFalsy();
-    });
-  });
 });
 

--- a/plugins/services/src/js/utils/__tests__/CreateServiceModalFormUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/CreateServiceModalFormUtil-test.js
@@ -1,0 +1,159 @@
+const CreateServiceModalFormUtil = require('../CreateServiceModalFormUtil');
+
+describe('CreateServiceModalFormUtil', function () {
+  describe('#applyPatch', function () {
+
+    it('should always return cloned objects', function () {
+      let data = {a: 'foo'};
+      let patch = {};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).not.toBe(data);
+    });
+
+    it('should not modify source data on empty patch', function () {
+      let data = {a: 'foo'};
+      let patch = {};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({a: 'foo'});
+    });
+
+    it('should create new fields if missing', function () {
+      let data = {a: 'foo'};
+      let patch = {b: 'bar'};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({a: 'foo', b: 'bar'});
+    });
+
+    it('should remove fields if patch value is undefined', function () {
+      let data = {a: 'foo'};
+      let patch = {a: undefined};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({});
+    });
+
+    it('should remove fields if patch value is null', function () {
+      let data = {a: 'foo'};
+      let patch = {a: null};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({});
+    });
+
+    it('should remove fields if patch value is \'\'', function () {
+      let data = {a: 'foo'};
+      let patch = {a: ''};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({});
+    });
+
+    it('should remove fields if patch value is {}', function () {
+      let data = {a: 'foo'};
+      let patch = {a: {}};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({});
+    });
+
+    it('should remove fields if patch value is []', function () {
+      let data = {a: 'foo'};
+      let patch = {a: []};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({});
+    });
+
+    it('should preserve string source type if array is given', function () {
+      let data = {a: 'foo'};
+      let patch = {a: ['a']};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({a: 'foo'});
+    });
+
+    it('should preserve string source type if object is given', function () {
+      let data = {a: 'foo'};
+      let patch = {a: {b: 'c'}};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({a: 'foo'});
+    });
+
+    it('should preserve string source type if number is given', function () {
+      let data = {a: 'foo'};
+      let patch = {a: 42};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({a: 'foo'});
+    });
+
+    it('should preserve null source type if null is given', function () {
+      let data = {a: null};
+      let patch = {a: null};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({a: null});
+    });
+
+    it('should preserve null source type if \'\' is given', function () {
+      let data = {a: null};
+      let patch = {a: ''};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({a: null});
+    });
+
+    it('should preserve null source type if [] is given', function () {
+      let data = {a: null};
+      let patch = {a: []};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({a: null});
+    });
+
+    it('should preserve null source type if {} is given', function () {
+      let data = {a: null};
+      let patch = {a: {}};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({a: null});
+    });
+
+  });
+
+  describe('#isEmptyValue', function () {
+    it('should consider `undefined` to be an empty value', function () {
+      expect(CreateServiceModalFormUtil.isEmptyValue(undefined)).toBeTruthy();
+    });
+
+    it('should consider `null` to be an empty value', function () {
+      expect(CreateServiceModalFormUtil.isEmptyValue(null)).toBeTruthy();
+    });
+
+    it('should consider `\'\'` to be an empty value', function () {
+      expect(CreateServiceModalFormUtil.isEmptyValue('')).toBeTruthy();
+    });
+
+    it('should consider `{}` to be an empty value', function () {
+      expect(CreateServiceModalFormUtil.isEmptyValue({})).toBeTruthy();
+    });
+
+    it('should consider `[]` to be an empty value', function () {
+      expect(CreateServiceModalFormUtil.isEmptyValue([])).toBeTruthy();
+    });
+
+    it('should consider `0` not to be an empty value', function () {
+      expect(CreateServiceModalFormUtil.isEmptyValue(0)).toBeFalsy();
+    });
+
+    it('should consider `\'a\'` not to be an empty value', function () {
+      expect(CreateServiceModalFormUtil.isEmptyValue('a')).toBeFalsy();
+    });
+
+    it('should consider `[1]` not to be an empty value', function () {
+      expect(CreateServiceModalFormUtil.isEmptyValue([1])).toBeFalsy();
+    });
+
+    it('should consider `{a: \'foo\'}` not to be an empty value', function () {
+      expect(CreateServiceModalFormUtil.isEmptyValue({a: 'foo'})).toBeFalsy();
+    });
+
+    it('should consider `NaN` not to be an empty value', function () {
+      expect(CreateServiceModalFormUtil.isEmptyValue(NaN)).toBeFalsy();
+    });
+
+    it('should consider `Infinity` not to be an empty value', function () {
+      expect(CreateServiceModalFormUtil.isEmptyValue(Infinity)).toBeFalsy();
+    });
+  });
+});
+


### PR DESCRIPTION
This PR introduces a utility function used by the `NewCreateServiceModalForm` to update the JSON content in the smartest way possible. This happens in two phases:

1. The form uses the batch reducers to create a "UI patch" to the JSON
2. It uses the `applyPatch` function apply the patch to the current JSON state

This function follows these principles:

1. An "empty" value in the patch removes the field.
2. The previous statement is not applied when the respective `data` field already contains an "empty" value. In that case, the original "empty" data value is perserved.
3. If both `data` and `patch` have a value in a field, but with different types, the value from `data` is preferred.