### PR TITLE
DCOS-12009: Don't lock JSON editor when user types

### DIFF
--- a/src/js/components/JSONEditor.js
+++ b/src/js/components/JSONEditor.js
@@ -293,7 +293,7 @@ class JSONEditor extends React.Component {
     }
 
     // Update the `isTyping` flag
-    this.isTyping = true;
+    this.isTyping = false;
     this.scheduleIsTypingReset(ISTYPING_TIMEOUT);
 
     // If we have errors don't continue with updating the local structures


### PR DESCRIPTION
Turns out our JSON editor is smart enough to detect where it should update and where not.
So this block is:
a) redundant
b) causes bugs described in the ticket