### PR TITLE
Fix pod env review section

### DIFF
--- a/plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.js
@@ -32,7 +32,7 @@ module.exports = ({appConfig}) => {
   }, combinedEnv);
 
   if (!combinedEnv.length) {
-    return null;
+    return <noscript />;
   }
 
   return (

--- a/plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.js
@@ -8,6 +8,10 @@ import ServiceConfigDisplayUtil from '../utils/ServiceConfigDisplayUtil';
 module.exports = ({appConfig}) => {
   let {environment={}, containers=[]} = appConfig;
 
+  if (!environment || !containers) {
+    return <noscript />;
+  }
+
   let combinedEnv = Object.keys(environment).reduce((memo, key) => {
     memo.push({
       key: <code>{key}</code>,


### PR DESCRIPTION
Return `<noscript />` if no env is defined as functional components always need to return something in order to properly update.