### PR TITLE
DCOS-12449: Add Public IP to cluster details page

### DIFF
--- a/src/js/pages/system/OverviewDetailTab.js
+++ b/src/js/pages/system/OverviewDetailTab.js
@@ -49,7 +49,7 @@ class OverviewDetailTab extends mixin(StoreMixin) {
       },
       {
         name: 'metadata',
-        events: ['dcosBuildInfoChange', 'dcosSuccess']
+        events: ['dcosBuildInfoChange', 'dcosSuccess', 'success']
       }
     ];
 
@@ -80,6 +80,7 @@ class OverviewDetailTab extends mixin(StoreMixin) {
 
   getClusterDetailsHash() {
     let ccid = ConfigStore.get('ccid');
+    let publicIP = this.getPublicIP();
     let productVersion = MetadataStore.version;
 
     if (Object.keys(ccid).length) {
@@ -92,9 +93,14 @@ class OverviewDetailTab extends mixin(StoreMixin) {
       productVersion = this.getLoading();
     }
 
+    if (publicIP == null) {
+      publicIP = this.getLoading();
+    }
+
     return {
       [`${Config.productName} Version`]: productVersion,
-      'Cryptographic Cluster ID': ccid
+      'Cryptographic Cluster ID': ccid,
+      'Public IP': publicIP
     };
   }
 
@@ -123,6 +129,18 @@ class OverviewDetailTab extends mixin(StoreMixin) {
     }];
   }
 
+  getPublicIP() {
+    const metadata = MetadataStore.get('metadata');
+
+    if ((typeof metadata !== 'object') ||
+      metadata.PUBLIC_IPV4 == null ||
+      metadata.PUBLIC_IPV4.length === 0) {
+      return null;
+    }
+
+    return metadata.PUBLIC_IPV4;
+  }
+
   render() {
     const buildInfo = MetadataStore.get('dcosBuildInfo');
     const marathonHash = this.getMarathonDetailsHash();
@@ -149,6 +167,9 @@ class OverviewDetailTab extends mixin(StoreMixin) {
           <ConfigurationMap>
             <ConfigurationMapHeading className="flush-top">
               Cluster Details
+            </ConfigurationMapHeading>
+            <ConfigurationMapHeading level={2}>
+              General
             </ConfigurationMapHeading>
             <HashMapDisplay hash={this.getClusterDetailsHash()} />
             {marathonDetails}

--- a/src/js/pages/system/OverviewDetailTab.js
+++ b/src/js/pages/system/OverviewDetailTab.js
@@ -10,6 +10,7 @@ import Config from '../../config/Config';
 import ConfigStore from '../../stores/ConfigStore';
 import ConfigurationMap from '../../components/ConfigurationMap';
 import ConfigurationMapHeading from '../../components/ConfigurationMapHeading';
+import {findNestedPropertyInObject} from '../../utils/Util';
 import HashMapDisplay from '../../components/HashMapDisplay';
 import Loader from '../../components/Loader';
 import MarathonStore from '../../../../plugins/services/src/js/stores/MarathonStore';
@@ -130,15 +131,15 @@ class OverviewDetailTab extends mixin(StoreMixin) {
   }
 
   getPublicIP() {
-    const metadata = MetadataStore.get('metadata');
+    const publicIP = findNestedPropertyInObject(
+      MetadataStore.get('metadata'), 'PUBLIC_IPV4'
+    );
 
-    if ((typeof metadata !== 'object') ||
-      metadata.PUBLIC_IPV4 == null ||
-      metadata.PUBLIC_IPV4.length === 0) {
+    if (!publicIP) {
       return null;
     }
 
-    return metadata.PUBLIC_IPV4;
+    return publicIP;
   }
 
   render() {


### PR DESCRIPTION
This PR adds the `General` heading and a `Public IP` entry to the cluster details page.

![](https://cl.ly/3w0e1e311n0w/Screen%20Shot%202017-01-11%20at%2010.40.14%20AM.png)