### PR TITLE
Ensure ServerErrorModal renders on top of any other open modal

### DIFF
--- a/src/js/components/ServerErrorModal.js
+++ b/src/js/components/ServerErrorModal.js
@@ -109,7 +109,7 @@ module.exports = class ServerErrorModal extends mixin(StoreMixin) {
 
     return (
       <Modal
-        modalWrapperClass="modal-generic-error"
+        modalWrapperClass="server-error-modal"
         modalClass="modal"
         onClose={this.handleModalClose}
         open={this.state.isOpen}

--- a/src/styles/components/modal/server-error/styles.less
+++ b/src/styles/components/modal/server-error/styles.less
@@ -1,0 +1,6 @@
+& when (@server-error-modal-enabled) {
+
+  .server-error-modal {
+    z-index: @z-index-server-error-modal;
+  }
+}

--- a/src/styles/components/modal/server-error/variables.less
+++ b/src/styles/components/modal/server-error/variables.less
@@ -1,0 +1,3 @@
+@server-error-modal-enabled: true;
+
+@z-index-server-error-modal: @z-index-modal + 1;

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -302,6 +302,11 @@
 @import 'components/modal/install-package/variables.less';
 @import 'components/modal/install-package/styles.less';
 
+// Server Error Modal
+
+@import 'components/modal/server-error/variables.less';
+@import 'components/modal/server-error/styles.less';
+
 // Multiple Form
 
 @import 'components/multiple-form/variables.less';


### PR DESCRIPTION
ServerErrorModal now renders with a higher z-index than all other modals. This is important to show errors for modals that do not handle the errors themselves.