### PR TITLE
DCOS-12480: Display 'Not Enabled' for disabled service endpoints

### DIFF
--- a/plugins/services/src/js/service-configuration/PodNetworkConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodNetworkConfigSection.js
@@ -40,7 +40,8 @@ class PodNetworkConfigSection extends React.Component {
       },
       {
         heading: 'Load Balanced Address',
-        prop: 'lbAddress'
+        prop: 'lbAddress',
+        placeholder: <em>Not Enabled</em>
       },
       {
         heading: 'Container',

--- a/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
@@ -145,7 +145,7 @@ class ServiceNetworkingConfigSection extends ServiceConfigBaseSectionDisplay {
                     );
                   }
 
-                  return getDisplayValue(undefined);
+                  return <em>Not Enabled</em>;
                 },
                 sortable: true
               }


### PR DESCRIPTION
This PR changes the _Not Configured_ text to _Not Enabled_ for disabled LB service endpoints.