### PR TITLE
DCOS-11854: Sidebar's visibility no longer affects page content

### DIFF
--- a/src/styles/layout/sidebar/styles.less
+++ b/src/styles/layout/sidebar/styles.less
@@ -14,17 +14,6 @@
     flex: 1 1 100%;
     max-width: 0;
     transition: max-width 0.25s;
-
-    & + .page {
-      transition: transform 0.25s;
-    }
-
-    .sidebar-visible & {
-
-      & + .page {
-        transform: translateX(@sidebar-width);
-      }
-    }
   }
 
   // Sidebar
@@ -385,20 +374,6 @@
       // Sidebar Wrapper
       .sidebar-wrapper {
 
-        .sidebar-visible & {
-
-          & + .page {
-            transform: translateX(@sidebar-width-screen-medium);
-          }
-        }
-
-        .sidebar-visible.sidebar-docked & {
-
-          & + .page {
-            transform: translateX(0);
-          }
-        }
-
         .sidebar-docked & {
           max-width: @sidebar-width-screen-medium;
         }
@@ -495,13 +470,6 @@
       // Sidebar Wrapper
       .sidebar-wrapper {
 
-        .sidebar-visible & {
-
-          & + .page {
-            transform: translateX(@sidebar-width-screen-large);
-          }
-        }
-
         .sidebar-docked & {
           max-width: @sidebar-width-screen-large;
         }
@@ -582,13 +550,6 @@
 
       // Sidebar Wrapper
       .sidebar-wrapper {
-
-        .sidebar-visible & {
-
-          & + .page {
-            transform: translateX(@sidebar-width-screen-jumbo);
-          }
-        }
 
         .sidebar-docked & {
           max-width: @sidebar-width-screen-jumbo;

--- a/src/styles/variables/variables-z-index.less
+++ b/src/styles/variables/variables-z-index.less
@@ -20,8 +20,8 @@
 @z-index-side-panel: 2000;
 @z-index-side-panel-container: @z-index-side-panel + 4;
 @z-index-side-panel-expand-button: @z-index-side-panel + 10;
-@z-index-sidebar-overlay: 1;
-@z-index-sidebar: @z-index-sidebar-overlay + 1;
+@z-index-sidebar: @z-index-modal - 1;
+@z-index-sidebar-overlay: @z-index-sidebar - 1;
 @z-index-tooltip: @z-index-modal-container + 1;
 // The error message comes in 'body' and 'modal' varieties
 @z-index-errormsg-floater-modal: @z-index-modal-container + 1;


### PR DESCRIPTION
This PR removes the offset of the page content when the sidebar's visibility is toggled (per @ashenden's request).

Before:
![](https://cl.ly/1Z1J0y0I0U3c/Screen%20Shot%202016-12-07%20at%2011.37.06%20AM.png)

After:
![](https://cl.ly/1C0S2b001o3X/Screen%20Shot%202016-12-07%20at%2011.35.30%20AM.png)