### PR TITLE
Upgrading raml-validator-loader to v0.1.6

### DIFF
--- a/webpack/modules/raml-validator-loader/lib/raml-validator-loader.js
+++ b/webpack/modules/raml-validator-loader/lib/raml-validator-loader.js
@@ -1104,9 +1104,19 @@ module.exports =
 	   * Compose a required property framgent
 	   */
 	  composeRequiredProperty: function composeRequiredProperty(property, validatorFn, context) {
-	    var ERROR_MESSAGE = context.getConstantString('ERROR_MESSAGES', 'PROP_MISSING', 'Missing property `{name}`');
+	    var errorPath = 'path';
+	    var ERROR_MESSAGE = void 0;
 
-	    return ['if (value.' + property + ' == null) {', '\terrors.push(new RAMLError(path, ' + ERROR_MESSAGE + ', {name: \'' + property + '\'}));', '} else {', '\terrors = errors.concat(' + validatorFn + '(value.' + property + ', path.concat([\'' + property + '\'])));', '}'];
+	    // If we are configured to show missing properties to their own path use
+	    // different error message and different error path.
+	    if (context.options.missingPropertiesOnTheirPath) {
+	      errorPath = 'path.concat([\'' + property + '\'])';
+	      ERROR_MESSAGE = context.getConstantString('ERROR_MESSAGES', 'PROP_MISSING', 'Missing property');
+	    } else {
+	      ERROR_MESSAGE = context.getConstantString('ERROR_MESSAGES', 'PROP_MISSING', 'Missing property `{name}`');
+	    }
+
+	    return ['if (value.' + property + ' == null) {', '\terrors.push(new RAMLError(' + errorPath + ', ' + ERROR_MESSAGE + ', {name: \'' + property + '\'}));', '} else {', '\terrors = errors.concat(' + validatorFn + '(value.' + property + ', path.concat([\'' + property + '\'])));', '}'];
 	  },
 
 
@@ -1290,7 +1300,22 @@ module.exports =
 	       *
 	       * @property {boolean}
 	       */
-	      patternPropertiesAreOptional: true
+	      patternPropertiesAreOptional: true,
+
+	      /**
+	       * If this flag is set to `true`, all missing properties will be emmited
+	       * in their path. For example, if property `foo` is missing on the object
+	       * `bar`, you will get an error:
+	       *
+	       * `bar.foo`: Missing property
+	       *
+	       * Instead of the default:
+	       *
+	       * `foo`: Missing property `bar`
+	       *
+	       * @property {boolean}
+	       */
+	      missingPropertiesOnTheirPath: true
 
 	    };
 

--- a/webpack/modules/raml-validator-loader/package.json
+++ b/webpack/modules/raml-validator-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raml-validator-loader",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Converts RAML document to javascript validation functions",
   "main": "lib/raml-validator-loader.js",
   "scripts": {

--- a/webpack/modules/raml-validator-loader/src/GeneratorContext.js
+++ b/webpack/modules/raml-validator-loader/src/GeneratorContext.js
@@ -14,7 +14,22 @@ class GeneratorContext {
        *
        * @property {boolean}
        */
-      patternPropertiesAreOptional: true
+      patternPropertiesAreOptional: true,
+
+      /**
+       * If this flag is set to `true`, all missing properties will be emmited
+       * in their path. For example, if property `foo` is missing on the object
+       * `bar`, you will get an error:
+       *
+       * `bar.foo`: Missing property
+       *
+       * Instead of the default:
+       *
+       * `foo`: Missing property `bar`
+       *
+       * @property {boolean}
+       */
+      missingPropertiesOnTheirPath: true
 
     };
 

--- a/webpack/modules/raml-validator-loader/src/__tests__/RAMLValidator-test.js
+++ b/webpack/modules/raml-validator-loader/src/__tests__/RAMLValidator-test.js
@@ -901,6 +901,41 @@ describe('RAMLValidator', function () {
 
     });
 
+    describe('Missing Properties', function () {
+
+      it('should include full path on missing property by default', function () {
+        let validator = createValidator([
+          '#%RAML 1.0',
+          'types:',
+          '  TestType:',
+          '    type: object',
+          '    properties:',
+          '      required: number',
+        ].join('\n'));
+        var errors = validator({})
+        expect(errors).toEqual([
+          {path: ['required'], message:'Missing property'}
+        ]);
+      });
+
+      it('should keep path of missing prop on object when configured', function () {
+        let classicConfig = {missingPropertiesOnTheirPath: false};
+        let validator = createValidator([
+          '#%RAML 1.0',
+          'types:',
+          '  TestType:',
+          '    type: object',
+          '    properties:',
+          '      required: number',
+        ].join('\n'), classicConfig);
+        var errors = validator({})
+        expect(errors).toEqual([
+          {path: [], message:'Missing property `required`'}
+        ]);
+      });
+
+    });
+
   });
 
   describe('Array Type', function () {

--- a/webpack/modules/raml-validator-loader/src/generators/HighOrderComposers.js
+++ b/webpack/modules/raml-validator-loader/src/generators/HighOrderComposers.js
@@ -235,12 +235,23 @@ const HighOrderComposers = {
    * Compose a required property framgent
    */
   composeRequiredProperty(property, validatorFn, context) {
-    let ERROR_MESSAGE = context.getConstantString('ERROR_MESSAGES',
-      'PROP_MISSING', 'Missing property `{name}`');
+    let errorPath = 'path';
+    let ERROR_MESSAGE;
+
+    // If we are configured to show missing properties to their own path use
+    // different error message and different error path.
+    if (context.options.missingPropertiesOnTheirPath) {
+      errorPath = `path.concat(['${property}'])`;
+      ERROR_MESSAGE = context.getConstantString('ERROR_MESSAGES',
+            'PROP_MISSING', 'Missing property');
+    } else {
+      ERROR_MESSAGE = context.getConstantString('ERROR_MESSAGES',
+            'PROP_MISSING', 'Missing property `{name}`');
+    }
 
     return [
       `if (value.${property} == null) {`,
-        `\terrors.push(new RAMLError(path, ${ERROR_MESSAGE}, {name: '${property}'}));`,
+        `\terrors.push(new RAMLError(${errorPath}, ${ERROR_MESSAGE}, {name: '${property}'}));`,
       `} else {`,
         `\terrors = errors.concat(${validatorFn}(value.${property}, path.concat(['${property}'])));`,
       `}`


### PR DESCRIPTION
## v0.1.6 Changelog

- **Change**: The path of missing property errors now points to the actual missing field.
- **Change**: This feature is controlled through the `missingPropertiesOnTheirPath` option flag