### PR TITLE
Update reactjs-components to 0.16.0-beta.5

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6684,9 +6684,9 @@
       "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz"
     },
     "reactjs-components": {
-      "version": "0.16.0-beta.2",
-      "from": "reactjs-components@0.16.0-beta.2",
-      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.16.0-beta.2.tgz"
+      "version": "0.16.0-beta.5",
+      "from": "reactjs-components@0.16.0-beta.5",
+      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.16.0-beta.5.tgz"
     },
     "reactjs-mixin": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-gemini-scrollbar": "2.1.0",
     "react-redux": "4.4.0",
     "react-router": "2.8.1",
-    "reactjs-components": "0.16.0-beta.2",
+    "reactjs-components": "0.16.0-beta.5",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
     "tv4": "1.2.7",


### PR DESCRIPTION
Notable changes:
* Toggle display property for caret (https://github.com/mesosphere/reactjs-components/commit/d0b7d6902e4bfa156ce930300ba0e6a47553dee6)
* Making modals stack on top of each other when multiple are open (https://github.com/mesosphere/reactjs-components/commit/5507ed47161bd2aa3ae56041acbf279e78682b1d)
* Allow setting classes on Gemini in Modals (https://github.com/mesosphere/reactjs-components/commit/40f97303078943127ce5db27f55845818574ad3c)
* Allow passing height to ModalContents (https://github.com/mesosphere/reactjs-components/commit/bb265d92243cfc97a747cb6486d6fbd486444e73)
* Add block class for tooltip (https://github.com/mesosphere/reactjs-components/commit/68e34d04ab90dd52a488c1a2ff080075012044ee)