### PR TITLE
DCOS-12657: Display service name only when VIP_* labels exist

### DIFF
--- a/plugins/services/src/js/service-configuration/PodNetworkConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodNetworkConfigSection.js
@@ -8,6 +8,7 @@ import ConfigurationMapRow from '../../../../../src/js/components/ConfigurationM
 import ConfigurationMapSection from '../../../../../src/js/components/ConfigurationMapSection';
 import ServiceConfigDisplayUtil from '../utils/ServiceConfigDisplayUtil';
 import ConfigurationMapValueWithDefault from '../components/ConfigurationMapValueWithDefault';
+import Networking from '../../../../../src/js/constants/Networking';
 
 const NETWORK_MODE_NAME = {
   'container': 'Container',
@@ -52,7 +53,7 @@ class PodNetworkConfigSection extends React.Component {
     const {onEditClick} = this.props;
     const appConfig = this.props.appConfig;
     const {containers = []} = appConfig;
-    let endpoints = containers.reduce((memo, container) => {
+    const endpoints = containers.reduce((memo, container) => {
       const {endpoints = []} = container;
 
       return memo.concat(
@@ -60,7 +61,7 @@ class PodNetworkConfigSection extends React.Component {
           const lbAddress = Object.keys(labels).reduce((memo, label) => {
             if (label.startsWith('VIP_')) {
               const [prefix, port] = labels[label].split(':');
-              memo.push(`${prefix}.marathon.lb4lb.thisdcos.directory:${port}`);
+              memo.push(`${prefix}.${Networking.L4LB_ADDRESS}:${port}`);
             }
 
             return memo;

--- a/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
@@ -8,7 +8,7 @@ import {
   getColumnHeadingFn,
   getDisplayValue
 } from '../utils/ServiceConfigDisplayUtil';
-import HostUtil from '../utils/HostUtil';
+import ServiceConfigUtil from '../utils/ServiceConfigUtil';
 import ServiceConfigBaseSectionDisplay from './ServiceConfigBaseSectionDisplay';
 import {findNestedPropertyInObject} from '../../../../../src/js/utils/Util';
 
@@ -47,7 +47,8 @@ class ServiceNetworkingConfigSection extends ServiceConfigBaseSectionDisplay {
             const keys = {
               name: 'name',
               port: 'port',
-              protocol: 'protocol'
+              protocol: 'protocol',
+              labels: 'labels'
             };
 
             const containerPortMappings = findNestedPropertyInObject(
@@ -101,12 +102,16 @@ class ServiceNetworkingConfigSection extends ServiceConfigBaseSectionDisplay {
                 prop: '',
                 className: getColumnClassNameFn(),
                 render(prop, row) {
-                  // TODO: Only render this when necessary, figure out when
-                  // necessary.
-                  const hostname = HostUtil.stringToHostname(appDefinition.id);
-                  const port = row[keys.port];
+                  const {port, labels} = row;
 
-                  return `${hostname}${Networking.L4LB_ADDRESS}:${port}`;
+                  if (labels && ServiceConfigUtil.hasVIPLabel(labels)) {
+                    return ServiceConfigUtil.buildHostName(
+                      appDefinition.id,
+                      port
+                    );
+                  }
+
+                  return getDisplayValue(undefined);
                 },
                 sortable: true
               }

--- a/plugins/services/src/js/utils/ServiceConfigUtil.js
+++ b/plugins/services/src/js/utils/ServiceConfigUtil.js
@@ -1,67 +1,18 @@
 import HostUtil from '../utils/HostUtil';
 import Networking from '../../../../../src/js/constants/Networking';
-import Util from '../../../../../src/js/utils/Util';
 
-const serviceAddressKey = 'Service Address';
+const ServiceConfigUtil = {
 
-function buildHostName(id, port) {
-  const hostname = HostUtil.stringToHostname(id);
-
-  return `${hostname}${Networking.L4LB_ADDRESS}:${port}`;
-}
-
-function defaultCreateLink(contents) {
-  return contents;
-}
-
-function hasVIPLabel(labels={}) {
-  return Object.keys(labels).find(function (key) {
-    return /^VIP_[0-9]+$/.test(key);
-  });
-}
-
-var ServiceConfigUtil = {
-  getCommandString(container) {
-    // Generic Service
-    if (container.cmd) {
-      return container.cmd;
-    }
-
-    // Pod
-    // https://github.com/mesosphere/marathon/blob/feature/pods/docs/docs/rest-api/public/api/v2/types/podContainer.raml#L61
-    const {shell, argv} =
-      Util.findNestedPropertyInObject(container, 'exec.command') || {};
-
-    if (shell) {
-      return shell;
-    }
-    if (Array.isArray(argv)) {
-      return argv.join(' ');
-    }
-
-    return null;
+  hasVIPLabel(labels = {}) {
+    return Object.keys(labels).find(function (key) {
+      return /^VIP_[0-9]+$/.test(key);
+    });
   },
 
-  getPortDefinitionGroups(id, portDefinitions, createLink = defaultCreateLink) {
-    return portDefinitions.map(function (portDefinition, index) {
-      const hash = Object.assign({}, portDefinition);
-      let headline = `Port Definition ${index + 1}`;
+  buildHostName(id, port) {
+    const hostname = HostUtil.stringToHostname(id);
 
-      if (portDefinition.name) {
-        headline += ` (${portDefinition.name})`;
-      }
-
-      // Check if this port is load balanced
-      if (hasVIPLabel(portDefinition.labels)) {
-        const link = buildHostName(id, portDefinition.port);
-        hash[serviceAddressKey] = createLink(link, link);
-      }
-
-      return {
-        hash,
-        headline
-      };
-    });
+    return `${hostname}${Networking.L4LB_ADDRESS}:${port}`;
   }
 
 };

--- a/plugins/services/src/js/utils/__tests__/ServiceConfigUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceConfigUtil-test.js
@@ -3,106 +3,27 @@ jest.dontMock('../ServiceConfigUtil');
 const ServiceConfigUtil = require('../ServiceConfigUtil');
 
 describe('ServiceConfigUtil', function () {
-  describe('#getCommandString', function () {
-    describe('pre-pods approach', function () {
-      it('returns container command', function () {
-        const container = {
-          cmd: 'sleep 10'
-        };
+  describe('#hasVIPLabel', function () {
 
-        expect(ServiceConfigUtil.getCommandString(container)).toEqual('sleep 10');
-      });
+    it('returns true', function () {
+      expect(
+        ServiceConfigUtil.hasVIPLabel({VIP_1: ''})
+      ).toBeTruthy();
     });
 
-    describe('pods approach', function () {
-      describe('shell command', function () {
-        it('returns container command', function () {
-          const container = {
-            exec: {
-              command: {
-                shell: 'sleep 10'
-              }
-            }
-          };
-          expect(ServiceConfigUtil.getCommandString(container)).toEqual('sleep 10');
-        });
-
-      });
-
-      describe('argv command', function () {
-        it('returns container command', function () {
-          const container = {
-            exec: {
-              command: {
-                argv: ['sleep', '10']
-              }
-            }
-          };
-          expect(ServiceConfigUtil.getCommandString(container)).toEqual('sleep 10');
-        });
-
-      });
-
+    it('returns false', function () {
+      expect(
+        ServiceConfigUtil.hasVIPLabel({LABEL: ''})
+      ).toBeFalsy();
     });
 
   });
 
-  describe('#getPortDefinitionGroups', function () {
-    describe('port definitions with no name', function () {
-      it('creates index-based headline', function () {
-        const portDefinitions = [{}];
-        const {headline} =
-          ServiceConfigUtil.getPortDefinitionGroups(1, portDefinitions)[0];
-
-        expect(headline).toEqual('Port Definition 1');
-      });
-
-    });
-
-    describe('named port definitions', function () {
-      it('adds the name to the headline', function () {
-        const portDefinitions = [{
-          name: 'portName'
-        }];
-        const {headline} =
-          ServiceConfigUtil.getPortDefinitionGroups('1234', portDefinitions)[0];
-
-        expect(headline).toEqual('Port Definition 1 (portName)');
-      });
-
-    });
-
-    describe('load-balanced ports', function () {
-      it('adds a service address to the definition', function () {
-        const portDefinitions = [{
-          port: 80,
-          labels: {
-            'VIP_0': '1.2.3.4:80'
-          }
-        }];
-        const {hash} =
-          ServiceConfigUtil.getPortDefinitionGroups('1234', portDefinitions)[0];
-
-        expect(hash['Service Address'])
-          .toEqual('1234.marathon.l4lb.thisdcos.directory:80');
-      });
-
-    });
-
-    describe('generic ports', function () {
-      it('doesn\'t add a service address to the definition', function () {
-        const portDefinitions = [{
-          port: 80,
-          labels: {
-            'SOME': 'LABEL'
-          }
-        }];
-        const {hash} =
-          ServiceConfigUtil.getPortDefinitionGroups('1234', portDefinitions)[0];
-
-        expect(hash['Service Address']).toBeUndefined();
-      });
-
+  describe('#buildHostName', function () {
+    it('adds a service address to the definition', function () {
+      expect(
+        ServiceConfigUtil.buildHostName('1234', 80)
+      ).toEqual('1234.marathon.l4lb.thisdcos.directory:80');
     });
 
   });


### PR DESCRIPTION
This PR ensures that we display a service address on the review screen and on the config tab only when we have a VIP_* port and `Not Configured` otherwise.

Since our old form is gone that util wen orphan, so I've reused some pieces of code in there and deleted obsolete bits: plugins/services/src/js/utils/ServiceConfigUtil.js