### PR TITLE
DCOS-12405: Conditionally show declined offers funnel &table

### DIFF
--- a/plugins/services/src/js/components/ServiceStatusWarning.js
+++ b/plugins/services/src/js/components/ServiceStatusWarning.js
@@ -16,8 +16,7 @@ class ServiceStatusWarning extends Component {
     const {item} = this.props;
     const queue = item.getQueue();
 
-    if (queue != null
-      && DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(queue)) {
+    if (DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(queue)) {
       const waitingSince = DateUtil.strToMs(queue.since);
       const timeWaiting = Date.now() - waitingSince;
 

--- a/plugins/services/src/js/components/ServiceStatusWarning.js
+++ b/plugins/services/src/js/components/ServiceStatusWarning.js
@@ -17,8 +17,7 @@ class ServiceStatusWarning extends Component {
     const queue = item.getQueue();
 
     if (DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(queue)) {
-      const waitingSince = DateUtil.strToMs(queue.since);
-      const timeWaiting = Date.now() - waitingSince;
+      const timeWaiting = DeclinedOffersUtil.getTimeWaiting(queue);
 
       return (
         <Tooltip

--- a/plugins/services/src/js/containers/pod-debug/PodDebugContainer.js
+++ b/plugins/services/src/js/containers/pod-debug/PodDebugContainer.js
@@ -8,6 +8,7 @@ import ConfigurationMapHeading from '../../../../../../src/js/components/Configu
 import ConfigurationMapSection from '../../../../../../src/js/components/ConfigurationMapSection';
 import DeclinedOffersHelpText from '../../constants/DeclinedOffersHelpText';
 import DeclinedOffersTable from '../../components/DeclinedOffersTable';
+import DeclinedOffersUtil from '../../utils/DeclinedOffersUtil';
 import HashMapDisplay from '../../../../../../src/js/components/HashMapDisplay';
 import MarathonStore from '../../stores/MarathonStore';
 import Pod from '../../structs/Pod';
@@ -38,7 +39,8 @@ class PodDebugTabView extends React.Component {
     const {pod} = this.props;
     const queue = pod.getQueue();
 
-    if (queue == null || queue.declinedOffers.offers == null) {
+    if (!DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(queue)
+      || queue.declinedOffers.offers == null) {
       return null;
     }
 
@@ -145,7 +147,8 @@ class PodDebugTabView extends React.Component {
     let mainContent = null;
     let offerCount = null;
 
-    if (queue == null || queue.declinedOffers.summary == null) {
+    if (!DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(queue)
+      || queue.declinedOffers.summary == null) {
       introText = 'Offers will appear here when your service is deploying or waiting for resources.';
     } else {
       const {declinedOffers: {summary}} = queue;

--- a/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
+++ b/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
@@ -8,6 +8,7 @@ import ConfigurationMapSection from '../../../../../../src/js/components/Configu
 import DateUtil from '../../../../../../src/js/utils/DateUtil';
 import DeclinedOffersHelpText from '../../constants/DeclinedOffersHelpText';
 import DeclinedOffersTable from '../../components/DeclinedOffersTable';
+import DeclinedOffersUtil from '../../utils/DeclinedOffersUtil';
 import HashMapDisplay from '../../../../../../src/js/components/HashMapDisplay';
 import MarathonStore from '../../stores/MarathonStore';
 import RecentOffersSummary from '../../components/RecentOffersSummary';
@@ -117,7 +118,8 @@ class ServiceDebugContainer extends React.Component {
       } else {
         introText = 'Rejected offer analysis is not currently supported.';
       }
-    } else if (queue == null || queue.declinedOffers.summary == null) {
+    } else if (!DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(queue)
+      || queue.declinedOffers.summary == null) {
       introText = 'Offers will appear here when your service is deploying or waiting for resources.';
     } else {
       const {declinedOffers: {summary}} = queue;
@@ -157,7 +159,8 @@ class ServiceDebugContainer extends React.Component {
 
     const queue = service.getQueue();
 
-    if (queue == null || queue.declinedOffers.offers == null) {
+    if (!DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(queue)
+      || queue.declinedOffers.offers == null) {
       return null;
     }
 

--- a/plugins/services/src/js/utils/DeclinedOffersUtil.js
+++ b/plugins/services/src/js/utils/DeclinedOffersUtil.js
@@ -214,16 +214,19 @@ const DeclinedOffersUtil = {
     });
   },
 
+  getTimeWaiting(queue) {
+    return Util.findNestedPropertyInObject(
+        queue, 'processedOffersSummary.lastUsedOfferAt'
+      ) || queue.since;
+  },
+
   shouldDisplayDeclinedOffersWarning(queue) {
     if (queue == null) {
       return false;
     }
 
-    const timeWaiting = Util.findNestedPropertyInObject(
-        queue, 'processedOffersSummary.lastUsedOfferAt'
-      ) || queue.since;
-
-    return Date.now() - DateUtil.strToMs(timeWaiting)
+    return Date.now()
+      - DateUtil.strToMs(DeclinedOffersUtil.getTimeWaiting(queue))
       >= DEPLOYMENT_WARNING_DELAY_MS;
   }
 };

--- a/plugins/services/src/js/utils/DeclinedOffersUtil.js
+++ b/plugins/services/src/js/utils/DeclinedOffersUtil.js
@@ -219,7 +219,11 @@ const DeclinedOffersUtil = {
       return false;
     }
 
-    return Date.now() - DateUtil.strToMs(queue.since)
+    const timeWaiting = Util.findNestedPropertyInObject(
+        queue, 'processedOffersSummary.lastUsedOfferAt'
+      ) || queue.since;
+
+    return Date.now() - DateUtil.strToMs(timeWaiting)
       >= DEPLOYMENT_WARNING_DELAY_MS;
   }
 };


### PR DESCRIPTION
This PR hides the declined offers funnel & table data from a service's debug tab until the service has been waiting or over 5 minutes.