### PR TITLE
Fixing conditional rendering on pod sections

### DIFF
--- a/plugins/services/src/js/service-configuration/PodContainerConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodContainerConfigSection.js
@@ -65,7 +65,7 @@ const PodContainerConfigSection = ({containerConfig, appConfig, onEditClick, ind
       </ConfigurationMapRow>
 
       {/* Resources */}
-      {fields.resources.cpus && (
+      {!!fields.resources.cpus && (
         <ConfigurationMapRow>
           <ConfigurationMapLabel>CPUs</ConfigurationMapLabel>
           <ConfigurationMapValue value={fields.resources.cpus} />
@@ -74,7 +74,7 @@ const PodContainerConfigSection = ({containerConfig, appConfig, onEditClick, ind
             tabViewID={tabViewID} />
         </ConfigurationMapRow>
       )}
-      {fields.resources.mem && (
+      {!!fields.resources.mem && (
         <ConfigurationMapRow>
           <ConfigurationMapLabel>Memory</ConfigurationMapLabel>
           <ConfigurationMapSizeValue value={fields.resources.mem} />
@@ -83,7 +83,7 @@ const PodContainerConfigSection = ({containerConfig, appConfig, onEditClick, ind
             tabViewID={tabViewID} />
         </ConfigurationMapRow>
       )}
-      {fields.resources.disk && (
+      {!!fields.resources.disk && (
         <ConfigurationMapRow>
           <ConfigurationMapLabel>Disk</ConfigurationMapLabel>
           <ConfigurationMapSizeValue value={fields.resources.disk} />
@@ -92,7 +92,7 @@ const PodContainerConfigSection = ({containerConfig, appConfig, onEditClick, ind
             tabViewID={tabViewID} />
         </ConfigurationMapRow>
       )}
-      {fields.resources.gpus && (
+      {!!fields.resources.gpus && (
         <ConfigurationMapRow>
           <ConfigurationMapLabel>GPUs</ConfigurationMapLabel>
           <ConfigurationMapValue value={fields.resources.gpus} />
@@ -103,7 +103,7 @@ const PodContainerConfigSection = ({containerConfig, appConfig, onEditClick, ind
       )}
 
       {/* Global Properties */}
-      {fields.user && (
+      {!!fields.user && (
         <ConfigurationMapRow>
           <ConfigurationMapLabel>Run as User</ConfigurationMapLabel>
           <ConfigurationMapValue value={fields.user} />
@@ -112,7 +112,7 @@ const PodContainerConfigSection = ({containerConfig, appConfig, onEditClick, ind
             tabViewID={tabViewID} />
         </ConfigurationMapRow>
       )}
-      {fields.command && (
+      {!!fields.command && (
         <ConfigurationMapRow>
           <ConfigurationMapLabel>Command</ConfigurationMapLabel>
           <ConfigurationMapMultilineValue value={fields.command} />

--- a/plugins/services/src/js/service-configuration/PodContainerConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodContainerConfigSection.js
@@ -65,7 +65,7 @@ const PodContainerConfigSection = ({containerConfig, appConfig, onEditClick, ind
       </ConfigurationMapRow>
 
       {/* Resources */}
-      {!!fields.resources.cpus && (
+      {Boolean(fields.resources.cpus) && (
         <ConfigurationMapRow>
           <ConfigurationMapLabel>CPUs</ConfigurationMapLabel>
           <ConfigurationMapValue value={fields.resources.cpus} />
@@ -74,7 +74,7 @@ const PodContainerConfigSection = ({containerConfig, appConfig, onEditClick, ind
             tabViewID={tabViewID} />
         </ConfigurationMapRow>
       )}
-      {!!fields.resources.mem && (
+      {Boolean(fields.resources.mem) && (
         <ConfigurationMapRow>
           <ConfigurationMapLabel>Memory</ConfigurationMapLabel>
           <ConfigurationMapSizeValue value={fields.resources.mem} />
@@ -83,7 +83,7 @@ const PodContainerConfigSection = ({containerConfig, appConfig, onEditClick, ind
             tabViewID={tabViewID} />
         </ConfigurationMapRow>
       )}
-      {!!fields.resources.disk && (
+      {Boolean(fields.resources.disk) && (
         <ConfigurationMapRow>
           <ConfigurationMapLabel>Disk</ConfigurationMapLabel>
           <ConfigurationMapSizeValue value={fields.resources.disk} />
@@ -92,7 +92,7 @@ const PodContainerConfigSection = ({containerConfig, appConfig, onEditClick, ind
             tabViewID={tabViewID} />
         </ConfigurationMapRow>
       )}
-      {!!fields.resources.gpus && (
+      {Boolean(fields.resources.gpus) && (
         <ConfigurationMapRow>
           <ConfigurationMapLabel>GPUs</ConfigurationMapLabel>
           <ConfigurationMapValue value={fields.resources.gpus} />
@@ -103,7 +103,7 @@ const PodContainerConfigSection = ({containerConfig, appConfig, onEditClick, ind
       )}
 
       {/* Global Properties */}
-      {!!fields.user && (
+      {Boolean(fields.user) && (
         <ConfigurationMapRow>
           <ConfigurationMapLabel>Run as User</ConfigurationMapLabel>
           <ConfigurationMapValue value={fields.user} />
@@ -112,7 +112,7 @@ const PodContainerConfigSection = ({containerConfig, appConfig, onEditClick, ind
             tabViewID={tabViewID} />
         </ConfigurationMapRow>
       )}
-      {!!fields.command && (
+      {Boolean(fields.command) && (
         <ConfigurationMapRow>
           <ConfigurationMapLabel>Command</ConfigurationMapLabel>
           <ConfigurationMapMultilineValue value={fields.command} />

--- a/plugins/services/src/js/service-configuration/PodGeneralConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodGeneralConfigSection.js
@@ -131,7 +131,7 @@ const PodGeneralConfigSection = ({appConfig, onEditClick}) => {
             onEditClick={onEditClick}
             tabViewID="services" />
         </ConfigurationMapRow>
-        {fields.backoff && (
+        {!!fields.backoff && (
           <ConfigurationMapRow>
             <ConfigurationMapLabel>Backoff</ConfigurationMapLabel>
             <DurationValue
@@ -142,7 +142,7 @@ const PodGeneralConfigSection = ({appConfig, onEditClick}) => {
               tabViewID="services" />
           </ConfigurationMapRow>
         )}
-        {fields.backoffFactor && (
+        {!!fields.backoffFactor && (
           <ConfigurationMapRow>
             <ConfigurationMapLabel>Backoff Factor</ConfigurationMapLabel>
             <ConfigurationMapValue value={fields.backoffFactor} />
@@ -151,7 +151,7 @@ const PodGeneralConfigSection = ({appConfig, onEditClick}) => {
               tabViewID="services" />
           </ConfigurationMapRow>
         )}
-        {fields.maxLaunchDelay && (
+        {!!fields.maxLaunchDelay && (
           <ConfigurationMapRow>
             <ConfigurationMapLabel>
               Backoff Max Launch Delay
@@ -164,7 +164,7 @@ const PodGeneralConfigSection = ({appConfig, onEditClick}) => {
               tabViewID="services" />
           </ConfigurationMapRow>
         )}
-        {fields.minimumHealthCapacity && (
+        {!!fields.minimumHealthCapacity && (
           <ConfigurationMapRow>
             <ConfigurationMapLabel>
               Upgrade Min Health Capacity
@@ -175,7 +175,7 @@ const PodGeneralConfigSection = ({appConfig, onEditClick}) => {
               tabViewID="services" />
           </ConfigurationMapRow>
         )}
-        {fields.maximumOverCapacity && (
+        {!!fields.maximumOverCapacity && (
           <ConfigurationMapRow>
             <ConfigurationMapLabel>
               Upgrade Max Overcapacity

--- a/plugins/services/src/js/service-configuration/PodGeneralConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodGeneralConfigSection.js
@@ -131,7 +131,7 @@ const PodGeneralConfigSection = ({appConfig, onEditClick}) => {
             onEditClick={onEditClick}
             tabViewID="services" />
         </ConfigurationMapRow>
-        {!!fields.backoff && (
+        {Boolean(fields.backoff) && (
           <ConfigurationMapRow>
             <ConfigurationMapLabel>Backoff</ConfigurationMapLabel>
             <DurationValue
@@ -142,7 +142,7 @@ const PodGeneralConfigSection = ({appConfig, onEditClick}) => {
               tabViewID="services" />
           </ConfigurationMapRow>
         )}
-        {!!fields.backoffFactor && (
+        {Boolean(fields.backoffFactor) && (
           <ConfigurationMapRow>
             <ConfigurationMapLabel>Backoff Factor</ConfigurationMapLabel>
             <ConfigurationMapValue value={fields.backoffFactor} />
@@ -151,7 +151,7 @@ const PodGeneralConfigSection = ({appConfig, onEditClick}) => {
               tabViewID="services" />
           </ConfigurationMapRow>
         )}
-        {!!fields.maxLaunchDelay && (
+        {Boolean(fields.maxLaunchDelay) && (
           <ConfigurationMapRow>
             <ConfigurationMapLabel>
               Backoff Max Launch Delay
@@ -164,7 +164,7 @@ const PodGeneralConfigSection = ({appConfig, onEditClick}) => {
               tabViewID="services" />
           </ConfigurationMapRow>
         )}
-        {!!fields.minimumHealthCapacity && (
+        {Boolean(fields.minimumHealthCapacity) && (
           <ConfigurationMapRow>
             <ConfigurationMapLabel>
               Upgrade Min Health Capacity
@@ -175,7 +175,7 @@ const PodGeneralConfigSection = ({appConfig, onEditClick}) => {
               tabViewID="services" />
           </ConfigurationMapRow>
         )}
-        {!!fields.maximumOverCapacity && (
+        {Boolean(fields.maximumOverCapacity) && (
           <ConfigurationMapRow>
             <ConfigurationMapLabel>
               Upgrade Max Overcapacity


### PR DESCRIPTION
I am quite confident this was fixed in one of my past PRs but I could have forgotten to push... this PR makes sure no `0`s appear when a conditional rendering case fails to match because of number 0.