### PR TITLE
DCOS-11911: Use new classes for errors and help text

### DIFF
--- a/src/js/components/form/FieldError.js
+++ b/src/js/components/form/FieldError.js
@@ -5,7 +5,7 @@ import {omit} from '../../utils/Util';
 
 const FieldError = (props) => {
   const {className} = props;
-  let classes = classNames('small text-danger flush-bottom', className);
+  let classes = classNames('form-control-feedback', className);
 
   return (
     <p

--- a/src/js/components/form/FieldHelp.js
+++ b/src/js/components/form/FieldHelp.js
@@ -6,7 +6,7 @@ import {omit} from '../../utils/Util';
 const FieldHelp = (props) => {
   const {className, textTransform} = props;
   let classes = classNames(
-    'small flush-bottom',
+    'form-control-feedback',
     className,
     {
       'text-uppercase': textTransform === 'uppercase',


### PR DESCRIPTION
This PR uses `.form-control-feedback` classes for both errors and help text. This results in both being red in color when there's an error, but that will be handled separately.

~~(hold until https://github.com/dcos/dcos-ui/pull/1691 merges)~~

![](https://cl.ly/3A0G372U3N2T/Screen%20Shot%202017-01-05%20at%203.17.26%20PM.png)

Related PRs:
https://github.com/dcos/dcos-ui/pull/1691
https://github.com/mesosphere/cnvs/pull/68
https://github.com/mesosphere/reactjs-components/pull/381#issuecomment-269245976