### PR TITLE
DCOS-12224: Handle missing protocol in app definition

### DIFF
--- a/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
@@ -79,8 +79,10 @@ class ServiceNetworkingConfigSection extends ServiceConfigBaseSectionDisplay {
                 prop: keys.protocol,
                 className: getColumnClassNameFn(),
                 render(prop, row) {
-                  return getDisplayValue(row[prop])
-                    .split(',').join(', ');
+                  let protocol = row[prop] || '';
+                  protocol = protocol.replace(',', ', ');
+
+                  return getDisplayValue(protocol);
                 },
                 sortable: true
               },

--- a/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
@@ -80,7 +80,7 @@ class ServiceNetworkingConfigSection extends ServiceConfigBaseSectionDisplay {
                 className: getColumnClassNameFn(),
                 render(prop, row) {
                   let protocol = row[prop] || '';
-                  protocol = protocol.replace(',', ', ');
+                  protocol = protocol.replace(/,\s*/g, ', ');
 
                   return getDisplayValue(protocol);
                 },


### PR DESCRIPTION
This PR adds a check for the situation when a protocol field is missing from the port mappings