### PR TITLE
Update raml-validator-loader to v0.1.5

### DIFF
--- a/webpack/modules/raml-validator-loader/lib/raml-validator-loader.js
+++ b/webpack/modules/raml-validator-loader/lib/raml-validator-loader.js
@@ -233,9 +233,20 @@ module.exports =
 	    }, []);
 
 	    //
+	    // Compose exports
+	    //
+	    var variableExports = [];
+	    if (ctx.constantTables['ERROR_MESSAGES'] != null) {
+	      variableExports.push('Validators.ERROR_MESSAGES = ERROR_MESSAGES;');
+	    }
+	    if (variableExports.length) {
+	      variableExports.unshift('// Expose properties that can be overriden remotely');
+	    }
+
+	    //
 	    // Compose the individual fragments into the full module source
 	    //
-	    return [].concat('module.exports = (function() {', _RAMLError2.default, globalTableFragments, '', privateValidatorFragments, '', validatorFragments, '', 'return Validators;', '})();').join('\n');
+	    return [].concat('module.exports = (function() {', _RAMLError2.default, globalTableFragments, '', privateValidatorFragments, '', validatorFragments, '', variableExports, '', 'return Validators;', '})();').join('\n');
 	  }
 
 	};
@@ -279,7 +290,7 @@ module.exports =
 	  isInlineType: function isInlineType(itype) {
 	    // So, a type that has no name, but is either an array or a value type
 	    // is considered an in-line definition, and has a dedicated specialisation
-	    return itype.nameId() == null && (itype.isArray() || itype.isValueType());
+	    return itype.nameId() == null && (itype.isArray() || itype.isValueType() || itype.isAssignableFrom());
 	  },
 
 
@@ -1189,7 +1200,7 @@ module.exports =
 	  object: function object(fragments, context) {
 	    var ERROR_MESSAGE = context.getConstantString('ERROR_MESSAGES', 'TYPE_NOT_OBJECT', 'Expecting an object');
 
-	    return [].concat('if (typeof value != "object") {', '\terrors.push(new RAMLError(path, ' + ERROR_MESSAGE + '));', '} else {', (0, _GeneratorUtil.indentFragments)(fragments), '}');
+	    return [].concat('if ((typeof value != "object") || (value === null)) {', '\terrors.push(new RAMLError(path, ' + ERROR_MESSAGE + '));', '} else {', (0, _GeneratorUtil.indentFragments)(fragments), '}');
 	  },
 
 	  /**

--- a/webpack/modules/raml-validator-loader/lib/raml-validator-loader.js
+++ b/webpack/modules/raml-validator-loader/lib/raml-validator-loader.js
@@ -166,10 +166,10 @@ module.exports =
 	  /**
 	   * Generate a full source using the given generator context
 	   *
-	   * @param {GeneratorContext} ctx - The generator context to use
+	   * @param {GeneratorContext} context - The generator context to use
 	   * @returns {String} The generated module source code
 	   */
-	  generate: function generate(ctx) {
+	  generate: function generate(context) {
 	    var itype = void 0;
 	    var privateValidatorFragments = ['var PrivateValidators = {'];
 	    var validatorFragments = ['var Validators = {'];
@@ -178,7 +178,7 @@ module.exports =
 	    // The following loop generates the validators for every type in the context
 	    // A validator generator might push more types while it's being processed.
 	    //
-	    while (itype = ctx.nextTypeInQueue()) {
+	    while (itype = context.nextTypeInQueue()) {
 	      var typeName = _RAMLUtil2.default.getTypeName(itype);
 	      var fragments = [];
 
@@ -199,7 +199,7 @@ module.exports =
 	      }
 
 	      // Compose the validator function
-	      fragments = fragments.concat(_GeneratorUtil2.default.indentFragments(this.commentBlock(comment)), ['\t' + typeName + ': function(value, path) {', '\t\tvar errors = [];', '\t\tpath = path || [];'], _GeneratorUtil2.default.indentFragments(_TypeValidator2.default.generateTypeValidator(itype, ctx), '\t\t'), ['\t\treturn errors;', '\t},', '']);
+	      fragments = fragments.concat(_GeneratorUtil2.default.indentFragments(this.commentBlock(comment)), ['\t' + typeName + ': function(value, path) {', '\t\tvar errors = [];', '\t\tpath = path || [];'], _GeneratorUtil2.default.indentFragments(_TypeValidator2.default.generateTypeValidator(itype, context), '\t\t'), ['\t\treturn errors;', '\t},', '']);
 
 	      // Inline types are stored in a different object, not exposed to the user
 	      if (_RAMLUtil2.default.isInlineType(itype)) {
@@ -217,8 +217,8 @@ module.exports =
 	    // While processing the types, the validator generators will populate
 	    // constants in the global constants table(s).
 	    //
-	    var globalTableFragments = Object.keys(ctx.constantTables).reduce(function (lines, tableName) {
-	      var table = ctx.constantTables[tableName];
+	    var globalTableFragments = Object.keys(context.constantTables).reduce(function (lines, tableName) {
+	      var table = context.constantTables[tableName];
 	      if (Array.isArray(table)) {
 	        // Array of anonymous expressions
 	        return lines.concat(['var ' + tableName + ' = ['], _GeneratorUtil2.default.indentFragments(table).map(function (line) {
@@ -236,7 +236,7 @@ module.exports =
 	    // Compose exports
 	    //
 	    var variableExports = [];
-	    if (ctx.constantTables['ERROR_MESSAGES'] != null) {
+	    if (context.constantTables['ERROR_MESSAGES'] != null) {
 	      variableExports.push('Validators.ERROR_MESSAGES = ERROR_MESSAGES;');
 	    }
 	    if (variableExports.length) {
@@ -290,7 +290,7 @@ module.exports =
 	  isInlineType: function isInlineType(itype) {
 	    // So, a type that has no name, but is either an array or a value type
 	    // is considered an in-line definition, and has a dedicated specialisation
-	    return itype.nameId() == null && (itype.isArray() || itype.isValueType() || itype.isAssignableFrom());
+	    return itype.nameId() == null && (itype.isArray() || itype.isValueType());
 	  },
 
 
@@ -424,6 +424,14 @@ module.exports =
 	    //
 	    if (this.isArrayOfType(itype)) {
 	      return this.getArrayOfTypeName(itype);
+	    }
+
+	    //
+	    // If the type is still anonymous, try to lookup it's type by
+	    // traversing the super classes
+	    //
+	    if (itype.nameId() == null) {
+	      return this.getTypeName(itype.superTypes()[0]);
 	    }
 
 	    // Return type name

--- a/webpack/modules/raml-validator-loader/package.json
+++ b/webpack/modules/raml-validator-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raml-validator-loader",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Converts RAML document to javascript validation functions",
   "main": "lib/raml-validator-loader.js",
   "scripts": {

--- a/webpack/modules/raml-validator-loader/package.json
+++ b/webpack/modules/raml-validator-loader/package.json
@@ -1,10 +1,10 @@
 {
   "name": "raml-validator-loader",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Converts RAML document to javascript validation functions",
   "main": "lib/raml-validator-loader.js",
   "scripts": {
-    "test": "./node_modules/.bin/jest",
+    "test": "./node_modules/.bin/jest -c jest.config.json",
     "build": "./node_modules/.bin/webpack"
   },
   "author": "",

--- a/webpack/modules/raml-validator-loader/src/Generator.js
+++ b/webpack/modules/raml-validator-loader/src/Generator.js
@@ -22,10 +22,10 @@ module.exports = {
   /**
    * Generate a full source using the given generator context
    *
-   * @param {GeneratorContext} ctx - The generator context to use
+   * @param {GeneratorContext} context - The generator context to use
    * @returns {String} The generated module source code
    */
-  generate: function(ctx) {
+  generate: function(context) {
     let itype;
     let privateValidatorFragments = [
       'var PrivateValidators = {'
@@ -38,7 +38,7 @@ module.exports = {
     // The following loop generates the validators for every type in the context
     // A validator generator might push more types while it's being processed.
     //
-    while (itype = ctx.nextTypeInQueue()) {
+    while (itype = context.nextTypeInQueue()) {
       let typeName = RAMLUtil.getTypeName(itype);
       let fragments = [];
 
@@ -75,7 +75,7 @@ module.exports = {
           '\t\tpath = path || [];'
         ],
         GeneratorUtil.indentFragments(
-          TypeValidator.generateTypeValidator(itype, ctx),
+          TypeValidator.generateTypeValidator(itype, context),
           '\t\t'
         ),
         [ '\t\treturn errors;',
@@ -99,9 +99,9 @@ module.exports = {
     // While processing the types, the validator generators will populate
     // constants in the global constants table(s).
     //
-    let globalTableFragments = Object.keys(ctx.constantTables)
+    let globalTableFragments = Object.keys(context.constantTables)
       .reduce(function(lines, tableName) {
-        let table = ctx.constantTables[tableName];
+        let table = context.constantTables[tableName];
         if (Array.isArray(table)) {
           // Array of anonymous expressions
           return lines.concat(
@@ -129,7 +129,7 @@ module.exports = {
     // Compose exports
     //
     let variableExports = [];
-    if (ctx.constantTables['ERROR_MESSAGES'] != null) {
+    if (context.constantTables['ERROR_MESSAGES'] != null) {
       variableExports.push('Validators.ERROR_MESSAGES = ERROR_MESSAGES;');
     }
     if (variableExports.length) {

--- a/webpack/modules/raml-validator-loader/src/Generator.js
+++ b/webpack/modules/raml-validator-loader/src/Generator.js
@@ -126,6 +126,17 @@ module.exports = {
       }, []);
 
     //
+    // Compose exports
+    //
+    let variableExports = [];
+    if (ctx.constantTables['ERROR_MESSAGES'] != null) {
+      variableExports.push('Validators.ERROR_MESSAGES = ERROR_MESSAGES;');
+    }
+    if (variableExports.length) {
+      variableExports.unshift('// Expose properties that can be overriden remotely');
+    }
+
+    //
     // Compose the individual fragments into the full module source
     //
     return [].concat(
@@ -136,6 +147,8 @@ module.exports = {
         privateValidatorFragments,
         '',
         validatorFragments,
+        '',
+        variableExports,
         '',
         'return Validators;',
       '})();'

--- a/webpack/modules/raml-validator-loader/src/__tests__/RAMLValidator-test.js
+++ b/webpack/modules/raml-validator-loader/src/__tests__/RAMLValidator-test.js
@@ -1,34 +1,9 @@
-const RAML = require('raml-1-parser');
-const Generator = require('../Generator');
-const GeneratorContext = require('../GeneratorContext');
-
-/**
- * Utility function that parses RAML on-the-fly, generates a validator object
- * and returns the validation function
- */
-function createValidator(ramlDocument, options={}, typeName='TestType') {
-  var raml = RAML.parseRAMLSync(ramlDocument);
-  var types = raml.types().reduce(function(types, type) {
-    types[type.name()] = type;
-    return types;
-  }, {});
-
-  // Generate code with the given type
-  var ctx = new GeneratorContext(options);
-  ctx.uses( types[typeName].runtimeType() );
-
-  // Generate code
-  var code = Generator.generate(ctx);
-  var typeValidators = eval(code.replace('module.exports = ', ''));
-
-  // Return the validator for this type
-  typeValidators[typeName].code = code;
-  return typeValidators[typeName];
-}
+const ValidatorUtil = require('./utils/ValidatorUtil');
+const createValidator = ValidatorUtil.createValidator;
 
 describe('RAMLValidator', function () {
 
-  describe('Scalar Types', function () {
+  describe('Native Types', function () {
 
     describe('#nil', function () {
 
@@ -268,6 +243,11 @@ describe('RAMLValidator', function () {
       it('should validate if object', function () {
         var errors = this.validator({})
         expect(errors.length).toEqual(0);
+      });
+
+      it('should return error if null', function () {
+        var errors = this.validator(null)
+        expect(errors.length).toEqual(1);
       });
 
       it('should return error if number', function () {

--- a/webpack/modules/raml-validator-loader/src/__tests__/utils/ValidatorUtil.js
+++ b/webpack/modules/raml-validator-loader/src/__tests__/utils/ValidatorUtil.js
@@ -16,11 +16,11 @@ module.exports = {
     }, {});
 
     // Generate code with the given type
-    var ctx = new GeneratorContext(options);
-    ctx.uses( types[typeName].runtimeType() );
+    var context = new GeneratorContext(options);
+    context.uses( types[typeName].runtimeType() );
 
     // Generate code
-    var code = Generator.generate(ctx);
+    var code = Generator.generate(context);
     var typeValidators = eval(code.replace('module.exports = ', ''));
 
     // Return the validator for this type

--- a/webpack/modules/raml-validator-loader/src/__tests__/utils/ValidatorUtil.js
+++ b/webpack/modules/raml-validator-loader/src/__tests__/utils/ValidatorUtil.js
@@ -1,0 +1,31 @@
+const RAML = require('raml-1-parser');
+const Generator = require('../../Generator');
+const GeneratorContext = require('../../GeneratorContext');
+
+module.exports = {
+
+  /**
+   * Utility function that parses RAML on-the-fly, generates a validator object
+   * and returns the validation function
+   */
+  createValidator: function(ramlDocument, options={}, typeName='TestType') {
+    var raml = RAML.parseRAMLSync(ramlDocument);
+    var types = raml.types().reduce(function(types, type) {
+      types[type.name()] = type;
+      return types;
+    }, {});
+
+    // Generate code with the given type
+    var ctx = new GeneratorContext(options);
+    ctx.uses( types[typeName].runtimeType() );
+
+    // Generate code
+    var code = Generator.generate(ctx);
+    var typeValidators = eval(code.replace('module.exports = ', ''));
+
+    // Return the validator for this type
+    typeValidators[typeName].code = code;
+    return typeValidators[typeName];
+  }
+
+}

--- a/webpack/modules/raml-validator-loader/src/generators/NativeValidators.js
+++ b/webpack/modules/raml-validator-loader/src/generators/NativeValidators.js
@@ -116,7 +116,7 @@ const NATIVE_TYPE_VALIDATORS = {
       'TYPE_NOT_OBJECT', 'Expecting an object');
 
     return [].concat(
-      `if (typeof value != "object") {`,
+      `if ((typeof value != "object") || (value === null)) {`,
         `\terrors.push(new RAMLError(path, ${ERROR_MESSAGE}));`,
       `} else {`,
         indentFragments( fragments ),

--- a/webpack/modules/raml-validator-loader/src/utils/RAMLUtil.js
+++ b/webpack/modules/raml-validator-loader/src/utils/RAMLUtil.js
@@ -28,7 +28,7 @@ module.exports = {
     // So, a type that has no name, but is either an array or a value type
     // is considered an in-line definition, and has a dedicated specialisation
     return (itype.nameId() == null) &&
-           (itype.isArray() || itype.isValueType());
+           (itype.isArray() || itype.isValueType() || itype.isAssignableFrom());
   },
 
   /**

--- a/webpack/modules/raml-validator-loader/src/utils/RAMLUtil.js
+++ b/webpack/modules/raml-validator-loader/src/utils/RAMLUtil.js
@@ -28,7 +28,7 @@ module.exports = {
     // So, a type that has no name, but is either an array or a value type
     // is considered an in-line definition, and has a dedicated specialisation
     return (itype.nameId() == null) &&
-           (itype.isArray() || itype.isValueType() || itype.isAssignableFrom());
+           (itype.isArray() || itype.isValueType());
   },
 
   /**
@@ -158,6 +158,14 @@ module.exports = {
     //
     if (this.isArrayOfType(itype)) {
       return this.getArrayOfTypeName(itype);
+    }
+
+    //
+    // If the type is still anonymous, try to lookup it's type by
+    // traversing the super classes
+    //
+    if (itype.nameId() == null) {
+      return this.getTypeName(itype.superTypes()[0]);
     }
 
     // Return type name


### PR DESCRIPTION
## v0.1.5 Changelog 

* **Fix:** Fixed a bug that incorrectly resolved supertype name
* **Internals:** Renaming `ctx` to `context`

## v0.1.4 Changelog 

* **Fix:** Handling some cases that ended up creating validators with `null` name
* **Fix:** Assuming `null` not to be a valid object value
* **Enhancement:** Exposing error messages, making them overridable by the user
* **Internals:** Re-arranging tests code