### PR TITLE
Fix modal header borders

### DIFF
--- a/src/styles/components/modal/login/styles.less
+++ b/src/styles/components/modal/login/styles.less
@@ -6,9 +6,8 @@
       overflow: visible;
 
       .modal-header,
-      .modal-body,
       .modal-footer {
-        box-shadow: none;
+        border: none;
       }
 
       .modal-header {

--- a/src/styles/components/modal/variables.less
+++ b/src/styles/components/modal/variables.less
@@ -1,5 +1,1 @@
 @modal-enabled: true;
-
-// Override CVNS' default box-shadow which is outside of the header and can be
-// covered up by other elements.
-@modal-header-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
CNVS now uses `border` instead of `box-shadow` for the separations between a modal's header and footer.

This PR removes an outdated variable override which caused a `box-shadow` to render in addition to the `border`.

It also removes the overrides in the login modal to reflect the new properties.