### PR TITLE
Display not supported not configured for empty fields, ref. DCOS-11676

### DIFF
--- a/plugins/services/src/js/components/ServiceConfigEnvironmentVariablesSectionDisplay.js
+++ b/plugins/services/src/js/components/ServiceConfigEnvironmentVariablesSectionDisplay.js
@@ -66,7 +66,8 @@ class ServiceConfigEnvironmentVariablesSectionDisplay extends ServiceConfigBaseS
             });
 
             return (
-              <Table key="secrets-table"
+              <Table
+                key="secrets-table"
                 className="table table-simple table-break-word flush-bottom"
                 columns={columns}
                 data={data} />

--- a/plugins/services/src/js/components/ServiceConfigPlacementConstraintsSectionDisplay.js
+++ b/plugins/services/src/js/components/ServiceConfigPlacementConstraintsSectionDisplay.js
@@ -75,7 +75,7 @@ class ServiceConfigPlacementConstraintsSectionDisplay extends ServiceConfigBaseS
 
             return (
               <Table key="constraints-table"
-                className="table table-simple table-break-word flush-bottom"
+                className="table table-simple table-break-word table-fixed-layout flush-bottom"
                 columns={columns}
                 data={mappedData} />
             );

--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -97,7 +97,17 @@ class ContainerServiceFormSection extends Component {
   }
 
   getGPUSInput(data) {
-    if (data.container && data.container.type !== MESOS) {
+    const disabled = data.container && data.container.type !== MESOS;
+    const inputFiled = (
+      <FieldInput
+        key="gpus-input"
+        name="gpus"
+        type="number"
+        disabled={disabled}
+        value={data.gpus} />
+    );
+
+    if (disabled) {
       return [
         <Tooltip
           key="gpus-input-tooltip"
@@ -111,22 +121,13 @@ class ContainerServiceFormSection extends Component {
             <Icon color="grey" id="lock" size="mini" />
           </FieldLabel>
         </Tooltip>,
-        <FieldInput
-          key="gpus-input"
-          name="gpus"
-          type="number"
-          disabled={true}
-          value={data.gpus} />
+        inputFiled
       ];
     }
 
     return [
       <FieldLabel key="gpus-label">GPUs</FieldLabel>,
-      <FieldInput
-        key="gpus-input"
-        name="gpus"
-        type="number"
-        value={data.gpus} />
+      inputFiled
     ];
   }
 
@@ -141,23 +142,27 @@ class ContainerServiceFormSection extends Component {
         `docker.${settingName}`
       );
 
+      let inputField = (
+        <FieldInput
+          checked={containerType !== DOCKER && Boolean(checked)}
+          name={`container.docker.${settingName}`}
+          type="checkbox"
+          disabled={containerType !== DOCKER}
+          value={settingName} />
+      );
+
       if (containerType !== DOCKER) {
         return (
           <FieldLabel key={index}>
-            <FieldInput
-              checked={false}
-              name={`container.docker.${settingName}`}
-              type="checkbox"
-              disabled={true}
-              value={settingName}/>
+            {inputField}
             <Tooltip
               content={dockerOnly}
               interactive={true}
               maxWidth={300}
               scrollContainer=".gm-scroll-view"
               wrapText={true}>
-                {label}
-                <Icon color="grey" id="lock" size="mini" />
+              {label}
+              <Icon color="grey" id="lock" size="mini" />
             </Tooltip>
             <FieldHelp>{helpText}</FieldHelp>
           </FieldLabel>
@@ -166,11 +171,7 @@ class ContainerServiceFormSection extends Component {
 
       return (
         <FieldLabel key={index}>
-          <FieldInput
-            checked={Boolean(checked)}
-            name={`container.docker.${settingName}`}
-            type="checkbox"
-            value={settingName} />
+          {inputField}
           {label}
           <FieldHelp>{helpText}</FieldHelp>
         </FieldLabel>

--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -112,7 +112,7 @@ class HealthChecksFormSection extends Component {
     const {data} = this.props;
 
     return data.portDefinitions.map((port, index) => {
-      return (<option value={index}>{port.name || index}</option>);
+      return (<option key={index} value={index}>{port.name || index}</option>);
     });
   }
 
@@ -170,7 +170,8 @@ class HealthChecksFormSection extends Component {
       const errors = errorsLens.at(key, {}).get(this.props.errors);
 
       return (
-        <FormGroupContainer key={key}
+        <FormGroupContainer
+          key={key}
           onRemove={this.props.onRemoveItem.bind(this,
             {value: key, path: 'healthChecks'})}>
           <div className="flex row">

--- a/plugins/services/src/js/service-configuration/GeneralServiceConfigSection.js
+++ b/plugins/services/src/js/service-configuration/GeneralServiceConfigSection.js
@@ -153,8 +153,8 @@ module.exports = {
           return String.fromCharCode(8212);
         }
 
-        return value.map((arg) => (
-          <pre className="flush transparent wrap">{arg}</pre>
+        return value.map((arg, index) => (
+          <pre key={index} className="flush transparent wrap">{arg}</pre>
         ));
       }
     },

--- a/plugins/services/src/js/service-configuration/GeneralServiceConfigSection.js
+++ b/plugins/services/src/js/service-configuration/GeneralServiceConfigSection.js
@@ -20,26 +20,11 @@ module.exports = {
     },
     {
       key: 'id',
-      label: 'Service ID',
-      transformValue: (value) => {
-        return value.split('/').pop();
-      }
+      label: 'Service ID'
     },
     {
       key: 'instances',
       label: 'Instances'
-    },
-    {
-      key: 'location',
-      label: 'Location',
-      transformValue: (value, appDefinition) => {
-        let idSegments = findNestedPropertyInObject(appDefinition, 'id')
-          .split('/');
-
-        idSegments.pop();
-
-        return `${idSegments.join('/')}/`;
-      }
     },
     {
       key: 'container.type',

--- a/plugins/services/src/js/service-configuration/GeneralServiceConfigSection.js
+++ b/plugins/services/src/js/service-configuration/GeneralServiceConfigSection.js
@@ -189,7 +189,7 @@ module.exports = {
         return (
           <Table
             key="artifacts-table"
-            className="table table-simple table-break-word flush-bottom"
+            className="table table-simple table-break-word table-fixed-layout flush-bottom"
             columns={columns}
             data={data} />
         );

--- a/plugins/services/src/js/service-configuration/GeneralServiceConfigSection.js
+++ b/plugins/services/src/js/service-configuration/GeneralServiceConfigSection.js
@@ -98,7 +98,7 @@ module.exports = {
       transformValue(value, appConfig) {
         const runtime = findNestedPropertyInObject(appConfig, 'container.type');
         // Disabled for DOCKER
-        if (runtime !== DOCKER) {
+        if (runtime !== DOCKER && value == null) {
           return getDisplayValue(null, true);
         }
 
@@ -112,7 +112,7 @@ module.exports = {
       transformValue(value, appConfig) {
         const runtime = findNestedPropertyInObject(appConfig, 'container.type');
         // Disabled for DOCKER
-        if (runtime !== DOCKER) {
+        if (runtime !== DOCKER && value == null) {
           return getDisplayValue(null, true);
         }
 
@@ -152,7 +152,7 @@ module.exports = {
       label: 'Args',
       transformValue(value = []) {
         if (!value.length) {
-          return String.fromCharCode(8212);
+          return getDisplayValue(null);
         }
 
         return value.map((arg, index) => (

--- a/plugins/services/src/js/service-configuration/HealthChecksServiceConfigSection.js
+++ b/plugins/services/src/js/service-configuration/HealthChecksServiceConfigSection.js
@@ -145,7 +145,7 @@ module.exports = {
         return (
           <Table
             key="command-health-checks"
-            className="table table-simple table-break-word flush-bottom"
+            className="table table-simple table-break-word table-fixed-layout flush-bottom"
             columns={columns}
             data={commandHealthChecks} />
         );

--- a/plugins/services/src/js/service-configuration/HealthChecksServiceConfigSection.js
+++ b/plugins/services/src/js/service-configuration/HealthChecksServiceConfigSection.js
@@ -78,8 +78,9 @@ module.exports = {
         ];
 
         return (
-          <Table key="service-endpoint-health-checks"
-            className="table table-simple table-break-word flush-bottom"
+          <Table
+            key="service-endpoint-health-checks"
+            className="table table-simple table-break-word table-fixed-layout flush-bottom"
             columns={columns}
             data={serviceEndpointHealthChecks} />
         );

--- a/plugins/services/src/js/service-configuration/HealthChecksServiceConfigSection.js
+++ b/plugins/services/src/js/service-configuration/HealthChecksServiceConfigSection.js
@@ -103,10 +103,14 @@ module.exports = {
             prop: 'command',
             render: (prop, row) => {
               let command = row[prop] || {};
+              let value = getDisplayValue(command.command);
+              if (!command.command) {
+                return value;
+              }
 
               return (
                 <pre className="flush transparent wrap">
-                  {getDisplayValue(command.command)}
+                  {value}
                 </pre>
               );
             },

--- a/plugins/services/src/js/service-configuration/HealthChecksServiceConfigSection.js
+++ b/plugins/services/src/js/service-configuration/HealthChecksServiceConfigSection.js
@@ -103,8 +103,8 @@ module.exports = {
             prop: 'command',
             render: (prop, row) => {
               let command = row[prop] || {};
-              let value = getDisplayValue(command.command);
-              if (!command.command) {
+              let value = getDisplayValue(command.value);
+              if (!command.value) {
                 return value;
               }
 

--- a/plugins/services/src/js/service-configuration/LabelsServiceConfigSection.js
+++ b/plugins/services/src/js/service-configuration/LabelsServiceConfigSection.js
@@ -48,7 +48,7 @@ module.exports = {
         return (
           <Table
             key="labels-table"
-            className="table table-simple table-break-word flush-bottom"
+            className="table table-simple table-break-word table-fixed-layout flush-bottom"
             columns={columns}
             data={data} />
         );

--- a/plugins/services/src/js/service-configuration/NetworkingServiceConfigSection.js
+++ b/plugins/services/src/js/service-configuration/NetworkingServiceConfigSection.js
@@ -103,7 +103,7 @@ module.exports = {
         return (
           <Table
             key="service-endpoints"
-            className="table table-simple table-break-word flush-bottom"
+            className="table table-simple table-break-word table-fixed-layout flush-bottom"
             columns={columns}
             data={portDefinitions} />
         );

--- a/plugins/services/src/js/service-configuration/PodNetworkConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodNetworkConfigSection.js
@@ -99,7 +99,7 @@ class PodNetworkConfigSection extends React.Component {
             Service Endpoints
           </Heading>
           <ConfigurationMapTable
-            className="table table-simple table-break-word flush-bottom"
+            className="table table-simple table-break-word table-fixed-layout flush-bottom"
             columnDefaults={{hideIfEmpty: true}}
             columns={this.getColumns()}
             data={endpoints} />

--- a/plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js
@@ -41,7 +41,7 @@ class PodPlacementConstraintsConfigSection extends React.Component {
         <Heading level={3}>Placement Constraints</Heading>
         <Section>
           <ConfigurationMapTable
-            className="table table-simple table-break-word flush-bottom"
+            className="table table-simple table-break-word table-fixed-layout flush-bottom"
             columns={this.getColumns()}
             columnDefaults={{
               hideIfempty: true,

--- a/plugins/services/src/js/service-configuration/PodStorageConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodStorageConfigSection.js
@@ -92,7 +92,7 @@ class PodStorageConfigSection extends React.Component {
         <Heading level={1}>Storage</Heading>
         <Section key="pod-general-section">
           <ConfigurationMapTable
-            className="table table-simple table-break-word flush-bottom"
+            className="table table-simple table-break-word table-fixed-layout flush-bottom"
             columnDefaults={{hideIfEmpty: true}}
             columns={this.getColumns()}
             data={volumeSummary} />

--- a/plugins/services/src/js/service-configuration/StorageServiceConfigSection.js
+++ b/plugins/services/src/js/service-configuration/StorageServiceConfigSection.js
@@ -17,7 +17,7 @@ module.exports = {
     },
     {
       key: 'container.volumes',
-      render: (volumes) => {
+      render(volumes) {
         if (volumes == null) {
           return null;
         }
@@ -26,7 +26,7 @@ module.exports = {
           {
             heading: getColumnHeadingFn('Volume'),
             prop: 'volume',
-            render: (prop, row) => {
+            render(prop, row) {
               let name = '';
 
               if (row.name != null) {
@@ -41,7 +41,7 @@ module.exports = {
           {
             heading: getColumnHeadingFn('Size'),
             prop: 'size',
-            render: (prop, row) => {
+            render(prop, row) {
               let value = row[prop];
 
               if (value == null) {
@@ -116,7 +116,7 @@ module.exports = {
         return (
           <Table
             key="service-volumes"
-            className="table table-simple table-break-word flush-bottom"
+            className="table table-simple table-break-word table-fixed-layout flush-bottom"
             columns={columns}
             data={volumesData} />
         );

--- a/plugins/services/src/js/utils/ServiceConfigDisplayUtil.js
+++ b/plugins/services/src/js/utils/ServiceConfigDisplayUtil.js
@@ -42,14 +42,16 @@ const ServiceConfigDisplayUtil = {
     );
   },
 
-  getDisplayValue(value) {
-    // Return the emdash character.
-    if (value == null || value === '') {
-      return String.fromCharCode(8212);
+  getDisplayValue(value, isDisabled = false) {
+    if (!isDisabled && (value == null || value === '')) {
+      return <i>Not Configured</i>;
+    }
+    if (isDisabled && (value == null || value === '')) {
+      return <i>Not Supported</i>;
     }
 
     // Display nested objects nicely if the render didn't already cover it.
-    if (isObject(value)) {
+    if (isObject(value) && !React.isValidElement(value)) {
       return (
         <pre className="flush transparent wrap">
           {JSON.stringify(value)}

--- a/plugins/services/src/js/utils/ServiceConfigDisplayUtil.js
+++ b/plugins/services/src/js/utils/ServiceConfigDisplayUtil.js
@@ -44,10 +44,10 @@ const ServiceConfigDisplayUtil = {
 
   getDisplayValue(value, isDisabled = false) {
     if (!isDisabled && (value == null || value === '')) {
-      return <i>Not Configured</i>;
+      return <em>Not Configured</em>;
     }
     if (isDisabled && (value == null || value === '')) {
-      return <i>Not Supported</i>;
+      return <em>Not Supported</em>;
     }
 
     // Display nested objects nicely if the render didn't already cover it.


### PR DESCRIPTION
This PR fixes a few small issues with the config review and displays 'Not Configured'/'Not Supported' for empty values, rather than `--`.

Before:
![](https://cl.ly/1r1A19280x1H/Image%202016-12-12%20at%2017.28.50.png)
![](https://cl.ly/0e2j3U0h3e3W/Image%202016-12-12%20at%2017.26.48.png)

After:
![](https://cl.ly/1c2V2f1y3F1G/Image%202016-12-12%20at%2017.25.16.png)
![](https://cl.ly/133c171Y2t32/Image%202016-12-12%20at%2017.25.49.png)