### PR TITLE
Updated CNVS from 1.1.4 to 1.1.6

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1230,9 +1230,9 @@
       "resolved": "https://registry.npmjs.org/closest/-/closest-0.0.1.tgz"
     },
     "cnvs": {
-      "version": "1.1.4",
-      "from": "cnvs@1.1.4",
-      "resolved": "https://registry.npmjs.org/cnvs/-/cnvs-1.1.4.tgz"
+      "version": "1.1.6",
+      "from": "cnvs@1.1.6",
+      "resolved": "https://registry.npmjs.org/cnvs/-/cnvs-1.1.6.tgz"
     },
     "co": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "browser-info": "0.4.0",
     "classnames": "2.2.3",
     "clipboard": "1.5.10",
-    "cnvs": "1.1.4",
+    "cnvs": "1.1.6",
     "cookie": "0.2.3",
     "d3": "3.5.16",
     "dcos-dygraphs": "1.1.0-beta.3",

--- a/src/js/components/modals/IdentifyModal.js
+++ b/src/js/components/modals/IdentifyModal.js
@@ -76,11 +76,11 @@ var IdentifyModal = React.createClass({
     var emailClassSet = classNames({
       'form-group': true,
       'flush-bottom': true,
-      'form-group-error': data.emailHasError
+      'form-group-danger': data.emailHasError
     });
 
     var emailHelpBlock = classNames({
-      'form-help-block': true,
+      'form-control-feedback': true,
       'hidden': !data.emailHasError
     });
 

--- a/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
+++ b/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
@@ -29,11 +29,11 @@ describe('Add Repository Form Modal', function () {
       .contains('Add')
       .click();
 
-    cy.get('.modal .form-help-block')
+    cy.get('.modal .form-control-feedback')
       .eq(0)
       .should('contain', 'Field cannot be empty.');
 
-    cy.get('.modal .form-help-block')
+    cy.get('.modal .form-control-feedback')
       .eq(1)
       .should('contain', 'Must be a valid url with http:// or https://');
   });
@@ -44,7 +44,7 @@ describe('Add Repository Form Modal', function () {
       .contains('Add')
       .click();
 
-    cy.get('.modal .form-help-block')
+    cy.get('.modal .form-control-feedback')
       .should('contain', 'Must be a valid url with http:// or https://');
   });
 


### PR DESCRIPTION
Double-check I did the shrinkwrap update correctly please.

Notable updates:
* Updated .button-flush with directional modifiers
* Fixed disabled buttons of type *-link
* Adjusted background of .form-control and .form-control-toggle
* Updated background style of .form-control style variants
* URI encode inline SVG strings
* Updated styling of `disabled` state for `form-control` component

Full diff here for reviewers: https://github.com/mesosphere/cnvs/compare/4e301e8951b74b7c4d6f959ef255651f7da6a11d...d2eb4d1477a0aab827071db210a7c638f9b3cc45