### PR TITLE
Fix container name defaults

### DIFF
--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -86,7 +86,7 @@ class GeneralServiceFormSection extends Component {
       return (
         <FormGroupContainer key={index}
           onRemove={this.props.onRemoveItem.bind(this, {value: index, path: 'containers'})}>
-          {item.name || `container ${index + 1}`}
+          {item.name || `container-${index + 1}`}
         </FormGroupContainer>
       );
     });

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -277,7 +277,7 @@ class NewCreateServiceModalForm extends Component {
   getContainerList(data) {
     if (data.containers && data.containers.length !== 0) {
       return data.containers.map((item, index) => {
-        let fakeContainer = {name: item.name || `container ${index + 1}`};
+        let fakeContainer = {name: item.name || `container-${index + 1}`};
 
         return (
           <TabButton

--- a/plugins/services/src/js/constants/NewPodDefaults.js
+++ b/plugins/services/src/js/constants/NewPodDefaults.js
@@ -1,7 +1,7 @@
 const NEW_POD_DEFAULTS = {
   containers: [
     {
-      name: 'container1',
+      name: 'container-1',
       resources: {
         cpus: 0.001
       }

--- a/plugins/services/src/js/reducers/serviceForm/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/Containers.js
@@ -303,7 +303,7 @@ module.exports = {
     if (joinedPath === 'containers') {
       switch (type) {
         case ADD_ITEM:
-          newState.push({name: `container ${newState.length + 1}`});
+          newState.push({name: `container-${newState.length + 1}`});
           this.cache.push({});
           this.endpoints.push({});
           break;
@@ -471,7 +471,7 @@ module.exports = {
     if (joinedPath === 'containers') {
       switch (type) {
         case ADD_ITEM:
-          newState.push({name: `container ${newState.length + 1}`});
+          newState.push({name: `container-${newState.length + 1}`});
           this.cache.push({});
           break;
         case REMOVE_ITEM:

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
@@ -19,7 +19,7 @@ describe('Containers', function () {
       batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
 
       expect(batch.reduce(Containers.JSONReducer.bind({})))
-        .toEqual([{name: 'container 1'}]);
+        .toEqual([{name: 'container-1'}]);
     });
 
   });


### PR DESCRIPTION
Adjust the multi-container default names to ensure they are in line with the API requirements. It also aligns the default spec with the generated ones.