### PR TITLE
DCOS-10987: [1/2] Separate JSON Flow

### DIFF
--- a/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
+++ b/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
@@ -1,0 +1,22 @@
+import React, {PropTypes} from 'react';
+
+class CreateServiceJsonOnly extends React.Component {
+  render() {
+    return (
+      <div>JSON Editor Placeholder</div>
+    );
+  }
+}
+
+CreateServiceJsonOnly.defaultProps = {
+  onChange() {},
+  onErrorStateChange() {}
+};
+
+CreateServiceJsonOnly.propTypes = {
+  onChange: PropTypes.func,
+  onErrorStateChange: PropTypes.func,
+  service: PropTypes.object
+};
+
+module.exports = CreateServiceJsonOnly;

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -68,10 +68,11 @@ class NewServiceFormModal extends Component {
 
     if (serviceReviewActive) {
       // Just hide review screen. Form or JSON mode will be
-      // activate dautomaticaly depending on their last state
+      // activated automaticaly depending on their last state
       this.setState({
         serviceReviewActive: false
       });
+
       return;
     }
 
@@ -81,6 +82,7 @@ class NewServiceFormModal extends Component {
         servicePickerActive: true,
         serviceFormActive: false
       });
+
       return;
     }
 
@@ -90,6 +92,7 @@ class NewServiceFormModal extends Component {
         servicePickerActive: true,
         serviceJsonActive: false
       });
+
       return;
     }
   }

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalServicePicker.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalServicePicker.js
@@ -49,7 +49,7 @@ class NewCreateServiceModalServicePicker extends React.Component {
     });
 
     return (
-      <div className="panel-grid row">
+      <div className="create-service-modal-service-picker-options panel-grid row">
         {customOptions}
       </div>
     );
@@ -65,24 +65,22 @@ class NewCreateServiceModalServicePicker extends React.Component {
 
   getServiceDeployOptions() {
     return (
-      <div className="container">
-        <div className="pod pod-taller flush-top flush-right flush-left">
-          <h3 className="short flush-top">
-            Run your own Service
-          </h3>
-          <p className="lead tall">
-            Create serice from one or more containers, run a command, or run from
-            Docker Compose.
-          </p>
-          {this.getCustomServiceGrid()}
-        </div>
+      <div className="create-service-modal-service-picker container text-align-center">
+        <h3 className="short flush-top">
+          Run your own Service
+        </h3>
+        <p className="lead tall">
+          Create service from one or more containers, run a command, or run from
+          Docker Compose.
+        </p>
+        {this.getCustomServiceGrid()}
       </div>
     );
   }
 
   getServiceOption(icon, title, index, service) {
     return (
-      <div className="panel-grid-item column-6 column-small-4 column-large-3"
+      <div className="create-service-modal-service-picker-option panel-grid-item column-12 column-small-4 column-large-3"
         key={index}>
         <Panel className="panel-interactive clickable"
           contentClass={[

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalServicePicker.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalServicePicker.js
@@ -1,44 +1,19 @@
-import mixin from 'reactjs-mixin';
 /* eslint-disable no-unused-vars */
 import React from 'react';
 /* eslint-enable no-unused-vars */
-import {StoreMixin} from 'mesosphere-shared-reactjs';
 
-import CosmosPackagesStore from '../../../../../../src/js/stores/CosmosPackagesStore';
+// import CosmosPackagesStore from '../../../../../../src/js/stores/CosmosPackagesStore';
 import defaultServiceImage from '../../../img/icon-service-default-medium@2x.png';
+import jsonServiceImage from '../../../img/service-image-json-medium@2x.png';
 import Image from '../../../../../../src/js/components/Image';
-import Loader from '../../../../../../src/js/components/Loader';
 import Panel from '../../../../../../src/js/components/Panel';
 
-class NewCreateServiceModalServicePicker extends mixin(StoreMixin) {
+class NewCreateServiceModalServicePicker extends React.Component {
   constructor() {
     super(...arguments);
 
     this.state = {
-      errorMessage: null,
-      isLoading: true
     };
-
-    this.store_listeners = [
-      {
-        name: 'cosmosPackages',
-        events: ['availableError', 'availableSuccess'],
-        suppressUpdate: true
-      }
-    ];
-  }
-
-  componentDidMount() {
-    super.componentDidMount(...arguments);
-    CosmosPackagesStore.fetchAvailablePackages();
-  }
-
-  onCosmosPackagesStoreAvailableError(errorMessage) {
-    this.setState({errorMessage});
-  }
-
-  onCosmosPackagesStoreAvailableSuccess() {
-    this.setState({errorMessage: null, isLoading: false});
   }
 
   handleServiceSelect(service) {
@@ -50,22 +25,20 @@ class NewCreateServiceModalServicePicker extends mixin(StoreMixin) {
       icon: (
         <Image fallbackSrc={defaultServiceImage} src={defaultServiceImage} />
       ),
-      label: 'Container Service'
+      label: 'Container Service',
+      type: 'app'
     }, {
       icon: (
         <Image fallbackSrc={defaultServiceImage} src={defaultServiceImage} />
       ),
-      label: 'Docker Compose'
+      label: 'Multi-Container (Pod)',
+      type: 'pod'
     }, {
       icon: (
-        <Image fallbackSrc={defaultServiceImage} src={defaultServiceImage} />
+        <Image fallbackSrc={jsonServiceImage} src={jsonServiceImage} />
       ),
-      label: 'JSON Configuration'
-    }, {
-      icon: (
-        <Image fallbackSrc={defaultServiceImage} src={defaultServiceImage} />
-      ),
-      label: 'Kubernetes YAML'
+      label: 'JSON Configuration',
+      type: 'json'
     }].map((item, index) => {
       return this.getServiceOption(
         this.getServiceOptionIconWrapper(item.icon),
@@ -102,16 +75,6 @@ class NewCreateServiceModalServicePicker extends mixin(StoreMixin) {
             Docker Compose.
           </p>
           {this.getCustomServiceGrid()}
-        </div>
-        <div>
-          <h3 className="short flush-top">
-            or, Run a DC/OS Service from Universe
-          </h3>
-          <p className="lead tall">
-            Don't see the service you were looking for? Contact your
-            administrator to make it available.
-          </p>
-          {this.getUniversePackagesGrid()}
         </div>
       </div>
     );
@@ -172,18 +135,6 @@ class NewCreateServiceModalServicePicker extends mixin(StoreMixin) {
   }
 
   render() {
-    if (this.state.isLoading) {
-      return (
-        <div className="flex-item-grow-1">
-          <Loader className="inverse" />
-        </div>
-      );
-    }
-
-    if (this.state.errorMessage != null) {
-      return this.state.errorMessage;
-    }
-
     return this.getServiceDeployOptions();
   }
 }

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalServicePicker.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalServicePicker.js
@@ -2,7 +2,6 @@
 import React from 'react';
 /* eslint-enable no-unused-vars */
 
-// import CosmosPackagesStore from '../../../../../../src/js/stores/CosmosPackagesStore';
 import defaultServiceImage from '../../../img/icon-service-default-medium@2x.png';
 import jsonServiceImage from '../../../img/service-image-json-medium@2x.png';
 import Image from '../../../../../../src/js/components/Image';

--- a/plugins/services/src/js/constants/NewPodDefaults.js
+++ b/plugins/services/src/js/constants/NewPodDefaults.js
@@ -1,0 +1,13 @@
+const NEW_POD_DEFAULTS = {
+  containers: [
+    {
+      cpus: 0.001,
+      instances: 1,
+      mem: 128
+    }
+  ]
+};
+
+module.exports = {
+  NEW_POD_DEFAULTS
+};

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -397,6 +397,11 @@
  * Views
  */
 
+// Create Service Modal
+
+@import 'views/create-service-modal/variables.less';
+@import 'views/create-service-modal/styles.less';
+
 // Dashboard
 
 @import 'views/dashboard/variables.less';

--- a/src/styles/views/create-service-modal/styles.less
+++ b/src/styles/views/create-service-modal/styles.less
@@ -1,0 +1,17 @@
+& when (@create-services-modal-enabled) {
+
+  .create-service-modal-service-picker {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .create-service-modal-service-picker-options {
+    display: flex;
+    justify-content: center;
+  }
+
+  .create-service-modal-service-picker-option {
+    flex: 0 0 auto;
+  }
+}

--- a/src/styles/views/create-service-modal/variables.less
+++ b/src/styles/views/create-service-modal/variables.less
@@ -1,0 +1,1 @@
+@create-services-modal-enabled: true;


### PR DESCRIPTION
This is the first PR for the separate JSON flow that cleans-up the `NewCreateServiceModalServicePicker`, keeping only the 3 acceptable options for now, and adding a placeholder for the JSON-only view.

@jfurrow I tried to center the buttons for making them look like the design, but I didn't want to mess-up the CSS. Can you have a look? https://mesosphere.invisionapp.com/d/main#/console/9042004/193660846/preview 