### PR TITLE
DCOS-12458: Fix keyboard tab navigation

### DIFF
--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -44,7 +44,7 @@ const containerRuntimes = {
     helpText: (
       <span>
         {'The default Mesos containerizer. '}
-        <a href="https://mesos.apache.org/documentation/latest/containerizer/#Mesos"
+        <a tabIndex="-1" href="https://mesos.apache.org/documentation/latest/containerizer/#Mesos"
           target="_blank">
           More information
         </a>.

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -344,7 +344,7 @@ class GeneralServiceFormSection extends Component {
     }
 
     return Object.keys(containerRuntimes).map((runtimeName, index) => {
-      let {helpText, label} = containerRuntimes[runtimeName];
+      const {helpText, label} = containerRuntimes[runtimeName];
       let field = (
         <FieldLabel className="text-align-left" key={index}>
           <FieldInput

--- a/src/js/components/JSONEditor.js
+++ b/src/js/components/JSONEditor.js
@@ -221,6 +221,9 @@ class JSONEditor extends React.Component {
   handleEditorLoad(editor) {
     this.aceEditor = editor;
 
+    // Disable tab index for JSON editor
+    this.aceEditor.renderer.textarea.setAttribute('tabIndex', -1);
+
     // Disable syntax highlighting worker, since we are responsible for feeding
     // the correct syntax error + provided error markers
     const editorSession = editor.getSession();


### PR DESCRIPTION
This PR fixes JSONEditor tab nav issue and removes tabindex from the documentation link so that it doesn't get in the way.

I also extracted a CNVS issue of missing :focus selectors: https://mesosphere.atlassian.net/browse/DCOS-13175