### PR TITLE
DCOS-11939: Pass update callback to ClusterHeader

### DIFF
--- a/src/js/components/ClusterHeader.js
+++ b/src/js/components/ClusterHeader.js
@@ -20,6 +20,12 @@ class ClusterHeader extends mixin(StoreMixin) {
     ];
   }
 
+  componentDidUpdate() {
+    if (this.props.onUpdate) {
+      this.props.onUpdate();
+    }
+  }
+
   shouldComponentUpdate(nextProps) {
     if (nextProps.useClipboard !== this.props.useClipboard) {
       return true;
@@ -91,6 +97,7 @@ ClusterHeader.defaultProps = {
 };
 
 ClusterHeader.propTypes = {
+  onUpdate: React.PropTypes.func,
   showCaret: React.PropTypes.bool,
   useClipboard: React.PropTypes.bool
 };

--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -8,6 +8,7 @@ import PluginSDK from 'PluginSDK';
 import {keyCodes} from '../utils/KeyboardUtil';
 import ClusterHeader from './ClusterHeader';
 import EventTypes from '../constants/EventTypes';
+import GeminiUtil from '../utils/GeminiUtil';
 import Icon from '../components/Icon';
 import InternalStorageMixin from '../mixins/InternalStorageMixin';
 import MesosSummaryStore from '../stores/MesosSummaryStore';
@@ -278,7 +279,11 @@ var Sidebar = React.createClass({
     const defaultItems = [
       {
         className: 'hidden',
-        html: <ClusterHeader showCaret={true} useClipboard={false} />,
+        html: (
+          <ClusterHeader showCaret={true}
+            useClipboard={false}
+            onUpdate={this.handleClusterHeaderUpdate} />
+        ),
         id: 'dropdown-trigger'
       },
       {
@@ -305,6 +310,10 @@ var Sidebar = React.createClass({
       <UserAccountDropdown
         menuItems={Hooks.applyFilter('userDropdownItems', defaultItems)} />
     );
+  },
+
+  handleClusterHeaderUpdate() {
+    GeminiUtil.updateWithRef(this.geminiRef);
   },
 
   handlePrimarySidebarLinkClick(element, isChildActive) {
@@ -371,7 +380,8 @@ var Sidebar = React.createClass({
             {this.getSidebarHeader()}
           </header>
           <GeminiScrollbar autoshow={true}
-            className="flex-item-grow-1 flex-item-shrink-1 gm-scrollbar-container-flex gm-scrollbar-container-flex-view">
+            className="flex-item-grow-1 flex-item-shrink-1 gm-scrollbar-container-flex gm-scrollbar-container-flex-view"
+            ref={(ref) => this.geminiRef = ref}>
             <div className="sidebar-content-wrapper">
               <div className="sidebar-sections pod pod-narrow">
                 {this.getNavigationSections()}


### PR DESCRIPTION
This PR allows an `onUpdate` callback function to be passed to the `ClusterHeader` component. This is necessary for the `Sidebar` because the `ClusterHeader`'s size will update when it receives the IP address of the cluster. When this happens, the height of the neighboring Gemini container needs to be updated.

A symptom of this was the Sidebar's dock icon rendering slightly off the viewport.

Before:
![](https://cl.ly/192R1g1F1D3C/Screen%20Shot%202016-12-08%20at%204.27.48%20PM.png)

After:
![](https://cl.ly/2M2f1X3j3J37/Screen%20Shot%202016-12-08%20at%204.26.57%20PM.png)