### PR TITLE
Bugfix: Add null check for containerRef in ScrollbarUtil

### DIFF
--- a/src/js/utils/ScrollbarUtil.js
+++ b/src/js/utils/ScrollbarUtil.js
@@ -29,8 +29,8 @@ const ScrollbarUtil = {
   },
 
   updateWithRef(containerRef) {
-    // Use the containers  gemini ref if present
-    if (containerRef.geminiRef != null) {
+    // Use the containers gemini ref if present
+    if (containerRef != null && containerRef.geminiRef != null) {
       this.updateWithRef(containerRef.geminiRef);
 
       return;


### PR DESCRIPTION
This PR adds a `null` check for `containerRef`.