### PR TITLE
Updating log timestamp format

### DIFF
--- a/src/js/stores/SystemLogStore.js
+++ b/src/js/stores/SystemLogStore.js
@@ -22,7 +22,7 @@ import SystemLogActions from '../events/SystemLogActions';
 import {APPEND, PREPEND} from '../constants/SystemLogTypes';
 import {findNestedPropertyInObject} from '../utils/Util';
 import {MESSAGE} from '../constants/LogFields';
-import {msToCTime} from '../utils/DateUtil';
+import {msToLogTime} from '../utils/DateUtil';
 
 // Max data storage, i.e. maximum 5MB per log stream
 const MAX_FILE_SIZE = 500000;
@@ -135,7 +135,7 @@ class SystemLogStore extends BaseStore {
       // entry.realtime_timestamp returns a unix time in microseconds
       // https://www.freedesktop.org/software/systemd/man/sd_journal_get_realtime_usec.html
       if (typeof entry.realtime_timestamp === 'number') {
-        lineData.push(msToCTime(entry.realtime_timestamp/1000));
+        lineData.push(msToLogTime(entry.realtime_timestamp/1000));
       }
       // Concat `:` to last element if there is data
       if (lineData.length) {

--- a/src/js/stores/__tests__/SystemLogStore-test.js
+++ b/src/js/stores/__tests__/SystemLogStore-test.js
@@ -368,7 +368,7 @@ describe('SystemLogStore', function () {
 
       const result = SystemLogStore.getFullLog('subscriptionID');
 
-      expect(result).toEqual('Thu Jan 01 00:00:10 1970: foo\nbar');
+      expect(result).toEqual('1970-01-01 12:00:10: foo\nbar');
     });
 
     it('returns empty string for a log that doesn\'t exist', function () {

--- a/src/js/utils/DateUtil.js
+++ b/src/js/utils/DateUtil.js
@@ -54,12 +54,12 @@ const DateUtil = {
   },
 
   /**
-   * Creates a ANSI C time string from time provided
+   * Creates a log timestamp string from time provided
    * @param  {Date|Number} ms number to convert to ANSI C time string
-   * @return {String} time string with the format 'ddd MMM DD HH:mm:ss YYYY'
+   * @return {String} time string with the format 'YYYY-MM-DD hh:mm:ss'
    */
-  msToCTime(ms) {
-    return moment(ms).utc().format('ddd MMM DD HH:mm:ss YYYY');
+  msToLogTime(ms) {
+    return moment(ms).utc().format('YYYY-MM-DD hh:mm:ss');
   },
 
   /**


### PR DESCRIPTION
This PR changes the format of the log timestamp to be `YYYY-MM-DD hh:mm:ss: MESSAGE` e.g. `2017-01-04 06:16:31: Some log message`