### PR TITLE
show healthchecks with unknown values

### DIFF
--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -175,7 +175,19 @@ class HealthChecksFormSection extends Component {
 
       if (!HealthCheckUtil.isKnownProtocol(healthCheck.protocol) &&
         healthCheck.protocol != null) {
-        return null;
+        return (
+          <FormGroupContainer
+            key={key}
+            onRemove={this.props.onRemoveItem.bind(this,
+              {value: key, path: 'healthChecks'})}>
+            <FieldLabel>
+              Unable to edit this HealthCheck
+            </FieldLabel>
+            <pre>
+              {JSON.stringify(healthCheck, null, 2)}
+            </pre>
+          </FormGroupContainer>
+        );
       }
 
       return (


### PR DESCRIPTION
~~BASED on #1670~~ Merged

Added support for healthchecks with unknown protocol in the ui. There might come design suggestion for this feature. With this PR it will be possible to delete healthchecks with unknown protocols from the form.

![image](https://cloud.githubusercontent.com/assets/156010/21386950/b4f5ba48-c775-11e6-9800-dbaecb7aeb54.png)

\cc @leemunroe 
