### PR TITLE
DCOS-12144: Allow gpus=0 for Docker

### DIFF
--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -102,7 +102,7 @@ class GeneralServiceFormSection extends Component {
       type = container.type;
     }
 
-    if (!ValidatorUtil.isEmpty(gpus)) {
+    if (!ValidatorUtil.isEmpty(gpus) && gpus !== 0) {
       isDisabled[DOCKER] = true;
       disabledTooltipContent = 'Docker Engine does not support GPU resources, please select Universal Container Runtime if you want to use GPU resources.';
     }


### PR DESCRIPTION
Our default definition has `gpus: 0` which blocks a user from selecting Docker Runtime. But Marathon and Mesos process `gpus: 0` fro Docker correctly. So we shouldn't block it as well.