### PR TITLE
[8/11] Create service-specific task detail page

### DIFF
--- a/plugins/services/src/js/pages/task-details/ServiceTaskDetailPage.js
+++ b/plugins/services/src/js/pages/task-details/ServiceTaskDetailPage.js
@@ -19,19 +19,20 @@ class ServiceTaskDetailPage extends React.Component {
     ];
 
     let task = MesosStateStore.getTaskFromTaskID(taskID);
-    if (task == null) {
-      return this.getNotFound('task', taskID);
+    let breadcrumbs;
+    if (task != null) {
+      breadcrumbs = (
+        <ServiceBreadcrumbs
+          serviceID={id}
+          taskID={task.getId()}
+          taskName={task.getName()}/>
+      );
+    } else {
+      breadcrumbs = <ServiceBreadcrumbs serviceID={id} />;
     }
 
-    const breadcrumbs = (
-      <ServiceBreadcrumbs
-        serviceID={id}
-        taskID={task.getId()}
-        taskName={task.getName()} />
-    );
-
     return (
-      <Page>
+      <Page dontScroll={true}>
         <Page.Header
           breadcrumbs={breadcrumbs}
           tabs={tabs}

--- a/plugins/services/src/js/pages/task-details/ServiceTaskDetailPage.js
+++ b/plugins/services/src/js/pages/task-details/ServiceTaskDetailPage.js
@@ -15,7 +15,7 @@ class ServiceTaskDetailPage extends React.Component {
     const tabs = [
       {label: 'Details', routePath: routePrefix + '/details'},
       {label: 'Files', routePath: routePrefix + '/files'},
-      {label: 'Logs', routePath: routePrefix + '/logs'}
+      {label: 'Logs', routePath: routePrefix + '/view'}
     ];
 
     let task = MesosStateStore.getTaskFromTaskID(taskID);

--- a/plugins/services/src/js/pages/task-details/ServiceTaskDetailPage.js
+++ b/plugins/services/src/js/pages/task-details/ServiceTaskDetailPage.js
@@ -15,7 +15,7 @@ class ServiceTaskDetailPage extends React.Component {
     const tabs = [
       {label: 'Details', routePath: routePrefix + '/details'},
       {label: 'Files', routePath: routePrefix + '/files'},
-      {label: 'Logs', routePath: routePrefix + '/view'}
+      {label: 'Logs', routePath: routePrefix + '/logs'}
     ];
 
     let task = MesosStateStore.getTaskFromTaskID(taskID);


### PR DESCRIPTION
This builds on work merged in #1483, moving service-specific code in the TaskDetail panel to a ServiceTaskDetailPage to clear the way for Jobs- and Network- TaskDetailPage. 