### PR TITLE
[local volumes] add residency if needed

### DIFF
--- a/plugins/services/src/js/reducers/JSONConfigReducers.js
+++ b/plugins/services/src/js/reducers/JSONConfigReducers.js
@@ -5,6 +5,7 @@ import {JSONReducer as fetch} from './serviceForm/Artifacts';
 import {JSONReducer as healthChecks} from './serviceForm/HealthChecks';
 import {JSONReducer as labels} from './serviceForm/Labels';
 import {JSONReducer as portDefinitions} from './serviceForm/PortDefinitions';
+import {JSONReducer as residency} from './serviceForm/Residency';
 import {JSONReducer as volumes} from './serviceForm/Volumes';
 import {JSONReducer as ipAddress} from './serviceForm/IpAddress';
 import {
@@ -36,6 +37,7 @@ module.exports = {
   constraints,
   fetch,
   portDefinitions,
+  residency,
   volumes,
   ipAddress
 };

--- a/plugins/services/src/js/reducers/JSONParserReducers.js
+++ b/plugins/services/src/js/reducers/JSONParserReducers.js
@@ -8,6 +8,7 @@ import {JSONParser as labels} from './serviceForm/Labels';
 import {JSONParser as localVolumes} from './serviceForm/LocalVolumes';
 import {JSONParser as portDefinitions} from './serviceForm/PortDefinitions';
 import {JSONParser as portMappings} from './serviceForm/PortMappings';
+import {JSONParser as residency} from './serviceForm/Residency';
 import {JSONParser as network} from './serviceForm/Network';
 import {simpleParser} from '../../../../../src/js/utils/ParserUtil';
 
@@ -38,5 +39,6 @@ module.exports = [
   localVolumes,
   externalVolumes,
   constraints,
+  residency,
   fetch
 ];

--- a/plugins/services/src/js/reducers/serviceForm/Residency.js
+++ b/plugins/services/src/js/reducers/serviceForm/Residency.js
@@ -1,0 +1,56 @@
+import Transaction from '../../../../../../src/js/structs/Transaction';
+import {SET, ADD_ITEM, REMOVE_ITEM} from '../../../../../../src/js/constants/TransactionTypes';
+
+module.exports = {
+  JSONReducer(state, {type, path, value}) {
+    if (this.localVolumes == null) {
+      this.localVolumes = [];
+    }
+
+    let joinedPath = path.join('.');
+
+    if (joinedPath.search('localVolumes') !== -1) {
+      if (joinedPath === 'localVolumes') {
+        switch (type) {
+          case ADD_ITEM:
+            this.localVolumes.push(false);
+            break;
+          case REMOVE_ITEM:
+            this.localVolumes = this.localVolumes.filter((item, index) => {
+              return index !== value;
+            });
+            break;
+        }
+      }
+      let index = path[1];
+      if (type === SET && `localVolumes.${index}.type` === joinedPath) {
+        this.localVolumes[index] = value === 'PERSISTENT';
+      }
+
+      let hasLocalVolumes = this.localVolumes.find((value) => {
+        return value;
+      });
+      if (hasLocalVolumes && this.residency == null) {
+        return {
+          relaunchEscalationTimeoutSeconds: 10,
+          taskLostBehavior: 'WAIT_FOREVER'
+        };
+      } else {
+        return this.residency;
+      }
+    }
+    if (type === SET && joinedPath === 'residency') {
+      this.residency = value;
+      return value;
+    }
+
+    return state;
+
+  },
+  JSONParser(state) {
+    if (state.residency == null) {
+      return [];
+    }
+    return new Transaction(['residency'], state.residency);
+  }
+};

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Residency-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Residency-test.js
@@ -1,0 +1,79 @@
+const Residency = require('../Residency');
+const Batch = require('../../../../../../../src/js/structs/Batch');
+const Transaction = require('../../../../../../../src/js/structs/Transaction');
+const {ADD_ITEM, REMOVE_ITEM, SET} =
+  require('../../../../../../../src/js/constants/TransactionTypes');
+
+describe('Residency', function () {
+  describe('#JSONReducer', function () {
+    it('it should return undefined as default', function () {
+      let batch = new Batch();
+
+      batch = batch.add(new Transaction(['id'], 'foo'));
+
+      expect(batch.reduce(Residency.JSONReducer.bind({}))).toEqual(undefined);
+    });
+
+    it('should return residency if residency ist set', function () {
+      let batch = new Batch();
+
+      batch = batch.add(new Transaction(['residency'], {foo: 'bar'}));
+
+      expect(batch.reduce(Residency.JSONReducer.bind({})))
+      .toEqual({foo: 'bar'});
+    });
+
+    it('should return undefined if a host volume is set', function () {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(['localVolumes'], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(['localVolumes', 0, 'type'], 'HOST'));
+
+      expect(batch.reduce(Residency.JSONReducer.bind({}))).toEqual(undefined);
+    });
+
+    it('should return residency if a persistent volume is set', function () {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(['localVolumes'], 0, ADD_ITEM));
+      batch =
+        batch.add(new Transaction(['localVolumes', 0, 'type'], 'PERSISTENT'));
+
+      expect(batch.reduce(Residency.JSONReducer.bind({}))).toEqual({
+        relaunchEscalationTimeoutSeconds: 10,
+        taskLostBehavior: 'WAIT_FOREVER'
+      });
+    });
+
+    it('should return undefined if a persistent volume is removed',
+      function () {
+        let batch = new Batch();
+        batch = batch.add(new Transaction(['localVolumes'], 0, ADD_ITEM));
+        batch =
+          batch.add(new Transaction(['localVolumes', 0, 'type'], 'PERSISTENT'));
+        batch = batch.add(new Transaction(['localVolumes'], 0, REMOVE_ITEM));
+
+        expect(batch.reduce(Residency.JSONReducer.bind({}))).toEqual(undefined);
+      });
+
+    it('should respect the parsed residency', function () {
+      let batch = new Batch();
+
+      batch = batch.add(new Transaction(['residency'], {foo: 'bar'}));
+      batch = batch.add(new Transaction(['localVolumes'], 0, ADD_ITEM));
+      batch =
+        batch.add(new Transaction(['localVolumes', 0, 'type'], 'PERSISTENT'));
+
+      expect(batch.reduce(Residency.JSONReducer.bind({})))
+      .toEqual({foo: 'bar'});
+    });
+  });
+
+  describe('#JSONParser', function () {
+    it('should return empty array if residency is not present', function () {
+      expect(Residency.JSONParser({id: 'test'})).toEqual([]);
+    });
+    it('should return a transaction if residency is present', function () {
+      expect(Residency.JSONParser({residency: {foo: 'bar'}}))
+      .toEqual({type: SET, path: ['residency'], value: {foo: 'bar'}});
+    });
+  });
+});


### PR DESCRIPTION
If one adds a local persistent volume also the residency has to be set. As we do not have any field in the form representing this. We only have a `JSONReducer` and `JSONParser` for this.

![residency mov](https://cloud.githubusercontent.com/assets/156010/21180672/61ecbcd2-c1fa-11e6-8151-53e5ce8cae8b.gif)

The erros which you see in the animation is addressed by: #1601 