### PR TITLE
DCOS-12222: Apply task table column widths via CSS

### DIFF
--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
@@ -18,16 +18,16 @@ import TimeAgo from '../../../../../../src/js/components/TimeAgo';
 import Units from '../../../../../../src/js/utils/Units';
 
 const tableColumnClasses = {
-  checkbox: 'pod-instances-table-column-checkbox',
-  name: 'pod-instances-table-column-primary',
-  address: 'pod-instances-table-column-host-address',
-  status: 'pod-instances-table-column-status',
-  health: 'pod-instances-table-column-health',
-  logs: 'pod-instances-table-column-logs',
-  cpus: 'pod-instances-table-column-cpus',
-  mem: 'pod-instances-table-column-mem',
-  updated: 'pod-instances-table-column-updated',
-  version: 'pod-instances-table-column-version'
+  checkbox: 'task-table-column-checkbox',
+  name: 'task-table-column-primary',
+  address: 'task-table-column-host-address',
+  status: 'task-table-column-status',
+  health: 'task-table-column-health',
+  logs: 'task-table-column-logs',
+  cpus: 'task-table-column-cpus',
+  mem: 'task-table-column-mem',
+  updated: 'task-table-column-updated',
+  version: 'task-table-column-version'
 };
 
 const METHODS_TO_BIND = [
@@ -446,7 +446,7 @@ class PodInstancesTable extends React.Component {
     return (
       <ExpandingTable
         allowMultipleSelect={true}
-        className="pod-instances-table expanding-table table table-hover table-borderless-outer table-borderless-inner-columns flush-bottom"
+        className="task-table expanding-table table table-hover table-borderless-outer table-borderless-inner-columns flush-bottom"
         childRowClassName="expanding-table-child"
         checkedItemsMap={checkedItems}
         columns={this.getColumns()}

--- a/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesContainer-test.js
+++ b/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesContainer-test.js
@@ -65,7 +65,7 @@ describe('PodInstancesContainer', function () {
 
       it('should properly return matching instances', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-primary')
+            this.instance, 'task-table-column-primary')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 
@@ -93,7 +93,7 @@ describe('PodInstancesContainer', function () {
 
       it('should properly return matching instances and containers', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-primary')
+            this.instance, 'task-table-column-primary')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 
@@ -113,7 +113,7 @@ describe('PodInstancesContainer', function () {
 
       it('should always show instance total resources', function () {
         var mem = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-mem')
+            this.instance, 'task-table-column-mem')
             .filter(JestUtil.filterByTagName('TD'))
             .reduce(JestUtil.reduceTextContentOfSelector(
               'span'), []);
@@ -146,7 +146,7 @@ describe('PodInstancesContainer', function () {
 
       it('should properly show all instances', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-primary')
+            this.instance, 'task-table-column-primary')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 
@@ -178,7 +178,7 @@ describe('PodInstancesContainer', function () {
 
       it('should properly show no instances', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-primary')
+            this.instance, 'task-table-column-primary')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 

--- a/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.js
+++ b/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.js
@@ -65,7 +65,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the name column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-primary')
+            this.instance, 'task-table-column-primary')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 
@@ -78,7 +78,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the address column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-host-address')
+            this.instance, 'task-table-column-host-address')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 
@@ -91,7 +91,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the status column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-status')
+            this.instance, 'task-table-column-status')
             .reduce(JestUtil.reduceTextContentOfSelector('.status-text'),
               []);
 
@@ -104,7 +104,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the cpu column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-cpus')
+            this.instance, 'task-table-column-cpus')
             .filter(JestUtil.filterByTagName('TD'))
             .map(JestUtil.mapTextContent);
 
@@ -117,7 +117,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the mem column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-mem')
+            this.instance, 'task-table-column-mem')
             .filter(JestUtil.filterByTagName('TD'))
             .map(JestUtil.mapTextContent);
 
@@ -130,7 +130,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the updated column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-updated')
+            this.instance, 'task-table-column-updated')
             .filter(JestUtil.filterByTagName('TD'))
             .map(JestUtil.mapTextContent);
 
@@ -143,7 +143,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the version column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-version')
+            this.instance, 'task-table-column-version')
             .filter(JestUtil.filterByTagName('TD'))
             .map(JestUtil.mapTextContent);
 
@@ -165,13 +165,13 @@ describe('PodInstancesTable', function () {
 
         // 1 click on the header (ascending)
         const columnHeader = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-primary')[0];
+            this.instance, 'task-table-column-primary')[0];
         TestUtils.Simulate.click(columnHeader);
       });
 
       it('should properly sort the name column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-primary')
+            this.instance, 'task-table-column-primary')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 
@@ -193,14 +193,14 @@ describe('PodInstancesTable', function () {
 
         // 2 clicks on the header (descending)
         const columnHeader = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-primary')[0];
+            this.instance, 'task-table-column-primary')[0];
         TestUtils.Simulate.click(columnHeader);
         TestUtils.Simulate.click(columnHeader);
       });
 
       it('should properly sort the name column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-primary')
+            this.instance, 'task-table-column-primary')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 
@@ -223,7 +223,7 @@ describe('PodInstancesTable', function () {
 
         // Expand all table rows by clicking on each one of them
         TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-primary'
+            this.instance, 'task-table-column-primary'
         ).forEach(function (element) {
           const target = element.querySelector('.is-expandable');
           if (target) {
@@ -234,7 +234,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the name column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-primary')
+            this.instance, 'task-table-column-primary')
             .reduce(JestUtil.reduceTextContentOfSelector(
               '.collapsing-string-full-string'), []);
 
@@ -253,7 +253,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the address column', function () {
         var columns = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-host-address');
+            this.instance, 'task-table-column-host-address');
         const agents = columns.reduce(JestUtil.reduceTextContentOfSelector(
             '.collapsing-string-full-string'), []);
         const ports = columns.reduce(JestUtil.reduceTextContentOfSelector('a'), []);
@@ -275,7 +275,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the status column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-status')
+            this.instance, 'task-table-column-status')
             .reduce(JestUtil.reduceTextContentOfSelector('.status-text'), []);
 
         expect(names).toEqual([
@@ -293,7 +293,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the cpu column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-cpus')
+            this.instance, 'task-table-column-cpus')
             .filter(JestUtil.filterByTagName('TD'))
             .reduce(JestUtil.reduceTextContentOfSelector('div > div > span'), []);
 
@@ -312,7 +312,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the mem column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-mem')
+            this.instance, 'task-table-column-mem')
             .filter(JestUtil.filterByTagName('TD'))
             .reduce(JestUtil.reduceTextContentOfSelector('div > div > span'), []);
 
@@ -331,7 +331,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the updated column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-updated')
+            this.instance, 'task-table-column-updated')
             .filter(JestUtil.filterByTagName('TD'))
             .reduce(JestUtil.reduceTextContentOfSelector('time'), []);
 
@@ -350,7 +350,7 @@ describe('PodInstancesTable', function () {
 
       it('should properly render the version column', function () {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
-            this.instance, 'pod-instances-table-column-version')
+            this.instance, 'task-table-column-version')
             .filter(JestUtil.filterByTagName('TD'))
             .map(JestUtil.mapTextContent);
 

--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -12,6 +12,20 @@ import TaskTableHeaderLabels from '../../constants/TaskTableHeaderLabels';
 import TaskUtil from '../../utils/TaskUtil';
 import Units from '../../../../../../src/js/utils/Units';
 
+const tableColumnClasses = {
+  checkbox: 'task-table-column-checkbox',
+  id: 'task-table-column-primary',
+  name: 'task-table-column-name',
+  address: 'task-table-column-host-address',
+  status: 'task-table-column-status',
+  health: 'task-table-column-health',
+  logs: 'task-table-column-logs',
+  cpus: 'task-table-column-cpus',
+  mem: 'task-table-column-mem',
+  updated: 'task-table-column-updated',
+  version: 'task-table-column-version'
+};
+
 const METHODS_TO_BIND = [
   'getStatusValue',
   'renderHeadline',
@@ -21,8 +35,6 @@ const METHODS_TO_BIND = [
   'renderStats',
   'renderVersion'
 ];
-
-const RIGHT_ALIGN_PROPS = ['cpus', 'disk', 'log', 'mem', 'version'];
 
 class TaskTable extends React.Component {
   constructor() {
@@ -46,10 +58,7 @@ class TaskTable extends React.Component {
   }
 
   getClassName(prop, sortBy, row) {
-    return classNames({
-      'text-align-right': RIGHT_ALIGN_PROPS.includes(prop),
-      'hidden-small-down': ['host', 'cpus', 'mem'].includes(prop),
-      'hidden-large-down': ['name', 'status', 'health', 'version', 'log'].includes(prop),
+    return classNames(tableColumnClasses[prop], {
       'highlight': prop === sortBy.prop,
       'clickable': row == null // this is a header
     });
@@ -115,7 +124,7 @@ class TaskTable extends React.Component {
         className,
         headerClassName: className,
         heading,
-        prop: 'log',
+        prop: 'logs',
         render: this.renderLog,
         sortable: false,
         sortFunction
@@ -175,17 +184,17 @@ class TaskTable extends React.Component {
   getColGroup() {
     return (
       <colgroup>
-        <col style={{width: '40px'}} />
+        <col className={tableColumnClasses.checkbox} />
         <col />
-        <col style={{width: '10%'}} className="hidden-medium-down" />
-        <col style={{width: '100px'}} className="hidden-small-down" />
-        <col style={{width: '80px'}} className="hidden-small-down" />
-        <col style={{width: '40px'}} className="hidden-small-down" />
-        <col style={{width: '40px'}} className="hidden-large-down" />
-        <col style={{width: '85px'}} className="hidden-small-down" />
-        <col style={{width: '85px'}} className="hidden-small-down" />
-        <col style={{width: '120px'}} />
-        <col style={{width: '110px'}} className="hidden-large-down"/>
+        <col className={tableColumnClasses.name} />
+        <col className={tableColumnClasses.address} />
+        <col className={tableColumnClasses.status} />
+        <col className={tableColumnClasses.health} />
+        <col className={tableColumnClasses.logs} />
+        <col className={tableColumnClasses.cpus} />
+        <col className={tableColumnClasses.mem} />
+        <col className={tableColumnClasses.updated} />
+        <col className={tableColumnClasses.version} />
       </colgroup>
     );
   }

--- a/src/styles/components/pod-instances-table/variables.less
+++ b/src/styles/components/pod-instances-table/variables.less
@@ -1,1 +1,0 @@
-@pod-instances-table-enabled: true;

--- a/src/styles/components/task-table/styles.less
+++ b/src/styles/components/task-table/styles.less
@@ -1,13 +1,12 @@
-& when (@pod-instances-table-enabled) {
+& when (@task-table-enabled) {
 
-  .pod-instances-table-column {
+  .task-table-column {
 
     &-host-address,
-    &-status,
-    &-health,
-    &-logs,
     &-cpus,
     &-mem,
+    &-name,
+    &-updated,
     &-version {
       display: none;
     }
@@ -18,6 +17,10 @@
 
     &-primary {
       width: auto;
+    }
+
+    &-name {
+      width: 80px;
     }
 
     &-host-address {
@@ -52,16 +55,21 @@
       white-space: break-all;
       width: 175px;
     }
+
+    &-cpus,
+    &-mem {
+      text-align: right;
+    }
   }
 }
 
-& when (@pod-instances-table-enabled) and (@layout-screen-small-enabled) {
+& when (@task-table-enabled) and (@layout-screen-small-enabled) {
 
   @media (min-width: @layout-screen-small-min-width) {
 
-    .pod-instances-table-column {
+    .task-table-column {
 
-      &-host-address {
+      &-name {
         display: table-cell;
 
         col& {
@@ -72,15 +80,12 @@
   }
 }
 
-& when (@pod-instances-table-enabled) and (@layout-screen-large-enabled) {
+& when (@task-table-enabled) and (@layout-screen-large-enabled) {
 
   @media (min-width: @layout-screen-large-min-width) {
 
-    .pod-instances-table-column {
+    .task-table-column {
 
-      &-status,
-      &-health,
-      &-logs,
       &-cpus,
       &-mem {
         display: table-cell;
@@ -89,16 +94,22 @@
           display: table-column;
         }
       }
+
+      &-name {
+        width: 120px;
+      }
     }
   }
 }
 
-& when (@pod-instances-table-enabled) and (@layout-screen-jumbo-enabled) {
+& when (@task-table-enabled) and (@layout-screen-jumbo-enabled) {
 
   @media (min-width: @layout-screen-jumbo-min-width) {
 
-    .pod-instances-table-column {
+    .task-table-column {
 
+      &-host-address,
+      &-updated,
       &-version {
         display: table-cell;
 

--- a/src/styles/components/task-table/variables.less
+++ b/src/styles/components/task-table/variables.less
@@ -1,0 +1,1 @@
+@task-table-enabled: true;

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -372,11 +372,6 @@
 @import 'components/panel/collapsing/variables.less';
 @import 'components/panel/collapsing/styles.less';
 
-// Pod Instances Table
-
-@import 'components/pod-instances-table/variables.less';
-@import 'components/pod-instances-table/styles.less';
-
 // Secret Value
 
 @import 'components/secret-value/variables.less';
@@ -411,6 +406,11 @@
 
 @import 'components/status-dots/variables.less';
 @import 'components/status-dots/styles.less';
+
+// Task Table
+
+@import 'components/task-table/variables.less';
+@import 'components/task-table/styles.less';
 
 // Toggle Button
 


### PR DESCRIPTION
This PR applies column width and display properties to the `TaskTable` via CSS. It uses the same styles that were previously used only for the `PodInstancesTable`. Therefore I renamed the stylesheets and classes to `task-table` and implemented them in the `PodInstancesTable` as well as the `TaskTable`.