### PR TITLE
DCOS-11817: Hide empty sidebar sections

### DIFF
--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -126,6 +126,11 @@ var Sidebar = React.createClass({
 
     return definition.map((group, index) => {
       let heading = null;
+      let menuItems = this.getNavigationGroup(group);
+
+      if (menuItems == null) {
+        return null;
+      }
 
       if (group.category !== 'root') {
         heading = (
@@ -139,7 +144,7 @@ var Sidebar = React.createClass({
         <div className="sidebar-section pod pod-short-bottom flush-top flush-left flush-right"
           key={index}>
           {heading}
-          {this.getNavigationGroup(group)}
+          {menuItems}
         </div>
       );
     });
@@ -195,7 +200,11 @@ var Sidebar = React.createClass({
       );
     });
 
-    return <ul className="sidebar-menu">{groupMenuItems}</ul>;
+    if (groupMenuItems.length) {
+      return <ul className="sidebar-menu">{groupMenuItems}</ul>;
+    }
+
+    return null;
   },
 
   getGroupSubmenu(path, children) {


### PR DESCRIPTION
This PR hides empty sidebar sections if there are no menu items available (e.g. if a user has limited permissions).

Before:
![](https://cl.ly/1q3v1k1k3F3Q/Screen%20Shot%202016-12-07%20at%2010.41.41%20AM.png)

After:
![](https://cl.ly/092j0i352z3P/Screen%20Shot%202016-12-07%20at%2010.40.33%20AM.png)