### PR TITLE
Increase width of Service ID input field on create flow

### DIFF
--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -408,7 +408,7 @@ class GeneralServiceFormSection extends Component {
 
         <FormRow>
           <FormGroup
-            className="column-8"
+            className="column-9"
             required={true}
             showError={Boolean(errors.id)}>
             <FieldLabel>
@@ -433,7 +433,7 @@ class GeneralServiceFormSection extends Component {
           </FormGroup>
 
           <FormGroup
-            className="column-4"
+            className="column-3"
             showError={Boolean(errors.instances)}>
             <FieldLabel>
               Instances


### PR DESCRIPTION
Increases the width of the Service ID field. Why?

* More space for the help text so it doesn't wrap
* Vertical alignment with the fields further down
* More space when working with IDs that contain long group names
* Instances doesn't need to be that wide

Before
![image](https://cloud.githubusercontent.com/assets/15963/21703649/97e600da-d368-11e6-9bd4-d2521bfcf153.png)

After
![image](https://cloud.githubusercontent.com/assets/15963/21703657/a5dc41f4-d368-11e6-9139-bda037add82f.png)

cc @jfurrow 