### PR TITLE
DCOS-12415: Fixed clipped descenders in elements that use text-overflow

### DIFF
--- a/src/styles/components/banner-plugin/styles.less
+++ b/src/styles/components/banner-plugin/styles.less
@@ -44,6 +44,7 @@
 
       // Make sure to use ellipsis on content more than container
       .content {
+        line-height: normal;
         overflow: hidden;
         text-align: right;
         text-overflow: ellipsis;

--- a/src/styles/components/breadcrumbs/styles.less
+++ b/src/styles/components/breadcrumbs/styles.less
@@ -67,6 +67,7 @@
           min-width: 0;
 
           a {
+            line-height: normal;
             text-overflow: ellipsis;
           }
         }

--- a/src/styles/components/collapsing-string/styles.less
+++ b/src/styles/components/collapsing-string/styles.less
@@ -20,6 +20,7 @@
 
   .collapsing-string-truncated-start,
   .collapsing-string-truncated-end {
+    line-height: normal;
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/src/styles/components/page-header/styles.less
+++ b/src/styles/components/page-header/styles.less
@@ -77,6 +77,7 @@
 
     &-breadcrumb {
       flex: 0 1 auto;
+      line-height: normal;
       margin: 0 @page-header-breadcrumbs-margin-right 0 0;
       min-width: 0;
       overflow: hidden;

--- a/src/styles/components/typography/styles.less
+++ b/src/styles/components/typography/styles.less
@@ -123,6 +123,7 @@
   }
 
   .text-overflow {
+    line-height: normal;
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -128,6 +128,7 @@
     flex: 1 1 auto;
     // This property is necessary for table cells to respect the text-overflow
     // property. http://stackoverflow.com/questions/9789723/css-text-overflow-in-a-table-cell
+    line-height: normal;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
This PR resets the `line-height` for all elements that use the `text-overflow` property. This prevents the descenders from being clipped in some browsers.

Before:
![](https://cl.ly/0r1k0M0B0b3B/Screen%20Shot%202017-01-05%20at%201.31.34%20PM.png)
After:
![](https://cl.ly/1M2t0g2r2l2w/Screen%20Shot%202017-01-05%20at%201.31.40%20PM.png)

Before:
![](https://cl.ly/2n0f1M1G0M2p/Screen%20Shot%202017-01-05%20at%201.27.41%20PM.png)
After:
![](https://cl.ly/2u190i371f21/Screen%20Shot%202017-01-05%20at%201.27.48%20PM.png)