### PR TITLE
Reduce tooltip font size

### DIFF
--- a/src/styles/components/tooltip/styles.less
+++ b/src/styles/components/tooltip/styles.less
@@ -7,6 +7,7 @@
       background: @tooltip-background-color;
       border-radius: 2px;
       color: @white;
+      font-size: 0.9rem;
       padding: 0.8rem 1rem;
 
       &:after {

--- a/src/styles/components/tooltip/styles.less
+++ b/src/styles/components/tooltip/styles.less
@@ -5,10 +5,10 @@
 
     .tooltip-content {
       background: @tooltip-background-color;
-      border-radius: 2px;
+      border-radius: @tooltip-border-radius;
       color: @white;
-      font-size: 0.9rem;
-      padding: 0.8rem 1rem;
+      font-size: @tooltip-font-size;
+      padding: @tooltip-padding-vertical @tooltip-padding-horizontal;
 
       &:after {
         border-color: @tooltip-background-color;

--- a/src/styles/components/tooltip/variables.less
+++ b/src/styles/components/tooltip/variables.less
@@ -5,3 +5,10 @@
  */
 
 @tooltip-background-color: #3a3c47;
+@tooltip-border-radius: 2px;
+
+@tooltip-font-size: 0.9rem;
+@tooltip-line-height: 1rem;
+
+@tooltip-padding-horizontal: 1rem;
+@tooltip-padding-vertical: 0.8rem;


### PR DESCRIPTION
These tooltips were obnoxiously huge IMO. @ashenden @leemunroe What do you think?

Before:
![](https://cl.ly/1N281h073I0j/Screen%20Shot%202016-11-29%20at%205.22.31%20PM.png)

After:
![](https://cl.ly/28110m2h2Y1m/Screen%20Shot%202016-11-29%20at%205.21.38%20PM.png)