### PR TITLE
Pass checked prop to checkbox

### DIFF
--- a/src/js/components/form/FieldInput.js
+++ b/src/js/components/form/FieldInput.js
@@ -4,17 +4,24 @@ import React from 'react';
 import {omit} from '../../utils/Util';
 
 const FieldInput = (props) => {
-  let {className, type} = props;
+  let {className, type, value} = props;
+  let additionalProps = {};
   let classes = classNames('form-control', className);
 
   let toggleIndicator;
   if (['radio', 'checkbox'].includes(type)) {
     toggleIndicator = <span className="form-control-toggle-indicator"></span>;
+
+    if (type === 'checkbox') {
+      additionalProps.checked = value;
+    }
   }
 
   return (
     <span>
-      <input className={classes} {...omit(props, ['className'])} />
+      <input className={classes}
+        {...omit(props, ['className'])}
+        {...additionalProps} />
       {toggleIndicator}
     </span>
   );


### PR DESCRIPTION
This PR passes the `checked` prop when `FieldInput`'s type is `checkbox`.

This is required for maintaining a checkbox's state if React reuses the `input` DOM node where the new checkbox's value differs from the previous.