### PR TITLE
DCOS-12404: Add missing requirePorts field

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -61,7 +61,11 @@
     "no-new": "off",
     "no-trailing-spaces": ["error", { "skipBlankLines": false }],
     "no-underscore-dangle": "off",
-    "no-unused-vars": ["error", {"args": "after-used", "argsIgnorePattern": "PluginSDK"}],
+    "no-unused-vars": ["error", {
+      "args": "after-used",
+      "argsIgnorePattern": "PluginSDK|^_",
+      "varsIgnorePattern": "^_"
+    }],
     "no-use-before-define": "off",
     "no-multiple-empty-lines": ["error", {"max": 1}],
     // Ternary

--- a/plugins/services/src/js/reducers/JSONConfigReducers.js
+++ b/plugins/services/src/js/reducers/JSONConfigReducers.js
@@ -7,6 +7,7 @@ import {JSONReducer as labels} from './serviceForm/Labels';
 import {JSONReducer as portDefinitions} from './serviceForm/PortDefinitions';
 import {JSONReducer as residency} from './serviceForm/Residency';
 import {JSONReducer as ipAddress} from './serviceForm/IpAddress';
+import {JSONReducer as requirePorts} from './serviceForm/RequirePorts';
 import {
   simpleFloatReducer,
   simpleIntReducer,
@@ -36,6 +37,7 @@ module.exports = {
   constraints,
   fetch,
   portDefinitions,
+  requirePorts,
   residency,
   ipAddress
 };

--- a/plugins/services/src/js/reducers/serviceForm/RequirePorts.js
+++ b/plugins/services/src/js/reducers/serviceForm/RequirePorts.js
@@ -1,0 +1,17 @@
+import {SET} from '../../../../../../src/js/constants/TransactionTypes';
+
+module.exports = {
+  JSONReducer(state, {path, type, value}) {
+    const [_base, index, field] = path;
+
+    if (!this.requriePorts) {
+      this.requriePorts = [];
+    }
+
+    if (field === 'hostPort' && type === SET) {
+      this.requriePorts[index] = value > 0;
+    }
+
+    return this.requriePorts.find((entry) => entry);
+  }
+};

--- a/plugins/services/src/js/reducers/serviceForm/RequirePorts.js
+++ b/plugins/services/src/js/reducers/serviceForm/RequirePorts.js
@@ -12,6 +12,7 @@ module.exports = {
       this.requriePorts[index] = value > 0;
     }
 
-    return this.requriePorts.find((entry) => entry);
+    // Make sure to return null for falsy values
+    return this.requriePorts.includes(true) || null;
   }
 };

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/RequirePorts-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/RequirePorts-test.js
@@ -1,0 +1,49 @@
+const RequirePorts = require('../RequirePorts');
+const Batch = require('../../../../../../../src/js/structs/Batch');
+const Transaction = require('../../../../../../../src/js/structs/Transaction');
+const {SET} =
+  require('../../../../../../../src/js/constants/TransactionTypes');
+
+describe('RequirePorts', function () {
+  describe('#JSONReducer', function () {
+    it('it should return undefined as default', function () {
+      let batch = new Batch();
+
+      batch = batch.add(new Transaction(['id'], 'foo'));
+
+      expect(batch.reduce(RequirePorts.JSONReducer.bind({}))).toEqual(undefined);
+    });
+
+    it('should return true if there is an endpoint with requested host port', function () {
+      let batch = new Batch();
+
+      batch = batch.add(new Transaction(['portDefinitions', 0, 'hostPort'], 80, SET));
+
+      expect(batch.reduce(RequirePorts.JSONReducer.bind({})))
+      .toEqual(true);
+    });
+
+    it('should return true if there is at least one endpoint with requested host port', function () {
+      let batch = new Batch();
+
+      batch = batch.add(new Transaction(['portDefinitions', 0, 'hostPort'], 80, SET));
+      batch = batch.add(new Transaction(['portDefinitions', 0, 'hostPort'], 0, SET));
+      batch = batch.add(new Transaction(['portDefinitions', 1, 'hostPort'], 8080, SET));
+
+      expect(batch.reduce(RequirePorts.JSONReducer.bind({})))
+      .toEqual(true);
+    });
+
+    it('should return undefined if all of the endpoints do not request host port', function () {
+      let batch = new Batch();
+
+      batch = batch.add(new Transaction(['portDefinitions', 0, 'hostPort'], 0, SET));
+      batch = batch.add(new Transaction(['portDefinitions', 1, 'hostPort'], 0, SET));
+      batch = batch.add(new Transaction(['portDefinitions', 2, 'hostPort'], 0, SET));
+
+      expect(batch.reduce(RequirePorts.JSONReducer.bind({})))
+      .toEqual(undefined);
+    });
+
+  });
+});

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/RequirePorts-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/RequirePorts-test.js
@@ -6,12 +6,12 @@ const {SET} =
 
 describe('RequirePorts', function () {
   describe('#JSONReducer', function () {
-    it('it should return undefined as default', function () {
+    it('it should return null as default', function () {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(['id'], 'foo'));
 
-      expect(batch.reduce(RequirePorts.JSONReducer.bind({}))).toEqual(undefined);
+      expect(batch.reduce(RequirePorts.JSONReducer.bind({}))).toEqual(null);
     });
 
     it('should return true if there is an endpoint with requested host port', function () {
@@ -34,7 +34,7 @@ describe('RequirePorts', function () {
       .toEqual(true);
     });
 
-    it('should return undefined if all of the endpoints do not request host port', function () {
+    it('should return null if all of the endpoints do not request host port', function () {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(['portDefinitions', 0, 'hostPort'], 0, SET));
@@ -42,7 +42,7 @@ describe('RequirePorts', function () {
       batch = batch.add(new Transaction(['portDefinitions', 2, 'hostPort'], 0, SET));
 
       expect(batch.reduce(RequirePorts.JSONReducer.bind({})))
-      .toEqual(undefined);
+      .toEqual(null);
     });
 
   });


### PR DESCRIPTION
This PR adds missing `requirePorts` field when a user specifies a hostPort for her Docker app with a Bridge network. This field is important because otherwise Marathon ignores specified hostPort and uses a random one.