### PR TITLE
DCOS-10470: [3/10] Fixing DSL JISON specs

### DIFF
--- a/src/resources/grammar/SearchDSL.jison
+++ b/src/resources/grammar/SearchDSL.jison
@@ -10,7 +10,8 @@ const {Merge, Operator} = require('../../js/utils/DSLParserUtil');
 
 %%
 \s+                                                 return 'WS';
-\s*[,]\s*                                           return 'COMMA';
+[,](?=\S)                                           return 'TIGHT_COMMA'
+\s*[,]\s                                            return 'COMMA';
 [a-z0-9_-]+\:          yytext=yytext.slice(0,-1);   return 'LABEL';
 \"(?:[^\"\\]|\\.)*?\"  yytext=yytext.slice(1,-1);   return 'STRING';
 \'(?:[^\'\\]|\\.)*?\'  yytext=yytext.slice(1,-1);   return 'STRING';
@@ -21,7 +22,7 @@ const {Merge, Operator} = require('../../js/utils/DSLParserUtil');
 
 /lex /* operator associations and precedence */
 
-%left 'COMMA' 'WS'
+%left 'TIGHT_COMMA' 'COMMA' 'WS'
 %start expressions
 
 %% /* language grammar */
@@ -36,7 +37,7 @@ lv  /* Label value(s) as an array */
         {$$ = [{text:yytext, start:@1.first_column, end:@1.last_column}];}
     | STRING
         {$$ = [{text:yytext, start:@1.first_column, end:@1.last_column}];}
-    | lv COMMA lv
+    | lv TIGHT_COMMA lv
         {$$ = [].concat($1, $3);}
     ;
 

--- a/src/resources/grammar/__tests__/SearchDSL-test.js
+++ b/src/resources/grammar/__tests__/SearchDSL-test.js
@@ -56,7 +56,7 @@ describe('SearchDSL', function () {
         expect(expr.ast.children[1].filterParams.label).toEqual('attrib');
       });
 
-      fit('should properly handle OR shorthand + OR with other operands', function () {
+      it('should properly handle OR shorthand + OR with other operands', function () {
         // NOTE: attrib:value1,value2 becomes -> attrib:value1, attrib:value2
         let expr = SearchDSL.parse('attrib:value1,value2, foo');
         expect(expr.ast.combinerType).toEqual(DSLCombinerTypes.OR);

--- a/src/resources/grammar/__tests__/SearchDSL-test.js
+++ b/src/resources/grammar/__tests__/SearchDSL-test.js
@@ -56,6 +56,29 @@ describe('SearchDSL', function () {
         expect(expr.ast.children[1].filterParams.label).toEqual('attrib');
       });
 
+      fit('should properly handle OR shorthand + OR with other operands', function () {
+        // NOTE: attrib:value1,value2 becomes -> attrib:value1, attrib:value2
+        let expr = SearchDSL.parse('attrib:value1,value2, foo');
+        expect(expr.ast.combinerType).toEqual(DSLCombinerTypes.OR);
+
+        expect(expr.ast.children[0].combinerType).toEqual(DSLCombinerTypes.OR);
+        expect(expr.ast.children[0].children[0].filterType)
+          .toEqual(DSLFilterTypes.ATTRIB);
+        expect(expr.ast.children[0].children[0].filterParams.text)
+          .toEqual('value1');
+        expect(expr.ast.children[0].children[0].filterParams.label)
+          .toEqual('attrib');
+        expect(expr.ast.children[0].children[1].filterType)
+          .toEqual(DSLFilterTypes.ATTRIB);
+        expect(expr.ast.children[0].children[1].filterParams.text)
+          .toEqual('value2');
+        expect(expr.ast.children[0].children[1].filterParams.label)
+          .toEqual('attrib');
+
+        expect(expr.ast.children[1].filterType).toEqual(DSLFilterTypes.FUZZY);
+        expect(expr.ast.children[1].filterParams.text).toEqual('foo');
+      });
+
       it('should correctly populate children', function () {
         let expr = SearchDSL.parse('text1 text2');
         expect(expr.ast.children[0].filterType).toEqual(DSLFilterTypes.FUZZY);


### PR DESCRIPTION
---
~~⚠️  Depends on #1491~~

---

[Diff between 1491 & This](https://github.com/dcos/dcos-ui/pull/1493/commits/f8c3b781c73bd122ab482e0d6bb8567672d5c697)

This PR Makes the JISON specifications a bit more tight regarding the multi-value attributes. In particular:

Introducing `TIGHT_COMMA` token that makes sure there is no whitespace around it, in order to differentiate between:

* Multi vlaues: `label:a,b,c`
* Multiple tokens: `label:a, label:b`