### PR TITLE
DCOS-11772: Fix NestedServiceLinks styling

### DIFF
--- a/plugins/services/src/js/pages/services/DeploymentsTab.js
+++ b/plugins/services/src/js/pages/services/DeploymentsTab.js
@@ -157,8 +157,8 @@ class DeploymentsTab extends mixin(StoreMixin) {
           <NestedServiceLinks
             serviceID={service.getId()}
             className="deployment-breadcrumb"
-            majorLinkClassName="deployment-breadcrumb-service-id table-cell-link-secondary"
-            minorLinkWrapperClassName="deployment-breadcrumb-crumb table-cell-link-secondary" />
+            majorLinkClassName="deployment-breadcrumb-service-id"
+            minorLinkWrapperClassName="deployment-breadcrumb-crumb" />
         </li>
       );
     });

--- a/src/js/components/NestedServiceLinks.js
+++ b/src/js/components/NestedServiceLinks.js
@@ -139,7 +139,7 @@ class NestedServiceLinks extends React.Component {
       minorLinkWrapperClassName
     } = this.props;
 
-    let classes = classNames(className);
+    let classes = classNames('nested-service-links', className);
 
     let majorLinkClasses = classNames(
       'text-overflow',
@@ -147,8 +147,8 @@ class NestedServiceLinks extends React.Component {
     );
 
     let minorLinkWrapperClasses = classNames(
-      'table-cell-details-secondary flex-box',
-      'flex-box-align-vertical-center table-cell-flex-box',
+      'table-cell-details-secondary flex',
+      'flex-align-items-center table-cell-flex-box',
       minorLinkWrapperClassName
     );
 

--- a/src/styles/components/nested-service-links/styles.less
+++ b/src/styles/components/nested-service-links/styles.less
@@ -22,6 +22,13 @@
       }
     }
   }
+
+  .nested-service-links {
+
+    .table-cell-value {
+      flex: 0 0 auto;
+    }
+  }
 }
 
 & when (@nested-service-links-enabled) and (@layout-screen-small-enabled) {


### PR DESCRIPTION
This PR...
* Removes superfluous classes passed from `DeploymentsTab`'s to `NestedServiceLInk` (these classes are meant to be assigned directly to the links, and this is done inside the `NestedServiceLInk` component itself)
* Removes superfluous `flex` classes in the `NestedServiceLInks` component (the flex properties are supplied by the `table-cell-flex` classes)
* Ensures the `table-cell-value` elements don't grow to fill its parent