### PR TITLE
Add Support for health checks with unknown protocols

### DIFF
--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -171,6 +171,11 @@ class HealthChecksFormSection extends Component {
     return data.map((healthCheck, key) => {
       const errors = errorsLens.at(key, {}).get(this.props.errors);
 
+      if (!['', 'HTTP', 'HTTPS', 'COMMAND'].includes(healthCheck.protocol) &&
+        healthCheck.protocol != null) {
+        return null;
+      }
+
       return (
         <FormGroupContainer
           key={key}

--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -173,7 +173,7 @@ class HealthChecksFormSection extends Component {
     return data.map((healthCheck, key) => {
       const errors = errorsLens.at(key, {}).get(this.props.errors);
 
-      if (HealthCheckUtil.isKnownProtocol(healthCheck.protocol) &&
+      if (!HealthCheckUtil.isKnownProtocol(healthCheck.protocol) &&
         healthCheck.protocol != null) {
         return null;
       }

--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -12,6 +12,8 @@ import FieldSelect from '../../../../../../src/js/components/form/FieldSelect';
 import FormGroup from '../../../../../../src/js/components/form/FormGroup';
 import FormGroupContainer from '../../../../../../src/js/components/form/FormGroupContainer';
 import FormRow from '../../../../../../src/js/components/form/FormRow';
+import {HTTP, HTTPS, COMMAND} from '../../constants/HealtCheckProtocols';
+import HealthCheckUtil from '../../utils/HealtCheckUtil';
 import Icon from '../../../../../../src/js/components/Icon';
 
 import {FormReducer as healthChecks} from '../../reducers/serviceForm/HealthChecks';
@@ -20,8 +22,8 @@ const errorsLens = Objektiv.attr('healthChecks', []);
 
 class HealthChecksFormSection extends Component {
   getAdvancedSettings(healthCheck, key) {
-    if (healthCheck.protocol !== 'COMMAND' && healthCheck.protocol !== 'HTTP' &&
-      healthCheck.protocol !== 'HTTPS') {
+    if (healthCheck.protocol !== COMMAND && healthCheck.protocol !== HTTP &&
+      healthCheck.protocol !== HTTPS) {
       return null;
     }
 
@@ -85,7 +87,7 @@ class HealthChecksFormSection extends Component {
   }
 
   getCommandFields(healthCheck, key) {
-    if (healthCheck.protocol !== 'COMMAND') {
+    if (healthCheck.protocol !== COMMAND) {
       return null;
     }
 
@@ -119,7 +121,7 @@ class HealthChecksFormSection extends Component {
   }
 
   getHTTPFields(healthCheck, key) {
-    if (healthCheck.protocol !== 'HTTP' && healthCheck.protocol !== 'HTTPS') {
+    if (healthCheck.protocol !== HTTP && healthCheck.protocol !== HTTPS) {
       return null;
     }
 
@@ -155,7 +157,7 @@ class HealthChecksFormSection extends Component {
         <FormGroup showError={false} className="column-12">
           <FieldLabel>
             <FieldInput
-              checked={healthCheck.protocol === 'HTTPS'}
+              checked={healthCheck.protocol === HTTPS}
               name={`healthChecks.${key}.https`}
               type="checkbox"
               value="HTTPS"/>
@@ -171,7 +173,7 @@ class HealthChecksFormSection extends Component {
     return data.map((healthCheck, key) => {
       const errors = errorsLens.at(key, {}).get(this.props.errors);
 
-      if (!['', 'HTTP', 'HTTPS', 'COMMAND'].includes(healthCheck.protocol) &&
+      if (HealthCheckUtil.isKnownProtocol(healthCheck.protocol) &&
         healthCheck.protocol != null) {
         return null;
       }
@@ -188,10 +190,10 @@ class HealthChecksFormSection extends Component {
               <FieldLabel>Protocol</FieldLabel>
               <FieldSelect name={`healthChecks.${key}.protocol`}
                 value={healthCheck.protocol &&
-                healthCheck.protocol.replace('HTTPS', 'HTTP')}>
+                healthCheck.protocol.replace(HTTPS, HTTP)}>
                 <option value="">Select Protocol</option>
-                <option value="COMMAND">Command</option>
-                <option value="HTTP">HTTP</option>
+                <option value={COMMAND}>Command</option>
+                <option value={HTTP}>HTTP</option>
               </FieldSelect>
               <FieldError>{errors.protocol}</FieldError>
             </FormGroup>

--- a/plugins/services/src/js/constants/HealtCheckProtocols.js
+++ b/plugins/services/src/js/constants/HealtCheckProtocols.js
@@ -1,0 +1,5 @@
+module.exports = {
+  HTTP: 'HTTP',
+  HTTPS: 'HTTPS',
+  COMMAND: 'COMMAND'
+};

--- a/plugins/services/src/js/reducers/serviceForm/HealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/HealthChecks.js
@@ -17,7 +17,7 @@ function mapHealthChecks(item) {
       };
     }
 
-    if (item.protocol.toUpperCase().replace('HTTPS', 'HTTP') === 'HTTP') {
+    if (item.protocol.toUpperCase() !== 'COMMAND') {
       newItem.path = item.path;
     }
   }
@@ -147,18 +147,10 @@ module.exports = {
             'https'
           ], true, SET));
         }
-        memo.push(new Transaction([
-          'healthChecks',
-          index,
-          'path'
-        ], item.path, SET));
-        memo.push(new Transaction([
-          'healthChecks',
-          index,
-          'portIndex'
-        ], item.portIndex, SET));
       }
       [
+        'path',
+        'portIndex',
         'gracePeriodSeconds',
         'intervalSeconds',
         'timeoutSeconds',

--- a/plugins/services/src/js/reducers/serviceForm/HealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/HealthChecks.js
@@ -3,6 +3,7 @@ import {
   REMOVE_ITEM,
   SET
 } from '../../../../../../src/js/constants/TransactionTypes';
+import {HTTP, HTTPS, COMMAND} from '../../constants/HealtCheckProtocols';
 import Util from '../../../../../../src/js/utils/Util';
 import Transaction from '../../../../../../src/js/structs/Transaction';
 
@@ -11,13 +12,13 @@ function mapHealthChecks(item) {
 
   if (item.protocol != null) {
     newItem.protocol = item.protocol;
-    if (item.protocol.toUpperCase() === 'COMMAND' && item.command != null) {
+    if (item.protocol.toUpperCase() === COMMAND && item.command != null) {
       newItem.command = {
         value: item.command
       };
     }
 
-    if (item.protocol.toUpperCase() !== 'COMMAND') {
+    if (item.protocol.toUpperCase() !== COMMAND) {
       newItem.path = item.path;
     }
   }
@@ -77,8 +78,8 @@ module.exports = {
       if (type === SET) {
         if (`healthChecks.${index}.protocol` === joinedPath) {
           this.healthChecks[index].protocol = value;
-          if (value === 'HTTP' && this.healthChecks[index].https) {
-            this.healthChecks[index].protocol = 'HTTPS';
+          if (value === HTTP && this.healthChecks[index].https) {
+            this.healthChecks[index].protocol = HTTPS;
           }
         }
         if (`healthChecks.${index}.portIndex` === joinedPath) {
@@ -105,9 +106,9 @@ module.exports = {
         if (`healthChecks.${index}.https` === joinedPath) {
           this.healthChecks[index].https = value;
           if (value === true) {
-            this.healthChecks[index].protocol = 'HTTPS';
+            this.healthChecks[index].protocol = HTTPS;
           } else {
-            this.healthChecks[index].protocol = 'HTTP';
+            this.healthChecks[index].protocol = HTTP;
           }
         }
       }
@@ -130,7 +131,7 @@ module.exports = {
         index,
         'protocol'
       ], item.protocol.toUpperCase(), SET));
-      if (item.protocol.toUpperCase() === 'COMMAND') {
+      if (item.protocol.toUpperCase() === COMMAND) {
         if (item.command != null && item.command.value != null) {
           memo.push(new Transaction([
             'healthChecks',
@@ -139,8 +140,8 @@ module.exports = {
           ], item.command.value, SET));
         }
       }
-      if (item.protocol.toUpperCase().replace('HTTPS', 'HTTP') === 'HTTP') {
-        if (item.protocol === 'HTTPS') {
+      if (item.protocol.toUpperCase().replace(HTTPS, HTTP) === HTTP) {
+        if (item.protocol === HTTPS) {
           memo.push(new Transaction([
             'healthChecks',
             index,
@@ -212,8 +213,8 @@ module.exports = {
       if (type === SET) {
         if (`healthChecks.${index}.protocol` === joinedPath) {
           state[index].protocol = value;
-          if (value === 'HTTP' && this.cache[index]) {
-            state[index].protocol = 'HTTPS';
+          if (value === HTTP && this.cache[index]) {
+            state[index].protocol = HTTPS;
           }
         }
         if (`healthChecks.${index}.portIndex` === joinedPath) {
@@ -240,9 +241,9 @@ module.exports = {
         if (`healthChecks.${index}.https` === joinedPath) {
           this.cache[index] = value;
           if (value === true) {
-            state[index].protocol = 'HTTPS';
+            state[index].protocol = HTTPS;
           } else {
-            state[index].protocol = 'HTTP';
+            state[index].protocol = HTTP;
           }
         }
       }

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/HealthChecks-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/HealthChecks-test.js
@@ -1,7 +1,7 @@
 const HealthChecks = require('../HealthChecks');
 const Batch = require('../../../../../../../src/js/structs/Batch');
 const Transaction = require('../../../../../../../src/js/structs/Transaction');
-const {ADD_ITEM, REMOVE_ITEM} =
+const {ADD_ITEM, REMOVE_ITEM, SET} =
   require('../../../../../../../src/js/constants/TransactionTypes');
 
 describe('Labels', function () {
@@ -17,83 +17,210 @@ describe('Labels', function () {
     it('should set the protocol', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['healthChecks'], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'COMMAND'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'COMMAND'));
 
       expect(batch.reduce(HealthChecks.JSONReducer.bind({}), {}))
-      .toEqual([{
-        protocol: 'COMMAND'
-      }]);
+      .toEqual([
+        {
+          protocol: 'COMMAND'
+        }
+      ]);
     });
 
     it('should set the right Command', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['healthChecks'], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'COMMAND'));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'command'], 'sleep 1000;'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'COMMAND'));
+      batch =
+        batch.add(new Transaction([
+          'healthChecks',
+          0,
+          'command'
+        ], 'sleep 1000;'));
 
       expect(batch.reduce(HealthChecks.JSONReducer.bind({}), {}))
-      .toEqual([{
-        protocol: 'COMMAND',
-        command: {
-          value: 'sleep 1000;'
+      .toEqual([
+        {
+          protocol: 'COMMAND',
+          command: {
+            value: 'sleep 1000;'
+          }
         }
-      }]);
+      ]);
     });
 
     it('should set the right path', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['healthChecks'], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
       batch = batch.add(new Transaction(['healthChecks', 0, 'path'], '/test'));
 
       expect(batch.reduce(HealthChecks.JSONReducer.bind({}), {}))
-      .toEqual([{
-        protocol: 'HTTP',
-        path: '/test'
-      }]);
+      .toEqual([
+        {
+          protocol: 'HTTP',
+          path: '/test'
+        }
+      ]);
     });
 
     it('should have a fully fledged health check object', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['healthChecks'], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
       batch = batch.add(new Transaction(['healthChecks', 0, 'https'], true));
       batch = batch.add(new Transaction(['healthChecks', 0, 'path'], '/test'));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'gracePeriodSeconds'], 1));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'intervalSeconds'], 2));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'timeoutSeconds'], 3));
+      batch =
+        batch.add(new Transaction([
+          'healthChecks',
+          0,
+          'gracePeriodSeconds'
+        ], 1));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'intervalSeconds'], 2));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'timeoutSeconds'], 3));
       batch = batch.add(
         new Transaction(['healthChecks', 0, 'maxConsecutiveFailures'], 4)
       );
 
       expect(batch.reduce(HealthChecks.JSONReducer.bind({}), {}))
-      .toEqual([{
-        protocol: 'HTTPS',
-        path: '/test',
-        gracePeriodSeconds: 1,
-        intervalSeconds: 2,
-        timeoutSeconds: 3,
-        maxConsecutiveFailures: 4
-      }]);
+      .toEqual([
+        {
+          protocol: 'HTTPS',
+          path: '/test',
+          gracePeriodSeconds: 1,
+          intervalSeconds: 2,
+          timeoutSeconds: 3,
+          maxConsecutiveFailures: 4
+        }
+      ]);
     });
 
     it('should remove the right item', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['healthChecks'], 0, ADD_ITEM));
       batch = batch.add(new Transaction(['healthChecks'], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'COMMAND'));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'path'], 'sleep 1000;'));
-      batch = batch.add(new Transaction(['healthChecks', 1, 'protocol'], 'HTTP'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'COMMAND'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'path'], 'sleep 1000;'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 1, 'protocol'], 'HTTP'));
       batch = batch.add(new Transaction(['healthChecks', 1, 'path'], '/test'));
       batch = batch.add(new Transaction(['healthChecks'], 0, REMOVE_ITEM));
 
       expect(batch.reduce(HealthChecks.JSONReducer.bind({}), {}))
-      .toEqual([{
-        protocol: 'HTTP',
-        path: '/test'
-      }]);
+      .toEqual([
+        {
+          protocol: 'HTTP',
+          path: '/test'
+        }
+      ]);
     });
 
+    it('should have a fully fledged health check object with unknown' +
+      ' protocol', function () {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(['healthChecks'], 0, ADD_ITEM));
+      batch =
+        batch.add(new Transaction([
+          'healthChecks',
+          0,
+          'protocol'
+        ], 'MESOS_HTTPS'));
+      batch = batch.add(new Transaction(['healthChecks', 0, 'path'], '/test'));
+      batch =
+        batch.add(new Transaction([
+          'healthChecks',
+          0,
+          'gracePeriodSeconds'
+        ], 1));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'intervalSeconds'], 2));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'timeoutSeconds'], 3));
+      batch = batch.add(
+        new Transaction(['healthChecks', 0, 'maxConsecutiveFailures'], 4)
+      );
+
+      expect(batch.reduce(HealthChecks.JSONReducer.bind({}), {}))
+      .toEqual([
+        {
+          protocol: 'MESOS_HTTPS',
+          path: '/test',
+          gracePeriodSeconds: 1,
+          intervalSeconds: 2,
+          timeoutSeconds: 3,
+          maxConsecutiveFailures: 4
+        }
+      ]);
+    });
+
+  });
+
+  describe('#JSONParser', function () {
+    it('should pass unknown protocol', function () {
+      expect(HealthChecks.JSONParser({
+        healthChecks: [
+          {
+            path: '/api/health',
+            portIndex: 0,
+            protocol: 'MESOS_HTTP',
+            gracePeriodSeconds: 300,
+            intervalSeconds: 60,
+            timeoutSeconds: 20,
+            maxConsecutiveFailures: 3
+          }
+        ]
+      })).toEqual([
+        {
+          type: ADD_ITEM,
+          value: 0,
+          path: ['healthChecks']
+        },
+        {
+          type: SET,
+          value: 'MESOS_HTTP',
+          path: ['healthChecks', 0, 'protocol']
+        },
+        {
+          type: SET,
+          value: '/api/health',
+          path: ['healthChecks', 0, 'path']
+        },
+        {
+          type: SET,
+          value: 0,
+          path: ['healthChecks', 0, 'portIndex']
+        },
+        {
+          type: SET,
+          value: 300,
+          path: ['healthChecks', 0, 'gracePeriodSeconds']
+        },
+        {
+          type: SET,
+          value: 60,
+          path: ['healthChecks', 0, 'intervalSeconds']
+        },
+        {
+          type: SET,
+          value: 20,
+          path: ['healthChecks', 0, 'timeoutSeconds']
+        },
+        {
+          type: SET,
+          value: 3,
+          path: ['healthChecks', 0, 'maxConsecutiveFailures']
+        }
+
+      ]);
+    });
   });
 
   describe('#FormReducer', function () {
@@ -108,89 +235,165 @@ describe('Labels', function () {
     it('should set the protocol', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['healthChecks'], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'COMMAND'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'COMMAND'));
 
       expect(batch.reduce(HealthChecks.FormReducer.bind({}), []))
-      .toEqual([{
-        protocol: 'COMMAND'
-      }]);
+      .toEqual([
+        {
+          protocol: 'COMMAND'
+        }
+      ]);
     });
 
     it('should set the right Command', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['healthChecks'], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'COMMAND'));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'command'], 'sleep 1000;'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'COMMAND'));
+      batch =
+        batch.add(new Transaction([
+          'healthChecks',
+          0,
+          'command'
+        ], 'sleep 1000;'));
 
       expect(batch.reduce(HealthChecks.FormReducer.bind({}), []))
-      .toEqual([{
-        protocol: 'COMMAND',
-        command: 'sleep 1000;'
-      }]);
+      .toEqual([
+        {
+          protocol: 'COMMAND',
+          command: 'sleep 1000;'
+        }
+      ]);
     });
 
     it('should set the right path', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['healthChecks'], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
       batch = batch.add(new Transaction(['healthChecks', 0, 'path'], '/test'));
 
       expect(batch.reduce(HealthChecks.FormReducer.bind({}), []))
-      .toEqual([{
-        protocol: 'HTTP',
-        path: '/test'
-      }]);
+      .toEqual([
+        {
+          protocol: 'HTTP',
+          path: '/test'
+        }
+      ]);
     });
 
     it('should have a fully fledged health check object', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['healthChecks'], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
       batch = batch.add(new Transaction(['healthChecks', 0, 'https'], true));
       batch = batch.add(new Transaction(['healthChecks', 0, 'path'], '/test'));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'gracePeriodSeconds'], 1));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'intervalSeconds'], 2));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'timeoutSeconds'], 3));
+      batch =
+        batch.add(new Transaction([
+          'healthChecks',
+          0,
+          'gracePeriodSeconds'
+        ], 1));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'intervalSeconds'], 2));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'timeoutSeconds'], 3));
       batch = batch.add(
         new Transaction(['healthChecks', 0, 'maxConsecutiveFailures'], 4)
       );
 
       expect(batch.reduce(HealthChecks.FormReducer.bind({}), []))
-      .toEqual([{
-        protocol: 'HTTPS',
-        path: '/test',
-        gracePeriodSeconds: 1,
-        intervalSeconds: 2,
-        timeoutSeconds: 3,
-        maxConsecutiveFailures: 4
-      }]);
+      .toEqual([
+        {
+          protocol: 'HTTPS',
+          path: '/test',
+          gracePeriodSeconds: 1,
+          intervalSeconds: 2,
+          timeoutSeconds: 3,
+          maxConsecutiveFailures: 4
+        }
+      ]);
+    });
+
+    it('should have a fully fledged health check object with unknown' +
+      ' protocol', function () {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(['healthChecks'], 0, ADD_ITEM));
+      batch =
+        batch.add(new Transaction([
+          'healthChecks',
+          0,
+          'protocol'
+        ], 'MESOS_HTTP'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'path'], '/api/health'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'portIndex'], 0));
+      batch =
+        batch.add(new Transaction([
+          'healthChecks',
+          0,
+          'gracePeriodSeconds'
+        ], 300));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'intervalSeconds'], 60));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'timeoutSeconds'], 20));
+      batch = batch.add(
+        new Transaction(['healthChecks', 0, 'maxConsecutiveFailures'], 3)
+      );
+
+      expect(batch.reduce(HealthChecks.FormReducer.bind({}), []))
+      .toEqual([
+        {
+          path: '/api/health',
+          portIndex: 0,
+          protocol: 'MESOS_HTTP',
+          gracePeriodSeconds: 300,
+          intervalSeconds: 60,
+          timeoutSeconds: 20,
+          maxConsecutiveFailures: 3
+        }
+      ]);
     });
 
     it('should keep https after switching protocol back to HTTP', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['healthChecks'], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
       batch = batch.add(new Transaction(['healthChecks', 0, 'https'], true));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'COMMAND'));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'COMMAND'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
 
-      expect(batch.reduce(HealthChecks.FormReducer.bind({}), [])).toEqual([{
-        protocol: 'HTTPS'
-      }]);
+      expect(batch.reduce(HealthChecks.FormReducer.bind({}), [])).toEqual([
+        {
+          protocol: 'HTTPS'
+        }
+      ]);
     });
 
     it('should set protocol to http if https was set', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['healthChecks'], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
       batch = batch.add(new Transaction(['healthChecks', 0, 'https'], true));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'COMMAND'));
-      batch = batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'COMMAND'));
+      batch =
+        batch.add(new Transaction(['healthChecks', 0, 'protocol'], 'HTTP'));
       batch = batch.add(new Transaction(['healthChecks', 0, 'https'], false));
 
-      expect(batch.reduce(HealthChecks.FormReducer.bind({}), [])).toEqual([{
-        protocol: 'HTTP'
-      }]);
+      expect(batch.reduce(HealthChecks.FormReducer.bind({}), [])).toEqual([
+        {
+          protocol: 'HTTP'
+        }
+      ]);
     });
 
   });

--- a/plugins/services/src/js/utils/HealtCheckUtil.js
+++ b/plugins/services/src/js/utils/HealtCheckUtil.js
@@ -1,0 +1,7 @@
+import HealthCheckProtocols from '../constants/HealtCheckProtocols';
+
+module.exports = {
+  isKnownProtocol(protocol) {
+    return ['', ...Object.values(HealthCheckProtocols)].includes(protocol);
+  }
+};

--- a/plugins/services/src/js/utils/__tests__/HealthCheckUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/HealthCheckUtil-test.js
@@ -1,0 +1,20 @@
+const HealthCheckUtil = require('../HealtCheckUtil');
+const HealthCheckProtocols = require('../../constants/HealtCheckProtocols');
+
+describe('HealthCheckUtil', function () {
+  describe('#IsKnowProtocol', function () {
+    it('should return true for an empty string', function () {
+      expect(HealthCheckUtil.isKnownProtocol('')).toEqual(true);
+    });
+
+    Object.values(HealthCheckProtocols).forEach((protocol) => {
+      it(`should return true for ${protocol}`, function () {
+        expect(HealthCheckUtil.isKnownProtocol(protocol)).toEqual(true);
+      });
+    });
+
+    it('should return false for a unknown protocol', function () {
+      expect(HealthCheckUtil.isKnownProtocol('MESOS_HTTP')).toEqual(false);
+    });
+  });
+});


### PR DESCRIPTION
This adds the support for healthchecks without a known protocol. We will omit those from the form

![image](https://cloud.githubusercontent.com/assets/156010/21386748/96d46d80-c774-11e6-9915-7e9afc4c2f55.png)
