### PR TITLE
DCOS-12773: Fix button text alignment in Safari

### DIFF
--- a/src/styles/components/buttons/styles.less
+++ b/src/styles/components/buttons/styles.less
@@ -8,6 +8,20 @@
     transform: translateX(-50%);
   }
 
+  // We need to override CNVS display properies for button elements, as flex is
+  // invalid in Safari and other browsers.
+  button {
+
+    &,
+    &.button {
+      display: inline-block;
+
+      &.button-block {
+        display: block;
+      }
+    }
+  }
+
   // TODO: Name this animation specifically.
   .button {
 


### PR DESCRIPTION
This PR unsets the `display: inline-flex` property applied by CNVS. `button` elements cannot be flex containers in some browsers (notably Safari).

Before:
![](https://cl.ly/0F342p1S463P/Screen%20Shot%202017-01-06%20at%204.31.41%20PM.png)

After:
![](https://cl.ly/3i1L2V3x1i41/Screen%20Shot%202017-01-06%20at%204.30.08%20PM.png)

I submitted an issue for CNVS here: https://github.com/mesosphere/cnvs/issues/83