### PR TITLE
DCOS-11759: [2/2] disable fields in Container, Health Checks and Volumes section

### DIFF
--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -280,7 +280,7 @@ class ContainerServiceFormSection extends Component {
           wrapText={true}>
             <FieldLabel>
               {'Container Image'}
-              <Icon color="grey" id="lock" size="mini" family="mini" />
+              <Icon color="grey" id="lock" size="mini" />
             </FieldLabel>
         </Tooltip>,
         <FieldInput

--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -151,13 +151,13 @@ class ContainerServiceFormSection extends Component {
               disabled={true}
               value={settingName}/>
             <Tooltip
-                content={dockerOnly}
-                interactive={true}
-                maxWidth={300}
-                scrollContainer=".gm-scroll-view"
-                wrapText={true}>
-              {label}
-              <Icon color="grey" id="lock" size="mini" family="mini"/>
+              content={dockerOnly}
+              interactive={true}
+              maxWidth={300}
+              scrollContainer=".gm-scroll-view"
+              wrapText={true}>
+                {label}
+                <Icon color="grey" id="lock" size="mini" family="mini"/>
             </Tooltip>
             <FieldHelp>{helpText}</FieldHelp>
           </FieldLabel>
@@ -272,22 +272,22 @@ class ContainerServiceFormSection extends Component {
         container.type === NONE) {
       return [
         <Tooltip
-            key="container-image-input-tooltip"
-            content="Mesos Runtime does not support container images, please select Docker Runtime or Universal Container Runtime if you want to use container images."
-            interactive={true}
-            maxWidth={300}
-            scrollContainer=".gm-scroll-view"
-            wrapText={true}>
-          <FieldLabel>
-            {'Container Image'}
-            <Icon color="grey" id="lock" size="mini" family="mini" />
-          </FieldLabel>
+          key="container-image-input-tooltip"
+          content="Mesos Runtime does not support container images, please select Docker Runtime or Universal Container Runtime if you want to use container images."
+          interactive={true}
+          maxWidth={300}
+          scrollContainer=".gm-scroll-view"
+          wrapText={true}>
+            <FieldLabel>
+              {'Container Image'}
+              <Icon color="grey" id="lock" size="mini" family="mini" />
+            </FieldLabel>
         </Tooltip>,
         <FieldInput
-            key="container-image-input"
-            name="container.docker.image"
-            disabled={true}
-            value={image} />
+          key="container-image-input"
+          name="container.docker.image"
+          disabled={true}
+          value={image} />
       ];
     }
 
@@ -324,8 +324,8 @@ class ContainerServiceFormSection extends Component {
 
           <FormGroup
             className="column-3"
-             required={true}
-             showError={Boolean(errors.cpus)}>
+            required={true}
+            showError={Boolean(errors.cpus)}>
             <FieldLabel>
               CPUs
             </FieldLabel>

--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -16,16 +16,19 @@ import MetadataStore from '../../../../../../src/js/stores/MetadataStore';
 import Icon from '../../../../../../src/js/components/Icon';
 import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
 
-const {DOCKER} = ContainerConstants.type;
+const {DOCKER, NONE, MESOS} = ContainerConstants.type;
 
 const containerSettings = {
   privileged: {
     label: <span>Grant Runtime Privileges</span>,
-    helpText: 'By default, containers are “unprivileged” and cannot, for example, run a Docker daemon inside a Docker container.'
+    helpText: 'By default, containers are “unprivileged” and cannot, for example, run a Docker daemon inside a Docker container.',
+    dockerOnly: 'Grant runtime privileges is only supported in Docker Runtime.'
+
   },
   forcePullImage: {
     label: <span>Force Pull Image On Launch</span>,
-    helpText: 'Force Docker to pull the image before launching each task.'
+    helpText: 'Force Docker to pull the image before launching each task.',
+    dockerOnly: 'Force pull image on launch is only supported in Docker Runtime.'
   }
 };
 
@@ -96,7 +99,7 @@ class ContainerServiceFormSection extends Component {
   }
 
   getGPUSInput(data) {
-    if (data.container && data.container.type === DOCKER) {
+    if (data.container && data.container.type !== MESOS) {
       return [
         <Tooltip
           key="gpus-input-tooltip"
@@ -132,11 +135,34 @@ class ContainerServiceFormSection extends Component {
     let {container = {}} = data;
     let typeErrors = errors.container && errors.container.type;
     let selections = Object.keys(containerSettings).map((settingName, index) => {
-      let {helpText, label} = containerSettings[settingName];
+      let {helpText, label, dockerOnly} = containerSettings[settingName];
       let checked = findNestedPropertyInObject(
         container,
         `docker.${settingName}`
       );
+
+      if (container && container.type !== DOCKER) {
+        return (
+          <FieldLabel>
+            <FieldInput
+              checked={false}
+              name={`container.docker.${settingName}`}
+              type="checkbox"
+              disabled={true}
+              value={settingName}/>
+            <Tooltip
+                content={dockerOnly}
+                interactive={true}
+                maxWidth={300}
+                scrollContainer=".gm-scroll-view"
+                wrapText={true}>
+              {label}
+              <Icon color="grey" id="lock" size="mini" family="mini"/>
+            </Tooltip>
+            <FieldHelp>{helpText}</FieldHelp>
+          </FieldLabel>
+        );
+      }
 
       return (
         <FieldLabel key={index}>
@@ -238,11 +264,47 @@ class ContainerServiceFormSection extends Component {
     );
   }
 
+  getImageInput(data) {
+    let {container = {}} = data;
+    let image = findNestedPropertyInObject(container, 'docker.image');
+
+    if (container == null || container.type == null ||
+        container.type === NONE) {
+      return [
+        <Tooltip
+            key="container-image-input-tooltip"
+            content="Mesos Runtime does not support container images, please select Docker Runtime or Universal Container Runtime if you want to use container images."
+            interactive={true}
+            maxWidth={300}
+            scrollContainer=".gm-scroll-view"
+            wrapText={true}>
+          <FieldLabel>
+            {'Container Image'}
+            <Icon color="grey" id="lock" size="mini" family="mini" />
+          </FieldLabel>
+        </Tooltip>,
+        <FieldInput
+            key="container-image-input"
+            name="container.docker.image"
+            disabled={true}
+            value={image} />
+      ];
+    }
+
+    return [
+      this.getImageLabel(),
+      <FieldInput
+        name="container.docker.image"
+        value={image} />,
+      <FieldHelp>
+        Enter a Docker image you want to run, e.g. nginx.
+      </FieldHelp>
+    ];
+  }
+
   render() {
     let {data, errors} = this.props;
 
-    let {container = {}} = data;
-    let image = findNestedPropertyInObject(container, 'docker.image');
     let imageErrors = findNestedPropertyInObject(
       errors,
       'container.docker.image'
@@ -256,13 +318,7 @@ class ContainerServiceFormSection extends Component {
         <p>Configure your container below. Enter a container image or command you want to run.</p>
         <div className="flex row">
           <FormGroup className="column-6" showError={Boolean(imageErrors)}>
-            {this.getImageLabel()}
-            <FieldInput
-              name="container.docker.image"
-              value={image} />
-            <FieldHelp>
-              Enter a Docker image you want to run, e.g. nginx.
-            </FieldHelp>
+            {this.getImageInput(data)}
             <FieldError>{imageErrors}</FieldError>
           </FormGroup>
 

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -27,6 +27,7 @@ describe('Container', function () {
 
     it('creates new container info when there is nothing', function () {
       let batch = new Batch();
+      batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
       batch = batch.add(
           new Transaction(['container', 'docker', 'image'], 'foo', SET)
       );
@@ -53,6 +54,7 @@ describe('Container', function () {
 
     it('sets privileged correctly', function () {
       let batch = new Batch();
+      batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
       batch = batch.add(
         new Transaction(['container', 'docker', 'privileged'], true, SET)
       );
@@ -63,11 +65,12 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({docker: {image: 'foo', privileged: true}});
+      )).toEqual({type: 'DOCKER', docker: {image: 'foo', privileged: true}});
     });
 
     it('sets privileged correctly to false', function () {
       let batch = new Batch();
+      batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
       batch = batch.add(
           new Transaction(['container', 'docker', 'image'], 'foo', SET)
       );
@@ -78,11 +81,12 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({docker: {image: 'foo', privileged: false}});
+      )).toEqual({type: 'DOCKER', docker: {image: 'foo', privileged: false}});
     });
 
     it('doesn\'t set privileged if path doesn\'t match type', function () {
       let batch = new Batch();
+      batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
       batch = batch.add(
           new Transaction(['container', 'docker', 'image'], 'foo', SET)
       );
@@ -93,11 +97,12 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({docker: {image: 'foo'}});
+      )).toEqual({type: 'DOCKER', docker: {image: 'foo'}});
     });
 
     it('sets forcePullImage correctly', function () {
       let batch = new Batch();
+      batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
       batch = batch.add(
           new Transaction(['container', 'docker', 'image'], 'foo', SET)
       );
@@ -108,11 +113,12 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({docker: {image: 'foo', forcePullImage: true}});
+      )).toEqual({type: 'DOCKER', docker: {image: 'foo', forcePullImage: true}});
     });
 
     it('sets forcePullImage correctly to false', function () {
       let batch = new Batch();
+      batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
       batch = batch.add(
         new Transaction(['container', 'docker', 'forcePullImage'], false, SET)
       );
@@ -123,7 +129,7 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({docker: {image: 'foo', forcePullImage: false}});
+      )).toEqual({type: 'DOCKER', docker: {image: 'foo', forcePullImage: false}});
     });
 
     it('doesn\'t set forcePullImage if path doesn\'t match type', function () {
@@ -140,6 +146,7 @@ describe('Container', function () {
 
     it('sets image correctly', function () {
       let batch = new Batch();
+      batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
       batch = batch.add(
         new Transaction(['container', 'docker', 'image'], 'foo', SET)
       );
@@ -147,11 +154,12 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({docker: {image: 'foo'}});
+      )).toEqual({type: 'DOCKER', docker: {image: 'foo'}});
     });
 
     it('changes image value correctly', function () {
       let batch = new Batch();
+      batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
       batch = batch.add(
         new Transaction(['container', 'docker', 'image'], 'bar', SET)
       );
@@ -159,7 +167,7 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({docker: {image: 'bar'}});
+      )).toEqual({type: 'DOCKER', docker: {image: 'bar'}});
     });
 
     it('doesn\'t set image if path doesn\'t match type', function () {


### PR DESCRIPTION
This PR introduces a feature where certain fields are disabled depending on the runtime environment. This needs also to be applied to the networking section as soon as it is done.

Mesos Runtime
![image](https://cloud.githubusercontent.com/assets/156010/20796513/c46e0100-b7d6-11e6-91af-fff4c571b1fc.png)
UCR Runtime:
![image](https://cloud.githubusercontent.com/assets/156010/20796520/cbb33c1e-b7d6-11e6-9796-5410bca0f676.png)
Docker Runtime:
![image](https://cloud.githubusercontent.com/assets/156010/20796532/d3903ca2-b7d6-11e6-9809-95cf4d5ac98d.png)
