### PR TITLE
DCOS-11961: Fix historical pod instance merge

### DIFF
--- a/plugins/services/src/js/utils/PodUtil.js
+++ b/plugins/services/src/js/utils/PodUtil.js
@@ -77,10 +77,25 @@ var PodUtil = {
             return memo;
           }
 
-          podInstance.containers = [].concat(
+          let combinedContainers = [].concat(
               podInstance.containers,
               historicalInstance.containers
           );
+
+          // Filter combined container list to remove potential duplicates
+          let containerIds = new Map();
+          combinedContainers =
+              combinedContainers.filter(function ({containerId}) {
+                if (!containerIds.has(containerId)) {
+                  containerIds.set(containerId);
+
+                  return true;
+                }
+
+                return false;
+              });
+
+          podInstance.containers = combinedContainers;
 
           return memo;
         }, podInstancesMap);

--- a/plugins/services/src/js/utils/PodUtil.js
+++ b/plugins/services/src/js/utils/PodUtil.js
@@ -51,7 +51,8 @@ var PodUtil = {
    *       that can be used to construct a PodInstance!
    *
    * @param {PodInstanceList} podInstances - An array of PodInstance objects
-   * @param {Array} historicalInstances - The output of getPodHistoricalInstances
+   * @param {Array} historicalInstances - The output of
+   *  getPodHistoricalInstances
    * @returns {PodInstanceList} The new array of PodInstance objects
    */
   mergeHistoricalInstanceList(podInstances, historicalInstances) {
@@ -61,29 +62,31 @@ var PodUtil = {
 
     // De-compose PodInstances into plain objects, so we always operate
     // with plain objects
-    let podInstancesMap = podInstances.reduceItems(function (memo, instance) {
-      memo[instance.getId()] = instance.get();
-      return memo;
-    }, {});
+    let podInstancesMap =
+        podInstances.reduceItems(function (memo, podInstance) {
+          memo[podInstance.getId()] = podInstance.get();
+          return memo;
+        }, {});
 
     // Then merge historical instance information in the pod instance map
-    podInstancesMap = historicalInstances.reduce(function (memo, instance) {
-      let podInstance = memo[instance.id];
-      if (podInstance === undefined) {
-        memo[instance.id] = instance;
-        return memo;
-      }
+    let combinedInstanceMap =
+        historicalInstances.reduce(function (memo, historicalInstance) {
+          let podInstance = memo[historicalInstance.id];
+          if (podInstance === undefined) {
+            memo[historicalInstance.id] = historicalInstance;
+            return memo;
+          }
 
-      podInstance.containers = [].concat(
-          podInstance.containers,
-          instance.containers
-        );
+          podInstance.containers = [].concat(
+              podInstance.containers,
+              historicalInstance.containers
+          );
 
-      return memo;
-    }, podInstancesMap);
+          return memo;
+        }, podInstancesMap);
 
     // Re-compose PodInstances from plain objects
-    let instances = Object.values(podInstancesMap).map(function (instance) {
+    let instances = Object.values(combinedInstanceMap).map(function (instance) {
       return new PodInstance(instance);
     });
     return new PodInstanceList({items: instances});

--- a/plugins/services/src/js/utils/__tests__/PodUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/PodUtil-test.js
@@ -9,10 +9,12 @@ describe('PodUtil', function () {
           'id': 'pod-a1',
           'containers': [
             {
-              'name': 'container-c1'
+              'name': 'container-c1',
+              'containerId': 'container-c1-id'
             },
             {
-              'name': 'container-c2'
+              'name': 'container-c2',
+              'containerId': 'container-c2-id'
             }
           ]
         }
@@ -69,7 +71,8 @@ describe('PodUtil', function () {
           'id': 'pod-a2',
           'containers': [
             {
-              'name': 'container-c1'
+              'name': 'container-c1',
+              'containerId': 'container-c1'
             }
           ]
         }
@@ -89,7 +92,8 @@ describe('PodUtil', function () {
           'id': 'pod-a1',
           'containers': [
             {
-              'name': 'container-c3'
+              'name': 'container-c3',
+              'containerId': 'container-c3-id'
             }
           ]
         }
@@ -102,6 +106,29 @@ describe('PodUtil', function () {
       expect(instances.getItems()[0].getContainers().length).toEqual(3);
       expect(instances.getItems()[0].getContainers()[2].get())
         .toEqual(historicalInstances[0].containers[0]);
+    });
+
+    it('should not duplicate containers', function () {
+      let instances = this.pod.getInstanceList();
+      let historicalInstances = [
+        {
+          'id': 'pod-a1',
+          'containers': [
+            {
+              'name': 'container-c2',
+              'containerId': 'container-c2-id'
+            }
+          ]
+        }
+      ];
+
+      instances = PodUtil.mergeHistoricalInstanceList(instances,
+          historicalInstances);
+
+      expect(instances.getItems().length).toEqual(1);
+      expect(instances.getItems()[0].getContainers().length).toEqual(2);
+      expect(instances.getItems()[0].getContainers()[1].get())
+          .toEqual(historicalInstances[0].containers[0]);
     });
   });
 


### PR DESCRIPTION
Implement calls to filter the combined (current and historical) list of pod containers to remove potential duplicates. 
This will fix issues with oscillating pod container data which was caused by duplicated containers.

Fixes DCOS-11961