### PR TITLE
Re-adding missing reverse of data, when reading reverse

### DIFF
--- a/plugins/services/src/js/components/LogView.js
+++ b/plugins/services/src/js/components/LogView.js
@@ -132,9 +132,9 @@ class LogView extends React.Component {
       return;
     }
 
+    this.checkIfCloseToTop(target);
     // Only update variables if user actually interacts with the view
     if (this.state.userScroll) {
-      this.checkIfCloseToTop(target);
       this.checkIfAwayFromBottom(target);
     }
   }

--- a/src/js/events/SystemLogActions.js
+++ b/src/js/events/SystemLogActions.js
@@ -165,6 +165,8 @@ const SystemLogActions = {
       let {eventPhase} = event;
 
       if (eventPhase === EventSource.CLOSED) {
+        // Reverse the items, as the come in opporsite order
+        items.reverse();
         AppDispatcher.handleServerAction({
           type: REQUEST_PREVIOUS_SYSTEM_LOG_SUCCESS,
           data: items,

--- a/src/js/events/__tests__/SystemLogActions-test.js
+++ b/src/js/events/__tests__/SystemLogActions-test.js
@@ -254,6 +254,34 @@ describe('SystemLogActions', function () {
       this.eventSource.dispatchEvent('error', closeEvent);
     });
 
+    it('reverses received data', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.data[0].foo).toEqual(1);
+        expect(action.data[1].foo).toEqual(0);
+      });
+
+      this.eventSource.dispatchEvent('message', {
+        data: '{"foo": 0}',
+        eventPhase: global.EventSource.OPEN,
+        origin: global.location.origin
+      });
+      this.eventSource.dispatchEvent('message', {
+        data: '{"foo": 1}',
+        eventPhase: global.EventSource.OPEN,
+        origin: global.location.origin
+      });
+      // Close before we the 3 events we have requested to show
+      // that we have reached the top
+      let closeEvent = {
+        data: {},
+        eventPhase: global.EventSource.CLOSED,
+        origin: global.location.origin
+      };
+      this.eventSource.dispatchEvent('error', closeEvent);
+    });
+
     it('dispatches the correct action when unsuccessful', function () {
       var id = AppDispatcher.register(function (payload) {
         var action = payload.action;


### PR DESCRIPTION
This PR fixes a bug where it would not reverse the received data, when reading in reverse order.
It also makes sure to always check if we are at the top of the logs, so we don't get stuck at a perceived infinite load at the top.

To test this out, deploy some service that has more than a page of logs and try to page to the top