### PR TITLE
DCOS-11792: Remove pods language and button from UI

### DIFF
--- a/plugins/services/src/js/components/modals/NewCreateServiceModalServicePicker.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalServicePicker.js
@@ -28,12 +28,6 @@ class NewCreateServiceModalServicePicker extends React.Component {
       type: 'app'
     }, {
       icon: (
-        <Image fallbackSrc={defaultServiceImage} src={defaultServiceImage} />
-      ),
-      label: 'Multi-Container (Pod)',
-      type: 'pod'
-    }, {
-      icon: (
         <Image fallbackSrc={jsonServiceImage} src={jsonServiceImage} />
       ),
       label: 'JSON Configuration',
@@ -63,14 +57,14 @@ class NewCreateServiceModalServicePicker extends React.Component {
   }
 
   getServiceDeployOptions() {
+    // TODO: Implement the correct copy when received. DCOS-11807
     return (
       <div className="create-service-modal-service-picker container text-align-center">
         <h4 className="short flush-top">
           Run your own Service
         </h4>
-        <p className="tall">
-          Create service from one or more containers, run a command, or run from
-          Docker Compose.
+        <p className="lead tall">
+          Create a service from a container or compose a custom JSON configuration.
         </p>
         {this.getCustomServiceGrid()}
       </div>

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalServicePicker.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalServicePicker.js
@@ -24,13 +24,13 @@ class NewCreateServiceModalServicePicker extends React.Component {
       icon: (
         <Image fallbackSrc={defaultServiceImage} src={defaultServiceImage} />
       ),
-      label: 'Container Service',
+      label: 'Use the Form',
       type: 'app'
     }, {
       icon: (
         <Image fallbackSrc={jsonServiceImage} src={jsonServiceImage} />
       ),
-      label: 'JSON Configuration',
+      label: 'Enter JSON',
       type: 'json'
     }].map((item, index) => {
       return this.getServiceOption(
@@ -64,7 +64,7 @@ class NewCreateServiceModalServicePicker extends React.Component {
           Run your own Service
         </h4>
         <p className="lead tall">
-          Create a service from a container or compose a custom JSON configuration.
+          Create a containerized service or run a command in one of two ways: use our form to be guided through the correct configuration, or enter your JSON configuration directly.
         </p>
         {this.getCustomServiceGrid()}
       </div>


### PR DESCRIPTION
This PR removes the `Multi-Container (Pod)` option from the UI and updates the language accordingly.

![](https://cl.ly/0N3l1Y0K0J2d/Screen%20Shot%202016-11-30%20at%204.10.41%20PM.png)