### PR TITLE
DCOS-9159: Disable tasks' restart button while its service is deploying

### DIFF
--- a/plugins/services/src/js/containers/tasks/ServiceTasksContainer.js
+++ b/plugins/services/src/js/containers/tasks/ServiceTasksContainer.js
@@ -67,9 +67,14 @@ class ServiceTasksContainer extends mixin(StoreMixin) {
       return <RequestErrorMsg />;
     }
 
-    let tasks = MesosStateStore.getTasksByService(this.props.service);
+    const {service} = this.props;
+    const tasks = MesosStateStore.getTasksByService(service);
 
-    return <TasksContainer params={this.props.params} tasks={tasks} />;
+    return (
+      <TasksContainer params={this.props.params}
+        service={service}
+        tasks={tasks} />
+    );
   }
 
   render() {

--- a/plugins/services/src/js/containers/tasks/TasksContainer.js
+++ b/plugins/services/src/js/containers/tasks/TasksContainer.js
@@ -188,7 +188,7 @@ TasksContainer.childContextTypes = {
 };
 
 TasksContainer.propTypes = {
-  service: PropTypes.instanceOf(Service),
+  service: PropTypes.instanceOf(Service).isRequired,
   tasks: PropTypes.array.isRequired,
   params: PropTypes.object.isRequired
 };

--- a/plugins/services/src/js/containers/tasks/TasksContainer.js
+++ b/plugins/services/src/js/containers/tasks/TasksContainer.js
@@ -2,6 +2,7 @@ import React, {PropTypes} from 'react';
 
 import ActionKeys from '../../constants/ActionKeys';
 import MarathonActions from '../../events/MarathonActions';
+import Service from '../../structs/Service';
 import ServiceActionItem from '../../constants/ServiceActionItem';
 import TaskModals from '../../components/modals/TaskModals';
 import TasksView from './TasksView';
@@ -169,7 +170,7 @@ class TasksContainer extends React.Component {
   render() {
     return (
       <div>
-        <TasksView
+        <TasksView service={this.props.service}
           params={this.props.params}
           tasks={this.props.tasks} />
         {this.getModals()}
@@ -187,6 +188,7 @@ TasksContainer.childContextTypes = {
 };
 
 TasksContainer.propTypes = {
+  service: PropTypes.instanceOf(Service),
   tasks: PropTypes.array.isRequired,
   params: PropTypes.object.isRequired
 };

--- a/plugins/services/src/js/containers/tasks/TasksView.js
+++ b/plugins/services/src/js/containers/tasks/TasksView.js
@@ -10,6 +10,7 @@ import FilterInputText from '../../../../../../src/js/components/FilterInputText
 import GraphQLTaskUtil from '../../utils/GraphQLTaskUtil';
 import Icon from '../../../../../../src/js/components/Icon';
 import SaveStateMixin from '../../../../../../src/js/mixins/SaveStateMixin';
+import Service from '../../structs/Service';
 import ServiceStatusTypes from '../../constants/ServiceStatusTypes';
 import StringUtil from '../../../../../../src/js/utils/StringUtil';
 import TaskStates from '../../constants/TaskStates';
@@ -281,6 +282,7 @@ TasksView.propTypes = {
   params: React.PropTypes.object.isRequired,
   inverseStyle: React.PropTypes.bool,
   itemID: React.PropTypes.string,
+  service: React.PropTypes.instanceOf(Service).isRequired,
   tasks: React.PropTypes.array
 };
 

--- a/plugins/services/src/js/containers/tasks/TasksView.js
+++ b/plugins/services/src/js/containers/tasks/TasksView.js
@@ -69,7 +69,7 @@ class TasksView extends mixin(SaveStateMixin) {
     this.setState({checkedItems});
   }
 
-  handleAcitonClick(killAction) {
+  handleActionClick(killAction) {
     const {checkedItems} = this.state;
 
     if (!Object.keys(checkedItems).length) {
@@ -167,11 +167,11 @@ class TasksView extends mixin(SaveStateMixin) {
     let handleStopClick = function () {};
 
     if (!isDeploying) {
-      handleRestartClick = this.handleStopClick.bind(this, 'restart');
+      handleRestartClick = this.handleActionClick.bind(this, 'restart');
     }
 
     if (!hasSchedulerTask) {
-      handleStopClick = this.handleStopClick.bind(this, 'stop');
+      handleStopClick = this.handleActionClick.bind(this, 'stop');
     }
 
     const restartButtonClasses = classNames('button button-link', {


### PR DESCRIPTION
This PR disables the task restart button when the service is deploying.

Here's the tooltip that appears:
![](https://cl.ly/0x2P3z3M3z2o/Screen%20Shot%202017-01-11%20at%201.22.52%20PM.png)