### PR TITLE
DCOS-11910: Fix inline form controls

### DIFF
--- a/src/styles/components/form-elements/styles.less
+++ b/src/styles/components/form-elements/styles.less
@@ -25,6 +25,19 @@
     }
   }
 
+  .form-control-inline {
+
+    // This is necessary to override CNVS specificity.
+    &,
+    label& {
+      display: inline-block;
+    }
+
+    & + .form-control-inline {
+      margin-left: @base-spacing-unit * 1/2;
+    }
+  }
+
   // TODO: Remove this when the full screen Create Service is implemented.
   .form-control-force-narrow {
 
@@ -49,12 +62,58 @@
   }
 }
 
+& when (@grid-enabled) and (@layout-screen-small-enabled) {
+
+  @media (min-width: @layout-screen-small-min-width) {
+
+    .form-control-inline {
+
+      & + .form-control-inline {
+        margin-left: @base-spacing-unit-screen-small * 1/2;
+      }
+    }
+  }
+}
+
+& when (@grid-enabled) and (@layout-screen-medium-enabled) {
+
+  @media (min-width: @layout-screen-medium-min-width) {
+
+    .form-control-inline {
+
+      & + .form-control-inline {
+        margin-left: @base-spacing-unit-screen-medium * 1/2;
+      }
+    }
+  }
+}
+
 & when (@grid-enabled) and (@layout-screen-large-enabled) {
 
   @media (min-width: @layout-screen-large-min-width) {
 
     .form-control-input-height {
       height: @form-control-height-screen-large;
+    }
+
+    .form-control-inline {
+
+      & + .form-control-inline {
+        margin-left: @base-spacing-unit-screen-large * 1/2;
+      }
+    }
+  }
+}
+
+& when (@grid-enabled) and (@layout-screen-jumbo-enabled) {
+
+  @media (min-width: @layout-screen-jumbo-min-width) {
+
+    .form-control-inline {
+
+      & + .form-control-inline {
+        margin-left: @base-spacing-unit-screen-jumbo * 1/2;
+      }
     }
   }
 }

--- a/src/styles/components/multiple-form/styles.less
+++ b/src/styles/components/multiple-form/styles.less
@@ -10,19 +10,6 @@
    * Inline Form Elements
    */
 
-  .form-element-inline {
-
-    // This is necessary to override CNVS specificity.
-    &,
-    label& {
-      display: inline-block;
-    }
-
-    & + .form-element-inline {
-      margin-left: @base-spacing-unit;
-    }
-  }
-
   .horizontal-center {
 
     .form-element-inline {


### PR DESCRIPTION
This PR fixes the inline radio buttons.

 We had a clash of classes going on here; the `form-element-inline` class is defined in `reactjs-components` and is meant for textboxes that don't look like textboxes until you begin editing them (the name should better reflect this, but that's not the issue at hand). I changed the class to `form-control-inline` to better align with the rest of our `form-control` family of classes.