### PR TITLE
DCOS-11609: Fixing JSONEditor corner cases

### DIFF
--- a/src/js/components/JSONEditor.js
+++ b/src/js/components/JSONEditor.js
@@ -65,6 +65,9 @@ const ISTYPING_TIMEOUT = 2000;
 class JSONEditor extends React.Component {
   constructor() {
     super(...arguments);
+    // Clone the given initial value
+    let initialText = JSON.stringify(this.props.value || {}, null, 2);
+    let initialValue = JSON.parse(initialText);
 
     // We are using the react-way of updating the component **only** when we
     // need to define a new text to work upon (ex. when the owner component has
@@ -73,14 +76,14 @@ class JSONEditor extends React.Component {
     // Updating the AceEditor on every render cycle seems to cause some trouble
     // to it's internals, that I couldn't pinpoint yet.
     this.state = {
-      initialText: ''
+      initialText
     };
 
     //
     // The following properties are part of the `internal`, non-react state
     // and is synchronized with the react through `componentWillReceiveProps`
     //
-    this.externalErrors = [];
+    this.externalErrors = (this.props.errors || []).slice();
     this.jsonError = null;
     this.jsonMeta = [];
     this.jsonText = '{}';
@@ -94,6 +97,9 @@ class JSONEditor extends React.Component {
     this.isTyping = false;
     this.timerIsTyping = null;
 
+    // Initial state synchronisation
+    this.updateLocalJsonState(initialValue);
+
     METHODS_TO_BIND.forEach((method) => {
       this[method] = this[method].bind(this);
     });
@@ -104,8 +110,10 @@ class JSONEditor extends React.Component {
    */
   componentWillReceiveProps(nextProps) {
     // Synchronise error updates
+    console.log('[JSONEditor] componentWillReceiveProps', nextProps, this.externalErrors);
     if (!deepEqual(this.externalErrors, nextProps.errors)) {
-      this.externalErrors = nextProps.errors || [];
+      this.externalErrors = (nextProps.errors || []).slice();
+      console.log('[JSONEditor] newErrors=', this.externalErrors);
       this.updateEditorState();
     }
 
@@ -432,10 +440,28 @@ class JSONEditor extends React.Component {
         return token.path.join('.') === errorPath;
       });
 
-      if (!token) {
+      // Root errors go to line 0
+      if (errorPath === '') {
+        memo.push({
+          row: 0,
+          text: error.message,
+          type: 'error'
+        });
         return memo;
       }
 
+      // Errors with invalid path also go to root, but gets
+      // prefixed with their path
+      if (!token) {
+        memo.push({
+          row: 0,
+          text: `${errorPath}: ${error.message}`,
+          type: 'error'
+        });
+        return memo;
+      }
+
+      // Otherwise errors get to the appropriate line
       memo.push({
         row: token.line - 1,
         text: error.message,

--- a/src/js/components/JSONEditor.js
+++ b/src/js/components/JSONEditor.js
@@ -110,10 +110,8 @@ class JSONEditor extends React.Component {
    */
   componentWillReceiveProps(nextProps) {
     // Synchronise error updates
-    console.log('[JSONEditor] componentWillReceiveProps', nextProps, this.externalErrors);
     if (!deepEqual(this.externalErrors, nextProps.errors)) {
       this.externalErrors = (nextProps.errors || []).slice();
-      console.log('[JSONEditor] newErrors=', this.externalErrors);
       this.updateEditorState();
     }
 

--- a/src/js/utils/JSONEditorUtil.js
+++ b/src/js/utils/JSONEditorUtil.js
@@ -75,7 +75,9 @@ var JSONEditorUtil = {
     if (oldObj === newObj) {
       return [];
     }
-    if (typeof oldObj !== typeof newObj) {
+    if ((typeof oldObj !== typeof newObj) ||
+       ((oldObj !== null) && (newObj === null)) ||
+       ((oldObj === null) && (newObj !== null))) {
       return [{path, value: newObj, previous: oldObj}];
     }
     if (typeof oldObj !== 'object') {
@@ -187,6 +189,12 @@ var JSONEditorUtil = {
 
       // Append new values in the order they appear at the end of the array
       return resultVal.concat(newValues);
+    }
+
+    // Since `null` is also considered an object, handle it before we reach
+    // the next statement where Object.keys will fail.
+    if ((oldVal == null) || (newVal == null)) {
+      return newVal;
     }
 
     if ((typeof oldVal === 'object') && (typeof newVal === 'object')) {

--- a/src/js/utils/__tests__/JSONEditorUtil-test.js
+++ b/src/js/utils/__tests__/JSONEditorUtil-test.js
@@ -184,6 +184,26 @@ describe('JSONEditorUtil', function () {
         {path: [], value: {a: {b: 'foo'}}, previous: {a: 'bar'}}
       ]);
     });
+
+    it('should handle null-to-object mutations', function () {
+      let a = {a: null};
+      let b = {a: {b: 'foo'}};
+
+      expect(JSONEditorUtil.deepObjectDiff(a, b)).toEqual([
+        {path: ['a'], value: {b: 'foo'}, previous: null},
+        {path: [], value: {a: {b: 'foo'}}, previous: {a: null}}
+      ]);
+    });
+
+    it('should handle object-to-null mutations', function () {
+      let a = {a: {b: 'foo'}};
+      let b = {a: null};
+
+      expect(JSONEditorUtil.deepObjectDiff(a, b)).toEqual([
+        {path: ['a'], value: null, previous: {b: 'foo'}},
+        {path: [], value: {a: null}, previous: {a: {b: 'foo'}}}
+      ]);
+    });
   });
 
   describe('#sortObjectKeys', function () {
@@ -294,6 +314,22 @@ describe('JSONEditorUtil', function () {
         {a:4, b:5, c:3, d:6},
         {b:4, a:5, c:8, d:6}
       ]});
+    });
+
+    it('should properly handle null-to-object comparisions', function () {
+      let a = {a: {b: 'foo', c: 'bar'}};
+      let b = {a: null};
+
+      let value = JSONEditorUtil.sortObjectKeys(a, b);
+      expect(value).toEqual({a: null});
+    });
+
+    it('should place object values in keys that were null before', function () {
+      let a = {a: null};
+      let b = {a: {b: 'foo', c: 'bar'}};
+
+      let value = JSONEditorUtil.sortObjectKeys(a, b);
+      expect(value).toEqual({a: {b: 'foo', c: 'bar'}});
     });
 
   });


### PR DESCRIPTION
This PR address some corner cases in the JSONEditor. Namely: the diff and sort algorithms were incorrectly treating `null` values as legit objects.

In addition this PR tries also fixes some minor issues:

* Errors with no paths and errors with missing paths always appear on line 1
* Initial `prop` values are now correctly handled