### PR TITLE
Not installing git hooks if files are the same

### DIFF
--- a/scripts/utils/git
+++ b/scripts/utils/git
@@ -26,6 +26,12 @@ install_hooks() {
     then
       header "Create symlink for ${hook} hook"
 
+      # Don't replace the same file
+      if cmp --silent scripts/${hook} .git/hooks/${hook}; then
+        info "Hook already exists"
+        continue
+      fi
+
       # Create a symlink or show  a promptif the target file exists.
       # If the response from the standard input begins with the character `y',
       # then unlink the target file so that the link may occur.


### PR DESCRIPTION
This PR doesn't prompt the user if the given git hook already exists and it's identical with the script we are about to install.