### PR TITLE
Extend column styling to include flush columns and automatic widths

### DIFF
--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -47,6 +47,11 @@
 @import 'layout/container/variables.less';
 @import 'layout/container/styles.less';
 
+// Grid
+
+@import 'layout/grid/variables.less';
+@import 'layout/grid/styles.less';
+
 // Header
 
 @import 'layout/header/styles.less';

--- a/src/styles/layout/grid/styles.less
+++ b/src/styles/layout/grid/styles.less
@@ -1,0 +1,66 @@
+& when (@grid-enabled) {
+
+  .column-auto {
+    padding-left: @grid-gutter-width / 2;
+    padding-right: @grid-gutter-width / 2;
+  }
+
+  [class*='column'] {
+
+    &.flush {
+      padding: 0;
+    }
+
+    &.flush-left {
+      padding-left: 0;
+    }
+
+    &.flush-right {
+      padding-right: 0;
+    }
+  }
+}
+
+& when (@grid-enabled) and (@layout-screen-small-enabled) {
+
+  @media (min-width: @layout-screen-small-min-width) {
+
+    .column-auto {
+      padding-left: @grid-gutter-width-screen-small / 2;
+      padding-right: @grid-gutter-width-screen-small / 2;
+    }
+  }
+}
+
+& when (@grid-enabled) and (@layout-screen-medium-enabled) {
+
+  @media (min-width: @layout-screen-medium-min-width) {
+
+    .column-auto {
+      padding-left: @grid-gutter-width-screen-medium / 2;
+      padding-right: @grid-gutter-width-screen-medium / 2;
+    }
+  }
+}
+
+& when (@grid-enabled) and (@layout-screen-large-enabled) {
+
+  @media (min-width: @layout-screen-large-min-width) {
+
+    .column-auto {
+      padding-left: @grid-gutter-width-screen-large / 2;
+      padding-right: @grid-gutter-width-screen-large / 2;
+    }
+  }
+}
+
+& when (@grid-enabled) and (@layout-screen-jumbo-enabled) {
+
+  @media (min-width: @layout-screen-jumbo-min-width) {
+
+    .column-auto {
+      padding-left: @grid-gutter-width-screen-jumbo / 2;
+      padding-right: @grid-gutter-width-screen-jumbo / 2;
+    }
+  }
+}

--- a/src/styles/layout/grid/variables.less
+++ b/src/styles/layout/grid/variables.less
@@ -1,0 +1,1 @@
+@grid-enabled: true;


### PR DESCRIPTION
This PR:
* allows `flush` family of classes to remove padding from columns
* adds a `column-auto` class which will receive the same padding as all columns, but has no defined width

Both of these are necessary for the following mockup:
![](https://cl.ly/11423o2Y181W/Screen%20Shot%202016-11-21%20at%202.32.00%20PM.png)