### PR TITLE
Align declined offers util with Marathon API

### DIFF
--- a/plugins/services/src/js/utils/DeclinedOffersUtil.js
+++ b/plugins/services/src/js/utils/DeclinedOffersUtil.js
@@ -110,10 +110,10 @@ const DecinedOffersUtil = {
     } else {
       requestedResources = {
         roles: Util.findNestedPropertyInObject(
-            app, 'scheduling.placement.acceptedResourceRoles'
+            app, 'acceptedResourceRoles'
           ) || ['*'],
         constraints: Util.findNestedPropertyInObject(
-          app, 'scheduling.placement.constraints'
+          app, 'constraints'
         ) || [],
         cpus: app.cpus || 0,
         mem: app.mem || 0,

--- a/plugins/services/src/js/utils/__tests__/DeclinedOffersUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/DeclinedOffersUtil-test.js
@@ -35,12 +35,8 @@ describe('DeclinedOffersUtil', function () {
           mem: 128,
           disk: 0,
           ports: [10010],
-          scheduling: {
-            placement: {
-              acceptedResourceRoles: ['*'],
-              constraints: [['hostname', 'UNIQUE']]
-            }
-          }
+          constraints: [['hostname', 'UNIQUE']],
+          acceptedResourceRoles: ['*']
         },
         processedOffersSummary: {
           processedOffersCount: 10,


### PR DESCRIPTION
Change the `acceptedResourceRoles` and  `constraints` path to be in line with Marathons app type definition.

For detailed app type definition, please see:
https://github.com/mesosphere/marathon/blob/6db4d9980af15b45bc3c8647335f39deef3f49bf/docs/docs/rest-api/public/api/v2/types/app.raml