### PR TITLE
Breadcrumbs not functioning properly after routes got changed, ref. DCOS-11768 and DCOS-12143

### DIFF
--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -344,6 +344,9 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
 
     return (
       <div className="flex flex-direction-top-to-bottom flex-item-grow-1 flex-item-shrink-1">
+        <div className="flex flex-item-shrink-0 control-group">
+          {this.getBreadcrumbs()}
+        </div>
         {this.getSubView()}
       </div>
     );

--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -31,7 +31,8 @@ const HIDE_BREADCRUMBS = [
   '/networking/networks/:overlayName/tasks/:taskID/details',
   '/nodes/:nodeID/tasks/:taskID/details',
   '/services/overview/:id/tasks/:taskID/details',
-  '/services/overview/:id/tasks/:taskID/logs(/:fileName)'
+  '/services/overview/:id/tasks/:taskID/logs(/:fileName)',
+  '/services/overview/:id/tasks/:taskID/files/view(/:filePath(/:innerPath))'
 ];
 
 class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {


### PR DESCRIPTION
This PR fixes a bug where the Breadcrumbs where removed from the file viewer here: https://github.com/dcos/dcos-ui/commit/ba2595e15c200cd3f26cbf25455ecbb9a8e2e15c#diff-5652f87ace9e089ce90959891680d61dL331

It also corrects how the breadcrumbs work when navigating files:
![](https://cl.ly/3g3w3H382h0B/Screen%20Recording%202016-12-16%20at%2017.39.gif)
