### PR TITLE
DCOS-12063: Changing the labels for healthchecks DSL filter

### DIFF
--- a/plugins/services/src/js/components/dsl/ServiceHealthDSLSection.js
+++ b/plugins/services/src/js/components/dsl/ServiceHealthDSLSection.js
@@ -10,10 +10,9 @@ import FieldLabel from '../../../../../../src/js/components/form/FieldLabel';
 import FormGroup from '../../../../../../src/js/components/form/FormGroup';
 
 const EXPRESSION_PARTS = {
-  is_healthy: DSLExpressionPart.attribute('health', 'healthy'),
-  is_unhealthy: DSLExpressionPart.attribute('health', 'unhealthy'),
-  is_idle: DSLExpressionPart.attribute('health', 'idle'),
-  is_na: DSLExpressionPart.attribute('health', 'na')
+  is_healthy: DSLExpressionPart.attribute('is', 'healthy'),
+  is_unhealthy: DSLExpressionPart.attribute('is', 'unhealthy'),
+  no_healthchecks: DSLExpressionPart.attribute('no', 'healthchecks')
 };
 
 class ServiceHealthDSLSection extends React.Component {
@@ -45,11 +44,11 @@ class ServiceHealthDSLSection extends React.Component {
               </FieldLabel>
               <FieldLabel>
                 <FieldInput
-                  checked={data.is_idle}
+                  checked={data.no_healthchecks}
                   disabled={!enabled}
-                  name="is_idle"
+                  name="no_healthchecks"
                   type="checkbox" />
-                Idle
+                N/A
               </FieldLabel>
             </FormGroup>
           </div>
@@ -62,14 +61,6 @@ class ServiceHealthDSLSection extends React.Component {
                   name="is_unhealthy"
                   type="checkbox" />
                 Unhealthy
-              </FieldLabel>
-              <FieldLabel>
-                <FieldInput
-                  checked={data.is_na}
-                  disabled={!enabled}
-                  name="is_na"
-                  type="checkbox" />
-                N/A
               </FieldLabel>
             </FormGroup>
           </div>

--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -27,6 +27,7 @@ import DSLFilterList from '../../../../../../src/js/structs/DSLFilterList';
 import ServiceAttributeIsFilter from '../../filters/ServiceAttributeIsFilter';
 import ServiceAttributeHealthFilter
   from '../../filters/ServiceAttributeHealthFilter';
+import ServiceAttributeNoHealthchecksFilter from '../../filters/ServiceAttributeNoHealthchecksFilter';
 import ServiceNameTextFilter from '../../filters/ServiceNameTextFilter';
 import ServiceAttributeIsPodFilter from '../../filters/ServiceAttributeIsPodFilter';
 import ServiceAttributeIsUniverseFilter from '../../filters/ServiceAttributeIsUniverseFilter';
@@ -82,6 +83,7 @@ const SERVICE_FILTERS = new DSLFilterList([
   new ServiceAttributeIsFilter(),
   new ServiceAttributeIsPodFilter(),
   new ServiceAttributeIsUniverseFilter(),
+  new ServiceAttributeNoHealthchecksFilter(),
   new ServiceNameTextFilter()
 ]);
 

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -232,12 +232,7 @@ class ServicesTable extends React.Component {
       verboseOverview = ` (${tasksRunning} of ${instancesCount} Instances)`;
     }
 
-    let queue = null;
-
-    if (!!service.getQueue) {
-      queue = service.getQueue();
-    }
-
+    let queue = service.getQueue();
     if (queue != null) {
       const waitingSince = DateUtil.strToMs(queue.since);
       const timeWaiting = Date.now() - waitingSince;

--- a/plugins/services/src/js/filters/ServiceAttributeHealthFilter.js
+++ b/plugins/services/src/js/filters/ServiceAttributeHealthFilter.js
@@ -2,12 +2,10 @@ import DSLFilterTypes from '../../../../../src/js/constants/DSLFilterTypes';
 import DSLFilter from '../../../../../src/js/structs/DSLFilter';
 import HealthStatus from '../constants/HealthStatus';
 
-const LABEL = 'health';
+const LABEL = 'is';
 
 const LABEL_TO_HEALTH = {
   healthy   : HealthStatus.HEALTHY,
-  idle      : HealthStatus.IDLE,
-  na        : HealthStatus.NA,
   unhealthy : HealthStatus.UNHEALTHY
 };
 

--- a/plugins/services/src/js/filters/ServiceAttributeNoHealthchecksFilter.js
+++ b/plugins/services/src/js/filters/ServiceAttributeNoHealthchecksFilter.js
@@ -1,0 +1,38 @@
+import DSLFilterTypes from '../../../../../src/js/constants/DSLFilterTypes';
+import DSLFilter from '../../../../../src/js/structs/DSLFilter';
+import HealthStatus from '../constants/HealthStatus';
+
+const LABEL = 'no';
+const LABEL_TEXT = 'healthchecks';
+
+/**
+ * This filter handles the `no:healthckecks` filter that returns the services
+ * without health checks
+ */
+class ServiceAttributeNoHealthchecksFilter extends DSLFilter {
+
+  /**
+   * Handle all `no:healthckecks` attribute filters.
+   *
+   * @override
+   */
+  filterCanHandle(filterType, filterArguments) {
+    return filterType === DSLFilterTypes.ATTRIB &&
+      filterArguments.label === LABEL &&
+      filterArguments.text.toLowerCase() === LABEL_TEXT;
+  }
+
+  /**
+   * Keep only services whose health checks is N/A
+   *
+   * @override
+   */
+  filterApply(resultset) {
+    return resultset.filterItems((service) => {
+      return service.getHealth() === HealthStatus.NA;
+    });
+  }
+
+}
+
+module.exports = ServiceAttributeNoHealthchecksFilter;

--- a/plugins/services/src/js/filters/__tests__/ServiceAttributeNoHealthchecksFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceAttributeNoHealthchecksFilter-test.js
@@ -1,16 +1,16 @@
 jest.dontMock('../../../../../../src/js/structs/DSLFilterList');
 jest.dontMock('../../../../../../src/resources/grammar/SearchDSL.jison');
 jest.dontMock('../../constants/HealthStatus');
-jest.dontMock('../ServiceAttributeHealthFilter');
+jest.dontMock('../ServiceAttributeNoHealthchecksFilter');
 jest.dontMock('../../../../../../src/js/structs/List');
 
 var DSLFilterList = require('../../../../../../src/js/structs/DSLFilterList');
 var SearchDSL = require('../../../../../../src/resources/grammar/SearchDSL.jison');
 var HealthStatus = require('../../constants/HealthStatus');
-var ServiceAttributeHealthFilter = require('../ServiceAttributeHealthFilter');
+var ServiceAttributeNoHealthchecksFilter = require('../ServiceAttributeNoHealthchecksFilter');
 var List = require('../../../../../../src/js/structs/List');
 
-describe('ServiceAttributeHealthFilter', function () {
+describe('ServiceAttributeNoHealthchecksFilter', function () {
 
   beforeEach(function () {
     this.mockItems = [
@@ -21,33 +21,22 @@ describe('ServiceAttributeHealthFilter', function () {
     ];
   });
 
-  it('Should correctly keep services in healthy state', function () {
+  it('Should correctly keep services without health checks', function () {
     let services = new List({items: this.mockItems});
-    let expr = SearchDSL.parse('is:healthy');
+    let expr = SearchDSL.parse('no:healthchecks');
 
-    let filters = new DSLFilterList().add(new ServiceAttributeHealthFilter());
+    let filters = new DSLFilterList().add(new ServiceAttributeNoHealthchecksFilter());
 
     expect(expr.filter(filters, services).getItems()).toEqual([
-      this.mockItems[0]
-    ]);
-  });
-
-  it('Should correctly keep services in unhealthy state', function () {
-    let services = new List({items: this.mockItems});
-    let expr = SearchDSL.parse('is:unhealthy');
-
-    let filters = new DSLFilterList().add(new ServiceAttributeHealthFilter());
-
-    expect(expr.filter(filters, services).getItems()).toEqual([
-      this.mockItems[1]
+      this.mockItems[3]
     ]);
   });
 
   it('Should correctly keep nothing on unknown states', function () {
     let services = new List({items: this.mockItems});
-    let expr = SearchDSL.parse('is:foo');
+    let expr = SearchDSL.parse('no:boo');
 
-    let filters = new DSLFilterList().add(new ServiceAttributeHealthFilter());
+    let filters = new DSLFilterList().add(new ServiceAttributeNoHealthchecksFilter());
 
     expect(expr.filter(filters, services).getItems()).toEqual([
     ]);
@@ -55,14 +44,14 @@ describe('ServiceAttributeHealthFilter', function () {
 
   it('Should be case-insensitive', function () {
     let services = new List({items: this.mockItems});
-    let expr = SearchDSL.parse('is:hEaLThY');
+    let expr = SearchDSL.parse('no:HeaLThchEckS');
 
     let filters = new DSLFilterList([
-      new ServiceAttributeHealthFilter()
+      new ServiceAttributeNoHealthchecksFilter()
     ]);
 
     expect(expr.filter(filters, services).getItems()).toEqual([
-      this.mockItems[0]
+      this.mockItems[3]
     ]);
   });
 });

--- a/plugins/services/src/js/structs/Service.js
+++ b/plugins/services/src/js/structs/Service.js
@@ -53,6 +53,10 @@ module.exports = class Service extends Item {
     return ServiceImages.NA_IMAGES;
   }
 
+  getQueue() {
+    return null;
+  }
+
   getWebURL() {
     return null;
   }


### PR DESCRIPTION
---
⚠️  ~Depends on #1564~ Merged

---

This PR renames `health:` health-check attribute to:

* `health:healthy` -> `is:healthy`
* `health:unhealthy` -> `is:unhealthy`
* `health:na` -> `no:healthchecks`
* `health:idle` -> Removed