### PR TITLE
Improving the package search, ref. DCOS-5779

### DIFF
--- a/src/js/utils/StringUtil.js
+++ b/src/js/utils/StringUtil.js
@@ -4,7 +4,7 @@ import React from 'react';
 /* eslint-enable no-unused-vars */
 
 const StringUtil = {
-  arrayToJoinedString(array=[], separator = ', ') {
+  arrayToJoinedString(array = [], separator = ', ') {
     if (Array.isArray(array)) {
       return array.join(separator);
     }
@@ -12,18 +12,37 @@ const StringUtil = {
     return '';
   },
 
+  getSearchTokens(searchString) {
+    if (!searchString) {
+      return [];
+    }
+
+    return String(searchString)
+      .toLowerCase()
+      // split on non-word characters and slash
+      .split(/[^\w\/]/)
+      .filter(Boolean);
+  },
+
   filterByString(objects, getter, searchString) {
-    var regex = StringUtil.escapeForRegExp(searchString);
-    var searchPattern = new RegExp(regex, 'i');
+    const searchItems = this.getSearchTokens(searchString);
 
     if (typeof getter === 'function') {
-      return objects.filter(function (obj) {
-        return searchPattern.test(getter(obj));
+      return objects.filter((obj) => {
+        return searchItems.some((item) => {
+          return this.getSearchTokens(getter(obj)).some((token) => {
+            return token.startsWith(item);
+          });
+        });
       });
     }
 
-    return objects.filter(function (obj) {
-      return searchPattern.test(obj[getter]);
+    return objects.filter((obj) => {
+      return searchItems.some((item) => {
+        return this.getSearchTokens(obj[getter]).some((token) => {
+          return token.startsWith(item);
+        });
+      });
     });
   },
 

--- a/src/js/utils/__tests__/StringUtil-test.js
+++ b/src/js/utils/__tests__/StringUtil-test.js
@@ -50,6 +50,27 @@ describe('StringUtil', function () {
 
   });
 
+  describe('#getSearchTokens', function () {
+
+    it('splits on non-word characters, but not slashes', function () {
+      expect(StringUtil.getSearchTokens('foo/bar\\.baz.quis,qux quux[quuz]corge grault,garply\twaldo\bfred'))
+        .toEqual(['foo/bar', 'baz', 'quis', 'qux', 'quux', 'quuz', 'corge', 'grault', 'garply', 'waldo', 'fred']);
+    });
+
+    it('returns converts input to string if not a string', function () {
+      expect(StringUtil.getSearchTokens(10)).toEqual(['10']);
+    });
+
+    it('removes empty strings', function () {
+      expect(StringUtil.getSearchTokens('bar\\.baz')).toEqual(['bar', 'baz']);
+    });
+
+    it('lowercases strings', function () {
+      expect(StringUtil.getSearchTokens('QuUx[qUuz]coRge')).toEqual(['quux', 'quuz', 'corge']);
+    });
+
+  });
+
   describe('#filterByString', function () {
 
     it('filters using a key as getter', function () {


### PR DESCRIPTION
Improving package search, so `ch` does not match Apache, since we are using startsWith:
![](https://cl.ly/3k0B0N2G0w2L/Screen%20Recording%202016-12-22%20at%2015.43.gif)