### PR TITLE
Fix Volumes tab bug

### DIFF
--- a/plugins/services/src/js/components/VolumeTable.js
+++ b/plugins/services/src/js/components/VolumeTable.js
@@ -145,7 +145,7 @@ class VolumeTable extends React.Component {
       routePath = `/nodes/${nodeID}/tasks/${taskID}/volumes/${volumeID}`;
     }
 
-    return <Link to={routePath}>{id}</Link>;
+    return <Link className="table-cell-link-primary" to={routePath}>{id}</Link>;
   }
 
   renderStatusColumn(prop, row) {

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -191,7 +191,9 @@ class ServiceDetail extends mixin(TabsMixin) {
     if (this.hasVolumes()) {
       tabs.push({
         label: 'Volumes', routePath: routePrefix + '/volumes',
-        callback: this.tabs_handleTabClick.bind('volumes'),
+        callback: () => {
+          this.setState({currentTab: 'volumes'});
+        },
         isActive: activeTab === 'volumes'
       });
     }

--- a/plugins/services/src/js/containers/volume-detail/VolumeDetail.js
+++ b/plugins/services/src/js/containers/volume-detail/VolumeDetail.js
@@ -1,9 +1,10 @@
 import classNames from 'classnames';
 import React from 'react';
 
-import Breadcrumbs from '../../../../../../src/js/components/Breadcrumbs';
+import Page from '../../../../../../src/js/components/Page';
 import DescriptionList from '../../../../../../src/js/components/DescriptionList';
 import DetailViewHeader from '../../../../../../src/js/components/DetailViewHeader';
+import ServiceBreadcrumbs from '../../components/ServiceBreadcrumbs';
 import VolumeStatus from '../../constants/VolumeStatus';
 
 class VolumeDetail extends React.Component {
@@ -32,13 +33,14 @@ class VolumeDetail extends React.Component {
     };
 
     return (
-      <div>
-        <Breadcrumbs routes={this.props.routes} params={this.props.params} />
+      <Page>
+        <Page.Header
+          breadcrumbs={<ServiceBreadcrumbs serviceID={service.id} />} />
         <DetailViewHeader
           subTitle={this.renderSubHeader()}
           title={volume.getId()} />
         <DescriptionList hash={detailsHash} />
-      </div>
+      </Page>
     );
   }
 }


### PR DESCRIPTION
This PR fixes a small bug where the Volumes tab would throw an error when selected. It also adds the `Page` and `Page.Header` component to the `VolumeDetail` page.