### PR TITLE
DCOS-10693: Prevent stop action for scheduler tasks

### DIFF
--- a/plugins/services/src/js/containers/tasks/TasksContainer.js
+++ b/plugins/services/src/js/containers/tasks/TasksContainer.js
@@ -169,7 +169,9 @@ class TasksContainer extends React.Component {
   render() {
     return (
       <div>
-        <TasksView params={this.props.params} tasks={this.props.tasks} />
+        <TasksView
+          params={this.props.params}
+          tasks={this.props.tasks} />
         {this.getModals()}
       </div>
     );

--- a/plugins/services/src/js/containers/tasks/TasksView.js
+++ b/plugins/services/src/js/containers/tasks/TasksView.js
@@ -153,6 +153,20 @@ class TasksView extends mixin(SaveStateMixin) {
     const hasSchedulerTask = tasks
       .some((task) => task.id in checkedItems && task.schedulerTask);
 
+    // Using Button's native "disabled" prop prevents onMouseLeave from
+    // being correctly called, preventing correct dismissal of the Tooltip.
+    //
+    // So we manually disable the button.
+    let onStopClick = () => {};
+
+    if (!hasSchedulerTask) {
+      onStopClick = this.handleKillClick.bind(this, 'stop');
+    }
+
+    let stopButtonClasses = classNames('button button-link', {
+      disabled: hasSchedulerTask
+    });
+
     return (
       <div className="button-collection flush-bottom">
         <button
@@ -161,17 +175,17 @@ class TasksView extends mixin(SaveStateMixin) {
           <Icon id="repeat" size="mini" />
           <span>Restart</span>
         </button>
-        <button
-          className="button button-link"
-          disabled={hasSchedulerTask}
-          onClick={this.handleKillClick.bind(this, 'stop')}>
-          <Tooltip
-            content="Stopping a scheduler task is not supported."
-            suppress={!hasSchedulerTask}>
-            <Icon id="circle-close" size="mini" />
-            <span>Stop</span>
-          </Tooltip>
-        </button>
+        <Tooltip
+          wrapperClassName="button-group"
+          content="Stopping a scheduler task is not supported."
+          suppress={!hasSchedulerTask}>
+          <button
+            className={stopButtonClasses}
+            onClick={onStopClick}>
+              <Icon id="circle-close" size="mini" />
+              <span>Stop</span>
+          </button>
+        </Tooltip>
       </div>
     );
   }

--- a/plugins/services/src/js/containers/tasks/TasksView.js
+++ b/plugins/services/src/js/containers/tasks/TasksView.js
@@ -67,7 +67,7 @@ class TasksView extends mixin(SaveStateMixin) {
     this.setState({checkedItems});
   }
 
-  handleKillClick(killAction) {
+  handleStopClick(killAction) {
     const {checkedItems} = this.state;
 
     if (!Object.keys(checkedItems).length) {
@@ -142,7 +142,7 @@ class TasksView extends mixin(SaveStateMixin) {
     );
   }
 
-  getKillButtons() {
+  getStopButtons() {
     const {tasks} = this.props;
     const {checkedItems} = this.state;
 
@@ -157,10 +157,10 @@ class TasksView extends mixin(SaveStateMixin) {
     // being correctly called, preventing correct dismissal of the Tooltip.
     //
     // So we manually disable the button.
-    let onStopClick = () => {};
+    let handleStopClick = function () {};
 
     if (!hasSchedulerTask) {
-      onStopClick = this.handleKillClick.bind(this, 'stop');
+      handleStopClick = this.handleStopClick.bind(this, 'stop');
     }
 
     let stopButtonClasses = classNames('button button-link', {
@@ -171,7 +171,7 @@ class TasksView extends mixin(SaveStateMixin) {
       <div className="button-collection flush-bottom">
         <button
           className="button button-link"
-          onClick={this.handleKillClick.bind(this, 'restart')}>
+          onClick={this.handleStopClick.bind(this, 'restart')}>
           <Icon id="repeat" size="mini" />
           <span>Restart</span>
         </button>
@@ -181,7 +181,7 @@ class TasksView extends mixin(SaveStateMixin) {
           suppress={!hasSchedulerTask}>
           <button
             className={stopButtonClasses}
-            onClick={onStopClick}>
+            onClick={handleStopClick}>
               <Icon id="circle-close" size="mini" />
               <span>Stop</span>
           </button>
@@ -235,7 +235,7 @@ class TasksView extends mixin(SaveStateMixin) {
             inverseStyle={inverseStyle}
             itemList={taskStates}
             selectedFilter={filterByStatus} />
-          {this.getKillButtons()}
+          {this.getStopButtons()}
         </FilterBar>
         {this.getTaskTable(filteredTasks, checkedItems)}
       </div>

--- a/plugins/services/src/js/containers/tasks/TasksView.js
+++ b/plugins/services/src/js/containers/tasks/TasksView.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import mixin from 'reactjs-mixin';
+import {Tooltip} from 'reactjs-components';
 import React from 'react';
 
 import FilterBar from '../../../../../../src/js/components/FilterBar';
@@ -148,32 +149,31 @@ class TasksView extends mixin(SaveStateMixin) {
     if (!Object.keys(checkedItems).length) {
       return null;
     }
-
-    let killButtons = [(
-      <div
-        className="button button-link"
-        onClick={this.handleKillClick.bind(this, 'restart')}>
-        <Icon id="repeat" size="mini" />
-        <span>Restart</span>
-      </div>
-    )];
-
     // Only show Stop if a scheduler task isn't selected
     const hasSchedulerTask = tasks
       .some((task) => task.id in checkedItems && task.schedulerTask);
 
-    if (!hasSchedulerTask) {
-      killButtons.push(
-        <div
+    return (
+      <div className="button-collection flush-bottom">
+        <button
           className="button button-link"
+          onClick={this.handleKillClick.bind(this, 'restart')}>
+          <Icon id="repeat" size="mini" />
+          <span>Restart</span>
+        </button>
+        <button
+          className="button button-link"
+          disabled={hasSchedulerTask}
           onClick={this.handleKillClick.bind(this, 'stop')}>
-          <Icon id="circle-close" size="mini" />
-          <span>Stop</span>
-        </div>
-      );
-    }
-
-    return <div className="button-collection flush-bottom">{killButtons}</div>;
+          <Tooltip
+            content="Stopping a scheduler task is not supported."
+            suppress={!hasSchedulerTask}>
+            <Icon id="circle-close" size="mini" />
+            <span>Stop</span>
+          </Tooltip>
+        </button>
+      </div>
+    );
   }
 
   render() {

--- a/plugins/services/src/js/containers/tasks/TasksView.js
+++ b/plugins/services/src/js/containers/tasks/TasksView.js
@@ -141,27 +141,39 @@ class TasksView extends mixin(SaveStateMixin) {
     );
   }
 
-  getKillButtons(hasCheckedTasks) {
-    if (!hasCheckedTasks) {
+  getKillButtons() {
+    const {tasks} = this.props;
+    const {checkedItems} = this.state;
+
+    if (!Object.keys(checkedItems).length) {
       return null;
     }
 
-    return (
-      <div className="button-collection flush-bottom">
-        <div
-          className="button button-link"
-          onClick={this.handleKillClick.bind(this, 'restart')}>
-          <Icon id="repeat" size="mini" />
-          <span>Restart</span>
-        </div>
+    let killButtons = [(
+      <div
+        className="button button-link"
+        onClick={this.handleKillClick.bind(this, 'restart')}>
+        <Icon id="repeat" size="mini" />
+        <span>Restart</span>
+      </div>
+    )];
+
+    // Only show Stop if a scheduler task isn't selected
+    const hasSchedulerTask = tasks
+      .some((task) => task.id in checkedItems && task.schedulerTask);
+
+    if (!hasSchedulerTask) {
+      killButtons.push(
         <div
           className="button button-link"
           onClick={this.handleKillClick.bind(this, 'stop')}>
           <Icon id="circle-close" size="mini" />
           <span>Stop</span>
         </div>
-      </div>
-    );
+      );
+    }
+
+    return <div className="button-collection flush-bottom">{killButtons}</div>;
   }
 
   render() {
@@ -209,7 +221,7 @@ class TasksView extends mixin(SaveStateMixin) {
             inverseStyle={inverseStyle}
             itemList={taskStates}
             selectedFilter={filterByStatus} />
-          {this.getKillButtons(hasCheckedTasks)}
+          {this.getKillButtons()}
         </FilterBar>
         {this.getTaskTable(filteredTasks, checkedItems)}
       </div>

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -34,6 +34,14 @@ function stopPolling() {
   }
 }
 
+function isSchedulerTask(task, schedulerTaskIds) {
+  if (schedulerTaskIds.includes(task.id)) {
+    return Object.assign({}, task, {schedulerTask: true});
+  }
+
+  return task;
+}
+
 class MesosStateStore extends GetSetBaseStore {
   constructor() {
     super(...arguments);
@@ -179,10 +187,21 @@ class MesosStateStore extends GetSetBaseStore {
     let services = this.get('lastMesosState').frameworks || [];
     let memberTasks = {};
 
-    services.forEach(function (service) {
+    const schedulerTaskIds = services.reduce((memo, service) => {
+      const serviceName = service.name.split('.').reverse().join('/');
+      const schedulerTask = this.getSchedulerTaskFromServiceName(serviceName);
+
+      if (schedulerTask) {
+        memo.push(schedulerTask.id);
+      }
+
+      return memo;
+    }, []);
+
+    services.forEach((service) => {
       service.tasks.forEach(function (task) {
         if (task.slave_id === nodeID) {
-          memberTasks[task.id] = task;
+          memberTasks[task.id] = isSchedulerTask(task, schedulerTaskIds);
         }
       });
       service.completed_tasks.forEach(function (task) {
@@ -268,6 +287,13 @@ class MesosStateStore extends GetSetBaseStore {
       return [];
     }
 
+    const schedulerTaskIds = [];
+
+    const schedulerTask = this.getSchedulerTaskFromServiceName(serviceName);
+    if (schedulerTask) {
+      schedulerTaskIds.push(schedulerTask.id);
+    }
+
     // Combine framework (if matching framework was found) and filtered
     // Marathon tasks. This will give you a list of framework tasks including
     // the scheduler tasks or a list of Marathon application tasks.
@@ -275,15 +301,17 @@ class MesosStateStore extends GetSetBaseStore {
       let {tasks = [], completed_tasks = {}, name} = framework;
       // Include tasks from framework match, if service is a Framework
       if (service instanceof Framework && name === serviceName) {
-        return serviceTasks.concat(tasks, completed_tasks);
+        return serviceTasks
+          .concat(tasks, completed_tasks)
+          .map((task) => isSchedulerTask(task, schedulerTaskIds));
       }
 
       // Filter marathon tasks by service name
       if (name === 'marathon') {
         return tasks.concat(completed_tasks)
-          .filter(function ({name}) {
-            return name === mesosTaskName;
-          }).concat(serviceTasks);
+          .filter(({name}) => name === mesosTaskName)
+          .concat(serviceTasks)
+          .map((task) => isSchedulerTask(task, schedulerTaskIds));
       }
 
       return serviceTasks;

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -34,7 +34,13 @@ function stopPolling() {
   }
 }
 
-function isSchedulerTask(task, schedulerTaskIds) {
+/**
+ * Assigns a property to task if it is a scheduler task.
+ * @param  {Object} task
+ * @param  {Array} schedulerTaskIds Array of scheduler task Ids
+ * @return {Object} task
+ */
+function assignSchedulerTaskField(task, schedulerTaskIds) {
   if (schedulerTaskIds.includes(task.id)) {
     return Object.assign({}, task, {schedulerTask: true});
   }
@@ -201,7 +207,7 @@ class MesosStateStore extends GetSetBaseStore {
     services.forEach((service) => {
       service.tasks.forEach(function (task) {
         if (task.slave_id === nodeID) {
-          memberTasks[task.id] = isSchedulerTask(task, schedulerTaskIds);
+          memberTasks[task.id] = assignSchedulerTaskField(task, schedulerTaskIds);
         }
       });
       service.completed_tasks.forEach(function (task) {
@@ -303,7 +309,7 @@ class MesosStateStore extends GetSetBaseStore {
       if (service instanceof Framework && name === serviceName) {
         return serviceTasks
           .concat(tasks, completed_tasks)
-          .map((task) => isSchedulerTask(task, schedulerTaskIds));
+          .map((task) => assignSchedulerTaskField(task, schedulerTaskIds));
       }
 
       // Filter marathon tasks by service name
@@ -311,7 +317,7 @@ class MesosStateStore extends GetSetBaseStore {
         return tasks.concat(completed_tasks)
           .filter(({name}) => name === mesosTaskName)
           .concat(serviceTasks)
-          .map((task) => isSchedulerTask(task, schedulerTaskIds));
+          .map((task) => assignSchedulerTaskField(task, schedulerTaskIds));
       }
 
       return serviceTasks;


### PR DESCRIPTION
Scheduler tasks don't like to be stopped so we disable the stop button if one is selected.

~~@leemunroe - should we hide this button or disable it? If we disable it, I presume we'd also want a tooltip to explain why.~~

**UPDATE**: The stop button is now disabled with a tooltip.

![](https://cl.ly/2n0D18143B06/Screen%20Recording%202016-12-14%20at%2011.46%20AM.gif)

https://mesosphere.atlassian.net/browse/DCOS-10693