### PR TITLE
Display pointer cursor for directories in TaskDirectoryTable

### DIFF
--- a/plugins/services/src/js/components/TaskDirectoryTable.js
+++ b/plugins/services/src/js/components/TaskDirectoryTable.js
@@ -30,7 +30,7 @@ class TaskDirectoryTable extends React.Component {
       iconID = 'folder';
       label = (
         <a
-          className="table-cell-link-primary"
+          className="table-cell-link-primary clickable"
           onClick={this.handleTaskClick.bind(this, value)}>
           {value}
         </a>


### PR DESCRIPTION
Adds the `clickable` class to an `a` tag without an `href`