### PR TITLE
Fix issue where routes might be undefined

### DIFF
--- a/src/js/components/Breadcrumbs.js
+++ b/src/js/components/Breadcrumbs.js
@@ -119,7 +119,8 @@ class Breadcrumbs extends React.Component {
 
 Breadcrumbs.defaultProps = {
   // Remove root '/' by default
-  shift: 0
+  shift: 0,
+  routes: []
 };
 
 Breadcrumbs.propTypes = {

--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -193,9 +193,11 @@ var Sidebar = React.createClass({
     let isChildActive = false;
 
     const childRoutesPaths = children.map(({path}) => path);
-    const childRoutesMap = Hooks
-        .applyFilter('secondaryNavigation', path, childRoutesPaths)
-        .reduce((routesMap, path) => routesMap.set(path, true), new Map());
+    const childRoutes = Hooks
+        .applyFilter('secondaryNavigation', path, childRoutesPaths) || [];
+    const childRoutesMap = childRoutes.reduce((routesMap, path) => {
+      return routesMap.set(path, true);
+    }, new Map());
     const filteredChildRoutes =
         children.filter(({path}) => childRoutesMap.has(path));
 

--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -193,11 +193,13 @@ var Sidebar = React.createClass({
     let isChildActive = false;
 
     const childRoutesPaths = children.map(({path}) => path);
-    const childRoutes = Hooks
-        .applyFilter('secondaryNavigation', path, childRoutesPaths) || [];
-    const childRoutesMap = childRoutes.reduce((routesMap, path) => {
-      return routesMap.set(path, true);
-    }, new Map());
+    const filteredPaths = Hooks
+        .applyFilter('secondaryNavigation', path, childRoutesPaths);
+
+    // Defaulting to unfiltered set of paths
+    const childRoutesMap = (filteredPaths || childRoutesPaths)
+        .reduce((routesMap, path) => routesMap.set(path, true), new Map());
+
     const filteredChildRoutes =
         children.filter(({path}) => childRoutesMap.has(path));
 


### PR DESCRIPTION
This PR fixes a couple of issues that emerges on an open cluster:
`Uncaught TypeError: Cannot read property 'reduce' of undefined(…)` in Sidebar.js
`Uncaught TypeError: Cannot read property 'length' of undefined(…)` in Breadcrumbs.js
