### PR TITLE
DCOS-11813: Fix edit pod interaction

### DIFF
--- a/plugins/services/src/js/utils/ServiceUtil.js
+++ b/plugins/services/src/js/utils/ServiceUtil.js
@@ -464,9 +464,10 @@ const ServiceUtil = {
       return false;
     }
 
+    // Only compare the service specs as everything else is status data
     return deepEqual(
-        this.getServiceJSON(serviceA),
-        this.getServiceJSON(serviceB)
+        serviceA.getSpec(),
+        serviceB.getSpec()
       );
   },
 


### PR DESCRIPTION
---

⚠️  #1450 needs to land first

---

This PR changes the service `isEqual` util, to only compare the service specs as everything else is status information and bound to frequent changes. Without this change we end up with unwanted updates of the service form which sometimes resulted in data loss.

Closes DCOS-11813