### PR TITLE
DCOS-11823: Fix PodInstancesTable layout

### DIFF
--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
@@ -16,6 +16,18 @@ import PodUtil from '../../utils/PodUtil';
 import TimeAgo from '../../../../../../src/js/components/TimeAgo';
 import Units from '../../../../../../src/js/utils/Units';
 
+const tableColumnClasses = {
+  checkbox: 'pod-instances-table-column-checkbox',
+  name: 'pod-instances-table-column-primary',
+  address: 'pod-instances-table-column-host-address',
+  status: 'pod-instances-table-column-status',
+  logs: 'pod-instances-table-column-logs',
+  cpus: 'pod-instances-table-column-cpus',
+  mem: 'pod-instances-table-column-mem',
+  updated: 'pod-instances-table-column-updated',
+  version: 'pod-instances-table-column-version'
+};
+
 const METHODS_TO_BIND = [
   'getColGroup',
   'handleItemCheck',
@@ -79,15 +91,15 @@ class PodInstancesTable extends React.Component {
   getColGroup() {
     return (
       <colgroup>
-        <col style={{width: '40px'}} />
+        <col className={tableColumnClasses.checkbox} />
         <col />
-        <col className="hidden-mini" />
-        <col className="hidden-mini" />
-        <col className="hidden-mini" />
-        <col className="hidden-mini" />
-        <col className="hidden-mini" />
-        <col />
-        <col className="hidden-medium hidden-small hidden-mini" />
+        <col className={tableColumnClasses.address} />
+        <col className={tableColumnClasses.status} />
+        <col className={tableColumnClasses.logs} />
+        <col className={tableColumnClasses.cpus} />
+        <col className={tableColumnClasses.mem} />
+        <col className={tableColumnClasses.updated} />
+        <col className={tableColumnClasses.version} />
       </colgroup>
     );
   }
@@ -110,21 +122,9 @@ class PodInstancesTable extends React.Component {
   }
 
   getColumnClassName(prop, sortBy, row) {
-    let hiddenMiniCols = [
-      'address',
-      'status',
-      'logs',
-      'cpus',
-      'mem',
-      'version'
-    ];
-
-    return classNames(`column-${prop}`, {
+    return classNames(tableColumnClasses[prop], {
       'highlight': prop === sortBy.prop,
-      'clickable': row == null,
-      'table-cell-task-dot': prop === 'status',
-      'hidden-medium hidden-small': prop === 'version',
-      'hidden-mini': hiddenMiniCols.includes(prop)
+      'clickable': row == null
     });
   }
 

--- a/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesContainer-test.js
+++ b/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesContainer-test.js
@@ -65,7 +65,7 @@ describe('PodInstancesContainer', function () {
 
       it('should properly return matching instances', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-name')
+            this.instance, 'pod-instances-table-column-primary')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 
@@ -93,7 +93,7 @@ describe('PodInstancesContainer', function () {
 
       it('should properly return matching instances and containers', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-name')
+            this.instance, 'pod-instances-table-column-primary')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 
@@ -113,7 +113,7 @@ describe('PodInstancesContainer', function () {
 
       it('should always show instance total resources', function () {
         var mem = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-mem')
+            this.instance, 'pod-instances-table-column-mem')
             .filter(JestUtil.filterByTagName('TD'))
             .reduce(JestUtil.reduceTextContentOfSelector(
               'span'), []);
@@ -146,7 +146,7 @@ describe('PodInstancesContainer', function () {
 
       it('should properly show all instances', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-name')
+            this.instance, 'pod-instances-table-column-primary')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 
@@ -178,7 +178,7 @@ describe('PodInstancesContainer', function () {
 
       it('should properly show no instances', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-name')
+            this.instance, 'pod-instances-table-column-primary')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 

--- a/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.js
+++ b/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.js
@@ -65,7 +65,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the name column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-name')
+            this.instance, 'pod-instances-table-column-primary')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 
@@ -78,7 +78,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the address column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-address')
+            this.instance, 'pod-instances-table-column-host-address')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 
@@ -91,7 +91,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the status column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-status')
+            this.instance, 'pod-instances-table-column-status')
             .reduce(JestUtil.reduceTextContentOfSelector('.status-text'),
               []);
 
@@ -104,7 +104,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the cpu column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-cpus')
+            this.instance, 'pod-instances-table-column-cpus')
             .filter(JestUtil.filterByTagName('TD'))
             .map(JestUtil.mapTextContent);
 
@@ -117,7 +117,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the mem column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-mem')
+            this.instance, 'pod-instances-table-column-mem')
             .filter(JestUtil.filterByTagName('TD'))
             .map(JestUtil.mapTextContent);
 
@@ -130,7 +130,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the updated column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-updated')
+            this.instance, 'pod-instances-table-column-updated')
             .filter(JestUtil.filterByTagName('TD'))
             .map(JestUtil.mapTextContent);
 
@@ -143,7 +143,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the version column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-version')
+            this.instance, 'pod-instances-table-column-version')
             .filter(JestUtil.filterByTagName('TD'))
             .map(JestUtil.mapTextContent);
 
@@ -165,13 +165,13 @@ describe('PodInstancesTable', function () {
 
         // 1 click on the header (ascending)
         let columnHeader = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-name')[0];
+            this.instance, 'pod-instances-table-column-primary')[0];
         TestUtils.Simulate.click(columnHeader);
       });
 
       it('should properly sort the name column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-name')
+            this.instance, 'pod-instances-table-column-primary')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 
@@ -193,14 +193,14 @@ describe('PodInstancesTable', function () {
 
         // 2 clicks on the header (descending)
         let columnHeader = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-name')[0];
+            this.instance, 'pod-instances-table-column-primary')[0];
         TestUtils.Simulate.click(columnHeader);
         TestUtils.Simulate.click(columnHeader);
       });
 
       it('should properly sort the name column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-name')
+            this.instance, 'pod-instances-table-column-primary')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 
@@ -223,7 +223,7 @@ describe('PodInstancesTable', function () {
 
         // Expand all table rows by clicking on each one of them
         TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-name'
+            this.instance, 'pod-instances-table-column-primary'
         ).forEach(function (element) {
           let target = element.querySelector('.is-expandable');
           if (target) {
@@ -234,7 +234,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the name column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-name')
+            this.instance, 'pod-instances-table-column-primary')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 
@@ -253,7 +253,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the address column', function () {
         var columns = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-address');
+            this.instance, 'pod-instances-table-column-host-address');
         let agents = columns.reduce(JestUtil.reduceTextContentOfSelector(
             '.collapsing-string-full-string'), []);
         let ports = columns.reduce(JestUtil.reduceTextContentOfSelector('a'), []);
@@ -275,7 +275,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the status column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-status')
+            this.instance, 'pod-instances-table-column-status')
             .reduce(JestUtil.reduceTextContentOfSelector('.status-text'), []);
 
         expect(names).toEqual([
@@ -293,7 +293,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the cpu column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-cpus')
+            this.instance, 'pod-instances-table-column-cpus')
             .filter(JestUtil.filterByTagName('TD'))
             .reduce(JestUtil.reduceTextContentOfSelector('div > div > span'), []);
 
@@ -312,7 +312,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the mem column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-mem')
+            this.instance, 'pod-instances-table-column-mem')
             .filter(JestUtil.filterByTagName('TD'))
             .reduce(JestUtil.reduceTextContentOfSelector('div > div > span'), []);
 
@@ -331,7 +331,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the updated column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-updated')
+            this.instance, 'pod-instances-table-column-updated')
             .filter(JestUtil.filterByTagName('TD'))
             .reduce(JestUtil.reduceTextContentOfSelector('time'), []);
 
@@ -350,7 +350,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the version column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'column-version')
+            this.instance, 'pod-instances-table-column-version')
             .filter(JestUtil.filterByTagName('TD'))
             .map(JestUtil.mapTextContent);
 

--- a/src/styles/components/pod-instances-table/styles.less
+++ b/src/styles/components/pod-instances-table/styles.less
@@ -1,48 +1,112 @@
 & when (@pod-instances-table-enabled) {
 
   .pod-instances-table {
+    table-layout: fixed;
 
     td {
       vertical-align: top;
     }
+  }
 
-    .column-logs {
-      padding-left: 0;
+  .pod-instances-table-column {
+
+    &-host-address,
+    &-status,
+    &-logs,
+    &-cpus,
+    &-mem,
+    &-version {
+      display: none;
     }
 
-    .column-checkbox {
-      width: 40px;
+    &-checkbox {
+      width: 30px;
     }
 
-    .column-name {
-      min-width: 150px;
-      width: 100%;
+    &-primary {
+      width: auto;
     }
 
-    .column-address {
-      max-width: 300px;
-      min-width: 120px;
-    }
-
-    .column-status {
-      min-width: 120px;
+    &-host-address {
       width: 120px;
     }
 
-    .column-cpus {
-      width: 64px;
+    &-status {
+      width: 90px;
     }
 
-    .column-version {
-      max-width: 300px;
-      min-width: 160px;
+    &-logs {
+      width: 32px;
     }
 
-    // TODO: Fix the specificity of table-cell-task-dot so this isn't necessary.
-    &.table {
+    &-cpus {
+      width: 65px;
+    }
 
-      .table-cell-task-dot {
-        max-width: none;
+    &-mem {
+      width: 80px;
+    }
+
+    &-updated {
+      width: 130px;
+    }
+
+    &-version {
+      white-space: break-all;
+      width: 175px;
+    }
+  }
+}
+
+& when (@pod-instances-table-enabled) and (@layout-screen-small-enabled) {
+
+  @media (min-width: @layout-screen-small-min-width) {
+
+    .pod-instances-table-column {
+
+      &-host-address {
+        display: table-cell;
+
+        col& {
+          display: table-column;
+        }
+      }
+    }
+  }
+}
+
+& when (@pod-instances-table-enabled) and (@layout-screen-large-enabled) {
+
+  @media (min-width: @layout-screen-large-min-width) {
+
+    .pod-instances-table-column {
+
+      &-status,
+      &-logs,
+      &-cpus,
+      &-mem {
+        display: table-cell;
+
+        col& {
+          display: table-column;
+        }
+      }
+    }
+  }
+}
+
+& when (@pod-instances-table-enabled) and (@layout-screen-jumbo-enabled) {
+
+  @media (min-width: @layout-screen-jumbo-min-width) {
+
+    .pod-instances-table-column {
+
+      &-version {
+        display: table-cell;
+
+        col& {
+          display: table-column;
+        }
       }
     }
   }


### PR DESCRIPTION
This PR fixes the `PodInstancesTable` layout. I've applied widths and responsiveness in a way that we haven't done before, so I'm interested to see what you guys think.

Instead of applying `hidden-*` classes and using inline `style` props, it uses classnames and external CSS. I think it's easier to reason about and it would allow us to change the width of certain columns in media queries. There would be a little extra work when creating new tables, but I think it's worth it. I'd be happy to apply this to the rest of the tables in the UI, if you all like it! :)

![](https://cl.ly/2i3i0y2z3308/Screen%20Shot%202016-12-01%20at%209.00.34%20PM.png)

---

In an unrelated note, for some reason when I apply the `pod-instances-table-column-primary` class to the related `col` in the `colgroup`, the sorting of the table gets reversed in one of the tests. WTF??? Am I missing something? We don't actually need the `colgroup` if we use this approach, but I left it here for now.