### PR TITLE
Fix ContainerServiceFormSection

### DIFF
--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -120,8 +120,9 @@ class ContainerServiceFormSection extends Component {
     }
 
     return [
-      <FieldLabel>GPUs</FieldLabel>,
+      <FieldLabel key="gpus-label">GPUs</FieldLabel>,
       <FieldInput
+        key="gpus-input"
         name="gpus"
         type="number"
         value={data.gpus} />


### PR DESCRIPTION
This fixes an issue in the ContainerServiceFormSection which resulted in throwing errors, because there where no keys on jsx elements in an array.

![image](https://cloud.githubusercontent.com/assets/156010/20831922/b6891b68-b887-11e6-81ae-932ae3dc1da0.png)
