### PR TITLE
DCOS-12149: Remove underscore dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8000,11 +8000,6 @@
       "from": "uid-safe@2.1.0",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.0.tgz"
     },
-    "underscore": {
-      "version": "1.7.0",
-      "from": "underscore@1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
-    },
     "uniq": {
       "version": "1.0.1",
       "from": "uniq@>=1.0.1 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "reactjs-components": "0.16.0-beta.6",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
-    "tv4": "1.2.7",
-    "underscore": "1.7.0"
+    "tv4": "1.2.7"
   },
   "devDependencies": {
     "autoprefixer": "6.3.6",


### PR DESCRIPTION
Looks like we don't use it