### PR TITLE
[Sidebar: 2 of 4] Remove mixins in favor of actual CSS properties

### DIFF
--- a/src/styles/layout/sidebar/styles.less
+++ b/src/styles/layout/sidebar/styles.less
@@ -1,4 +1,4 @@
-// TODO: Reduce the specificity.
+// TODO: Reduce the specificity. DCOS-11785
 & when (@sidebar-enabled) {
 
   // Sidebar
@@ -6,7 +6,7 @@
     background: @sidebar-background-color;
   }
 
-  // TODO: Fix this positioning.
+  // TODO: Fix this positioning. DCOS-11784
   // Navigation
   .navigation {
     left: -100%;
@@ -79,7 +79,7 @@
         margin-right: 12px;
       }
 
-      // TODO: Apply a class to these elements.
+      // TODO: Apply a class to these elements. DCOS-11785
       & > *:not(a):not(span) {
         margin-right: @sidebar-menu-item-content-padding-horizontal;
 
@@ -89,7 +89,7 @@
       }
 
       // TODO: Give these elements classes, don't select more than one,
-      // remove !important.
+      // remove !important. DCOS-11785
       & > a,
       & > span {
         align-items: center;

--- a/src/styles/layout/sidebar/styles.less
+++ b/src/styles/layout/sidebar/styles.less
@@ -1,5 +1,4 @@
-// TODO: Reduce the specificity, remove the mixin declarations in favor of
-// normal styles.
+// TODO: Reduce the specificity.
 & when (@sidebar-enabled) {
 
   // Sidebar
@@ -17,7 +16,6 @@
 
   // Sidebar Section
   .sidebar-section {
-    .element-spacing(sidebar-section, short, screen-medium);
 
     &:last-of-type {
       margin-bottom: 0;
@@ -26,13 +24,17 @@
 
     // Sidebar Section Header
     .sidebar-section-header {
-      .element-shape-style(sidebar-section-header);
-      .element-spacing(sidebar-section-header, null, null);
-      .element-text-size(sidebar-section-header, null);
-      .element-text-style(sidebar-section-header);
-      .property-variant(sidebar-section-header, height);
       align-items: center;
+      color: @sidebar-section-header-color;
       display: flex;
+      font-size: @sidebar-section-header-font-size;
+      font-weight: @sidebar-section-header-font-weight;
+      height: @sidebar-section-header-height;
+      line-height: @sidebar-section-header-line-height;
+      margin: @sidebar-section-header-margin-top @sidebar-section-header-margin-right @sidebar-section-header-margin-bottom @sidebar-section-header-margin-left;
+      padding-left: @sidebar-section-header-padding-left;
+      padding-right: @sidebar-section-header-padding-right;
+      text-transform: @sidebar-section-header-text-transform;
 
       &:empty {
         display: none;
@@ -43,17 +45,22 @@
   // Sidebar Menu
   .sidebar-menu {
     .clearfix();
-    .element-shape-style(sidebar-menu);
-    margin-bottom: 0;
+    margin-bottom: @sidebar-menu-margin-bottom;
 
     li {
-      .element-shape-style(sidebar-menu-item);
-      .element-spacing(sidebar-menu-item, null, null);
-      .element-text-size(sidebar-menu-item, null);
-      .element-text-style(sidebar-menu-item);
-      .property-variant(sidebar-menu-item, min-height, height, null, null);
+      background: @sidebar-menu-item-background-color;
+      color: @sidebar-menu-item-color;
       display: block;
-      transition: background-color 0.15s ease;
+      font-size: @sidebar-menu-item-font-size;
+      font-weight: @sidebar-menu-item-font-weight;
+      line-height: @sidebar-menu-item-line-height;
+      margin-bottom: @sidebar-menu-item-margin-bottom;
+      margin-left: @sidebar-menu-item-margin-left;
+      margin-right: @sidebar-menu-item-margin-right;
+      min-height: @sidebar-menu-item-height;
+      padding-left: @sidebar-menu-item-padding-left;
+      padding-right: @sidebar-menu-item-padding-right;
+      transition: background 0.15s ease;
 
       &:empty {
         display: none;
@@ -72,29 +79,34 @@
         margin-right: 12px;
       }
 
+      // TODO: Apply a class to these elements.
       & > *:not(a):not(span) {
-        .property-variant(sidebar-menu-item-content, margin-right, padding-horizontal, null, null);
+        margin-right: @sidebar-menu-item-content-padding-horizontal;
 
         &:last-child {
           margin-right: 0;
         }
       }
 
-      // TODO: Give these elements classes, don't select more than one.
+      // TODO: Give these elements classes, don't select more than one,
+      // remove !important.
       & > a,
       & > span {
-        .element-shape-style(sidebar-menu-item-link);
-        .element-spacing(sidebar-menu-item-link, null, null);
-        .element-text-style(sidebar-menu-item-link);
-        .property-variant(sidebar-menu-item, height);
         align-items: center;
+        background: @sidebar-menu-item-link-background-color;
+        color: @sidebar-menu-item-link-color;
         display: flex;
         flex: 1 1 auto;
+        height: @sidebar-menu-item-height;
+        margin-left: @sidebar-menu-item-link-margin-left;
+        margin-right: @sidebar-menu-item-link-margin-right;
+        padding-left: @sidebar-menu-item-link-padding-left;
+        padding-right: @sidebar-menu-item-link-padding-right;
         text-decoration: none !important;
-        transition: background-color 0.15s ease;
+        transition: background 0.15s ease;
 
         & > * {
-          .property-variant(sidebar-menu-item-content, margin-right, padding-horizontal, null, null);
+          margin-right: @sidebar-menu-item-content-padding-horizontal;
 
           &:last-child {
             margin-right: 0;
@@ -105,30 +117,30 @@
       & > a {
 
         &:hover {
-          .element-shape-style(sidebar-menu-item-link-hover);
-          .element-text-style(sidebar-menu-item-link-hover);
+          background: @sidebar-menu-item-link-hover-background-color;
+          color: @sidebar-menu-item-link-hover-color;
           cursor: pointer;
         }
 
         &:active {
-          .element-shape-style(sidebar-menu-item-link-active);
-          .element-text-style(sidebar-menu-item-link-active);
+          background: @sidebar-menu-item-link-active-background-color;
+          color: @sidebar-menu-item-link-active-color;
         }
       }
 
       &.selected:not(.open) {
-        .element-shape-style(sidebar-menu-item-selected);
+        background: @sidebar-menu-item-selected-background-color;
       }
 
       &.selected,
       &.selected.open {
-        .element-text-style(sidebar-menu-item-selected);
+        color: @sidebar-menu-item-selected-color;
 
         & > a,
         & > a:hover,
         & > a:active {
-          .element-shape-style(sidebar-menu-item-link-selected);
-          .element-text-style(sidebar-menu-item-link-selected);
+          background: @sidebar-menu-item-link-selected-background-color;
+          color: @sidebar-menu-item-link-selected-color;
         }
 
         .badge {
@@ -137,59 +149,71 @@
       }
 
       &.open {
-        .element-shape-style(sidebar-submenu);
-        .element-text-style(sidebar-menu-item-open);
+        background: @sidebar-submenu-background-color;
+        color: @sidebar-menu-item-open-color;
 
         & > span,
         & > a {
-          .element-shape-style(sidebar-menu-item-open);
-          .element-text-style(sidebar-menu-item-open);
+          background: @sidebar-menu-item-open-background-color;
+          color: @sidebar-menu-item-open-color;
         }
       }
 
       & > ul {
-        .element-spacing(sidebar-submenu, null, null);
+        margin-bottom: @sidebar-submenu-margin-bottom;
+        margin-top: @sidebar-submenu-margin-top;
+        padding-bottom: @sidebar-submenu-padding-bottom;
+        padding-top: @sidebar-submenu-padding-top;
 
         li {
-          .element-shape-style(sidebar-submenu-item);
-          .element-spacing(sidebar-submenu-item, null, null);
-          .element-text-size(sidebar-submenu-item, null);
-          .element-text-style(sidebar-submenu-item);
-          .property-variant(sidebar-submenu-item, min-height, height, null, null);
+          background-color: @sidebar-submenu-item-background-color;
+          color: @sidebar-submenu-item-color;
           display: block;
+          font-size: @sidebar-submenu-item-font-size;
+          font-weight: @sidebar-submenu-item-font-weight;
+          line-height: @sidebar-submenu-item-line-height;
+          margin-left: @sidebar-submenu-item-margin-left;
+          margin-right: @sidebar-submenu-item-margin-right;
+          min-height: @sidebar-submenu-item-height;
+          padding-left: @sidebar-submenu-item-padding-left;
+          padding-right: @sidebar-submenu-item-padding-right;
+          text-transform: @sidebar-submenu-item-text-transform;
 
           &.selected {
 
             & > a,
             & > a:hover,
             & > a:active {
-              .element-shape-style(sidebar-submenu-item-link-selected);
-              .element-text-style(sidebar-submenu-item-link-selected);
+              background: @sidebar-submenu-item-link-selected-background-color;
+              color: @sidebar-submenu-item-link-selected-color;
             }
           }
 
           & > span,
           & > a {
-            .element-shape-style(sidebar-submenu-item-link);
-            .element-spacing(sidebar-submenu-item-link, null, null);
-            .element-text-style(sidebar-submenu-item-link);
-            .property-variant(sidebar-submenu-item, height);
             align-items: center;
+            background: @sidebar-submenu-item-link-background-color;
+            color: @sidebar-submenu-item-link-color;
             display: flex;
+            height: @sidebar-submenu-item-height;
+            margin-left: @sidebar-submenu-item-link-margin-left;
+            margin-right: @sidebar-submenu-item-link-margin-right;
+            padding-left: @sidebar-submenu-item-link-padding-left;
+            padding-right: @sidebar-submenu-item-link-padding-right;
             text-decoration: none !important;
           }
 
           & > a {
 
             &:hover {
-              .element-shape-style(sidebar-submenu-item-link-hover);
-              .element-text-style(sidebar-submenu-item-link-hover);
+              background: @sidebar-submenu-item-link-hover-background-color;
+              color: @sidebar-submenu-item-link-hover-color;
               cursor: pointer;
             }
 
             &:active {
-              .element-shape-style(sidebar-submenu-item-link-active);
-              .element-text-style(sidebar-submenu-item-link-active);
+              background: @sidebar-submenu-item-link-active-background-color;
+              color: @sidebar-submenu-item-link-active-color;
             }
           }
         }
@@ -210,13 +234,13 @@
 
       // Sidebar Section
       .sidebar-section {
-        .element-spacing(sidebar-section, null, screen-small);
 
         // Sidebar Section Header
         .sidebar-section-header {
-          .element-spacing(sidebar-section-header, null, screen-small);
-          .element-text-size(sidebar-section-header, screen-small);
-          .property-variant(sidebar-section-header, height, null, screen-small);
+          margin-left: @sidebar-section-header-margin-left-screen-small;
+          margin-right: @sidebar-section-header-margin-right-screen-small;
+          padding-left: @sidebar-section-header-padding-left-screen-small;
+          padding-right: @sidebar-section-header-padding-right-screen-small;
         }
       }
 
@@ -224,36 +248,43 @@
       .sidebar-menu {
 
         li {
-          .element-spacing(sidebar-menu-item, null, screen-small);
-          .element-text-size(sidebar-submenu-item, screen-small);
-          .property-variant(sidebar-menu-item, min-height, height, null, screen-small);
+          margin-left: @sidebar-menu-item-margin-left-screen-small;
+          margin-right: @sidebar-menu-item-margin-right-screen-small;
+          padding-left: @sidebar-menu-item-padding-left-screen-small;
+          padding-right: @sidebar-menu-item-padding-right-screen-small;
 
           & > *:not(a):not(span) {
-            .property-variant(sidebar-menu-item-content, margin-right, padding-horizontal, null, screen-small);
+            margin-right: @sidebar-menu-item-content-padding-horizontal-screen-small;
           }
 
           & > span,
           & > a {
-            .element-spacing(sidebar-menu-item-link, null, screen-small);
-            .property-variant(sidebar-menu-item, height, null, screen-small);
+            margin-left: @sidebar-menu-item-link-margin-left-screen-small;
+            margin-right: @sidebar-menu-item-link-margin-right-screen-small;
+            padding-left: @sidebar-menu-item-link-padding-left-screen-small;
+            padding-right: @sidebar-menu-item-link-padding-right-screen-small;
 
             & > * {
-              .property-variant(sidebar-menu-item-content, margin-right, padding-horizontal, null, screen-small);
+              margin-right: @sidebar-menu-item-content-padding-horizontal-screen-small;
             }
           }
 
           & > ul {
-            .element-spacing(sidebar-submenu, null, screen-small);
+            padding-bottom: @sidebar-submenu-padding-bottom-screen-small;
+            padding-top: @sidebar-submenu-padding-top-screen-small;
 
             li {
-              .element-spacing(sidebar-submenu-item, null, screen-small);
-              .element-text-size(sidebar-submenu-item, screen-small);
-              .property-variant(sidebar-submenu-item, min-height, height, null, screen-small);
+              margin-left: @sidebar-submenu-item-margin-left-screen-small;
+              margin-right: @sidebar-submenu-item-margin-right-screen-small;
+              padding-left: @sidebar-submenu-item-padding-left-screen-small;
+              padding-right: @sidebar-submenu-item-padding-right-screen-small;
 
               & > span,
               & > a {
-                .element-spacing(sidebar-submenu-item-link, null, screen-small);
-                .property-variant(sidebar-submenu-item, height, null, screen-small);
+                margin-left: @sidebar-submenu-item-link-margin-left-screen-small;
+                margin-right: @sidebar-submenu-item-link-margin-right-screen-small;
+                padding-left: @sidebar-submenu-item-link-padding-left-screen-small;
+                padding-right: @sidebar-submenu-item-link-padding-right-screen-small;
               }
             }
           }
@@ -284,13 +315,13 @@
 
       // Sidebar Section
       .sidebar-section {
-        .element-spacing(sidebar-section, null, screen-medium);
 
         // Sidebar Section Header
         .sidebar-section-header {
-          .element-spacing(sidebar-section-header, null, screen-medium);
-          .element-text-size(sidebar-section-header, screen-medium);
-          .property-variant(sidebar-section-header, height, null, screen-medium);
+          margin-left: @sidebar-section-header-margin-left-screen-medium;
+          margin-right: @sidebar-section-header-margin-right-screen-medium;
+          padding-left: @sidebar-section-header-padding-left-screen-medium;
+          padding-right: @sidebar-section-header-padding-right-screen-medium;
         }
       }
 
@@ -298,36 +329,41 @@
       .sidebar-menu {
 
         li {
-          .element-spacing(sidebar-menu-item, null, screen-medium);
-          .element-text-size(sidebar-submenu-item, screen-medium);
-          .property-variant(sidebar-menu-item, min-height, height, null, screen-medium);
+          margin-left: @sidebar-menu-item-margin-left-screen-medium;
+          margin-right: @sidebar-menu-item-margin-right-screen-medium;
+          padding-left: @sidebar-menu-item-padding-left-screen-medium;
+          padding-right: @sidebar-menu-item-padding-right-screen-medium;
 
           & > *:not(a):not(span) {
-            .property-variant(sidebar-menu-item-content, margin-right, padding-horizontal, null, screen-medium);
+            margin-right: @sidebar-menu-item-content-padding-horizontal-screen-medium;
           }
 
           & > span,
           & > a {
-            .element-spacing(sidebar-menu-item-link, null, screen-medium);
-            .property-variant(sidebar-menu-item, height, null, screen-medium);
+            margin-left: @sidebar-menu-item-link-margin-left-screen-medium;
+            margin-right: @sidebar-menu-item-link-margin-right-screen-medium;
+            padding-left: @sidebar-menu-item-link-padding-left-screen-medium;
+            padding-right: @sidebar-menu-item-link-padding-right-screen-medium;
 
             & > * {
-              .property-variant(sidebar-menu-item-content, margin-right, padding-horizontal, null, screen-medium);
+              margin-right: @sidebar-menu-item-content-padding-horizontal-screen-medium;
             }
           }
 
           & > ul {
-            .element-spacing(sidebar-submenu, null, screen-medium);
 
             li {
-              .element-spacing(sidebar-submenu-item, null, screen-medium);
-              .element-text-size(sidebar-submenu-item, screen-medium);
-              .property-variant(sidebar-submenu-item, min-height, height, null, screen-medium);
+              margin-left: @sidebar-submenu-item-margin-left-screen-medium;
+              margin-right: @sidebar-submenu-item-margin-right-screen-medium;
+              padding-left: @sidebar-submenu-item-padding-left-screen-medium;
+              padding-right: @sidebar-submenu-item-padding-right-screen-medium;
 
               & > span,
               & > a {
-                .element-spacing(sidebar-submenu-item-link, null, screen-medium);
-                .property-variant(sidebar-submenu-item, height, null, screen-medium);
+                margin-left: @sidebar-submenu-item-link-margin-left-screen-medium;
+                margin-right: @sidebar-submenu-item-link-margin-right-screen-medium;
+                padding-left: @sidebar-submenu-item-link-padding-left-screen-medium;
+                padding-right: @sidebar-submenu-item-link-padding-right-screen-medium;
               }
             }
           }
@@ -351,13 +387,13 @@
 
       // Sidebar Section
       .sidebar-section {
-        .element-spacing(sidebar-section, null, screen-large);
 
         // Sidebar Section Header
         .sidebar-section-header {
-          .element-spacing(sidebar-section-header, null, screen-large);
-          .element-text-size(sidebar-section-header, screen-large);
-          .property-variant(sidebar-section-header, height, null, screen-large);
+          margin-left: @sidebar-section-header-margin-left-screen-large;
+          margin-right: @sidebar-section-header-margin-right-screen-large;
+          padding-left: @sidebar-section-header-padding-left-screen-large;
+          padding-right: @sidebar-section-header-padding-right-screen-large;
         }
       }
 
@@ -365,57 +401,44 @@
       .sidebar-menu {
 
         li {
-          .element-spacing(sidebar-menu-item, null, screen-large);
-          .element-text-size(sidebar-menu-item, screen-large);
-          .property-variant(sidebar-menu-item, min-height, height, null, screen-large);
+          margin-left: @sidebar-menu-item-margin-left-screen-large;
+          margin-right: @sidebar-menu-item-margin-right-screen-large;
+          padding-left: @sidebar-menu-item-padding-left-screen-large;
+          padding-right: @sidebar-menu-item-padding-right-screen-large;
 
           & > *:not(a):not(span) {
-            .property-variant(sidebar-menu-item-content, margin-right, padding-horizontal, null, screen-large);
+            margin-right: @sidebar-menu-item-content-padding-horizontal-screen-large;
           }
 
           & > span,
           & > a {
-            .element-spacing(sidebar-menu-item-link, null, screen-large);
-            .property-variant(sidebar-menu-item, height, null, screen-large);
+            margin-left: @sidebar-menu-item-link-margin-left-screen-large;
+            margin-right: @sidebar-menu-item-link-margin-right-screen-large;
+            padding-left: @sidebar-menu-item-link-padding-left-screen-large;
+            padding-right: @sidebar-menu-item-link-padding-right-screen-large;
 
             & > * {
-              .property-variant(sidebar-menu-item-content, margin-right, padding-horizontal, null, screen-large);
+              margin-right: @sidebar-menu-item-content-padding-horizontal-screen-large;
             }
           }
 
           & > ul {
-            .element-spacing(sidebar-submenu, null, screen-large);
+            padding-bottom: @sidebar-submenu-padding-bottom-screen-large;
+            padding-top: @sidebar-submenu-padding-top-screen-large;
 
             li {
-              .element-spacing(sidebar-submenu-item, null, screen-large);
-              .element-text-size(sidebar-submenu-item, screen-large);
-              .property-variant(sidebar-submenu-item, min-height, height, null, screen-large);
+              margin-left: @sidebar-submenu-item-margin-left-screen-large;
+              margin-right: @sidebar-submenu-item-margin-right-screen-large;
+              padding-left: @sidebar-submenu-item-padding-left-screen-large;
+              padding-right: @sidebar-submenu-item-padding-right-screen-large;
 
               & > span,
               & > a {
-                .element-spacing(sidebar-submenu-item-link, null, screen-large);
-                .property-variant(sidebar-submenu-item, height, null, screen-large);
+                margin-left: @sidebar-submenu-item-link-margin-left-screen-large;
+                margin-right: @sidebar-submenu-item-link-margin-right-screen-large;
+                padding-left: @sidebar-submenu-item-link-padding-left-screen-large;
+                padding-right: @sidebar-submenu-item-link-padding-right-screen-large;
               }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  // TODO: Remove in 1.9
-  @media (min-width: @layout-screen-medium-min-height) {
-
-    & when (@sidebar-enabled) and (@sidebar-screen-medium-enabled) {
-
-      .sidebar {
-
-        &.is-expanded {
-
-          .sidebar-content {
-
-            .sidebar-logo-container {
-              display: none;
             }
           }
         }
@@ -438,13 +461,13 @@
 
       // Sidebar Section
       .sidebar-section {
-        .element-spacing(sidebar-section, null, screen-jumbo);
 
         // Sidebar Section Header
         .sidebar-section-header {
-          .element-spacing(sidebar-section-header, null, screen-jumbo);
-          .element-text-size(sidebar-section-header, screen-jumbo);
-          .property-variant(sidebar-section-header, height, null, screen-jumbo);
+          margin-left: @sidebar-section-header-margin-left-screen-jumbo;
+          margin-right: @sidebar-section-header-margin-right-screen-jumbo;
+          padding-left: @sidebar-section-header-padding-left-screen-jumbo;
+          padding-right: @sidebar-section-header-padding-right-screen-jumbo;
         }
       }
 
@@ -452,36 +475,43 @@
       .sidebar-menu {
 
         li {
-          .element-spacing(sidebar-menu-item, null, screen-jumbo);
-          .element-text-size(sidebar-menu-item, screen-jumbo);
-          .property-variant(sidebar-menu-item, min-height, height, null, screen-jumbo);
+          margin-left: @sidebar-menu-item-margin-left-screen-jumbo;
+          margin-right: @sidebar-menu-item-margin-right-screen-jumbo;
+          padding-left: @sidebar-menu-item-padding-left-screen-jumbo;
+          padding-right: @sidebar-menu-item-padding-right-screen-jumbo;
 
           & > *:not(a):not(span) {
-            .property-variant(sidebar-menu-item-content, margin-right, padding-horizontal, null, screen-jumbo);
+            margin-right: @sidebar-menu-item-content-padding-horizontal-screen-jumbo;
           }
 
           & > span,
           & > a {
-            .element-spacing(sidebar-menu-item-link, null, screen-jumbo);
-            .property-variant(sidebar-menu-item, height, null, screen-jumbo);
+            margin-left: @sidebar-menu-item-link-margin-left-screen-jumbo;
+            margin-right: @sidebar-menu-item-link-margin-right-screen-jumbo;
+            padding-left: @sidebar-menu-item-link-padding-left-screen-jumbo;
+            padding-right: @sidebar-menu-item-link-padding-right-screen-jumbo;
 
             & > * {
-              .property-variant(sidebar-menu-item-content, margin-right, padding-horizontal, null, screen-jumbo);
+              margin-right: @sidebar-menu-item-content-padding-horizontal-screen-jumbo;
             }
           }
 
           & > ul {
-            .element-spacing(sidebar-submenu, null, screen-jumbo);
+            padding-bottom: @sidebar-submenu-padding-bottom-screen-jumbo;
+            padding-top: @sidebar-submenu-padding-top-screen-jumbo;
 
             li {
-              .element-spacing(sidebar-submenu-item, null, screen-jumbo);
-              .element-text-size(sidebar-submenu-item, screen-jumbo);
-              .property-variant(sidebar-submenu-item, min-height, height, null, screen-jumbo);
+              margin-left: @sidebar-submenu-item-margin-left-screen-jumbo;
+              margin-right: @sidebar-submenu-item-margin-right-screen-jumbo;
+              padding-left: @sidebar-submenu-item-padding-left-screen-jumbo;
+              padding-right: @sidebar-submenu-item-padding-right-screen-jumbo;
 
               & > span,
               & > a {
-                .element-spacing(sidebar-submenu-item-link, null, screen-jumbo);
-                .property-variant(sidebar-submenu-item, height, null, screen-jumbo);
+                margin-left: @sidebar-submenu-item-link-margin-left-screen-jumbo;
+                margin-right: @sidebar-submenu-item-link-margin-right-screen-jumbo;
+                padding-left: @sidebar-submenu-item-link-padding-left-screen-jumbo;
+                padding-right: @sidebar-submenu-item-link-padding-right-screen-jumbo;
               }
             }
           }

--- a/src/styles/layout/sidebar/variables.less
+++ b/src/styles/layout/sidebar/variables.less
@@ -15,72 +15,6 @@
 
 @sidebar-background-color: color-lighten(@neutral, -40);
 
-/* Layout */
-
-// Margin Top
-
-@sidebar-section-margin-top: null;
-@sidebar-section-margin-top-screen-small: null;
-@sidebar-section-margin-top-screen-medium: null;
-@sidebar-section-margin-top-screen-large: null;
-@sidebar-section-margin-top-screen-jumbo: null;
-
-// Margin Bottom
-
-@sidebar-section-margin-bottom: null;//@pod-margin-bottom * @pod-short-margin-bottom-scale;
-@sidebar-section-margin-bottom-screen-small: null;//@pod-margin-bottom-screen-small * @pod-short-margin-bottom-scale;
-@sidebar-section-margin-bottom-screen-medium: null;//@pod-margin-bottom-screen-medium * @pod-short-margin-bottom-scale;
-@sidebar-section-margin-bottom-screen-large: null;//@pod-margin-bottom-screen-large * @pod-short-margin-bottom-scale;
-@sidebar-section-margin-bottom-screen-jumbo: null;//@pod-margin-bottom-screen-jumbo * @pod-short-margin-bottom-scale;
-
-// Margin Left
-
-@sidebar-section-margin-left: null;
-@sidebar-section-margin-left-screen-small: null;
-@sidebar-section-margin-left-screen-medium: null;
-@sidebar-section-margin-left-screen-large: null;
-@sidebar-section-margin-left-screen-jumbo: null;
-
-// Margin Right
-
-@sidebar-section-margin-right: null;
-@sidebar-section-margin-right-screen-small: null;
-@sidebar-section-margin-right-screen-medium: null;
-@sidebar-section-margin-right-screen-large: null;
-@sidebar-section-margin-right-screen-jumbo: null;
-
-// Padding Top
-
-@sidebar-section-padding-top: null;
-@sidebar-section-padding-top-screen-small: null;
-@sidebar-section-padding-top-screen-medium: null;
-@sidebar-section-padding-top-screen-large: null;
-@sidebar-section-padding-top-screen-jumbo: null;
-
-// Padding Bottom
-
-@sidebar-section-padding-bottom: null;
-@sidebar-section-padding-bottom-screen-small: null;
-@sidebar-section-padding-bottom-screen-medium: null;
-@sidebar-section-padding-bottom-screen-large: null;
-@sidebar-section-padding-bottom-screen-jumbo: null;
-
-// Padding Left
-
-@sidebar-section-padding-left: null;
-@sidebar-section-padding-left-screen-small: null;
-@sidebar-section-padding-left-screen-medium: null;
-@sidebar-section-padding-left-screen-large: null;
-@sidebar-section-padding-left-screen-jumbo: null;
-
-// Padding Right
-
-@sidebar-section-padding-right: null;
-@sidebar-section-padding-right-screen-small: null;
-@sidebar-section-padding-right-screen-medium: null;
-@sidebar-section-padding-right-screen-large: null;
-@sidebar-section-padding-right-screen-jumbo: null;
-
 /*
  * Sidebar Section Header
  */
@@ -88,76 +22,40 @@
 /* Styling */
 
 @sidebar-section-header-color: color-lighten(@neutral, 40);
-@sidebar-section-header-font-family: null;
-@sidebar-section-header-font-style: null;
 @sidebar-section-header-font-weight: 600;
 @sidebar-section-header-text-transform: uppercase;
-@sidebar-section-header-text-shadow: null;
-@sidebar-section-header-text-decoration: null;
-@sidebar-section-header-text-rendering: null;
-@sidebar-section-header-background-color: null;
-@sidebar-section-header-background-gradient-color-top: null;
-@sidebar-section-header-background-gradient-color-bottom: null;
-@sidebar-section-header-border-width: null;
-@sidebar-section-header-border-color: null;
-@sidebar-section-header-border-style: null;
-@sidebar-section-header-border-top-width: null;
-@sidebar-section-header-border-top-color: null;
-@sidebar-section-header-border-top-style: null;
-@sidebar-section-header-border-right-width: null;
-@sidebar-section-header-border-right-color: null;
-@sidebar-section-header-border-right-style: null;
-@sidebar-section-header-border-bottom-width: null;
-@sidebar-section-header-border-bottom-color: null;
-@sidebar-section-header-border-bottom-style: null;
-@sidebar-section-header-border-left-width: null;
-@sidebar-section-header-border-left-color: null;
-@sidebar-section-header-border-left-style: null;
-@sidebar-section-header-shadow: null;
 
 /* Text Size */
 
 // Font Size
 
 @sidebar-section-header-font-size: 0.9rem;
-@sidebar-section-header-font-size-screen-small: null;
-@sidebar-section-header-font-size-screen-medium: null;
-@sidebar-section-header-font-size-screen-large: null;
-@sidebar-section-header-font-size-screen-jumbo: null;
 
 // Line Height
 
 @sidebar-section-header-line-height: 0.9rem;
-@sidebar-section-header-line-height-screen-small: @sidebar-section-header-font-size-screen-small;
-@sidebar-section-header-line-height-screen-medium: @sidebar-section-header-font-size-screen-medium;
-@sidebar-section-header-line-height-screen-large: @sidebar-section-header-font-size-screen-large;
-@sidebar-section-header-line-height-screen-jumbo: @sidebar-section-header-font-size-screen-jumbo;
 
 /* Layout */
 
 // Height
 
 @sidebar-section-header-height: 36px;
-@sidebar-section-header-height-screen-small: null;
-@sidebar-section-header-height-screen-medium: null;
-@sidebar-section-header-height-screen-large: null;
-@sidebar-section-header-height-screen-jumbo: null;
 
 // Margin Top
 
 @sidebar-section-header-margin-top: 0;
-@sidebar-section-header-margin-top-screen-small: null;
-@sidebar-section-header-margin-top-screen-medium: null;
-@sidebar-section-header-margin-top-screen-large: null;
-@sidebar-section-header-margin-top-screen-jumbo: null;
+@sidebar-section-header-margin-top-screen-small: 0;
+@sidebar-section-header-margin-top-screen-medium: 0;
+@sidebar-section-header-margin-top-screen-large: 0;
+@sidebar-section-header-margin-top-screen-jumbo: 0;
 
 // Margin Bottom
 
 @sidebar-section-header-margin-bottom: 0;
-@sidebar-section-header-margin-bottom-screen-small: null;
-@sidebar-section-header-margin-bottom-screen-medium: null;
-@sidebar-section-header-margin-bottom-screen-large: null;
-@sidebar-section-header-margin-bottom-screen-jumbo: null;
+@sidebar-section-header-margin-bottom-screen-small: 0;
+@sidebar-section-header-margin-bottom-screen-medium: 0;
+@sidebar-section-header-margin-bottom-screen-large: 0;
+@sidebar-section-header-margin-bottom-screen-jumbo: 0;
 
 // Margin Left
 
@@ -174,22 +72,6 @@
 @sidebar-section-header-margin-right-screen-medium: -@pod-margin-right-screen-medium * @pod-narrow-margin-right-scale;
 @sidebar-section-header-margin-right-screen-large: -@pod-margin-right-screen-large * @pod-narrow-margin-right-scale;
 @sidebar-section-header-margin-right-screen-jumbo: -@pod-margin-right-screen-jumbo * @pod-narrow-margin-right-scale;
-
-// Padding Top
-
-@sidebar-section-header-padding-top: null;
-@sidebar-section-header-padding-top-screen-small: null;
-@sidebar-section-header-padding-top-screen-medium: null;
-@sidebar-section-header-padding-top-screen-large: null;
-@sidebar-section-header-padding-top-screen-jumbo: null;
-
-// Padding Bottom
-
-@sidebar-section-header-padding-bottom: null;
-@sidebar-section-header-padding-bottom-screen-small: null;
-@sidebar-section-header-padding-bottom-screen-medium: null;
-@sidebar-section-header-padding-bottom-screen-large: null;
-@sidebar-section-header-padding-bottom-screen-jumbo: null;
 
 // Padding Left
 
@@ -211,27 +93,9 @@
  * Sidebar Menu
  */
 
-/* Styling */
+/* Layout */
 
-@sidebar-menu-background-color: null;
-@sidebar-menu-background-gradient-color-top: null;
-@sidebar-menu-background-gradient-color-bottom: null;
-@sidebar-menu-border-width: null;
-@sidebar-menu-border-color: null;
-@sidebar-menu-border-style: null;
-@sidebar-menu-border-top-width: null;
-@sidebar-menu-border-top-color: null;
-@sidebar-menu-border-top-style: null;
-@sidebar-menu-border-right-width: null;
-@sidebar-menu-border-right-color: null;
-@sidebar-menu-border-right-style: null;
-@sidebar-menu-border-bottom-width: null;
-@sidebar-menu-border-bottom-color: null;
-@sidebar-menu-border-bottom-style: null;
-@sidebar-menu-border-left-width: null;
-@sidebar-menu-border-left-color: null;
-@sidebar-menu-border-left-style: null;
-@sidebar-menu-shadow: null;
+@sidebar-menu-margin-bottom: 0;
 
 /*
  * Sidebar Menu Item
@@ -242,136 +106,38 @@
 // Default
 
 @sidebar-menu-item-color: color-lighten(@neutral, 80);
-@sidebar-menu-item-font-family: null;
-@sidebar-menu-item-font-style: null;
 @sidebar-menu-item-font-weight: 500;
-@sidebar-menu-item-text-transform: null;
-@sidebar-menu-item-text-shadow: null;
-@sidebar-menu-item-text-decoration: null;
-@sidebar-menu-item-text-rendering: null;
 @sidebar-menu-item-background-color: color-lighten(@neutral, -40);
-@sidebar-menu-item-background-gradient-color-top: null;
-@sidebar-menu-item-background-gradient-color-bottom: null;
-@sidebar-menu-item-border-width: null;
-@sidebar-menu-item-border-color: null;
-@sidebar-menu-item-border-style: null;
-@sidebar-menu-item-border-top-width: null;
-@sidebar-menu-item-border-top-color: null;
-@sidebar-menu-item-border-top-style: null;
-@sidebar-menu-item-border-right-width: null;
-@sidebar-menu-item-border-right-color: null;
-@sidebar-menu-item-border-right-style: null;
-@sidebar-menu-item-border-bottom-width: null;
-@sidebar-menu-item-border-bottom-color: null;
-@sidebar-menu-item-border-bottom-style: null;
-@sidebar-menu-item-border-left-width: null;
-@sidebar-menu-item-border-left-color: null;
-@sidebar-menu-item-border-left-style: null;
-@sidebar-menu-item-shadow: null;
 
 // Selected
 
 @sidebar-menu-item-selected-color: @white;
-@sidebar-menu-item-selected-font-family: null;
-@sidebar-menu-item-selected-font-style: null;
-@sidebar-menu-item-selected-font-weight: null;
-@sidebar-menu-item-selected-text-transform: null;
-@sidebar-menu-item-selected-text-shadow: null;
-@sidebar-menu-item-selected-text-decoration: null;
-@sidebar-menu-item-selected-text-rendering: null;
 @sidebar-menu-item-selected-background-color: color-lighten(@neutral, 0);
-@sidebar-menu-item-selected-background-gradient-color-top: null;
-@sidebar-menu-item-selected-background-gradient-color-bottom: null;
-@sidebar-menu-item-selected-border-width: null;
-@sidebar-menu-item-selected-border-color: null;
-@sidebar-menu-item-selected-border-style: null;
-@sidebar-menu-item-selected-border-top-width: null;
-@sidebar-menu-item-selected-border-top-color: null;
-@sidebar-menu-item-selected-border-top-style: null;
-@sidebar-menu-item-selected-border-right-width: null;
-@sidebar-menu-item-selected-border-right-color: null;
-@sidebar-menu-item-selected-border-right-style: null;
-@sidebar-menu-item-selected-border-bottom-width: null;
-@sidebar-menu-item-selected-border-bottom-color: null;
-@sidebar-menu-item-selected-border-bottom-style: null;
-@sidebar-menu-item-selected-border-left-width: null;
-@sidebar-menu-item-selected-border-left-color: null;
-@sidebar-menu-item-selected-border-left-style: null;
-@sidebar-menu-item-selected-shadow: null;
 
 // Open
 
 @sidebar-menu-item-open-color: @white;
-@sidebar-menu-item-open-font-family: null;
-@sidebar-menu-item-open-font-style: null;
-@sidebar-menu-item-open-font-weight: null;
-@sidebar-menu-item-open-text-transform: null;
-@sidebar-menu-item-open-text-shadow: null;
-@sidebar-menu-item-open-text-decoration: null;
-@sidebar-menu-item-open-text-rendering: null;
 @sidebar-menu-item-open-background-color: color-lighten(@neutral, -20);
-@sidebar-menu-item-open-background-gradient-color-top: null;
-@sidebar-menu-item-open-background-gradient-color-bottom: null;
-@sidebar-menu-item-open-border-width: null;
-@sidebar-menu-item-open-border-color: null;
-@sidebar-menu-item-open-border-style: null;
-@sidebar-menu-item-open-border-top-width: null;
-@sidebar-menu-item-open-border-top-color: null;
-@sidebar-menu-item-open-border-top-style: null;
-@sidebar-menu-item-open-border-right-width: null;
-@sidebar-menu-item-open-border-right-color: null;
-@sidebar-menu-item-open-border-right-style: null;
-@sidebar-menu-item-open-border-bottom-width: null;
-@sidebar-menu-item-open-border-bottom-color: null;
-@sidebar-menu-item-open-border-bottom-style: null;
-@sidebar-menu-item-open-border-left-width: null;
-@sidebar-menu-item-open-border-left-color: null;
-@sidebar-menu-item-open-border-left-style: null;
-@sidebar-menu-item-open-shadow: null;
 
 /* Text Size */
 
 // Font Size
 
 @sidebar-menu-item-font-size: 1rem;
-@sidebar-menu-item-font-size-screen-small: null;
-@sidebar-menu-item-font-size-screen-medium: null;
-@sidebar-menu-item-font-size-screen-large: null;
-@sidebar-menu-item-font-size-screen-jumbo: null;
 
 // Line Height
 
 @sidebar-menu-item-line-height: 1rem;
-@sidebar-menu-item-line-height-screen-small: @sidebar-menu-item-font-size-screen-small;
-@sidebar-menu-item-line-height-screen-medium: @sidebar-menu-item-font-size-screen-medium;
-@sidebar-menu-item-line-height-screen-large: @sidebar-menu-item-font-size-screen-large;
-@sidebar-menu-item-line-height-screen-jumbo: @sidebar-menu-item-font-size-screen-jumbo;
 
 /* Layout */
 
 // Height
 
 @sidebar-menu-item-height: 48px;
-@sidebar-menu-item-height-screen-small: null;
-@sidebar-menu-item-height-screen-medium: null;
-@sidebar-menu-item-height-screen-large: null;
-@sidebar-menu-item-height-screen-jumbo: null;
-
-// Margin Top
-
-@sidebar-menu-item-margin-top: null;
-@sidebar-menu-item-margin-top-screen-small: null;
-@sidebar-menu-item-margin-top-screen-medium: null;
-@sidebar-menu-item-margin-top-screen-large: null;
-@sidebar-menu-item-margin-top-screen-jumbo: null;
 
 // Margin Bottom
 
 @sidebar-menu-item-margin-bottom: 0;
-@sidebar-menu-item-margin-bottom-screen-small: null;
-@sidebar-menu-item-margin-bottom-screen-medium: null;
-@sidebar-menu-item-margin-bottom-screen-large: null;
-@sidebar-menu-item-margin-bottom-screen-jumbo: null;
 
 // Margin Left
 
@@ -388,22 +154,6 @@
 @sidebar-menu-item-margin-right-screen-medium: -@pod-margin-right-screen-medium * @pod-narrow-margin-right-scale;
 @sidebar-menu-item-margin-right-screen-large: -@pod-margin-right-screen-large * @pod-narrow-margin-right-scale;
 @sidebar-menu-item-margin-right-screen-jumbo: -@pod-margin-right-screen-jumbo * @pod-narrow-margin-right-scale;
-
-// Padding Top
-
-@sidebar-menu-item-padding-top: null;
-@sidebar-menu-item-padding-top-screen-small: null;
-@sidebar-menu-item-padding-top-screen-medium: null;
-@sidebar-menu-item-padding-top-screen-large: null;
-@sidebar-menu-item-padding-top-screen-jumbo: null;
-
-// Padding Bottom
-
-@sidebar-menu-item-padding-bottom: null;
-@sidebar-menu-item-padding-bottom-screen-small: null;
-@sidebar-menu-item-padding-bottom-screen-medium: null;
-@sidebar-menu-item-padding-bottom-screen-large: null;
-@sidebar-menu-item-padding-bottom-screen-jumbo: null;
 
 // Padding Left
 
@@ -440,140 +190,24 @@
 // Default
 
 @sidebar-menu-item-link-color: color-lighten(@neutral, 80);
-@sidebar-menu-item-link-font-family: null;
-@sidebar-menu-item-link-font-style: null;
-@sidebar-menu-item-link-font-weight: null;
-@sidebar-menu-item-link-text-transform: null;
-@sidebar-menu-item-link-text-shadow: null;
-@sidebar-menu-item-link-text-decoration: null;
-@sidebar-menu-item-link-text-rendering: null;
 @sidebar-menu-item-link-background-color: color-lighten(@neutral, -40);
-@sidebar-menu-item-link-background-gradient-color-top: null;
-@sidebar-menu-item-link-background-gradient-color-bottom: null;
-@sidebar-menu-item-link-border-width: null;
-@sidebar-menu-item-link-border-color: null;
-@sidebar-menu-item-link-border-style: null;
-@sidebar-menu-item-link-border-top-width: null;
-@sidebar-menu-item-link-border-top-color: null;
-@sidebar-menu-item-link-border-top-style: null;
-@sidebar-menu-item-link-border-right-width: null;
-@sidebar-menu-item-link-border-right-color: null;
-@sidebar-menu-item-link-border-right-style: null;
-@sidebar-menu-item-link-border-bottom-width: null;
-@sidebar-menu-item-link-border-bottom-color: null;
-@sidebar-menu-item-link-border-bottom-style: null;
-@sidebar-menu-item-link-border-left-width: null;
-@sidebar-menu-item-link-border-left-color: null;
-@sidebar-menu-item-link-border-left-style: null;
-@sidebar-menu-item-link-shadow: null;
 
 // Hover
 
 @sidebar-menu-item-link-hover-color: @white;
-@sidebar-menu-item-link-hover-font-family: null;
-@sidebar-menu-item-link-hover-font-style: null;
-@sidebar-menu-item-link-hover-font-weight: null;
-@sidebar-menu-item-link-hover-text-transform: null;
-@sidebar-menu-item-link-hover-text-shadow: null;
-@sidebar-menu-item-link-hover-text-decoration: null;
-@sidebar-menu-item-link-hover-text-rendering: null;
 @sidebar-menu-item-link-hover-background-color: color-lighten(@neutral, -30);
-@sidebar-menu-item-link-hover-background-gradient-color-top: null;
-@sidebar-menu-item-link-hover-background-gradient-color-bottom: null;
-@sidebar-menu-item-link-hover-border-width: null;
-@sidebar-menu-item-link-hover-border-color: null;
-@sidebar-menu-item-link-hover-border-style: null;
-@sidebar-menu-item-link-hover-border-top-width: null;
-@sidebar-menu-item-link-hover-border-top-color: null;
-@sidebar-menu-item-link-hover-border-top-style: null;
-@sidebar-menu-item-link-hover-border-right-width: null;
-@sidebar-menu-item-link-hover-border-right-color: null;
-@sidebar-menu-item-link-hover-border-right-style: null;
-@sidebar-menu-item-link-hover-border-bottom-width: null;
-@sidebar-menu-item-link-hover-border-bottom-color: null;
-@sidebar-menu-item-link-hover-border-bottom-style: null;
-@sidebar-menu-item-link-hover-border-left-width: null;
-@sidebar-menu-item-link-hover-border-left-color: null;
-@sidebar-menu-item-link-hover-border-left-style: null;
-@sidebar-menu-item-link-hover-shadow: null;
 
 // Active
 
 @sidebar-menu-item-link-active-color: color-lighten(@neutral, 70);
-@sidebar-menu-item-link-active-font-family: null;
-@sidebar-menu-item-link-active-font-style: null;
-@sidebar-menu-item-link-active-font-weight: null;
-@sidebar-menu-item-link-active-text-transform: null;
-@sidebar-menu-item-link-active-text-shadow: null;
-@sidebar-menu-item-link-active-text-decoration: null;
-@sidebar-menu-item-link-active-text-rendering: null;
 @sidebar-menu-item-link-active-background-color: color-lighten(@neutral, -35);
-@sidebar-menu-item-link-active-background-gradient-color-top: null;
-@sidebar-menu-item-link-active-background-gradient-color-bottom: null;
-@sidebar-menu-item-link-active-border-width: null;
-@sidebar-menu-item-link-active-border-color: null;
-@sidebar-menu-item-link-active-border-style: null;
-@sidebar-menu-item-link-active-border-top-width: null;
-@sidebar-menu-item-link-active-border-top-color: null;
-@sidebar-menu-item-link-active-border-top-style: null;
-@sidebar-menu-item-link-active-border-right-width: null;
-@sidebar-menu-item-link-active-border-right-color: null;
-@sidebar-menu-item-link-active-border-right-style: null;
-@sidebar-menu-item-link-active-border-bottom-width: null;
-@sidebar-menu-item-link-active-border-bottom-color: null;
-@sidebar-menu-item-link-active-border-bottom-style: null;
-@sidebar-menu-item-link-active-border-left-width: null;
-@sidebar-menu-item-link-active-border-left-color: null;
-@sidebar-menu-item-link-active-border-left-style: null;
-@sidebar-menu-item-link-active-shadow: null;
 
 // Selected
 
 @sidebar-menu-item-link-selected-color: @white;
-@sidebar-menu-item-link-selected-font-family: null;
-@sidebar-menu-item-link-selected-font-style: null;
-@sidebar-menu-item-link-selected-font-weight: null;
-@sidebar-menu-item-link-selected-text-transform: null;
-@sidebar-menu-item-link-selected-text-shadow: null;
-@sidebar-menu-item-link-selected-text-decoration: null;
-@sidebar-menu-item-link-selected-text-rendering: null;
 @sidebar-menu-item-link-selected-background-color: @purple;//color-lighten(@neutral, 0);
-@sidebar-menu-item-link-selected-background-gradient-color-top: null;
-@sidebar-menu-item-link-selected-background-gradient-color-bottom: null;
-@sidebar-menu-item-link-selected-border-width: null;
-@sidebar-menu-item-link-selected-border-color: null;
-@sidebar-menu-item-link-selected-border-style: null;
-@sidebar-menu-item-link-selected-border-top-width: null;
-@sidebar-menu-item-link-selected-border-top-color: null;
-@sidebar-menu-item-link-selected-border-top-style: null;
-@sidebar-menu-item-link-selected-border-right-width: null;
-@sidebar-menu-item-link-selected-border-right-color: null;
-@sidebar-menu-item-link-selected-border-right-style: null;
-@sidebar-menu-item-link-selected-border-bottom-width: null;
-@sidebar-menu-item-link-selected-border-bottom-color: null;
-@sidebar-menu-item-link-selected-border-bottom-style: null;
-@sidebar-menu-item-link-selected-border-left-width: null;
-@sidebar-menu-item-link-selected-border-left-color: null;
-@sidebar-menu-item-link-selected-border-left-style: null;
-@sidebar-menu-item-link-selected-shadow: null;
 
 /* Layout */
-
-// Margin Top
-
-@sidebar-menu-item-link-margin-top: null;
-@sidebar-menu-item-link-margin-top-screen-small: null;
-@sidebar-menu-item-link-margin-top-screen-medium: null;
-@sidebar-menu-item-link-margin-top-screen-large: null;
-@sidebar-menu-item-link-margin-top-screen-jumbo: null;
-
-// Margin Bottom
-
-@sidebar-menu-item-link-margin-bottom: null;
-@sidebar-menu-item-link-margin-bottom-screen-small: null;
-@sidebar-menu-item-link-margin-bottom-screen-medium: null;
-@sidebar-menu-item-link-margin-bottom-screen-large: null;
-@sidebar-menu-item-link-margin-bottom-screen-jumbo: null;
 
 // Margin Left
 
@@ -590,22 +224,6 @@
 @sidebar-menu-item-link-margin-right-screen-medium: @sidebar-menu-item-margin-right-screen-medium;
 @sidebar-menu-item-link-margin-right-screen-large: @sidebar-menu-item-margin-right-screen-large;
 @sidebar-menu-item-link-margin-right-screen-jumbo: @sidebar-menu-item-margin-right-screen-jumbo;
-
-// Padding Top
-
-@sidebar-menu-item-link-padding-top: null;
-@sidebar-menu-item-link-padding-top-screen-small: null;
-@sidebar-menu-item-link-padding-top-screen-medium: null;
-@sidebar-menu-item-link-padding-top-screen-large: null;
-@sidebar-menu-item-link-padding-top-screen-jumbo: null;
-
-// Padding Bottom
-
-@sidebar-menu-item-link-padding-bottom: null;
-@sidebar-menu-item-link-padding-bottom-screen-small: null;
-@sidebar-menu-item-link-padding-bottom-screen-medium: null;
-@sidebar-menu-item-link-padding-bottom-screen-large: null;
-@sidebar-menu-item-link-padding-bottom-screen-jumbo: null;
 
 // Padding Left
 
@@ -630,58 +248,16 @@
 /* Styling */
 
 @sidebar-submenu-background-color: color-lighten(@neutral, -30);
-@sidebar-submenu-background-gradient-color-top: null;
-@sidebar-submenu-background-gradient-color-bottom: null;
-@sidebar-submenu-border-width: null;
-@sidebar-submenu-border-color: null;
-@sidebar-submenu-border-style: null;
-@sidebar-submenu-border-top-width: null;
-@sidebar-submenu-border-top-color: null;
-@sidebar-submenu-border-top-style: null;
-@sidebar-submenu-border-right-width: null;
-@sidebar-submenu-border-right-color: null;
-@sidebar-submenu-border-right-style: null;
-@sidebar-submenu-border-bottom-width: null;
-@sidebar-submenu-border-bottom-color: null;
-@sidebar-submenu-border-bottom-style: null;
-@sidebar-submenu-border-left-width: null;
-@sidebar-submenu-border-left-color: null;
-@sidebar-submenu-border-left-style: null;
-@sidebar-submenu-shadow: null;
 
 /* Layout */
 
 // Margin Top
 
 @sidebar-submenu-margin-top: 0;
-@sidebar-submenu-margin-top-screen-small: null;
-@sidebar-submenu-margin-top-screen-medium: null;
-@sidebar-submenu-margin-top-screen-large: null;
-@sidebar-submenu-margin-top-screen-jumbo: null;
 
 // Margin Bottom
 
 @sidebar-submenu-margin-bottom: 0;
-@sidebar-submenu-margin-bottom-screen-small: null;
-@sidebar-submenu-margin-bottom-screen-medium: null;
-@sidebar-submenu-margin-bottom-screen-large: null;
-@sidebar-submenu-margin-bottom-screen-jumbo: null;
-
-// Margin Left
-
-@sidebar-submenu-margin-left: null;
-@sidebar-submenu-margin-left-screen-small: null;
-@sidebar-submenu-margin-left-screen-medium: null;
-@sidebar-submenu-margin-left-screen-large: null;
-@sidebar-submenu-margin-left-screen-jumbo: null;
-
-// Margin Right
-
-@sidebar-submenu-margin-right: null;
-@sidebar-submenu-margin-right-screen-small: null;
-@sidebar-submenu-margin-right-screen-medium: null;
-@sidebar-submenu-margin-right-screen-large: null;
-@sidebar-submenu-margin-right-screen-jumbo: null;
 
 // Padding Top
 
@@ -699,22 +275,6 @@
 @sidebar-submenu-padding-bottom-screen-large: @pod-margin-bottom-screen-large * @pod-shorter-margin-bottom-scale;
 @sidebar-submenu-padding-bottom-screen-jumbo: @pod-margin-bottom-screen-jumbo * @pod-shorter-margin-bottom-scale;
 
-// Padding Left
-
-@sidebar-submenu-padding-left: null;
-@sidebar-submenu-padding-left-screen-small: null;
-@sidebar-submenu-padding-left-screen-medium: null;
-@sidebar-submenu-padding-left-screen-large: null;
-@sidebar-submenu-padding-left-screen-jumbo: null;
-
-// Padding Right
-
-@sidebar-submenu-padding-right: null;
-@sidebar-submenu-padding-right-screen-small: null;
-@sidebar-submenu-padding-right-screen-medium: null;
-@sidebar-submenu-padding-right-screen-large: null;
-@sidebar-submenu-padding-right-screen-jumbo: null;
-
 /*
  * Sidebar Submenu Item
  */
@@ -724,136 +284,25 @@
 // Default
 
 @sidebar-submenu-item-color: color-lighten(@neutral, 60);
-@sidebar-submenu-item-font-family: null;
-@sidebar-submenu-item-font-style: null;
 @sidebar-submenu-item-font-weight: 500;
 @sidebar-submenu-item-text-transform: none;
-@sidebar-submenu-item-text-shadow: null;
-@sidebar-submenu-item-text-decoration: null;
-@sidebar-submenu-item-text-rendering: null;
 @sidebar-submenu-item-background-color: color-lighten(@neutral, -30);
-@sidebar-submenu-item-background-gradient-color-top: null;
-@sidebar-submenu-item-background-gradient-color-bottom: null;
-@sidebar-submenu-item-border-width: null;
-@sidebar-submenu-item-border-color: null;
-@sidebar-submenu-item-border-style: null;
-@sidebar-submenu-item-border-top-width: null;
-@sidebar-submenu-item-border-top-color: null;
-@sidebar-submenu-item-border-top-style: null;
-@sidebar-submenu-item-border-right-width: null;
-@sidebar-submenu-item-border-right-color: null;
-@sidebar-submenu-item-border-right-style: null;
-@sidebar-submenu-item-border-bottom-width: null;
-@sidebar-submenu-item-border-bottom-color: null;
-@sidebar-submenu-item-border-bottom-style: null;
-@sidebar-submenu-item-border-left-width: null;
-@sidebar-submenu-item-border-left-color: null;
-@sidebar-submenu-item-border-left-style: null;
-@sidebar-submenu-item-shadow: null;
-
-// Selected
-
-@sidebar-submenu-item-selected-color: null;
-@sidebar-submenu-item-selected-font-family: null;
-@sidebar-submenu-item-selected-font-style: null;
-@sidebar-submenu-item-selected-font-weight: null;
-@sidebar-submenu-item-selected-text-transform: null;
-@sidebar-submenu-item-selected-text-shadow: null;
-@sidebar-submenu-item-selected-text-decoration: null;
-@sidebar-submenu-item-selected-text-rendering: null;
-@sidebar-submenu-item-selected-background-color: null;
-@sidebar-submenu-item-selected-background-gradient-color-top: null;
-@sidebar-submenu-item-selected-background-gradient-color-bottom: null;
-@sidebar-submenu-item-selected-border-width: null;
-@sidebar-submenu-item-selected-border-color: null;
-@sidebar-submenu-item-selected-border-style: null;
-@sidebar-submenu-item-selected-border-top-width: null;
-@sidebar-submenu-item-selected-border-top-color: null;
-@sidebar-submenu-item-selected-border-top-style: null;
-@sidebar-submenu-item-selected-border-right-width: null;
-@sidebar-submenu-item-selected-border-right-color: null;
-@sidebar-submenu-item-selected-border-right-style: null;
-@sidebar-submenu-item-selected-border-bottom-width: null;
-@sidebar-submenu-item-selected-border-bottom-color: null;
-@sidebar-submenu-item-selected-border-bottom-style: null;
-@sidebar-submenu-item-selected-border-left-width: null;
-@sidebar-submenu-item-selected-border-left-color: null;
-@sidebar-submenu-item-selected-border-left-style: null;
-@sidebar-submenu-item-selected-shadow: null;
-
-// Open
-
-@sidebar-submenu-item-open-color: null;
-@sidebar-submenu-item-open-font-family: null;
-@sidebar-submenu-item-open-font-style: null;
-@sidebar-submenu-item-open-font-weight: null;
-@sidebar-submenu-item-open-text-transform: null;
-@sidebar-submenu-item-open-text-shadow: null;
-@sidebar-submenu-item-open-text-decoration: null;
-@sidebar-submenu-item-open-text-rendering: null;
-@sidebar-submenu-item-open-background-color: null;
-@sidebar-submenu-item-open-background-gradient-color-top: null;
-@sidebar-submenu-item-open-background-gradient-color-bottom: null;
-@sidebar-submenu-item-open-border-width: null;
-@sidebar-submenu-item-open-border-color: null;
-@sidebar-submenu-item-open-border-style: null;
-@sidebar-submenu-item-open-border-top-width: null;
-@sidebar-submenu-item-open-border-top-color: null;
-@sidebar-submenu-item-open-border-top-style: null;
-@sidebar-submenu-item-open-border-right-width: null;
-@sidebar-submenu-item-open-border-right-color: null;
-@sidebar-submenu-item-open-border-right-style: null;
-@sidebar-submenu-item-open-border-bottom-width: null;
-@sidebar-submenu-item-open-border-bottom-color: null;
-@sidebar-submenu-item-open-border-bottom-style: null;
-@sidebar-submenu-item-open-border-left-width: null;
-@sidebar-submenu-item-open-border-left-color: null;
-@sidebar-submenu-item-open-border-left-style: null;
-@sidebar-submenu-item-open-shadow: null;
 
 /* Text Size */
 
 // Font Size
 
 @sidebar-submenu-item-font-size: 0.9rem;
-@sidebar-submenu-item-font-size-screen-small: null;
-@sidebar-submenu-item-font-size-screen-medium: null;
-@sidebar-submenu-item-font-size-screen-large: null;
-@sidebar-submenu-item-font-size-screen-jumbo: null;
 
 // Line Height
 
 @sidebar-submenu-item-line-height: 1rem;
-@sidebar-submenu-item-line-height-screen-small: @sidebar-submenu-item-font-size-screen-small;
-@sidebar-submenu-item-line-height-screen-medium: @sidebar-submenu-item-font-size-screen-medium;
-@sidebar-submenu-item-line-height-screen-large: @sidebar-submenu-item-font-size-screen-large;
-@sidebar-submenu-item-line-height-screen-jumbo: @sidebar-submenu-item-font-size-screen-jumbo;
 
 /* Layout */
 
 // Height
 
 @sidebar-submenu-item-height: 36px;
-@sidebar-submenu-item-height-screen-small: null;
-@sidebar-submenu-item-height-screen-medium: null;
-@sidebar-submenu-item-height-screen-large: null;
-@sidebar-submenu-item-height-screen-jumbo: null;
-
-// Margin Top
-
-@sidebar-submenu-item-margin-top: null;
-@sidebar-submenu-item-margin-top-screen-small: null;
-@sidebar-submenu-item-margin-top-screen-medium: null;
-@sidebar-submenu-item-margin-top-screen-large: null;
-@sidebar-submenu-item-margin-top-screen-jumbo: null;
-
-// Margin Bottom
-
-@sidebar-submenu-item-margin-bottom: null;
-@sidebar-submenu-item-margin-bottom-screen-small: null;
-@sidebar-submenu-item-margin-bottom-screen-medium: null;
-@sidebar-submenu-item-margin-bottom-screen-large: null;
-@sidebar-submenu-item-margin-bottom-screen-jumbo: null;
 
 // Margin Left
 
@@ -870,22 +319,6 @@
 @sidebar-submenu-item-margin-right-screen-medium: @sidebar-menu-item-margin-right-screen-medium;
 @sidebar-submenu-item-margin-right-screen-large: @sidebar-menu-item-margin-right-screen-large;
 @sidebar-submenu-item-margin-right-screen-jumbo: @sidebar-menu-item-margin-right-screen-jumbo;
-
-// Padding Top
-
-@sidebar-submenu-item-padding-top: null;
-@sidebar-submenu-item-padding-top-screen-small: null;
-@sidebar-submenu-item-padding-top-screen-medium: null;
-@sidebar-submenu-item-padding-top-screen-large: null;
-@sidebar-submenu-item-padding-top-screen-jumbo: null;
-
-// Padding Bottom
-
-@sidebar-submenu-item-padding-bottom: null;
-@sidebar-submenu-item-padding-bottom-screen-small: null;
-@sidebar-submenu-item-padding-bottom-screen-medium: null;
-@sidebar-submenu-item-padding-bottom-screen-large: null;
-@sidebar-submenu-item-padding-bottom-screen-jumbo: null;
 
 // Padding Left
 
@@ -912,140 +345,24 @@
 // Default
 
 @sidebar-submenu-item-link-color: color-lighten(@neutral, 60);
-@sidebar-submenu-item-link-font-family: null;
-@sidebar-submenu-item-link-font-style: null;
-@sidebar-submenu-item-link-font-weight: null;
-@sidebar-submenu-item-link-text-transform: null;
-@sidebar-submenu-item-link-text-shadow: null;
-@sidebar-submenu-item-link-text-decoration: null;
-@sidebar-submenu-item-link-text-rendering: null;
 @sidebar-submenu-item-link-background-color: color-lighten(@neutral, -30);
-@sidebar-submenu-item-link-background-gradient-color-top: null;
-@sidebar-submenu-item-link-background-gradient-color-bottom: null;
-@sidebar-submenu-item-link-border-width: null;
-@sidebar-submenu-item-link-border-color: null;
-@sidebar-submenu-item-link-border-style: null;
-@sidebar-submenu-item-link-border-top-width: null;
-@sidebar-submenu-item-link-border-top-color: null;
-@sidebar-submenu-item-link-border-top-style: null;
-@sidebar-submenu-item-link-border-right-width: null;
-@sidebar-submenu-item-link-border-right-color: null;
-@sidebar-submenu-item-link-border-right-style: null;
-@sidebar-submenu-item-link-border-bottom-width: null;
-@sidebar-submenu-item-link-border-bottom-color: null;
-@sidebar-submenu-item-link-border-bottom-style: null;
-@sidebar-submenu-item-link-border-left-width: null;
-@sidebar-submenu-item-link-border-left-color: null;
-@sidebar-submenu-item-link-border-left-style: null;
-@sidebar-submenu-item-link-shadow: null;
 
 // Hover
 
 @sidebar-submenu-item-link-hover-color: color-lighten(@neutral, 80);
-@sidebar-submenu-item-link-hover-font-family: null;
-@sidebar-submenu-item-link-hover-font-style: null;
-@sidebar-submenu-item-link-hover-font-weight: null;
-@sidebar-submenu-item-link-hover-text-transform: null;
-@sidebar-submenu-item-link-hover-text-shadow: null;
-@sidebar-submenu-item-link-hover-text-decoration: null;
-@sidebar-submenu-item-link-hover-text-rendering: null;
 @sidebar-submenu-item-link-hover-background-color: color-lighten(@neutral, -10);
-@sidebar-submenu-item-link-hover-background-gradient-color-top: null;
-@sidebar-submenu-item-link-hover-background-gradient-color-bottom: null;
-@sidebar-submenu-item-link-hover-border-width: null;
-@sidebar-submenu-item-link-hover-border-color: null;
-@sidebar-submenu-item-link-hover-border-style: null;
-@sidebar-submenu-item-link-hover-border-top-width: null;
-@sidebar-submenu-item-link-hover-border-top-color: null;
-@sidebar-submenu-item-link-hover-border-top-style: null;
-@sidebar-submenu-item-link-hover-border-right-width: null;
-@sidebar-submenu-item-link-hover-border-right-color: null;
-@sidebar-submenu-item-link-hover-border-right-style: null;
-@sidebar-submenu-item-link-hover-border-bottom-width: null;
-@sidebar-submenu-item-link-hover-border-bottom-color: null;
-@sidebar-submenu-item-link-hover-border-bottom-style: null;
-@sidebar-submenu-item-link-hover-border-left-width: null;
-@sidebar-submenu-item-link-hover-border-left-color: null;
-@sidebar-submenu-item-link-hover-border-left-style: null;
-@sidebar-submenu-item-link-hover-shadow: null;
 
 // Active
 
 @sidebar-submenu-item-link-active-color: color-lighten(@neutral, 60);
-@sidebar-submenu-item-link-active-font-family: null;
-@sidebar-submenu-item-link-active-font-style: null;
-@sidebar-submenu-item-link-active-font-weight: null;
-@sidebar-submenu-item-link-active-text-transform: null;
-@sidebar-submenu-item-link-active-text-shadow: null;
-@sidebar-submenu-item-link-active-text-decoration: null;
-@sidebar-submenu-item-link-active-text-rendering: null;
 @sidebar-submenu-item-link-active-background-color: color-lighten(@neutral, -20);
-@sidebar-submenu-item-link-active-background-gradient-color-top: null;
-@sidebar-submenu-item-link-active-background-gradient-color-bottom: null;
-@sidebar-submenu-item-link-active-border-width: null;
-@sidebar-submenu-item-link-active-border-color: null;
-@sidebar-submenu-item-link-active-border-style: null;
-@sidebar-submenu-item-link-active-border-top-width: null;
-@sidebar-submenu-item-link-active-border-top-color: null;
-@sidebar-submenu-item-link-active-border-top-style: null;
-@sidebar-submenu-item-link-active-border-right-width: null;
-@sidebar-submenu-item-link-active-border-right-color: null;
-@sidebar-submenu-item-link-active-border-right-style: null;
-@sidebar-submenu-item-link-active-border-bottom-width: null;
-@sidebar-submenu-item-link-active-border-bottom-color: null;
-@sidebar-submenu-item-link-active-border-bottom-style: null;
-@sidebar-submenu-item-link-active-border-left-width: null;
-@sidebar-submenu-item-link-active-border-left-color: null;
-@sidebar-submenu-item-link-active-border-left-style: null;
-@sidebar-submenu-item-link-active-shadow: null;
 
 // Selected
 
 @sidebar-submenu-item-link-selected-color: @white;
-@sidebar-submenu-item-link-selected-font-family: null;
-@sidebar-submenu-item-link-selected-font-style: null;
-@sidebar-submenu-item-link-selected-font-weight: null;
-@sidebar-submenu-item-link-selected-text-transform: null;
-@sidebar-submenu-item-link-selected-text-shadow: null;
-@sidebar-submenu-item-link-selected-text-decoration: null;
-@sidebar-submenu-item-link-selected-text-rendering: null;
 @sidebar-submenu-item-link-selected-background-color: @purple;//color-lighten(@neutral, 0);
-@sidebar-submenu-item-link-selected-background-gradient-color-top: null;
-@sidebar-submenu-item-link-selected-background-gradient-color-bottom: null;
-@sidebar-submenu-item-link-selected-border-width: null;
-@sidebar-submenu-item-link-selected-border-color: null;
-@sidebar-submenu-item-link-selected-border-style: null;
-@sidebar-submenu-item-link-selected-border-top-width: null;
-@sidebar-submenu-item-link-selected-border-top-color: null;
-@sidebar-submenu-item-link-selected-border-top-style: null;
-@sidebar-submenu-item-link-selected-border-right-width: null;
-@sidebar-submenu-item-link-selected-border-right-color: null;
-@sidebar-submenu-item-link-selected-border-right-style: null;
-@sidebar-submenu-item-link-selected-border-bottom-width: null;
-@sidebar-submenu-item-link-selected-border-bottom-color: null;
-@sidebar-submenu-item-link-selected-border-bottom-style: null;
-@sidebar-submenu-item-link-selected-border-left-width: null;
-@sidebar-submenu-item-link-selected-border-left-color: null;
-@sidebar-submenu-item-link-selected-border-left-style: null;
-@sidebar-submenu-item-link-selected-shadow: null;
 
 /* Layout */
-
-// Margin Top
-
-@sidebar-submenu-item-link-margin-top: null;
-@sidebar-submenu-item-link-margin-top-screen-small: null;
-@sidebar-submenu-item-link-margin-top-screen-medium: null;
-@sidebar-submenu-item-link-margin-top-screen-large: null;
-@sidebar-submenu-item-link-margin-top-screen-jumbo: null;
-
-// Margin Bottom
-
-@sidebar-submenu-item-link-margin-bottom: null;
-@sidebar-submenu-item-link-margin-bottom-screen-small: null;
-@sidebar-submenu-item-link-margin-bottom-screen-medium: null;
-@sidebar-submenu-item-link-margin-bottom-screen-large: null;
-@sidebar-submenu-item-link-margin-bottom-screen-jumbo: null;
 
 // Margin Left
 
@@ -1062,22 +379,6 @@
 @sidebar-submenu-item-link-margin-right-screen-medium: @sidebar-submenu-item-margin-right-screen-medium;
 @sidebar-submenu-item-link-margin-right-screen-large: @sidebar-submenu-item-margin-right-screen-large;
 @sidebar-submenu-item-link-margin-right-screen-jumbo: @sidebar-submenu-item-margin-right-screen-jumbo;
-
-// Padding Top
-
-@sidebar-submenu-item-link-padding-top: null;
-@sidebar-submenu-item-link-padding-top-screen-small: null;
-@sidebar-submenu-item-link-padding-top-screen-medium: null;
-@sidebar-submenu-item-link-padding-top-screen-large: null;
-@sidebar-submenu-item-link-padding-top-screen-jumbo: null;
-
-// Padding Bottom
-
-@sidebar-submenu-item-link-padding-bottom: null;
-@sidebar-submenu-item-link-padding-bottom-screen-small: null;
-@sidebar-submenu-item-link-padding-bottom-screen-medium: null;
-@sidebar-submenu-item-link-padding-bottom-screen-large: null;
-@sidebar-submenu-item-link-padding-bottom-screen-jumbo: null;
 
 // Padding Left
 


### PR DESCRIPTION
This PR... 
* removes the CNVS mixins used in the sidebar and replaces with the necessary properties
* removes `null` sidebar variables
* removes old CSS for the version info in the sidebar