### PR TITLE
DCOS-12274: Show rejected offers warning in service breadcrumb

### DIFF
--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -4,6 +4,7 @@ import {Link} from 'react-router';
 import {DCOSStore} from 'foundation-ui';
 import HealthBar from './HealthBar';
 import PageHeaderBreadcrumbs from '../../../../../src/js/components/NewPageHeaderBreadcrumbs';
+import ServiceStatusWarning from './ServiceStatusWarning';
 
 function getHealthStatus(serviceID) {
   if (serviceID == null) {
@@ -25,6 +26,7 @@ function getHealthStatus(serviceID) {
   return (
     <div className="service-page-header-status page-header-breadcrumb-content-secondary muted">
       {`${serviceStatus} (${runningTasksCount} of ${instancesCount})`}
+      <ServiceStatusWarning item={service} showDebugInstruction={true} />
       <HealthBar isDeploying={isDeploying}
         tasksSummary={tasksSummary}
         instancesCount={instancesCount}/>

--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -4,7 +4,7 @@ import {Link} from 'react-router';
 import {DCOSStore} from 'foundation-ui';
 import HealthBar from './HealthBar';
 import PageHeaderBreadcrumbs from '../../../../../src/js/components/NewPageHeaderBreadcrumbs';
-import ServiceStatusWarning from './ServiceStatusWarning';
+import ServiceStatusWarningWithDebugInformation from './ServiceStatusWarningWithDebugInstruction';
 
 function getHealthStatus(serviceID) {
   if (serviceID == null) {
@@ -26,7 +26,7 @@ function getHealthStatus(serviceID) {
   return (
     <div className="service-page-header-status page-header-breadcrumb-content-secondary muted">
       {`${serviceStatus} (${runningTasksCount} of ${instancesCount})`}
-      <ServiceStatusWarning item={service} showDebugInstruction={true} />
+      <ServiceStatusWarningWithDebugInformation item={service} />
       <HealthBar isDeploying={isDeploying}
         tasksSummary={tasksSummary}
         instancesCount={instancesCount}/>

--- a/plugins/services/src/js/components/ServiceStatusWarning.js
+++ b/plugins/services/src/js/components/ServiceStatusWarning.js
@@ -18,7 +18,7 @@ const getTooltipContent = (timeWaiting, showDebugInstruction) => {
 };
 
 const ServiceStatusWarning = ({item, showDebugInstruction}) => {
-  queue = item.getQueue();
+  const queue = item.getQueue();
 
   if (queue != null) {
     const waitingSince = DateUtil.strToMs(queue.since);

--- a/plugins/services/src/js/components/ServiceStatusWarning.js
+++ b/plugins/services/src/js/components/ServiceStatusWarning.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import {Tooltip} from 'reactjs-components';
+
+import DateUtil from '../../../../../src/js/utils/DateUtil';
+import Icon from '../../../../../src/js/components/Icon';
+import Pod from '../structs/Pod';
+import Service from '../structs/Service';
+import ServiceTree from '../structs/ServiceTree';
+
+const getTooltipContent = (timeWaiting, showDebugInstruction) => {
+  const additionalCopy = showDebugInstruction
+    ? ' See more information in the debug tab.'
+    : '';
+
+  return `DC/OS has been waiting for resources and unable to complete this deployment for ${DateUtil.getDuration(timeWaiting, null)}.${additionalCopy}`;
+};
+
+const ServiceStatusWarning = ({item, showDebugInstruction}) => {
+  queue = item.getQueue();
+
+  if (queue != null) {
+    const waitingSince = DateUtil.strToMs(queue.since);
+    const timeWaiting = Date.now() - waitingSince;
+
+    // If the item has been waiting for less than five minutes, we don't
+    // display the warning.
+    if (timeWaiting >= 1000 * 60 * 5) {
+      return (
+        <Tooltip
+          content={getTooltipContent(timeWaiting, showDebugInstruction)}
+          width={250}
+          wrapText={true}
+          wrapperClassName="tooltip-wrapper status-waiting-indicator">
+          <Icon color="red" id="yield" size="mini" />
+        </Tooltip>
+      );
+    }
+  }
+
+  return <noscript />;
+};
+
+ServiceStatusWarning.defaultProps = {
+  showDebugInstruction: false
+};
+
+ServiceStatusWarning.propTypes = {
+  item: React.PropTypes.oneOfType([
+    React.PropTypes.instanceOf(Service),
+    React.PropTypes.instanceOf(ServiceTree),
+    React.PropTypes.instanceOf(Pod)
+  ]),
+  showDebugInstruction: React.PropTypes.bool
+};
+
+module.exports = ServiceStatusWarning;

--- a/plugins/services/src/js/components/ServiceStatusWarning.js
+++ b/plugins/services/src/js/components/ServiceStatusWarning.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Component} from 'react';
 import {Tooltip} from 'reactjs-components';
 
 import DateUtil from '../../../../../src/js/utils/DateUtil';
@@ -8,30 +8,32 @@ import Pod from '../structs/Pod';
 import Service from '../structs/Service';
 import ServiceTree from '../structs/ServiceTree';
 
-const getTooltipContent = (timeWaiting) => {
-  return `DC/OS has been waiting for resources and unable to complete this deployment for ${DateUtil.getDuration(timeWaiting, null)}.`;
-};
-
-const ServiceStatusWarning = ({item}) => {
-  const queue = item.getQueue();
-
-  if (queue != null
-    && DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(queue)) {
-    const waitingSince = DateUtil.strToMs(queue.since);
-    const timeWaiting = Date.now() - waitingSince;
-
-    return (
-      <Tooltip
-        content={getTooltipContent(timeWaiting)}
-        width={250}
-        wrapText={true}
-        wrapperClassName="tooltip-wrapper status-waiting-indicator">
-        <Icon color="red" id="yield" size="mini" />
-      </Tooltip>
-    );
+class ServiceStatusWarning extends Component {
+  getTooltipContent(timeWaiting) {
+    return `DC/OS has been waiting for resources and unable to complete this deployment for ${DateUtil.getDuration(timeWaiting, null)}.`;
   }
+  render() {
+    const {item} = this.props;
+    const queue = item.getQueue();
 
-  return <noscript />;
+    if (queue != null
+      && DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(queue)) {
+      const waitingSince = DateUtil.strToMs(queue.since);
+      const timeWaiting = Date.now() - waitingSince;
+
+      return (
+        <Tooltip
+          content={this.getTooltipContent(timeWaiting)}
+          width={250}
+          wrapText={true}
+          wrapperClassName="tooltip-wrapper status-waiting-indicator">
+          <Icon color="red" id="yield" size="mini" />
+        </Tooltip>
+      );
+    }
+
+    return <noscript />;
+  }
 };
 
 ServiceStatusWarning.propTypes = {

--- a/plugins/services/src/js/components/ServiceStatusWarning.js
+++ b/plugins/services/src/js/components/ServiceStatusWarning.js
@@ -2,12 +2,11 @@ import React from 'react';
 import {Tooltip} from 'reactjs-components';
 
 import DateUtil from '../../../../../src/js/utils/DateUtil';
+import DeclinedOffersUtil from '../utils/DeclinedOffersUtil';
 import Icon from '../../../../../src/js/components/Icon';
 import Pod from '../structs/Pod';
 import Service from '../structs/Service';
 import ServiceTree from '../structs/ServiceTree';
-
-const DEPLOYMENT_WARNING_DELAY_MS = 1000 * 60 * 5;
 
 const getTooltipContent = (timeWaiting, showDebugInstruction) => {
   const additionalCopy = showDebugInstruction
@@ -20,23 +19,20 @@ const getTooltipContent = (timeWaiting, showDebugInstruction) => {
 const ServiceStatusWarning = ({item, showDebugInstruction}) => {
   const queue = item.getQueue();
 
-  if (queue != null) {
+  if (queue != null
+    && DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(queue)) {
     const waitingSince = DateUtil.strToMs(queue.since);
     const timeWaiting = Date.now() - waitingSince;
 
-    // If the item has been waiting for less than five minutes, we don't
-    // display the warning.
-    if (timeWaiting >= DEPLOYMENT_WARNING_DELAY_MS) {
-      return (
-        <Tooltip
-          content={getTooltipContent(timeWaiting, showDebugInstruction)}
-          width={250}
-          wrapText={true}
-          wrapperClassName="tooltip-wrapper status-waiting-indicator">
-          <Icon color="red" id="yield" size="mini" />
-        </Tooltip>
-      );
-    }
+    return (
+      <Tooltip
+        content={getTooltipContent(timeWaiting, showDebugInstruction)}
+        width={250}
+        wrapText={true}
+        wrapperClassName="tooltip-wrapper status-waiting-indicator">
+        <Icon color="red" id="yield" size="mini" />
+      </Tooltip>
+    );
   }
 
   return <noscript />;

--- a/plugins/services/src/js/components/ServiceStatusWarning.js
+++ b/plugins/services/src/js/components/ServiceStatusWarning.js
@@ -7,6 +7,8 @@ import Pod from '../structs/Pod';
 import Service from '../structs/Service';
 import ServiceTree from '../structs/ServiceTree';
 
+const DEPLOYMENT_WARNING_DELAY_MS = 1000 * 60 * 5;
+
 const getTooltipContent = (timeWaiting, showDebugInstruction) => {
   const additionalCopy = showDebugInstruction
     ? ' See more information in the debug tab.'
@@ -24,7 +26,7 @@ const ServiceStatusWarning = ({item, showDebugInstruction}) => {
 
     // If the item has been waiting for less than five minutes, we don't
     // display the warning.
-    if (timeWaiting >= 1000 * 60 * 5) {
+    if (timeWaiting >= DEPLOYMENT_WARNING_DELAY_MS) {
       return (
         <Tooltip
           content={getTooltipContent(timeWaiting, showDebugInstruction)}

--- a/plugins/services/src/js/components/ServiceStatusWarning.js
+++ b/plugins/services/src/js/components/ServiceStatusWarning.js
@@ -8,15 +8,11 @@ import Pod from '../structs/Pod';
 import Service from '../structs/Service';
 import ServiceTree from '../structs/ServiceTree';
 
-const getTooltipContent = (timeWaiting, showDebugInstruction) => {
-  const additionalCopy = showDebugInstruction
-    ? ' See more information in the debug tab.'
-    : '';
-
-  return `DC/OS has been waiting for resources and unable to complete this deployment for ${DateUtil.getDuration(timeWaiting, null)}.${additionalCopy}`;
+const getTooltipContent = (timeWaiting) => {
+  return `DC/OS has been waiting for resources and unable to complete this deployment for ${DateUtil.getDuration(timeWaiting, null)}.`;
 };
 
-const ServiceStatusWarning = ({item, showDebugInstruction}) => {
+const ServiceStatusWarning = ({item}) => {
   const queue = item.getQueue();
 
   if (queue != null
@@ -26,7 +22,7 @@ const ServiceStatusWarning = ({item, showDebugInstruction}) => {
 
     return (
       <Tooltip
-        content={getTooltipContent(timeWaiting, showDebugInstruction)}
+        content={getTooltipContent(timeWaiting)}
         width={250}
         wrapText={true}
         wrapperClassName="tooltip-wrapper status-waiting-indicator">
@@ -38,17 +34,12 @@ const ServiceStatusWarning = ({item, showDebugInstruction}) => {
   return <noscript />;
 };
 
-ServiceStatusWarning.defaultProps = {
-  showDebugInstruction: false
-};
-
 ServiceStatusWarning.propTypes = {
   item: React.PropTypes.oneOfType([
     React.PropTypes.instanceOf(Service),
     React.PropTypes.instanceOf(ServiceTree),
     React.PropTypes.instanceOf(Pod)
-  ]),
-  showDebugInstruction: React.PropTypes.bool
+  ])
 };
 
 module.exports = ServiceStatusWarning;

--- a/plugins/services/src/js/components/ServiceStatusWarningWithDebugInstruction.js
+++ b/plugins/services/src/js/components/ServiceStatusWarningWithDebugInstruction.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import {Tooltip} from 'reactjs-components';
+
+import DateUtil from '../../../../../src/js/utils/DateUtil';
+import DeclinedOffersUtil from '../utils/DeclinedOffersUtil';
+import Icon from '../../../../../src/js/components/Icon';
+import Pod from '../structs/Pod';
+import Service from '../structs/Service';
+import ServiceTree from '../structs/ServiceTree';
+
+const getTooltipContent = (timeWaiting) => {
+  const additionalCopy = ' See more information in the debug tab.';
+
+  return `DC/OS has been waiting for resources and unable to complete this deployment for ${DateUtil.getDuration(timeWaiting, null)}.${additionalCopy}`;
+};
+
+const ServiceStatusWarningWithDebugInstruction = ({item}) => {
+  const queue = item.getQueue();
+
+  if (queue != null
+    && DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(queue)) {
+    const waitingSince = DateUtil.strToMs(queue.since);
+    const timeWaiting = Date.now() - waitingSince;
+
+    return (
+      <Tooltip
+        content={getTooltipContent(timeWaiting)}
+        width={250}
+        wrapText={true}
+        wrapperClassName="tooltip-wrapper status-waiting-indicator">
+        <Icon color="red" id="yield" size="mini" />
+      </Tooltip>
+    );
+  }
+
+  return <noscript />;
+};
+
+ServiceStatusWarningWithDebugInstruction.propTypes = {
+  item: React.PropTypes.oneOfType([
+    React.PropTypes.instanceOf(Service),
+    React.PropTypes.instanceOf(ServiceTree),
+    React.PropTypes.instanceOf(Pod)
+  ])
+};
+
+module.exports = ServiceStatusWarningWithDebugInstruction;

--- a/plugins/services/src/js/components/ServiceStatusWarningWithDebugInstruction.js
+++ b/plugins/services/src/js/components/ServiceStatusWarningWithDebugInstruction.js
@@ -1,47 +1,12 @@
-import React from 'react';
-import {Tooltip} from 'reactjs-components';
-
 import DateUtil from '../../../../../src/js/utils/DateUtil';
-import DeclinedOffersUtil from '../utils/DeclinedOffersUtil';
-import Icon from '../../../../../src/js/components/Icon';
-import Pod from '../structs/Pod';
-import Service from '../structs/Service';
-import ServiceTree from '../structs/ServiceTree';
+import ServiceStatusWarning from './ServiceStatusWarning';
 
-const getTooltipContent = (timeWaiting) => {
-  const additionalCopy = ' See more information in the debug tab.';
+class ServiceStatusWarningWithDebugInstruction extends ServiceStatusWarning {
+  getTooltipContent(timeWaiting) {
+    const additionalCopy = ' See more information in the debug tab.';
 
-  return `DC/OS has been waiting for resources and unable to complete this deployment for ${DateUtil.getDuration(timeWaiting, null)}.${additionalCopy}`;
-};
-
-const ServiceStatusWarningWithDebugInstruction = ({item}) => {
-  const queue = item.getQueue();
-
-  if (queue != null
-    && DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(queue)) {
-    const waitingSince = DateUtil.strToMs(queue.since);
-    const timeWaiting = Date.now() - waitingSince;
-
-    return (
-      <Tooltip
-        content={getTooltipContent(timeWaiting)}
-        width={250}
-        wrapText={true}
-        wrapperClassName="tooltip-wrapper status-waiting-indicator">
-        <Icon color="red" id="yield" size="mini" />
-      </Tooltip>
-    );
+    return `DC/OS has been waiting for resources and unable to complete this deployment for ${DateUtil.getDuration(timeWaiting, null)}.${additionalCopy}`;
   }
-
-  return <noscript />;
-};
-
-ServiceStatusWarningWithDebugInstruction.propTypes = {
-  item: React.PropTypes.oneOfType([
-    React.PropTypes.instanceOf(Service),
-    React.PropTypes.instanceOf(ServiceTree),
-    React.PropTypes.instanceOf(Pod)
-  ])
-};
+}
 
 module.exports = ServiceStatusWarningWithDebugInstruction;

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -1,10 +1,9 @@
 import classNames from 'classnames';
-import {Dropdown, Table, Tooltip} from 'reactjs-components';
+import {Dropdown, Table} from 'reactjs-components';
 import {Link} from 'react-router';
 import React, {PropTypes} from 'react';
 import {ResourceTableUtil} from 'foundation-ui';
 
-import DateUtil from '../../../../../../src/js/utils/DateUtil';
 import Framework from '../../structs/Framework';
 import HealthBar from '../../components/HealthBar';
 import Links from '../../../../../../src/js/constants/Links';
@@ -13,6 +12,7 @@ import NestedServiceLinks from '../../../../../../src/js/components/NestedServic
 import Pod from '../../structs/Pod';
 import Service from '../../structs/Service';
 import ServiceActionItem from '../../constants/ServiceActionItem';
+import ServiceStatusWarning from '../../components/ServiceStatusWarning';
 import ServiceTableHeaderLabels from '../../constants/ServiceTableHeaderLabels';
 import ServiceTableUtil from '../../utils/ServiceTableUtil';
 import ServiceTree from '../../structs/ServiceTree';
@@ -222,7 +222,6 @@ class ServicesTable extends React.Component {
     let serviceStatusClassSet = StatusMapping[serviceStatus] || '';
     let tasksSummary = service.getTasksSummary();
     const {tasksRunning} = tasksSummary;
-    let tooltip = null;
 
     let isDeploying = serviceStatus === 'Deploying';
 
@@ -230,26 +229,6 @@ class ServicesTable extends React.Component {
     let verboseOverview = ` (${tasksRunning} ${StringUtil.pluralize('Instance', tasksRunning)})`;
     if (tasksRunning !== instancesCount) {
       verboseOverview = ` (${tasksRunning} of ${instancesCount} Instances)`;
-    }
-
-    const queue = service.getQueue();
-    if (queue != null) {
-      const waitingSince = DateUtil.strToMs(queue.since);
-      const timeWaiting = Date.now() - waitingSince;
-
-      // If the service has been waiting for less than five minutes, we don't
-      // display the warning.
-      if (timeWaiting >= 1000 * 60 * 5) {
-        tooltip = (
-          <Tooltip
-            content={`DC/OS has been waiting for resources and unable to complete this deployment for ${DateUtil.getDuration(timeWaiting, null)}.`}
-            maxWidth={250}
-            wrapText={true}
-            wrapperClassName="tooltip-wrapper status-waiting-indicator">
-            <Icon color="red" id="yield" size="mini" />
-          </Tooltip>
-        );
-      }
     }
 
     return (
@@ -265,7 +244,7 @@ class ServicesTable extends React.Component {
           <span className={serviceStatusClassSet}>{serviceStatus}</span>
           <span className="hidden-large-down">{verboseOverview}</span>
           <span className="hidden-jumbo-up">{conciseOverview}</span>
-          {tooltip}
+          <ServiceStatusWarning item={service} />
         </span>
       </div>
     );

--- a/plugins/services/src/js/utils/DeclinedOffersUtil.js
+++ b/plugins/services/src/js/utils/DeclinedOffersUtil.js
@@ -1,7 +1,9 @@
+import DateUtil from '../../../../../src/js/utils/DateUtil';
 import DeclinedOffersReasons from '../constants/DeclinedOffersReasons';
 import Util from '../../../../../src/js/utils/Util';
 
-const unavailableText = 'N/A';
+const DEPLOYMENT_WARNING_DELAY_MS = 1000 * 60 * 5;
+const UNAVAILABLE_TEXT = 'N/A';
 
 const rangeReducer = (accumulator, range) => {
   accumulator.push(`${range.begin} – ${range.end}`);
@@ -24,7 +26,7 @@ const constraintsReducer = (accumulator, constraint) => {
   }
 
   if (!value) {
-    value = unavailableText;
+    value = UNAVAILABLE_TEXT;
   }
 
   accumulator.push(`${name}:${value}`);
@@ -129,14 +131,14 @@ const DecinedOffersUtil = {
 
     return {
       roles: {
-        requested: requestedResources.roles.join(', ') || unavailableText,
+        requested: requestedResources.roles.join(', ') || UNAVAILABLE_TEXT,
         offers: roleOfferSummary.processed,
         matched: roleOfferSummary.processed - roleOfferSummary.declined
       },
       constraints: {
         requested: requestedResources.constraints.map((constraint = []) => {
           return constraint.join(':');
-        }).join(', ') || unavailableText,
+        }).join(', ') || UNAVAILABLE_TEXT,
         offers: constraintOfferSummary.processed,
         matched: constraintOfferSummary.processed
           - constraintOfferSummary.declined
@@ -159,7 +161,7 @@ const DecinedOffersUtil = {
       ports: {
         requested: requestedResources.ports.map((resourceArr = []) => {
           return resourceArr.join(', ');
-        }).join(', ') || unavailableText,
+        }).join(', ') || UNAVAILABLE_TEXT,
         offers: portOfferSummary.processed,
         matched: portOfferSummary.processed - portOfferSummary.declined
       }
@@ -210,6 +212,15 @@ const DecinedOffersUtil = {
         })
       };
     });
+  },
+
+  shouldDisplayDeclinedOffersWarning(queue) {
+    if (queue == null) {
+      return false;
+    }
+
+    return Date.now() - DateUtil.strToMs(queue.since)
+      >= DEPLOYMENT_WARNING_DELAY_MS;
   }
 };
 


### PR DESCRIPTION
This PR displays the rejected offers warning icon & tooltip in the service breadcrumb and moves the corresponding code to a separate component.

![](https://cl.ly/360n420u0A45/Screen%20Shot%202016-12-14%20at%204.37.56%20PM.png)