### PR TITLE
Two small fixes for the kebab menu

### DIFF
--- a/src/js/components/PageHeaderActionsMenu.js
+++ b/src/js/components/PageHeaderActionsMenu.js
@@ -28,9 +28,10 @@ const getDropdownItemFromComponent = (child, index) => {
   };
 };
 
-const PageHeaderActionsMenu = ({children}) => {
+const PageHeaderActionsMenu = ({anchorRight, children}) => {
   return (
     <Dropdown
+      anchorRight={anchorRight}
       buttonClassName="button button-link"
       items={getMenuItems(children)}
       onItemSelection={handleItemSelection}

--- a/src/js/components/PageHeaderActionsMenu.js
+++ b/src/js/components/PageHeaderActionsMenu.js
@@ -22,7 +22,7 @@ const handleItemSelection = (item) => {
 
 const getDropdownItemFromComponent = (child, index) => {
   return {
-    clickHandler: child.props.clickHandler,
+    onItemSelect: child.props.onItemSelect,
     html: child,
     id: index
   };


### PR DESCRIPTION
This builds on the work in #1481 and fixes two small errors:

- the `anchorRight` property was not being passed to the `Dropdown`, so the dropdown on the right of the page header was appearing off the screen.
- the `clickHandler` child property was not updated to `onItemSelect` everywhere, so it defined actions were not working. 