### PR TITLE
Adds flag to docker container.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,5 @@ services:
       dockerfile: ./Dockerfile.dev
     volumes:
       - ./:/usr/src/dcos-ui
+    ipc: host
     working_dir: /usr/src


### PR DESCRIPTION
To use host resources, this avoids Chrome crashing in container due to it not GCing on time.