### PR TITLE
Removes integration test that doesn't pass consistently as application loads too fast.

### DIFF
--- a/tests/smoke-cy.js
+++ b/tests/smoke-cy.js
@@ -7,14 +7,6 @@ describe('DC/OS UI [00j]', function () {
     .visitUrl({url: '/', identify: true, fakeAnalytics: true});
   });
 
-  context('Loader', function () {
-
-    it('shows the pulsing pineapple', function () {
-      cy.get('#application .application-loading-indicator .icon.icon-logo-mark');
-    });
-
-  });
-
   context('Dashboard [00k]', function () {
 
     beforeEach(function () {


### PR DESCRIPTION
Open to suggestion on how to fix this, but right now the Config.js file gets bundled with the application and that's where we tell the application how much time to wait before rendering.