### PR TITLE
Fix Mount's wrapper propType

### DIFF
--- a/foundation-ui/mount/Mount.js
+++ b/foundation-ui/mount/Mount.js
@@ -102,7 +102,7 @@ Mount.propTypes = {
   limit: PropTypes.number,
   children: PropTypes.element,
   type: PropTypes.string.isRequired,
-  wrapper: PropTypes.node
+  wrapper: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
 };
 
 module.exports = Mount;


### PR DESCRIPTION
This PR fixes the `Mount`'s `wrapper` `propTypes` definition. I believe this is the intended behavior, as the `wrapper` prop is passed as the first argument to `React.createElement` which can only be a string, function, or class (in this case, `PropTypes.func` covers both a function and class).

cc @mlunoe @orlandohohmeier 