### PR TITLE
Fix 404 for all the plugins

### DIFF
--- a/src/js/routes/index.js
+++ b/src/js/routes/index.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import {Route, Redirect} from 'react-router';
 import {Hooks} from 'PluginSDK';
 
@@ -15,9 +16,18 @@ import services from '../../../plugins/services/src/js/routes/services';
 import settings from './settings';
 import styles from './styles'; // eslint-disable-line
 import universe from './universe';
+import Util from '../utils/Util';
 
 // Modules that produce routes
 let routeFactories = [Organization, Network];
+
+// Pass through component, passes all the props to its children
+// needed because react-router can't handle more than 1 level of children
+// without a component
+const PassThroughComponent = (props) => {
+  const childProps = Util.omit(props, 'children');
+  return React.cloneElement(props.children, childProps);
+};
 
 function getApplicationRoutes() {
   // Statically defined routes
@@ -34,12 +44,8 @@ function getApplicationRoutes() {
     universe,
     cluster,
     components,
-    settings,
-    {
-      type: Route,
-      path: '*',
-      component: NotFoundPage
-    }
+    settings
+    // Plugins routes will be appended to this array
   );
 
   routeFactories.forEach(function (routeFactory) {
@@ -49,12 +55,21 @@ function getApplicationRoutes() {
   routes = [
     {
       type: Route,
+      component: Index,
       children: [
         {
           type: Route,
           id: 'index',
-          component: Index,
-          children: routes
+          children: routes,
+          component: PassThroughComponent
+        },
+        {
+          // Please make sure this is THE LAST route and is not inside of id: 'index'
+          // as this is a glob route and matching stops here
+          // making all the routes going after this point unreachable
+          type: Route,
+          path: '*',
+          component: NotFoundPage
         }
       ]
     }


### PR DESCRIPTION
I kept NotFoundPage Route being a child of Index while keeping it away from being in the main routes array.

Otherwise plugins routes go after the glob * NotFoundPage Route and therefore become unreachable.
