### PR TITLE
DCOS-12130: Use inline-block for dropdown-toggle elements

### DIFF
--- a/src/styles/components/dropdown-menus/styles.less
+++ b/src/styles/components/dropdown-menus/styles.less
@@ -13,7 +13,16 @@
   }
 
   .dropdown-toggle {
+    display: inline-block;
     white-space: nowrap;
+
+    &,
+    &.button {
+
+      &:after {
+        margin-top: @button-dropdown-caret-margin-top / -2;
+      }
+    }
 
     &.button-split-content {
 


### PR DESCRIPTION
Firefox doesn't treat pseudo-elements as regular flex elements, so I've decided to change `.dropdown-toggle` elements to `inline-block` rather than `inline-flex`. Here's a codepen to illustrate the issue: http://codepen.io/yeahjohnnn/pen/ObBOBG