### PR TITLE
Fixing integration tests for ServicesTab

### DIFF
--- a/tests/pages/services/ServicesTab-cy.js
+++ b/tests/pages/services/ServicesTab-cy.js
@@ -1,5 +1,7 @@
 describe('ServicesTab', function () {
+
   context('Service not found page', function () {
+
     beforeEach(function () {
       cy.configureCluster({
         mesos: '1-for-each-health',
@@ -11,28 +13,6 @@ describe('ServicesTab', function () {
 
     it('should show the \'Not Found\' alert panel', function () {
       cy.get('.page-body-content').contains('Page not found');
-    });
-  });
-
-  xcontext('Tab highlighting', function () {
-    beforeEach(function () {
-      cy.configureCluster({
-        mesos: '1-for-each-health',
-        nodeHealth: true
-      });
-
-      cy.visitUrl({url: '/services'});
-    });
-
-    it('should have an active services tab', function () {
-      cy.get('.menu-tabbed-item-label.active .menu-tabbed-item-label-text').contains('Services')
-        .should('to.have.length', 1);
-    });
-
-    it('should be able to go to deployments tab', function () {
-      cy.get('.menu-tabbed-item-label').contains('Deployments').click();
-      cy.get('.menu-tabbed-item-label.active .menu-tabbed-item-label-text')
-        .contains('Deployments').should('to.have.length', 1);
     });
   });
 });


### PR DESCRIPTION
**Note:** Tabs are no longer present (Services|Deployments), hence the deleted test.

![](https://cl.ly/3i22290u2t2I/Image%202016-12-19%20at%204.37.09%20PM.png)