### PR TITLE
DCOS-12464: Display seconds in the health checks review section

### DIFF
--- a/plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js
@@ -4,10 +4,10 @@ import {Table} from 'reactjs-components';
 import {
   getColumnClassNameFn,
   getColumnHeadingFn,
-  getDisplayValue,
-  renderMillisecondsFromSeconds
+  getDisplayValue
 } from '../utils/ServiceConfigDisplayUtil';
 import ConfigurationMapEditAction from '../components/ConfigurationMapEditAction';
+import ConfigurationMapDurationValue from '../components/ConfigurationMapDurationValue';
 import ServiceConfigBaseSectionDisplay from './ServiceConfigBaseSectionDisplay';
 import Util from '../../../../../src/js/utils/Util';
 
@@ -43,7 +43,7 @@ class ServiceHealthChecksConfigSection extends ServiceConfigBaseSectionDisplay {
         {
           key: 'healthChecks',
           render(healthChecks) {
-            let serviceEndpointHealthChecks = healthChecks.filter(
+            const serviceEndpointHealthChecks = healthChecks.filter(
               (healthCheck) => {
                 return ['HTTP', 'HTTPS', 'TCP'].includes(healthCheck.protocol);
               }
@@ -72,21 +72,39 @@ class ServiceHealthChecksConfigSection extends ServiceConfigBaseSectionDisplay {
                 heading: getColumnHeadingFn('Grace Period'),
                 prop: 'gracePeriodSeconds',
                 className: getColumnClassNameFn(),
-                render: renderMillisecondsFromSeconds,
+                render(prop, row) {
+                  return (
+                    <ConfigurationMapDurationValue
+                      units="sec"
+                      value={row[prop]} />
+                  );
+                },
                 sortable: true
               },
               {
                 heading: getColumnHeadingFn('Interval'),
                 prop: 'intervalSeconds',
                 className: getColumnClassNameFn(),
-                render: renderMillisecondsFromSeconds,
+                render(prop, row) {
+                  return (
+                    <ConfigurationMapDurationValue
+                      units="sec"
+                      value={row[prop]} />
+                  );
+                },
                 sortable: true
               },
               {
                 heading: getColumnHeadingFn('Timeout'),
                 prop: 'timeoutSeconds',
                 className: getColumnClassNameFn(),
-                render: renderMillisecondsFromSeconds,
+                render(prop, row) {
+                  return (
+                    <ConfigurationMapDurationValue
+                      units="sec"
+                      value={row[prop]} />
+                  );
+                },
                 sortable: true
               },
               {
@@ -131,7 +149,7 @@ class ServiceHealthChecksConfigSection extends ServiceConfigBaseSectionDisplay {
         {
           key: 'healthChecks',
           render(healthChecks) {
-            let commandHealthChecks = healthChecks.filter((healthCheck) => {
+            const commandHealthChecks = healthChecks.filter((healthCheck) => {
               return healthCheck.protocol === 'COMMAND';
             });
 
@@ -141,7 +159,7 @@ class ServiceHealthChecksConfigSection extends ServiceConfigBaseSectionDisplay {
                 prop: 'command',
                 render: (prop, row) => {
                   const command = row[prop] || {};
-                  let value = getDisplayValue(command.value);
+                  const value = getDisplayValue(command.value);
                   if (!command.value) {
                     return value;
                   }
@@ -159,21 +177,39 @@ class ServiceHealthChecksConfigSection extends ServiceConfigBaseSectionDisplay {
                 heading: getColumnHeadingFn('Grace Period'),
                 prop: 'gracePeriodSeconds',
                 className: getColumnClassNameFn(),
-                render: renderMillisecondsFromSeconds,
+                render(prop, row) {
+                  return (
+                    <ConfigurationMapDurationValue
+                      units="sec"
+                      value={row[prop]} />
+                  );
+                },
                 sortable: true
               },
               {
                 heading: getColumnHeadingFn('Interval'),
                 prop: 'intervalSeconds',
                 className: getColumnClassNameFn(),
-                render: renderMillisecondsFromSeconds,
+                render(prop, row) {
+                  return (
+                    <ConfigurationMapDurationValue
+                      units="sec"
+                      value={row[prop]} />
+                  );
+                },
                 sortable: true
               },
               {
                 heading: getColumnHeadingFn('Timeout'),
                 prop: 'timeoutSeconds',
                 className: getColumnClassNameFn(),
-                render: renderMillisecondsFromSeconds,
+                render(prop, row) {
+                  return (
+                    <ConfigurationMapDurationValue
+                      units="sec"
+                      value={row[prop]} />
+                  );
+                },
                 sortable: true
               },
               {

--- a/plugins/services/src/js/utils/ServiceConfigDisplayUtil.js
+++ b/plugins/services/src/js/utils/ServiceConfigDisplayUtil.js
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
 
-import {getDuration} from '../../../../../src/js/utils/DateUtil';
 import {isObject} from '../../../../../src/js/utils/Util';
 import Icon from '../../../../../src/js/components/Icon';
 
@@ -66,17 +65,8 @@ const ServiceConfigDisplayUtil = {
         <em>&nbsp;Shared</em>
       </span>
     );
-  },
-
-  renderMillisecondsFromSeconds(prop, row) {
-    let value = row[prop];
-
-    if (value != null) {
-      value = getDuration(value);
-    }
-
-    return ServiceConfigDisplayUtil.getDisplayValue(value);
   }
+
 };
 
 module.exports = ServiceConfigDisplayUtil;

--- a/src/js/utils/MomentJSConfig.js
+++ b/src/js/utils/MomentJSConfig.js
@@ -4,7 +4,7 @@ moment.updateLocale('en', {
   relativeTime: {
     future: 'in %s',
     past: '%s ago',
-    s: 'seconds',
+    s: '%d seconds',
     m: 'a minute',
     mm: '%d minutes',
     h: 'an hour',


### PR DESCRIPTION
This PR addresses the issue with seconds not being displayed in the Health checks review section.
The reason was that `moment.js` library doesn't display the amount of seconds by default like it's not that relevant.

ℹ️  Please note `.humanize()` method doesn't only display seconds by default but it also makes some assumptions on how to round up the numbers. I.e. it will display `a minute` for a value > 45 seconds and `an hour` for a value > 50 minutes. We might want to correct that as well.

Before:
<img width="855" alt="image 2016-12-13 at 3 16 43 pm" src="https://cloud.githubusercontent.com/assets/186223/21613290/ea7b88c8-d1d4-11e6-99b8-37c79c15156d.png">

After:
![screen shot 2017-01-03 at 16 51 03](https://cloud.githubusercontent.com/assets/186223/21613271/da318d64-d1d4-11e6-9d9f-04af9ad645d0.png)
