### PR TITLE
Add page header to dashboard

### DIFF
--- a/src/js/pages/DashboardPage.js
+++ b/src/js/pages/DashboardPage.js
@@ -33,6 +33,14 @@ function getMesosState() {
   };
 }
 
+const DashboardBreadcrumbs = () => {
+  const crumbs = [
+    <Link to="/dashboard" key={-1}>Dashboard</Link>
+  ];
+
+  return <Page.Header.Breadcrumbs iconID="graph" breadcrumbs={crumbs} />;
+};
+
 var DashboardPage = React.createClass({
 
   displayName: 'DashboardPage',
@@ -155,6 +163,7 @@ var DashboardPage = React.createClass({
 
     return (
       <Page title="Dashboard">
+        <Page.Header breadcrumbs={<DashboardBreadcrumbs />} />
         <div className="panel-grid row">
           <div className={columnClasses}>
             <Panel


### PR DESCRIPTION
Without the page header, there's no way to toggle the sidebar's visibility. This is especially bad for mobile devices because there's literally no way to navigate the app. This was approved by design as a quick fix.