### PR TITLE
Fix link to a logs Tab from the service tasks table

### DIFF
--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
@@ -329,7 +329,7 @@ class PodInstancesTable extends React.Component {
 
     return (
       <Link
-        to={`/services/overview/${id}/tasks/${taskID}/view`}
+        to={`/services/overview/${id}/tasks/${taskID}/logs`}
         title={row.name}>
         <Icon color="grey" id="page-document" size="mini" />
       </Link>

--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -225,7 +225,7 @@ class TaskTable extends React.Component {
     let title = task.name || task.id;
     let {id, nodeID} = this.props.params;
 
-    let linkTo = `/services/overview/${id}/tasks/${task.id}/view`;
+    let linkTo = `/services/overview/${encodeURIComponent(id)}/tasks/${task.id}/logs`;
     if (nodeID != null) {
       linkTo = `/nodes/${nodeID}/tasks/${task.id}/view`;
     }


### PR DESCRIPTION
Fix link to a log tab from a service tasks table // cc @mlunoe 

![screen shot 2016-12-02 at 17 50 18](https://cloud.githubusercontent.com/assets/186223/20842504/09452e84-b8b8-11e6-92b9-ebb9673d6619.png)
