### PR TITLE
DCOS-12660: Default network type to HOST

### DIFF
--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -274,8 +274,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
   }
 
   getServiceEndpoints() {
-    const {errors, data: {portDefinitions}} = this.props;
-    const network = findNestedPropertyInObject(this.props.data, 'networkType');
+    const {errors, data: {portDefinitions, networkType = HOST}} = this.props;
 
     return portDefinitions.map((portDefinition, index) => {
       let portMappingFields = null;
@@ -288,7 +287,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
         `container.docker.portMappings.${index}.name`
       );
 
-      if (portDefinition.portMapping || [BRIDGE, HOST].includes(network)) {
+      if (portDefinition.portMapping || [BRIDGE, HOST].includes(networkType)) {
         portMappingFields = (
           <FormRow>
             {this.getHostPortFields(portDefinition, index)}
@@ -305,7 +304,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
             {value: index, path: 'portDefinitions'}
           )}>
           <FormRow>
-            {this.getContainerPortField(portDefinition, network, errors, index)}
+            {this.getContainerPortField(portDefinition, networkType, errors, index)}
             <FormGroup className="column-6" showError={Boolean(nameError)}>
               <FieldLabel>
                 Service Endpoint Name
@@ -316,7 +315,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
                 value={portDefinition.name} />
               <FieldError>{nameError}</FieldError>
             </FormGroup>
-            {this.getPortMappingCheckbox(portDefinition, network, index)}
+            {this.getPortMappingCheckbox(portDefinition, networkType, index)}
           </FormRow>
           {portMappingFields}
           {this.getLoadBalancedServiceAddressField(portDefinition, index)}

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -50,7 +50,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
   getHostPortFields(portDefinition, index) {
     let placeholder;
     const {errors} = this.props;
-    let hostPortError = findNestedPropertyInObject(
+    const hostPortError = findNestedPropertyInObject(
       errors,
       `portDefinitions.${index}.port`
     ) || findNestedPropertyInObject(
@@ -62,7 +62,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
       placeholder = `$PORT${index}`;
     }
 
-    let tooltipContent = (
+    const tooltipContent = (
       <span>
         {`This host port will be accessible as an environment variable called '$PORT${index}'. `}
         <a href="https://mesosphere.github.io/marathon/docs/ports.html" about="_blank">
@@ -115,7 +115,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
 
   getLoadBalancedServiceAddressField({containerPort, hostPort, loadBalanced, vip}, index) {
     const {errors} = this.props;
-    let loadBalancedError = findNestedPropertyInObject(
+    const loadBalancedError = findNestedPropertyInObject(
       errors,
       `portDefinitions.${index}.labels`
     ) || findNestedPropertyInObject(
@@ -172,7 +172,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
 
   getProtocolField(portDefinition, index) {
     const {errors} = this.props;
-    let protocolError = findNestedPropertyInObject(
+    const protocolError = findNestedPropertyInObject(
       errors,
       `portDefinitions.${index}.protocol`
     ) || findNestedPropertyInObject(


### PR DESCRIPTION
Switching a Mesos Runtime app Network type leaves you with a wrong form for service endpoints

This PR fixes demonstrated behavior:

![jan-09-2017 19-50-24](https://cloud.githubusercontent.com/assets/186223/21778904/92d476a4-d6a5-11e6-8315-4121ac93295d.gif)

