### PR TITLE
Fix PodInstanceTable column layout

### DIFF
--- a/src/styles/components/pod-instances-table/styles.less
+++ b/src/styles/components/pod-instances-table/styles.less
@@ -1,7 +1,6 @@
 & when (@pod-instances-table-enabled) {
 
   .pod-instances-table {
-    table-layout: fixed;
 
     td {
       vertical-align: top;


### PR DESCRIPTION
TIL, we shouldn't use `table-layout: fixed` if we're going to hide columns at certain breakpoints. Not sure why I didn't see this behavior earlier...

Before:
![](https://cl.ly/010V3v0c2J0M/Screen%20Shot%202016-12-03%20at%201.34.50%20PM.png)

After:
![](https://cl.ly/2Q0p3y2Z2j0t/Screen%20Shot%202016-12-03%20at%201.34.10%20PM.png)