### PR TITLE
Fix Sidebar z-index

### DIFF
--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -316,14 +316,14 @@ var Sidebar = React.createClass({
 
     if (SidebarStore.get('isVisible')) {
       overlay = (
-        <div className="sidebar-overlay" onClick={this.handleOverlayClick} />
+        <div className="sidebar-backdrop" onClick={this.handleOverlayClick} />
       );
     }
 
     return (
       <div className="sidebar-wrapper">
         <CSSTransitionGroup
-          transitionName="sidebar-overlay"
+          transitionName="sidebar-backdrop"
           transitionEnterTimeout={250}
           transitionLeaveTimeout={250}>
           {overlay}

--- a/src/styles/layout/sidebar/styles.less
+++ b/src/styles/layout/sidebar/styles.less
@@ -44,9 +44,14 @@
     }
   }
 
-  .sidebar-overlay {
-    &:extend(.modal-backdrop);
+  .sidebar-backdrop {
+    background: @modal-backdrop-background-color;
+    height: 100%;
+    left: 0;
+    position: fixed;
+    top: 0;
     transition: opacity 0.25s;
+    width: 100%;
     z-index: @z-index-sidebar-overlay;
 
     &-enter {

--- a/src/styles/variables/variables-z-index.less
+++ b/src/styles/variables/variables-z-index.less
@@ -20,7 +20,7 @@
 @z-index-side-panel: 2000;
 @z-index-side-panel-container: @z-index-side-panel + 4;
 @z-index-side-panel-expand-button: @z-index-side-panel + 10;
-@z-index-sidebar-overlay: @z-index-modal-backdrop + 1;
+@z-index-sidebar-overlay: 1;
 @z-index-sidebar: @z-index-sidebar-overlay + 1;
 @z-index-tooltip: @z-index-modal-container + 1;
 // The error message comes in 'body' and 'modal' varieties


### PR DESCRIPTION
This PR fixes the Sidebar z-index issue. I also renamed `sidebar-overlay` to `sidebar-backdrop` to match the same concept in the `Modal`.

I removed the use of `extend` because the `modal-backdrop` is defined higher in the source order than `sidebar-backdrop`, so the specificity was impossible to override without `!important` and I would feel gross for doing that.