### PR TITLE
DCOS-11678: health check review screen

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/HealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/HealthChecks.js
@@ -13,7 +13,7 @@ function mapHealthChecks(item) {
     newItem.protocol = item.protocol;
     if (item.protocol.toUpperCase() === 'COMMAND' && item.command != null) {
       newItem.command = {
-        value: item.command
+        command: item.command
       };
     }
 
@@ -73,16 +73,16 @@ module.exports = {
           this.healthChecks[index].path = value;
         }
         if (`healthChecks.${index}.gracePeriodSeconds` === joinedPath) {
-          this.healthChecks[index].gracePeriodSeconds = value;
+          this.healthChecks[index].gracePeriodSeconds = parseInt(value, 10);
         }
         if (`healthChecks.${index}.intervalSeconds` === joinedPath) {
-          this.healthChecks[index].intervalSeconds = value;
+          this.healthChecks[index].intervalSeconds = parseInt(value, 10);
         }
         if (`healthChecks.${index}.timeoutSeconds` === joinedPath) {
-          this.healthChecks[index].timeoutSeconds = value;
+          this.healthChecks[index].timeoutSeconds = parseInt(value, 10);
         }
         if (`healthChecks.${index}.maxConsecutiveFailures` === joinedPath) {
-          this.healthChecks[index].maxConsecutiveFailures = value;
+          this.healthChecks[index].maxConsecutiveFailures = parseInt(value, 10);
         }
         if (`healthChecks.${index}.https` === joinedPath) {
           this.healthChecks[index].https = value;
@@ -113,12 +113,12 @@ module.exports = {
         'protocol'
       ], item.protocol.toUpperCase(), SET));
       if (item.protocol.toUpperCase() === 'COMMAND') {
-        if (item.command != null && item.command.value != null) {
+        if (item.command != null && item.command.command != null) {
           memo.push(new Transaction([
             'healthChecks',
             index,
             'command'
-          ], item.command.value, SET));
+          ], item.command.command, SET));
         }
       }
       if (item.protocol.toUpperCase().replace('HTTPS', 'HTTP') === 'HTTP') {

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/HealthChecks-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/HealthChecks-test.js
@@ -35,7 +35,7 @@ describe('Labels', function () {
       .toEqual([{
         protocol: 'COMMAND',
         command: {
-          value: 'sleep 1000;'
+          command: 'sleep 1000;'
         }
       }]);
     });

--- a/plugins/services/src/js/service-configuration/HealthChecksServiceConfigSection.js
+++ b/plugins/services/src/js/service-configuration/HealthChecksServiceConfigSection.js
@@ -21,6 +21,7 @@ module.exports = {
         let serviceEndpointHealthChecks = healthChecks.filter(
           (healthCheck) => {
             return healthCheck.protocol === 'HTTP'
+              || healthCheck.protocol === 'HTTPS'
               || healthCheck.protocol === 'TCP';
           }
         );
@@ -103,7 +104,7 @@ module.exports = {
 
               return (
                 <pre className="flush transparent wrap">
-                  {ServiceConfigDisplayUtil.getDisplayValue(command.value)}
+                  {ServiceConfigDisplayUtil.getDisplayValue(command.command)}
                 </pre>
               );
             },

--- a/scripts/pre-install
+++ b/scripts/pre-install
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
-MARATHON_TAG="1.4.0-snap25"
+MARATHON_TAG="1.4.0-snap29"
 
 # Import utils
 source ${SCRIPT_PATH}/utils/git


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/156010/20713173/86504832-b647-11e6-8fe5-c710a27a7caf.png)

This adds the Health checks to the review screen. It also introduces the new format for Command Healthchecks which is for marathon. 1.4.0
```JSON
{
  "protocol": "COMMAND",
  "command": {
    "command": "sleep 100; exit 0"
  }
}
```

Right now the validator will complain that the advanced settings are not set but in the RAML they have a default value provided. I talked offline with @wavesoft and we decided that in that case the values are not required. 