### PR TITLE
Make layout classes optional in ServiceConfigDisplay

### DIFF
--- a/plugins/services/src/js/components/ServiceConfigDisplay.js
+++ b/plugins/services/src/js/components/ServiceConfigDisplay.js
@@ -73,15 +73,11 @@ class ServiceConfigDisplay extends React.Component {
 
   render() {
     return (
-      <div className="flex-item-grow-1">
-        <div className="container">
-          <ConfigurationMap>
-            <MountService.Mount
-              type={this.getMountType()}
-              appConfig={this.props.appConfig} />
-          </ConfigurationMap>
-        </div>
-      </div>
+      <ConfigurationMap>
+        <MountService.Mount
+          type={this.getMountType()}
+          appConfig={this.props.appConfig} />
+      </ConfigurationMap>
     );
   };
 }

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -242,7 +242,13 @@ class NewServiceFormModal extends Component {
   getModalContent() {
     // NOTE: Always prioritize review screen check
     if (this.state.serviceReviewActive) {
-      return <ServiceConfigDisplay appConfig={this.state.serviceConfig} />;
+      return (
+        <div className="flex-item-grow-1">
+          <div className="container">
+            <ServiceConfigDisplay appConfig={this.state.serviceConfig} />
+          </div>
+        </div>
+      );
     }
 
     if (this.state.servicePickerActive) {


### PR DESCRIPTION
This PR removes layout divs from the `ServiceConfigDisplay` component so that its parent can use whatever it wants.