### PR TITLE
DCOS-12642: Fixing lost characters when typing in Jobs filter

### DIFF
--- a/src/js/components/JobSearchFilter.js
+++ b/src/js/components/JobSearchFilter.js
@@ -1,65 +1,23 @@
-import mixin from 'reactjs-mixin';
 /* eslint-disable no-unused-vars */
 import React from 'react';
 /* eslint-enable no-unused-vars */
-
 import FilterInputText from './FilterInputText';
-import QueryParamsMixin from '../mixins/QueryParamsMixin';
-import JobFilterTypes from '../constants/JobFilterTypes';
 
-const METHODS_TO_BIND = ['setSearchString'];
-
-class JobSearchFilter extends mixin(QueryParamsMixin) {
-  constructor() {
-    super(...arguments);
-
-    this.state = {
-      searchString: ''
-    };
-
-    METHODS_TO_BIND.forEach((method) => {
-      this[method] = this[method].bind(this);
-    });
-  }
-
-  componentDidMount() {
-    this.updateFilterStatus();
-  }
-
-  componentWillReceiveProps() {
-    this.updateFilterStatus();
-  }
-
-  setSearchString(filterValue) {
-    this.setQueryParam(JobFilterTypes.TEXT, filterValue);
-    this.props.handleFilterChange(filterValue, JobFilterTypes.TEXT);
-  }
-
-  updateFilterStatus() {
-    const {state} = this;
-    const searchString =
-      this.getQueryParamObject()[JobFilterTypes.TEXT] || '';
-
-    if (searchString !== state.searchString) {
-      this.setState({searchString},
-        this.props.handleFilterChange.bind(null, searchString, JobFilterTypes.TEXT));
-    }
-  }
-
+class JobSearchFilter extends React.Component {
   render() {
     return (
       <FilterInputText
         className="flush-bottom"
-        handleFilterChange={this.setSearchString}
+        handleFilterChange={this.props.onChange}
         placeholder="Search"
-        searchString={this.state.searchString} />
+        searchString={this.props.value} />
     );
   }
 };
 
 JobSearchFilter.propTypes = {
-  handleFilterChange: React.PropTypes.func.isRequired,
-  location: React.PropTypes.object.isRequired
+  onChange: React.PropTypes.func.isRequired,
+  value: React.PropTypes.string
 };
 
 module.exports = JobSearchFilter;

--- a/src/js/pages/__tests__/JobsTab-test.js
+++ b/src/js/pages/__tests__/JobsTab-test.js
@@ -15,11 +15,9 @@ const JestUtil = require('../../utils/JestUtil');
 const AlertPanel = require('../../components/AlertPanel');
 const MetronomeUtil = require('../../utils/MetronomeUtil');
 const DCOSStore = require('foundation-ui').DCOSStore;
-const QueryParamsMixin = require('../../mixins/QueryParamsMixin');
 const JobsTab = require('../jobs/JobsTab');
 const JobTree = require('../../structs/JobTree');
 const JobsTable = require('../../pages/jobs/JobsTable');
-const UserSettingsStore = require('../../stores/UserSettingsStore');
 
 describe('JobsTab', function () {
 
@@ -33,39 +31,6 @@ describe('JobsTab', function () {
 
   afterEach(function () {
     ReactDOM.unmountComponentAtNode(this.container);
-  });
-
-  describe('Query parameters', function () {
-
-    afterEach(UserSettingsStore.__reset);
-
-    it('are set to the default values if not stored', function () {
-      ReactDOM.render(
-        JestUtil.stubRouterContext(JobsTab, {params: {id: '/'}}),
-        this.container
-      );
-
-      expect(QueryParamsMixin.setQueryParam).toHaveBeenCalledWith(
-        'searchString', ''
-      );
-    });
-
-    it('are reinstated if stored', function () {
-      UserSettingsStore.__setKeyResponse('savedStates', {
-        jobsPage: {
-          searchString: 'foo'
-        }
-      });
-      ReactDOM.render(
-        JestUtil.stubRouterContext(JobsTab, {params: {id: '/'}}),
-        this.container
-      );
-
-      expect(QueryParamsMixin.setQueryParam).toHaveBeenCalledWith(
-        'searchString', 'foo'
-      );
-    });
-
   });
 
   describe('#render', function () {

--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -61,7 +61,6 @@ class JobsTab extends mixin(StoreMixin) {
 
   componentWillReceiveProps(nextProps) {
     super.componentWillReceiveProps(...arguments);
-    console.log(nextProps);
     this.updateFromProps(nextProps);
   }
 

--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -75,9 +75,8 @@ class JobsTab extends mixin(StoreMixin) {
   handleFilterChange(filterValue) {
     const {router} = this.context;
     const {location: {pathname}} = this.props;
-    const query = {};
+    const query = {[JobFilterTypes.TEXT]: filterValue};
 
-    query[JobFilterTypes.TEXT] = filterValue;
     router.push({pathname, query});
 
     this.setState({
@@ -102,7 +101,7 @@ class JobsTab extends mixin(StoreMixin) {
   }
 
   updateFromProps(props) {
-    const {location={query:{}}} = props;
+    const {location = {query:{}}} = props;
 
     if (location.query[JobFilterTypes.TEXT] != null) {
       const state = {};


### PR DESCRIPTION
This PR removes the `QueryParamsMixin` and `SaveStateMixin` (for consistency) from the `JobsTab`, and fixes an issue where letters were dropped when typing in the Jobs search filter.

In detail:
* `QueryParamsMixin` is not using the `nextProps` coming from the `componentWillReceiveProps` in order to synchronize the component state from the query parameters, and
* Mix-ins are considered deprecated, therefore I didn't fix the problem there, rather I re-used the same approach as from the `ServicesContainer`
* `SaveStateMixin` was racing the `QueryParamsMixin` and causing another set of problems. However I do agree that we are losing some of the functionality and perhaps has to be re-introduced in another way (without using mix-ins).
