### PR TITLE
DCOS-12289: Fix json generation for host volumes

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/Volumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/Volumes.js
@@ -60,6 +60,10 @@ module.exports = {
       this.docker = value !== '';
     }
 
+    if (joinedPath === 'container.type') {
+      this.docker = value !== 'NONE';
+    }
+
     if (path[0] === 'externalVolumes') {
       if (joinedPath === 'externalVolumes') {
         switch (type) {

--- a/plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js
@@ -106,6 +106,7 @@ class ServiceStorageConfigSection extends ServiceConfigBaseSectionDisplay {
                 volume.size = appVolume.persistent.size;
                 volume.type.push('Persistent', 'Local');
               } else if (appVolume.external != null) {
+                volume.size = appVolume.external.size;
                 volume.type.push('External');
               } else {
                 volume.type.push('Host', 'Volume');

--- a/plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js
@@ -67,7 +67,7 @@ class ServiceStorageConfigSection extends ServiceConfigBaseSectionDisplay {
                   const value = row[prop];
 
                   if (value == null) {
-                    return getDisplayValue(value);
+                    return getDisplayValue(value, row.isHostVolume);
                   }
 
                   return formatResource('disk', value);
@@ -96,7 +96,8 @@ class ServiceStorageConfigSection extends ServiceConfigBaseSectionDisplay {
               const volume = {
                 name: null,
                 size: null,
-                type: []
+                type: [],
+                isHostVolume: false
               };
 
               volume.containerPath = appVolume.containerPath;
@@ -109,6 +110,7 @@ class ServiceStorageConfigSection extends ServiceConfigBaseSectionDisplay {
                 volume.size = appVolume.external.size;
                 volume.type.push('External');
               } else {
+                volume.isHostVolume = true;
                 volume.type.push('Host', 'Volume');
               }
 
@@ -121,7 +123,10 @@ class ServiceStorageConfigSection extends ServiceConfigBaseSectionDisplay {
                 shouldDisplayHostPath = true;
               }
 
-              volume.hostPath = getDisplayValue(appVolume.hostPath);
+              volume.hostPath = getDisplayValue(
+                appVolume.hostPath,
+                !volume.isHostVolume
+              );
 
               return volume;
             });


### PR DESCRIPTION
Host volumes should only be rendered if the
runtime type is MESOS or DOCKER or a docker image
has been set

close DCOS-12289