### PR TITLE
Service name > Service ID in service create form

### DIFF
--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -302,7 +302,7 @@ class GeneralServiceFormSection extends Component {
           Services
         </h2>
         <p>
-          Configure your service below. Start by giving your service an Id.
+          Configure your service below. Start by giving your service an ID.
         </p>
 
         <FormRow>

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -302,7 +302,7 @@ class GeneralServiceFormSection extends Component {
           Services
         </h2>
         <p>
-          Configure your service below. Start by giving your service a name.
+          Configure your service below. Start by giving your service an Id.
         </p>
 
         <FormRow>
@@ -311,7 +311,7 @@ class GeneralServiceFormSection extends Component {
             required={true}
             showError={Boolean(errors.id)}>
             <FieldLabel>
-              Service Name
+              Service ID
             </FieldLabel>
             <FieldInput
               name="id"


### PR DESCRIPTION
Changed copy from `SERVICE NAME` to `SERVICE ID` which now aligns with the config section (REVIEW & RUN).

![](https://cl.ly/0z2g1a1S0O05/Image%202016-12-26%20at%204.09.01%20PM.png)