### PR TITLE
Updating reactjs-components to v0.16.0-beta.8

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6684,9 +6684,9 @@
       "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz"
     },
     "reactjs-components": {
-      "version": "0.16.0-beta.6",
-      "from": "reactjs-components@0.16.0-beta.6",
-      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.16.0-beta.6.tgz"
+      "version": "0.16.0-beta.8",
+      "from": "reactjs-components@0.16.0-beta.8",
+      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.16.0-beta.8.tgz"
     },
     "reactjs-mixin": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-gemini-scrollbar": "2.1.0",
     "react-redux": "4.4.0",
     "react-router": "2.8.1",
-    "reactjs-components": "0.16.0-beta.6",
+    "reactjs-components": "0.16.0-beta.8",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
     "tv4": "1.2.7"


### PR DESCRIPTION
This PR contains a fix for VirtualList scroll event not bubbling: https://github.com/mesosphere/reactjs-components/pull/384
And cnvs peer requirement update to 1.1.4: https://github.com/mesosphere/reactjs-components/pull/379