### PR TITLE
Adjusting the scroll container listener to be the page content

### DIFF
--- a/src/js/components/DisplayPackagesTable.js
+++ b/src/js/components/DisplayPackagesTable.js
@@ -103,6 +103,7 @@ class DisplayPackagesTable extends React.Component {
         className="table table-hover table-hide-header table-borderless-outer table-borderless-inner-columns flush-bottom"
         columns={this.getColumns()}
         colGroup={this.getColGroup()}
+        containerSelector=".page-body"
         data={this.props.packages.getItems().slice()} />
     );
   }


### PR DESCRIPTION
---
ℹ️ This is the same fix as for release 1.8: https://github.com/dcos/dcos-ui/pull/1688

---

Before:
![](https://cl.ly/3F1K353g3e3J/Screen%20Recording%202016-12-22%20at%2013.54.gif)
After:
![](https://cl.ly/2t2E0J2J2c1G/Screen%20Recording%202016-12-22%20at%2013.56.gif)