### PR TITLE
Rename variable/class names to improve readability

### DIFF
--- a/plugins/services/src/js/components/dsl/ServiceHealthDSLSection.js
+++ b/plugins/services/src/js/components/dsl/ServiceHealthDSLSection.js
@@ -10,10 +10,10 @@ import FieldLabel from '../../../../../../src/js/components/form/FieldLabel';
 import FormGroup from '../../../../../../src/js/components/form/FormGroup';
 
 const EXPRESSION_PARTS = {
-  is_healthy: DSLExpressionPart.attrib('health', 'healthy'),
-  is_unhealthy: DSLExpressionPart.attrib('health', 'unhealthy'),
-  is_idle: DSLExpressionPart.attrib('health', 'idle'),
-  is_na: DSLExpressionPart.attrib('health', 'na')
+  is_healthy: DSLExpressionPart.attribute('health', 'healthy'),
+  is_unhealthy: DSLExpressionPart.attribute('health', 'unhealthy'),
+  is_idle: DSLExpressionPart.attribute('health', 'idle'),
+  is_na: DSLExpressionPart.attribute('health', 'na')
 };
 
 class ServiceHealthDSLSection extends React.Component {

--- a/plugins/services/src/js/components/dsl/ServiceStatusDSLSection.js
+++ b/plugins/services/src/js/components/dsl/ServiceStatusDSLSection.js
@@ -10,11 +10,11 @@ import FieldLabel from '../../../../../../src/js/components/form/FieldLabel';
 import FormGroup from '../../../../../../src/js/components/form/FormGroup';
 
 const EXPRESSION_PARTS = {
-  is_running: DSLExpressionPart.attrib('is', 'running'),
-  is_deploying: DSLExpressionPart.attrib('is', 'deploying'),
-  is_suspended: DSLExpressionPart.attrib('is', 'suspended'),
-  is_delayed: DSLExpressionPart.attrib('is', 'delayed'),
-  is_waiting: DSLExpressionPart.attrib('is', 'waiting')
+  is_running: DSLExpressionPart.attribute('is', 'running'),
+  is_deploying: DSLExpressionPart.attribute('is', 'deploying'),
+  is_suspended: DSLExpressionPart.attribute('is', 'suspended'),
+  is_delayed: DSLExpressionPart.attribute('is', 'delayed'),
+  is_waiting: DSLExpressionPart.attribute('is', 'waiting')
 };
 
 class ServiceStatusDSLSection extends React.Component {

--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -24,8 +24,9 @@ import RequestErrorMsg from '../../../../../../src/js/components/RequestErrorMsg
 
 import DSLExpression from '../../../../../../src/js/structs/DSLExpression';
 import DSLFilterList from '../../../../../../src/js/structs/DSLFilterList';
-import ServiceAttribIsFilter from '../../filters/ServiceAttribIsFilter';
-import ServiceAttribHealthFilter from '../../filters/ServiceAttribHealthFilter';
+import ServiceAttributeIsFilter from '../../filters/ServiceAttributeIsFilter';
+import ServiceAttributeHealthFilter
+  from '../../filters/ServiceAttributeHealthFilter';
 import ServiceNameTextFilter from '../../filters/ServiceNameTextFilter';
 
 import {
@@ -74,8 +75,8 @@ import {
 
 const SERVICE_FILTERS = new DSLFilterList([
   new ServiceNameTextFilter(),
-  new ServiceAttribHealthFilter(),
-  new ServiceAttribIsFilter()
+  new ServiceAttributeHealthFilter(),
+  new ServiceAttributeIsFilter()
 ]);
 
 /**

--- a/plugins/services/src/js/filters/ServiceAttributeHealthFilter.js
+++ b/plugins/services/src/js/filters/ServiceAttributeHealthFilter.js
@@ -17,7 +17,7 @@ const LABEL_TO_HEALTH = {
 class SearviceAttribHealthFilter extends DSLFilter {
 
   /**
-   * Handle all `health:XXXX` attrib filters that we can handle.
+   * Handle all `health:XXXX` attribute filters that we can handle.
    *
    * @override
    */

--- a/plugins/services/src/js/filters/ServiceAttributeIsFilter.js
+++ b/plugins/services/src/js/filters/ServiceAttributeIsFilter.js
@@ -19,7 +19,7 @@ const LABEL_TO_INSTANCE = {
 class ServiceAttribIsFilter extends DSLFilter {
 
   /**
-   * Handle all `is:XXXX` attrib filters that we can handle.
+   * Handle all `is:XXXX` attribute filters that we can handle.
    *
    * @override
    */

--- a/plugins/services/src/js/filters/ServiceNameTextFilter.js
+++ b/plugins/services/src/js/filters/ServiceNameTextFilter.js
@@ -7,7 +7,7 @@ import DSLFilter from '../../../../../src/js/structs/DSLFilter';
 class ServiceNameTextFilter extends DSLFilter {
 
   /**
-   * Handle all `name` attrib filters that we can handle.
+   * Handle all `name` attribute filters that we can handle.
    *
    * @override
    */

--- a/plugins/services/src/js/filters/__tests__/ServiceAttributeHealthFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceAttributeHealthFilter-test.js
@@ -1,16 +1,16 @@
 jest.dontMock('../../../../../../src/js/structs/DSLFilterList');
 jest.dontMock('../../../../../../src/resources/grammar/SearchDSL.jison');
 jest.dontMock('../../constants/HealthStatus');
-jest.dontMock('../ServiceAttribHealthFilter');
+jest.dontMock('../ServiceAttributeHealthFilter');
 jest.dontMock('../../../../../../src/js/structs/List');
 
 var DSLFilterList = require('../../../../../../src/js/structs/DSLFilterList');
 var SearchDSL = require('../../../../../../src/resources/grammar/SearchDSL.jison');
 var HealthStatus = require('../../constants/HealthStatus');
-var ServiceAttribHealthFilter = require('../ServiceAttribHealthFilter');
+var ServiceAttributeHealthFilter = require('../ServiceAttributeHealthFilter');
 var List = require('../../../../../../src/js/structs/List');
 
-describe('ServiceAttribHealthFilter', function () {
+describe('ServiceAttributeHealthFilter', function () {
 
   beforeEach(function () {
     this.mockItems = [
@@ -25,7 +25,7 @@ describe('ServiceAttribHealthFilter', function () {
     let services = new List({items: this.mockItems});
     let expr = SearchDSL.parse('health:healthy');
 
-    let filters = new DSLFilterList().add(new ServiceAttribHealthFilter());
+    let filters = new DSLFilterList().add(new ServiceAttributeHealthFilter());
 
     expect(expr.filter(filters, services).getItems()).toEqual([
       this.mockItems[0]
@@ -36,7 +36,7 @@ describe('ServiceAttribHealthFilter', function () {
     let services = new List({items: this.mockItems});
     let expr = SearchDSL.parse('health:unhealthy');
 
-    let filters = new DSLFilterList().add(new ServiceAttribHealthFilter());
+    let filters = new DSLFilterList().add(new ServiceAttributeHealthFilter());
 
     expect(expr.filter(filters, services).getItems()).toEqual([
       this.mockItems[1]
@@ -47,7 +47,7 @@ describe('ServiceAttribHealthFilter', function () {
     let services = new List({items: this.mockItems});
     let expr = SearchDSL.parse('health:idle');
 
-    let filters = new DSLFilterList().add(new ServiceAttribHealthFilter());
+    let filters = new DSLFilterList().add(new ServiceAttributeHealthFilter());
 
     expect(expr.filter(filters, services).getItems()).toEqual([
       this.mockItems[2]
@@ -58,7 +58,7 @@ describe('ServiceAttribHealthFilter', function () {
     let services = new List({items: this.mockItems});
     let expr = SearchDSL.parse('health:na');
 
-    let filters = new DSLFilterList().add(new ServiceAttribHealthFilter());
+    let filters = new DSLFilterList().add(new ServiceAttributeHealthFilter());
 
     expect(expr.filter(filters, services).getItems()).toEqual([
       this.mockItems[3]
@@ -69,7 +69,7 @@ describe('ServiceAttribHealthFilter', function () {
     let services = new List({items: this.mockItems});
     let expr = SearchDSL.parse('health:foo');
 
-    let filters = new DSLFilterList().add(new ServiceAttribHealthFilter());
+    let filters = new DSLFilterList().add(new ServiceAttributeHealthFilter());
 
     expect(expr.filter(filters, services).getItems()).toEqual([
     ]);
@@ -80,7 +80,7 @@ describe('ServiceAttribHealthFilter', function () {
     let expr = SearchDSL.parse('health:hEaLThY');
 
     let filters = new DSLFilterList([
-      new ServiceAttribHealthFilter()
+      new ServiceAttributeHealthFilter()
     ]);
 
     expect(expr.filter(filters, services).getItems()).toEqual([

--- a/plugins/services/src/js/filters/__tests__/ServiceAttributeIsFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceAttributeIsFilter-test.js
@@ -1,16 +1,16 @@
 jest.dontMock('../../../../../../src/js/structs/DSLFilterList');
 jest.dontMock('../../../../../../src/resources/grammar/SearchDSL.jison');
 jest.dontMock('../../constants/ServiceStatus');
-jest.dontMock('../ServiceAttribIsFilter');
+jest.dontMock('../ServiceAttributeIsFilter');
 jest.dontMock('../../../../../../src/js/structs/List');
 
 var DSLFilterList = require('../../../../../../src/js/structs/DSLFilterList');
 var SearchDSL = require('../../../../../../src/resources/grammar/SearchDSL.jison');
 var ServiceStatus = require('../../constants/ServiceStatus');
-var ServiceAttribIsFilter = require('../ServiceAttribIsFilter');
+var ServiceAttributeIsFilter = require('../ServiceAttributeIsFilter');
 var List = require('../../../../../../src/js/structs/List');
 
-describe('ServiceAttribIsFilter', function () {
+describe('ServiceAttributeIsFilter', function () {
 
   beforeEach(function () {
     this.mockItems = [
@@ -27,7 +27,7 @@ describe('ServiceAttribIsFilter', function () {
     let services = new List({items: this.mockItems});
     let expr = SearchDSL.parse('is:delayed');
 
-    let filters = new DSLFilterList().add(new ServiceAttribIsFilter());
+    let filters = new DSLFilterList().add(new ServiceAttributeIsFilter());
 
     expect(expr.filter(filters, services).getItems()).toEqual([
       this.mockItems[0]
@@ -38,7 +38,7 @@ describe('ServiceAttribIsFilter', function () {
     let services = new List({items: this.mockItems});
     let expr = SearchDSL.parse('is:deploying');
 
-    let filters = new DSLFilterList().add(new ServiceAttribIsFilter());
+    let filters = new DSLFilterList().add(new ServiceAttributeIsFilter());
 
     expect(expr.filter(filters, services).getItems()).toEqual([
       this.mockItems[1]
@@ -49,7 +49,7 @@ describe('ServiceAttribIsFilter', function () {
     let services = new List({items: this.mockItems});
     let expr = SearchDSL.parse('is:running');
 
-    let filters = new DSLFilterList().add(new ServiceAttribIsFilter());
+    let filters = new DSLFilterList().add(new ServiceAttributeIsFilter());
 
     expect(expr.filter(filters, services).getItems()).toEqual([
       this.mockItems[2]
@@ -60,7 +60,7 @@ describe('ServiceAttribIsFilter', function () {
     let services = new List({items: this.mockItems});
     let expr = SearchDSL.parse('is:suspended');
 
-    let filters = new DSLFilterList().add(new ServiceAttribIsFilter());
+    let filters = new DSLFilterList().add(new ServiceAttributeIsFilter());
 
     expect(expr.filter(filters, services).getItems()).toEqual([
       this.mockItems[3]
@@ -71,7 +71,7 @@ describe('ServiceAttribIsFilter', function () {
     let services = new List({items: this.mockItems});
     let expr = SearchDSL.parse('is:waiting');
 
-    let filters = new DSLFilterList().add(new ServiceAttribIsFilter());
+    let filters = new DSLFilterList().add(new ServiceAttributeIsFilter());
 
     expect(expr.filter(filters, services).getItems()).toEqual([
       this.mockItems[4]
@@ -82,7 +82,7 @@ describe('ServiceAttribIsFilter', function () {
     let services = new List({items: this.mockItems});
     let expr = SearchDSL.parse('is:na');
 
-    let filters = new DSLFilterList().add(new ServiceAttribIsFilter());
+    let filters = new DSLFilterList().add(new ServiceAttributeIsFilter());
 
     expect(expr.filter(filters, services).getItems()).toEqual([
       this.mockItems[5]
@@ -93,7 +93,7 @@ describe('ServiceAttribIsFilter', function () {
     let services = new List({items: this.mockItems});
     let expr = SearchDSL.parse('is:foo');
 
-    let filters = new DSLFilterList().add(new ServiceAttribIsFilter());
+    let filters = new DSLFilterList().add(new ServiceAttributeIsFilter());
 
     expect(expr.filter(filters, services).getItems()).toEqual([
     ]);
@@ -104,7 +104,7 @@ describe('ServiceAttribIsFilter', function () {
     let expr = SearchDSL.parse('is:dElAyED');
 
     let filters = new DSLFilterList([
-      new ServiceAttribIsFilter()
+      new ServiceAttributeIsFilter()
     ]);
 
     expect(expr.filter(filters, services).getItems()).toEqual([

--- a/src/js/structs/DSLASTNodes.js
+++ b/src/js/structs/DSLASTNodes.js
@@ -15,8 +15,8 @@ class ASTNode {
      * position of each relevant text portions that composes this token.
      *
      * In 99.9% of the cases, this is an array with only 1 tuple. However, when
-     * the `attrib:value1,value2` shorthand is used, this array will contain
-     * 2 tuples, pointing to the `attrib:` and `valueX` parts separately.
+     * the `attribute:value1,value2` shorthand is used, this array will contain
+     * 2 tuples, pointing to the `attribute:` and `valueX` parts separately.
      *
      * @var {Array}
      */

--- a/src/js/structs/DSLExpressionPart.js
+++ b/src/js/structs/DSLExpressionPart.js
@@ -15,7 +15,7 @@ import {FilterNode} from './DSLASTNodes';
  *
  *   // Create a boolean property that is defined when the attribute is:healthy
  *   // exists in the parsed DSL
- *   is_healthy: DSLExpressionPart.attrib('is', 'healthy'),
+ *   is_healthy: DSLExpressionPart.attribute('is', 'healthy'),
  *
  *   // Create a string property that contains the first exact-match node
  *   text: DSLExpressionPart.exact,
@@ -44,7 +44,7 @@ import {FilterNode} from './DSLASTNodes';
  */
 class DSLExpressionPart {
 
-  static attrib(label, text=undefined) {
+  static attribute(label, text=undefined) {
     return new FilterNode(0, 0, DSLFilterTypes.ATTRIB, {label, text});
   }
 

--- a/src/js/structs/DSLFilter.js
+++ b/src/js/structs/DSLFilter.js
@@ -8,7 +8,8 @@ class DSLFilter {
    * Returns true if the filter can be applied to the given operand
    *
    * @abstract
-   * @param {DSLFilterTypes} filterType - The filter type (ex. fuzzy or attrib)
+   * @param {DSLFilterTypes} filterType -
+   *  The filter type (ex. fuzzy or attribute)
    * @param {Object} filterArguments - The filter arguments
    * @returns {Boolean} True if the filter can be applied to the given operand
    */
@@ -21,7 +22,8 @@ class DSLFilter {
    *
    * @abstract
    * @param {List} resultset - The list with the results to filter
-   * @param {DSLFilterTypes} filterType - The filter type (ex. fuzzy or attrib)
+   * @param {DSLFilterTypes} filterType -
+   *  The filter type (ex. fuzzy or attribute)
    * @param {Object} filterArguments - The filter arguments
    * @returns {List} Returns the new, filtered list
    */
@@ -33,7 +35,8 @@ class DSLFilter {
    * Return typeahead components for the given state of the filter
    *
    * @abstract
-   * @param {DSLFilterTypes} filterType - The filter type (ex. fuzzy or attrib)
+   * @param {DSLFilterTypes} filterType -
+   *  The filter type (ex. fuzzy or attribute)
    * @param {Object} filterArguments - The filter arguments
    * @returns {Array} Returns an array of React.Components to display in the typeahead dropdown
    */

--- a/src/js/structs/__tests__/DSLExpressionPart-test.js
+++ b/src/js/structs/__tests__/DSLExpressionPart-test.js
@@ -4,19 +4,21 @@ const DSLExpressionPart = require('../DSLExpressionPart');
 
 describe('DSLExpressionPart', function () {
 
-  it('should correct create an .attrib(\'label\') filter', function () {
-    let ret = DSLExpressionPart.attrib('label');
+  it('should correct create an .attribute(\'label\') filter', function () {
+    let ret = DSLExpressionPart.attribute('label');
 
     expect(ret.filterType).toEqual(DSLFilterTypes.ATTRIB);
     expect(ret.filterParams).toEqual({label: 'label'});
   });
 
-  it('should correct create an .attrib(\'label\', \'text\') filter', function () {
-    let ret = DSLExpressionPart.attrib('label', 'text');
+  it('should correct create an .attribute(\'label\', \'text\') filter',
+    function () {
+      let ret = DSLExpressionPart.attribute('label', 'text');
 
-    expect(ret.filterType).toEqual(DSLFilterTypes.ATTRIB);
-    expect(ret.filterParams).toEqual({label: 'label', text: 'text'});
-  });
+      expect(ret.filterType).toEqual(DSLFilterTypes.ATTRIB);
+      expect(ret.filterParams).toEqual({label: 'label', text: 'text'});
+    }
+  );
 
   it('should correct create an .exact filter', function () {
     let ret = DSLExpressionPart.exact;

--- a/src/js/utils/DSLParserUtil.js
+++ b/src/js/utils/DSLParserUtil.js
@@ -14,9 +14,10 @@ import DSLFilterList from '../structs/DSLFilterList';
  * in order to actually apply the filter chain on a resultset. Note that this
  * factory function will be created by the AST parser.
  *
- * For example, when the expression: `string AND attrib:value` is encountered,
- * two run-time filter functions will be produced by the `filterFunctionFactory`
- * function (see below), and combined into one, using this function.
+ * For example, when the expression: `string AND attribute:value`
+ * is encountered, two run-time filter functions will be produced by the
+ * `filterFunctionFactory` function (see below), and combined into one,
+ * using this function.
  *
  * @private
  * @param {CombineNode} ast - The AST node for the combine operator

--- a/src/js/utils/DSLUpdateUtil.js
+++ b/src/js/utils/DSLUpdateUtil.js
@@ -102,9 +102,9 @@ const DSLUpdateUtil = {
       end = position[1][1] + offset;
 
       // Increase the scope to the entire value only if the node is the only
-      // value in the attrib. To test for this, we are checking if the character
-      // right before is the label ':' and the character after is a whitespace
-      // or a comma with whitespace
+      // value in the attribute. To test for this, we are checking if the
+      // character right before is the label ':' and the character after is a
+      // whitespace or a comma with whitespace
       if ((src[start - 1] === ':') && (endingRegex.exec(src.substr(end)))) {
         start = position[0][0] + offset;
         end = position[1][1] + offset;

--- a/src/js/utils/DSLUtil.js
+++ b/src/js/utils/DSLUtil.js
@@ -172,7 +172,7 @@ const DSLUtil = {
           return memo;
 
         //
-        // Properties created through .exact filter will get a string value
+        // Properties created through exact filter will get a string value
         //
         case DSLFilterTypes.EXACT:
           if (matchingNodes.length === 0) {
@@ -184,7 +184,7 @@ const DSLUtil = {
           return memo;
 
         //
-        // Properties created through .fuzzy filter will get a string value,
+        // Properties created through fuzzy filter will get a string value,
         // composed by joining together any individual item in the string
         //
         case DSLFilterTypes.FUZZY:

--- a/src/js/utils/DSLUtil.js
+++ b/src/js/utils/DSLUtil.js
@@ -165,7 +165,7 @@ const DSLUtil = {
 
       switch (matchAgainst.filterType) {
         //
-        // Properties created through .attrib() filter will get a boolean value
+        // Properties created through attribute filter will get a boolean value
         //
         case DSLFilterTypes.ATTRIB:
           memo[prop] = (matchingNodes.length === 1);

--- a/src/js/utils/__tests__/DSLParserUtil-test.js
+++ b/src/js/utils/__tests__/DSLParserUtil-test.js
@@ -14,7 +14,7 @@ class AttribFilter extends DSLFilter {
   }
   filterApply(resultset) {
     return resultset.filterItems((item) => {
-      return item.text.indexOf('attrib') !== -1;
+      return item.text.indexOf('attribute') !== -1;
     });
   }
 }
@@ -45,10 +45,10 @@ describe('DSLParserUtil', function () {
 
   beforeEach(function () {
     this.mockData = new List({items: [
-      {text: 'attrib'},
+      {text: 'attribute'},
       {text: 'fuzzy'},
       {text: 'exact'},
-      {text: 'attrib fuzzy'}
+      {text: 'attribute fuzzy'}
     ]});
   });
 
@@ -86,8 +86,8 @@ describe('DSLParserUtil', function () {
       ]);
 
       expect(filter(filters, this.mockData).getItems()).toEqual([
-        {text: 'attrib'},
-        {text: 'attrib fuzzy'}
+        {text: 'attribute'},
+        {text: 'attribute fuzzy'}
       ]);
     });
 
@@ -166,7 +166,7 @@ describe('DSLParserUtil', function () {
 
       expect(filter(filters, this.mockData).getItems()).toEqual([
         {text: 'fuzzy'},
-        {text: 'attrib fuzzy'}
+        {text: 'attribute fuzzy'}
       ]);
     });
 
@@ -207,7 +207,7 @@ describe('DSLParserUtil', function () {
       ]);
 
       expect(filter(filters, this.mockData).getItems()).toEqual([
-        {text: 'attrib fuzzy'}
+        {text: 'attribute fuzzy'}
       ]);
     });
 
@@ -248,8 +248,8 @@ describe('DSLParserUtil', function () {
       ]);
 
       expect(filter(filters, this.mockData).getItems()).toEqual([
-        {text: 'attrib'},
-        {text: 'attrib fuzzy'},
+        {text: 'attribute'},
+        {text: 'attribute fuzzy'},
         {text: 'fuzzy'}
       ]);
     });

--- a/src/js/utils/__tests__/DSLUpdateUtil-test.js
+++ b/src/js/utils/__tests__/DSLUpdateUtil-test.js
@@ -139,7 +139,7 @@ describe('DSLUpdateUtil', function () {
 
   describe('#applyAdd', function () {
 
-    it('should correctly add one attrib node to an expression', function () {
+    it('should correctly add one attribute node to an expression', function () {
       let expression = new DSLExpression('foo bar');
       let node = new DSLASTNodes.FilterNode(0, 0, DSLFilterTypes.ATTRIB, {
         label: 'label', text: 'text'
@@ -169,7 +169,7 @@ describe('DSLUpdateUtil', function () {
         .toEqual('foo bar "text"');
     });
 
-    it('should correctly add two attrib nodes to an expression', function () {
+    it('should correctly add two attribute nodes to an expression', function () {
       let expression = new DSLExpression('foo bar');
       let node = new DSLASTNodes.FilterNode(0, 0, DSLFilterTypes.ATTRIB, {
         label: 'label', text: 'text'
@@ -179,7 +179,7 @@ describe('DSLUpdateUtil', function () {
         .toEqual('foo bar label:text label:text');
     });
 
-    it('should correctly add one attrib node to an expression with OR', function () {
+    it('should correctly add one attribute node to an expression with OR', function () {
       let expression = new DSLExpression('foo bar');
       let node = new DSLASTNodes.FilterNode(0, 0, DSLFilterTypes.ATTRIB, {
         label: 'label', text: 'text'
@@ -209,7 +209,7 @@ describe('DSLUpdateUtil', function () {
         .toEqual('foo bar, "text"');
     });
 
-    it('should correctly create multi-value attrib when adding with OR', function () {
+    it('should correctly create multi-value attribute when adding with OR', function () {
       let expression = new DSLExpression('foo bar label:some');
       let node = new DSLASTNodes.FilterNode(0, 0, DSLFilterTypes.ATTRIB, {
         label: 'label', text: 'text'
@@ -375,15 +375,15 @@ describe('DSLUpdateUtil', function () {
 
   describe('#applyDelete', function () {
 
-    it('should correctly delete one attrib node', function () {
-      let expression = new DSLExpression('is:attrib');
+    it('should correctly delete one attribute node', function () {
+      let expression = new DSLExpression('is:attribute');
       let deleteNodes = [expression.ast];
 
       expect(DSLUpdateUtil.applyDelete(expression, deleteNodes).value)
         .toEqual('');
     });
 
-    it('should correctly delete first in multiple attrib nodes', function () {
+    it('should correctly delete first in multiple attribute nodes', function () {
       let expression = new DSLExpression('is:a is:b is:c');
       let deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -396,7 +396,7 @@ describe('DSLUpdateUtil', function () {
         .toEqual('is:b is:c');
     });
 
-    it('should correctly delete last in multiple attrib nodes', function () {
+    it('should correctly delete last in multiple attribute nodes', function () {
       let expression = new DSLExpression('is:a is:b is:c');
       let deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -409,7 +409,7 @@ describe('DSLUpdateUtil', function () {
         .toEqual('is:a is:b');
     });
 
-    it('should correctly delete internal in multiple attrib nodes', function () {
+    it('should correctly delete internal in multiple attribute nodes', function () {
       let expression = new DSLExpression('is:a is:b is:c');
       let deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -422,7 +422,7 @@ describe('DSLUpdateUtil', function () {
         .toEqual('is:a is:c');
     });
 
-    it('should correctly delete first in multi-value attrib nodes', function () {
+    it('should correctly delete first in multi-value attribute nodes', function () {
       let expression = new DSLExpression('is:a,b,c');
       let deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -435,7 +435,7 @@ describe('DSLUpdateUtil', function () {
         .toEqual('is:b,c');
     });
 
-    it('should correctly delete internal in multi-value attrib nodes', function () {
+    it('should correctly delete internal in multi-value attribute nodes', function () {
       let expression = new DSLExpression('is:a,b,c');
       let deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -448,7 +448,7 @@ describe('DSLUpdateUtil', function () {
         .toEqual('is:a,c');
     });
 
-    it('should correctly delete last in multi-value attrib nodes', function () {
+    it('should correctly delete last in multi-value attribute nodes', function () {
       let expression = new DSLExpression('is:a,b,c');
       let deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -461,7 +461,7 @@ describe('DSLUpdateUtil', function () {
         .toEqual('is:a,b');
     });
 
-    it('should correctly delete one in multiple attrib nodes', function () {
+    it('should correctly delete one in multiple attribute nodes', function () {
       let expression = new DSLExpression('is:a is:b, is:c');
       let deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -474,7 +474,7 @@ describe('DSLUpdateUtil', function () {
         .toEqual('is:a, is:c');
     });
 
-    it('should correctly delete one in multi-value attrib node', function () {
+    it('should correctly delete one in multi-value attribute node', function () {
       let expression = new DSLExpression('is:a,b,c');
       let deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,

--- a/src/js/utils/__tests__/DSLUtil-test.js
+++ b/src/js/utils/__tests__/DSLUtil-test.js
@@ -15,7 +15,7 @@ describe('DSLUtil', function () {
   describe('#reduceAstFilters', function () {
 
     it('should be called for every filter in the tree', function () {
-      let ast = new DSLExpression('foo bar (is:attrib "exact")').ast;
+      let ast = new DSLExpression('foo bar (is:attribute "exact")').ast;
       let handler = jest.fn();
 
       DSLUtil.reduceAstFilters(ast, handler);
@@ -27,13 +27,13 @@ describe('DSLUtil', function () {
       expect(texts).toEqual([
         'foo',
         'bar',
-        'attrib',
+        'attribute',
         'exact'
       ]);
     });
 
     it('should correctly return and process memo', function () {
-      let ast = new DSLExpression('foo bar (is:attrib "exact")').ast;
+      let ast = new DSLExpression('foo bar (is:attribute "exact")').ast;
       let texts = DSLUtil.reduceAstFilters(ast, (memo, filter) => {
         return memo.concat(filter.filterParams.text);
       }, []);
@@ -41,7 +41,7 @@ describe('DSLUtil', function () {
       expect(texts).toEqual([
         'foo',
         'bar',
-        'attrib',
+        'attribute',
         'exact'
       ]);
     });
@@ -80,7 +80,7 @@ describe('DSLUtil', function () {
 
     beforeEach(function () {
       this.parts = {
-        attr: DSLExpressionPart.attrib('is', 'foo'),
+        attr: DSLExpressionPart.attribute('is', 'foo'),
         exact: DSLExpressionPart.exact,
         fuzzy: DSLExpressionPart.fuzzy
       };
@@ -92,13 +92,13 @@ describe('DSLUtil', function () {
       expect(DSLUtil.canProcessParts(expression, this.parts)).toBeTruthy();
     });
 
-    it('should return true when expression has a single attrib node', function () {
+    it('should return true when expression has a single attribute node', function () {
       const expression = new DSLExpression('is:foo');
 
       expect(DSLUtil.canProcessParts(expression, this.parts)).toBeTruthy();
     });
 
-    it('should return false when expression has a repeating attrib node', function () {
+    it('should return false when expression has a repeating attribute node', function () {
       const expression = new DSLExpression('is:foo is:foo');
 
       expect(DSLUtil.canProcessParts(expression, this.parts)).toBeFalsy();
@@ -174,8 +174,8 @@ describe('DSLUtil', function () {
       ];
     });
 
-    it('should return all occurrences of attrib match', function () {
-      let filter = DSLExpressionPart.attrib('is', 'foo');
+    it('should return all occurrences of attribute match', function () {
+      let filter = DSLExpressionPart.attribute('is', 'foo');
 
       expect(DSLUtil.findNodesByFilter(this.ast, filter)).toEqual([
         this.attribs[0], this.attribs[2]
@@ -200,7 +200,7 @@ describe('DSLUtil', function () {
 
     beforeEach(function () {
       this.parts = {
-        attr: DSLExpressionPart.attrib('is', 'foo'),
+        attr: DSLExpressionPart.attribute('is', 'foo'),
         exact: DSLExpressionPart.exact,
         fuzzy: DSLExpressionPart.fuzzy
       };
@@ -250,7 +250,7 @@ describe('DSLUtil', function () {
 
   describe('#getNodeString', function () {
 
-    it('should correctly return the string of attrib nodes', function () {
+    it('should correctly return the string of attribute nodes', function () {
       let node = new DSLASTNodes.FilterNode(0, 0, DSLFilterTypes.ATTRIB, {
         label: 'label', text: 'text'
       });


### PR DESCRIPTION
---
⚠️  _This branch includes features that will be introduced with #1549, don't merge before the respective branch landed._

---
Change all DSL variable and class names from `attrib` to `attribute` to improve readability.

See [diff here](https://github.com/dcos/dcos-ui/compare/ic/feat/DCOS-10470-new-dsl-components-9...orlandohohmeier/refactor/adjust-dsl-class-and-variable-names)

/cc @wavesoft 