### PR TITLE
DCOS-11539: Adjust table cell alignment

### DIFF
--- a/src/js/components/ExpandingTable.js
+++ b/src/js/components/ExpandingTable.js
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React from 'react';
 import {Table} from 'reactjs-components';
 
@@ -90,24 +91,35 @@ class ExpandingTable extends React.Component {
 
   render() {
     let {props} = this;
+    let classes = classNames(props.className, {
+      [`table-align-${props.alignCells}`]: props.alignCells != null
+    });
     let TableComponent = props.tableComponent;
 
     return (
       <TableComponent
-        {...Util.omit(props, ['childRowClassName'])}
+        className={classes}
+        {...Util.omit(props, ['alignCells', 'className', 'childRowClassName'])}
         columns={this.getColumns(props.columns)} />
     );
   }
 }
 
 ExpandingTable.defaultProps = {
+  alignCells: 'top',
   childRowClassName: 'text-overflow',
   expandAll: false,
   tableComponent: Table
 };
 
 ExpandingTable.propTypes = {
+  alignCells: React.PropTypes.oneOf(['top', 'middle', 'bottom']),
   childRowClassName: React.PropTypes.string,
+  className: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ]),
   expandAll: React.PropTypes.bool,
   tableComponent: React.PropTypes.func
 };

--- a/src/styles/components/deployments-table/styles.less
+++ b/src/styles/components/deployments-table/styles.less
@@ -2,10 +2,6 @@
 
   .deployments-table {
 
-    td {
-      vertical-align: top;
-    }
-
     // TODO: Apply this more globally.
     .deployment-services-list,
     .deployment-start-time,

--- a/src/styles/components/pod-instances-table/styles.less
+++ b/src/styles/components/pod-instances-table/styles.less
@@ -1,12 +1,5 @@
 & when (@pod-instances-table-enabled) {
 
-  .pod-instances-table {
-
-    td {
-      vertical-align: top;
-    }
-  }
-
   .pod-instances-table-column {
 
     &-host-address,

--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -68,7 +68,7 @@
       // This property is necessary for table cells to respect the text-overflow
       // property. http://stackoverflow.com/questions/9789723/css-text-overflow-in-a-table-cell
       max-width: 0;
-      vertical-align: top;
+      vertical-align: middle;
     }
 
     .table-header-title {
@@ -173,6 +173,30 @@
 
   .table-fixed-layout {
     table-layout: fixed;
+  }
+
+  &.table-align {
+
+    &-top {
+
+      td {
+        vertical-align: top;
+      }
+    }
+
+    &-middle {
+
+      td {
+        vertical-align: middle;
+      }
+    }
+
+    &-bottom {
+
+      td {
+        vertical-align: bottom;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This PR adjusts table cell alignment in several ways. Here's what's up:
* Adds classes for vertically aligning table cells `top`, `middle`, or `bottom`
* Adds `alignCells` prop to `ExpandingTable` and defaults to `top`
* Removes all of the places we specified vertical alignment contextually, because this is now handled by the `ExpandingTable` itself
* Resets default alignment for all table cells to `vertical-align: middle`