### PR TITLE
DCOS-11958: Add missing task states

### DIFF
--- a/plugins/services/src/js/constants/TaskStates.js
+++ b/plugins/services/src/js/constants/TaskStates.js
@@ -52,6 +52,31 @@ const TaskStates = {
   TASK_ERROR: {
     stateTypes: ['completed', 'failure'],
     displayName: 'Error'
+  },
+
+  TASK_GONE: {
+    stateTypes: ['completed', 'failure'],
+    displayName: 'Gone'
+  },
+
+  TASK_GONE_BY_OPERATOR: {
+    stateTypes: ['completed', 'failure'],
+    displayName: 'Gone by operator'
+  },
+
+  TASK_DROPPED: {
+    stateTypes: ['completed', 'failure'],
+    displayName: 'Dropped'
+  },
+
+  TASK_UNREACHABLE: {
+    stateTypes: ['completed', 'failure'],
+    displayName: 'Unreachable'
+  },
+
+  TASK_UNKNOWN: {
+    stateTypes: ['completed', 'failure'],
+    displayName: 'Unknown'
   }
 };
 


### PR DESCRIPTION
This PR adds missing task states.

This is a quickfix™

We should consider having a function returning `{stateTypes, displayName}` instead of object lookup so we could work around a new missing task state. Sadly proxies are still missing in IE.