### PR TITLE
Replace cluster icon in network detail pages with network icon

### DIFF
--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetail.js
@@ -24,7 +24,7 @@ const NetworksDetailBreadcrumbs = ({overlayID, overlay}) => {
     crumbs.push(<span>{overlayID}</span>);
   }
 
-  return <Page.Header.Breadcrumbs iconID="cluster" breadcrumbs={crumbs} />;
+  return <Page.Header.Breadcrumbs iconID="network" breadcrumbs={crumbs} />;
 };
 
 const METHODS_TO_BIND = [

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskPage.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskPage.js
@@ -26,7 +26,7 @@ const NetworksDetailTaskBreadcrumbs = ({overlayID, overlay, taskID, task}) => {
     crumbs.push(<span>{taskID}</span>);
   }
 
-  return <Page.Header.Breadcrumbs iconID="cluster" breadcrumbs={crumbs} />;
+  return <Page.Header.Breadcrumbs iconID="network" breadcrumbs={crumbs} />;
 };
 
 class VirtualNetworkTaskPage extends React.Component {


### PR DESCRIPTION
This PR replaces the cluster icon in network detail pages with the network icon. 

![screen shot 2016-12-07 at 7 04 48 pm](https://cloud.githubusercontent.com/assets/2989362/20996102/1011b9a2-bcb0-11e6-8d80-b2642740ad18.png)

