### PR TITLE
[Logs 1 of 2] DCOS-12769: Make paging in log view a bit snappier

### DIFF
--- a/plugins/services/src/js/components/LogView.js
+++ b/plugins/services/src/js/components/LogView.js
@@ -176,19 +176,12 @@ class LogView extends React.Component {
   }
 
   checkIfCloseToTop(container) {
-    const {closeToTop} = this.state;
     const distanceFromTop = DOMUtils.getDistanceFromTop(container);
-    if (distanceFromTop < 100 && !closeToTop) {
-      this.setState({closeToTop: true}, () => {
-        const {hasLoadedTop, fetchPreviousLogs} = this.props;
-        if (!hasLoadedTop) {
-          fetchPreviousLogs();
-        }
-      });
-    }
-
-    if (distanceFromTop > 100 && closeToTop) {
-      this.setState({closeToTop: false});
+    if (distanceFromTop < 100) {
+      const {hasLoadedTop, fetchPreviousLogs} = this.props;
+      if (!hasLoadedTop) {
+        fetchPreviousLogs();
+      }
     }
   }
 

--- a/plugins/services/src/js/components/LogView.js
+++ b/plugins/services/src/js/components/LogView.js
@@ -28,7 +28,7 @@ class LogView extends React.Component {
     });
 
     this.handleLogContainerScroll = Util.throttleScroll(
-      this.handleLogContainerScroll, 500
+      this.handleLogContainerScroll, 50
     );
 
     this.handleWindowResize = Util.debounce(
@@ -177,7 +177,7 @@ class LogView extends React.Component {
 
   checkIfCloseToTop(container) {
     const distanceFromTop = DOMUtils.getDistanceFromTop(container);
-    if (distanceFromTop < 100) {
+    if (distanceFromTop < 2000) {
       const {hasLoadedTop, fetchPreviousLogs} = this.props;
       if (!hasLoadedTop) {
         fetchPreviousLogs();

--- a/plugins/services/src/js/pages/task-details/TaskLogsTab.js
+++ b/plugins/services/src/js/pages/task-details/TaskLogsTab.js
@@ -43,6 +43,7 @@ class TaskLogsTab extends mixin(StoreMixin) {
       direction: APPEND,
       hasError: false,
       streams: [],
+      isFetchingPrevious: false,
       isLoading: true
     };
 
@@ -79,7 +80,11 @@ class TaskLogsTab extends mixin(StoreMixin) {
       return;
     }
 
-    this.setState({hasError: true, isLoading: false});
+    this.setState({
+      hasError: true,
+      isFetchingPrevious: false,
+      isLoading: false
+    });
   }
 
   onSystemLogStoreSuccess(subscriptionID, direction) {
@@ -87,7 +92,12 @@ class TaskLogsTab extends mixin(StoreMixin) {
       return;
     }
 
-    this.setState({hasError: false, direction, isLoading: false});
+    this.setState({
+      hasError: false,
+      direction,
+      isFetchingPrevious: false,
+      isLoading: false
+    });
   }
 
   onSystemLogStoreStreamError() {
@@ -118,6 +128,11 @@ class TaskLogsTab extends mixin(StoreMixin) {
   }
 
   handleFetchPreviousLog() {
+    // Ongoing previous log fetch, wait for that to complete
+    if (this.state.isFetchingPrevious) {
+      return;
+    }
+
     const {task} = this.props;
     const {subscriptionID} = this.state;
 
@@ -128,6 +143,7 @@ class TaskLogsTab extends mixin(StoreMixin) {
       subscriptionID
     });
     SystemLogStore.fetchLogRange(task.slave_id, params);
+    this.setState({isFetchingPrevious: true});
   }
 
   handleAtBottomChange(isAtBottom) {
@@ -238,7 +254,6 @@ class TaskLogsTab extends mixin(StoreMixin) {
 
     // This is a hacky way of interacting with the API to be able to download
     // logs with a POST request
-
     return (
       <form
         key="download"

--- a/plugins/services/src/js/pages/task-details/TaskLogsTab.js
+++ b/plugins/services/src/js/pages/task-details/TaskLogsTab.js
@@ -20,7 +20,7 @@ const METHODS_TO_BIND = [
   'handleItemSelection'
 ];
 
-const PAGE_ENTRY_COUNT = 100;
+const PAGE_ENTRY_COUNT = 200;
 
 function getLogParameters(task, options) {
   let {framework_id:frameworkID, executor_id:executorID, id} = task;
@@ -136,10 +136,13 @@ class TaskLogsTab extends mixin(StoreMixin) {
     const {task} = this.props;
     const {subscriptionID} = this.state;
 
-    // Get a full page of previous log entries
+    // Stop tailing before fetching preiovus logs
+    SystemLogStore.stopTailing(this.state.subscriptionID);
+    // Fetch two pages previous log entries to gain more leverage to explore
+    // previous logs
     const params = getLogParameters(task, {
       filter: {STREAM: this.state.selectedStream},
-      limit: PAGE_ENTRY_COUNT,
+      limit: 2 * PAGE_ENTRY_COUNT,
       subscriptionID
     });
     SystemLogStore.fetchLogRange(task.slave_id, params);

--- a/src/js/stores/SystemLogStore.js
+++ b/src/js/stores/SystemLogStore.js
@@ -208,6 +208,9 @@ class SystemLogStore extends BaseStore {
   }
 
   processLogError(subscriptionID, data) {
+    if (!this.logs[subscriptionID]) {
+      this.logs[subscriptionID] = {entries: [], totalSize: 0};
+    }
     this.emit(SYSTEM_LOG_REQUEST_ERROR, subscriptionID, data);
   }
 
@@ -228,6 +231,9 @@ class SystemLogStore extends BaseStore {
   }
 
   processLogPrependError(subscriptionID, data) {
+    if (!this.logs[subscriptionID]) {
+      this.logs[subscriptionID] = {entries: [], totalSize: 0};
+    }
     this.emit(SYSTEM_LOG_REQUEST_ERROR, subscriptionID, data);
   }
 

--- a/src/js/stores/SystemLogStore.js
+++ b/src/js/stores/SystemLogStore.js
@@ -24,9 +24,6 @@ import {findNestedPropertyInObject} from '../utils/Util';
 import {MESSAGE} from '../constants/LogFields';
 import {msToLogTime} from '../utils/DateUtil';
 
-// Max data storage, i.e. maximum 5MB per log stream
-const MAX_FILE_SIZE = 500000;
-
 class SystemLogStore extends BaseStore {
   constructor() {
     super(...arguments);
@@ -99,22 +96,6 @@ class SystemLogStore extends BaseStore {
 
     // Update new size
     newLogData.totalSize += length;
-    // Remove entries until we have room for next entry
-    while (newLogData.totalSize > 0 && newLogData.entries.length > 0 &&
-      newLogData.totalSize > MAX_FILE_SIZE) {
-      let removedEntry;
-      if (eventType === APPEND) {
-        removedEntry = newLogData.entries.shift();
-        // Removing from top, let's update hasLoadedTop
-        newLogData.hasLoadedTop = false;
-      } else {
-        removedEntry = newLogData.entries.pop();
-      }
-      newLogData.totalSize -= findNestedPropertyInObject(
-        removedEntry,
-        `fields.${MESSAGE}.length`
-      ) || 0;
-    }
 
     return newLogData;
   }

--- a/src/js/stores/__tests__/SystemLogStore-test.js
+++ b/src/js/stores/__tests__/SystemLogStore-test.js
@@ -54,34 +54,6 @@ describe('SystemLogStore', function () {
       expect(result.totalSize).toEqual(15);
     });
 
-    it('removes from beginning when size exceeds MAX_FILE_SIZE', function () {
-      const entires = [
-        {fields: {MESSAGE: 'foo'}},
-        {fields: {MESSAGE: 'bar'}},
-        {fields: {MESSAGE: 'baz'}}
-      ];
-      const logData = {
-        entries: [
-          {fields: {MESSAGE: 'one'}},
-          {fields: {MESSAGE: 'two'}}
-        ],
-        // Allow room for one more entry, but not the two following
-        totalSize: 500000 - 3
-      };
-      const result = SystemLogStore.addEntries(
-        logData,
-        entires,
-        SystemLogTypes.APPEND
-      );
-
-      const entries = result.entries.map((entry) => {
-        return entry.fields.MESSAGE;
-      });
-
-      expect(entries).toEqual(['foo', 'bar', 'baz']);
-      expect(result.totalSize).toEqual(500000);
-    });
-
     it('doesn\'t remove when there is no length added', function () {
       const entires = [
         {fields: {MESSAGE: ''}},
@@ -135,32 +107,6 @@ describe('SystemLogStore', function () {
 
       expect(entries).toEqual(['foo', 'bar', 'baz', 'one', 'two']);
       expect(result.totalSize).toEqual(15);
-    });
-
-    it('removes from beginning when size exceeds MAX_FILE_SIZE', function () {
-      const entries = [
-        {fields: {MESSAGE: 'foo'}},
-        {fields: {MESSAGE: 'bar'}},
-        {fields: {MESSAGE: 'baz'}}
-      ];
-      const logData = {
-        entries: [
-          {fields: {MESSAGE: 'one'}},
-          {fields: {MESSAGE: 'two'}}
-        ],
-        // Allow room for two more entry, but not the last one
-        totalSize: 500000 - 6
-      };
-      const result = SystemLogStore.addEntries(
-        logData,
-        entries,
-        SystemLogTypes.PREPEND
-      );
-
-      expect(result.entries.map((entry) => {
-        return entry.fields.MESSAGE;
-      })).toEqual(['foo', 'bar', 'baz', 'one']);
-      expect(result.totalSize).toEqual(500000);
     });
 
     it('doesn\'t remove when there is no length added', function () {
@@ -218,32 +164,6 @@ describe('SystemLogStore', function () {
         .toEqual('one\ntwo\nfoo\nbar\nbaz');
     });
 
-    it('removes from beginning when size exceeds MAX_FILE_SIZE', function () {
-      resetLogData('subscriptionID', {
-        entries: [
-          {fields: {MESSAGE: 'one'}},
-          {fields: {MESSAGE: 'two'}}
-        ],
-        // Allow room for one more entry, but not the two following
-        totalSize: 500000 - 3
-      });
-      SystemLogStore.processLogEntry(
-        'subscriptionID',
-        {fields: {MESSAGE: 'foo'}}
-      );
-      SystemLogStore.processLogEntry(
-        'subscriptionID',
-        {fields: {MESSAGE: 'bar'}}
-      );
-      SystemLogStore.processLogEntry(
-        'subscriptionID',
-        {fields: {MESSAGE: 'baz'}}
-      );
-
-      expect(SystemLogStore.getFullLog('subscriptionID'))
-        .toEqual('foo\nbar\nbaz');
-    });
-
     it('doesn\'t add empty MESSAGEs', function () {
       resetLogData('subscriptionID', {
         entries: [
@@ -283,26 +203,6 @@ describe('SystemLogStore', function () {
 
       expect(SystemLogStore.getFullLog('subscriptionID'))
         .toEqual('foo\nbar\nbaz\none\ntwo');
-    });
-
-    it('removes from beginning when size exceeds MAX_FILE_SIZE', function () {
-      resetLogData('subscriptionID', {
-        entries: [
-          {fields: {MESSAGE: 'one'}},
-          {fields: {MESSAGE: 'two'}}
-        ],
-        // Allow room for two more entry, but not the last one
-        totalSize: 500000 - 6
-      });
-
-      SystemLogStore.processLogPrepend('subscriptionID', false, [
-        {fields: {MESSAGE: 'foo'}},
-        {fields: {MESSAGE: 'bar'}},
-        {fields: {MESSAGE: 'baz'}}
-      ]);
-
-      expect(SystemLogStore.getFullLog('subscriptionID'))
-        .toEqual('foo\nbar\nbaz\none');
     });
 
     it('doesn\'t remove when there is no length added', function () {


### PR DESCRIPTION
Logs 1 of 2 PR: https://github.com/dcos/dcos-ui/pull/1736
Logs 2 of 2 PR: https://github.com/dcos/dcos-ui/pull/1745

This PR also resolves: DCOS-12737

![](https://cl.ly/2G0M1a362q3t/Screen%20Recording%202017-01-05%20at%2015.06.gif)

This PR fixes a few issues related to the same thing - making the paging become smoother:
- It initializes the logs no matter what response comes from the server, so we do not see 'Empty Log' when there is an error.
- It stop debouncing `componentDidUpdate` in  the log view, so it actually goes to bottom initially
- It removes log window so the position calculation in `componentDidUpdate` continues to work
- It lets the container handle when to retrieve a previous page, instead of assuming an ongoing request when at the top.

Initially, the paging goes pretty fast, but eventually the journald bug manifests and loading becomes increasingly slower. This is not handled by this PR.