### PR TITLE
[1/11] Page template headers

### DIFF
--- a/src/js/components/NewPageHeader.js
+++ b/src/js/components/NewPageHeader.js
@@ -10,6 +10,7 @@ class PageHeader extends React.Component {
     let {
       props: {
         actions,
+        addButton,
         breadcrumbs,
         className,
         innerClassName,
@@ -48,7 +49,9 @@ class PageHeader extends React.Component {
         <div className={innerClasses}>
           <div className={primaryContentClasses}>
             {breadcrumbs}
-            <NewPageHeaderActions actions={actions} />
+            <NewPageHeaderActions
+              actions={actions}
+              addButton={addButton} />
           </div>
           <div className={secondaryContentClasses}>
             <NewPageHeaderTabs tabs={tabs} />
@@ -72,6 +75,7 @@ PageHeader.defaultProps = {
 };
 
 PageHeader.propTypes = {
+  addButton: React.PropTypes.object,
   actions: React.PropTypes.array,
   breadcrumbs: React.PropTypes.node.isRequired,
   className: classProps,

--- a/src/js/components/NewPageHeader.js
+++ b/src/js/components/NewPageHeader.js
@@ -47,7 +47,7 @@ class PageHeader extends React.Component {
       <div className={classes}>
         <div className={innerClasses}>
           <div className={primaryContentClasses}>
-            <NewPageHeaderBreadcrumbs breadcrumbs={breadcrumbs} />
+            {breadcrumbs}
             <NewPageHeaderActions actions={actions} />
           </div>
           <div className={secondaryContentClasses}>
@@ -73,7 +73,7 @@ PageHeader.defaultProps = {
 
 PageHeader.propTypes = {
   actions: React.PropTypes.array,
-  breadcrumbs: React.PropTypes.array.isRequired,
+  breadcrumbs: React.PropTypes.node.isRequired,
   className: classProps,
   innerClassName: classProps,
   primaryContentClassName: classProps,
@@ -81,5 +81,9 @@ PageHeader.propTypes = {
   secondaryContentDetail: React.PropTypes.node,
   tabs: React.PropTypes.array
 };
+
+PageHeader.Breadcrumbs = NewPageHeaderBreadcrumbs;
+PageHeader.Actions = NewPageHeaderActions;
+PageHeader.Tabs = NewPageHeaderTabs;
 
 module.exports = PageHeader;

--- a/src/js/components/NewPageHeaderActions.js
+++ b/src/js/components/NewPageHeaderActions.js
@@ -1,27 +1,68 @@
 import classNames from 'classnames/dedupe';
 import React from 'react';
+import {Tooltip} from 'reactjs-components';
+
+import Icon from './Icon';
+import PageHeaderActionsMenu from './PageHeaderActionsMenu';
 
 class PageHeaderActions extends React.Component {
-  render() {
-    let {props: {actions}} = this;
 
-    let actionElements = actions.map(function (action, index) {
-      if (action.node) {
-        return action.node;
-      }
+  renderActionsMenu() {
+    const {actions} = this.props;
 
-      let classes = classNames('button button-rounded', action.className);
+    if (actions.length > 0) {
+      const dropdownElements = actions.map(function (action, index) {
+        if (React.isValidElement(action)) {
+          return action;
+        }
+
+        return (
+          <span onItemSelect={action.onItemSelect} key={index}>
+            {action.label}
+          </span>
+        );
+      });
 
       return (
-        <button className={classes} key={index} onClick={action.clickHandler}>
-          {action.label}
+        <PageHeaderActionsMenu>
+          {dropdownElements}
+        </PageHeaderActionsMenu>
+      );
+    }
+  }
+
+  renderAddButton() {
+    const {addButton} = this.props;
+    if (addButton != null) {
+      const {label, onItemSelect, className} = addButton;
+      const buttonClasses = classNames(
+          'button button-link flush-left flush-right',
+          className
+      );
+
+      const button = (
+        <button className={buttonClasses} onClick={onItemSelect}>
+          <Icon id="plus" size="mini" />
         </button>
       );
-    });
 
+      if (label != null) {
+        return (
+          <Tooltip content={label}>{button}</Tooltip>
+        );
+      }
+
+      return button;
+    }
+  }
+
+  render() {
     return (
-      <div className="page-header-actions button-collection flush-bottom">
-        {actionElements}
+      <div className="page-header-actions">
+        <div className="button-collection-flush-bottom">
+          {this.renderAddButton()}
+          {this.renderActionsMenu()}
+        </div>
       </div>
     );
   }
@@ -38,12 +79,20 @@ const classProps = React.PropTypes.oneOfType([
 ]);
 
 PageHeaderActions.propTypes = {
+  addButton: React.PropTypes.shape({
+    className: classProps,
+    clickHandler: React.PropTypes.func,
+    label: React.PropTypes.node
+  }),
   actions: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      className: classProps,
-      clickHandler: React.PropTypes.func,
-      label: React.PropTypes.node
-    })
+    React.PropTypes.oneOf(
+      React.PropTypes.node,
+      React.PropTypes.shape({
+        className: classProps,
+        clickHandler: React.PropTypes.func.isRequired,
+        label: React.PropTypes.node.isRequired
+      })
+    )
   )
 };
 

--- a/src/js/components/NewPageHeaderBreadcrumbs.js
+++ b/src/js/components/NewPageHeaderBreadcrumbs.js
@@ -1,28 +1,8 @@
-import {Dropdown} from 'reactjs-components';
 import React from 'react';
 
 import Icon from './Icon';
 
 class PageHeaderBreadcrumbs extends React.Component {
-  getBreadcrumbSubMenuItem(menuItem) {
-    let {iconID, label, routePath} = menuItem;
-
-    if (iconID) {
-      return {
-        className: 'hidden',
-        id: 'default',
-        selectedHtml: (
-          <h3 className="flush">
-            <Icon family="product" id={iconID} size="small" />
-            {label}
-          </h3>
-        ),
-        routePath
-      };
-    }
-
-    return {id: routePath, html: label, routePath};
-  }
 
   getCaret(index) {
     return (
@@ -33,70 +13,28 @@ class PageHeaderBreadcrumbs extends React.Component {
     );
   }
 
-  getPrimaryBreadcrumb(breadcrumb) {
-    let breadcrumbContent = null;
-
-    if (breadcrumb.submenu) {
-      let dropdownItems = breadcrumb.submenu.map(this.getBreadcrumbSubMenuItem);
-
-      breadcrumbContent = (
-        <Dropdown
-          buttonClassName="button dropdown-toggle"
-          dropdownMenuClassName="dropdown-menu"
-          dropdownMenuListClassName="dropdown-menu-list"
-          dropdownMenuListItemClassName="clickable"
-          wrapperClassName="dropdown"
-          items={dropdownItems}
-          onItemSelection={this.handleBreadcrumbSubmenuItemSelect}
-          persistentID="default"
-          transition={true}
-          transitionName="dropdown-menu" />
-      );
-    } else {
-      breadcrumbContent = breadcrumb.label;
-    }
-
-    return (
-      <li className="page-header-breadcrumb-primary h3 flush-top flush-left"
-        key="primary-breadcrumb">
-        {breadcrumbContent}
-      </li>
-    );
-  }
-
-  getSecondaryBreadcrumb(breadcrumb, index) {
-    let {label = null, prefix = null, suffix = null} = breadcrumb;
-
-    return (
-      <li className="page-header-breadcrumb-secondary h3 flush-top flush-left"
-        key={index}>
-        {prefix}
-        {label}
-        {suffix}
-      </li>
-    );
-  }
-
-  handleBreadcrumbSubmenuItemSelect(menuItem) {
-    console.log(menuItem);
-  }
-
   render() {
-    let {props: {breadcrumbs}} = this;
+    let {props: {iconID, breadcrumbs}} = this;
+
+    const containerIcon = (
+      <li className="page-header-breadcrumb-secondary h3 flush-top flush-left" key="-1">
+        <Icon family="product" id={iconID} size="small" />
+      </li>
+    );
 
     let breadcrumbElements = breadcrumbs.reduce((memo, breadcrumb, index) => {
-      if (index === 0) {
-        memo.push(this.getPrimaryBreadcrumb(breadcrumb));
-      } else {
-        memo.push(this.getSecondaryBreadcrumb(breadcrumb, index));
-      }
+      memo.push(
+        <li className="page-header-breadcrumb-secondary h3 flush-top flush-left" key={index}>
+          {breadcrumb}
+        </li>
+      );
 
       if (index !== breadcrumbs.length - 1) {
         memo.push(this.getCaret(index));
       }
 
       return memo;
-    }, []);
+    }, [containerIcon]);
 
     return (
       <ul className="page-header-breadcrumbs list list-unstyled list-inline flush">
@@ -107,21 +45,8 @@ class PageHeaderBreadcrumbs extends React.Component {
 }
 
 PageHeaderBreadcrumbs.propTypes = {
-  breadcrumbs: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      iconID: React.PropTypes.string,
-      label: React.PropTypes.node.isRequired,
-      prefix: React.PropTypes.node,
-      submenu: React.PropTypes.arrayOf(
-        React.PropTypes.shape({
-          iconID: React.PropTypes.string,
-          label: React.PropTypes.node.isRequired,
-          routePath: React.PropTypes.string.isRequired
-        })
-      ),
-      suffix: React.PropTypes.node
-    })
-  ).isRequired
+  iconID: React.PropTypes.string.isRequired,
+  breadcrumbs: React.PropTypes.arrayOf(React.PropTypes.node).isRequired
 };
 
 module.exports = PageHeaderBreadcrumbs;

--- a/src/js/components/NewPageHeaderTabs.js
+++ b/src/js/components/NewPageHeaderTabs.js
@@ -12,13 +12,13 @@ class PageHeaderTabs extends React.Component {
       let linkClasses = classNames('menu-tabbed-item-label', {active: isActive});
 
       let innerLinkSpan = <span className="menu-tabbed-item-label-text">{tab.label}</span>;
+      let link = tab.callback == null
+          ? <Link className={linkClasses} to={tab.routePath}>{innerLinkSpan}</Link>
+          : <a className={linkClasses} onClick={callback}>{innerLinkSpan}</a>;
+
       return (
         <li className={classes} key={index}>
-          <Link className={linkClasses} to={tab.routePath}>
-            <span className="tab-item-label-text">
-              {tab.label}
-            </span>
-          </Link>
+          {link}
         </li>
       );
     });
@@ -42,7 +42,8 @@ PageHeaderTabs.propTypes = {
     React.PropTypes.shape({
       isActive: React.PropTypes.bool,
       label: React.PropTypes.node.isRequired,
-      routePath: React.PropTypes.string.isRequired
+      routePath: React.PropTypes.string,
+      callback: React.PropTypes.func
     })
   )
 };

--- a/src/js/components/NewPageHeaderTabs.js
+++ b/src/js/components/NewPageHeaderTabs.js
@@ -11,10 +11,24 @@ class PageHeaderTabs extends React.Component {
       let classes = classNames('menu-tabbed-item', {active: isActive});
       let linkClasses = classNames('menu-tabbed-item-label', {active: isActive});
 
-      let innerLinkSpan = <span className="menu-tabbed-item-label-text">{tab.label}</span>;
-      let link = tab.callback == null
-          ? <Link className={linkClasses} to={tab.routePath}>{innerLinkSpan}</Link>
-          : <a className={linkClasses} onClick={callback}>{innerLinkSpan}</a>;
+      let innerLinkSpan = (
+        <span className="menu-tabbed-item-label-text">
+          {tab.label}
+        </span>
+      );
+      let link = (
+        <a className={linkClasses} onClick={callback}>
+          {innerLinkSpan}
+        </a>
+      );
+
+      if (tab.callback == null) {
+        link = (
+          <Link className={linkClasses} to={tab.routePath}>
+            {innerLinkSpan}
+          </Link>
+        );
+      }
 
       return (
         <li className={classes} key={index}>

--- a/src/js/components/NewPageHeaderTabs.js
+++ b/src/js/components/NewPageHeaderTabs.js
@@ -7,10 +7,11 @@ class PageHeaderTabs extends React.Component {
     let {props: {tabs}} = this;
 
     let tabElements = tabs.map(function (tab, index) {
-      let {isActive} = tab;
-      let classes = classNames('tab-item', {active: isActive});
-      let linkClasses = classNames('tab-item-label', {active: isActive});
+      let {isActive, callback} = tab;
+      let classes = classNames('menu-tabbed-item', {active: isActive});
+      let linkClasses = classNames('menu-tabbed-item-label', {active: isActive});
 
+      let innerLinkSpan = <span className="menu-tabbed-item-label-text">{tab.label}</span>;
       return (
         <li className={classes} key={index}>
           <Link className={linkClasses} to={tab.routePath}>
@@ -23,9 +24,11 @@ class PageHeaderTabs extends React.Component {
     });
 
     return (
-      <ul className="menu-tabbed flush-bottom">
-        {tabElements}
-      </ul>
+      <div className="page-header-navigation">
+        <ul className="menu-tabbed">
+          {tabElements}
+        </ul>
+      </div>
     );
   }
 }

--- a/src/js/components/Page.js
+++ b/src/js/components/Page.js
@@ -8,8 +8,14 @@ import InternalStorageMixin from '../mixins/InternalStorageMixin';
 import NewPageHeader from '../components/NewPageHeader';
 import SidebarToggle from '../components/SidebarToggle';
 
-const PageHeader = ({breadcrumbs, tabs = []}) => {
-  return <NewPageHeader breadcrumbs={breadcrumbs} tabs={tabs} />;
+const PageHeader = ({breadcrumbs, tabs = [], actions = [], addButton}) => {
+  return (
+    <NewPageHeader
+      actions={actions}
+      addButton={addButton}
+      breadcrumbs={breadcrumbs}
+      tabs={tabs} />
+  );
 };
 
 PageHeader.Breadcrumbs = NewPageHeader.Breadcrumbs;

--- a/src/js/components/Page.js
+++ b/src/js/components/Page.js
@@ -7,6 +7,7 @@ import GeminiUtil from '../utils/GeminiUtil';
 import InternalStorageMixin from '../mixins/InternalStorageMixin';
 import NewPageHeader from '../components/NewPageHeader';
 import SidebarToggle from '../components/SidebarToggle';
+import TemplateUtil from '../utils/TemplateUtil';
 
 const PageHeader = ({actions, addButton, breadcrumbs, tabs}) => {
   return (
@@ -18,9 +19,11 @@ const PageHeader = ({actions, addButton, breadcrumbs, tabs}) => {
   );
 };
 
-PageHeader.Breadcrumbs = NewPageHeader.Breadcrumbs;
-PageHeader.Actions = NewPageHeader.Actions;
-PageHeader.Tabs = NewPageHeader.Tabs;
+TemplateUtil.defineChildren(PageHeader, {
+  Breadcrumbs: NewPageHeader.Breadcrumbs,
+  Actions: NewPageHeader.Actions,
+  Tabs: NewPageHeader.Actions
+});
 
 PageHeader.defaultProps = {
   actions: [],
@@ -33,10 +36,6 @@ PageHeader.propTypes = {
   breadcrumbs: React.PropTypes.node,
   tabs: React.PropTypes.array
 };
-
-const PAGE_TEMPLATE_COMPONENTS = [
-  PageHeader
-];
 
 var Page = React.createClass({
 
@@ -85,11 +84,9 @@ var Page = React.createClass({
     var data = this.internalStorage_get();
     if (data.rendered === true) {
       // Avoid rendering template children twice
-      // TODO move to a template utility library
-      return React.Children.toArray(this.props.children)
-        .filter(function (child) {
-          return !PAGE_TEMPLATE_COMPONENTS.includes(child.type);
-        });
+      return TemplateUtil.filterTemplateChildren(
+        this.constructor, this.props.children
+      );
     }
     return null;
   },
@@ -106,21 +103,10 @@ var Page = React.createClass({
     );
   },
 
-  // TODO move this to a template utility library
   getPageHeader() {
-    // Allow components to be updated by subclasses
-    const {Header} = this.constructor;
-    // Allow components to be disabled by subclasses
-    if (Header == null) {
-      return null;
-    }
-
-    // Find the first child of the defined type
-    // or null, if no such component exists
-    return React.Children.toArray(this.props.children)
-      .find((child) => {
-        return child.type === Header;
-      });
+    return TemplateUtil.getChildOfType(
+      this.props.children, this.constructor.Header
+    );
   },
 
   getTitle(title) {
@@ -189,6 +175,6 @@ var Page = React.createClass({
   }
 });
 
-Page.Header = PageHeader;
+TemplateUtil.defineChildren(Page, {Header: PageHeader});
 
 module.exports = Page;

--- a/src/js/components/Page.js
+++ b/src/js/components/Page.js
@@ -8,7 +8,7 @@ import InternalStorageMixin from '../mixins/InternalStorageMixin';
 import NewPageHeader from '../components/NewPageHeader';
 import SidebarToggle from '../components/SidebarToggle';
 
-const PageHeader = ({breadcrumbs, tabs = [], actions = [], addButton}) => {
+const PageHeader = ({actions, addButton, breadcrumbs, tabs}) => {
   return (
     <NewPageHeader
       actions={actions}
@@ -22,7 +22,14 @@ PageHeader.Breadcrumbs = NewPageHeader.Breadcrumbs;
 PageHeader.Actions = NewPageHeader.Actions;
 PageHeader.Tabs = NewPageHeader.Tabs;
 
+PageHeader.defaultProps = {
+  actions: [],
+  tabs: []
+};
+
 PageHeader.propTypes = {
+  actions: React.PropTypes.array,
+  addButton: React.PropTypes.object,
   breadcrumbs: React.PropTypes.node,
   tabs: React.PropTypes.array
 };

--- a/src/js/utils/TemplateUtil.js
+++ b/src/js/utils/TemplateUtil.js
@@ -1,0 +1,62 @@
+import React from 'react';
+
+const TemplateUtil = {
+
+  /**
+   * Defines each item in children as a template child of the parent class.
+   *
+   * As well as adding the component to its parent namespace, this method
+   * tracks each template item together with its reference on
+   *
+   * @param {React.Component} Parent
+   * @param {React.Children} children
+   */
+  defineChildren(Parent, children) {
+    Object.assign(Parent, children);
+
+    if (Parent.templateItems == null) {
+      Parent.templateItems = children;
+    } else {
+      Object.assign(Parent.templateItems, children);
+    }
+  },
+
+  /**
+   * Gets all types of template children for a given component.
+   *
+   * @return {Array} a list of children.
+   */
+  getTypesOfTemplateChildren({templateItems = {}}) {
+    return Object.values(templateItems);
+  },
+
+  /**
+   * Get all children of an instance which are not template children.
+   *
+   * @param {React.Component} T
+   * @param {React.Children} children
+   *
+   * @return {Array} a list of children.
+   */
+  filterTemplateChildren(T, children) {
+    const types = this.getTypesOfTemplateChildren(T);
+    return React.Children.toArray(children)
+        .filter((child) => !types.includes(child.type));
+  },
+
+  /**
+   * Returns the first child with
+   *
+   * @param {React.Children} children
+   * @param {React.Component} T
+   *
+   * @return {React.Component} a single child of type <T>.
+   */
+  getChildOfType(children, T) {
+    return React.Children.toArray(children)
+      .find((child) => child.type === T);
+  }
+
+};
+
+module.exports = TemplateUtil;

--- a/src/js/utils/__tests__/TemplateUtil-test.js
+++ b/src/js/utils/__tests__/TemplateUtil-test.js
@@ -1,0 +1,64 @@
+jest.dontMock('../TemplateUtil');
+const React = require('react');
+const TemplateUtil = require('../TemplateUtil');
+
+describe('Template Util', function () {
+  const DummyHeader = () => <h1>Header</h1>;
+  const DummyHeader2 = () => <h2>Header 2</h2>;
+  const DummyFooter = () => <p>Footer</p>;
+
+  beforeEach(function () {
+    this.DummyPage = () => (
+      <div>
+        <DummyHeader />
+        <p>A regular child 1</p>
+        <p>A regular child 2</p>
+      </div>
+    );
+    TemplateUtil.defineChildren(this.DummyPage, {Header: DummyHeader});
+  });
+
+  describe('#defineChildren', function () {
+
+    it('makes children accessible via the parent constructor', function () {
+      expect(this.DummyPage.Header).toBe(DummyHeader);
+    });
+
+    it('tracks the type of each child', function () {
+      TemplateUtil.defineChildren(this.DummyPage, {Footer: DummyFooter});
+      expect(TemplateUtil.getTypesOfTemplateChildren(this.DummyPage))
+          .toEqual([DummyHeader, DummyFooter]);
+    });
+
+    it('allows a template children to be overridden', function () {
+      TemplateUtil.defineChildren(this.DummyPage, {Header: DummyHeader2});
+      expect(this.DummyPage.Header).toBe(DummyHeader2);
+    });
+
+  });
+
+  describe('#filterTemplateChildren', function () {
+    it('returns all children of an instance which are not template children', function () {
+      const children = TemplateUtil.filterTemplateChildren(
+          this.DummyPage, [
+            <DummyHeader/>,
+            <p>A regular child 1</p>,
+            <p>A regular child 2</p>
+          ]
+      );
+      expect(children.map((child) => child.type)).toEqual(['p', 'p']);
+    });
+  });
+
+  describe('#getChildOfType', function () {
+    it('returns the first child of an instance with the appropriate type', function () {
+      const child = TemplateUtil.getChildOfType([
+        <DummyHeader/>,
+        <p>A regular child 1</p>,
+        <p>A regular child 2</p>
+      ], DummyHeader);
+      expect(child.type).toBe(DummyHeader);
+    });
+  });
+
+});


### PR DESCRIPTION
This PR introduces the new Page Header components. In order to keep noise low, I've stayed relatively faithful to the original interface of the components. 

The page header is wrapped in a utility component and added to the Page namespace in order to allow subclasses of Page to override it. 

The intent is to allow every view to control its header by defining itself as a page, eg

```
<Page>
  <Page.Header breadcrumbs={...} />
  {usual page content here}
</Page>
```