### PR TITLE
Opimize mesos state store scheduler handling

### DIFF
--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -245,19 +245,13 @@ class MesosStateStore extends GetSetBaseStore {
   }
 
   getSchedulerTaskFromServiceName(serviceName) {
-    const tasks = this.getTasksFromServiceName('marathon');
-    return tasks.find(function (task) {
-      let labels = task.labels;
+    const tasks = this.getSchedulerTasks();
 
-      if (!labels) {
-        return false;
-      }
+    return tasks.find(function ({labels}) {
 
-      const frameworkName = labels.find(function (label) {
-        return label.key === 'DCOS_PACKAGE_FRAMEWORK_NAME';
+      return labels.some(({key, value}) => {
+        return key === 'DCOS_PACKAGE_FRAMEWORK_NAME' && value === serviceName;
       });
-
-      return frameworkName && frameworkName.value === serviceName;
     });
   }
 

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -229,6 +229,21 @@ class MesosStateStore extends GetSetBaseStore {
     return new Task(foundTask);
   }
 
+  /**
+   * @return {Array} list of scheduler tasks
+   */
+  getSchedulerTasks() {
+    const tasks = this.getTasksFromServiceName('marathon');
+
+    return tasks.filter(function ({labels}) {
+      if (!labels) {
+        return false;
+      }
+
+      return labels.some(({key}) => key === 'DCOS_PACKAGE_FRAMEWORK_NAME');
+    });
+  }
+
   getSchedulerTaskFromServiceName(serviceName) {
     const tasks = this.getTasksFromServiceName('marathon');
     return tasks.find(function (task) {

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -230,22 +230,9 @@ class MesosStateStore extends GetSetBaseStore {
   }
 
   getSchedulerTaskFromServiceName(serviceName) {
-    const frameworks = this.get('lastMesosState').frameworks;
-
-    if (!frameworks) {
-      return null;
-    }
-
-    const framework = frameworks.find(function (framework) {
-      return framework.name.toLowerCase() === 'marathon';
-    });
-
-    if (!framework || !framework.tasks) {
-      return null;
-    }
-
-    const result = framework.tasks.find(function (task) {
-      const labels = task.labels;
+    const tasks = this.getTasksFromServiceName('marathon');
+    return tasks.find(function (task) {
+      let labels = task.labels;
 
       if (!labels) {
         return false;
@@ -257,8 +244,6 @@ class MesosStateStore extends GetSetBaseStore {
 
       return frameworkName && frameworkName.value === serviceName;
     });
-
-    return result;
   }
 
   getTasksFromServiceName(serviceName) {

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -251,10 +251,15 @@ describe('MesosStateStore', function () {
         return {
           frameworks: [{
             name: 'marathon',
-            tasks: [{
-              id: 1,
-              labels: [{key: 'DCOS_PACKAGE_FRAMEWORK_NAME', value: 'foo'}]
-            }]
+            tasks: [
+              {
+                id: 'foo',
+                labels: [{key: 'DCOS_PACKAGE_FRAMEWORK_NAME', value: 'foo'}]
+              },
+              {
+                id: 'bar'
+              }
+            ]
           }]
         };
       };
@@ -264,15 +269,24 @@ describe('MesosStateStore', function () {
       MesosStateStore.get = this.get;
     });
 
-    it('should find a currently running task', function () {
-      var result = MesosStateStore.getSchedulerTaskFromServiceName('foo');
-      expect(result.id).toEqual(1);
+    it('should return the matching scheduler task', function () {
+      const schedulerTask =
+        MesosStateStore.getSchedulerTaskFromServiceName('foo');
+
+      expect(schedulerTask).toEqual({
+        id: 'foo',
+        labels: [{key: 'DCOS_PACKAGE_FRAMEWORK_NAME', value: 'foo'}]
+      });
     });
 
-    it('shouldn\'t find a task', function () {
-      var result = MesosStateStore.getSchedulerTaskFromServiceName('bar');
-      expect(result).toEqual(undefined);
-    });
+    it('should return undefined if no matching scheduler task was found',
+      function () {
+        const schedulerTask =
+          MesosStateStore.getSchedulerTaskFromServiceName('bar');
+
+        expect(schedulerTask).toEqual(undefined);
+      }
+    );
   });
 
   describe('#getPodHistoricalInstances', function () {

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -180,6 +180,52 @@ describe('MesosStateStore', function () {
     });
   });
 
+  describe('#getSchedulerTasks', function () {
+    beforeEach(function () {
+      this.get = MesosStateStore.get;
+      MesosStateStore.get = function () {
+        return {
+          frameworks: [{
+            name: 'marathon',
+            tasks: [
+              {
+                id: 1,
+                labels: [{key: 'DCOS_PACKAGE_FRAMEWORK_NAME', value: 'foo'}]
+              },
+              {
+                id: 2
+              },
+              {
+                id: 3,
+                labels: [{key: 'DCOS_PACKAGE_FRAMEWORK_NAME', value: 'bar'}]
+              }
+            ]
+          }]
+        };
+      };
+    });
+
+    afterEach(function () {
+      MesosStateStore.get = this.get;
+    });
+
+    it('should return scheduler tasks', function () {
+      const schedulerTasks = MesosStateStore.getSchedulerTasks();
+
+      expect(schedulerTasks).toEqual([
+        {
+          id: 1,
+          labels: [{key: 'DCOS_PACKAGE_FRAMEWORK_NAME', value: 'foo'}]
+        },
+        {
+          id: 3,
+          labels: [{key: 'DCOS_PACKAGE_FRAMEWORK_NAME', value: 'bar'}]
+        }
+      ]);
+    });
+
+  });
+
   describe('#getSchedulerTaskFromServiceName', function () {
     beforeEach(function () {
       this.get = MesosStateStore.get;

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -183,26 +183,6 @@ describe('MesosStateStore', function () {
   describe('#getSchedulerTasks', function () {
     beforeEach(function () {
       this.get = MesosStateStore.get;
-      MesosStateStore.get = function () {
-        return {
-          frameworks: [{
-            name: 'marathon',
-            tasks: [
-              {
-                id: 1,
-                labels: [{key: 'DCOS_PACKAGE_FRAMEWORK_NAME', value: 'foo'}]
-              },
-              {
-                id: 2
-              },
-              {
-                id: 3,
-                labels: [{key: 'DCOS_PACKAGE_FRAMEWORK_NAME', value: 'bar'}]
-              }
-            ]
-          }]
-        };
-      };
     });
 
     afterEach(function () {
@@ -210,18 +190,56 @@ describe('MesosStateStore', function () {
     });
 
     it('should return scheduler tasks', function () {
-      const schedulerTasks = MesosStateStore.getSchedulerTasks();
+      MesosStateStore.get = function () {
+        return {
+          frameworks: [{
+            name: 'marathon',
+            tasks: [
+              {
+                id: 'foo',
+                labels: [{key: 'DCOS_PACKAGE_FRAMEWORK_NAME', value: 'foo'}]
+              },
+              {
+                id: 'bar'
+              },
+              {
+                id: 'baz',
+                labels: [{key: 'DCOS_PACKAGE_FRAMEWORK_NAME', value: 'baz'}]
+              }
+            ]
+          }]
+        };
+      };
 
+      const schedulerTasks = MesosStateStore.getSchedulerTasks();
       expect(schedulerTasks).toEqual([
         {
-          id: 1,
+          id: 'foo',
           labels: [{key: 'DCOS_PACKAGE_FRAMEWORK_NAME', value: 'foo'}]
         },
         {
-          id: 3,
-          labels: [{key: 'DCOS_PACKAGE_FRAMEWORK_NAME', value: 'bar'}]
+          id: 'baz',
+          labels: [{key: 'DCOS_PACKAGE_FRAMEWORK_NAME', value: 'baz'}]
         }
       ]);
+    });
+
+    it('should not return plain tasks', function () {
+      MesosStateStore.get = function () {
+        return {
+          frameworks: [{
+            name: 'marathon',
+            tasks: [
+              {
+                id: 'foo'
+              }
+            ]
+          }]
+        };
+      };
+
+      const schedulerTasks = MesosStateStore.getSchedulerTasks();
+      expect(schedulerTasks).toEqual([]);
     });
 
   });


### PR DESCRIPTION
---
⚠️  ~~_This branch depends on changes that will be introduced with #1566_~~

---

Improve `MesosStateStore` scheduler task handling by introducing a new method to retrieve the list of scheduler tasks and simplifying the existing methods. These changes will reduce the number of `framework`/`task` list iterations. 

/cc @MatApple 