### PR TITLE
DCOS-12618: Fix typeahead dropdown alignment

### DIFF
--- a/src/styles/components/typeahead/styles.less
+++ b/src/styles/components/typeahead/styles.less
@@ -4,19 +4,11 @@
 
     .typeahead {
 
-      .form-control {
-
-        &.bootstrap-typeahead-input-hint {
-          // Overriding `!important`s in Canvas' .form-control-group
-          margin-bottom: 0 !important;
-          margin-top: 0 !important;
-        }
-      }
-
       .dropdown-menu {
-        margin-left: calc(-1 * (@icon-mini-width + @form-control-border-width) ~' - ' (-2 * @form-control-padding-left));
+        margin-left: @typeahead-dropdown-menu-margin-left;
+        margin-top: @typeahead-dropdown-menu-margin-top;
+        min-width: @typeahead-dropdown-menu-width;
         position: absolute;
-        width: calc(~'100% +' @icon-mini-width + @form-control-border-width ~' + ' (3 * @form-control-padding-left));
 
         .dropdown-menu-list {
 
@@ -105,7 +97,6 @@
       .typeahead {
 
         .dropdown-menu {
-          margin-left: calc(-1 * (@icon-mini-width + @form-control-border-width) ~' - ' (-2 * @form-control-padding-left));
           // We are matching the width of .filter-input-text-group
           // as defined in reactjs-components
           min-width: 200px;

--- a/src/styles/components/typeahead/variables.less
+++ b/src/styles/components/typeahead/variables.less
@@ -1,1 +1,6 @@
 @typeahead-enabled: true;
+
+@typeahead-dropdown-menu-margin-left: calc(-@icon-mini-width ~' - ' @form-control-add-on-padding-horizontal ~' - ' @form-control-padding-left ~' - ' @form-control-border-width);
+@typeahead-dropdown-menu-margin-top: 10px;
+
+@typeahead-dropdown-menu-width: calc(~'100% +' @icon-mini-width ~' + ' @form-control-add-on-padding-horizontal ~' + ' @form-control-padding-left * 2 ~' + ' @form-control-border-width * 2);


### PR DESCRIPTION
This PR fixes the alignment of the typeahead dropdown and removes some outdated margin overrides.

Before:
![](https://cl.ly/2w0f1x283H33/Screen%20Shot%202017-01-05%20at%2012.43.17%20PM.png)

After:
![](https://cl.ly/3V2s372F1X11/Screen%20Shot%202017-01-05%20at%2012.42.10%20PM.png)