### PR TITLE
DCOS-12741: Wrapping jobs error page in a <Page/>

### DIFF
--- a/src/js/pages/jobs/JobDetailPage.js
+++ b/src/js/pages/jobs/JobDetailPage.js
@@ -209,9 +209,7 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
     return (
       <Page>
         <Page.Header breadcrumbs={<JobsBreadcrumbs/>} />
-        <div className="pod">
-          <RequestErrorMsg />
-        </div>
+        <RequestErrorMsg />
       </Page>
     );
   }

--- a/src/js/pages/jobs/JobDetailPage.js
+++ b/src/js/pages/jobs/JobDetailPage.js
@@ -207,9 +207,12 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
 
   getErrorScreen() {
     return (
-      <div className="pod">
-        <RequestErrorMsg />
-      </div>
+      <Page>
+        <Page.Header breadcrumbs={<JobsBreadcrumbs/>} />
+        <div className="pod">
+          <RequestErrorMsg />
+        </div>
+      </Page>
     );
   }
 


### PR DESCRIPTION
The error screen in the Jobs page was not wrapped in a `<Page />` component. This PR fixes this.

<img width="980" alt="screen shot 2017-01-10 at 17 17 23" src="https://cloud.githubusercontent.com/assets/883486/21814194/c4259e96-d758-11e6-8cf4-56286644e661.png">

Closes DCOS-12741