### PR TITLE
Adjust the pre-commit task order

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -8,26 +8,28 @@ source ${SCRIPT_PATH}/utils/message
 
 title "Run pre-commit hook..."
 
-# Get a list of staged javascript files and only lint and test changed files
+# Get a list of staged JavaScript and Less files
 staged_javascript_files=$(get_staged_files_with_name '*.js');
+staged_less_files=$(get_staged_files_with_name '*.less');
+
+# Lint staged JavaScript and Less files
 if [ -n "${staged_javascript_files}" ]
 then
   header "Lint staged JavaScript files..."
   npm run eslint --silent -- ${staged_javascript_files} || exit $?
   info "Staged JavaScript looks good"
-
-  header "Test staged JavaScript files.."
-  npm run test --silent -- --findRelatedTests \
-    ${staged_javascript_files} || exit $?
 fi
-
-
-
-# Get a list of staged less files and only lint changed files
-staged_less_files=$(get_staged_files_with_name '*.less');
 if [ -n "${staged_less_files}" ]
 then
   header "Lint staged Less files..."
   npm run stylelint --silent -- ${staged_less_files} || exit $?
   info "Staged Less looks good"
+fi
+
+# Test staged JavaScript files
+if [ -n "${staged_javascript_files}" ]
+then
+  header "Test staged JavaScript files.."
+  npm run test --silent -- --findRelatedTests \
+    ${staged_javascript_files} || exit $?
 fi


### PR DESCRIPTION
Change the task order to first lint all files and then run the tests to catch stylistic issues faster, as the tests might take some time to run.

/cc @mlunoe 