### PR TITLE
[multi container]: Container image format

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/Containers.js
@@ -25,8 +25,8 @@ function containersParser(state) {
     if (item.name) {
       memo.push(new Transaction(['containers', index, 'name'], item.name));
     }
-    if (item.image) {
-      memo.push(new Transaction(['containers', index, 'image'], item.image));
+    if (item.image && item.image.id) {
+      memo.push(new Transaction(['containers', index, 'image'], item.image.id));
     }
     if (item.resources != null) {
       const {resources} = item;
@@ -216,7 +216,10 @@ module.exports = {
     }
 
     if (type === SET && joinedPath === `containers.${index}.image`) {
-      newState[index] = Object.assign({}, newState[index], {image: value});
+      newState[index] =
+        Object.assign({},
+            newState[index],
+            {image: {id: value, kind: 'DOCKER'}});
     }
 
     return newState;


### PR DESCRIPTION
This fixes the structure of the image field in containers from
```JSON
{
  "image": "imagename"
}
```
to 
```JSON
{
  "image": {
    "id": "imagename",
    "kind": "DOCKER"
}
```

My understanding is that we currently only support `DOCKER` images.