### PR TITLE
[multi container] endpoint tests

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/Containers.js
@@ -570,7 +570,7 @@ module.exports = {
           break;
       }
 
-      const fieldNames = ['name', 'protocol', 'automaticPort', 'loadBalanced'];
+      const fieldNames = ['name', 'protocol', 'automaticPort', 'loadBalanced', 'vip'];
       const numericalFiledNames = ['containerPort', 'hostPort'];
 
       if (type === SET && fieldNames.includes(name)) {

--- a/plugins/services/src/js/reducers/serviceForm/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/Containers.js
@@ -34,7 +34,6 @@ const defaultEndpointsFieldValues = {
   labels: null,
   loadBalanced: false,
   name: null,
-  portMapping: false,
   protocol: 'tcp',
   servicePort: null,
   vip: null
@@ -413,7 +412,6 @@ module.exports = {
         'name',
         'protocol',
         'automaticPort',
-        'portMapping',
         'loadBalanced',
         'vip'
       ];
@@ -572,13 +570,7 @@ module.exports = {
           break;
       }
 
-      const fieldNames = [
-        'name',
-        'protocol',
-        'automaticPort',
-        'portMapping',
-        'loadBalanced'
-      ];
+      const fieldNames = ['name', 'protocol', 'automaticPort', 'loadBalanced'];
       const numericalFiledNames = ['containerPort', 'hostPort'];
 
       if (type === SET && fieldNames.includes(name)) {

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
@@ -454,7 +454,7 @@ describe('Containers', function () {
           ]);
         });
 
-        it('should set the right contianer Port', function () {
+        it('should set the right container Port', function () {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
@@ -738,5 +738,750 @@ describe('Containers', function () {
     });
   });
 
-  // FormReducer is the same as JSONReducer
+  describe('#FormReducer', function () {
+    describe('endpoints', function () {
+      describe('Host Mode', function () {
+
+        it('should have one endpoint', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          expect(batch.reduce(Containers.FormReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  automaticPort: true,
+                  hostPort: null,
+                  labels: null,
+                  name: null,
+                  loadBalanced: false,
+                  vip: null,
+                  protocol: 'tcp',
+                  servicePort: null,
+                  containerPort: null
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should have one endpoint with name', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'name'
+              ], 'foo'));
+
+          expect(batch.reduce(Containers.FormReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  automaticPort: true,
+                  hostPort: null,
+                  labels: null,
+                  name: 'foo',
+                  loadBalanced: false,
+                  vip: null,
+                  protocol: 'tcp',
+                  servicePort: null,
+                  containerPort: null
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should have one endpoint with name and a hostport', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'name'
+              ], 'foo'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'automaticPort'
+              ], false));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'hostPort'
+              ], 8080));
+
+          expect(batch.reduce(Containers.FormReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  automaticPort: false,
+                  hostPort: 8080,
+                  labels: null,
+                  name: 'foo',
+                  loadBalanced: false,
+                  vip: null,
+                  protocol: 'tcp',
+                  servicePort: null,
+                  containerPort: null
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should set the protocol right', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'HOST'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'protocol'
+              ], 'udp'));
+
+          expect(batch.reduce(Containers.FormReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  automaticPort: true,
+                  hostPort: null,
+                  labels: null,
+                  name: null,
+                  loadBalanced: false,
+                  vip: null,
+                  protocol: 'udp',
+                  servicePort: null,
+                  containerPort: null
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should set protocol to unknown value', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'HOST'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'protocol'
+              ], 'foo'));
+
+          expect(batch.reduce(Containers.FormReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  automaticPort: true,
+                  hostPort: null,
+                  labels: null,
+                  name: null,
+                  loadBalanced: false,
+                  vip: null,
+                  protocol: 'foo',
+                  servicePort: null,
+                  containerPort: null
+                }
+              ]
+            }
+          ]);
+        });
+
+      });
+
+      describe('container Mode', function () {
+
+        it('should have one endpoint', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          expect(batch.reduce(Containers.FormReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  automaticPort: true,
+                  hostPort: null,
+                  labels: null,
+                  name: null,
+                  loadBalanced: false,
+                  vip: null,
+                  protocol: 'tcp',
+                  servicePort: null,
+                  containerPort: null
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should have one endpoint with name', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'name'
+              ], 'foo'));
+
+          expect(batch.reduce(Containers.FormReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  automaticPort: true,
+                  hostPort: null,
+                  labels: null,
+                  name: 'foo',
+                  loadBalanced: false,
+                  vip: null,
+                  protocol: 'tcp',
+                  servicePort: null,
+                  containerPort: null
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should have one endpoint with name and a hostport', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'name'
+              ], 'foo'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'automaticPort'
+              ], false));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'hostPort'
+              ], 8080));
+
+          expect(batch.reduce(Containers.FormReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  automaticPort: false,
+                  hostPort: 8080,
+                  labels: null,
+                  name: 'foo',
+                  loadBalanced: false,
+                  vip: null,
+                  protocol: 'tcp',
+                  servicePort: null,
+                  containerPort: null
+                }
+
+              ]
+            }
+          ]);
+        });
+
+        it('should set the protocol right', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'protocol'
+              ], 'udp'));
+
+          expect(batch.reduce(Containers.FormReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  automaticPort: true,
+                  hostPort: null,
+                  labels: null,
+                  name: null,
+                  loadBalanced: false,
+                  vip: null,
+                  protocol: 'udp',
+                  servicePort: null,
+                  containerPort: null
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should set protocol to unknown value', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'protocol'
+              ], 'foo'));
+
+          expect(batch.reduce(Containers.FormReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  automaticPort: true,
+                  hostPort: null,
+                  labels: null,
+                  name: null,
+                  loadBalanced: false,
+                  vip: null,
+                  protocol: 'foo',
+                  servicePort: null,
+                  containerPort: null
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should set the right container Port', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'containerPort'
+              ], '8080'));
+
+          expect(batch.reduce(Containers.FormReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  automaticPort: true,
+                  hostPort: null,
+                  labels: null,
+                  name: null,
+                  loadBalanced: false,
+                  vip: null,
+                  protocol: 'tcp',
+                  servicePort: null,
+                  containerPort: 8080
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should set the right vip', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+          batch = batch.add(new Transaction(['id'], '/foobar'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'containerPort'
+              ], '8080'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'loadBalanced'
+              ], true));
+
+          expect(batch.reduce(Containers.FormReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  automaticPort: true,
+                  hostPort: null,
+                  labels: null,
+                  name: null,
+                  loadBalanced: true,
+                  vip: null,
+                  protocol: 'tcp',
+                  servicePort: null,
+                  containerPort: 8080
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should set the right custom vip', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+          batch = batch.add(new Transaction(['id'], '/foobar'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'containerPort'
+              ], '8080'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'loadBalanced'
+              ], true));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'vip'
+              ], '1.3.3.7:8080'));
+
+          expect(batch.reduce(Containers.FormReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  automaticPort: true,
+                  hostPort: null,
+                  labels: null,
+                  name: null,
+                  loadBalanced: true,
+                  vip: '1.3.3.7:8080',
+                  protocol: 'tcp',
+                  servicePort: null,
+                  containerPort: 8080
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should set the right vip after id change', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+          batch = batch.add(new Transaction(['id'], '/foobar'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'containerPort'
+              ], '8080'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'loadBalanced'
+              ], true));
+
+          batch = batch.add(new Transaction(['id'], '/barfoo'));
+
+          expect(batch.reduce(Containers.FormReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  automaticPort: true,
+                  hostPort: null,
+                  labels: null,
+                  name: null,
+                  loadBalanced: true,
+                  vip: null,
+                  protocol: 'tcp',
+                  servicePort: null,
+                  containerPort: 8080
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should set the right custom vip even after id change', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+          batch = batch.add(new Transaction(['id'], '/foobar'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'containerPort'
+              ], '8080'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'loadBalanced'
+              ], true));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'vip'
+              ], '1.3.3.7:8080'));
+
+          batch = batch.add(new Transaction(['id'], '/barfoo'));
+
+          expect(batch.reduce(Containers.FormReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  automaticPort: true,
+                  hostPort: null,
+                  labels: null,
+                  name: null,
+                  loadBalanced: true,
+                  containerPort: 8080,
+                  vip: '1.3.3.7:8080',
+                  protocol: 'tcp',
+                  servicePort: null
+                }
+              ]
+            }
+          ]);
+        });
+
+      });
+    });
+  });
 });

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
@@ -12,7 +12,7 @@ describe('Containers', function () {
       let batch = new Batch();
 
       expect(batch.reduce(Containers.JSONReducer.bind({}), []))
-        .toEqual([]);
+      .toEqual([]);
     });
 
     it('returns an array as default with a container path Transaction', function () {
@@ -23,6 +23,720 @@ describe('Containers', function () {
         .toEqual([DEFAULT_POD_CONTAINER]);
     });
 
+    describe('endpoints', function () {
+      describe('Host Mode', function () {
+
+        it('should have one endpoint', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          expect(batch.reduce(Containers.JSONReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  name: null,
+                  hostPort: 0,
+                  protocol: [
+                    'tcp'
+                  ]
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should have one endpoint with name', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'name'
+              ], 'foo'));
+
+          expect(batch.reduce(Containers.JSONReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  name: 'foo',
+                  hostPort: 0,
+                  protocol: [
+                    'tcp'
+                  ]
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should have one endpoint with name and a hostport', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'HOST'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'name'
+              ], 'foo'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'automaticPort'
+              ], false));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'hostPort'
+              ], 8080));
+
+          expect(batch.reduce(Containers.JSONReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  name: 'foo',
+                  hostPort: 8080,
+                  protocol: [
+                    'tcp'
+                  ]
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should set the protocol right', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'HOST'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'protocol'
+              ], 'udp'));
+
+          expect(batch.reduce(Containers.JSONReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  name: null,
+                  hostPort: 0,
+                  protocol: [
+                    'udp'
+                  ]
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should set protocol to unknown value', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'HOST'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'protocol'
+              ], 'foo'));
+
+          expect(batch.reduce(Containers.JSONReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  name: null,
+                  hostPort: 0,
+                  protocol: [
+                    'foo'
+                  ]
+                }
+              ]
+            }
+          ]);
+        });
+
+      });
+
+      describe('container Mode', function () {
+
+        it('should have one endpoint', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          expect(batch.reduce(Containers.JSONReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  name: null,
+                  hostPort: 0,
+                  containerPort: null,
+                  labels: null,
+                  protocol: [
+                    'tcp'
+                  ]
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should have one endpoint with name', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'name'
+              ], 'foo'));
+
+          expect(batch.reduce(Containers.JSONReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  name: 'foo',
+                  containerPort: null,
+                  labels: null,
+                  hostPort: 0,
+                  protocol: [
+                    'tcp'
+                  ]
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should have one endpoint with name and a hostport', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'name'
+              ], 'foo'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'automaticPort'
+              ], false));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'hostPort'
+              ], 8080));
+
+          expect(batch.reduce(Containers.JSONReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  name: 'foo',
+                  containerPort: null,
+                  labels: null,
+                  hostPort: 8080,
+                  protocol: [
+                    'tcp'
+                  ]
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should set the protocol right', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'protocol'
+              ], 'udp'));
+
+          expect(batch.reduce(Containers.JSONReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  name: null,
+                  containerPort: null,
+                  labels: null,
+                  hostPort: 0,
+                  protocol: [
+                    'udp'
+                  ]
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should set protocol to unknown value', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'protocol'
+              ], 'foo'));
+
+          expect(batch.reduce(Containers.JSONReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  name: null,
+                  containerPort: null,
+                  labels: null,
+                  hostPort: 0,
+                  protocol: [
+                    'foo'
+                  ]
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should set the right contianer Port', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'containerPort'
+              ], '8080'));
+
+          expect(batch.reduce(Containers.JSONReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  name: null,
+                  containerPort: 8080,
+                  labels: null,
+                  hostPort: 0,
+                  protocol: [
+                    'tcp'
+                  ]
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should set the right vip', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+          batch = batch.add(new Transaction(['id'], '/foobar'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'containerPort'
+              ], '8080'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'loadBalanced'
+              ], true));
+
+          expect(batch.reduce(Containers.JSONReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  name: null,
+                  containerPort: 8080,
+                  labels: {
+                    'VIP_0': '/foobar:8080'
+                  },
+                  hostPort: 0,
+                  protocol: [
+                    'tcp'
+                  ]
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should set the right custom vip', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+          batch = batch.add(new Transaction(['id'], '/foobar'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'containerPort'
+              ], '8080'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'loadBalanced'
+              ], true));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'vip'
+              ], '1.3.3.7:8080'));
+
+          expect(batch.reduce(Containers.JSONReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  name: null,
+                  containerPort: 8080,
+                  labels: {
+                    'VIP_0': '1.3.3.7:8080'
+                  },
+                  hostPort: 0,
+                  protocol: [
+                    'tcp'
+                  ]
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should set the right vip after id change', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+          batch = batch.add(new Transaction(['id'], '/foobar'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'containerPort'
+              ], '8080'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'loadBalanced'
+              ], true));
+
+          batch = batch.add(new Transaction(['id'], '/barfoo'));
+
+          expect(batch.reduce(Containers.JSONReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  name: null,
+                  containerPort: 8080,
+                  labels: {
+                    'VIP_0': '/barfoo:8080'
+                  },
+                  hostPort: 0,
+                  protocol: [
+                    'tcp'
+                  ]
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should set the right custom vip even after id change', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+
+          batch = batch.add(new Transaction(['network'], 'CONTAINER.foo'));
+          batch = batch.add(new Transaction(['id'], '/foobar'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints'
+              ], 0, ADD_ITEM));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'containerPort'
+              ], '8080'));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'loadBalanced'
+              ], true));
+
+          batch =
+              batch.add(new Transaction([
+                'containers',
+                0,
+                'endpoints',
+                0,
+                'vip'
+              ], '1.3.3.7:8080'));
+
+          batch = batch.add(new Transaction(['id'], '/barfoo'));
+
+          expect(batch.reduce(Containers.JSONReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container 1',
+              endpoints: [
+                {
+                  name: null,
+                  containerPort: 8080,
+                  labels: {
+                    'VIP_0': '1.3.3.7:8080'
+                  },
+                  hostPort: 0,
+                  protocol: [
+                    'tcp'
+                  ]
+                }
+              ]
+            }
+          ]);
+        });
+
+      });
+    });
   });
+
   // FormReducer is the same as JSONReducer
 });

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
@@ -41,7 +41,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   name: null,
@@ -79,7 +83,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   name: 'foo',
@@ -137,7 +145,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   name: 'foo',
@@ -177,7 +189,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   name: null,
@@ -217,7 +233,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   name: null,
@@ -252,7 +272,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   name: null,
@@ -294,7 +318,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   name: 'foo',
@@ -354,7 +382,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   name: 'foo',
@@ -396,7 +428,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   name: null,
@@ -438,7 +474,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   name: null,
@@ -480,7 +520,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   name: null,
@@ -532,7 +576,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   name: null,
@@ -595,7 +643,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   name: null,
@@ -651,7 +703,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   name: null,
@@ -716,7 +772,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   name: null,
@@ -757,7 +817,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   automaticPort: true,
@@ -799,7 +863,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   automaticPort: true,
@@ -859,7 +927,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   automaticPort: false,
@@ -903,7 +975,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   automaticPort: true,
@@ -947,7 +1023,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   automaticPort: true,
@@ -986,7 +1066,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   automaticPort: true,
@@ -1030,7 +1114,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   automaticPort: true,
@@ -1092,7 +1180,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   automaticPort: false,
@@ -1137,7 +1229,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   automaticPort: true,
@@ -1181,7 +1277,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   automaticPort: true,
@@ -1225,7 +1325,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   automaticPort: true,
@@ -1279,7 +1383,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   automaticPort: true,
@@ -1342,7 +1450,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   automaticPort: true,
@@ -1398,7 +1510,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   automaticPort: true,
@@ -1463,7 +1579,11 @@ describe('Containers', function () {
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
             {
-              name: 'container 1',
+              name: 'container-1',
+              resources: {
+                cpus: 0.001,
+                mem: 32
+              },
               endpoints: [
                 {
                   automaticPort: true,

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerNetwork-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerNetwork-test.js
@@ -1,0 +1,42 @@
+const MultiContainerNetwork = require('../MultiContainerNetwork');
+const Networking = require('../../../../../../../src/js/constants/Networking');
+const Batch = require('../../../../../../../src/js/structs/Batch');
+const Transaction = require('../../../../../../../src/js/structs/Transaction');
+
+describe('MultiContainerNetwork', function () {
+  describe('#JSONReducer', function () {
+    it('should be host default type', function () {
+      let batch = new Batch();
+
+      expect(batch.reduce(MultiContainerNetwork.JSONReducer.bind({})))
+      .toEqual({mode: 'host'});
+    });
+    it('should return a host object', function () {
+      let batch = new Batch();
+
+      batch = batch.add(new Transaction(['network'], Networking.type.HOST));
+
+      expect(batch.reduce(MultiContainerNetwork.JSONReducer.bind({}), {}))
+        .toEqual({mode: 'host'});
+    });
+
+    it('should return a container object', function () {
+      let batch = new Batch();
+
+      batch = batch.add(new Transaction(['network'], `${Networking.type.CONTAINER}.foo`));
+
+      expect(batch.reduce(MultiContainerNetwork.JSONReducer.bind({}), {}))
+      .toEqual({mode: 'container', name: 'foo'});
+    });
+
+    it('should return a container object', function () {
+      let batch = new Batch();
+
+      batch = batch.add(new Transaction(['network'], `${Networking.type.CONTAINER}.foo`));
+      batch = batch.add(new Transaction(['network'], Networking.type.HOST));
+
+      expect(batch.reduce(MultiContainerNetwork.JSONReducer.bind({}), {}))
+      .toEqual({mode: 'host'});
+    });
+  });
+});

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Volumes-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Volumes-test.js
@@ -9,7 +9,7 @@ describe('Volumes', function () {
     it('should return an empty array if no volumes are set', function () {
       let batch = new Batch();
 
-      expect(batch.reduce(Volumes.JSONReducer, [])).toEqual([]);
+      expect(batch.reduce(Volumes.JSONReducer.bind({}), [])).toEqual([]);
     });
 
     it('should return a local volume', function () {

--- a/src/js/structs/Batch.js
+++ b/src/js/structs/Batch.js
@@ -87,7 +87,7 @@ class Batch {
   reduce(callback, data) {
     // Run at least once even if there are no actions in the batch
     if (this.length === 0) {
-      return callback(data, {value: 'INIT'}, 0);
+      return callback(data, {path: [], value: 'INIT'}, 0);
     }
 
     return this.reduce(callback, data);

--- a/src/js/structs/__tests__/Batch-test.js
+++ b/src/js/structs/__tests__/Batch-test.js
@@ -61,7 +61,7 @@ describe('Batch', function () {
         return [sum, action, index];
       }, 'initial');
 
-      expect(args).toEqual(['initial', {value: 'INIT'}, 0]);
+      expect(args).toEqual(['initial', {path: [], value: 'INIT'}, 0]);
     });
 
     it('should not run reducers more than number than values', function () {


### PR DESCRIPTION
Based on #1573

This Introduces the endpoints tests for `JSONReducers` and `FormReducers`.

And also the network reducer got some tests.

On the way I fixed some issues which would never occur except in test cases.

For example set the path for the initial transaction in the batch.