### PR TITLE
Fix TaskTable column responsiveness

### DIFF
--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -16,7 +16,7 @@ const tableColumnClasses = {
   checkbox: 'task-table-column-checkbox',
   id: 'task-table-column-primary',
   name: 'task-table-column-name',
-  address: 'task-table-column-host-address',
+  host: 'task-table-column-host-address',
   status: 'task-table-column-status',
   health: 'task-table-column-health',
   logs: 'task-table-column-logs',
@@ -187,7 +187,7 @@ class TaskTable extends React.Component {
         <col className={tableColumnClasses.checkbox} />
         <col />
         <col className={tableColumnClasses.name} />
-        <col className={tableColumnClasses.address} />
+        <col className={tableColumnClasses.host} />
         <col className={tableColumnClasses.status} />
         <col className={tableColumnClasses.health} />
         <col className={tableColumnClasses.logs} />

--- a/src/styles/components/task-table/styles.less
+++ b/src/styles/components/task-table/styles.less
@@ -80,6 +80,23 @@
   }
 }
 
+& when (@task-table-enabled) and (@layout-screen-medium-enabled) {
+
+  @media (min-width: @layout-screen-medium-min-width) {
+
+    .task-table-column {
+
+      &-host-address {
+        display: table-cell;
+
+        col& {
+          display: table-column;
+        }
+      }
+    }
+  }
+}
+
 & when (@task-table-enabled) and (@layout-screen-large-enabled) {
 
   @media (min-width: @layout-screen-large-min-width) {
@@ -108,7 +125,6 @@
 
     .task-table-column {
 
-      &-host-address,
       &-updated,
       &-version {
         display: table-cell;


### PR DESCRIPTION
This PR fixes the following:
* the `TaskTable`'s key for the `host` column was incorrect, so the class wasn't being applied properly
* the responsiveness has been adjusted so that the `host` column appears at screen size medium and up, rather than large and up