### PR TITLE
[2/11] New headers for service pages

### DIFF
--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import {Link} from 'react-router';
+
+import PageHeaderBreadcrumbs from '../../../../../src/js/components/NewPageHeaderBreadcrumbs';
+
+const ServiceBreadcrumbs = ({serviceID, taskID, taskName}) => {
+  const trimmedServiceID = decodeURIComponent(serviceID).replace(/^\//, '');
+  const ids = trimmedServiceID.split('/');
+  let aggregateIDs = '';
+
+  const crumbs = [<Link to="services" key={-1}>Services</Link>];
+
+  if (serviceID != null && trimmedServiceID.length > 0) {
+    let serviceCrumbs = ids.map(function (id, index) {
+      aggregateIDs += encodeURIComponent(`/${id}`);
+
+      return (
+        <Link to={`/services/overview/${aggregateIDs}`} key={index}>{id}</Link>
+      );
+    });
+
+    crumbs.push(...serviceCrumbs);
+  }
+
+  if (taskID != null && taskName != null) {
+    let encodedTaskID = encodeURIComponent(taskID);
+    crumbs.push(
+      <Link to={`services/overview/${aggregateIDs}/tasks/${encodedTaskID}`} index={taskID}>{taskName}</Link>
+    );
+  }
+
+  return <PageHeaderBreadcrumbs iconID="services" breadcrumbs={crumbs} />;
+
+};
+
+module.exports = ServiceBreadcrumbs;

--- a/plugins/services/src/js/containers/pod-detail/PodDetail.js
+++ b/plugins/services/src/js/containers/pod-detail/PodDetail.js
@@ -77,20 +77,54 @@ class PodDetail extends mixin(TabsMixin) {
     return (<PodInstancesContainer pod={pod} />);
   }
 
+  getActions() {
+    const {pod} = this.props;
+    const instanceCount = pod.getInstancesCount();
+
+    const actions = [];
+
+    actions.push({
+      label: 'Edit',
+      onItemSelect:  this.handleActionEdit
+    });
+
+    actions.push({
+      label: 'Scale',
+      onItemSelect: this.handleActionScale
+    });
+
+    if (instanceCount > 0) {
+      actions.push({
+        label: 'Suspend',
+        onItemSelect: this.handleActionSuspend
+      });
+    }
+
+    actions.push({
+      className: 'text-danger',
+      label: 'Destroy',
+      onItemSelect: this.handleActionDestroy
+    });
+
+    return actions;
+  }
+
+  getTabs() {
+    return [
+      {label: 'Instances', callback: () => { this.setState({currentTab: 'instances'}); }},
+      {label: 'Configuration', callback: () => { this.setState({currentTab: 'configuration'}); }},
+      {label: 'Debug', callback: () => { this.setState({currentTab: 'debug'}); }}
+    ];
+  }
+
   render() {
     const {modals, pod} = this.props;
 
     const breadcrumbs = <ServiceBreadcrumbs serviceID={pod.id} />;
 
-    const tabs = [
-      {label: 'Instances', callback: () => { this.setState({currentTab: 'instances'}); }},
-      {label: 'Configuration', callback: () => { this.setState({currentTab: 'configuration'}); }},
-      {label: 'Debug', callback: () => { this.setState({currentTab: 'debug'}); }}
-    ];
-
     return (
       <Page>
-        <Page.Header breadcrumbs={breadcrumbs} tabs={tabs}>
+        <Page.Header actions={this.getActions()} breadcrumbs={breadcrumbs} tabs={this.getTabs()}>
           <PodHeader
             onDestroy={this.handleActionDestroy}
             onEdit={this.handleActionEdit}

--- a/plugins/services/src/js/containers/pod-detail/PodDetail.js
+++ b/plugins/services/src/js/containers/pod-detail/PodDetail.js
@@ -2,7 +2,8 @@ import mixin from 'reactjs-mixin';
 import React, {PropTypes} from 'react';
 import {routerShape} from 'react-router';
 
-import Breadcrumbs from '../../../../../../src/js/components/Breadcrumbs';
+import ServiceBreadcrumbs from '../../components/ServiceBreadcrumbs';
+import Page from '../../../../../../src/js/components/Page';
 import Pod from '../../structs/Pod';
 import PodConfigurationContainer from '../pod-configuration/PodConfigurationContainer';
 import PodDebugContainer from '../pod-debug/PodDebugContainer';
@@ -77,20 +78,30 @@ class PodDetail extends mixin(TabsMixin) {
   }
 
   render() {
-    const {pod} = this.props;
+    const {modals, pod} = this.props;
+
+    const breadcrumbs = <ServiceBreadcrumbs serviceID={pod.id} />;
+
+    const tabs = [
+      {label: 'Instances', callback: () => { this.setState({currentTab: 'instances'}); }},
+      {label: 'Configuration', callback: () => { this.setState({currentTab: 'configuration'}); }},
+      {label: 'Debug', callback: () => { this.setState({currentTab: 'debug'}); }}
+    ];
 
     return (
-      <div>
-        <Breadcrumbs routes={this.props.routes} params={this.props.params} />
-        <PodHeader
-          onDestroy={this.handleActionDestroy}
-          onEdit={this.handleActionEdit}
-          onScale={this.handleActionScale}
-          onSuspend={this.handleActionSuspend}
-          pod={pod}
-          tabs={this.tabs_getUnroutedTabs()} />
+      <Page>
+        <Page.Header breadcrumbs={breadcrumbs} tabs={tabs}>
+          <PodHeader
+            onDestroy={this.handleActionDestroy}
+            onEdit={this.handleActionEdit}
+            onScale={this.handleActionScale}
+            onSuspend={this.handleActionSuspend}
+            pod={pod}
+            tabs={this.tabs_getUnroutedTabs()} />
+        </Page.Header>
         {this.tabs_getTabView()}
-      </div>
+        {modals}
+      </Page>
     );
   }
 }
@@ -105,6 +116,7 @@ PodDetail.contextTypes = {
 };
 
 PodDetail.propTypes = {
+  modals: PropTypes.node,
   pod: React.PropTypes.instanceOf(Pod)
 };
 

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -113,18 +113,72 @@ class ServiceDetail extends mixin(TabsMixin) {
     );
   }
 
-  render() {
-    const {modals, service} = this.props;
-    let {id} = service;
+  getActions() {
+    const {service} = this.props;
+    const {modalHandlers} = this.context;
+    const instanceCount = service.getInstancesCount();
 
-    const breadcrumbs = <ServiceBreadcrumbs serviceID={id} />;
+    const actions = [];
 
+    actions.push({
+      label: 'Edit',
+      onItemSelect: modalHandlers.editService
+    });
+
+    if (instanceCount > 0) {
+      actions.push({
+        label: 'Restart',
+        onItemSelect: modalHandlers.restartService
+      });
+    }
+
+    actions.push({
+      label: 'Scale',
+      onItemSelect: modalHandlers.scaleService
+    });
+
+    if (instanceCount > 0) {
+      actions.push({
+        label: 'Suspend',
+        onItemSelect: modalHandlers.suspendService
+      });
+    }
+
+    actions.push({
+      className: 'text-danger',
+      label: 'Destroy',
+      onItemSelect: modalHandlers.deleteService
+    });
+
+    return actions;
+  }
+
+  getTabs() {
+    const {service:{id}} = this.props;
     const routePrefix = `/services/overview/${encodeURIComponent(id)}`;
-    const tabs = [
-      {label: 'Instances', callback: () => { this.setState({currentTab: 'tasks'}); }},
-      {label: 'Configuration', callback: () => { this.setState({currentTab: 'configuration'}); }},
-      {label: 'Debug', callback: () => { this.setState({currentTab: 'debug'}); }}
-    ];
+
+    const tabs = [];
+
+    tabs.push({
+      label: 'Instances',
+      callback: () => {
+        this.setState({currentTab: 'tasks'});
+      }
+    });
+
+    tabs.push({
+      label: 'Configuration',
+      callback: () => {
+        this.setState({currentTab: 'configuration'});
+      }
+    });
+
+    tabs.push({
+      label: 'Debug',
+      callback: () => {
+        this.setState({currentTab: 'debug'});
+      }
+    });
 
     if (this.hasVolumes()) {
       tabs.push({
@@ -133,9 +187,19 @@ class ServiceDetail extends mixin(TabsMixin) {
       });
     }
 
+    return tabs;
+  }
+
+  render() {
+    const {modals, service:{id}} = this.props;
+    const breadcrumbs = <ServiceBreadcrumbs serviceID={id} />;
+
     return (
       <Page>
-        <Page.Header tabs={tabs} breadcrumbs={breadcrumbs} iconID="services" />
+        <Page.Header actions={this.getActions()}
+            tabs={this.getTabs()}
+            breadcrumbs={breadcrumbs}
+            iconID="services" />
         {this.tabs_getTabView()}
         {modals}
       </Page>
@@ -145,6 +209,7 @@ class ServiceDetail extends mixin(TabsMixin) {
 
 ServiceDetail.contextTypes = {
   modalHandlers: PropTypes.shape({
+    editService: PropTypes.func,
     scaleService: PropTypes.func,
     restartService: PropTypes.func,
     suspendService: PropTypes.func,

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -133,9 +133,6 @@ class ServiceDetail extends mixin(TabsMixin) {
       });
     }
 
-    // TODO add ServiceInfo to header actions
-    /* <ServiceInfo onActionsItemSelection={this.onActionsItemSelection}
-         service={service} tabs={this.tabs_getUnroutedTabs()} />*/
     return (
       <Page>
         <Page.Header tabs={tabs} breadcrumbs={breadcrumbs} iconID="services" />

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -69,7 +69,7 @@ class ServiceDetail extends mixin(TabsMixin) {
 
   hasVolumes() {
     return !!this.props.service &&
-        this.props.service.getVolumes().getItems().length > 0;
+      this.props.service.getVolumes().getItems().length > 0;
   }
 
   checkForVolumes() {
@@ -197,9 +197,9 @@ class ServiceDetail extends mixin(TabsMixin) {
     return (
       <Page>
         <Page.Header actions={this.getActions()}
-            tabs={this.getTabs()}
-            breadcrumbs={breadcrumbs}
-            iconID="services" />
+          tabs={this.getTabs()}
+          breadcrumbs={breadcrumbs}
+          iconID="services" />
         {this.tabs_getTabView()}
         {modals}
       </Page>

--- a/plugins/services/src/js/containers/service-detail/__tests__/ServiceDetail-test.js
+++ b/plugins/services/src/js/containers/service-detail/__tests__/ServiceDetail-test.js
@@ -1,6 +1,8 @@
 jest.dontMock('../../../../../../../src/js/components/CollapsingString');
 jest.dontMock('../../../../../../../src/js/components/DetailViewHeader');
 jest.dontMock('../../../../../../../src/js/stores/MesosStateStore');
+jest.dontMock('../../../../../../../src/js/components/Page');
+jest.dontMock('../../../../../../../src/js/mixins/InternalStorageMixin');
 jest.dontMock('../ServiceDetail');
 jest.dontMock('../../service-debug/ServiceDebugContainer');
 jest.dontMock('../../service-configuration/ServiceConfigurationContainer');

--- a/plugins/services/src/js/containers/service-detail/__tests__/ServiceDetail-test.js
+++ b/plugins/services/src/js/containers/service-detail/__tests__/ServiceDetail-test.js
@@ -60,14 +60,6 @@ describe('ServiceDetail', function () {
     ReactDOM.unmountComponentAtNode(this.container);
   });
 
-  describe('#render', function () {
-
-    it('renders service info name', function () {
-      expect(this.node.querySelector('.h1 .collapsing-string-full-string').textContent).toEqual('test');
-    });
-
-  });
-
   describe('#renderConfigurationTabView', function () {
 
     it('renders the configuration tab', function () {

--- a/plugins/services/src/js/containers/service-detail/__tests__/ServiceDetail-test.js
+++ b/plugins/services/src/js/containers/service-detail/__tests__/ServiceDetail-test.js
@@ -45,10 +45,26 @@ describe('ServiceDetail', function () {
     }
   });
 
+  const contextTypes = {
+    modalHandlers: React.PropTypes.object
+  };
+
+  const context = {
+    modalHandlers: {
+      editService() {},
+      scaleService() {},
+      restartService() {},
+      suspendService() {},
+      deleteService() {}
+    }
+  };
+
   beforeEach(function () {
     this.container = document.createElement('div');
     this.wrapper = ReactDOM.render(
-      JestUtil.stubRouterContext(ServiceDetail, {service}),
+      JestUtil.stubRouterContext(
+        ServiceDetail, {service}, {}, contextTypes, context
+      ),
       this.container
     );
     this.instance =

--- a/plugins/services/src/js/containers/services/ServiceTreeView.js
+++ b/plugins/services/src/js/containers/services/ServiceTreeView.js
@@ -1,14 +1,15 @@
 import React, {PropTypes} from 'react';
 
 import EmptyServiceTree from './EmptyServiceTree';
+import ServiceBreadcrumbs from '../../components/ServiceBreadcrumbs';
 import ServiceSearchFilter from './ServiceSearchFilter';
 import ServiceSidebarFilters from './ServiceSidebarFilters';
 import ServiceTree from '../../structs/ServiceTree';
 import ServicesTable from './ServicesTable';
 
-import Breadcrumbs from '../../../../../../src/js/components/Breadcrumbs';
 import FilterBar from '../../../../../../src/js/components/FilterBar';
 import FilterHeadline from '../../../../../../src/js/components/FilterHeadline';
+import Page from '../../../../../../src/js/components/Page';
 
 class ServiceTreeView extends React.Component {
 
@@ -41,13 +42,12 @@ class ServiceTreeView extends React.Component {
       );
     }
 
-    return (
-      <Breadcrumbs routes={this.props.routes} params={this.props.params} />
-    );
+    return null;
   }
 
   render() {
     const {
+      modals,
       serviceTree,
       services
     } = this.props;
@@ -56,46 +56,54 @@ class ServiceTreeView extends React.Component {
 
     if (serviceTree.getItems().length) {
       return (
-        <div className="flex">
-          <ServiceSidebarFilters
-            countByValue={services.countByFilter}
-            filters={services.filters}
-            handleFilterChange={this.props.handleFilterChange}
-            services={services.all} />
-          <div className="flex-grow">
-            {this.getHeadline()}
-            <FilterBar rightAlignLastNChildren={2}>
-              <ServiceSearchFilter
-                handleFilterChange={this.props.handleFilterChange}
-                filters={services.filters || {}} />
-              <button className="button button-stroke"
-                onClick={modalHandlers.createGroup}>
-                Create Group
-              </button>
-              <button className="button button-success"
-                onClick={modalHandlers.createService}>
-                Run a Service
-              </button>
-            </FilterBar>
-            <ServicesTable services={services.filtered}
-              isFiltered={!!Object.keys(services.filters).length}
-              modalHandlers={modalHandlers} />
+        <Page>
+          <Page.Header breadcrumbs={<ServiceBreadcrumbs serviceID={serviceTree.id} />} />
+          <div className="flex">
+            <ServiceSidebarFilters
+              countByValue={services.countByFilter}
+              filters={services.filters}
+              handleFilterChange={this.props.handleFilterChange}
+              services={services.all} />
+            <div className="flex-grow">
+              {this.getHeadline()}
+              <FilterBar rightAlignLastNChildren={2}>
+                <ServiceSearchFilter
+                  handleFilterChange={this.props.handleFilterChange}
+                  filters={services.filters || {}} />
+                <button className="button button-stroke"
+                  onClick={modalHandlers.createGroup}>
+                  Create Group
+                </button>
+                <button className="button button-success"
+                  onClick={modalHandlers.createService}>
+                  Run a Service
+                </button>
+              </FilterBar>
+              <ServicesTable services={services.filtered}
+                isFiltered={!!Object.keys(services.filters).length}
+                modalHandlers={modalHandlers} />
+            </div>
           </div>
-        </div>
+          {modals}
+        </Page>
       );
-    };
+    }
 
     return (
-      <EmptyServiceTree
-        onCreateGroup={modalHandlers.createGroup}
-        onCreateService={modalHandlers.createService} />
+      <Page>
+        <Page.Header breadcrumbs={<ServiceBreadcrumbs serviceID={serviceTree.id} />} />
+        <EmptyServiceTree
+          onCreateGroup={modalHandlers.createGroup}
+          onCreateService={modalHandlers.createService} />
+        {modals}
+      </Page>
     );
   }
 }
 
 ServiceTreeView.contextTypes = {
   modalHandlers: PropTypes.shape({
-    creatGroup: PropTypes.func,
+    createGroup: PropTypes.func,
     createService: PropTypes.func
   }).isRequired
 };
@@ -110,6 +118,7 @@ const servicesProps = PropTypes.shape({
 ServiceTreeView.propTypes = {
   clearFilters: PropTypes.func.isRequired,
   handleFilterChange: PropTypes.func.isRequired,
+  modals: PropTypes.node,
   serviceTree: PropTypes.instanceOf(ServiceTree),
   services: servicesProps
 };

--- a/plugins/services/src/js/containers/services/ServiceTreeView.js
+++ b/plugins/services/src/js/containers/services/ServiceTreeView.js
@@ -57,7 +57,11 @@ class ServiceTreeView extends React.Component {
     if (serviceTree.getItems().length) {
       return (
         <Page>
-          <Page.Header breadcrumbs={<ServiceBreadcrumbs serviceID={serviceTree.id} />} />
+          <Page.Header
+            breadcrumbs={<ServiceBreadcrumbs serviceID={serviceTree.id} />}
+            actions={[{onItemSelect: modalHandlers.createGroup, label: 'Create Group'}]}
+            addButton={{onItemSelect: modalHandlers.createService, label: 'Run a Service'}}
+            />
           <div className="flex">
             <ServiceSidebarFilters
               countByValue={services.countByFilter}

--- a/plugins/services/src/js/containers/services/ServiceTreeView.js
+++ b/plugins/services/src/js/containers/services/ServiceTreeView.js
@@ -70,18 +70,10 @@ class ServiceTreeView extends React.Component {
               services={services.all} />
             <div className="flex-grow">
               {this.getHeadline()}
-              <FilterBar rightAlignLastNChildren={2}>
+              <FilterBar>
                 <ServiceSearchFilter
                   handleFilterChange={this.props.handleFilterChange}
                   filters={services.filters || {}} />
-                <button className="button button-stroke"
-                  onClick={modalHandlers.createGroup}>
-                  Create Group
-                </button>
-                <button className="button button-success"
-                  onClick={modalHandlers.createService}>
-                  Run a Service
-                </button>
               </FilterBar>
               <ServicesTable services={services.filtered}
                 isFiltered={!!Object.keys(services.filters).length}

--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -625,7 +625,7 @@ class ServicesContainer extends React.Component {
       <Page>
         <Page.Header breadcrumbs={<ServiceBreadcrumbs />} />
         <ServiceItemNotFound
-            message={`The service with the ID of "${itemId}" could not be found.`} />
+          message={`The service with the ID of "${itemId}" could not be found.`} />
       </Page>
     );
   }

--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -8,6 +8,7 @@ import Pod from '../../structs/Pod';
 import PodDetail from '../pod-detail/PodDetail';
 import Service from '../../structs/Service';
 import ServiceActionItem from '../../constants/ServiceActionItem';
+import ServiceBreadcrumbs from '../../components/ServiceBreadcrumbs';
 import ServiceDetail from '../service-detail/ServiceDetail';
 import ServiceItemNotFound from '../../components/ServiceItemNotFound';
 import ServiceModals from '../../components/modals/ServiceModals';
@@ -19,6 +20,7 @@ import AppDispatcher from '../../../../../../src/js/events/AppDispatcher';
 import ContainerUtil from '../../../../../../src/js/utils/ContainerUtil';
 import Icon from '../../../../../../src/js/components/Icon';
 import Loader from '../../../../../../src/js/components/Loader';
+import Page from '../../../../../../src/js/components/Page';
 import RequestErrorMsg from '../../../../../../src/js/components/RequestErrorMsg';
 
 import {
@@ -558,7 +560,12 @@ class ServicesContainer extends React.Component {
 
     // Still Loading
     if (isLoading) {
-      return <Loader />;
+      return (
+        <Page>
+          <Page.Header breadcrumbs={<ServiceBreadcrumbs />} />
+          <Loader />
+        </Page>
+      );
     }
 
     // API Failures
@@ -568,25 +575,21 @@ class ServicesContainer extends React.Component {
 
     if (item instanceof Pod) {
       return (
-        <div>
-          <PodDetail
-            actions={this.getActions()}
-            pod={item} />
-          {this.getModals(item)}
-        </div>
+        <PodDetail
+          actions={this.getActions()}
+          pod={item}
+          modals={this.getModals(item)} />
       );
     }
 
     if (item instanceof Service) {
       return (
-        <div>
-          <ServiceDetail
-            actions={this.getActions()}
-            params={this.props.params}
-            routes={this.props.routes}
-            service={item} />
-          {this.getModals(item)}
-        </div>
+        <ServiceDetail
+          actions={this.getActions()}
+          params={this.props.params}
+          routes={this.props.routes}
+          service={item}
+          modals={this.getModals(item)} />
       );
     }
 
@@ -605,23 +608,25 @@ class ServicesContainer extends React.Component {
         filters
       };
 
+      // TODO move modals to Page
       return (
-        <div>
-          <ServiceTreeView
-            clearFilters={this.clearFilters}
-            handleFilterChange={this.handleFilterChange}
-            params={this.props.params}
-            routes={this.props.routes}
-            services={services}
-            serviceTree={item} />
-          {this.getModals(item)}
-        </div>
+        <ServiceTreeView
+          clearFilters={this.clearFilters}
+          handleFilterChange={this.handleFilterChange}
+          params={this.props.params}
+          routes={this.props.routes}
+          services={services}
+          serviceTree={item}
+          modals={this.getModals(item)} />
       );
     }
     // Not found
     return (
-      <ServiceItemNotFound
-        message={`The service with the ID of "${itemId}" could not be found.`} />
+      <Page>
+        <Page.Header breadcrumbs={<ServiceBreadcrumbs />} />
+        <ServiceItemNotFound
+            message={`The service with the ID of "${itemId}" could not be found.`} />
+      </Page>
     );
   }
 }

--- a/plugins/services/src/js/pages/ServicesPage.js
+++ b/plugins/services/src/js/pages/ServicesPage.js
@@ -3,7 +3,6 @@ import {routerShape} from 'react-router';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
 import Icon from '../../../../../src/js/components/Icon';
-import Page from '../../../../../src/js/components/Page';
 import RouterUtil from '../../../../../src/js/utils/RouterUtil';
 import TabsMixin from '../../../../../src/js/mixins/TabsMixin';
 
@@ -71,17 +70,7 @@ var ServicesPage = React.createClass({
   },
 
   render() {
-    // Make sure to grow when logs are displayed
-    let routes = this.props.routes;
-
-    return (
-      <Page
-        navigation={this.getNavigation()}
-        dontScroll={routes[routes.length - 1].dontScroll}
-        title="Services">
-        {this.props.children}
-      </Page>
-    );
+    return this.props.children;
   }
 
 });

--- a/plugins/services/src/js/pages/__tests__/DeploymentsTab-test.js
+++ b/plugins/services/src/js/pages/__tests__/DeploymentsTab-test.js
@@ -2,6 +2,8 @@ jest.unmock('moment');
 jest.unmock('../../../../../../src/js/components/CollapsingString');
 jest.unmock('../services/DeploymentsTab');
 jest.unmock('../../../../../../src/js/components/TimeAgo');
+jest.unmock('../../../../../../src/js/components/Page');
+jest.unmock('../../../../../../src/js/mixins/InternalStorageMixin');
 jest.unmock('../../structs/DeploymentsList');
 jest.unmock('../../structs/Deployment');
 

--- a/plugins/services/src/js/pages/services/DeploymentsTab.js
+++ b/plugins/services/src/js/pages/services/DeploymentsTab.js
@@ -334,12 +334,10 @@ class DeploymentsTab extends mixin(StoreMixin) {
 
     return (
       <Page>
-        <Page.Header breadcrumbs={<DeploymentsBreadcrumbs />}>
-          <Link to="services">Services</Link> &gt; <Link to="services/deployments">Deployments</Link>
-          <h4 className="flush-top">
-            {deploymentsCount} Active {deploymentsLabel}
-          </h4>
-        </Page.Header>
+        <Page.Header breadcrumbs={<DeploymentsBreadcrumbs />} />
+        <h4 className="flush-top">
+          {deploymentsCount} Active {deploymentsLabel}
+        </h4>
         <Table
           className="table table-borderless-outer table-borderless-inner-columns
             flush-bottom deployments-table"

--- a/plugins/services/src/js/pages/services/DeploymentsTab.js
+++ b/plugins/services/src/js/pages/services/DeploymentsTab.js
@@ -15,6 +15,7 @@ import Loader from '../../../../../../src/js/components/Loader';
 import MarathonActions from '../../events/MarathonActions';
 import ModalHeading from '../../../../../../src/js/components/modals/ModalHeading';
 import NestedServiceLinks from '../../../../../../src/js/components/NestedServiceLinks';
+import Page from '../../../../../../src/js/components/Page';
 import StatusBar from '../../../../../../src/js/components/StatusBar';
 import StringUtil from '../../../../../../src/js/utils/StringUtil';
 import TimeAgo from '../../../../../../src/js/components/TimeAgo';
@@ -50,6 +51,15 @@ function columnClassNameGetter(prop, sortBy, row) {
   }
   return classSet;
 }
+
+const DeploymentsBreadcrumbs = () => {
+  const crumbs = [
+    <Link to="services" key={-1}>Services</Link>,
+    <Link to="services/deployments" key={0}>Deployments</Link>
+  ];
+
+  return <Page.Header.Breadcrumbs iconID="services" breadcrumbs={crumbs} />;
+};
 
 class DeploymentsTab extends mixin(StoreMixin) {
 
@@ -304,10 +314,13 @@ class DeploymentsTab extends mixin(StoreMixin) {
 
   renderEmpty() {
     return (
-      <AlertPanel
-        title="No active deployments">
-        <p className="flush">Active deployments will be shown here.</p>
-      </AlertPanel>
+      <Page>
+        <Page.Header breadcrumbs={<DeploymentsBreadcrumbs/>} />
+        <AlertPanel
+          title="No active deployments">
+          <p className="flush">Active deployments will be shown here.</p>
+        </AlertPanel>
+      </Page>
     );
   }
 
@@ -320,10 +333,13 @@ class DeploymentsTab extends mixin(StoreMixin) {
     let deploymentsLabel = StringUtil.pluralize('Deployment', deploymentsCount);
 
     return (
-      <div>
-        <h4 className="flush-top">
-          {deploymentsCount} Active {deploymentsLabel}
-        </h4>
+      <Page>
+        <Page.Header breadcrumbs={<DeploymentsBreadcrumbs />}>
+          <Link to="services">Services</Link> &gt; <Link to="services/deployments">Deployments</Link>
+          <h4 className="flush-top">
+            {deploymentsCount} Active {deploymentsLabel}
+          </h4>
+        </Page.Header>
         <Table
           className="table table-borderless-outer table-borderless-inner-columns
             flush-bottom deployments-table"
@@ -331,7 +347,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
           colGroup={this.getColGroup()}
           data={deploymentsItems.slice()} />
         {this.renderRollbackModal()}
-      </div>
+      </Page>
     );
   }
 

--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -355,9 +355,9 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
 
     const breadcrumbs = (
       <ServiceBreadcrumbs
-          serviceID={this.props.params.id}
-          taskID={task.getId()}
-          taskName={task.getName()} />
+        serviceID={this.props.params.id}
+        taskID={task.getId()}
+        taskName={task.getName()} />
     );
 
     let {id, taskID} = this.props.params;

--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -6,14 +6,15 @@ import {routerShape, formatPattern} from 'react-router';
 /* eslint-enable no-unused-vars */
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
-import Breadcrumbs from '../../../../../../src/js/components/Breadcrumbs';
 import DetailViewHeader from '../../../../../../src/js/components/DetailViewHeader';
 import InternalStorageMixin from '../../../../../../src/js/mixins/InternalStorageMixin';
 import Loader from '../../../../../../src/js/components/Loader';
 import ManualBreadcrumbs from '../../../../../../src/js/components/ManualBreadcrumbs';
 import MesosStateStore from '../../../../../../src/js/stores/MesosStateStore';
+import Page from '../../../../../../src/js/components/Page';
 import RequestErrorMsg from '../../../../../../src/js/components/RequestErrorMsg';
 import RouterUtil from '../../../../../../src/js/utils/RouterUtil';
+import ServiceBreadcrumbs from '../../components/ServiceBreadcrumbs';
 import StatusMapping from '../../constants/StatusMapping';
 import TabsMixin from '../../../../../../src/js/mixins/TabsMixin';
 import TaskDirectoryStore from '../../stores/TaskDirectoryStore';
@@ -26,6 +27,7 @@ const METHODS_TO_BIND = [
   'onTaskDirectoryStoreSuccess'
 ];
 
+// TODO remove
 const HIDE_BREADCRUMBS = [
   '/jobs/:id/tasks/:taskID/details',
   '/networking/networks/:overlayName/tasks/:taskID/details',
@@ -351,12 +353,31 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
       return this.getNotFound('task', this.props.params.taskID);
     }
 
+    const breadcrumbs = (
+      <ServiceBreadcrumbs
+          serviceID={this.props.params.id}
+          taskID={task.getId()}
+          taskName={task.getName()} />
+    );
+
+    let {id, taskID} = this.props.params;
+    let routePrefix = `/services/overview/${encodeURIComponent(id)}/tasks/${encodeURIComponent(taskID)}`;
+
+    const tabs = [
+      {label: 'Details', routePath: routePrefix + '/details'},
+      {label: 'Files', routePath: routePrefix + '/files'},
+      {label: 'Logs', routePath: routePrefix + '/logs'}
+    ];
+
+    // TODO move basic info to actions
+    /* {this.getBasicInfo()} */
     return (
-      <div className="flex flex-direction-top-to-bottom flex-item-grow-1 flex-item-shrink-1">
-        <Breadcrumbs routes={this.props.routes} params={this.props.params} />
-        {this.getBasicInfo()}
-        {this.getSubView()}
-      </div>
+      <Page>
+        <Page.Header breadcrumbs={breadcrumbs} iconID="services" tabs={tabs} />
+        <div className="flex flex-direction-top-to-bottom flex-item-grow-1 flex-item-shrink-1">
+          {this.getSubView()}
+        </div>
+      </Page>
     );
   }
 }

--- a/plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.js
+++ b/plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.js
@@ -3,6 +3,8 @@ jest.dontMock('../TaskDetail');
 jest.dontMock('../../../stores/MarathonStore');
 jest.dontMock('../../../../../../../src/js/stores/MesosStateStore');
 jest.dontMock('../../../../../../../src/js/stores/MesosSummaryStore');
+jest.dontMock('../../../../../../../src/js/components/Page');
+jest.dontMock('../../../../../../../src/js/mixins/InternalStorageMixin');
 
 const JestUtil = require('../../../../../../../src/js/utils/JestUtil');
 

--- a/src/js/utils/JestUtil.js
+++ b/src/js/utils/JestUtil.js
@@ -132,24 +132,26 @@ const JestUtil = {
    * @param {React.Component} Component
    * @param {object} [props]
    * @param {object} [routerStubs]
+   * @param {object} [contextTypes]
+   * @param {object} [context]
    * @returns {React.Element} wrapped component element
    */
-  stubRouterContext(Component, props = {}, routerStubs) {
+  stubRouterContext(Component, props={}, routerStubs={}, contextTypes={}, context={}) {
     // Create wrapper component
     class WrappedComponent extends React.Component {
 
       static get childContextTypes() {
-        return {
+        return Object.assign({
           router: routerShape,
           routeDepth: React.PropTypes.number
-        };
+        }, contextTypes);
       }
 
       getChildContext() {
-        return {
+        return Object.assign({
           router: Object.assign(RouterStub, routerStubs),
           routeDepth: 0
-        };
+        }, context);
       }
 
       render() {

--- a/src/styles/components/page-header/styles.less
+++ b/src/styles/components/page-header/styles.less
@@ -19,6 +19,7 @@
     }
   }
 
+  // TODO: Removed unused classes. DCOS-11900
   .page-header-title-container {
     align-items: center;
     display: flex;
@@ -128,6 +129,7 @@
     align-items: center;
     display: flex;
     flex: 1 1 auto;
+    min-height: @button-height;
     min-width: 0;
 
     // This extra classname is necessary to override specificity from CNVS.
@@ -346,6 +348,7 @@
       }
 
       .page-header-breadcrumbs {
+        min-height: @button-height-screen-large;
 
         &.list-inline {
 


### PR DESCRIPTION
---
⚠️   _This branch depends on features that will be introduced with #1482 and #1498_

---

This PR adopts the new headers introduced in #1482 and uses them in the Service pages. 

- [x] New-style breadcrumbs
- [x] New-style tertiary nav tabs
- [x] Dropdown Action menu
- [x] Template utils
- [x] Passing tests

Known issues (will be remedied outside this PR):
 - Breadcrumbs do not yet collapse
 - Non-routed tabs do not get an active state

![screen shot 2016-12-02 at 4 15 48 pm](https://cloud.githubusercontent.com/assets/2989362/20854674/a3925dbc-b8aa-11e6-8f22-937a690013b2.png)
