### PR TITLE
Create text transformation classes

### DIFF
--- a/plugins/services/src/js/schemas/service-schema/EnvironmentVariables.js
+++ b/plugins/services/src/js/schemas/service-schema/EnvironmentVariables.js
@@ -39,7 +39,7 @@ let EnvironmentVariables = {
       itemShape: {
         properties: {
           key: {
-            inputClass: 'form-control upper-cased',
+            inputClass: 'form-control text-uppercase',
             title: 'Key',
             type: 'string'
           },

--- a/src/js/components/form/FieldHelp.js
+++ b/src/js/components/form/FieldHelp.js
@@ -4,8 +4,15 @@ import React from 'react';
 import {omit} from '../../utils/Util';
 
 const FieldHelp = (props) => {
-  let {className} = props;
-  let classes = classNames('small flush-bottom', className);
+  let {className, textTransform} = props;
+  let classes = classNames(
+    'small flush-bottom',
+    className,
+    {
+      'text-uppercase': textTransform === 'uppercase',
+      'text-no-transform': textTransform === 'none'
+    }
+  );
 
   return (
     <p
@@ -14,13 +21,18 @@ const FieldHelp = (props) => {
   );
 };
 
+FieldHelp.defaultProps = {
+  textTransform: 'none'
+};
+
 FieldHelp.propTypes = {
   // Classes
   className: React.PropTypes.oneOfType([
     React.PropTypes.array,
     React.PropTypes.object,
     React.PropTypes.string
-  ])
+  ]),
+  textTransform: React.PropTypes.oneOf(['none', 'uppercase'])
 };
 
 module.exports = FieldHelp;

--- a/src/styles/components/typography/styles.less
+++ b/src/styles/components/typography/styles.less
@@ -136,8 +136,11 @@
     word-wrap: break-word;
   }
 
-  // TODO: Audit the need for this upper-cased class.
-  .upper-cased {
+  .text-uppercase {
     text-transform: uppercase;
+  }
+
+  .text-no-transform {
+    text-transform: none;
   }
 }


### PR DESCRIPTION
This PR...
* Adds the `textTransform` prop to `FieldHelp` and defaults to `none`
* Renames the `upper-cased` class to `text-uppercase` to better match related classes
* Introduces `text-no-transform` to remove text transformation when needed