### PR TITLE
DCOS-9310: Adjust default job memory

### DIFF
--- a/src/js/constants/JobResources.js
+++ b/src/js/constants/JobResources.js
@@ -1,0 +1,7 @@
+const JobResources = {
+  DEFAULT_CPUS: 0.01,
+  DEFAULT_DISK: 0,
+  DEFAULT_MEM: 128
+};
+
+module.exports = JobResources;

--- a/src/js/schemas/job-schema/General.js
+++ b/src/js/schemas/job-schema/General.js
@@ -4,6 +4,7 @@ import React from 'react';
 import JobValidatorUtil from '../../utils/JobValidatorUtil';
 import ValidatorUtil from '../../utils/ValidatorUtil';
 import MesosConstants from '../../../../plugins/services/src/js/constants/MesosConstants';
+import JobResources from '../../constants/JobResources';
 
 const General = {
   title: 'General',
@@ -43,7 +44,7 @@ const General = {
       properties: {
         cpus: {
           title: 'CPUs',
-          default: MesosConstants.MIN_CPUS,
+          default: JobResources.DEFAULT_CPUS,
           description: 'The amount of CPUs the job requires',
           type:'number',
           getter(job) {
@@ -63,7 +64,7 @@ const General = {
         },
         mem: {
           title: 'Mem (MiB)',
-          default: MesosConstants.MIN_MEM,
+          default: JobResources.DEFAULT_MEM,
           type: 'number',
           getter(job) {
             return `${job.getMem()}`;
@@ -82,7 +83,7 @@ const General = {
         },
         disk: {
           title: 'Disk (MiB)',
-          default: 0,
+          default: JobResources.DEFAULT_DISK,
           type: 'number',
           getter(job) {
             return `${job.getDisk()}`;

--- a/src/js/structs/Job.js
+++ b/src/js/structs/Job.js
@@ -2,7 +2,11 @@ import {cleanJobJSON} from '../utils/CleanJSONUtil';
 import DateUtil from '../utils/DateUtil';
 import Item from './Item';
 import JobRunList from './JobRunList';
-import MesosConstants from '../../../plugins/services/src/js/constants/MesosConstants';
+import {
+  DEFAULT_CPUS,
+  DEFAULT_DISK,
+  DEFAULT_MEM
+} from '../constants/JobResources';
 
 module.exports = class Job extends Item {
   getActiveRuns() {
@@ -16,7 +20,7 @@ module.exports = class Job extends Item {
   }
 
   getCpus() {
-    const {cpus = MesosConstants.MIN_CPUS} = this.get('run') || {};
+    const {cpus = DEFAULT_CPUS} = this.get('run') || {};
 
     return cpus;
   }
@@ -32,7 +36,7 @@ module.exports = class Job extends Item {
   }
 
   getDisk() {
-    const {disk = 0} = this.get('run') || {};
+    const {disk = DEFAULT_DISK} = this.get('run') || {};
 
     return disk;
   }
@@ -58,7 +62,7 @@ module.exports = class Job extends Item {
   }
 
   getMem() {
-    const {mem = MesosConstants.MIN_MEM} = this.get('run') || {};
+    const {mem = DEFAULT_MEM} = this.get('run') || {};
 
     return mem;
   }

--- a/src/js/structs/__tests__/Job-test.js
+++ b/src/js/structs/__tests__/Job-test.js
@@ -1,5 +1,10 @@
 const Job = require('../Job');
 const JobRunList = require('../JobRunList');
+const {
+  DEFAULT_CPUS,
+  DEFAULT_DISK,
+  DEFAULT_MEM
+} = require('../../constants/JobResources');
 
 describe('Job', function () {
 
@@ -49,14 +54,14 @@ describe('Job', function () {
         run: {}
       });
 
-      expect(job.getCpus()).toEqual(0.01);
+      expect(job.getCpus()).toEqual(DEFAULT_CPUS);
     });
 
     it('defaults to the correct value if run configuration is undefined',
       function () {
         const job = new Job({});
 
-        expect(job.getCpus()).toEqual(0.01);
+        expect(job.getCpus()).toEqual(DEFAULT_CPUS);
       }
     );
 
@@ -113,14 +118,14 @@ describe('Job', function () {
         run: {}
       });
 
-      expect(job.getDisk()).toEqual(0);
+      expect(job.getDisk()).toEqual(DEFAULT_DISK);
     });
 
     it('defaults to the correct value if run configuration is undefined',
       function () {
         const job = new Job({});
 
-        expect(job.getDisk()).toEqual(0);
+        expect(job.getDisk()).toEqual(DEFAULT_DISK);
       }
     );
 
@@ -212,14 +217,14 @@ describe('Job', function () {
         run: {}
       });
 
-      expect(job.getMem()).toEqual(32);
+      expect(job.getMem()).toEqual(DEFAULT_MEM);
     });
 
     it('defaults to the correct value if run configuration is undefined',
       function () {
         const job = new Job({});
 
-        expect(job.getMem()).toEqual(32);
+        expect(job.getMem()).toEqual(DEFAULT_MEM);
       }
     );
 

--- a/src/js/utils/__tests__/JobUtil-test.js
+++ b/src/js/utils/__tests__/JobUtil-test.js
@@ -83,7 +83,7 @@ describe('JobUtil', function () {
           run: {
             cmd: 'sleep 1000;',
             cpus: 0.01,
-            mem: 32,
+            mem: 128,
             disk: 0
           },
           schedules: []


### PR DESCRIPTION
Introduce job resource defaults and use the new constants instead of Mesos constants to properly define job defaults that match the API.

Closes DCOS-9310