### PR TITLE
DCOS-9749: Enable USER network for Mesos runtime

### DIFF
--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -412,9 +412,10 @@ class NetworkingFormSection extends mixin(StoreMixin) {
   getServiceEndpointsSection() {
     const {container, portDefinitions} = this.props.data;
     const runtimeType = findNestedPropertyInObject(container, 'type');
-    const networkType = findNestedPropertyInObject(this.props.data, 'networkType');
+    const networkType =
+      findNestedPropertyInObject(this.props.data, 'networkType') || '';
 
-    // Port service endpoints unavailable for Mesos tasks
+    // Service Endpoints are unavailable for Mesos tasks
     if (runtimeType === NONE && networkType.startsWith(Networking.type.USER)) {
       return null;
     }

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -409,6 +409,44 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     return this.getHostServiceEndpoints(portDefinitions);
   }
 
+  getServiceEndpointsSection() {
+    const {container, portDefinitions} = this.props.data;
+    const runtimeType = findNestedPropertyInObject(container, 'type');
+    const networkType = findNestedPropertyInObject(this.props.data, 'networkType');
+
+    // Port service endpoints unavailable for Mesos tasks
+    if (runtimeType === NONE && networkType.startsWith(Networking.type.USER)) {
+      return null;
+    }
+
+    return [
+      <h3 className="short-bottom" key="service-endpoints-header">
+        Service Endpoints
+      </h3>,
+      <p key="service-endpoints-description">
+        DC/OS can automatically generate a Service Address to connect to each of your load balanced endpoints.
+      </p>,
+      this.getServiceEndpoints(),
+      <FormRow key="service-endpoints-add-button">
+        <FormGroup className="column-12">
+          <button
+            type="button"
+            onBlur={(event) => { event.stopPropagation(); }}
+            className="button button-primary-link button-flush"
+            onClick={this.props.onAddItem.bind(
+              this,
+              {
+                value: portDefinitions.length,
+                path: 'portDefinitions'
+              }
+            )}>
+            <Icon color="purple" id="plus" size="tiny" /> Add Service Endpoint
+          </button>
+        </FormGroup>
+      </FormRow>
+    ];
+  }
+
   getVirtualNetworks(disabledMap) {
     return VirtualNetworksStore.getOverlays().mapItems((overlay) => {
       let name = overlay.getName();
@@ -488,7 +526,6 @@ class NetworkingFormSection extends mixin(StoreMixin) {
   }
 
   render() {
-    let {portDefinitions} = this.props.data;
     let networkError = findNestedPropertyInObject(
       this.props.errors,
       'container.docker.network'
@@ -528,30 +565,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
             <FieldError>{networkError}</FieldError>
           </FormGroup>
         </FormRow>
-        <h3 className="short-bottom">
-          Service Endpoints
-        </h3>
-        <p>
-          DC/OS can automatically generate a Service Address to connect to each of your load balanced endpoints.
-        </p>
-        {this.getServiceEndpoints()}
-        <FormRow>
-          <FormGroup className="column-12">
-            <button
-              type="button"
-              onBlur={(event) => { event.stopPropagation(); }}
-              className="button button-primary-link button-flush"
-              onClick={this.props.onAddItem.bind(
-                this,
-                {
-                  value: portDefinitions.length,
-                  path: 'portDefinitions'
-                }
-              )}>
-              <Icon color="purple" id="plus" size="tiny" /> Add Service Endpoint
-            </button>
-          </FormGroup>
-        </FormRow>
+        {this.getServiceEndpointsSection()}
       </div>
     );
   }
@@ -585,4 +599,3 @@ NetworkingFormSection.configReducers = {
 };
 
 module.exports = NetworkingFormSection;
-

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -438,7 +438,6 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     // Runtime is Mesos
     if (!type || type === NONE) {
       disabledMap[Networking.type.BRIDGE] = 'BRIDGE networking is not compatible with the Mesos runtime';
-      disabledMap[Networking.type.USER] = 'USER networking is not compatible with the Mesos runtime';
     }
 
     // Runtime is Universal Container Runtime

--- a/plugins/services/src/js/reducers/JSONParserReducers.js
+++ b/plugins/services/src/js/reducers/JSONParserReducers.js
@@ -1,4 +1,4 @@
-import ContainerConstants from '../constants/ContainerConstants';
+import {JSONParser as container} from './serviceForm/Container';
 import {JSONParser as constraints} from './serviceForm/Constraints';
 import {JSONParser as fetch} from './serviceForm/Artifacts';
 import {JSONParser as environmentVariables} from './serviceForm/EnvironmentVariables';
@@ -11,38 +11,19 @@ import {JSONParser as portMappings} from './serviceForm/PortMappings';
 import {JSONParser as residency} from './serviceForm/Residency';
 import {JSONParser as network} from './serviceForm/Network';
 import {simpleParser} from '../../../../../src/js/utils/ParserUtil';
-import {findNestedPropertyInObject} from '../../../../../src/js/utils/Util';
-import Transaction from '../../../../../src/js/structs/Transaction';
-
-const {MESOS, DOCKER} = ContainerConstants.type;
 
 module.exports = [
   simpleParser(['id']),
   simpleParser(['instances']),
-  function (state) {
-    let value = findNestedPropertyInObject(state, 'container.type');
-
-    if (value == null) {
-      value = 'NONE';
-    }
-
-    return new Transaction(['container', 'type'], value);
-  },
-  simpleParser(['container', DOCKER.toLowerCase(), 'image']),
-  simpleParser(['container', MESOS.toLowerCase(), 'image']),
-  simpleParser(['container', DOCKER.toLowerCase(), 'forcePullImage']),
-  simpleParser(['container', MESOS.toLowerCase(), 'forcePullImage']),
-  simpleParser(['container', DOCKER.toLowerCase(), 'privileged']),
-  simpleParser(['container', MESOS.toLowerCase(), 'privileged']),
-  network,
   simpleParser(['cpus']),
   simpleParser(['mem']),
   simpleParser(['disk']),
   simpleParser(['gpus']),
   simpleParser(['cmd']),
+  container,
+  network,
   portDefinitions,
-  // Note: must come after portDefinitions, as it uses its information!
-  portMappings,
+  portMappings, // Note: must come after portDefinitions, as it uses its information!
   environmentVariables,
   labels,
   healthChecks,

--- a/plugins/services/src/js/reducers/JSONParserReducers.js
+++ b/plugins/services/src/js/reducers/JSONParserReducers.js
@@ -11,13 +11,23 @@ import {JSONParser as portMappings} from './serviceForm/PortMappings';
 import {JSONParser as residency} from './serviceForm/Residency';
 import {JSONParser as network} from './serviceForm/Network';
 import {simpleParser} from '../../../../../src/js/utils/ParserUtil';
+import {findNestedPropertyInObject} from '../../../../../src/js/utils/Util';
+import Transaction from '../../../../../src/js/structs/Transaction';
 
 const {MESOS, DOCKER} = ContainerConstants.type;
 
 module.exports = [
   simpleParser(['id']),
   simpleParser(['instances']),
-  simpleParser(['container', 'type']),
+  function (state) {
+    let value = findNestedPropertyInObject(state, 'container.type');
+
+    if (value == null) {
+      value = 'NONE';
+    }
+
+    return new Transaction(['container', 'type'], value);
+  },
   simpleParser(['container', DOCKER.toLowerCase(), 'image']),
   simpleParser(['container', MESOS.toLowerCase(), 'image']),
   simpleParser(['container', DOCKER.toLowerCase(), 'forcePullImage']),

--- a/plugins/services/src/js/reducers/serviceForm/Container.js
+++ b/plugins/services/src/js/reducers/serviceForm/Container.js
@@ -1,9 +1,12 @@
-import {SET, ADD_ITEM, REMOVE_ITEM} from '../../../../../../src/js/constants/TransactionTypes';
 import {combineReducers} from '../../../../../../src/js/utils/ReducerUtil';
-import ContainerConstants from '../../constants/ContainerConstants';
+import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
 import {JSONReducer as volumes} from './Volumes';
-import ValidatorUtil from '../../../../../../src/js/utils/ValidatorUtil';
+import {SET, ADD_ITEM, REMOVE_ITEM} from '../../../../../../src/js/constants/TransactionTypes';
+import {simpleParser, combineParsers} from '../../../../../../src/js/utils/ParserUtil';
+import ContainerConstants from '../../constants/ContainerConstants';
 import docker from './Docker';
+import Transaction from '../../../../../../src/js/structs/Transaction';
+import ValidatorUtil from '../../../../../../src/js/utils/ValidatorUtil';
 
 const {DOCKER, MESOS, NONE} = ContainerConstants.type;
 
@@ -171,6 +174,7 @@ module.exports = {
 
     return newState;
   },
+
   FormReducer(_, ...args) {
     if (this.internalState == null) {
       this.internalState = {};
@@ -210,5 +214,23 @@ module.exports = {
     }
 
     return newState;
-  }
+  },
+
+  JSONParser: combineParsers([
+    function (state) {
+      let value = findNestedPropertyInObject(state, 'container.type');
+
+      if (value == null) {
+        value = 'NONE';
+      }
+
+      return new Transaction(['container', 'type'], value);
+    },
+    simpleParser(['container', DOCKER.toLowerCase(), 'image']),
+    simpleParser(['container', MESOS.toLowerCase(), 'image']),
+    simpleParser(['container', DOCKER.toLowerCase(), 'forcePullImage']),
+    simpleParser(['container', MESOS.toLowerCase(), 'forcePullImage']),
+    simpleParser(['container', DOCKER.toLowerCase(), 'privileged']),
+    simpleParser(['container', MESOS.toLowerCase(), 'privileged'])
+  ])
 };

--- a/plugins/services/src/js/reducers/serviceForm/Network.js
+++ b/plugins/services/src/js/reducers/serviceForm/Network.js
@@ -1,17 +1,25 @@
 import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
 import Transaction from '../../../../../../src/js/structs/Transaction';
+import Networking from '../../../../../../src/js/constants/Networking';
+
+const {USER} = Networking.type;
 
 module.exports = {
   JSONReducer: null,
 
   JSONParser(state) {
     let transactions = [];
-    let networkType = findNestedPropertyInObject(state,
-        'container.docker.network');
-    let networkName = findNestedPropertyInObject(state, 'ipAddress.networkName');
+    let networkType =
+      findNestedPropertyInObject(state, 'container.docker.network');
+    let networkName =
+      findNestedPropertyInObject(state, 'ipAddress.networkName');
 
-    if (networkType == null) {
-      return [];
+    if (networkType == null && networkName == null) {
+      return transactions;
+    }
+
+    if (networkName != null) {
+      networkType = USER;
     }
 
     if (networkName != null && networkType != null) {

--- a/plugins/services/src/js/reducers/serviceForm/Network.js
+++ b/plugins/services/src/js/reducers/serviceForm/Network.js
@@ -29,15 +29,15 @@ module.exports = {
         'network'
       ], `${networkType}.${networkName}`));
 
-      let group = findNestedPropertyInObject(state, 'ipAddress.group');
+      let groups = findNestedPropertyInObject(state, 'ipAddress.groups');
       let discovery = findNestedPropertyInObject(state, 'ipAddress.discovery');
       let labels = findNestedPropertyInObject(state, 'ipAddress.labels');
 
-      if (group != null) {
+      if (groups != null) {
         transactions.push(new Transaction([
           'ipAddress',
-          'group'
-        ], group));
+          'groups'
+        ], groups));
       }
 
       if (labels != null) {

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Network-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Network-test.js
@@ -1,0 +1,80 @@
+const Network = require('../Network');
+const {SET} = require('../../../../../../../src/js/constants/TransactionTypes');
+
+describe('Network', function () {
+  describe('#JSONParser', function () {
+    it('should return an empty array', function () {
+      expect(Network.JSONParser({})).toEqual([]);
+    });
+
+    it('defaults networkType to USER when only networkName is defined', function () {
+      const state = {
+        ipAddress: {
+          networkName: 'dcos'
+        }
+      };
+      expect(Network.JSONParser(state)).toEqual([
+        {type: SET, value: 'USER.dcos', path: ['container', 'docker', 'network']}
+      ]);
+    });
+
+    it('sets BRIDGE networkType', function () {
+      const state = {
+        container: {
+          docker: {
+            network: 'BRIDGE'
+          }
+        }
+      };
+      expect(Network.JSONParser(state)).toEqual([
+        {type: SET, value: 'BRIDGE', path: ['container', 'docker', 'network']}
+      ]);
+    });
+
+    it('sets HOST networkType', function () {
+      const state = {
+        container: {
+          docker: {
+            network: 'HOST'
+          }
+        }
+      };
+      expect(Network.JSONParser(state)).toEqual([
+        {type: SET, value: 'HOST', path: ['container', 'docker', 'network']}
+      ]);
+    });
+
+    it('sets USER networkType with optional fields', function () {
+      const state = {
+        container: {
+          docker: {
+            network: 'USER'
+          }
+        },
+        ipAddress: {
+          networkName: 'dcos',
+          groups: ['group1'],
+          labels: {
+            label1: 'label1 value'
+          },
+          discovery: {
+            ports: [
+              { number: 80, name: 'http', protocol: 'tcp' }
+            ]
+          }
+        }
+      };
+      expect(Network.JSONParser(state)).toEqual([
+        {type: SET, value: 'USER.dcos', path: ['container', 'docker', 'network']},
+        {type: SET, value: ['group1'], path: ['ipAddress', 'groups']},
+        {type: SET, value: {label1: 'label1 value'}, path: ['ipAddress', 'labels']},
+        {
+          type: SET,
+          value: {
+            ports: [{ number: 80, name: 'http', protocol: 'tcp' }]
+          },
+          path: ['ipAddress', 'discovery']}
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
This PR:
* Enables USER network for Mesos runtime, as it turned out to be available.
* Introduces an initial transaction that sets `container.type` to `NONE`. 
Otherwise setting the network type would also create a `container` section.
* Fixes a typo/bug handling `groups` section in `ipAddress` properly.

As you can see it does 3 things, which could be bad if they weren't closely related, though I still can extract 2 PRs if you insist.

Example definition:
```JSON
{
  "id": "/mesos-user-network",
  "cmd": "sleep 1000",
  "instances": 1,
  "cpus": 0.1,
  "mem": 128,
  "disk": 0,
  "ipAddress": {
    "networkName": "dcos"
  }
}
```