### PR TITLE
Show job status in job detail page header

### DIFF
--- a/src/js/components/breadcrumbs/JobsBreadcrumbs.js
+++ b/src/js/components/breadcrumbs/JobsBreadcrumbs.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 import PageHeaderBreadcrumbs from '../../components/NewPageHeaderBreadcrumbs';
 
-const JobsBreadcrumbs = ({jobID, taskID, taskName}) => {
+const JobsBreadcrumbs = ({jobID, taskID, taskName, jobStatus}) => {
   let aggregateIDs = '';
   const crumbs = [
     <Link to="/jobs">Jobs</Link>
@@ -11,13 +11,28 @@ const JobsBreadcrumbs = ({jobID, taskID, taskName}) => {
 
   if (jobID != null && jobID.length > 0) {
     const ids = jobID.split('.');
+
     const jobsCrumbs = ids.map(function (id, index) {
+      let status;
       if (aggregateIDs !== '') {
         aggregateIDs += '.';
       }
       aggregateIDs += id;
 
-      return <Link to={`/jobs/${aggregateIDs}`} key={index}>{id}</Link>;
+      if (index === ids.length - 1 && jobStatus != null) {
+        status = (
+          <div className="service-page-header-status page-header-breadcrumb-content-secondary muted">
+            {`(${jobStatus})`}
+          </div>
+        );
+      }
+
+      return (
+        <div>
+          <Link to={`/jobs/${aggregateIDs}`} key={index}>{id}</Link>
+          {status}
+        </div>
+      );
     });
     crumbs.push(...jobsCrumbs);
   }

--- a/src/js/pages/jobs/JobDetailPage.js
+++ b/src/js/pages/jobs/JobDetailPage.js
@@ -240,6 +240,24 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
     }
   }
 
+  getJobStatus(job) {
+    let longestRunningTask = null;
+    const longestRunningActiveRun = job.getActiveRuns()
+      .getLongestRunningActiveRun();
+
+    if (longestRunningActiveRun != null) {
+      longestRunningTask = longestRunningActiveRun.getTasks()
+        .getLongestRunningTask();
+    }
+
+    if (longestRunningTask == null) {
+      return null;
+    }
+
+    const status = TaskStates[longestRunningTask.getStatus()];
+    return status.displayName;
+  }
+
   getSubTitle(job) {
     const nodes = [];
     const scheduleText = this.getPrettySchedule(job);
@@ -382,12 +400,13 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
     }
 
     let job = MetronomeStore.getJob(this.props.params.id);
+    const jobStatus = this.getJobStatus(job);
 
     return (
       <Page>
         <Page.Header
           actions={this.getActions()}
-          breadcrumbs={<JobsBreadcrumbs jobID={job.getId()} />}
+          breadcrumbs={<JobsBreadcrumbs jobID={job.getId()} jobStatus={jobStatus} />}
           tabs={this.getTabs()} />
         {this.tabs_getTabView(job)}
         <JobFormModal isEdit={true}

--- a/src/js/pages/jobs/JobDetailPage.js
+++ b/src/js/pages/jobs/JobDetailPage.js
@@ -255,6 +255,7 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
     }
 
     const status = TaskStates[longestRunningTask.getStatus()];
+
     return status.displayName;
   }
 


### PR DESCRIPTION
This PR introduces a status field to the jobs breadcrumbs, allowing an arbitrary job status to be shown. 

The jobs page uses this to show the status of the longest running task associated with a job. This is the same behaviour as the earlier jobs detail page header. 

![son et lumier](https://d3vv6lp55qjaqc.cloudfront.net/items/2T1B0M1C1Z18272i2H0F/Screen%20Recording%202016-12-20%20at%2002.49%20PM.gif?X-CloudApp-Visitor-Id=1905462&v=89e5b192)