### PR TITLE
Update reactjs-components to 0.16.0-beta.9

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6684,9 +6684,9 @@
       "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz"
     },
     "reactjs-components": {
-      "version": "0.16.0-beta.8",
-      "from": "reactjs-components@0.16.0-beta.8",
-      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.16.0-beta.8.tgz"
+      "version": "0.16.0-beta.9",
+      "from": "reactjs-components@0.16.0-beta.9",
+      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.16.0-beta.9.tgz"
     },
     "reactjs-mixin": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-gemini-scrollbar": "2.1.0",
     "react-redux": "4.4.0",
     "react-router": "2.8.1",
-    "reactjs-components": "0.16.0-beta.8",
+    "reactjs-components": "0.16.0-beta.9",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
     "tv4": "1.2.7"


### PR DESCRIPTION
Changes:
* ~~bubble scroll events from `VirtualList` https://github.com/mesosphere/reactjs-components/pull/384~~
* removed keydown mixin resulting in dramatic performance improvements https://github.com/mesosphere/reactjs-components/pull/380
* updated CNVS to 1.1.6 https://github.com/mesosphere/reactjs-components/pull/381