### PR TITLE
DCOS-12858: Update download endpoint for logs

### DIFF
--- a/plugins/services/src/js/pages/task-details/TaskLogsTab.js
+++ b/plugins/services/src/js/pages/task-details/TaskLogsTab.js
@@ -253,21 +253,21 @@ class TaskLogsTab extends mixin(StoreMixin) {
   getDownloadButton() {
     const {task} = this.props;
     const {selectedStream} = this.state;
-    const params = getLogParameters(task, {filter: {STREAM: selectedStream}});
+    const params = getLogParameters(task, {
+      // This will be added to the name
+      postfix: selectedStream && selectedStream.toLowerCase(),
+      filter: {STREAM: selectedStream}
+    });
 
     // This is a hacky way of interacting with the API to be able to download
     // logs with a POST request
     return (
-      <form
-        key="download"
-        action={SystemLogUtil.getUrl(task.slave_id, params, false)}
-        method="POST">
-        <button
-          className="button button-stroke"
-          disabled={!task}>
-          <Icon id="download" size="mini" />
-        </button>
-      </form>
+      <a
+        className="button button-stroke"
+        disabled={!task}
+        href={SystemLogUtil.getUrl(task.slave_id, params, false, '/download')}>
+        <Icon id="download" size="mini" />
+      </a>
     );
   }
 

--- a/src/js/utils/SystemLogUtil.js
+++ b/src/js/utils/SystemLogUtil.js
@@ -3,9 +3,10 @@ import Config from '../config/Config';
 const paramOptions = [
   'cursor',
   'limit',
+  'postfix',
+  'read_reverse',
   'skip_prev',
-  'skip_next',
-  'read_reverse'
+  'skip_next'
 ];
 
 const SystemLogUtil = {
@@ -17,18 +18,20 @@ const SystemLogUtil = {
    * @param {String} [options.cursor] ID of the cursor to request entries from
    * @param {String} [options.subscriptionID] ID to emit events to,
    *   if omitted a new one will be created
+   * @param {String} [options.containerID] ID for container to retrieve logs from
+   * @param {String} [options.executorID] ID for executor to retrieve logs from
+   * @param {String} [options.frameworkID] ID for framework to retrieve logs from
+   * @param {Object} [options.filter] filter parameters to add to URL
+   * @param {Number} [options.limit] limit how many entries to receive
+   * @param {Number} [options.postfix] postifx to add to the download name
+   * @param {String} [options.read_reverse] will read events in reverse order if set to true
    * @param {Number} [options.skip_prev] how many entries backwards to look
    * @param {Number} [options.skip_next] how many entries to look ahead
-   * @param {Number} [options.limit] limit how many entries to receive
-   * @param {Object} [options.filter] filter parameters to add to URL
-   * @param {String} [options.frameworkID] ID for framework to retrieve logs from
-   * @param {String} [options.executorID] ID for executor to retrieve logs from
-   * @param {String} [options.containerID] ID for container to retrieve logs from
-   * @param {String} [options.read_reverse] will read events in reverse order if set to true
-   * @param {Boolean} [isStream = true] whether to use stream or range endpoint
+   * @param {Boolean} [isStream = true] whether to use stream or range base
+   * @param {String} [endpoint = ''] add aditional endpoint to the url
    * @returns {String} URL for system logs request
    */
-  getUrl(nodeID, options, isStream = true) {
+  getUrl(nodeID, options, isStream = true, endpoint = '') {
     const {filter = {}} = options;
 
     const range = paramOptions.reduce((memo, key) => {
@@ -49,9 +52,9 @@ const SystemLogUtil = {
       return memo;
     }, range);
 
-    let endpoint = 'range';
+    let base = 'range';
     if (isStream) {
-      endpoint = 'stream';
+      base = 'stream';
     }
 
     const idArray = ['framework', 'executor', 'container'].reduce(function (memo, key) {
@@ -63,7 +66,7 @@ const SystemLogUtil = {
       return memo;
     }, []);
 
-    return `${Config.logsAPIPrefix}/${nodeID}/logs/v1/${endpoint}/${idArray.join('/')}?${paramsArray.join('&')}`;
+    return `${Config.logsAPIPrefix}/${nodeID}/logs/v1/${base}/${idArray.join('/')}${endpoint}?${paramsArray.join('&')}`;
   }
 };
 

--- a/src/js/utils/__tests__/SystemLogUtil-test.js
+++ b/src/js/utils/__tests__/SystemLogUtil-test.js
@@ -59,11 +59,12 @@ describe('SystemLogUtil', function () {
       var result = SystemLogUtil.getUrl('foo', {
         cursor: 'cursor',
         limit: 'lim&it',
+        postfix: 'postfix',
         filter: {'param/1': 'param/1', 'param\\2': 'param\\2'}
       });
 
       expect(result).toEqual(
-        '/system/v1/agent/foo/logs/v1/stream/?cursor=cursor&limit=lim%26it&filter=param%2F1:param%2F1&filter=param%5C2:param%5C2'
+        '/system/v1/agent/foo/logs/v1/stream/?cursor=cursor&limit=lim%26it&postfix=postfix&filter=param%2F1:param%2F1&filter=param%5C2:param%5C2'
       );
     });
 
@@ -141,6 +142,20 @@ describe('SystemLogUtil', function () {
       expect(result).toEqual(
         '/system/v1/agent/foo/logs/v1/range/' +
         'framework/bar/executor/baz/container/quis?cursor=cursor'
+      );
+    });
+
+    it('should add aditional endpoint to the URL', function () {
+      var result = SystemLogUtil.getUrl('foo', {
+        cursor: 'cursor',
+        frameworkID: 'bar',
+        executorID: 'baz',
+        containerID: 'quis'
+      }, false, '/download');
+
+      expect(result).toEqual(
+        '/system/v1/agent/foo/logs/v1/range/' +
+        'framework/bar/executor/baz/container/quis/download?cursor=cursor'
       );
     });
 


### PR DESCRIPTION
Resolves DCOS-12761 as well.

This PR updates the download endpoint for the logs:
![](https://cl.ly/0c3p2U0Z361A/Screen%20Recording%202017-01-06%20at%2014.22.gif)

Please review using a cluster from this PR: https://github.com/dcos/dcos/pull/1122