### PR TITLE
Add the capability to save HTTPS for healthChecks

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/HealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/HealthChecks.js
@@ -7,7 +7,7 @@ import Util from '../../../../../../src/js/utils/Util';
 import Transaction from '../../../../../../src/js/structs/Transaction';
 
 function mapHealthChecks(item) {
-  const newItem = Util.omit(item, ['path', 'command', 'protocol']);
+  const newItem = Util.omit(item, ['path', 'command', 'protocol', 'https']);
 
   if (item.protocol != null) {
     newItem.protocol = item.protocol;
@@ -62,6 +62,9 @@ module.exports = {
       if (type === SET) {
         if (`healthChecks.${index}.protocol` === joinedPath) {
           this.healthChecks[index].protocol = value;
+          if (value === 'HTTP' && this.healthChecks[index].https) {
+            this.healthChecks[index].protocol = 'HTTPS';
+          }
         }
         if (`healthChecks.${index}.command` === joinedPath) {
           this.healthChecks[index].command = value;
@@ -82,6 +85,7 @@ module.exports = {
           this.healthChecks[index].maxConsecutiveFailures = value;
         }
         if (`healthChecks.${index}.https` === joinedPath) {
+          this.healthChecks[index].https = value;
           if (value === true) {
             this.healthChecks[index].protocol = 'HTTPS';
           } else {
@@ -153,6 +157,9 @@ module.exports = {
     if (path == null) {
       return state;
     }
+    if (this.cache == null) {
+      this.cache = [];
+    }
 
     let joinedPath = path.join('.');
 
@@ -175,6 +182,9 @@ module.exports = {
       if (type === SET) {
         if (`healthChecks.${index}.protocol` === joinedPath) {
           state[index].protocol = value;
+          if (value === 'HTTP' && this.cache[index]) {
+            state[index].protocol = 'HTTPS';
+          }
         }
         if (`healthChecks.${index}.command` === joinedPath) {
           state[index].command = value;
@@ -195,6 +205,7 @@ module.exports = {
           state[index].maxConsecutiveFailures = value;
         }
         if (`healthChecks.${index}.https` === joinedPath) {
+          this.cache[index] = value;
           if (value === true) {
             state[index].protocol = 'HTTPS';
           } else {

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/HealthChecks-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/HealthChecks-test.js
@@ -166,5 +166,32 @@ describe('Labels', function () {
       }]);
     });
 
+    it('should keep https after switching protocol back to HTTP', function () {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(['healthChecks'], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
+      batch = batch.add(new Transaction(['healthChecks', 0, 'https'], true));
+      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'COMMAND'));
+      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
+
+      expect(batch.reduce(HealthChecks.FormReducer.bind({}), [])).toEqual([{
+        protocol: 'HTTPS'
+      }]);
+    });
+
+    it('should set protocol to http if https was set', function () {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(['healthChecks'], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
+      batch = batch.add(new Transaction(['healthChecks', 0, 'https'], true));
+      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'COMMAND'));
+      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
+      batch = batch.add(new Transaction(['healthChecks', 0, 'https'], false));
+
+      expect(batch.reduce(HealthChecks.FormReducer.bind({}), [])).toEqual([{
+        protocol: 'HTTP'
+      }]);
+    });
+
   });
 });


### PR DESCRIPTION
If you switch to HTTP protocol and check the HTTPS checkbox and then switch to protocol COMMAND and then beck to HTTP the HTTPS setting would be lost. This PR adds the feature to keep the value saved.