### PR TITLE
DCOS-11957: Add redirect after destroying a service

### DIFF
--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -10,7 +10,8 @@ import Pod from '../../structs/Pod';
 import Service from '../../structs/Service';
 import ServiceTree from '../../structs/ServiceTree';
 
-const REDIRECT_DELAY = 500;
+// This needs to be at least equal to @modal-animation-duration
+const REDIRECT_DELAY = 300;
 const METHODS_TO_BIND = [
   'handleRightButtonClick'
 ];
@@ -124,7 +125,8 @@ class ServiceDestroyModal extends React.Component {
   redirectToServices() {
     const {router} = this.context;
 
-    // Delayed redirect so that Modal has some time to be closed
+    // Close the modal and redirect after the close animation has completed
+    this.props.onClose();
     setTimeout(() => {
       router.push({pathname: '/services/overview'});
     }, REDIRECT_DELAY);

--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -1,6 +1,7 @@
 import {Confirm} from 'reactjs-components';
-import React, {PropTypes} from 'react';
+import {routerShape} from 'react-router';
 import PureRender from 'react-addons-pure-render-mixin';
+import React, {PropTypes} from 'react';
 
 import AppLockedMessage from './AppLockedMessage';
 import Framework from '../../structs/Framework';
@@ -8,6 +9,11 @@ import ModalHeading from '../../../../../../src/js/components/modals/ModalHeadin
 import Pod from '../../structs/Pod';
 import Service from '../../structs/Service';
 import ServiceTree from '../../structs/ServiceTree';
+
+const REDIRECT_DELAY = 500;
+const METHODS_TO_BIND = [
+  'handleRightButtonClick'
+];
 
 class ServiceDestroyModal extends React.Component {
   constructor() {
@@ -18,6 +24,10 @@ class ServiceDestroyModal extends React.Component {
     };
 
     this.shouldComponentUpdate = PureRender.shouldComponentUpdate.bind(this);
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
   }
 
   componentWillUpdate(nextProps) {
@@ -65,6 +75,11 @@ class ServiceDestroyModal extends React.Component {
     return this.state.errorMsg && /force=true/.test(this.state.errorMsg);
   }
 
+  handleRightButtonClick() {
+    this.props.deleteItem(this.shouldForceUpdate());
+    this.redirectToServices();
+  }
+
   getDestroyMessage() {
     const {service} = this.props;
     let serviceName = '';
@@ -106,9 +121,17 @@ class ServiceDestroyModal extends React.Component {
     );
   }
 
+  redirectToServices() {
+    const {router} = this.context;
+
+    // Delayed redirect so that Modal has some time to be closed
+    setTimeout(() => {
+      router.push({pathname: '/services/overview'});
+    }, REDIRECT_DELAY);
+  }
+
   render() {
     const {
-      deleteItem,
       isPending,
       onClose,
       open,
@@ -125,7 +148,7 @@ class ServiceDestroyModal extends React.Component {
       itemText = 'Group';
     }
 
-    let heading = (
+    const heading = (
       <ModalHeading className="text-danger">
         Destroy {itemText}
       </ModalHeading>
@@ -141,7 +164,7 @@ class ServiceDestroyModal extends React.Component {
         leftButtonCallback={onClose}
         rightButtonText={`Destroy ${itemText}`}
         rightButtonClassName="button button-danger"
-        rightButtonCallback={() => deleteItem(this.shouldForceUpdate())}
+        rightButtonCallback={this.handleRightButtonClick}
         showHeader={true}>
         {this.getDestroyMessage()}
         {this.getErrorMessage()}
@@ -149,6 +172,10 @@ class ServiceDestroyModal extends React.Component {
     );
   }
 }
+
+ServiceDestroyModal.contextTypes = {
+  router: routerShape
+};
 
 ServiceDestroyModal.propTypes = {
   deleteItem: PropTypes.func.isRequired,


### PR DESCRIPTION
This PR adds a delayed redirect after a service got destroyed via the `ServiceDestroyModal`.
We have to delay the redirect because Router redirects faster than our code manages to close the modal which results in the Modal inviting you to destroy the root `/` group as well.