### PR TITLE
Adjust the  continuation indent size

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ trim_trailing_whitespace = true
 end_of_line = lf
 
 [*.js]
-continuation_indent_size = 4
+continuation_indent_size = 2
 indent_brace_style = OTBS
 quote_type = single
 spaces_around_operators = true


### PR DESCRIPTION
Change the continuation indent size from 4 to 2 as an indentation of 4 often was pointed out as a stylistic issues during reviews.

/cc @dcos/frontend 