### PR TITLE
DCOS-11735: Properly handling Pods in the Service

### DIFF
--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -70,7 +70,7 @@ class NewServiceFormModal extends Component {
   componentWillReceiveProps(nextProps) {
     if (!ServiceUtil.isEqual(this.props.service, nextProps.service)) {
       this.setState({
-        serviceConfig: this.getNormalizedServiceConfig(nextProps.service)
+        serviceConfig: nextProps.service.getSpec()
       });
     }
   }
@@ -362,7 +362,7 @@ class NewServiceFormModal extends Component {
   getResetState(nextProps = this.props) {
     let newState = {
       isJSONModeActive: false,
-      serviceConfig: this.getNormalizedServiceConfig(nextProps.service),
+      serviceConfig: nextProps.service.getSpec(),
       serviceFormActive: false,
       serviceJsonActive: false,
       servicePickerActive: true,
@@ -393,23 +393,6 @@ class NewServiceFormModal extends Component {
         label
       }
     ];
-  }
-
-  /**
-   * Normalize the given `service` instance/config in order to match the
-   * specifications required by the editing/reviewing components
-   *
-   * @param {Pod|Application|Object} service - The service to normalize
-   * @returns {Pod|Application} Returns a pod or an application
-   */
-  getNormalizedServiceConfig(service) {
-    // A Pod is defined by it's specifications, *NOT* by it's state. Therefore
-    // we must extract and operate upon the `PodSpec` from the `Pod`.
-    if (service instanceof Pod) {
-      return service.getSpec();
-    }
-
-    return service;
   }
 
   render() {

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -16,6 +16,7 @@ import NewCreateServiceModalForm from './NewCreateServiceModalForm';
 import CreateServiceJsonOnly from './CreateServiceJsonOnly';
 import Service from '../../structs/Service';
 import ServiceConfigDisplay from '../ServiceConfigDisplay';
+import ServiceUtil from '../../utils/ServiceUtil';
 import ToggleButton from '../../../../../../src/js/components/ToggleButton';
 import Util from '../../../../../../src/js/utils/Util';
 
@@ -60,6 +61,17 @@ class NewServiceFormModal extends Component {
 
     if (shouldClose) {
       this.handleClose();
+    }
+  }
+
+  /**
+   * @override
+   */
+  componentWillReceiveProps(nextProps) {
+    if (!ServiceUtil.isEqual(this.props.service, nextProps.service)) {
+      this.setState({
+        serviceConfig: this.getNormalizedServiceConfig(nextProps.service)
+      });
     }
   }
 
@@ -114,26 +126,6 @@ class NewServiceFormModal extends Component {
     this.setState({isJSONModeActive: !this.state.isJSONModeActive});
   }
 
-  getResetState(nextProps = this.props) {
-    let newState = {
-      isJSONModeActive: false,
-      serviceConfig: nextProps.service,
-      serviceFormActive: false,
-      serviceJsonActive: false,
-      servicePickerActive: true,
-      serviceReviewActive: false,
-      serviceFormHasErrors: false
-    };
-
-    // Switch directly to form if edit
-    if (nextProps.isEdit) {
-      newState.servicePickerActive = false;
-      newState.serviceFormActive = true;
-    }
-
-    return newState;
-  }
-
   handleServiceChange(newService) {
     this.setState({
       serviceConfig: newService
@@ -155,7 +147,7 @@ class NewServiceFormModal extends Component {
           serviceFormActive: true,
           serviceConfig: new Application(
             Object.assign(
-              {id: this.props.service.id},
+              {id: this.props.service.getId()},
               NEW_APP_DEFAULTS
             )
           )
@@ -168,7 +160,7 @@ class NewServiceFormModal extends Component {
           serviceFormActive: true,
           serviceConfig: new Pod(
             Object.assign(
-              {id: this.props.service.id},
+              {id: this.props.service.getId()},
               NEW_POD_DEFAULTS
             )
           )
@@ -367,6 +359,26 @@ class NewServiceFormModal extends Component {
     return [];
   }
 
+  getResetState(nextProps = this.props) {
+    let newState = {
+      isJSONModeActive: false,
+      serviceConfig: this.getNormalizedServiceConfig(nextProps.service),
+      serviceFormActive: false,
+      serviceJsonActive: false,
+      servicePickerActive: true,
+      serviceReviewActive: false,
+      serviceFormHasErrors: false
+    };
+
+    // Switch directly to form if edit
+    if (nextProps.isEdit) {
+      newState.servicePickerActive = false;
+      newState.serviceFormActive = true;
+    }
+
+    return newState;
+  }
+
   getSecondaryActions() {
     let {servicePickerActive, serviceFormActive} = this.state;
     let label = 'Back';
@@ -381,6 +393,23 @@ class NewServiceFormModal extends Component {
         label
       }
     ];
+  }
+
+  /**
+   * Normalize the given `service` instance/config in order to match the
+   * specifications required by the editing/reviewing components
+   *
+   * @param {Pod|Application|Object} service - The service to normalize
+   * @returns {Pod|Application} Returns a pod or an application
+   */
+  getNormalizedServiceConfig(service) {
+    // A Pod is defined by it's specifications, *NOT* by it's state. Therefore
+    // we must extract and operate upon the `PodSpec` from the `Pod`.
+    if (service instanceof Pod) {
+      return service.getSpec();
+    }
+
+    return service;
   }
 
   render() {

--- a/plugins/services/src/js/utils/ServiceUtil.js
+++ b/plugins/services/src/js/utils/ServiceUtil.js
@@ -1,4 +1,6 @@
 import {Hooks} from 'PluginSDK';
+import deepEqual from 'deep-equal';
+
 import Application from '../structs/Application';
 import ApplicationSpec from '../structs/ApplicationSpec';
 import Framework from '../structs/Framework';
@@ -453,8 +455,18 @@ const ServiceUtil = {
   },
 
   createFormModelFromSchema(schema, service = new Application()) {
-
     return getFindPropertiesRecursive(service, schema.properties);
+  },
+
+  isEqual(serviceA, serviceB) {
+    if (serviceA.constructor !== serviceB.constructor) {
+      return false;
+    }
+
+    return deepEqual(
+        this.getServiceJSON(serviceA),
+        this.getServiceJSON(serviceB)
+      );
   },
 
   getDefinitionFromSpec(spec) {

--- a/plugins/services/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceUtil-test.js
@@ -985,4 +985,39 @@ describe('ServiceUtil', function () {
     });
   });
 
+  describe('#isEqual', function () {
+    it('should return false if services have different type', function () {
+      let serviceA = new Application({
+        id: 'foo'
+      });
+      let serviceB = new Pod({
+        id: 'foo'
+      });
+
+      expect(ServiceUtil.isEqual(serviceA, serviceB)).toBeFalsy();
+    });
+
+    it('should return false if same type but diferent content', function () {
+      let serviceA = new Application({
+        id: 'foo'
+      });
+      let serviceB = new Application({
+        id: 'bar'
+      });
+
+      expect(ServiceUtil.isEqual(serviceA, serviceB)).toBeFalsy();
+    });
+
+    it('should return true if same type and same content', function () {
+      let serviceA = new Application({
+        id: 'foo'
+      });
+      let serviceB = new Application({
+        id: 'foo'
+      });
+
+      expect(ServiceUtil.isEqual(serviceA, serviceB)).toBeTruthy();
+    });
+  });
+
 });


### PR DESCRIPTION
This PR ensures that the `NewServiceFormModal` components always work on the correct data. 
In particular, when a `Pod` instance is given, it should operate on it's `PodSpec` contents an not on the `Pod` instance itself. 