### PR TITLE
DCOS-11886: Prevent .row styles from mucking with .panel-grid children

### DIFF
--- a/src/styles/components/panel/styles.less
+++ b/src/styles/components/panel/styles.less
@@ -48,6 +48,14 @@
     .panel {
       margin-bottom: @panel-grid-margin-vertical;
     }
+
+    &.row {
+
+      &:after,
+      &:before {
+        display: none;
+      }
+    }
   }
 
   .panel-interactive {


### PR DESCRIPTION
This PR fixes a bug where the `:before` and `:after` pseudo elements from `.row` were rendering in Safari and causing the `.panel-grid` children to wrap in Safari.

Before:
![](https://cl.ly/2A2M3F0H3F32/Screen%20Shot%202016-12-19%20at%204.20.56%20PM.png)

After:
![](https://cl.ly/1x2A1n0G1m1t/Screen%20Shot%202016-12-19%20at%204.19.36%20PM.png)