### PR TITLE
Replace British 'behaviour' with American 'behavior'

### DIFF
--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -24,7 +24,7 @@ const {type: {MESOS, DOCKER, NONE}, labelMap} = ContainerConstants;
 const containerRuntimes = {
   [NONE]: {
     label: <span>{labelMap[NONE]}</span>,
-    helpText: 'Normal behaviour'
+    helpText: 'Normal behavior'
   },
   [MESOS]: {
     label: <span>{labelMap[MESOS]}</span>,


### PR DESCRIPTION
I could not find any other conspicuous Britishisms in the codebase. 