### PR TITLE
Fix badge styling on PackageDetail header

### DIFF
--- a/src/js/pages/universe/PackageDetailTab.js
+++ b/src/js/pages/universe/PackageDetailTab.js
@@ -171,7 +171,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
       // TODO: Convert this to .pill-label.
       return (
         <span className="badge-container selected-badge">
-          <span className="badge badge-large flush-left">
+          <span className="badge badge-large">
             Selected
           </span>
           {versionTag}

--- a/src/styles/views/packages/styles.less
+++ b/src/styles/views/packages/styles.less
@@ -14,6 +14,7 @@
   .selected-badge {
 
     .badge {
+      margin-left: 0;
       margin-right: @base-spacing-unit * 1/4;
     }
   }


### PR DESCRIPTION
The `flush-left` class was removing both margin and padding from the badge.