### PR TITLE
DCOS-12205: Use defs instead of symbol in SVG sprite

### DIFF
--- a/webpack/plugins/svg-compiler-plugin.js
+++ b/webpack/plugins/svg-compiler-plugin.js
@@ -16,7 +16,7 @@ SVGCompilerPlugin.prototype.apply = function(compiler) {
     let files = glob.sync('**/*.svg', {cwd: baseDir});
     let svgSpriter = new SVGSprite({
       mode: {
-        symbol: true
+        defs: true
       },
       shape: {
         id: {
@@ -34,7 +34,7 @@ SVGCompilerPlugin.prototype.apply = function(compiler) {
     });
 
     svgSpriter.compile(function (error, result, data) {
-      content = result.symbol.sprite.contents.toString();
+      content = result.defs.sprite.contents.toString();
     });
 
     // Insert this list into the Webpack build as a new file asset:


### PR DESCRIPTION
This PR uses `<defs>` instead of `<symbol>` for the SVG sprite. This fixes SVGs that use gradients in Firefox and doesn't break them in other browsers (even IE11 and Edge)!