### PR TITLE
Allow field label to match input height

### DIFF
--- a/src/js/components/form/FieldLabel.js
+++ b/src/js/components/form/FieldLabel.js
@@ -4,7 +4,7 @@ import React from 'react';
 import {omit} from '../../utils/Util';
 
 const FieldLabel = (props) => {
-  let {children, className, required} = props;
+  let {children, className, matchInputHeight, required} = props;
   let isToggle = false;
   React.Children.forEach(children, (child) => {
     let {props = {}} = child;
@@ -22,16 +22,29 @@ const FieldLabel = (props) => {
     requiredNode = <span className="text-danger"> *</span>;
   }
 
-  return (
-    <label className={classes} {...omit(props, Object.keys(FieldLabel.propTypes))}>
+  let label = (
+    <label className={classes}
+      {...omit(props, Object.keys(FieldLabel.propTypes))}>
       {children}
       {requiredNode}
     </label>
+  );
+
+  if (!matchInputHeight) {
+    return label;
+  }
+
+  return (
+    <div className="form-control-input-height">
+      {label}
+    </div>
   );
 };
 
 FieldLabel.propTypes = {
   children: React.PropTypes.node,
+  // Vertically center the element based on the height of input fields
+  matchInputHeight: React.PropTypes.bool,
   // Optional boolean to show a required indicator
   required: React.PropTypes.bool,
 

--- a/src/styles/components/form-elements/styles.less
+++ b/src/styles/components/form-elements/styles.less
@@ -7,6 +7,12 @@
     }
   }
 
+  .form-control-input-height {
+    align-items: center;
+    display: flex;
+    height: @form-control-height;
+  }
+
   .form-control-group-add-on {
     white-space: nowrap;
 
@@ -39,5 +45,15 @@
     position: absolute;
     right: 0;
     top: 0;
+  }
+}
+
+& when (@grid-enabled) and (@layout-screen-large-enabled) {
+
+  @media (min-width: @layout-screen-large-min-width) {
+
+    .form-control-input-height {
+      height: @form-control-height-screen-large;
+    }
   }
 }


### PR DESCRIPTION
This PR adds ability for `FieldLabel` elements to match the height of `input` elements. This is useful for implementing the following design:
![](https://cl.ly/1p3I3A3c3337/Screen%20Shot%202016-11-21%20at%202.23.58%20PM.png)

Note: Right now the `@form-control-height` only has a `large` screen variant, so that's the only media query you'll see here.