### PR TITLE
Bug fix: Duplicate logs from range request, ref. DCOS-11818, DCOS-11819, DCOS-11820

### DIFF
--- a/plugins/services/src/js/pages/task-details/TaskLogsTab.js
+++ b/plugins/services/src/js/pages/task-details/TaskLogsTab.js
@@ -20,7 +20,7 @@ const METHODS_TO_BIND = [
   'handleItemSelection'
 ];
 
-const PAGE_ENTRY_COUNT = 50;
+const PAGE_ENTRY_COUNT = 100;
 
 function getLogParameters(task, options) {
   let {framework_id:frameworkID, executor_id:executorID, id} = task;
@@ -70,7 +70,8 @@ class TaskLogsTab extends mixin(StoreMixin) {
    */
   componentWillUnmount() {
     super.componentWillUnmount();
-    SystemLogStore.stopTailing(this.state.subscriptionID);
+    // Unusubscribe and clean up stored log lines
+    SystemLogStore.stopTailing(this.state.subscriptionID, true);
   }
 
   onSystemLogStoreError(subscriptionID) {
@@ -154,6 +155,9 @@ class TaskLogsTab extends mixin(StoreMixin) {
       limit: 0,
       skip_prev: PAGE_ENTRY_COUNT
     });
+
+    // Unusubscribe and clean up stored log lines
+    SystemLogStore.stopTailing(this.state.subscriptionID, true);
     const subscriptionID = SystemLogStore.startTailing(task.slave_id, params);
     this.setState({isLoading: true, selectedStream, subscriptionID});
   }

--- a/plugins/services/src/js/pages/task-details/TaskLogsTab.js
+++ b/plugins/services/src/js/pages/task-details/TaskLogsTab.js
@@ -124,7 +124,6 @@ class TaskLogsTab extends mixin(StoreMixin) {
     const params = getLogParameters(task, {
       filter: {STREAM: this.state.selectedStream},
       limit: PAGE_ENTRY_COUNT,
-      skip_prev: PAGE_ENTRY_COUNT,
       subscriptionID
     });
     SystemLogStore.fetchLogRange(task.slave_id, params);

--- a/src/js/events/__tests__/SystemLogActions-test.js
+++ b/src/js/events/__tests__/SystemLogActions-test.js
@@ -156,7 +156,7 @@ describe('SystemLogActions', function () {
     beforeEach(function () {
       SystemLogActions.fetchLogRange(
         'foo',
-        {cursor: 'bar', skip_prev: 10, subscriptionID: 'subscriptionID'}
+        {cursor: 'bar', limit: 3, subscriptionID: 'subscriptionID'}
       );
     });
 
@@ -170,7 +170,7 @@ describe('SystemLogActions', function () {
     it('fetches data from the correct URL', function () {
       let mostRecent = global.EventSource.calls.mostRecent();
       expect(mostRecent.args[0])
-        .toEqual('/system/v1/agent/foo/logs/v1/range/?cursor=bar&skip_prev=10');
+        .toEqual('/system/v1/agent/foo/logs/v1/range/?cursor=bar&limit=3&read_reverse=true');
       expect(mostRecent.args[1]).toEqual({withCredentials: true});
     });
 
@@ -244,11 +244,8 @@ describe('SystemLogActions', function () {
       };
       this.eventSource.dispatchEvent('message', messageEvent);
       this.eventSource.dispatchEvent('message', messageEvent);
-      // Send same cursor
-      this.eventSource.dispatchEvent(
-        'message',
-        Object.assign({}, messageEvent, {data: '{"cursor": "bar"}'})
-      );
+      // Close before we the 3 events we have requested to show
+      // that we have reached the top
       let closeEvent = {
         data: {},
         eventPhase: global.EventSource.CLOSED,

--- a/src/js/stores/SystemLogStore.js
+++ b/src/js/stores/SystemLogStore.js
@@ -147,7 +147,11 @@ class SystemLogStore extends BaseStore {
     return SystemLogActions.subscribe(nodeID, options);
   }
 
-  stopTailing(subscriptionID) {
+  stopTailing(subscriptionID, shouldClearData = false) {
+    if (shouldClearData) {
+      delete this.logs[subscriptionID];
+    }
+
     SystemLogActions.unsubscribe(subscriptionID);
   }
 
@@ -160,6 +164,7 @@ class SystemLogStore extends BaseStore {
     if (!cursor || this.hasLoadedTop(subscriptionID)) {
       return false;
     }
+
     SystemLogActions.fetchLogRange(
       nodeID,
       Object.assign({cursor}, options)

--- a/src/js/utils/SystemLogUtil.js
+++ b/src/js/utils/SystemLogUtil.js
@@ -1,5 +1,13 @@
 import Config from '../config/Config';
 
+const paramOptions = [
+  'cursor',
+  'limit',
+  'skip_prev',
+  'skip_next',
+  'read_reverse'
+];
+
 const SystemLogUtil = {
   /**
    * Creates a URL to use with the events stream for logs
@@ -16,13 +24,14 @@ const SystemLogUtil = {
    * @param {String} [options.frameworkID] ID for framework to retrieve logs from
    * @param {String} [options.executorID] ID for executor to retrieve logs from
    * @param {String} [options.containerID] ID for container to retrieve logs from
+   * @param {String} [options.read_reverse] will read events in reverse order if set to true
    * @param {Boolean} [isStream = true] whether to use stream or range endpoint
    * @returns {String} URL for system logs request
    */
   getUrl(nodeID, options, isStream = true) {
     let {filter = {}} = options;
 
-    let range = ['cursor', 'limit', 'skip_prev', 'skip_next'].reduce(function (memo, key) {
+    let range = paramOptions.reduce((memo, key) => {
       if (options[key] !== '' && options[key] != null) {
         memo.push(`${key}=${encodeURIComponent(options[key])}`);
       }


### PR DESCRIPTION
This PR fixes a few bugs for the log view, that should now:
1. Close open connections when done viewing a log file.
2. Handle when the logs take up _more_ vertical space than container better
3. Handle when the logs take up _less_ vertical space than container (including requesting to see if we have reached the top)
4. Handle receiving duplicate logs (requesting previous logs with `skip_prev` was buggy, so we are using `read_reverse` instead).
![](https://cl.ly/3A2r3d2I1q3Y/Screen%20Recording%202016-12-08%20at%2018.24.gif)