### PR TITLE
[1/3]: Expose MountService

### DIFF
--- a/foundation-ui/index.js
+++ b/foundation-ui/index.js
@@ -2,10 +2,16 @@ import DCOSStore from './stores/DCOSStore';
 import ResourceTableUtil from './utils/ResourceTableUtil';
 import RoutingService from './routing';
 import NavigationService from './navigation';
+import {MountService} from './mount';
+import Mount from './mount/Mount';
 
 module.exports = {
   DCOSStore,
+  MountService: {
+    Mount,
+    MountService
+  },
+  NavigationService,
   ResourceTableUtil,
-  RoutingService,
-  NavigationService
+  RoutingService
 };

--- a/foundation-ui/mount/index.js
+++ b/foundation-ui/mount/index.js
@@ -1,7 +1,5 @@
-import Mount from './Mount';
 import MountService from './MountService';
 
 module.exports = {
-  Mount,
   MountService: new MountService()
 };

--- a/src/js/plugin-bridge/Loader.js
+++ b/src/js/plugin-bridge/Loader.js
@@ -17,6 +17,7 @@ const requireModals = require.context('../components/modals', false);
 // Foundation
 const requireRouting = require.context('../../../foundation-ui/routing', false);
 const requireNavigation = require.context('../../../foundation-ui/navigation', false);
+const requireFoundation = require.context('../../../foundation-ui', false);
 let requireExternalPlugin = function () {
   return {};
 };
@@ -97,6 +98,8 @@ function requireModule(dir, name) {
       return requireEvents(path);
     case 'routing':
       return requireRouting(path);
+    case 'foundation-ui':
+      return requireFoundation(path);
     case 'systemPages':
       return requireSystemPages(path);
     case 'stores':
@@ -116,7 +119,7 @@ function requireModule(dir, name) {
     case 'internalPlugin':
       return requirePlugin(path);
     default:
-      throw Error('No loader for directory');
+      throw Error(`No loader for directory: ${dir}`);
   }
 }
 

--- a/src/js/plugin-bridge/PluginModules.js
+++ b/src/js/plugin-bridge/PluginModules.js
@@ -87,5 +87,8 @@ module.exports = {
   },
   navigation: {
     navigation: 'index'
+  },
+  'foundation-ui': {
+    'foundation-ui': 'index'
   }
 };


### PR DESCRIPTION
[1/3] : https://github.com/dcos/dcos-ui/pull/1413
[2/3] : https://github.com/dcos/dcos-ui/pull/1414
[3/3] : https://github.com/dcos/dcos-ui/pull/1418

This PR exposes `MountService` on the `foundation-ui` package
and the whole `foundation-ui` on the plugin-bridge

I removed Mount from mount/index to resolve a circular dependency in Mount.js
I'm open to a better solution.

Usage:
```
const {MountService: {Mount, MountService}} = SDK.get('foundation-ui');
```