### PR TITLE
Fix forcePullImage bug, where it would show up in JSON when runtime is UCR

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/Container.js
+++ b/plugins/services/src/js/reducers/serviceForm/Container.js
@@ -196,11 +196,6 @@ module.exports = {
       delete newState.docker;
     }
 
-    if (newState.docker && newState.type !== DOCKER) {
-      delete newState.docker.privileged;
-      delete newState.docker.forcePullImage;
-    }
-
     if (ValidatorUtil.isEmpty(newState.volumes)) {
       delete newState.volumes;
     }

--- a/plugins/services/src/js/reducers/serviceForm/Docker.js
+++ b/plugins/services/src/js/reducers/serviceForm/Docker.js
@@ -1,13 +1,33 @@
 import {combineReducers, simpleReducer} from '../../../../../../src/js/utils/ReducerUtil';
+import ContainerConstants from '../../constants/ContainerConstants';
 import networkingReducer from './Networking';
 import Networking from '../../../../../../src/js/constants/Networking';
 import {SET} from '../../../../../../src/js/constants/TransactionTypes';
 
+const {DOCKER} = ContainerConstants.type;
+
 const {BRIDGE, HOST, USER} = Networking.type;
 
+function getContainerSettingsReducer(name) {
+  return function (_, {type, path = [], value}) {
+    const joinedPath = path.join('.');
+    if (joinedPath === 'container.type' && Boolean(value)) {
+      this.networkType = value;
+    }
+    if (type === SET && joinedPath === `container.docker.${name}`) {
+      this.value = Boolean(value);
+    }
+    if (this.networkType === DOCKER) {
+      return this.value;
+    }
+
+    return null;
+  };
+}
+
 module.exports = combineReducers({
-  privileged: simpleReducer('container.docker.privileged', null),
-  forcePullImage: simpleReducer('container.docker.forcePullImage', null),
+  privileged: getContainerSettingsReducer('privileged'),
+  forcePullImage: getContainerSettingsReducer('forcePullImage'),
   image: simpleReducer('container.docker.image', ''),
   network(state, {type, path = [], value}) {
     const joinedPath = path.join('.');

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -145,6 +145,41 @@ describe('Container', function () {
       )).toEqual(null);
     });
 
+    it('removes forcePullImage when runtime is changed', function () {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
+      batch = batch.add(
+        new Transaction(['container', 'docker', 'forcePullImage'], true, SET)
+      );
+      batch = batch.add(new Transaction(['container', 'type'], 'MESOS', SET));
+      batch = batch.add(
+          new Transaction(['container', 'docker', 'image'], 'foo', SET)
+      );
+
+      expect(batch.reduce(
+        Container.JSONReducer.bind({}),
+        {}
+      )).toEqual({type: 'MESOS', docker: {image: 'foo'}});
+    });
+
+    it('remembers forcePullImage from earlier setting', function () {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
+      batch = batch.add(
+        new Transaction(['container', 'docker', 'forcePullImage'], true, SET)
+      );
+      batch = batch.add(new Transaction(['container', 'type'], 'MESOS', SET));
+      batch = batch.add(
+          new Transaction(['container', 'docker', 'image'], 'foo', SET)
+      );
+      batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
+
+      expect(batch.reduce(
+        Container.JSONReducer.bind({}),
+        {}
+      )).toEqual({type: 'DOCKER', docker: {image: 'foo', forcePullImage: true}});
+    });
+
     it('sets image correctly', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));


### PR DESCRIPTION
Steps to reproduce:
1. Set the runtime to DOCKER
2. Check `forcePullImage`
3. Change to runtime to UCR
4. `forcePullImage` will still show up in the JSON

Before:
![](https://cl.ly/190v0o18093l/Screen%20Recording%202017-01-10%20at%2014.30.gif)

After:
![](https://cl.ly/060T2f3T0r3U/Screen%20Recording%202017-01-10%20at%2014.32.gif)

This PR fixes that issue by letting the individual container settings handle their own results over using simpleReducers.