### PR TITLE
DCOS-12431: Apply flex class to AccessDeniedPage

### DIFF
--- a/src/js/components/AccessDeniedPage.js
+++ b/src/js/components/AccessDeniedPage.js
@@ -37,7 +37,7 @@ module.exports = class AccessDeniedPage extends React.Component {
     return (
       <div className="application-wrapper">
         <div className="page">
-          <div className="page-body-content vertical-center">
+          <div className="page-body-content vertical-center flex-item-grow-1">
             <AlertPanel title="Access denied">
               <p className="tall">
                 You do not have access to this service. Please contact your {Config.productName} administrator or see <a href={MetadataStore.buildDocsURI('/administration/id-and-access-mgt/')} target="_blank">security documentation</a> for more information.


### PR DESCRIPTION
This fixes a bug in Safari where the absence of `flex-grow: 1` prevented the content from being visible, so it was just a blank white page.

After:
![](https://cl.ly/3w051u0Q2w0H/Screen%20Shot%202017-01-04%20at%201.29.45%20PM.png)