### PR TITLE
DCOS-11743: Networking section IA restructure

### DIFF
--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -28,7 +28,7 @@ const METHODS_TO_BIND = [
 
 const HIDE_BREADCRUMBS = [
   '/jobs/:id/tasks/:taskID/details',
-  '/network/virtual-networks/:overlayName/tasks/:taskID/details',
+  '/networking/networks/:overlayName/tasks/:taskID/details',
   '/nodes/:nodeID/tasks/:taskID/details',
   '/services/overview/:id/tasks/:taskID/details',
   '/services/overview/:id/tasks/:taskID/logs(/:fileName)'

--- a/plugins/services/src/js/schemas/service-schema/Networking.js
+++ b/plugins/services/src/js/schemas/service-schema/Networking.js
@@ -51,7 +51,7 @@ const Networking = {
       }
     },
     ports: {
-      title: 'Service Endpoints',
+      title: 'Service Addresses',
       description: (
         <span>
           Configure the ports and endpoints you would like to use to talk to your service, or we can assign a random port for you. <a href="https://docs.mesosphere.com/overview/service-discovery/" target="_blank">Learn more about ports</a>.

--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -26,7 +26,7 @@ let defaultMenuItems = [
   '/jobs',
   '/universe',
   '/nodes',
-  '/network',
+  '/networking',
   '/security',
   '/cluster',
   '/components',

--- a/src/js/pages/NetworkPage.js
+++ b/src/js/pages/NetworkPage.js
@@ -14,9 +14,9 @@ import TabsUtil from '../utils/TabsUtil';
 import TabsMixin from '../mixins/TabsMixin';
 
 let DEFAULT_NETWORK_TABS = {
-  '/network/virtual-networks': {
-    content: 'Virtual Networks',
-    priority: 10
+  '/networking/networks': {
+    content: 'Networks',
+    priority: 20
   }
 };
 
@@ -33,7 +33,7 @@ class NetworkPage extends mixin(TabsMixin) {
     );
 
     // Add filter to register default tab for Overview Tab
-    Hooks.addFilter('virtual-networks-subtabs', function (tabs) {
+    Hooks.addFilter('networks-subtabs', function (tabs) {
       return Object.assign(tabs, DEFAULT_NETWORK_SUB_TABS);
     });
 
@@ -155,7 +155,7 @@ NetworkPage.contextTypes = {
 NetworkPage.routeConfig = {
   label: 'Networking',
   icon: <Icon id="network-hierarchical-inverse" size="small" family="small" />,
-  matches: /^\/network/
+  matches: /^\/networking/
 };
 
 NetworkPage.willTransitionTo = function () {

--- a/src/js/pages/network/VirtualNetworksTab.js
+++ b/src/js/pages/network/VirtualNetworksTab.js
@@ -116,7 +116,7 @@ class VirtualNetworksTabContent extends mixin(StoreMixin) {
       <div>
         <FilterHeadline
           onReset={this.resetFilter}
-          name="Virtual Network"
+          name="Network"
           currentLength={filteredOverlayList.getItems().length}
           totalLength={overlayList.getItems().length} />
         <FilterBar>
@@ -140,8 +140,8 @@ class VirtualNetworksTabContent extends mixin(StoreMixin) {
 }
 
 VirtualNetworksTabContent.routeConfig = {
-  label: 'Virtual Networks',
-  matches: /^\/network\/virtual-networks/
+  label: 'Networks',
+  matches: /^\/networking\/networks/
 };
 
 module.exports = VirtualNetworksTabContent;

--- a/src/js/pages/network/VirtualNetworksTable.js
+++ b/src/js/pages/network/VirtualNetworksTable.js
@@ -6,9 +6,9 @@ import {Table} from 'reactjs-components';
 import OverlayList from '../../structs/OverlayList';
 
 const headerMapping = {
-  name: 'VIRTUAL NETWORK NAME',
-  subnet: 'SUBNET',
-  prefix: 'AGENT PREFIX LENGTH'
+  name: 'Name',
+  subnet: 'Subnet',
+  prefix: 'Agent Prefix Length'
 };
 
 class VirtualNetworksTable extends React.Component {
@@ -70,7 +70,7 @@ class VirtualNetworksTable extends React.Component {
       <Link
         className="table-cell-link-primary"
         title={overlayName}
-        to={`/network/virtual-networks/${overlayName}`}>
+        to={`/networking/networks/${overlayName}`}>
         {overlayName}
       </Link>
     );

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
@@ -31,8 +31,8 @@ class VirtualNetworkDetail extends mixin(StoreMixin, TabsMixin) {
 
     // Virtual Network Detail Tabs
     this.tabs_tabs = {
-      '/network/virtual-networks/:overlayName': 'Tasks',
-      '/network/virtual-networks/:overlayName/details': 'Details'
+      '/networking/networks/:overlayName': 'Tasks',
+      '/networking/networks/:overlayName/details': 'Details'
     };
 
     this.store_listeners = [

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
@@ -165,7 +165,7 @@ class VirtualNetworkTaskTab extends mixin(StoreMixin) {
         className={classes}
         key={value}
         title={title}
-        to={`/network/virtual-networks/${overlayName}/tasks/${taskID}`}>
+        to={`/networking/networks/${overlayName}/tasks/${taskID}`}>
         {value}
       </Link>
     );

--- a/src/js/routes/factories/network.js
+++ b/src/js/routes/factories/network.js
@@ -20,15 +20,15 @@ let RouteFactory = {
     let virtualNetworksRoute = [
       {
         type: Route,
-        path: 'virtual-networks',
+        path: 'networks',
         component: VirtualNetworksTab,
         isInSidebar: true,
         buildBreadCrumb() {
           return {
             getCrumbs() {
               return [{
-                label: 'Virtual Networks',
-                route: {to: '/network/virtual-networks'}
+                label: 'Networks',
+                route: {to: '/networking/networks'}
               }];
             }
           };
@@ -36,7 +36,7 @@ let RouteFactory = {
       },
       {
         type: Route,
-        path: 'virtual-networks/:overlayName',
+        path: 'networks/:overlayName',
         component: VirtualNetworkDetail,
         children: [
           {
@@ -45,14 +45,14 @@ let RouteFactory = {
             hideHeaderNavigation: true,
             buildBreadCrumb() {
               return {
-                parentCrumb: '/network/virtual-networks',
+                parentCrumb: '/networking/networks',
                 getCrumbs(params) {
                   let {overlayName} = params;
 
                   return [{
                     label: overlayName,
                     route: {
-                      to: '/network/virtual-networks/:overlayName',
+                      to: '/networking/networks/:overlayName',
                       params: {overlayName}
                     }
                   }];
@@ -67,14 +67,14 @@ let RouteFactory = {
             hideHeaderNavigation: true,
             buildBreadCrumb() {
               return {
-                parentCrumb: '/network/virtual-networks',
+                parentCrumb: '/networking/networks',
                 getCrumbs(params) {
                   let {overlayName} = params;
 
                   return [{
                     label: overlayName,
                     route: {
-                      to: '/network/virtual-networks/:overlayName',
+                      to: '/networking/networks/:overlayName',
                       params: {overlayName}
                     }
                   }];
@@ -86,17 +86,17 @@ let RouteFactory = {
       },
       {
         type: Redirect,
-        path: '/network/virtual-networks/:overlayName/tasks/:taskID',
-        to: '/network/virtual-networks/:overlayName/tasks/:taskID/details'
+        path: '/networking/networks/:overlayName/tasks/:taskID',
+        to: '/networking/networks/:overlayName/tasks/:taskID/details'
       },
       {
         type: Route,
-        path: 'virtual-networks/:overlayName/tasks/:taskID',
+        path: 'networks/:overlayName/tasks/:taskID',
         component: TaskDetail,
         hideHeaderNavigation: true,
         buildBreadCrumb() {
           return {
-            parentCrumb: '/network/virtual-networks/:overlayName/tasks',
+            parentCrumb: '/networking/networks/:overlayName/tasks',
             getCrumbs(params) {
               return [{label: params.taskID}];
             }
@@ -112,14 +112,14 @@ let RouteFactory = {
             type: Route,
             buildBreadCrumb() {
               return {
-                parentCrumb: '/network/virtual-networks/:overlayName/tasks/:taskID',
+                parentCrumb: '/networking/networks/:overlayName/tasks/:taskID',
                 getCrumbs() { return []; }
               };
             }
           },
           {
             component: TaskFilesTab,
-            fileViewerRoutePath: '/network/virtual-networks/:overlayName/tasks/:taskID/view(/:filePath(/:innerPath))',
+            fileViewerRoutePath: '/networking/networks/:overlayName/tasks/:taskID/view(/:filePath(/:innerPath))',
             hideHeaderNavigation: true,
             isTab: true,
             path: 'files',
@@ -127,7 +127,7 @@ let RouteFactory = {
             type: Route,
             buildBreadCrumb() {
               return {
-                parentCrumb: '/network/virtual-networks/:overlayName/tasks/:taskID',
+                parentCrumb: '/networking/networks/:overlayName/tasks/:taskID',
                 getCrumbs() { return []; }
               };
             }
@@ -142,7 +142,7 @@ let RouteFactory = {
             type: Route,
             buildBreadCrumb() {
               return {
-                parentCrumb: '/network/virtual-networks/:overlayName/tasks/:taskID',
+                parentCrumb: '/networking/networks/:overlayName/tasks/:taskID',
                 getCrumbs() { return []; }
               };
             }
@@ -157,8 +157,8 @@ let RouteFactory = {
       routes: virtualNetworksRoute,
       redirect: {
         type: Redirect,
-        from: '/network',
-        to: '/network/virtual-networks'
+        from: '/networking',
+        to: '/networking/networks'
       }
     });
   },
@@ -171,7 +171,7 @@ let RouteFactory = {
       redirect,
       {
         type: Route,
-        path: 'network',
+        path: 'networking',
         component: NetworkPage,
         category: 'resources',
         isInSidebar: true,

--- a/src/js/utils/VirtualNetworkUtil.js
+++ b/src/js/utils/VirtualNetworkUtil.js
@@ -14,8 +14,8 @@ const VirtualNetworkUtil = {
         icon={<Icon id="network-hierarchical" color="neutral" size="jumbo" />}>
         <p className="flush">
           {'Could not find the requested virtual network. Go to '}
-          <Link to="/network/virtual-networks">
-            Virtual Networks
+          <Link to="/networking/networks">
+            Networks
           </Link> overview to see all virtual networks.
         </p>
       </AlertPanel>


### PR DESCRIPTION
⛔️  Blocks https://github.com/mesosphere/dcos-ui-plugins-private/pull/463

---

This PR changes strings and reorganizes the sidebar to match the latest mockups.

The following routes have been renamed:
`/network/` -> `/networking/`
`/network/virtual-networks/` -> `/networking/networks/`