### PR TITLE
DCOS-12867: Fix un-minified JS in production build

### DIFF
--- a/src/resources/grammar/SearchDSL.jison
+++ b/src/resources/grammar/SearchDSL.jison
@@ -2,9 +2,9 @@
 /*              common filter description language.                           */
 
 %{
-const DSLParserUtil = require('../../js/utils/DSLParserUtil');
-const Merge = DSLParserUtil.Merge;
-const Operator = DSLParserUtil.Operator;
+var DSLParserUtil = require('../../js/utils/DSLParserUtil');
+var Merge = DSLParserUtil.Merge;
+var Operator = DSLParserUtil.Operator;
 %}
 
 /* lexical grammar */

--- a/src/resources/grammar/SearchDSL.jison
+++ b/src/resources/grammar/SearchDSL.jison
@@ -2,7 +2,9 @@
 /*              common filter description language.                           */
 
 %{
-const {Merge, Operator} = require('../../js/utils/DSLParserUtil');
+const DSLParserUtil = require('../../js/utils/DSLParserUtil');
+const Merge = DSLParserUtil.Merge;
+const Operator = DSLParserUtil.Operator;
 %}
 
 /* lexical grammar */


### PR DESCRIPTION
This PR removes the desctructuring assignment which was causing `UglifyJS` to throw an error. This file is not transpiled so we can't use ES6 features here.