### PR TITLE
Introduce PageHeaderActionsMenu component

### DIFF
--- a/src/js/components/PageHeaderActionsMenu.js
+++ b/src/js/components/PageHeaderActionsMenu.js
@@ -28,18 +28,17 @@ const getDropdownItemFromComponent = (child, index) => {
   };
 };
 
-const PageHeaderActionsMenu = (props) => {
+const PageHeaderActionsMenu = ({children}) => {
   return (
     <Dropdown
       buttonClassName="button button-link"
-      items={getMenuItems(props.children)}
+      items={getMenuItems(children)}
       onItemSelection={handleItemSelection}
       persistentID="trigger"
       transition={true}
       dropdownMenuClassName="dropdown-menu"
       dropdownMenuListClassName="dropdown-menu-list"
-      wrapperClassName="dropdown"
-      {...props} />
+      wrapperClassName="dropdown" />
   );
 };
 

--- a/src/js/components/PageHeaderActionsMenu.js
+++ b/src/js/components/PageHeaderActionsMenu.js
@@ -20,11 +20,11 @@ const handleItemSelection = (item) => {
   }
 };
 
-const getDropdownItemFromComponent = (child) => {
+const getDropdownItemFromComponent = (child, index) => {
   return {
     clickHandler: child.props.clickHandler,
     html: child,
-    id: child.key
+    id: index
   };
 };
 
@@ -53,8 +53,7 @@ PageHeaderActionsMenu.propTypes = {
     React.PropTypes.shape({
       props: React.PropTypes.shape({
         clickHandler: React.PropTypes.func
-      }),
-      key: React.PropTypes.string.isRequired
+      })
     })
   )
 };

--- a/src/js/components/PageHeaderActionsMenu.js
+++ b/src/js/components/PageHeaderActionsMenu.js
@@ -15,8 +15,8 @@ const getMenuItems = (children) => {
 };
 
 const handleItemSelection = (item) => {
-  if (item.clickHandler) {
-    item.clickHandler();
+  if (item.onItemSelect) {
+    item.onItemSelect();
   }
 };
 
@@ -53,7 +53,7 @@ PageHeaderActionsMenu.propTypes = {
   children: React.PropTypes.arrayOf(
     React.PropTypes.shape({
       props: React.PropTypes.shape({
-        clickHandler: React.PropTypes.func
+        onItemSelect: React.PropTypes.func
       })
     })
   )

--- a/src/js/components/PageHeaderActionsMenu.js
+++ b/src/js/components/PageHeaderActionsMenu.js
@@ -48,6 +48,7 @@ PageHeaderActionsMenu.defaultProps = {
 };
 
 PageHeaderActionsMenu.propTypes = {
+  // anchorRight gets passed to Dropdown. It's truthy here unlike in the Dropdown.
   anchorRight: React.PropTypes.bool,
   children: React.PropTypes.arrayOf(
     React.PropTypes.shape({

--- a/src/js/components/PageHeaderActionsMenu.js
+++ b/src/js/components/PageHeaderActionsMenu.js
@@ -1,0 +1,62 @@
+import {Dropdown} from 'reactjs-components';
+import React from 'react';
+
+import Icon from './Icon';
+
+const getMenuItems = (children) => {
+  return [
+    {
+      className: 'hidden',
+      html: <Icon id="ellipsis-vertical" size="mini" />,
+      id: 'trigger'
+    },
+    ...React.Children.map(children, getDropdownItemFromComponent)
+  ];
+};
+
+const handleItemSelection = (item) => {
+  if (item.clickHandler) {
+    item.clickHandler();
+  }
+};
+
+const getDropdownItemFromComponent = (child) => {
+  return {
+    clickHandler: child.props.clickHandler,
+    html: child,
+    id: child.key
+  };
+};
+
+const PageHeaderActionsMenu = (props) => {
+  return (
+    <Dropdown
+      buttonClassName="button button-link"
+      items={getMenuItems(props.children)}
+      onItemSelection={handleItemSelection}
+      persistentID="trigger"
+      transition={true}
+      dropdownMenuClassName="dropdown-menu"
+      dropdownMenuListClassName="dropdown-menu-list"
+      wrapperClassName="dropdown"
+      {...props} />
+  );
+};
+
+PageHeaderActionsMenu.defaultProps = {
+  anchorRight: true
+};
+
+PageHeaderActionsMenu.propTypes = {
+  anchorRight: React.PropTypes.bool,
+  children: React.PropTypes.arrayOf(
+    React.PropTypes.shape({
+      props: React.PropTypes.shape({
+        clickHandler: React.PropTypes.func
+      }),
+      key: React.PropTypes.string.isRequired
+    })
+  )
+};
+
+module.exports = PageHeaderActionsMenu;

--- a/src/styles/components/page-header/styles.less
+++ b/src/styles/components/page-header/styles.less
@@ -22,6 +22,7 @@
   .page-header-title-container {
     align-items: center;
     display: flex;
+    height: @button-height;
     padding-left: @page-header-title-padding-left;
     position: relative;
     transition: padding-left 0.25s;
@@ -309,6 +310,7 @@
     & when (@page-header-enabled) and (@page-header-screen-large-enabled) {
 
       .page-header-title-container {
+        height: @button-height-screen-large;
         padding-left: @page-header-title-padding-left-screen-large;
       }
 


### PR DESCRIPTION
This PR introduces a component called `PageHeaderActionsMenu` which is really just a wrapper for the `Dropdown`. Here's how I propose it works:

```jsx
<PageHeaderActionsMenu>
  <span clickHandler={() => console.log('hello')}>
    Hello!
  </span>
  <span clickHandler={() => console.log('goodbye')}>
    Goodbye!
  </span>
</PageHeaderActionsMenu>
```

Each child of `PageHeaderActionsMenu` will be rendered as an item in the `Dropdown` without being modified. When selected, it will call the child's `clickHandler` prop.

Sneak peek:
![](https://d3vv6lp55qjaqc.cloudfront.net/items/451Q0x2l1H0n3S2v0527/Screen%20Shot%202016-12-02%20at%203.24.20%20PM.png?X-CloudApp-Visitor-Id=1972842)

---

@philipnrmn In the new `PageHeader` component, this should be wrapped inside `div.button-collection.flush-bottom`, which will provide the proper layout for a neighboring action button. Here's an example of how that markup might look:

```jsx
<div className="page-header-actions">
  <div className="button-collection flush-bottom">
    <button className="button button-link">
      <Icon id="plus" size="mini" />
    </button>
    <PageHeaderActionsMenu>
      <span clickHandler={() => console.log('hello')}>
        Hello!
      </span>
      <span clickHandler={() => console.log('goodbye')}>
        Goodbye!
      </span>
    </PageHeaderActionsMenu>
  </div>
</div>
```