### PR TITLE
DCOS-12661: Differentiate between Host and Container Port

### DIFF
--- a/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
@@ -85,8 +85,8 @@ class ServiceNetworkingConfigSection extends ServiceConfigBaseSectionDisplay {
             const containerPortMappings = findNestedPropertyInObject(
               appDefinition, 'container.docker.portMappings'
             );
-            if ((portDefinitions == null || portDefinitions.length === 0) &&
-              containerPortMappings != null && containerPortMappings.length !== 0) {
+            if (containerPortMappings != null
+              && containerPortMappings.length !== 0) {
               portDefinitions = containerPortMappings;
               keys.port = 'hostPort';
             }

--- a/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
@@ -12,7 +12,7 @@ import ServiceConfigUtil from '../utils/ServiceConfigUtil';
 import ServiceConfigBaseSectionDisplay from './ServiceConfigBaseSectionDisplay';
 import {findNestedPropertyInObject} from '../../../../../src/js/utils/Util';
 
-const getNetworkType = (networkType, appDefinition) => {
+function getNetworkType(networkType, appDefinition) {
   networkType = networkType || Networking.type.HOST;
   const networkName = findNestedPropertyInObject(
     appDefinition,


### PR DESCRIPTION
* Uses `Host Port` for the column heading rather than the vague `Port`
* Adds a `Container Port` column when network type is anything but `HOST`
* Fixes the service address string concatenation when network type is anything but `HOST`

![](https://cl.ly/0W0c1H3R3P1t/Screen%20Shot%202017-01-10%20at%2010.59.21%20AM.png)
![](https://cl.ly/1s2x45082u37/Screen%20Shot%202017-01-10%20at%2010.59.07%20AM.png)
![](https://cl.ly/1R1O2r0d1A1D/Screen%20Shot%202017-01-10%20at%2011.00.14%20AM.png)