### PR TITLE
DCOS-10987: [2/2] Separate JSON Flow

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6573,9 +6573,9 @@
       }
     },
     "react-ace": {
-      "version": "3.4.1",
-      "from": "react-ace@latest",
-      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-3.4.1.tgz"
+      "version": "3.7.0",
+      "from": "react-ace@3.7.0",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-3.7.0.tgz"
     },
     "react-addons-css-transition-group": {
       "version": "0.14.7",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettycron": "0.10.0",
     "query-string": "4.1.0",
     "react": "0.14.7",
-    "react-ace": "3.4.1",
+    "react-ace": "3.7.0",
     "react-addons-css-transition-group": "0.14.7",
     "react-addons-pure-render-mixin": "0.14.7",
     "react-addons-test-utils": "0.14.7",

--- a/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
+++ b/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
@@ -1,7 +1,7 @@
 import React, {PropTypes} from 'react';
 
 import Application from '../../structs/Application';
-import Pod from '../../structs/Pod';
+import PodSpec from '../../structs/PodSpec';
 import JSONEditor from '../../../../../../src/js/components/JSONEditor';
 
 import AppValidators from '../../../../../../src/resources/raml/marathon/v2/types/app.raml';
@@ -71,7 +71,7 @@ class CreateServiceJsonOnly extends React.Component {
   handleJSONChange(jsonObject) {
     let newObject;
     if (ServiceValidatorUtil.isPodSpecDefinition(jsonObject)) {
-      newObject = new Pod(jsonObject);
+      newObject = new PodSpec(jsonObject);
     } else {
       newObject = new Application(jsonObject);
     }

--- a/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
+++ b/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
@@ -1,5 +1,7 @@
 import React, {PropTypes} from 'react';
 
+import Application from '../../structs/Application';
+import Pod from '../../structs/Pod';
 import JSONEditor from '../../../../../../src/js/components/JSONEditor';
 
 import AppValidators from '../../../../../../src/resources/raml/marathon/v2/types/app.raml';
@@ -67,7 +69,14 @@ class CreateServiceJsonOnly extends React.Component {
   }
 
   handleJSONChange(jsonObject) {
-    this.props.onChange(jsonObject);
+    let newObject;
+    if (ServiceValidatorUtil.isPodSpecDefinition(jsonObject)) {
+      newObject = new Pod(jsonObject);
+    } else {
+      newObject = new Application(jsonObject);
+    }
+
+    this.props.onChange(newObject);
   }
 
   handleJSONErrorStateChange(errorState) {

--- a/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
+++ b/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
@@ -87,16 +87,29 @@ class CreateServiceJsonOnly extends React.Component {
   render() {
     let {appConfig, errorList} = this.state;
 
+    // Note: The `transform` parameter is just a hack to properly align the
+    //       error message.
+    let editorStyles = {
+      position: 'absolute',
+      'transform': 'translateX(0)',
+      'webkitTransform': 'translateX(0)',
+      'mozTransform': 'translateX(0)',
+      'msTransform': 'translateX(0)',
+      'oTransform': 'translateX(0)'
+    };
+
     return (
       <div className="flex flex-item-grow-1">
         <div className="container">
           <JSONEditor
             errors={errorList}
+            className="modal-full-screen-fill-body"
             onChange={this.handleJSONChange}
             showGutter={true}
             showPrintMargin={false}
+            style={editorStyles}
             theme="monokai"
-            height="400px"
+            height="100%"
             value={appConfig}
             width="100%" />
         </div>

--- a/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
+++ b/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
@@ -46,8 +46,6 @@ class CreateServiceJsonOnly extends React.Component {
    * @override
    */
   componentDidUpdate(prevProps, prevState) {
-    window.ReactDOM = ReactDOM;
-    window.fiddle = this;
     let hasErrors = (this.state.errorList.length !== 0) || this.state.jsonHasErrors;
     let hadErrors = (prevState.errorList.length !== 0) || prevState.jsonHasErrors;
 

--- a/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
+++ b/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
@@ -9,7 +9,8 @@ import ServiceValidatorUtil from '../../utils/ServiceValidatorUtil';
 import ServiceUtil from '../../utils/ServiceUtil';
 
 const METHODS_TO_BIND = [
-  'handleJSONChange'
+  'handleJSONChange',
+  'handleJSONErrorStateChange'
 ];
 
 const APP_ERROR_VALIDATORS = [
@@ -27,8 +28,9 @@ class CreateServiceJsonOnly extends React.Component {
 
     this.state = Object.assign(
       {
+        appConfig: {},
         errorList: [],
-        appConfig: {}
+        jsonHasErrors: false
       },
       this.getNewStateForJSON(
         ServiceUtil.getServiceJSON(this.props.service)
@@ -44,8 +46,10 @@ class CreateServiceJsonOnly extends React.Component {
    * @override
    */
   componentDidUpdate(prevProps, prevState) {
-    let hasErrors = this.state.errorList.length !== 0;
-    let hadErrors = prevState.errorList.length !== 0;
+    window.ReactDOM = ReactDOM;
+    window.fiddle = this;
+    let hasErrors = (this.state.errorList.length !== 0) || this.state.jsonHasErrors;
+    let hadErrors = (prevState.errorList.length !== 0) || prevState.jsonHasErrors;
 
     // Notify parent component for our error state
     if (hasErrors !== hadErrors) {
@@ -66,6 +70,12 @@ class CreateServiceJsonOnly extends React.Component {
 
   handleJSONChange(jsonObject) {
     this.props.onChange(jsonObject);
+  }
+
+  handleJSONErrorStateChange(errorState) {
+    this.setState({
+      jsonHasErrors: !!errorState
+    });
   }
 
   getNewStateForJSON(appConfig) {
@@ -91,29 +101,22 @@ class CreateServiceJsonOnly extends React.Component {
     //       error message.
     let editorStyles = {
       position: 'absolute',
-      'transform': 'translateX(0)',
-      'webkitTransform': 'translateX(0)',
-      'mozTransform': 'translateX(0)',
-      'msTransform': 'translateX(0)',
-      'oTransform': 'translateX(0)'
+      'transform': 'translateX(0)'
     };
 
     return (
-      <div className="flex flex-item-grow-1">
-        <div className="container">
-          <JSONEditor
-            errors={errorList}
-            className="modal-full-screen-fill-body"
-            onChange={this.handleJSONChange}
-            showGutter={true}
-            showPrintMargin={false}
-            style={editorStyles}
-            theme="monokai"
-            height="100%"
-            value={appConfig}
-            width="100%" />
-        </div>
-      </div>
+      <JSONEditor
+        errors={errorList}
+        className="modal-full-screen-fill-body"
+        onChange={this.handleJSONChange}
+        onErrorStateChange={this.handleJSONErrorStateChange}
+        showGutter={true}
+        showPrintMargin={false}
+        style={editorStyles}
+        theme="monokai"
+        height="100%"
+        value={appConfig}
+        width="100%" />
     );
   }
 }

--- a/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
+++ b/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
@@ -1,9 +1,106 @@
 import React, {PropTypes} from 'react';
 
+import JSONEditor from '../../../../../../src/js/components/JSONEditor';
+
+import AppValidators from '../../../../../../src/resources/raml/marathon/v2/types/app.raml';
+import DataValidatorUtil from '../../../../../../src/js/utils/DataValidatorUtil';
+import PodValidators from '../../../../../../src/resources/raml/marathon/v2/types/pod.raml';
+import ServiceValidatorUtil from '../../utils/ServiceValidatorUtil';
+import ServiceUtil from '../../utils/ServiceUtil';
+
+const METHODS_TO_BIND = [
+  'handleJSONChange'
+];
+
+const APP_ERROR_VALIDATORS = [
+  AppValidators.App
+];
+
+const POD_ERROR_VALIDATORS = [
+  PodValidators.Pod
+];
+
 class CreateServiceJsonOnly extends React.Component {
+
+  constructor() {
+    super(...arguments);
+
+    this.state = Object.assign(
+      {
+        errorList: [],
+        appConfig: {}
+      },
+      this.getNewStateForJSON(
+        ServiceUtil.getServiceJSON(this.props.service)
+      )
+    );
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  /**
+   * @override
+   */
+  componentDidUpdate(prevProps, prevState) {
+    let hasErrors = this.state.errorList.length !== 0;
+    let hadErrors = prevState.errorList.length !== 0;
+
+    // Notify parent component for our error state
+    if (hasErrors !== hadErrors) {
+      this.props.onErrorStateChange(hasErrors);
+    }
+  }
+
+  /**
+   * @override
+   */
+  componentWillReceiveProps(nextProps) {
+    this.setState(
+      this.getNewStateForJSON(
+        ServiceUtil.getServiceJSON(nextProps.service)
+      )
+    );
+  }
+
+  handleJSONChange(jsonObject) {
+    this.props.onChange(jsonObject);
+  }
+
+  getNewStateForJSON(appConfig) {
+    let isPod = ServiceValidatorUtil.isPodSpecDefinition(appConfig);
+
+    // Pick validators according to JSON specification type
+    let validators = APP_ERROR_VALIDATORS;
+    if (isPod) {
+      validators = POD_ERROR_VALIDATORS;
+    }
+
+    // Compile the list of errors
+    let errorList = DataValidatorUtil.validate(appConfig, validators);
+
+    // Update the error display
+    return {appConfig, errorList};
+  }
+
   render() {
+    let {appConfig, errorList} = this.state;
+
     return (
-      <div>JSON Editor Placeholder</div>
+      <div className="flex flex-item-grow-1">
+        <div className="container">
+          <JSONEditor
+            errors={errorList}
+            onChange={this.handleJSONChange}
+            showGutter={true}
+            showPrintMargin={false}
+            theme="monokai"
+            height="400px"
+            value={appConfig}
+            width="100%" />
+        </div>
+      </div>
     );
   }
 }

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -72,7 +72,6 @@ class NewServiceFormModal extends Component {
       this.setState({
         serviceReviewActive: false
       });
-
       return;
     }
 
@@ -82,7 +81,6 @@ class NewServiceFormModal extends Component {
         servicePickerActive: true,
         serviceFormActive: false
       });
-
       return;
     }
 
@@ -92,7 +90,6 @@ class NewServiceFormModal extends Component {
         servicePickerActive: true,
         serviceJsonActive: false
       });
-
       return;
     }
   }
@@ -152,6 +149,7 @@ class NewServiceFormModal extends Component {
             )
           )
         });
+        console.log('Turning on form (app)', this.state);
         break;
 
       case 'pod':
@@ -165,19 +163,16 @@ class NewServiceFormModal extends Component {
             )
           )
         });
+        console.log('Turning on form (pod)', this.state);
         break;
 
       case 'json':
         this.setState({
           servicePickerActive: false,
           serviceJsonActive: true,
-          serviceConfig: new Application(
-            Object.assign(
-              {id: this.props.service.id},
-              NEW_POD_DEFAULTS
-            )
-          )
+          serviceConfig: this.props.service
         });
+        console.log('Turning on json', this.state);
         break;
 
     };
@@ -245,6 +240,10 @@ class NewServiceFormModal extends Component {
   }
 
   getModalContent() {
+    console.log('Render, review=', this.state.serviceReviewActive,
+      ', picker=', this.state.servicePickerActive,
+      ', form=', this.state.serviceFormActive,
+      ', json=', this.state.serviceJsonActive);
 
     // NOTE: Always prioritize review screen check
     if (this.state.serviceReviewActive) {

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -149,7 +149,6 @@ class NewServiceFormModal extends Component {
             )
           )
         });
-        console.log('Turning on form (app)', this.state);
         break;
 
       case 'pod':
@@ -163,7 +162,6 @@ class NewServiceFormModal extends Component {
             )
           )
         });
-        console.log('Turning on form (pod)', this.state);
         break;
 
       case 'json':
@@ -172,7 +170,6 @@ class NewServiceFormModal extends Component {
           serviceJsonActive: true,
           serviceConfig: this.props.service
         });
-        console.log('Turning on json', this.state);
         break;
 
     };
@@ -240,11 +237,6 @@ class NewServiceFormModal extends Component {
   }
 
   getModalContent() {
-    console.log('Render, review=', this.state.serviceReviewActive,
-      ', picker=', this.state.servicePickerActive,
-      ', form=', this.state.serviceFormActive,
-      ', json=', this.state.serviceJsonActive);
-
     // NOTE: Always prioritize review screen check
     if (this.state.serviceReviewActive) {
       return (

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -4,8 +4,8 @@ import deepEqual from 'deep-equal';
 
 import Alert from '../../../../../../src/js/components/Alert';
 import AppValidators from '../../../../../../src/resources/raml/marathon/v2/types/app.raml';
-import CreateServiceModalFormUtil from '../../utils/CreateServiceModalFormUtil';
 import Batch from '../../../../../../src/js/structs/Batch';
+import CreateServiceModalFormUtil from '../../utils/CreateServiceModalFormUtil';
 import ContainerServiceFormSection from '../forms/ContainerServiceFormSection';
 import {combineParsers} from '../../../../../../src/js/utils/ParserUtil';
 import {combineReducers} from '../../../../../../src/js/utils/ReducerUtil';
@@ -15,6 +15,7 @@ import HealthChecksFormSection from '../forms/HealthChecksFormSection';
 import JSONConfigReducers from '../../reducers/JSONConfigReducers';
 import JSONParserReducers from '../../reducers/JSONParserReducers';
 import JSONEditor from '../../../../../../src/js/components/JSONEditor';
+import ServiceUtil from '../../utils/ServiceUtil';
 import TabButton from '../../../../../../src/js/components/TabButton';
 import TabButtonList from '../../../../../../src/js/components/TabButtonList';
 import Tabs from '../../../../../../src/js/components/Tabs';
@@ -49,18 +50,6 @@ const inputConfigReducers = combineReducers(
   Object.assign({}, ...SECTIONS.map((item) => item.configReducers))
 );
 
-function getServiceJSON(service) {
-  if (!service) {
-    return {};
-  }
-
-  if (service.toJSON !== undefined) {
-    return service.toJSON();
-  }
-
-  return service;
-}
-
 class NewCreateServiceModalForm extends Component {
   constructor() {
     super(...arguments);
@@ -74,7 +63,7 @@ class NewCreateServiceModalForm extends Component {
       },
       this.getNewStateForJSON(
         CreateServiceModalFormUtil.stripEmptyProperties(
-          getServiceJSON(this.props.service)
+          ServiceUtil.getServiceJSON(this.props.service)
         ),
         false
       )
@@ -92,8 +81,8 @@ class NewCreateServiceModalForm extends Component {
    * @override
    */
   componentWillReceiveProps(nextProps) {
-    let prevJSON = getServiceJSON(this.props.service);
-    let nextJSON = getServiceJSON(nextProps.service);
+    let prevJSON = ServiceUtil.getServiceJSON(this.props.service);
+    let nextJSON = ServiceUtil.getServiceJSON(nextProps.service);
 
     // Note: We ignore changes that might derrive from the `onChange` event
     //       handler. In that case the contents of nextJSON would be the same
@@ -128,8 +117,8 @@ class NewCreateServiceModalForm extends Component {
     //       handler. In that case the contents of nextJSON would be the same
     //       as the contents of the last rendered appConfig in the state.
     //
-    let prevJSON = getServiceJSON(this.props.service);
-    let nextJSON = getServiceJSON(nextProps.service);
+    let prevJSON = ServiceUtil.getServiceJSON(this.props.service);
+    let nextJSON = ServiceUtil.getServiceJSON(nextProps.service);
     if (!deepEqual(prevJSON, nextJSON) &&
         !deepEqual(this.state.appConfig, nextJSON)) {
       console.log('Will update because service changed');

--- a/plugins/services/src/js/constants/NewPodDefaults.js
+++ b/plugins/services/src/js/constants/NewPodDefaults.js
@@ -1,9 +1,10 @@
 const NEW_POD_DEFAULTS = {
   containers: [
     {
-      cpus: 0.001,
-      instances: 1,
-      mem: 128
+      name: 'container1',
+      resources: {
+        cpus: 0.001
+      }
     }
   ]
 };

--- a/plugins/services/src/js/utils/ServiceUtil.js
+++ b/plugins/services/src/js/utils/ServiceUtil.js
@@ -472,6 +472,18 @@ const ServiceUtil = {
     return definition;
   },
 
+  getServiceJSON(service) {
+    if (!service) {
+      return {};
+    }
+
+    if (service.toJSON !== undefined) {
+      return service.toJSON();
+    }
+
+    return service;
+  },
+
   getServiceNameFromTaskID(taskID) {
     let serviceName = taskID.split('.')[0].split('_');
     return serviceName[serviceName.length - 1];

--- a/src/js/components/JSONEditor.js
+++ b/src/js/components/JSONEditor.js
@@ -67,7 +67,6 @@ class JSONEditor extends React.Component {
     super(...arguments);
     // Clone the given initial value
     let initialText = JSON.stringify(this.props.value || {}, null, 2);
-    let initialValue = JSON.parse(initialText);
 
     // We are using the react-way of updating the component **only** when we
     // need to define a new text to work upon (ex. when the owner component has

--- a/src/js/components/JSONEditor.js
+++ b/src/js/components/JSONEditor.js
@@ -98,7 +98,7 @@ class JSONEditor extends React.Component {
     this.timerIsTyping = null;
 
     // Initial state synchronisation
-    this.updateLocalJsonState(initialValue);
+    this.updateLocalJsonState(initialText);
 
     METHODS_TO_BIND.forEach((method) => {
       this[method] = this[method].bind(this);

--- a/src/js/components/JSONEditor.js
+++ b/src/js/components/JSONEditor.js
@@ -336,8 +336,12 @@ class JSONEditor extends React.Component {
       return;
     }
 
-    // Merge current annotations with the annotations we are going to show
-    this.aceEditor.getSession().setAnnotations(this.getErrorMarkers());
+    // Defer the annotation update, since for some reason ACE editor
+    // does not get updated if the update comes from the same stack call
+    // that set it's state.
+    setTimeout(() => {
+      this.aceEditor.getSession().setAnnotations(this.getErrorMarkers());
+    }, 1);
   }
 
   /**

--- a/src/styles/components/modal/full-screen/styles.less
+++ b/src/styles/components/modal/full-screen/styles.less
@@ -56,6 +56,14 @@
     }
   }
 
+  .modal-full-screen-fill-body {
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
+
   .modal-full-screen-leave {
 
     .modal {


### PR DESCRIPTION
---
⚠️  Depends on https://github.com/dcos/dcos-ui/pull/1408

---

This PR introduces the first draft of the json-only editor view. There is proper error validation and integration with the review screen.

![new-json-only mov](https://cloud.githubusercontent.com/assets/883486/20566565/cfb85a98-b195-11e6-8442-085a5ba56bc0.gif)

The following things are missing:

- [x] Use the correct classes to make the JSON editor occupy the full size -- @jfurrow I might need some help here
- [x] Fix the floating error message (caused by the hack required on the side-by-side view)
- [x] Fix an annoying bug that displays an error the first time the JSON editor is shown
