### PR TITLE
DCOS-11395: Fix scroll behavior in advanced package installation form

### DIFF
--- a/src/js/components/modals/InstallPackageModal.js
+++ b/src/js/components/modals/InstallPackageModal.js
@@ -428,15 +428,15 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
           packageVersion={version}
           configuration={this.getPackageConfiguration()} />
         <div className="modal-footer">
-          <div className="button-collection flush">
+          <div className="button-collection flush-bottom">
             <button
-              className="button button-large flush"
+              className="button button-large"
               onClick={this.handleChangeTab.bind(this, 'advancedInstall')}>
               Back
             </button>
             <button
               disabled={!cosmosPackage || pendingRequest}
-              className="button button-success button-large flush"
+              className="button button-success button-large"
               onClick={this.handleInstallPackage}>
               {buttonText}
             </button>
@@ -616,7 +616,7 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
         modalWrapperClass={modalWrapperClasses}
         onClose={this.handleModalClose}
         open={props.open}
-        scrollContainerClass="modal-install-package-scroll-container"
+        scrollContainerClass="multiple-form-modal-body"
         showFooter={false}
         useGemini={false}>
         {this.getModalContents()}

--- a/src/styles/components/modal/install-package/styles.less
+++ b/src/styles/components/modal/install-package/styles.less
@@ -13,11 +13,8 @@
         flex-basis: 677px;
         max-height: none;
 
-        .modal-install-package-scroll-container {
-          flex: 1 1 auto;
-          max-width: 100%;
-          min-height: 0;
-          position: relative;
+        .multiple-form-modal-body {
+          display: block;
         }
       }
 
@@ -31,15 +28,13 @@
         display: flex;
         flex: 1 1 auto;
         flex-direction: column;
-        height: 100%;
         min-height: 0;
         position: relative;
 
         .tab-form-wrapper {
           display: flex;
-          flex: 1;
+          flex: 1 1 auto;
           flex-direction: column;
-          height: 100%;
         }
 
         .modal-header {
@@ -49,12 +44,22 @@
         .multiple-form {
           display: flex;
           flex: 1 1 auto;
+          height: auto;
           min-height: 0;
         }
 
+        .multiple-form-left-column,
         .multiple-form-right-column {
-          flex: 1 1 auto;
+          height: auto;
           min-height: 0;
+        }
+
+        .multiple-form-left-column {
+          flex: 1 1 33%;
+        }
+
+        .multiple-form-right-column {
+          flex: 1 1 67%;
         }
       }
 


### PR DESCRIPTION
This PR fixes the problems that were present in Firefox and Safari. Previously, Safari wouldn't render anything in this form, and it wouldn't scroll in Firefox.

The combination of `TabForm` + `SchemaForm` + `GeminiScrollbar` in a modal is super fragile, so the fix is not obvious.

Before (Safari):
![](https://cl.ly/2B1B1Z1p3w1B/Screen%20Recording%202016-12-13%20at%2003.39%20PM.gif)

After (Safari):
![](https://cl.ly/0T1h2Z1K1q44/Screen%20Recording%202016-12-13%20at%2003.36%20PM.gif)