### PR TITLE
Fixes bug where listeners would not get called under some conditions

### DIFF
--- a/src/js/plugin-bridge/Hooks.js
+++ b/src/js/plugin-bridge/Hooks.js
@@ -98,13 +98,16 @@ module.exports = function Hooks() {
         return value;
       }
 
+      // Clone listeners, this will guarantee they all get called
+      listeners = Object.assign({}, listeners);
+
       // Sort the listeners by priority
       let priorities = Object.keys(listeners);
       priorities.sort();
 
       priorities.forEach(function (priority) {
-        // Call all listeners
-        listeners[priority].forEach(function (listener) {
+        // Clone and call all listeners
+        listeners[priority].slice(0).forEach(function (listener) {
           // Creates new arguments array to call the listener with
           let groupedArgs = args.slice();
           groupedArgs.unshift(value);
@@ -152,13 +155,16 @@ module.exports = function Hooks() {
         return;
       }
 
+      // Clone listeners, this will guarantee they all get called
+      listeners = Object.assign({}, listeners);
+
       // Sort the listeners by priority
       let priorities = Object.keys(listeners);
       priorities.sort();
 
       priorities.forEach(function (priority) {
-        // Call all listeners
-        listeners[priority].forEach(function (listener) {
+        // Clone and call all listeners
+        listeners[priority].slice(0).forEach(function (listener) {
           listener.apply(null, args);
         });
       });

--- a/src/js/plugin-bridge/__tests__/Hooks-test.js
+++ b/src/js/plugin-bridge/__tests__/Hooks-test.js
@@ -126,6 +126,17 @@ describe('HooksAPI', function () {
       expect(fakeAction2.calls.count()).toEqual(1);
     });
 
+    it('doesn\'t skip other listeners when removing current listener', function () {
+      let fakeAction2 = () => {
+        this.hooks.removeAction('foo', fakeAction2);
+      };
+      this.hooks.addAction('foo', fakeAction2);
+      let fakeAction3 = jasmine.createSpy('fakeAction3');
+      this.hooks.addAction('foo', fakeAction3);
+      this.hooks.doAction('foo', 'bar');
+      expect(fakeAction3.calls.count()).toEqual(1);
+    });
+
   });
 
   describe('#removeFilter', function () {
@@ -166,6 +177,17 @@ describe('HooksAPI', function () {
       this.hooks.applyFilter('foo', 'bar');
       expect(this.fakeFilter.calls.count()).toEqual(0);
       expect(fakeFilter2.calls.count()).toEqual(1);
+    });
+
+    it('doesn\'t skip other listeners when removing current listener', function () {
+      let fakeAction2 = () => {
+        this.hooks.removeFilter('foo', fakeAction2);
+      };
+      this.hooks.addFilter('foo', fakeAction2);
+      let fakeAction3 = jasmine.createSpy('fakeAction3');
+      this.hooks.addFilter('foo', fakeAction3);
+      this.hooks.applyFilter('foo', 'bar');
+      expect(fakeAction3.calls.count()).toEqual(1);
     });
 
   });


### PR DESCRIPTION
Fixes bug where removing a listener mid-execution of listeners, would cause subsequent listener to not get called as array was mutated.