### PR TITLE
Fix sidebar's dock/undocked local storage saving

### DIFF
--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -13,7 +13,6 @@ import InternalStorageMixin from '../mixins/InternalStorageMixin';
 import MesosSummaryStore from '../stores/MesosSummaryStore';
 import MetadataStore from '../stores/MetadataStore';
 import PrimarySidebarLink from '../components/PrimarySidebarLink';
-import SaveStateMixin from '../mixins/SaveStateMixin';
 import SidebarActions from '../events/SidebarActions';
 import SidebarStore from '../stores/SidebarStore';
 import UserAccountDropdown from './UserAccountDropdown';
@@ -42,20 +41,10 @@ var Sidebar = React.createClass({
 
   displayName: 'Sidebar',
 
-  saveState_key: 'sidebar',
-
-  saveState_properties: ['isDocked'],
-
-  mixins: [SaveStateMixin, InternalStorageMixin],
+  mixins: [InternalStorageMixin],
 
   contextTypes: {
     router: routerShape
-  },
-
-  getInitialState() {
-    return {
-      isDocked: false
-    };
   },
 
   componentDidMount() {
@@ -75,14 +64,6 @@ var Sidebar = React.createClass({
         'transitionend',
         this.handleSidebarTransitionEnd
       );
-    }
-
-    if (this.state.isDocked !== SidebarStore.get('isDocked')) {
-      if (this.state.isDocked) {
-        SidebarActions.undock();
-      } else {
-        SidebarActions.dock();
-      }
     }
 
     global.window.addEventListener('keydown', this.handleKeyPress, true);
@@ -312,8 +293,6 @@ var Sidebar = React.createClass({
       } else {
         SidebarActions.dock();
       }
-
-      this.saveState_save();
     });
   },
 

--- a/src/js/constants/UserSettings.js
+++ b/src/js/constants/UserSettings.js
@@ -1,0 +1,3 @@
+module.exports = {
+  SAVED_STATE_KEY: 'savedStates'
+};

--- a/src/js/mixins/SaveStateMixin.js
+++ b/src/js/mixins/SaveStateMixin.js
@@ -1,7 +1,6 @@
 import Config from '../config/Config';
 import UserSettingsStore from '../stores/UserSettingsStore';
-
-const SAVED_STATE_KEY = 'savedStates';
+import {SAVED_STATE_KEY} from '../constants/UserSettings';
 
 const SaveStateMixin = {
   componentWillMount() {

--- a/src/js/stores/SidebarStore.js
+++ b/src/js/stores/SidebarStore.js
@@ -18,8 +18,12 @@ import {
   SIDEBAR_CHANGE,
   SIDEBAR_WIDTH_CHANGE
 } from '../constants/EventTypes';
+import {SAVED_STATE_KEY} from '../constants/UserSettings';
+
 import AppDispatcher from '../events/AppDispatcher';
 import GetSetBaseStore from './GetSetBaseStore';
+import UserSettingsStore from '../stores/UserSettingsStore';
+import Util from '../utils/Util';
 
 class SidebarStore extends GetSetBaseStore {
   constructor() {
@@ -51,11 +55,17 @@ class SidebarStore extends GetSetBaseStore {
           var nextDockedState = action.data;
 
           if (this.get('isDocked') !== nextDockedState) {
+            let savedStates = UserSettingsStore.getKey(SAVED_STATE_KEY) || {};
+
             this.set({
               isVisible: nextDockedState ? false : nextDockedState,
               isDocked: nextDockedState
             });
+
             this.emitChange(SIDEBAR_CHANGE);
+
+            savedStates.sidebar = {isDocked: nextDockedState};
+            UserSettingsStore.setKey(SAVED_STATE_KEY, savedStates);
           }
           break;
         case REQUEST_SIDEBAR_CLOSE:
@@ -89,8 +99,16 @@ class SidebarStore extends GetSetBaseStore {
   }
 
   init() {
+    let isDocked = Util.findNestedPropertyInObject(
+      UserSettingsStore.getKey(SAVED_STATE_KEY), 'sidebar.isDocked'
+    );
+
+    if (isDocked == null) {
+      isDocked = true;
+    }
+
     this.set({
-      isDocked: true,
+      isDocked,
       isVisible: false,
       versions: {}
     });


### PR DESCRIPTION
This PR fixes a bug with saving the sidebar's state in local storage. The state of the sidebar is held within `SidebarStore`, so all logic for saving to local storage has been moved there.

This also fixes an ugly bug where if you've cleared your local storage for DC/OS UI and log in to your cluster, an error in the sidebar prevented the dashboard from rendering entirely. 🐛 