### PR TITLE
DCOS-12147: Allow ternary operator

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -59,6 +59,10 @@
     "no-unused-vars": ["error", {"args": "after-used", "argsIgnorePattern": "PluginSDK"}],
     "no-use-before-define": "off",
     "no-multiple-empty-lines": ["error", {"max": 1}],
+    // Ternary
+    "no-nested-ternary": ["error"],
+    "no-unneeded-ternary": ["error"],
+    "multiline-ternary": "off", // allow both multiline and single line
     "react/jsx-filename-extension": "off",
     "keyword-spacing": ["error"],
     "semi": ["error"],


### PR DESCRIPTION
This PR enables 2 eslint rules to tame ternary:
`no-nested-ternary` - ensures that we don't nest them
`no-unneeded-ternary` - ensures that we don't do `value ? true : false` stuff
`multiline-ternary` is off to explicitly show that we don't yet have a decision on whether we always break a ternary into multiple lines them or we always use single line. So both are allowed. http://eslint.org/docs/rules/multiline-ternary