### PR TITLE
Add z-index to FormGroupContainer's remove button

### DIFF
--- a/src/js/components/form/FormGroupContainer.js
+++ b/src/js/components/form/FormGroupContainer.js
@@ -6,7 +6,7 @@ const FormGroupContainer = (props) => {
   let removeButton = null;
   if (props.onRemove != null) {
     removeButton = (
-      <div className="form-group-container-action-button">
+      <div className="form-group-container-action-button-group">
         <a className="button button-primary-link"
           onClick={props.onRemove}>
           <Icon id="close" color="grey" size="tiny"/>

--- a/src/js/components/form/FormGroupContainer.js
+++ b/src/js/components/form/FormGroupContainer.js
@@ -6,7 +6,7 @@ const FormGroupContainer = (props) => {
   let removeButton = null;
   if (props.onRemove != null) {
     removeButton = (
-      <div className="form-remove">
+      <div className="form-group-container-action-button">
         <a className="button button-primary-link"
           onClick={props.onRemove}>
           <Icon id="close" color="grey" size="tiny"/>

--- a/src/styles/components/form-elements/styles.less
+++ b/src/styles/components/form-elements/styles.less
@@ -45,6 +45,7 @@
     position: absolute;
     right: 0;
     top: 0;
+    z-index: @z-index-form-group-container-remove-button;
   }
 }
 

--- a/src/styles/components/form-elements/styles.less
+++ b/src/styles/components/form-elements/styles.less
@@ -41,11 +41,11 @@
     position: absolute;
   }
 
-  .form-group-container-action-button {
+  .form-group-container-action-button-group {
     position: absolute;
     right: 0;
     top: 0;
-    z-index: @z-index-form-group-container-remove-button;
+    z-index: @z-index-form-group-container-action-button-group;
   }
 }
 

--- a/src/styles/components/form-elements/styles.less
+++ b/src/styles/components/form-elements/styles.less
@@ -41,7 +41,7 @@
     position: absolute;
   }
 
-  .form-remove {
+  .form-group-container-action-button {
     position: absolute;
     right: 0;
     top: 0;

--- a/src/styles/variables/variables-z-index.less
+++ b/src/styles/variables/variables-z-index.less
@@ -5,7 +5,7 @@
 @z-index-dygraph-chart: @z-index-side-panel + 10;
 @z-index-dygraph-hover-label: 100;
 @gemini-scrollbar-handle: @z-index-header-tabs + 1;
-@z-index-form-group-container-remove-button: 1;
+@z-index-form-group-container-action-button-group: 1;
 @z-index-header: 1000;
 @z-index-header-border: 1;
 @z-index-header-tabs: @z-index-header-border + 1;

--- a/src/styles/variables/variables-z-index.less
+++ b/src/styles/variables/variables-z-index.less
@@ -5,6 +5,7 @@
 @z-index-dygraph-chart: @z-index-side-panel + 10;
 @z-index-dygraph-hover-label: 100;
 @gemini-scrollbar-handle: @z-index-header-tabs + 1;
+@z-index-form-group-container-remove-button: 1;
 @z-index-header: 1000;
 @z-index-header-border: 1;
 @z-index-header-tabs: @z-index-header-border + 1;


### PR DESCRIPTION
This PR:
* Renames `.form-remove` to `.form-group-container-action-button`
* Gives a z-index to `.form-group-container-action-button` to prevent it from rendering below sibling elements