### PR TITLE
DCOS-11728: Force hardware acceleration for tooltips

### DIFF
--- a/src/styles/components/tooltip/styles.less
+++ b/src/styles/components/tooltip/styles.less
@@ -1,6 +1,7 @@
 & when (@tooltip-enabled) {
 
   .tooltip {
+    will-change: opacity, transform, visibility;
     z-index: @z-index-tooltip;
 
     .tooltip-content {
@@ -8,7 +9,10 @@
       border-radius: @tooltip-border-radius;
       color: @white;
       font-size: @tooltip-font-size;
+      -moz-osx-font-smoothing: grayscale;
+      -webkit-font-smoothing: antialiased;
       padding: @tooltip-padding-vertical @tooltip-padding-horizontal;
+      transition: translateZ(0);
 
       &:after {
         border-color: @tooltip-background-color;

--- a/src/styles/components/tooltip/styles.less
+++ b/src/styles/components/tooltip/styles.less
@@ -9,6 +9,9 @@
       border-radius: @tooltip-border-radius;
       color: @white;
       font-size: @tooltip-font-size;
+      // Autoprefixer doesn't transform these font-smoothing properties because
+      // the property has not yet been accepted in the CSS spec. If it becomes
+      // part of the CSS spec, Stylelint will complain about these prefixes.
       -moz-osx-font-smoothing: grayscale;
       -webkit-font-smoothing: antialiased;
       padding: @tooltip-padding-vertical @tooltip-padding-horizontal;


### PR DESCRIPTION
This PR implements two changes:
* The `will-change` property on the tooltip itself which should force hardware acceleration even when the tooltip is not being animated
* A specific anti-aliasing property to prevent the browser from switching on the fly

You may be wondering what the vendor prefixes are doing here! Autoprefixer doesn't currently handle these, so the vendor prefixes are sanctioned by Stylelint.