### PR TITLE
DCOS-9609: Pass target param down to the auth service

### DIFF
--- a/src/js/events/AuthActions.js
+++ b/src/js/events/AuthActions.js
@@ -10,9 +10,14 @@ import AppDispatcher from '../events/AppDispatcher';
 import Config from '../config/Config';
 
 const AuthActions = {
-  login(credentials) {
+  login(credentials, target) {
+    let query = '';
+    if (target) {
+      query = `?target=${encodeURIComponent(target)}`;
+    }
+
     RequestUtil.json({
-      url: `${Config.rootUrl}${Config.acsAPIPrefix}/auth/login`,
+      url: `${Config.rootUrl}${Config.acsAPIPrefix}/auth/login${query}`,
       method: 'POST',
       data: credentials,
       success() {

--- a/src/js/events/__tests__/AuthActions-test.js
+++ b/src/js/events/__tests__/AuthActions-test.js
@@ -1,3 +1,4 @@
+jest.dontMock('query-string');
 jest.dontMock('../AuthActions');
 
 const RequestUtil = require('mesosphere-shared-reactjs').RequestUtil;
@@ -8,6 +9,19 @@ const AuthActions = require('../AuthActions');
 const Config = require('../../config/Config');
 
 describe('AuthActions', function () {
+
+  describe('extra params', function () {
+
+    it('passes extra parameters down to the auth service via query string params', function () {
+      spyOn(RequestUtil, 'json');
+
+      AuthActions.login(undefined, 'boo');
+
+      expect(RequestUtil.json.calls.mostRecent().args[0].url)
+        .toEqual(Config.acsAPIPrefix + '/auth/login?target=boo');
+    });
+
+  });
 
   describe('#login', function () {
 


### PR DESCRIPTION
This PR allows us to provide a specific `target` when we perform a login action.
Which will be handled by the `IAM` service