### PR TITLE
Hide containerPort field if network type is not defined

### DIFF
--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -213,7 +213,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
   }
 
   getContainerPortField(portDefinition, network, errors, index) {
-    if (network === HOST) {
+    if (network == null || network === HOST) {
       return null;
     }
 


### PR DESCRIPTION
This PR fixes a bug where the form displays the `containerPort` field when the network type has not yet been defined.