### PR TITLE
DCOS-11803: Improve consistency of service creation modal spacing

### DIFF
--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -89,11 +89,7 @@ class ContainerServiceFormSection extends Component {
       );
     }
 
-    return (
-      <div className="artifacts-section">
-        {content}
-      </div>
-    );
+    return content;
   }
 
   getGPUSInput(data) {
@@ -199,13 +195,15 @@ class ContainerServiceFormSection extends Component {
           </FormGroup>
         </FormRow>
         {this.getArtifactsInputs(data.fetch)}
-        <div>
-          <a
-            className="button button-primary-link button-flush"
-            onClick={this.props.onAddItem.bind(this, {value: data.fetch.length, path: 'fetch'})}>
-            + Add Artifact
-          </a>
-        </div>
+        <FormRow>
+          <FormGroup className="column-12">
+            <a
+              className="button button-primary-link button-flush"
+              onClick={this.props.onAddItem.bind(this, {value: data.fetch.length, path: 'fetch'})}>
+              <Icon color="purple" id="plus" size="tiny" /> Add Artifact
+            </a>
+          </FormGroup>
+        </FormRow>
       </AdvancedSectionContent>
     );
   }
@@ -361,14 +359,16 @@ class ContainerServiceFormSection extends Component {
           </FormGroup>
         </FormRow>
 
-        <FormGroup showError={Boolean(errors.cmd)}>
-          {this.getCMDLabel()}
-          <FieldTextarea name="cmd" value={data.cmd} />
-          <FieldHelp>
-            A shell command for your container to execute.
-          </FieldHelp>
-          <FieldError>{errors.cmd}</FieldError>
-        </FormGroup>
+        <FormRow>
+          <FormGroup className="column-12" showError={Boolean(errors.cmd)}>
+            {this.getCMDLabel()}
+            <FieldTextarea name="cmd" value={data.cmd} />
+            <FieldHelp>
+              A shell command for your container to execute.
+            </FieldHelp>
+            <FieldError>{errors.cmd}</FieldError>
+          </FormGroup>
+        </FormRow>
 
         <AdvancedSection>
           <AdvancedSectionLabel>

--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -14,6 +14,7 @@ import FieldInput from '../../../../../../src/js/components/form/FieldInput';
 import FieldLabel from '../../../../../../src/js/components/form/FieldLabel';
 import FieldTextarea from '../../../../../../src/js/components/form/FieldTextarea';
 import FormGroup from '../../../../../../src/js/components/form/FormGroup';
+import FormRow from '../../../../../../src/js/components/form/FormRow';
 import Icon from '../../../../../../src/js/components/Icon';
 import MetadataStore from '../../../../../../src/js/stores/MetadataStore';
 
@@ -24,7 +25,6 @@ const containerSettings = {
     label: <span>Grant Runtime Privileges</span>,
     helpText: 'By default, containers are “unprivileged” and cannot, for example, run a Docker daemon inside a Docker container.',
     dockerOnly: 'Grant runtime privileges is only supported in Docker Runtime.'
-
   },
   forcePullImage: {
     label: <span>Force Pull Image On Launch</span>,
@@ -60,7 +60,7 @@ class ContainerServiceFormSection extends Component {
       }
 
       return (
-        <div key={index} className="flex row">
+        <FormRow key={index}>
           <FormGroup
             className="column-10"
             showError={Boolean(errors[index])}>
@@ -75,17 +75,17 @@ class ContainerServiceFormSection extends Component {
             <DeleteRowButton
               onClick={this.props.onRemoveItem.bind(this, {value: index, path: 'fetch'})} />
           </FormGroup>
-        </div>
+        </FormRow>
       );
     });
 
     if (data.length === 0) {
       content = (
-        <div className="flex row">
+        <FormRow>
           <FormGroup className="column-10">
             {getArtifactsLabel()}
           </FormGroup>
-        </div>
+        </FormRow>
       );
     }
 
@@ -184,7 +184,7 @@ class ContainerServiceFormSection extends Component {
           <FieldError>{typeErrors}</FieldError>
         </FormGroup>
 
-        <div className="flex row">
+        <FormRow>
           <FormGroup className="column-4" showError={Boolean(!gpuDisabled && errors.gpus)}>
             {this.getGPUSInput(data)}
             <FieldError>{errors.gpus}</FieldError>
@@ -197,7 +197,7 @@ class ContainerServiceFormSection extends Component {
               value={data.disk} />
             <FieldError>{errors.disk}</FieldError>
           </FormGroup>
-        </div>
+        </FormRow>
         {this.getArtifactsInputs(data.fetch)}
         <div>
           <a
@@ -318,11 +318,12 @@ class ContainerServiceFormSection extends Component {
 
     return (
       <div>
-        <h2 className="short-top short-bottom">
+        <h2 className="short-bottom">
           Container
         </h2>
         <p>Configure your container below. Enter a container image or command you want to run.</p>
-        <div className="flex row">
+
+        <FormRow>
           <FormGroup
             className="column-6"
             showError={Boolean(containerType != null && containerType !== NONE && imageErrors)}>
@@ -344,6 +345,7 @@ class ContainerServiceFormSection extends Component {
               value={data.cpus} />
             <FieldError>{errors.cpus}</FieldError>
           </FormGroup>
+
           <FormGroup
             className="column-3"
             required={true}
@@ -357,7 +359,7 @@ class ContainerServiceFormSection extends Component {
               value={data.mem} />
             <FieldError>{errors.mem}</FieldError>
           </FormGroup>
-        </div>
+        </FormRow>
 
         <FormGroup showError={Boolean(errors.cmd)}>
           {this.getCMDLabel()}

--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -9,6 +9,7 @@ import FieldInput from '../../../../../../src/js/components/form/FieldInput';
 import FieldLabel from '../../../../../../src/js/components/form/FieldLabel';
 import FormGroup from '../../../../../../src/js/components/form/FormGroup';
 import FormRow from '../../../../../../src/js/components/form/FormRow';
+import Icon from '../../../../../../src/js/components/Icon';
 
 class EnvironmentFormSection extends Component {
 
@@ -109,13 +110,15 @@ class EnvironmentFormSection extends Component {
           Set up environment variables for each task your service launches.
         </p>
         {this.getEnvironmentLines(data.env)}
-        <div>
-          <a
-            className="button button-primary-link button-flush"
-            onClick={this.props.onAddItem.bind(this, {value: data.env.length, path: 'env'})}>
-            + Add Environment Variable
-          </a>
-        </div>
+        <FormRow>
+          <FormGroup className="column-12">
+            <a
+              className="button button-primary-link button-flush"
+              onClick={this.props.onAddItem.bind(this, {value: data.env.length, path: 'env'})}>
+              <Icon color="purple" id="plus" size="tiny" /> Add Environment Variable
+            </a>
+          </FormGroup>
+        </FormRow>
         <h2 className="short-bottom">
           Labels
         </h2>
@@ -123,13 +126,15 @@ class EnvironmentFormSection extends Component {
           Attach metadata to expose additional information to other services.
         </p>
         {this.getLabelsLines(data.labels)}
-        <div>
-          <a
-            className="button button-primary-link button-flush"
-            onClick={this.props.onAddItem.bind(this, {value: data.labels.length, path: 'labels'})}>
-            + Add Label
-          </a>
-        </div>
+        <FormRow>
+          <FormGroup className="column-12">
+            <a
+              className="button button-primary-link button-flush"
+              onClick={this.props.onAddItem.bind(this, {value: data.labels.length, path: 'labels'})}>
+              <Icon color="purple" id="plus" size="tiny" /> Add Label
+            </a>
+          </FormGroup>
+        </FormRow>
         <MountService.Mount
           type="CreateService:EnvironmentFormSection"
           data={data}

--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -8,6 +8,7 @@ import FieldError from '../../../../../../src/js/components/form/FieldError';
 import FieldInput from '../../../../../../src/js/components/form/FieldInput';
 import FieldLabel from '../../../../../../src/js/components/form/FieldLabel';
 import FormGroup from '../../../../../../src/js/components/form/FormGroup';
+import FormRow from '../../../../../../src/js/components/form/FormRow';
 
 class EnvironmentFormSection extends Component {
 
@@ -23,7 +24,7 @@ class EnvironmentFormSection extends Component {
       }
 
       return (
-        <div key={key} className="flex row">
+        <FormRow key={key}>
           <FormGroup
             className="column-3"
             required={false}>
@@ -49,7 +50,7 @@ class EnvironmentFormSection extends Component {
             <DeleteRowButton
               onClick={this.props.onRemoveItem.bind(this, {value: key, path: 'env'})}/>
           </FormGroup>
-        </div>
+        </FormRow>
       );
     });
   }
@@ -66,7 +67,7 @@ class EnvironmentFormSection extends Component {
       }
 
       return (
-        <div key={key} className="flex row">
+        <FormRow key={key}>
           <FormGroup
             className="column-3">
             {keyLabel}
@@ -91,7 +92,7 @@ class EnvironmentFormSection extends Component {
             <DeleteRowButton
               onClick={this.props.onRemoveItem.bind(this, {value: key, path: 'labels'})}/>
           </FormGroup>
-        </div>
+        </FormRow>
       );
     });
   }
@@ -100,7 +101,7 @@ class EnvironmentFormSection extends Component {
     let {data, errors} = this.props;
 
     return (
-      <div className="form flush-bottom">
+      <div>
         <h2 className="flush-top short-bottom">
           Environment Variables
         </h2>

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -239,13 +239,15 @@ class GeneralServiceFormSection extends Component {
             </h3>
             <p>Constraints control where apps run to allow optimization for either fault tolerance or locality.</p>
             {this.getPlacementConstraints(data.constraints)}
-            <div>
-              <a
-                className="button button-primary-link button-flush"
-                onClick={this.props.onAddItem.bind(this, {value: data.constraints.length, path: 'constraints'})}>
-                + Add Placement Constraint
-              </a>
-            </div>
+            <FormRow>
+              <FormGroup className="column-12">
+                <a
+                  className="button button-primary-link button-flush"
+                  onClick={this.props.onAddItem.bind(this, {value: data.constraints.length, path: 'constraints'})}>
+                  <Icon color="purple" id="plus" size="tiny" /> Add Placement Constraint
+                </a>
+              </FormGroup>
+            </FormRow>
           </AdvancedSectionContent>
         </AdvancedSection>
 

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -13,6 +13,7 @@ import FieldHelp from '../../../../../../src/js/components/form/FieldHelp';
 import FieldInput from '../../../../../../src/js/components/form/FieldInput';
 import FieldLabel from '../../../../../../src/js/components/form/FieldLabel';
 import FormGroup from '../../../../../../src/js/components/form/FormGroup';
+import FormRow from '../../../../../../src/js/components/form/FormRow';
 import General from '../../reducers/serviceForm/General';
 import Icon from '../../../../../../src/js/components/Icon';
 import MetadataStore from '../../../../../../src/js/stores/MetadataStore';
@@ -50,7 +51,7 @@ class GeneralServiceFormSection extends Component {
       }
 
       return (
-        <div key={index} className="flex row">
+        <FormRow key={index}>
           <FormGroup
             className="column-3"
             required={true}
@@ -88,7 +89,7 @@ class GeneralServiceFormSection extends Component {
             <DeleteRowButton
               onClick={this.props.onRemoveItem.bind(this, {value: index, path: 'constraints'})}/>
           </FormGroup>
-        </div>
+        </FormRow>
       );
     });
   }
@@ -165,17 +166,15 @@ class GeneralServiceFormSection extends Component {
     );
 
     return (
-      <div className="form flush-bottom">
-        <div className="form-row-element">
-          <h2 className="form-header flush-top short-bottom">
-            Services
-          </h2>
-          <p>
-            Configure your service below. Start by giving your service a name.
-          </p>
-        </div>
+      <div>
+        <h2 className="flush-top short-bottom">
+          Services
+        </h2>
+        <p>
+          Configure your service below. Start by giving your service a name.
+        </p>
 
-        <div className="flex row">
+        <FormRow>
           <FormGroup
             className="column-8"
             required={true}
@@ -204,9 +203,9 @@ class GeneralServiceFormSection extends Component {
               value={data.instances} />
             <FieldError>{errors.instances}</FieldError>
           </FormGroup>
-        </div>
+        </FormRow>
 
-        <h3 className="short-top short-bottom">
+        <h3 className="short-bottom">
           {'Container Runtime '}
           <Tooltip
             content={runtimeTooltipContent}
@@ -222,7 +221,6 @@ class GeneralServiceFormSection extends Component {
           {this.getRuntimeSelections(data)}
           <FieldError>{typeErrors}</FieldError>
         </FormGroup>
-
         <AdvancedSection>
           <AdvancedSectionLabel>
             Advanced Service Settings

--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -12,6 +12,7 @@ import FieldSelect from '../../../../../../src/js/components/form/FieldSelect';
 import FormGroup from '../../../../../../src/js/components/form/FormGroup';
 import FormGroupContainer from '../../../../../../src/js/components/form/FormGroupContainer';
 import FormRow from '../../../../../../src/js/components/form/FormRow';
+import Icon from '../../../../../../src/js/components/Icon';
 
 import {FormReducer as healthChecks} from '../../reducers/serviceForm/HealthChecks';
 
@@ -209,12 +210,14 @@ class HealthChecksFormSection extends Component {
           the application{'\''}s tasks.
         </p>
         {this.getHealthChecksLines(data.healthChecks)}
-        <div>
-          <a className="button button-primary-link button-flush"
-            onClick={this.props.onAddItem.bind(this, {value: data.healthChecks.length, path: 'healthChecks'})}>
-            + Add Health Check
-          </a>
-        </div>
+        <FormRow>
+          <FormGroup className="column-12">
+            <a className="button button-primary-link button-flush"
+              onClick={this.props.onAddItem.bind(this, {value: data.healthChecks.length, path: 'healthChecks'})}>
+              <Icon color="purple" id="plus" size="tiny" /> Add Health Check
+            </a>
+          </FormGroup>
+        </FormRow>
       </div>
     );
   }

--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -11,6 +11,7 @@ import FieldLabel from '../../../../../../src/js/components/form/FieldLabel';
 import FieldSelect from '../../../../../../src/js/components/form/FieldSelect';
 import FormGroup from '../../../../../../src/js/components/form/FormGroup';
 import FormGroupContainer from '../../../../../../src/js/components/form/FormGroupContainer';
+import FormRow from '../../../../../../src/js/components/form/FormRow';
 
 import {FormReducer as healthChecks} from '../../reducers/serviceForm/HealthChecks';
 
@@ -31,7 +32,7 @@ class HealthChecksFormSection extends Component {
           Advanced Health Check Settings
         </AdvancedSectionLabel>
         <AdvancedSectionContent>
-          <div className="flex row">
+          <FormRow>
             <FormGroup
                 className="column-3"
                 showError={Boolean(errors.gracePeriodSeconds)}>
@@ -76,7 +77,7 @@ class HealthChecksFormSection extends Component {
                   value={healthCheck.maxConsecutiveFailures}/>
               <FieldError>{errors.maxConsecutiveFailures}</FieldError>
             </FormGroup>
-          </div>
+          </FormRow>
         </AdvancedSectionContent>
       </AdvancedSection>
     );
@@ -93,7 +94,7 @@ class HealthChecksFormSection extends Component {
       .get(this.props.errors);
 
     return (
-      <div className="flex row">
+      <FormRow>
         <FormGroup
           className="column-12"
           showError={Boolean(errors.value)}>
@@ -104,7 +105,7 @@ class HealthChecksFormSection extends Component {
             value={healthCheck.command}/>
           <FieldError>{errors.value}</FieldError>
         </FormGroup>
-      </div>
+      </FormRow>
     );
   }
 
@@ -124,7 +125,7 @@ class HealthChecksFormSection extends Component {
     const errors = errorsLens.at(key, {}).get(this.props.errors);
 
     return [(
-      <div className="flex row" key="path">
+      <FormRow key="path">
         <FormGroup
           className="column-6"
           showError={false}>
@@ -146,10 +147,10 @@ class HealthChecksFormSection extends Component {
             value={healthCheck.path}/>
           <FieldError>{errors.path}</FieldError>
         </FormGroup>
-      </div>
+      </FormRow>
     ),
     (
-      <div className="row flex" key="HTTPS">
+      <FormRow key="HTTPS">
         <FormGroup showError={false} className="column-12">
           <FieldLabel>
             <FieldInput
@@ -161,7 +162,7 @@ class HealthChecksFormSection extends Component {
           </FieldLabel>
           <FieldError>{errors.protocol}</FieldError>
         </FormGroup>
-      </div>
+      </FormRow>
     )];
   }
 
@@ -173,7 +174,7 @@ class HealthChecksFormSection extends Component {
         <FormGroupContainer key={key}
           onRemove={this.props.onRemoveItem.bind(this,
             {value: key, path: 'healthChecks'})}>
-          <div className="flex row">
+          <FormRow>
             <FormGroup
               className="column-6"
               showError={Boolean(errors.protocol)}>
@@ -187,7 +188,7 @@ class HealthChecksFormSection extends Component {
               </FieldSelect>
               <FieldError>{errors.protocol}</FieldError>
             </FormGroup>
-          </div>
+          </FormRow>
           {this.getCommandFields(healthCheck, key)}
           {this.getHTTPFields(healthCheck, key)}
           {this.getAdvancedSettings(healthCheck, key)}
@@ -199,16 +200,14 @@ class HealthChecksFormSection extends Component {
   render() {
     let {data} = this.props;
     return (
-      <div className="form flush-bottom">
-        <div className="form-row-element">
-          <h2 className="form-header flush-top short-bottom">
-            Health Checks
-          </h2>
-          <p>
-            Health checks may be specified per application to be run against
-            the application{'\''}s tasks.
-          </p>
-        </div>
+      <div>
+        <h2 className="form-header flush-top short-bottom">
+          Health Checks
+        </h2>
+        <p>
+          Health checks may be specified per application to be run against
+          the application{'\''}s tasks.
+        </p>
         {this.getHealthChecksLines(data.healthChecks)}
         <div>
           <a className="button button-primary-link button-flush"

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -547,19 +547,23 @@ class NetworkingFormSection extends mixin(StoreMixin) {
           DC/OS can automatically generate a Service Address to connect to each of your load balanced endpoints.
         </p>
         {this.getServiceEndpoints()}
-        <button
-          type="button"
-          onBlur={(event) => { event.stopPropagation(); }}
-          className="button button-primary-link button-flush"
-          onClick={this.props.onAddItem.bind(
-            this,
-            {
-              value: portDefinitions.length,
-              path: 'portDefinitions'
-            }
-          )}>
-          <Icon color="purple" id="plus" size="tiny" /> Add Service Endpoint
-        </button>
+        <FormRow>
+          <FormGroup className="column-12">
+            <button
+              type="button"
+              onBlur={(event) => { event.stopPropagation(); }}
+              className="button button-primary-link button-flush"
+              onClick={this.props.onAddItem.bind(
+                this,
+                {
+                  value: portDefinitions.length,
+                  path: 'portDefinitions'
+                }
+              )}>
+              <Icon color="purple" id="plus" size="tiny" /> Add Service Endpoint
+            </button>
+          </FormGroup>
+        </FormRow>
       </div>
     );
   }

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -8,6 +8,7 @@ import FieldInput from '../../../../../../src/js/components/form/FieldInput';
 import FieldLabel from '../../../../../../src/js/components/form/FieldLabel';
 import FieldError from '../../../../../../src/js/components/form/FieldError';
 import FieldSelect from '../../../../../../src/js/components/form/FieldSelect';
+import FormRow from '../../../../../../src/js/components/form/FormRow';
 import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
 import {SET} from '../../../../../../src/js/constants/TransactionTypes';
 import FormGroup from '../../../../../../src/js/components/form/FormGroup';
@@ -141,7 +142,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     }
 
     return [
-      <div className="flex row" key="title">
+      <FormRow key="title">
         <FormGroup className="column-9">
           <FieldLabel>
             Load Balanced Service Address
@@ -150,8 +151,8 @@ class NetworkingFormSection extends mixin(StoreMixin) {
             </FieldHelp>
           </FieldLabel>
         </FormGroup>
-      </div>,
-      <div className="flex flex-align-items-center row" key="toggle">
+      </FormRow>,
+      <FormRow key="toggle">
         <FormGroup
           className="column-auto"
           showError={Boolean(loadBalancedError)}>
@@ -169,7 +170,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
             {address}
           </span>
         </FormGroup>
-      </div>
+      </FormRow>
     ];
   }
 
@@ -188,7 +189,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
         <FieldLabel>
           Protocol
         </FieldLabel>
-        <div className="flex row">
+        <FormRow>
           <FormGroup className="column-auto">
             <FieldLabel matchInputHeight={true}>
               <FieldInput
@@ -209,7 +210,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
               UDP
             </FieldLabel>
           </FormGroup>
-        </div>
+        </FormRow>
         <FieldError>{protocolError}</FieldError>
       </FormGroup>
     );
@@ -231,10 +232,10 @@ class NetworkingFormSection extends mixin(StoreMixin) {
         `container.docker.portMappings.${index}.name`
       );
       let portMappingFields = (
-        <div className="flex row">
+        <FormRow>
           {this.getHostPortFields(portDefinition, index)}
           {this.getProtocolField(portDefinition, index)}
-        </div>
+        </FormRow>
       );
 
       return (
@@ -244,7 +245,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
             this,
             {value: index, path: 'portDefinitions'}
           )}>
-          <div className="flex row">
+          <FormRow>
             <FormGroup
               className="column-3"
               showError={Boolean(containerPortError)}>
@@ -268,7 +269,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
                 value={portDefinition.name} />
               <FieldError>{nameError}</FieldError>
             </FormGroup>
-          </div>
+          </FormRow>
           {portMappingFields}
           {this.getLoadBalancedServiceAddressField(portDefinition, index)}
         </FormGroupContainer>
@@ -295,7 +296,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
             this,
             {value: index, path: 'portDefinitions'}
           )}>
-          <div className="flex row">
+          <FormRow>
             <FormGroup className="column-6" showError={Boolean(nameError)}>
               <FieldLabel>
                 Service Endpoint Name
@@ -306,11 +307,11 @@ class NetworkingFormSection extends mixin(StoreMixin) {
                 value={portDefinition.name} />
               <FieldError>{nameError}</FieldError>
             </FormGroup>
-          </div>
-          <div className="flex row">
+          </FormRow>
+          <FormRow>
             {this.getHostPortFields(portDefinition, index)}
             {this.getProtocolField(portDefinition, index)}
-          </div>
+          </FormRow>
           {this.getLoadBalancedServiceAddressField(portDefinition, index)}
         </FormGroupContainer>
       );
@@ -339,10 +340,10 @@ class NetworkingFormSection extends mixin(StoreMixin) {
 
       if (portDefinition.portMapping) {
         portMappingFields = (
-          <div className="flex row">
+          <FormRow>
             {this.getHostPortFields(portDefinition, index)}
             {this.getProtocolField(portDefinition, index)}
-          </div>
+          </FormRow>
         );
       }
 
@@ -359,7 +360,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
             this,
             {value: index, path: 'portDefinitions'}
           )}>
-          <div className="flex row">
+          <FormRow>
             <FormGroup
               className="column-3"
               showError={Boolean(containerPortError)}>
@@ -395,7 +396,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
                   {portMappingLabel}
               </FieldLabel>
             </FormGroup>
-          </div>
+          </FormRow>
           {portMappingFields}
           {this.getLoadBalancedServiceAddressField(portDefinition, index)}
         </FormGroupContainer>
@@ -515,14 +516,14 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     );
 
     return (
-      <div className="form flush-bottom">
+      <div>
         <h2 className="flush-top short-bottom">
           Networking
         </h2>
         <p>
           Configure the networking for your service.
         </p>
-        <div className="flex row">
+        <FormRow>
           <FormGroup className="column-6" showError={Boolean(networkError)}>
             <FieldLabel>
               {'Network Type '}
@@ -538,29 +539,27 @@ class NetworkingFormSection extends mixin(StoreMixin) {
             {this.getTypeSelections()}
             <FieldError>{networkError}</FieldError>
           </FormGroup>
-        </div>
-        <h3 className="flush-top short-bottom">
+        </FormRow>
+        <h3 className="short-bottom">
           Service Endpoints
         </h3>
         <p>
           DC/OS can automatically generate a Service Address to connect to each of your load balanced endpoints.
         </p>
         {this.getServiceEndpoints()}
-        <div>
-          <button
-            type="button"
-            onBlur={(event) => { event.stopPropagation(); }}
-            className="button button-primary-link button-flush"
-            onClick={this.props.onAddItem.bind(
-              this,
-              {
-                value: portDefinitions.length,
-                path: 'portDefinitions'
-              }
-            )}>
-            <Icon color="purple" id="plus" size="tiny" /> Add Service Endpoint
-          </button>
-        </div>
+        <button
+          type="button"
+          onBlur={(event) => { event.stopPropagation(); }}
+          className="button button-primary-link button-flush"
+          onClick={this.props.onAddItem.bind(
+            this,
+            {
+              value: portDefinitions.length,
+              path: 'portDefinitions'
+            }
+          )}>
+          <Icon color="purple" id="plus" size="tiny" /> Add Service Endpoint
+        </button>
       </div>
     );
   }
@@ -594,3 +593,4 @@ NetworkingFormSection.configReducers = {
 };
 
 module.exports = NetworkingFormSection;
+

--- a/plugins/services/src/js/components/forms/VolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/VolumesFormSection.js
@@ -10,6 +10,7 @@ import {FormReducer as localVolumes} from '../../reducers/serviceForm/LocalVolum
 import {FormReducer as externalVolumes} from '../../reducers/serviceForm/ExternalVolumes';
 import FormGroupContainer from '../../../../../../src/js/components/form/FormGroupContainer';
 import FormRow from '../../../../../../src/js/components/form/FormRow';
+import Icon from '../../../../../../src/js/components/Icon';
 
 const errorsLens = Objektiv.attr('container', {}).attr('volumes', []);
 
@@ -228,7 +229,7 @@ class VolumesFormSection extends Component {
           <a
             className="button button-primary-link button-flush"
             onClick={this.props.onAddItem.bind(this, {value: data.localVolumes.length, path: 'localVolumes'})}>
-            + Add Local Volumes
+            <Icon color="purple" id="plus" size="tiny" /> Add Local Volumes
           </a>
         </div>
         <h2 className="short-bottom">
@@ -238,13 +239,15 @@ class VolumesFormSection extends Component {
           Set up volumes variables for each task your service launches.
         </p>
         {this.getExternalVolumesLines(data.externalVolumes, data.localVolumes.length)}
-        <div>
-          <a
-            className="button button-primary-link button-flush"
-            onClick={this.props.onAddItem.bind(this, {value: data.localVolumes.length, path: 'externalVolumes'})}>
-            + Add External Volumes
-          </a>
-        </div>
+        <FormRow>
+          <FormGroup className="column-12">
+            <a
+              className="button button-primary-link button-flush"
+              onClick={this.props.onAddItem.bind(this, {value: data.localVolumes.length, path: 'externalVolumes'})}>
+              <Icon color="purple" id="plus" size="tiny" /> Add External Volumes
+            </a>
+          </FormGroup>
+        </FormRow>
       </div>
     );
   }

--- a/plugins/services/src/js/components/forms/VolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/VolumesFormSection.js
@@ -9,6 +9,7 @@ import FormGroup from '../../../../../../src/js/components/form/FormGroup';
 import {FormReducer as localVolumes} from '../../reducers/serviceForm/LocalVolumes';
 import {FormReducer as externalVolumes} from '../../reducers/serviceForm/ExternalVolumes';
 import FormGroupContainer from '../../../../../../src/js/components/form/FormGroupContainer';
+import FormRow from '../../../../../../src/js/components/form/FormRow';
 
 const errorsLens = Objektiv.attr('container', {}).attr('volumes', []);
 
@@ -30,7 +31,7 @@ class VolumesFormSection extends Component {
       .containerPath;
 
     return (
-      <div className="flex row">
+      <FormRow>
         <FormGroup
           className="column-3"
           required={false}
@@ -53,7 +54,7 @@ class VolumesFormSection extends Component {
             value={volume.containerPath}/>
           <FieldError>{containerPathError}</FieldError>
         </FormGroup>
-      </div>
+      </FormRow>
     );
   }
 
@@ -68,7 +69,7 @@ class VolumesFormSection extends Component {
     const modeError = errors.mode;
 
     return (
-      <div className="flex row">
+      <FormRow>
         <FormGroup
           className="column-4"
           required={false}
@@ -100,7 +101,7 @@ class VolumesFormSection extends Component {
             <option value="RO">READ ONLY</option>
           </FieldSelect>
         </FormGroup>
-      </div>
+      </FormRow>
     );
   }
 
@@ -135,7 +136,7 @@ class VolumesFormSection extends Component {
             this,
             {value: key, path: 'localVolumes'}
           )}>
-          <div className="flex row">
+          <FormRow>
             <FormGroup
               className="column-6"
               required={false}
@@ -147,7 +148,7 @@ class VolumesFormSection extends Component {
                 {this.getHostOption(dockerImage)}
               </FieldSelect>
             </FormGroup>
-          </div>
+          </FormRow>
           {this.getPersistentVolumeConfig(volume, key)}
           {this.getHostVolumeConfig(volume, key)}
         </FormGroupContainer>
@@ -182,7 +183,7 @@ class VolumesFormSection extends Component {
             this,
             {value: key, path: 'externalVolumes'}
           )}>
-          <div className="flex row">
+          <FormRow>
             <FormGroup
               className="column-6"
               required={false}
@@ -205,7 +206,7 @@ class VolumesFormSection extends Component {
                 value={volumes.containerPath}/>
               <FieldError>{containerPathError}</FieldError>
             </FormGroup>
-          </div>
+          </FormRow>
         </FormGroupContainer>
       );
     });
@@ -215,7 +216,7 @@ class VolumesFormSection extends Component {
     let {data} = this.props;
 
     return (
-      <div className="form flush-bottom">
+      <div>
         <h2 className="flush-top short-bottom">
           Local Volumes Variables
         </h2>
@@ -230,7 +231,7 @@ class VolumesFormSection extends Component {
             + Add Local Volumes
           </a>
         </div>
-        <h2 className="flush-top short-bottom">
+        <h2 className="short-bottom">
           External Volumes Variables
         </h2>
         <p>

--- a/src/js/components/form/FormRow.js
+++ b/src/js/components/form/FormRow.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const FormRow = ({children}) => {
+  return (
+    <div className="form-row row">
+      {children}
+    </div>
+  );
+};
+
+module.exports = FormRow;

--- a/src/js/components/form/index.js
+++ b/src/js/components/form/index.js
@@ -10,6 +10,7 @@ import FieldSelect from './FieldSelect';
 import FieldTextarea from './FieldTextarea';
 import FormGroup from './FormGroup';
 import FormGroupContainer from './FormGroupContainer';
+import FormRow from './FormRow';
 
 module.exports = {
   AdvancedSection,
@@ -23,5 +24,6 @@ module.exports = {
   FieldSelect,
   FieldTextarea,
   FormGroup,
-  FormGroupContainer
+  FormGroupContainer,
+  FormRow
 };

--- a/src/styles/components/advanced-section/styles.less
+++ b/src/styles/components/advanced-section/styles.less
@@ -1,9 +1,10 @@
 & when (@advanced-section-enabled) {
 
   .advanced-section {
+    margin-top: @advanced-section-margin-top;
 
     &-content {
-      margin-top: @pod-margin-top;
+      margin-top: @advanced-section-content-margin-top;
     }
 
     &-label {
@@ -11,10 +12,10 @@
       &,
       &:hover {
         text-decoration: none;
+      }
 
-        .icon {
-          margin-right: @base-spacing-unit * 1/4;
-        }
+      .icon {
+        margin-right: @advanced-section-icon-margin-right;
       }
     }
   }
@@ -25,19 +26,16 @@
   @media (min-width: @layout-screen-small-min-width) {
 
     .advanced-section {
+      margin-top: @advanced-section-margin-top-screen-small;
 
       &-content {
-        margin-top: @pod-margin-top-screen-small;
+        margin-top: @advanced-section-content-margin-top-screen-small;
       }
 
       &-label {
 
-        &,
-        &:hover {
-
-          .icon {
-            margin-right: @base-spacing-unit-screen-small * 1/4;
-          }
+        .icon {
+          margin-right: @advanced-section-icon-margin-right-screen-small;
         }
       }
     }
@@ -49,19 +47,16 @@
   @media (min-width: @layout-screen-medium-min-width) {
 
     .advanced-section {
+      margin-top: @advanced-section-margin-top-screen-medium;
 
       &-content {
-        margin-top: @pod-margin-top-screen-medium;
+        margin-top: @advanced-section-content-margin-top-screen-medium;
       }
 
       &-label {
 
-        &,
-        &:hover {
-
-          .icon {
-            margin-right: @base-spacing-unit-screen-medium * 1/4;
-          }
+        .icon {
+          margin-right: @advanced-section-icon-margin-right-screen-medium;
         }
       }
     }
@@ -73,19 +68,16 @@
   @media (min-width: @layout-screen-large-min-width) {
 
     .advanced-section {
+      margin-top: @advanced-section-margin-top-screen-large;
 
       &-content {
-        margin-top: @pod-margin-top-screen-large;
+        margin-top: @advanced-section-content-margin-top-screen-large;
       }
 
       &-label {
 
-        &,
-        &:hover {
-
-          .icon {
-            margin-right: @base-spacing-unit-screen-large * 1/4;
-          }
+        .icon {
+          margin-right: @advanced-section-icon-margin-right-screen-large;
         }
       }
     }
@@ -97,19 +89,16 @@
   @media (min-width: @layout-screen-jumbo-min-width) {
 
     .advanced-section {
+      margin-top: @advanced-section-margin-top-screen-jumbo;
 
       &-content {
-        margin-top: @pod-margin-top-screen-jumbo;
+        margin-top: @advanced-section-content-margin-top-screen-jumbo;
       }
 
       &-label {
 
-        &,
-        &:hover {
-
-          .icon {
-            margin-right: @base-spacing-unit-screen-jumbo * 1/4;
-          }
+        .icon {
+          margin-right: @advanced-section-icon-margin-right-screen-jumbo;
         }
       }
     }

--- a/src/styles/components/advanced-section/variables.less
+++ b/src/styles/components/advanced-section/variables.less
@@ -1,1 +1,19 @@
 @advanced-section-enabled: true;
+
+@advanced-section-margin-top: @base-spacing-unit * 3/4;
+@advanced-section-margin-top-screen-small: @base-spacing-unit-screen-small * 3/4;
+@advanced-section-margin-top-screen-medium: @base-spacing-unit-screen-medium * 3/4;
+@advanced-section-margin-top-screen-large: @base-spacing-unit-screen-large * 3/4;
+@advanced-section-margin-top-screen-jumbo: @base-spacing-unit-screen-jumbo * 3/4;
+
+@advanced-section-icon-margin-right: @base-spacing-unit * 1/4;
+@advanced-section-icon-margin-right-screen-small: @base-spacing-unit-screen-small * 1/4;
+@advanced-section-icon-margin-right-screen-medium: @base-spacing-unit-screen-medium * 1/4;
+@advanced-section-icon-margin-right-screen-large: @base-spacing-unit-screen-large * 1/4;
+@advanced-section-icon-margin-right-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/4;
+
+@advanced-section-content-margin-top: @pod-margin-top * @pod-short-margin-top-scale;
+@advanced-section-content-margin-top-screen-small: @pod-margin-top-screen-small * @pod-short-margin-top-scale;
+@advanced-section-content-margin-top-screen-medium: @pod-margin-top-screen-medium * @pod-short-margin-top-scale;
+@advanced-section-content-margin-top-screen-large: @pod-margin-top-screen-large * @pod-short-margin-top-scale;
+@advanced-section-content-margin-top-screen-jumbo: @pod-margin-top-screen-jumbo * @pod-short-margin-top-scale;

--- a/src/styles/components/form-elements/form-group/styles.less
+++ b/src/styles/components/form-elements/form-group/styles.less
@@ -1,0 +1,13 @@
+& when (@form-group-enabled) {
+
+  .form-group {
+
+    label,
+    .label {
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+}

--- a/src/styles/components/form-elements/form-group/variables.less
+++ b/src/styles/components/form-elements/form-group/variables.less
@@ -1,0 +1,1 @@
+@form-group-enabled: true;

--- a/src/styles/components/form-elements/form-row/styles.less
+++ b/src/styles/components/form-elements/form-row/styles.less
@@ -5,14 +5,6 @@
   .form-row {
     display: flex;
     margin-bottom: @form-row-margin-bottom;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-
-    .form-group {
-      margin-bottom: 0;
-    }
   }
 }
 

--- a/src/styles/components/form-elements/form-row/styles.less
+++ b/src/styles/components/form-elements/form-row/styles.less
@@ -5,6 +5,14 @@
   .form-row {
     display: flex;
     margin-bottom: @form-row-margin-bottom;
+
+    & + .form-row {
+      margin-top: @form-row-margin-top;
+    }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 }
 
@@ -14,6 +22,10 @@
 
     .form-row {
       margin-bottom: @form-row-margin-bottom-screen-small;
+
+      & + .form-row {
+        margin-top: @form-row-margin-top-screen-small;
+      }
     }
   }
 }
@@ -24,6 +36,10 @@
 
     .form-row {
       margin-bottom: @form-row-margin-bottom-screen-medium;
+
+      & + .form-row {
+        margin-top: @form-row-margin-top-screen-medium;
+      }
     }
   }
 }
@@ -34,6 +50,10 @@
 
     .form-row {
       margin-bottom: @form-row-margin-bottom-screen-large;
+
+      & + .form-row {
+        margin-top: @form-row-margin-top-screen-large;
+      }
     }
   }
 }
@@ -44,6 +64,10 @@
 
     .form-row {
       margin-bottom: @form-row-margin-bottom-screen-jumbo;
+
+      & + .form-row {
+        margin-top: @form-row-margin-top-screen-jumbo;
+      }
     }
   }
 }

--- a/src/styles/components/form-elements/form-row/styles.less
+++ b/src/styles/components/form-elements/form-row/styles.less
@@ -1,0 +1,57 @@
+& when (@form-row-enabled) {
+
+  // When .form-row is used, we remove the margins from .form-group and apply
+  // them to the row itself.
+  .form-row {
+    display: flex;
+    margin-bottom: @form-row-margin-bottom;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    .form-group {
+      margin-bottom: 0;
+    }
+  }
+}
+
+& when (@form-row-enabled) and (@layout-screen-small-enabled) {
+
+  @media (min-width: @layout-screen-small-min-width) {
+
+    .form-row {
+      margin-bottom: @form-row-margin-bottom-screen-small;
+    }
+  }
+}
+
+& when (@form-row-enabled) and (@layout-screen-medium-enabled) {
+
+  @media (min-width: @layout-screen-medium-min-width) {
+
+    .form-row {
+      margin-bottom: @form-row-margin-bottom-screen-medium;
+    }
+  }
+}
+
+& when (@form-row-enabled) and (@layout-screen-large-enabled) {
+
+  @media (min-width: @layout-screen-large-min-width) {
+
+    .form-row {
+      margin-bottom: @form-row-margin-bottom-screen-large;
+    }
+  }
+}
+
+& when (@form-row-enabled) and (@layout-screen-jumbo-enabled) {
+
+  @media (min-width: @layout-screen-jumbo-min-width) {
+
+    .form-row {
+      margin-bottom: @form-row-margin-bottom-screen-jumbo;
+    }
+  }
+}

--- a/src/styles/components/form-elements/form-row/variables.less
+++ b/src/styles/components/form-elements/form-row/variables.less
@@ -1,7 +1,7 @@
 @form-row-enabled: true;
 
-@form-row-margin-bottom: @form-group-margin-bottom;
-@form-row-margin-bottom-screen-small: @form-group-margin-bottom-screen-small;
-@form-row-margin-bottom-screen-medium: @form-group-margin-bottom-screen-medium;
-@form-row-margin-bottom-screen-large: @form-group-margin-bottom-screen-large;
-@form-row-margin-bottom-screen-jumbo: @form-group-margin-bottom-screen-jumbo;
+@form-row-margin-bottom: @form-group-margin-bottom * -1;
+@form-row-margin-bottom-screen-small: @form-group-margin-bottom-screen-small * -1;
+@form-row-margin-bottom-screen-medium: @form-group-margin-bottom-screen-medium * -1;
+@form-row-margin-bottom-screen-large: @form-group-margin-bottom-screen-large * -1;
+@form-row-margin-bottom-screen-jumbo: @form-group-margin-bottom-screen-jumbo * -1;

--- a/src/styles/components/form-elements/form-row/variables.less
+++ b/src/styles/components/form-elements/form-row/variables.less
@@ -1,0 +1,7 @@
+@form-row-enabled: true;
+
+@form-row-margin-bottom: @form-group-margin-bottom;
+@form-row-margin-bottom-screen-small: @form-group-margin-bottom-screen-small;
+@form-row-margin-bottom-screen-medium: @form-group-margin-bottom-screen-medium;
+@form-row-margin-bottom-screen-large: @form-group-margin-bottom-screen-large;
+@form-row-margin-bottom-screen-jumbo: @form-group-margin-bottom-screen-jumbo;

--- a/src/styles/components/form-elements/form-row/variables.less
+++ b/src/styles/components/form-elements/form-row/variables.less
@@ -5,3 +5,9 @@
 @form-row-margin-bottom-screen-medium: @form-group-margin-bottom-screen-medium * -1;
 @form-row-margin-bottom-screen-large: @form-group-margin-bottom-screen-large * -1;
 @form-row-margin-bottom-screen-jumbo: @form-group-margin-bottom-screen-jumbo * -1;
+
+@form-row-margin-top: @form-group-margin-bottom;
+@form-row-margin-top-screen-small: @form-group-margin-bottom-screen-small;
+@form-row-margin-top-screen-medium: @form-group-margin-bottom-screen-medium;
+@form-row-margin-top-screen-large: @form-group-margin-bottom-screen-large;
+@form-row-margin-top-screen-jumbo: @form-group-margin-bottom-screen-jumbo;

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -247,6 +247,16 @@
 @import 'components/form-elements/variables.less';
 @import 'components/form-elements/styles.less';
 
+// Form Elements: Form Group
+
+@import 'components/form-elements/form-group/variables.less';
+@import 'components/form-elements/form-group/styles.less';
+
+// Form Elements: Form Row
+
+@import 'components/form-elements/form-row/variables.less';
+@import 'components/form-elements/form-row/styles.less';
+
 // Icons
 
 @import 'components/icons/variables.less';


### PR DESCRIPTION
This PR aims to improve the consistency of the spacing in the service creation modal. Originally I intended to create a `FormSection` component, but it is @ashenden's intentions for the margin on headings in the form to create the desired visual spacing.

I created a `FormRow` component which should be used to wrap `FormGroup` elements. Doing so will apply a negative bottom margin on the `FormRow` element to offset the margins applied by `FormGroup` children. This means that `FormRow` must always contain `FormGroup` elements.

The structure of all form sections should be as follows (of course with any number of `FormRow` or `FormGroup` elements):

```jsx
/* Notice the .flush-top on the first heading. */
<h2 className="short-bottom flush-top">Top-level Heading</h2>
<FormRow>
  <FormGroup />
</FormRow>
/* Subsequent headings require the margin from the heading's style. */
<h3 className="short-bottom">Sub-heading of first section</h3>
<FormRow>
  <FormGroup />
</FormRow>
<h2 className="short-bottom">Top-level Heading</h2>
<FormRow>
  <FormGroup />
</FormRow>
```

It might be worth introducing a `FormSectionHeading` component to apply the proper classes for us, but we would still need to provide some configuration options, so I'm not sure how useful it would be.