### PR TITLE
Fixing wrong boolean check for container checkboxes

### DIFF
--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -140,7 +140,7 @@ class ContainerServiceFormSection extends Component {
 
       let inputField = (
         <FieldInput
-          checked={containerType !== DOCKER && Boolean(checked)}
+          checked={containerType === DOCKER && Boolean(checked)}
           name={`container.docker.${settingName}`}
           type="checkbox"
           disabled={containerType !== DOCKER}


### PR DESCRIPTION
Fixes the checkboxes in the container settings:
![](https://cl.ly/031H233U3H26/Screen%20Recording%202016-12-15%20at%2016.35.gif)