### PR TITLE
Adjusting the scroll container listener to be the page content

### DIFF
--- a/src/js/components/DisplayPackagesTable.js
+++ b/src/js/components/DisplayPackagesTable.js
@@ -103,6 +103,7 @@ class DisplayPackagesTable extends React.Component {
         className="table table-hover no-header inverse table-borderless-outer table-borderless-inner-columns flush-bottom"
         columns={this.getColumns()}
         colGroup={this.getColGroup()}
+        containerSelector=".page-content"
         data={this.props.packages.getItems().slice()} />
     );
   }


### PR DESCRIPTION
---
ℹ️ This is the same fix as for master here: https://github.com/dcos/dcos-ui/pull/1689

---

Before:
![](https://cl.ly/233J1Z2C2R0H/Screen%20Recording%202016-12-22%20at%2013.49.gif)

After:
![](https://cl.ly/233J1Z2C2R0H/Screen%20Recording%202016-12-22%20at%2013.49.gif)