### PR TITLE
Revert "Adjusting the scroll container listener to be the page content"

### DIFF
--- a/src/js/components/DisplayPackagesTable.js
+++ b/src/js/components/DisplayPackagesTable.js
@@ -103,7 +103,6 @@ class DisplayPackagesTable extends React.Component {
         className="table table-hover no-header inverse table-borderless-outer table-borderless-inner-columns flush-bottom"
         columns={this.getColumns()}
         colGroup={this.getColGroup()}
-        containerSelector=".page-content"
         data={this.props.packages.getItems().slice()} />
     );
   }


### PR DESCRIPTION
Reverts dcos/dcos-ui#1688

Fix being applied here: https://github.com/dcos/dcos-ui/pull/1698