### PR TITLE
DCOS-11493:Add hooks to OverviewDetailTab

### DIFF
--- a/src/js/pages/system/OverviewDetailTab.js
+++ b/src/js/pages/system/OverviewDetailTab.js
@@ -1,4 +1,5 @@
 import mixin from 'reactjs-mixin';
+import {Hooks} from 'PluginSDK';
 import {Link} from 'react-router';
 /* eslint-disable no-unused-vars */
 import React from 'react';
@@ -31,7 +32,7 @@ class OverviewDetailTab extends mixin(StoreMixin) {
       open: false
     };
 
-    this.store_listeners = [
+    this.store_listeners = Hooks.applyFilter('OverviewDetailTab:StoreListeners', [
       {
         name: 'config',
         events: ['ccidSuccess']
@@ -44,13 +45,16 @@ class OverviewDetailTab extends mixin(StoreMixin) {
         name: 'metadata',
         events: ['dcosSuccess']
       }
-    ];
+    ]);
   }
 
   componentDidMount() {
     super.componentDidMount(...arguments);
     ConfigStore.fetchCCID();
     MarathonStore.fetchMarathonInstanceInfo();
+
+    Hooks.applyFilter('OverviewDetailTab:DidMountCallbacks', [])
+      .forEach((cb) => cb());
   }
 
   getLoading() {
@@ -71,10 +75,11 @@ class OverviewDetailTab extends mixin(StoreMixin) {
       productVersion = this.getLoading();
     }
 
-    return {
+    // Allow plugins to add to the cluster details hash
+    return Hooks.applyFilter('OverviewDetailTab:ClusterDetails', {
       [`${Config.productName} Version`]: productVersion,
       'Cryptographic Cluster ID': ccid
-    };
+    });
   }
 
   getMarathonDetailsHash() {

--- a/src/js/pages/system/OverviewDetailTab.js
+++ b/src/js/pages/system/OverviewDetailTab.js
@@ -1,5 +1,6 @@
 import mixin from 'reactjs-mixin';
 import {Link} from 'react-router';
+import {MountService} from 'foundation-ui';
 /* eslint-disable no-unused-vars */
 import React from 'react';
 /* eslint-enable no-unused-vars */
@@ -113,6 +114,8 @@ class OverviewDetailTab extends mixin(StoreMixin) {
             </ConfigurationMapHeading>
             <HashMapDisplay hash={this.getClusterDetailsHash()} />
             {marathonDetails}
+            <MountService.Mount
+              type="OverviewDetailTab:AdditionalClusterDetails" />
           </ConfigurationMap>
         </div>
       </Page>

--- a/src/js/pages/system/OverviewDetailTab.js
+++ b/src/js/pages/system/OverviewDetailTab.js
@@ -1,5 +1,4 @@
 import mixin from 'reactjs-mixin';
-import {Hooks} from 'PluginSDK';
 import {Link} from 'react-router';
 /* eslint-disable no-unused-vars */
 import React from 'react';
@@ -32,7 +31,7 @@ class OverviewDetailTab extends mixin(StoreMixin) {
       open: false
     };
 
-    this.store_listeners = Hooks.applyFilter('OverviewDetailTab:StoreListeners', [
+    this.store_listeners = [
       {
         name: 'config',
         events: ['ccidSuccess']
@@ -45,16 +44,13 @@ class OverviewDetailTab extends mixin(StoreMixin) {
         name: 'metadata',
         events: ['dcosSuccess']
       }
-    ]);
+    ];
   }
 
   componentDidMount() {
     super.componentDidMount(...arguments);
     ConfigStore.fetchCCID();
     MarathonStore.fetchMarathonInstanceInfo();
-
-    Hooks.applyFilter('OverviewDetailTab:DidMountCallbacks', [])
-      .forEach((cb) => cb());
   }
 
   getLoading() {
@@ -75,11 +71,10 @@ class OverviewDetailTab extends mixin(StoreMixin) {
       productVersion = this.getLoading();
     }
 
-    // Allow plugins to add to the cluster details hash
-    return Hooks.applyFilter('OverviewDetailTab:ClusterDetails', {
+    return {
       [`${Config.productName} Version`]: productVersion,
       'Cryptographic Cluster ID': ccid
-    });
+    };
   }
 
   getMarathonDetailsHash() {


### PR DESCRIPTION
ℹ️ See https://github.com/dcos/dcos-ui/pull/1652#issuecomment-269611508 before reviewing

This PR adds hooks to the `OverviewDetailTab` in order to allow plugins to

 - manipulate the store_listeners hash
 - add their own callbacks on componentDidMount
 - manipulate the data for the cluster details `dt` element