### PR TITLE
Update to reactjs-components@0.16.0-beta.6

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6684,9 +6684,9 @@
       "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz"
     },
     "reactjs-components": {
-      "version": "0.16.0-beta.5",
-      "from": "reactjs-components@0.16.0-beta.5",
-      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.16.0-beta.5.tgz"
+      "version": "0.16.0-beta.6",
+      "from": "reactjs-components@0.16.0-beta.6",
+      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.16.0-beta.6.tgz"
     },
     "reactjs-mixin": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-gemini-scrollbar": "2.1.0",
     "react-redux": "4.4.0",
     "react-router": "2.8.1",
-    "reactjs-components": "0.16.0-beta.5",
+    "reactjs-components": "0.16.0-beta.6",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
     "tv4": "1.2.7",


### PR DESCRIPTION
This update includes a fix for checkboxes and radio buttons; they all use the new CNVS styling now.