### PR TITLE
DCOS-12847: Use var instead of let in JISON parser

### DIFF
--- a/src/resources/grammar/SearchDSL.jison
+++ b/src/resources/grammar/SearchDSL.jison
@@ -61,7 +61,7 @@ e   /* Operators */
         /* NOTE: We expand the comma-separated list of values as individual
                  label:value tokens, combined with an OR operator */
         {$$ = $2.reduce(function (last_fn, v) {
-            let fn = Operator.attribute($1, v.text, @1.first_column, @1.last_column, v.start, v.end);
+            var fn = Operator.attribute($1, v.text, @1.first_column, @1.last_column, v.start, v.end);
             if (last_fn) {
                 return Merge.or(last_fn, fn);
             } else {


### PR DESCRIPTION
This PR uses `var` instead of `let` in the JISON parser generator because this won't be transpiled by Babel. This fixes an error thrown in any browser that doesn't support the use of `let` variable declarations.