### PR TITLE
DCOS-11638: Fixing recursive application of applyPatch

### DIFF
--- a/plugins/services/src/js/utils/CreateServiceModalFormUtil.js
+++ b/plugins/services/src/js/utils/CreateServiceModalFormUtil.js
@@ -14,6 +14,12 @@ const CreateServiceModalFormUtil = {
       return object;
     }
 
+    // Pick base object according to type
+    let baseObject = {};
+    if (Array.isArray(object)) {
+      baseObject = [];
+    }
+
     return Object.keys(object).reduce(function (memo, key) {
       if (!ValidatorUtil.isEmpty(object[key])) {
         // Apply the strip function recursively and keep only non-empty values
@@ -23,7 +29,7 @@ const CreateServiceModalFormUtil = {
         }
       }
       return memo;
-    }, {});
+    }, baseObject);
   },
 
   /**
@@ -50,13 +56,20 @@ const CreateServiceModalFormUtil = {
     }
 
     // Prefer `data` type if we have a type clash
-    if (typeof data !== typeof patch) {
+    if ((typeof data !== typeof patch) ||
+        (Array.isArray(data) !== Array.isArray(patch))) {
       return data;
     }
 
     // Non-object types just pass through
     if (typeof patch !== 'object') {
       return patch;
+    }
+
+    // Pick base object according to type
+    let baseObject = Object.assign({}, data);
+    if (Array.isArray(data)) {
+      baseObject = [];
     }
 
     // Walk object types
@@ -91,7 +104,7 @@ const CreateServiceModalFormUtil = {
       memo[key] = value;
 
       return memo;
-    }, Object.assign({}, data));
+    }, baseObject);
   }
 };
 

--- a/plugins/services/src/js/utils/CreateServiceModalFormUtil.js
+++ b/plugins/services/src/js/utils/CreateServiceModalFormUtil.js
@@ -76,9 +76,15 @@ const CreateServiceModalFormUtil = {
       let value = CreateServiceModalFormUtil.applyPatch(memo[key], patch[key]);
 
       // If a field was emptied, remove it from the object, to keep structures
-      // as clean as possible.
+      // as clean as possible. (Again, only if the base value in `data` is not
+      // empty)
       if (ValidatorUtil.isEmpty(value)) {
+        if (ValidatorUtil.isEmpty(memo[key])) {
+          return memo;
+        }
+
         delete memo[key];
+
         return memo;
       }
 

--- a/plugins/services/src/js/utils/CreateServiceModalFormUtil.js
+++ b/plugins/services/src/js/utils/CreateServiceModalFormUtil.js
@@ -67,9 +67,10 @@ const CreateServiceModalFormUtil = {
     }
 
     // Pick base object according to type
-    let baseObject = Object.assign({}, data);
-    if (Array.isArray(data)) {
-      baseObject = [];
+    // (Note that arrays get replaced, but objects get merged)
+    let baseObject = [];
+    if (!Array.isArray(data)) {
+      baseObject = Object.assign({}, data);
     }
 
     // Walk object types

--- a/plugins/services/src/js/utils/__tests__/CreateServiceModalFormUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/CreateServiceModalFormUtil-test.js
@@ -108,6 +108,26 @@ describe('CreateServiceModalFormUtil', function () {
       expect(patched).toEqual({a: null});
     });
 
+    it('should remove empty fields from patch objects', function () {
+      let data = {a: null};
+      let patch = {a: {b: null, c:'', d:'foo'}};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({a: {d: 'foo'}});
+    });
+
+    it('should recursively remove empty fields from patch objects', function () {
+      let data = {a: {b: 'foo', c: {d: 'bar'}}};
+      let patch = {a: {b: 'foo', c: {d: null}}};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({a: {b: 'foo'}});
+    });
+
+    it('should strip empty propeties from patch-only objects', function () {
+      let data = {};
+      let patch = {a: {b: 'foo', c: {d: null}}};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({a: {b: 'foo'}});
+    });
   });
 });
 

--- a/plugins/services/src/js/utils/__tests__/CreateServiceModalFormUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/CreateServiceModalFormUtil-test.js
@@ -108,6 +108,13 @@ describe('CreateServiceModalFormUtil', function () {
       expect(patched).toEqual({a: null});
     });
 
+    it('should preserve [] source type if number is given', function () {
+      let data = {a: [1, 2, 3]};
+      let patch = {a: 42};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({a: [1, 2, 3]});
+    });
+
     it('should remove empty fields from patch objects', function () {
       let data = {a: null};
       let patch = {a: {b: null, c:'', d:'foo'}};
@@ -136,6 +143,40 @@ describe('CreateServiceModalFormUtil', function () {
       expect(patched).toEqual({a: {b: 'foo'}});
     });
 
+    it('should properly create new array structures', function () {
+      let data = {};
+      let patch = {a: [{b: 'foo'}, {c: 'bar'}]};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({a: [{b: 'foo'}, {c: 'bar'}]});
+    });
+
+    it('should not create empty array structures', function () {
+      let data = {};
+      let patch = {a: []};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({});
+    });
+
+    it('should not create array structures that contain empty items', function () {
+      let data = {};
+      let patch = {a: [null, undefined, '', {}]};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({});
+    });
+
+    it('should replace array structures when patching', function () {
+      let data = {a: [1, 2, 3, 4]};
+      let patch = {a: [3, 4]};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({a: [3, 4]});
+    });
+
+    it('should remove array structures with empty value', function () {
+      let data = {a: [1, 2]};
+      let patch = {a: null};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({});
+    });
   });
 });
 

--- a/plugins/services/src/js/utils/__tests__/CreateServiceModalFormUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/CreateServiceModalFormUtil-test.js
@@ -115,6 +115,13 @@ describe('CreateServiceModalFormUtil', function () {
       expect(patched).toEqual({a: {d: 'foo'}});
     });
 
+    it('should keep the original empty value if patch object is empty', function () {
+      let data = {a: {}};
+      let patch = {a: {b: null, c:'', d:undefined}};
+      let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
+      expect(patched).toEqual({a: {}});
+    });
+
     it('should recursively remove empty fields from patch objects', function () {
       let data = {a: {b: 'foo', c: {d: 'bar'}}};
       let patch = {a: {b: 'foo', c: {d: null}}};
@@ -128,6 +135,7 @@ describe('CreateServiceModalFormUtil', function () {
       let patched = CreateServiceModalFormUtil.applyPatch(data, patch);
       expect(patched).toEqual({a: {b: 'foo'}});
     });
+
   });
 });
 


### PR DESCRIPTION
This PR makes sure `CreateServiceModalFormUtil.applyPatch` is called recursively in order to remove objects that become empty after the first pass. For example:

For example given an input:
```js
{
  "object": {
    "value": ""
  }
}
```

Previously was producing:
```js
{
  "object": {
  }
}
```

But now it produces:
```js
{
}
```