### PR TITLE
JSONEditor: Better handling of error paths

### DIFF
--- a/src/js/components/JSONEditor.js
+++ b/src/js/components/JSONEditor.js
@@ -478,7 +478,7 @@ class JSONEditor extends React.Component {
         }
 
         return memo;
-      }, [{path: [], line: 0}]);
+      }, [{path: [], row: 0}]);
 
       // Find the most specific token line
       let candidate = candidates


### PR DESCRIPTION
This PR is fixing some issues the #1471 is introducing. In detail, when the JSON editor cannot find a token on the given path, it will try the parent paths until it reaches the root.