### PR TITLE
Allow multiple add actions in PageHeaderActions

### DIFF
--- a/src/js/components/NewPageHeader.js
+++ b/src/js/components/NewPageHeader.js
@@ -75,7 +75,10 @@ PageHeader.defaultProps = {
 };
 
 PageHeader.propTypes = {
-  addButton: React.PropTypes.object,
+  addButton: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object
+  ]),
   actions: React.PropTypes.array,
   breadcrumbs: React.PropTypes.node.isRequired,
   className: classProps,

--- a/src/js/components/NewPageHeaderActions.js
+++ b/src/js/components/NewPageHeaderActions.js
@@ -5,26 +5,28 @@ import {Tooltip} from 'reactjs-components';
 import Icon from './Icon';
 import PageHeaderActionsMenu from './PageHeaderActionsMenu';
 
+const getDropdownActions = (action, index) => {
+  if (React.isValidElement(action)) {
+    return action;
+  }
+
+  const {className, label, onItemSelect} = action;
+  const itemClasses = classNames(className);
+
+  return (
+    <span className={itemClasses} onItemSelect={onItemSelect} key={index}>
+      {label}
+    </span>
+  );
+};
+
 class PageHeaderActions extends React.Component {
 
   renderActionsMenu() {
     const {actions} = this.props;
 
     if (actions.length > 0) {
-      const dropdownElements = actions.map(function (action, index) {
-        if (React.isValidElement(action)) {
-          return action;
-        }
-
-        const {className, label, onItemSelect} = action;
-        const itemClasses = classNames(className);
-
-        return (
-          <span className={itemClasses} onItemSelect={onItemSelect} key={index}>
-            {label}
-          </span>
-        );
-      });
+      const dropdownElements = actions.map(getDropdownActions);
 
       return (
         <PageHeaderActionsMenu>
@@ -36,6 +38,17 @@ class PageHeaderActions extends React.Component {
 
   renderAddButton() {
     const {addButton} = this.props;
+
+    if (Array.isArray(addButton) && addButton.length > 0) {
+      const dropdownElements = addButton.map(getDropdownActions);
+
+      return (
+        <PageHeaderActionsMenu iconID="plus">
+          {dropdownElements}
+        </PageHeaderActionsMenu>
+      );
+    }
+
     if (addButton != null) {
       const {label, onItemSelect, className} = addButton;
       const buttonClasses = classNames(
@@ -81,20 +94,21 @@ const classProps = React.PropTypes.oneOfType([
   React.PropTypes.string
 ]);
 
+const menuActionsProps = React.PropTypes.shape({
+  className: classProps,
+  onItemSelect: React.PropTypes.func.isRequired,
+  label: React.PropTypes.node.isRequired
+});
+
 PageHeaderActions.propTypes = {
-  addButton: React.PropTypes.shape({
-    className: classProps,
-    onItemSelect: React.PropTypes.func,
-    label: React.PropTypes.node
-  }),
+  addButton: React.PropTypes.oneOfType([
+    React.PropTypes.arrayOf(menuActionsProps),
+    menuActionsProps
+  ]),
   actions: React.PropTypes.arrayOf(
     React.PropTypes.oneOfType([
       React.PropTypes.node,
-      React.PropTypes.shape({
-        className: classProps,
-        onItemSelect: React.PropTypes.func.isRequired,
-        label: React.PropTypes.node.isRequired
-      })
+      menuActionsProps
     ])
   )
 };

--- a/src/js/components/Page.js
+++ b/src/js/components/Page.js
@@ -32,7 +32,10 @@ PageHeader.defaultProps = {
 
 PageHeader.propTypes = {
   actions: React.PropTypes.array,
-  addButton: React.PropTypes.object,
+  addButton: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object
+  ]),
   breadcrumbs: React.PropTypes.node,
   tabs: React.PropTypes.array
 };

--- a/src/js/components/PageHeaderActionsMenu.js
+++ b/src/js/components/PageHeaderActionsMenu.js
@@ -3,11 +3,11 @@ import React from 'react';
 
 import Icon from './Icon';
 
-const getMenuItems = (children) => {
+const getMenuItems = (children, iconID) => {
   return [
     {
       className: 'hidden',
-      html: <Icon id="ellipsis-vertical" size="mini" />,
+      html: <Icon id={iconID} size="mini" />,
       id: 'trigger'
     },
     ...React.Children.map(children, getDropdownItemFromComponent)
@@ -28,12 +28,12 @@ const getDropdownItemFromComponent = (child, index) => {
   };
 };
 
-const PageHeaderActionsMenu = ({anchorRight, children}) => {
+const PageHeaderActionsMenu = ({anchorRight, children, iconID}) => {
   return (
     <Dropdown
       anchorRight={anchorRight}
       buttonClassName="button button-link"
-      items={getMenuItems(children)}
+      items={getMenuItems(children, iconID)}
       onItemSelection={handleItemSelection}
       persistentID="trigger"
       transition={true}
@@ -44,7 +44,8 @@ const PageHeaderActionsMenu = ({anchorRight, children}) => {
 };
 
 PageHeaderActionsMenu.defaultProps = {
-  anchorRight: true
+  anchorRight: true,
+  iconID: 'ellipsis-vertical'
 };
 
 PageHeaderActionsMenu.propTypes = {
@@ -56,7 +57,8 @@ PageHeaderActionsMenu.propTypes = {
         onItemSelect: React.PropTypes.func
       })
     })
-  )
+  ),
+  iconID: React.PropTypes.string
 };
 
 module.exports = PageHeaderActionsMenu;


### PR DESCRIPTION
This PR allows the add button in the page header to be a dropdown with multiple add actions. It also introduces a default prop in `PageHeaderActionsMenu` for the icon ID.

You can pass an array of objects as follows:
```jsx
<Page.Header addButton={[
  {onItemSelect: modalHandlers.createService, label: 'Run a Service'},
  {onItemSelect: modalHandlers.createService, label: 'Run a Better Service!'}
]} />
```

![](https://cl.ly/3W3J3B0x0j1O/Screen%20Shot%202016-12-06%20at%2011.33.27%20AM.png)