### PR TITLE
DCOS-12454: Add Universe link to service picker via MountService

### DIFF
--- a/plugins/services/src/js/components/modals/NewCreateServiceModalServicePicker.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalServicePicker.js
@@ -1,3 +1,4 @@
+import {MountService} from 'foundation-ui';
 /* eslint-disable no-unused-vars */
 import React from 'react';
 /* eslint-enable no-unused-vars */
@@ -70,9 +71,11 @@ class NewCreateServiceModalServicePicker extends React.Component {
         <h4 className="short flush-top">
           Run your own Service
         </h4>
-        <p className="lead tall">
-          Create a containerized service or run a command in one of two ways: use our form to be guided through the correct configuration, or enter your JSON configuration directly.
-        </p>
+        <MountService.Mount type="CreateService:ServicePicker:IntroductoryText">
+          <p className="lead tall">
+            Create a containerized service or run a command in one of two ways: use our form to be guided through the correct configuration, or enter your JSON configuration directly.
+          </p>
+        </MountService.Mount>
         {this.getCustomServiceGrid()}
       </div>
     );

--- a/src/js/pages/UniversePage.js
+++ b/src/js/pages/UniversePage.js
@@ -1,6 +1,20 @@
+import {MountService} from 'foundation-ui';
 import React from 'react';
 
 import Icon from '../components/Icon';
+
+const IntroductoryText = () => {
+  return (
+    <p className="lead tall">
+      Create a containerized service or run a command in one of two ways: use our form to be guided through the correct configuration, or enter your JSON configuration directly. You may also <a href="#/universe">browse the package repository</a>.
+    </p>
+  );
+};
+
+MountService.MountService.registerComponent(
+  IntroductoryText,
+  'CreateService:ServicePicker:IntroductoryText'
+);
 
 class UniversePage extends React.Component {
   render() {


### PR DESCRIPTION
This PR uses the `MountService` component to add a link to the Universe page from the service picker.

I'm adding `hold merge` until I get approved copy from the docs team: https://mesosphere.atlassian.net/browse/DCOS-12454.

![](https://cl.ly/2m2M0H0g2J0o/Screen%20Shot%202017-01-05%20at%2011.28.47%20AM.png)