### PR TITLE
Use window instead of global in webpack post loader

### DIFF
--- a/webpack/webpack.config.babel.js
+++ b/webpack/webpack.config.babel.js
@@ -141,7 +141,7 @@ module.exports = {
                 // Webpack doo doo's its pants with some of this CSS for
                 // some stupid reason. So this is why we encode the CSS.
                 const encoded = new Buffer(css).toString('base64');
-                const js = `var css = '${encoded}';css = atob(css);var tag = global.document.createElement('style');tag.innerHTML = css;global.document.head.appendChild(tag);`;
+                const js = `var css = '${encoded}';css = atob(css);var tag = window.document.createElement('style');tag.innerHTML = css;window.document.head.appendChild(tag);`;
 
                 return `<script>${js}</script>`;
               }


### PR DESCRIPTION
`global` is not defined here because it runs outside of the webpack bundle, so we need to use `window` instead.