### PR TITLE
Page header styling updates

### DIFF
--- a/src/js/components/NewPageHeader.js
+++ b/src/js/components/NewPageHeader.js
@@ -4,6 +4,7 @@ import React from 'react';
 import NewPageHeaderActions from './NewPageHeaderActions';
 import NewPageHeaderBreadcrumbs from './NewPageHeaderBreadcrumbs';
 import NewPageHeaderTabs from './NewPageHeaderTabs';
+import SidebarToggle from './SidebarToggle';
 
 class PageHeader extends React.Component {
   render() {
@@ -27,7 +28,7 @@ class PageHeader extends React.Component {
       innerClassName
     );
     let primaryContentClasses = classNames(
-      'page-header-content-section',
+      'page-header-content-section page-header-content-section-primary',
       primaryContentClassName
     );
     let secondaryContentClasses = classNames(
@@ -48,6 +49,7 @@ class PageHeader extends React.Component {
       <div className={classes}>
         <div className={innerClasses}>
           <div className={primaryContentClasses}>
+            <SidebarToggle />
             {breadcrumbs}
             <NewPageHeaderActions
               actions={actions}

--- a/src/js/components/NewPageHeaderActions.js
+++ b/src/js/components/NewPageHeaderActions.js
@@ -52,7 +52,7 @@ class PageHeaderActions extends React.Component {
     if (addButton != null) {
       const {label, onItemSelect, className} = addButton;
       const buttonClasses = classNames(
-          'button button-link flush-left flush-right',
+          'button button-link button-narrow',
           className
       );
 

--- a/src/js/components/NewPageHeaderBreadcrumbs.js
+++ b/src/js/components/NewPageHeaderBreadcrumbs.js
@@ -6,7 +6,7 @@ class PageHeaderBreadcrumbs extends React.Component {
 
   getCaret(index) {
     return (
-      <li className="page-header-breadcrumb-caret flush-top flush-left"
+      <li className="page-header-breadcrumb page-header-breadcrumb-caret"
         key={`caret-${index}`}>
         <Icon color="light-grey" id="caret-right" size="mini" />
       </li>
@@ -17,14 +17,14 @@ class PageHeaderBreadcrumbs extends React.Component {
     let {props: {iconID, breadcrumbs}} = this;
 
     const containerIcon = (
-      <li className="page-header-breadcrumb-secondary h3 flush-top flush-left" key="-1">
+      <li className="page-header-breadcrumb page-header-breadcrumb-icon" key="-1">
         <Icon family="product" id={iconID} size="small" />
       </li>
     );
 
     let breadcrumbElements = breadcrumbs.reduce((memo, breadcrumb, index) => {
       memo.push(
-        <li className="page-header-breadcrumb-secondary h3 flush-top flush-left" key={index}>
+        <li className="page-header-breadcrumb h3" key={index}>
           {breadcrumb}
         </li>
       );
@@ -37,7 +37,7 @@ class PageHeaderBreadcrumbs extends React.Component {
     }, [containerIcon]);
 
     return (
-      <ul className="page-header-breadcrumbs list list-unstyled list-inline flush">
+      <ul className="page-header-breadcrumbs">
         {breadcrumbElements}
       </ul>
     );

--- a/src/js/components/PageHeaderActionsMenu.js
+++ b/src/js/components/PageHeaderActionsMenu.js
@@ -7,7 +7,7 @@ const getMenuItems = (children, iconID) => {
   return [
     {
       className: 'hidden',
-      html: <Icon id={iconID} size="mini" />,
+      html: <Icon id={iconID} color="light-grey" size="mini" />,
       id: 'trigger'
     },
     ...React.Children.map(children, getDropdownItemFromComponent)
@@ -32,7 +32,7 @@ const PageHeaderActionsMenu = ({anchorRight, children, iconID}) => {
   return (
     <Dropdown
       anchorRight={anchorRight}
-      buttonClassName="button button-link"
+      buttonClassName="button button-link button-narrow"
       items={getMenuItems(children, iconID)}
       onItemSelection={handleItemSelection}
       persistentID="trigger"

--- a/src/styles/components/page-header/styles.less
+++ b/src/styles/components/page-header/styles.less
@@ -17,176 +17,143 @@
       position: absolute;
       width: 100%;
     }
-  }
 
-  // TODO: Removed unused classes. DCOS-11900
-  .page-header-title-container {
-    align-items: center;
-    display: flex;
-    height: @button-height;
-    padding-left: @page-header-title-padding-left;
-    position: relative;
-    transition: padding-left 0.25s;
-  }
+    &-content-section {
+      align-items: center;
+      display: flex;
 
-  .page-header-sidebar-toggle {
-    cursor: pointer;
-    display: block;
-    flex: 0 0 auto;
-    left: @page-header-sidebar-toggle-left;
-    opacity: 0.35;
-    padding: @page-header-sidebar-toggle-padding;
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    transition: opacity 0.15s;
-
-    &:hover {
-      opacity: 0.7;
-    }
-  }
-
-  .page-header-sidebar-toggle-label {
-    display: none;
-  }
-
-  .page-header-content-section {
-    align-items: center;
-    display: flex;
-  }
-
-  .page-header-title {
-    color: @page-header-title-color;
-    flex: 0 0 auto;
-    font-size: @page-header-title-font-size;
-    font-weight: @page-header-title-font-weight;
-    line-height: @page-header-title-line-height;
-    margin-bottom: @page-header-title-margin-bottom;
-    margin-top: @page-header-title-margin-top;
-
-    /* Layout Variants */
-
-    &.short {
-      margin-bottom: @page-header-title-margin-bottom * @page-header-title-short-margin-bottom-scale;
-      margin-top: @page-header-title-margin-top * @page-header-title-short-margin-top-scale;
-    }
-
-    &.tall {
-      margin-bottom: @page-header-title-margin-bottom * @page-header-title-tall-margin-bottom-scale;
-      margin-top: @page-header-title-margin-top * @page-header-title-tall-margin-top-scale;
-    }
-
-    /* Styling Variants */
-
-    &.emphasis,
-    .emphasis {
-      color: @page-header-title-emphasis-color;
-      font-weight: @page-header-title-emphasis-font-weight;
-    }
-
-    &.muted,
-    .muted {
-      color: @page-header-title-muted-color;
-    }
-
-    &.inverse {
-      color: @page-header-title-inverse-color;
-
-      &.emphasis,
-      .emphasis {
-        color: @page-header-title-inverse-emphasis-color;
+      &-primary {
+        min-height: @button-height;
+        padding-left: @page-header-content-section-primary-padding-left;
+        position: relative;
+        transition: padding-left 0.25s;
       }
 
-      &.muted,
-      .muted {
-        color: @page-header-title-inverse-muted-color;
-      }
-    }
-  }
+      &-secondary {
 
-  .page-header-navigation {
-    align-items: flex-start;
-    display: flex;
-
-    .menu-tabbed {
-      margin-bottom: 0;
-    }
-
-    & when not (@pod-margin-top = null) {
-      padding-top: @pod-margin-top;
-    }
-
-    & when not (@pod-margin-bottom = null) {
-      margin-bottom: -@pod-margin-bottom;
-    }
-  }
-
-  .page-header-content-section-secondary-detail {
-    margin-left: auto;
-  }
-
-  .page-header-breadcrumbs {
-    align-items: center;
-    display: flex;
-    flex: 1 1 auto;
-    min-height: @button-height;
-    min-width: 0;
-
-    // This extra classname is necessary to override specificity from CNVS.
-    &.list-inline {
-
-      & > li {
-        display: inline-block;
-        float: none;
-        line-height: 2rem;
-        margin-right: @base-spacing-unit * 1/4;
-        vertical-align: middle;
-
-        &:last-child {
-          margin-right: 0;
+        &-detail {
+          margin-left: auto;
         }
       }
     }
-  }
 
-  .page-header-breadcrumb-primary {
-    flex: 0 0 auto;
+    &-sidebar-toggle {
+      cursor: pointer;
+      display: block;
+      flex: 0 0 auto;
+      left: @page-header-sidebar-toggle-left;
+      opacity: 0.35;
+      padding: @page-header-sidebar-toggle-padding;
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      transition: opacity 0.15s;
 
-    .icon {
-      margin-right: @base-spacing-unit * 1/8;
-    }
+      &:hover {
+        opacity: 0.7;
+      }
 
-    .dropdown {
-
-      .button {
-        background: none;
-        border: 0;
-        border-radius: 0;
-        padding: 0;
+      &-label {
+        display: none;
       }
     }
-  }
 
-  .page-header-breadcrumb-secondary {
-    flex: 0 1 auto;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    &-breadcrumbs {
+      align-items: center;
+      color: @page-header-breadcrumbs-color;
+      display: flex;
+      flex: 1 1 auto;
+      font-size: @page-header-breadcrumbs-font-size;
+      font-weight: @page-header-breadcrumbs-font-weight;
+      list-style: none;
+      margin-bottom: 0;
+      min-width: 0;
 
-    &:last-child {
-      flex: 0 0 auto;
-      min-width: auto;
-      overflow: visible;
+      a {
+        color: @page-header-breadcrumbs-link-color;
+        text-decoration: none;
+
+        &:hover {
+          color: @page-header-breadcrumbs-link-hover-color;
+        }
+      }
     }
-  }
 
-  .page-header-breadcrumb-caret {
-    flex: 0 0 auto;
-  }
+    &-breadcrumb {
+      flex: 0 1 auto;
+      margin: 0 @page-header-breadcrumbs-margin-right 0 0;
+      min-width: 0;
+      overflow: hidden;
+      padding: 0;
+      text-overflow: ellipsis;
+      white-space: nowrap;
 
-  .page-header-actions {
-    flex: 0 0 auto;
+      &:last-child {
+        flex: 0 0 auto;
+        margin-right: 0;
+        min-width: auto;
+        overflow: visible;
+      }
+
+      &:before {
+        display: none;
+      }
+
+      &-icon {
+        flex: 0 0 auto;
+        margin-left: 0;
+        margin-top: 0;
+      }
+
+      &-caret {
+        flex: 0 0 auto;
+        min-width: auto;
+      }
+
+      /* Styling Variants */
+
+      .emphasis {
+        color: @page-header-breadcrumbs-emphasis-color;
+        font-weight: @page-header-breadcrumbs-emphasis-font-weight;
+      }
+
+      .muted {
+        color: @page-header-breadcrumbs-muted-color;
+      }
+
+      &.inverse {
+        color: @page-header-breadcrumbs-inverse-color;
+
+        .emphasis {
+          color: @page-header-breadcrumbs-inverse-emphasis-color;
+        }
+
+        .muted {
+          color: @page-header-breadcrumbs-inverse-muted-color;
+        }
+      }
+    }
+
+    &-navigation {
+      align-items: flex-start;
+      display: flex;
+
+      .menu-tabbed {
+        margin-bottom: 0;
+      }
+
+      & when not (@pod-margin-top = null) {
+        padding-top: @pod-margin-top;
+      }
+
+      & when not (@pod-margin-bottom = null) {
+        margin-bottom: -@pod-margin-bottom;
+      }
+    }
+
+    &-actions {
+      flex: 0 0 auto;
+    }
   }
 }
 
@@ -196,40 +163,33 @@
 
     & when (@page-header-enabled) and (@page-header-screen-small-enabled) {
 
-      .page-header-title-container {
-        padding-left: @page-header-title-padding-left-screen-small;
-      }
+      .page-header {
 
-      .page-header-navigation {
+        &-content-section {
 
-        & when not (@pod-margin-top-screen-small = null) {
-          padding-top: @pod-margin-top-screen-small;
-        }
-
-        & when not (@pod-margin-bottom-screen-small = null) {
-          margin-bottom: -@pod-margin-bottom-screen-small;
-        }
-      }
-
-      .page-header-sidebar-toggle {
-        left: @page-header-sidebar-toggle-left-screen-small;
-        padding: @page-header-sidebar-toggle-padding-screen-small;
-      }
-
-      .page-header-breadcrumbs {
-
-        &.list-inline {
-
-          & > li {
-            margin-right: @base-spacing-unit-screen-small * 1/4;
+          &-primary {
+            padding-left: @page-header-content-section-primary-padding-left-screen-small;
           }
         }
-      }
 
-      .page-header-breadcrumb-primary {
+        &-sidebar-toggle {
+          left: @page-header-sidebar-toggle-left-screen-small;
+          padding: @page-header-sidebar-toggle-padding-screen-small;
+        }
 
-        .icon {
-          margin-right: @base-spacing-unit-screen-small * 1/8;
+        &-breadcrumb {
+          margin-right: @page-header-breadcrumbs-margin-right-screen-small;
+        }
+
+        &-navigation {
+
+          & when not (@pod-margin-top-screen-small = null) {
+            padding-top: @pod-margin-top-screen-small;
+          }
+
+          & when not (@pod-margin-bottom-screen-small = null) {
+            margin-bottom: -@pod-margin-bottom-screen-small;
+          }
         }
       }
     }
@@ -242,63 +202,41 @@
 
     & when (@page-header-enabled) and (@page-header-screen-medium-enabled) {
 
-      .page-header-title-container {
-        padding-left: @page-header-title-padding-left-screen-medium;
+      .page-header {
 
-        .sidebar-docked & {
-          padding-left: 0;
-        }
-      }
+        &-content-section {
 
-      .page-header-title {
-        margin-bottom: @page-header-title-margin-bottom * @page-header-title-margin-bottom-screen-medium;
-        margin-top: @page-header-title-margin-top * @page-header-title-margin-top-screen-medium;
+          &-primary {
+            padding-left: @page-header-content-section-primary-padding-left-screen-medium;
 
-        &.short {
-          margin-bottom: @page-header-title-margin-bottom * @page-header-title-margin-bottom-screen-medium * @page-header-title-short-margin-bottom-scale;
-          margin-top: @page-header-title-margin-top * @page-header-title-margin-top-screen-medium * @page-header-title-short-margin-top-scale;
-        }
-
-        &.tall {
-          margin-bottom: @page-header-title-margin-bottom * @page-header-title-margin-bottom-screen-medium * @page-header-title-tall-margin-bottom-scale;
-          margin-top: @page-header-title-margin-top * @page-header-title-margin-top-screen-medium * @page-header-title-tall-margin-top-scale;
-        }
-      }
-
-      .page-header-sidebar-toggle {
-        left: @page-header-sidebar-toggle-left-screen-medium;
-        padding: @page-header-sidebar-toggle-padding-screen-medium;
-
-        .sidebar-docked & {
-          display: none;
-        }
-      }
-
-      .page-header-navigation {
-
-        & when not (@pod-margin-top-screen-medium = null) {
-          padding-top: @pod-margin-top-screen-medium;
-        }
-
-        & when not (@pod-margin-bottom-screen-medium = null) {
-          margin-bottom: -@pod-margin-bottom-screen-medium;
-        }
-      }
-
-      .page-header-breadcrumbs {
-
-        &.list-inline {
-
-          & > li {
-            margin-right: @base-spacing-unit-screen-medium * 1/4;
+            .sidebar-docked & {
+              padding-left: 0;
+            }
           }
         }
-      }
 
-      .page-header-breadcrumb-primary {
+        &-sidebar-toggle {
+          left: @page-header-sidebar-toggle-left-screen-medium;
+          padding: @page-header-sidebar-toggle-padding-screen-medium;
 
-        .icon {
-          margin-right: @base-spacing-unit-screen-medium * 1/8;
+          .sidebar-docked & {
+            display: none;
+          }
+        }
+
+        &-breadcrumb {
+          margin-right: @page-header-breadcrumbs-margin-right-screen-medium;
+        }
+
+        &-navigation {
+
+          & when not (@pod-margin-top-screen-medium = null) {
+            padding-top: @pod-margin-top-screen-medium;
+          }
+
+          & when not (@pod-margin-bottom-screen-medium = null) {
+            margin-bottom: -@pod-margin-bottom-screen-medium;
+          }
         }
       }
     }
@@ -311,57 +249,34 @@
 
     & when (@page-header-enabled) and (@page-header-screen-large-enabled) {
 
-      .page-header-title-container {
-        height: @button-height-screen-large;
-        padding-left: @page-header-title-padding-left-screen-large;
-      }
+      .page-header {
 
-      .page-header-title {
-        margin-bottom: @page-header-title-margin-bottom * @page-header-title-margin-bottom-screen-large;
-        margin-top: @page-header-title-margin-top * @page-header-title-margin-top-screen-large;
+        &-content-section {
 
-        &.short {
-          margin-bottom: @page-header-title-margin-bottom * @page-header-title-margin-bottom-screen-large * @page-header-title-short-margin-bottom-scale;
-          margin-top: @page-header-title-margin-top * @page-header-title-margin-top-screen-large * @page-header-title-short-margin-top-scale;
-        }
-
-        &.tall {
-          margin-bottom: @page-header-title-margin-bottom * @page-header-title-margin-bottom-screen-large * @page-header-title-tall-margin-bottom-scale;
-          margin-top: @page-header-title-margin-top * @page-header-title-margin-top-screen-large * @page-header-title-tall-margin-top-scale;
-        }
-      }
-
-      .page-header-sidebar-toggle {
-        left: @page-header-sidebar-toggle-left-screen-large;
-        padding: @page-header-sidebar-toggle-padding-screen-large;
-      }
-
-      .page-header-navigation {
-
-        & when not (@pod-margin-top-screen-large = null) {
-          padding-top: @pod-margin-top-screen-large;
-        }
-
-        & when not (@pod-margin-bottom-screen-large = null) {
-          margin-bottom: -@pod-margin-bottom-screen-large;
-        }
-      }
-
-      .page-header-breadcrumbs {
-        min-height: @button-height-screen-large;
-
-        &.list-inline {
-
-          & > li {
-            margin-right: @base-spacing-unit-screen-large * 1/4;
+          &-primary {
+            min-height: @button-height-screen-large;
+            padding-left: @page-header-content-section-primary-padding-left-screen-large;
           }
         }
-      }
 
-      .page-header-breadcrumb-primary {
+        &-sidebar-toggle {
+          left: @page-header-sidebar-toggle-left-screen-large;
+          padding: @page-header-sidebar-toggle-padding-screen-large;
+        }
 
-        .icon {
-          margin-right: @base-spacing-unit-screen-large * 1/8;
+        &-breadcrumb {
+          margin-right: @page-header-breadcrumbs-margin-right-screen-large;
+        }
+
+        &-navigation {
+
+          & when not (@pod-margin-top-screen-large = null) {
+            padding-top: @pod-margin-top-screen-large;
+          }
+
+          & when not (@pod-margin-bottom-screen-large = null) {
+            margin-bottom: -@pod-margin-bottom-screen-large;
+          }
         }
       }
     }
@@ -374,40 +289,33 @@
 
     & when (@page-header-enabled) and (@page-header-screen-jumbo-enabled) {
 
-      .page-header-title-container {
-        padding-left: @page-header-title-padding-left-screen-jumbo;
-      }
+      .page-header {
 
-      .page-header-navigation {
+        &-content-section {
 
-        & when not (@pod-margin-top-screen-jumbo = null) {
-          padding-top: @pod-margin-top-screen-jumbo;
-        }
-
-        & when not (@pod-margin-bottom-screen-jumbo = null) {
-          margin-bottom: -@pod-margin-bottom-screen-jumbo;
-        }
-      }
-
-      .page-header-sidebar-toggle {
-        left: @page-header-sidebar-toggle-left-screen-jumbo;
-        padding: @page-header-sidebar-toggle-padding-screen-jumbo;
-      }
-
-      .page-header-breadcrumbs {
-
-        &.list-inline {
-
-          & > li {
-            margin-right: @base-spacing-unit-screen-jumbo * 1/4;
+          &-primary {
+            padding-left: @page-header-content-section-primary-padding-left-screen-jumbo;
           }
         }
-      }
 
-      .page-header-breadcrumb-primary {
+        &-sidebar-toggle {
+          left: @page-header-sidebar-toggle-left-screen-jumbo;
+          padding: @page-header-sidebar-toggle-padding-screen-jumbo;
+        }
 
-        .icon {
-          margin-right: @base-spacing-unit-screen-jumbo * 1/8;
+        &-breadcrumb {
+          margin-right: @page-header-breadcrumbs-margin-right-screen-large;
+        }
+
+        &-navigation {
+
+          & when not (@pod-margin-top-screen-large = null) {
+            padding-top: @pod-margin-top-screen-jumbo;
+          }
+
+          & when not (@pod-margin-bottom-screen-large = null) {
+            margin-bottom: -@pod-margin-bottom-screen-jumbo;
+          }
         }
       }
     }

--- a/src/styles/components/page-header/variables.less
+++ b/src/styles/components/page-header/variables.less
@@ -21,11 +21,11 @@
 @page-header-sidebar-toggle-padding-screen-large: @base-spacing-unit-screen-large * 1/2;
 @page-header-sidebar-toggle-padding-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/2;
 
-@page-header-sidebar-toggle-margin-right: @base-spacing-unit * 1/8;
-@page-header-sidebar-toggle-margin-right-screen-small: @base-spacing-unit-screen-small * 1/8;
-@page-header-sidebar-toggle-margin-right-screen-medium: @base-spacing-unit-screen-medium * 1/8;
-@page-header-sidebar-toggle-margin-right-screen-large: @base-spacing-unit-screen-large * 1/8;
-@page-header-sidebar-toggle-margin-right-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/8;
+@page-header-sidebar-toggle-margin-right: @base-spacing-unit * 1/4;
+@page-header-sidebar-toggle-margin-right-screen-small: @base-spacing-unit-screen-small * 1/4;
+@page-header-sidebar-toggle-margin-right-screen-medium: @base-spacing-unit-screen-medium * 1/4;
+@page-header-sidebar-toggle-margin-right-screen-large: @base-spacing-unit-screen-large * 1/4;
+@page-header-sidebar-toggle-margin-right-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/4;
 
 @page-header-sidebar-toggle-left: @page-header-sidebar-toggle-padding * -1;
 @page-header-sidebar-toggle-left-screen-small: @page-header-sidebar-toggle-padding-screen-small * -1;
@@ -34,71 +34,90 @@
 @page-header-sidebar-toggle-left-screen-jumbo: @page-header-sidebar-toggle-padding-screen-jumbo * -1;
 
 /*
- * Page Header Title
+ * Page Header Breadcrumbs
  */
 
 // Layout
 
-@page-header-title-padding-left: @icon-mini-width + @page-header-sidebar-toggle-padding + @page-header-sidebar-toggle-margin-right;
-@page-header-title-padding-left-screen-small: @icon-mini-width + @page-header-sidebar-toggle-padding-screen-small + @page-header-sidebar-toggle-margin-right-screen-small;
-@page-header-title-padding-left-screen-medium: @icon-mini-width + @page-header-sidebar-toggle-padding-screen-medium + @page-header-sidebar-toggle-margin-right-screen-medium;
-@page-header-title-padding-left-screen-large: @icon-mini-width + @page-header-sidebar-toggle-padding-screen-large + @page-header-sidebar-toggle-margin-right-screen-large;
-@page-header-title-padding-left-screen-jumbo: @icon-mini-width + @page-header-sidebar-toggle-padding-screen-jumbo + @page-header-sidebar-toggle-margin-right-screen-jumbo;
+@page-header-breadcrumbs-margin-right: @base-spacing-unit * 1/2;
+@page-header-breadcrumbs-margin-right-screen-small: @base-spacing-unit-screen-small * 1/2;
+@page-header-breadcrumbs-margin-right-screen-medium: @base-spacing-unit-screen-medium * 1/2;
+@page-header-breadcrumbs-margin-right-screen-large: @base-spacing-unit-screen-large * 1/2;
+@page-header-breadcrumbs-margin-right-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/2;
+
+/*
+ * Page Header Content Sections
+ */
+
+// Layout
+
+@page-header-content-section-primary-padding-left: @icon-mini-width + @page-header-sidebar-toggle-padding + @page-header-sidebar-toggle-margin-right;
+@page-header-content-section-primary-padding-left-screen-small: @icon-mini-width + @page-header-sidebar-toggle-padding-screen-small + @page-header-sidebar-toggle-margin-right-screen-small;
+@page-header-content-section-primary-padding-left-screen-medium: @icon-mini-width + @page-header-sidebar-toggle-padding-screen-medium + @page-header-sidebar-toggle-margin-right-screen-medium;
+@page-header-content-section-primary-padding-left-screen-large: @icon-mini-width + @page-header-sidebar-toggle-padding-screen-large + @page-header-sidebar-toggle-margin-right-screen-large;
+@page-header-content-section-primary-padding-left-screen-jumbo: @icon-mini-width + @page-header-sidebar-toggle-padding-screen-jumbo + @page-header-sidebar-toggle-margin-right-screen-jumbo;
+
+/*
+ * Page Header Breadcrumb
+ */
 
 // Text Styling
 
 /* Normal */
 
-@page-header-title-color: color-lighten(@neutral, 0);
-@page-header-title-font-weight: 500;
+@page-header-breadcrumbs-color: color-lighten(@neutral, 0);
+@page-header-breadcrumbs-font-weight: 500;
 
 /* Emphasis (.emphasis) */
 
-@page-header-title-emphasis-color: color-lighten(@neutral, -20);
-@page-header-title-emphasis-font-weight: 800;
+@page-header-breadcrumbs-emphasis-color: color-lighten(@neutral, -20);
+@page-header-breadcrumbs-emphasis-font-weight: 800;
 
 /* Muted (.muted) */
 
-@page-header-title-muted-color: color-lighten(@neutral, 60);
+@page-header-breadcrumbs-muted-color: color-lighten(@neutral, 60);
 
 /* Inverse (.inverse) */
 
-@page-header-title-inverse-color: color-lighten(@neutral, 100);
+@page-header-breadcrumbs-inverse-color: color-lighten(@neutral, 100);
 
 /* Inverse Emphasis (.inverse.emphasis) */
 
-@page-header-title-inverse-emphasis-color: color-lighten(@neutral, 100);
+@page-header-breadcrumbs-inverse-emphasis-color: color-lighten(@neutral, 100);
 
 /* Inverse Muted (.inverse.muted) */
 
-@page-header-title-inverse-muted-color: color-lighten(@neutral, 40);
+@page-header-breadcrumbs-inverse-muted-color: color-lighten(@neutral, 40);
 
 // Text Size
 
 /* Font Size */
 
-@page-header-title-font-size: 1.45rem;
+@page-header-breadcrumbs-font-size: 1.45rem;
 
 /* Line Height */
 
-@page-header-title-line-height: @page-header-title-font-size * 1.1;
+@page-header-breadcrumbs-line-height: @page-header-breadcrumbs-font-size * 1.1;
 
 // Layout
 
 /* Margin */
 
-@page-header-title-margin-top: 1.7rem;
-@page-header-title-margin-top-screen-medium: 1.1 * 1.7rem;
-@page-header-title-margin-top-screen-large: 1.2 * 1.7rem;
+@page-header-breadcrumbs-margin-top: 1.7rem;
+@page-header-breadcrumbs-margin-top-screen-medium: 1.1 * 1.7rem;
+@page-header-breadcrumbs-margin-top-screen-large: 1.2 * 1.7rem;
 
-@page-header-title-margin-bottom: 1.3rem;
-@page-header-title-margin-bottom-screen-medium: 1.1 * 1.3rem;
-@page-header-title-margin-bottom-screen-large: 1.2 * 1.3rem;
+@page-header-breadcrumbs-margin-bottom: 1.3rem;
+@page-header-breadcrumbs-margin-bottom-screen-medium: 1.1 * 1.3rem;
+@page-header-breadcrumbs-margin-bottom-screen-large: 1.2 * 1.3rem;
 
 /* Layout Variants */
 
-@page-header-title-short-margin-top-scale: 0.5;
-@page-header-title-short-margin-bottom-scale: 0.5;
+@page-header-breadcrumbs-short-margin-top-scale: 0.5;
+@page-header-breadcrumbs-short-margin-bottom-scale: 0.5;
 
-@page-header-title-tall-margin-top-scale: 2;
-@page-header-title-tall-margin-bottom-scale: 2;
+@page-header-breadcrumbs-tall-margin-top-scale: 2;
+@page-header-breadcrumbs-tall-margin-bottom-scale: 2;
+
+@page-header-breadcrumbs-link-color: color-lighten(@neutral, 20);
+@page-header-breadcrumbs-link-hover-color: @neutral;


### PR DESCRIPTION
This PR cleans up the page header styles and applies them to the new components. It also adds the `SidebarToggle` component from the old page header. :arrow_left: :arrow_right:

![](https://cl.ly/031W2X0V0L0H/Screen%20Shot%202016-12-06%20at%2011.19.08%20PM.png)