### PR TITLE
Fix access denied page styling

### DIFF
--- a/src/js/components/AccessDeniedPage.js
+++ b/src/js/components/AccessDeniedPage.js
@@ -35,16 +35,16 @@ module.exports = class AccessDeniedPage extends React.Component {
 
   render() {
     return (
-      <div className="page flex flex-direction-top-to-bottom flex-item-grow-1">
-        <div className="page-body-content flex flex-direction-top-to-bottom
-          flex-item-grow-1 horizontal-center vertical-center">
-          <AlertPanel
-            footer={this.getFooter()}
-            title="Access denied">
-            <p className="tall">
-              You do not have access to this service. Please contact your {Config.productName} administrator or see <a href={MetadataStore.buildDocsURI('/administration/id-and-access-mgt/')} target="_blank">security documentation</a> for more information.
-            </p>
-          </AlertPanel>
+      <div className="application-wrapper">
+        <div className="page">
+          <div className="page-body-content vertical-center">
+            <AlertPanel title="Access denied">
+              <p className="tall">
+                You do not have access to this service. Please contact your {Config.productName} administrator or see <a href={MetadataStore.buildDocsURI('/administration/id-and-access-mgt/')} target="_blank">security documentation</a> for more information.
+              </p>
+              {this.getFooter()}
+            </AlertPanel>
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
This PR simplifies the classes applied in `AccessDeniedPage` and adds `application-wrapper` which is meant to wrap everything in DC/OS UI.

💩 Before:
![](https://cl.ly/2I2L2l2Q3m2j/Screen%20Shot%202016-12-07%20at%2010.08.29%20AM.png)

✨ After:
![](https://cl.ly/3p1A0W2T1q2b/Screen%20Shot%202016-12-07%20at%2010.07.09%20AM.png)