### PR TITLE
Formatting messages to be equal to CLI format

### DIFF
--- a/src/js/constants/LogFields.js
+++ b/src/js/constants/LogFields.js
@@ -1,0 +1,8 @@
+const LogFields = {
+  HOSTNAME: '_HOSTNAME',
+  MESSAGE: 'MESSAGE',
+  PID: '_PID',
+  SYSLOG_IDENTIFIER: 'SYSLOG_IDENTIFIER'
+};
+
+module.exports = LogFields;

--- a/src/js/stores/SystemLogStore.js
+++ b/src/js/stores/SystemLogStore.js
@@ -19,7 +19,8 @@ import {
 import BaseStore from './BaseStore';
 import SystemLogActions from '../events/SystemLogActions';
 import {APPEND, PREPEND} from '../constants/SystemLogTypes';
-import Util from '../utils/Util';
+import {findNestedPropertyInObject} from '../utils/Util';
+import {msToCTime} from '../utils/DateUtil';
 
 // Max data storage, i.e. maximum 5MB per log stream
 const MAX_FILE_SIZE = 500000;
@@ -88,7 +89,7 @@ class SystemLogStore extends BaseStore {
       newLogData.entries = entries.concat(logData.entries);
     }
     let length = entries.reduce((sum, entry) => {
-      return sum + Util.findNestedPropertyInObject(
+      return sum + findNestedPropertyInObject(
         entry,
         'fields.MESSAGE.length'
       ) || 0;
@@ -107,7 +108,7 @@ class SystemLogStore extends BaseStore {
       } else {
         removedEntry = newLogData.entries.pop();
       }
-      newLogData.totalSize -= Util.findNestedPropertyInObject(
+      newLogData.totalSize -= findNestedPropertyInObject(
         removedEntry,
         'fields.MESSAGE.length'
       ) || 0;
@@ -117,13 +118,52 @@ class SystemLogStore extends BaseStore {
   }
 
   getFullLog(subscriptionID) {
-    let entries = Util.findNestedPropertyInObject(
+    let entries = findNestedPropertyInObject(
       this.logs[subscriptionID],
       'entries'
     ) || [];
 
-    return entries.map(function (entry) {
-      return Util.findNestedPropertyInObject(entry, 'fields.MESSAGE') || '';
+    // Formatting logs as we do in the CLI:
+    // https://github.com/dcos/dcos-cli/pull/817/files#diff-8f3b06e62cf338c8e4e2ac6414447d26R260
+    return entries.filter((entry) => {
+      return Boolean(findNestedPropertyInObject(entry, 'fields.MESSAGE'));
+    }).map(function (entry) {
+      const {fields = {}} = entry;
+      let lineData = [];
+      // entry.realtime_timestamp returns a unix time in microseconds
+      // https://www.freedesktop.org/software/systemd/man/sd_journal_get_realtime_usec.html
+      if (typeof entry.realtime_timestamp === 'number') {
+        lineData.push(msToCTime(entry.realtime_timestamp/1000));
+      }
+
+      // Optional fields
+      ['_HOSTNAME', 'SYSLOG_IDENTIFIER'].forEach((optionalField) => {
+        if (fields[optionalField]) {
+          lineData.push(fields[optionalField]);
+        }
+      });
+
+      // Concat to SYSLOG_IDENTIFIER if available
+      if (fields['_PID'] && fields['SYSLOG_IDENTIFIER']) {
+        const lastElement = lineData[lineData.length - 1];
+        lineData[lineData.length - 1] = `${lastElement}[${fields['_PID']}]`;
+      }
+
+      // If SYSLOG_IDENTIFIER is not available just add as separate field
+      if (fields['_PID'] && !fields['SYSLOG_IDENTIFIER']) {
+        lineData.push(`[${fields['_PID']}]`);
+      }
+
+      // Concat `:` to last element if there is data
+      if (lineData.length) {
+        const lastElement = lineData[lineData.length - 1];
+        lineData[lineData.length - 1] = `${lastElement}:`;
+      }
+
+      lineData.push(fields['MESSAGE']);
+
+      // Format: `date _HOSTNAME SYSLOG_IDENTIFIER[_PID]: MESSAGE`
+      return `${lineData.join(' ')}`;
     }).join('\n');
   }
 
@@ -157,7 +197,7 @@ class SystemLogStore extends BaseStore {
 
   fetchLogRange(nodeID, options) {
     let {subscriptionID} = options;
-    let cursor = Util.findNestedPropertyInObject(
+    let cursor = findNestedPropertyInObject(
       this.logs[subscriptionID],
       'entries.0.cursor'
     );

--- a/src/js/utils/DateUtil.js
+++ b/src/js/utils/DateUtil.js
@@ -54,6 +54,15 @@ const DateUtil = {
   },
 
   /**
+   * Creates a ANSI C time string from time provided
+   * @param  {Date|Number} ms number to convert to ANSI C time string
+   * @return {String} time string with the format 'ddd MMM DD HH:mm:ss YYYY'
+   */
+  msToCTime(ms) {
+    return moment(ms).utc().format('ddd MMM DD HH:mm:ss YYYY');
+  },
+
+  /**
   /**
    * Creates relative time based on now and the time provided
    * @param  {Date|Number} ms number to convert to relative time string

--- a/src/js/utils/__tests__/DateUtil-test.js
+++ b/src/js/utils/__tests__/DateUtil-test.js
@@ -59,44 +59,6 @@ describe('DateUtil', function () {
     });
   });
 
-  describe('#msToCTime', function () {
-    beforeEach(function () {
-      // Clean up application timers.
-      jasmine.clock().uninstall();
-      // Install our custom jasmine timers.
-      jasmine.clock().install();
-      jasmine.clock().mockDate(new Date(2016, 3, 19));
-    });
-
-    it('should return the correct string for AM', function () {
-      // December is 11 due to months being 0-based index.
-      var christmas = new Date(2015, 11, 25, 8, 13);
-      var christmasValue = christmas.valueOf();
-
-      var result = DateUtil.msToCTime(christmasValue);
-
-      expect(result).toEqual('Fri Dec 25 16:13:00 2015');
-    });
-
-    it('should return the correct string for PM', function () {
-      var halloween = new Date(2015, 9, 31, 20, 30);
-      var halloweenValue = halloween.valueOf();
-
-      var result = DateUtil.msToCTime(halloweenValue);
-
-      expect(result).toEqual('Sun Nov 01 03:30:00 2015');
-    });
-
-    it('can handle older dates', function () {
-      var specialDay = new Date(1993, 9, 19, 11, 29);
-      var specialDayValue = specialDay.valueOf();
-
-      var result = DateUtil.msToCTime(specialDayValue);
-
-      expect(result).toEqual('Tue Oct 19 18:29:00 1993');
-    });
-  });
-
   describe('#msToDateStr', function () {
     it('should return the correct string for AM', function () {
       // December is 11 due to months being 0-based index.

--- a/src/js/utils/__tests__/DateUtil-test.js
+++ b/src/js/utils/__tests__/DateUtil-test.js
@@ -59,6 +59,44 @@ describe('DateUtil', function () {
     });
   });
 
+  describe('#msToCTime', function () {
+    beforeEach(function () {
+      // Clean up application timers.
+      jasmine.clock().uninstall();
+      // Install our custom jasmine timers.
+      jasmine.clock().install();
+      jasmine.clock().mockDate(new Date(2016, 3, 19));
+    });
+
+    it('should return the correct string for AM', function () {
+      // December is 11 due to months being 0-based index.
+      var christmas = new Date(2015, 11, 25, 8, 13);
+      var christmasValue = christmas.valueOf();
+
+      var result = DateUtil.msToCTime(christmasValue);
+
+      expect(result).toEqual('Fri Dec 25 16:13:00 2015');
+    });
+
+    it('should return the correct string for PM', function () {
+      var halloween = new Date(2015, 9, 31, 20, 30);
+      var halloweenValue = halloween.valueOf();
+
+      var result = DateUtil.msToCTime(halloweenValue);
+
+      expect(result).toEqual('Sun Nov 01 03:30:00 2015');
+    });
+
+    it('can handle older dates', function () {
+      var specialDay = new Date(1993, 9, 19, 11, 29);
+      var specialDayValue = specialDay.valueOf();
+
+      var result = DateUtil.msToCTime(specialDayValue);
+
+      expect(result).toEqual('Tue Oct 19 18:29:00 1993');
+    });
+  });
+
   describe('#msToDateStr', function () {
     it('should return the correct string for AM', function () {
       // December is 11 due to months being 0-based index.


### PR DESCRIPTION
This PR introduces a new format for log lines that follows the CLI (see here https://github.com/dcos/dcos-cli/pull/817/files#diff-8f3b06e62cf338c8e4e2ac6414447d26R260):
![](https://cl.ly/2M402q3K2y23/Image%202016-12-15%20at%2013.00.30.png)