### PR TITLE
DCOS-13184: Moving cleanServiceJSON to the correct place

### DIFF
--- a/plugins/services/src/js/structs/Application.js
+++ b/plugins/services/src/js/structs/Application.js
@@ -1,5 +1,6 @@
 import ApplicationSpec from './ApplicationSpec';
 import Config from '../../../../../src/js/config/Config';
+import {cleanServiceJSON} from '../../../../../src/js/utils/CleanJSONUtil';
 import FrameworkUtil from '../utils/FrameworkUtil';
 import HealthStatus from '../constants/HealthStatus';
 import Service from './Service';
@@ -16,7 +17,11 @@ module.exports = class Application extends Service {
    * @override
    */
   getSpec() {
-    return new ApplicationSpec(this.get());
+    // Strip state information and other useless information from the
+    // application in order to compose a spec.
+    return new ApplicationSpec(
+      cleanServiceJSON(this.get())
+    );
   }
 
   /**

--- a/plugins/services/src/js/structs/ApplicationSpec.js
+++ b/plugins/services/src/js/structs/ApplicationSpec.js
@@ -1,11 +1,6 @@
-import {cleanServiceJSON} from '../../../../../src/js/utils/CleanJSONUtil';
 import ServiceSpec from './ServiceSpec';
 
 module.exports = class ApplicationSpec extends ServiceSpec {
-  constructor(spec) {
-    super(cleanServiceJSON(spec));
-  }
-
   getAcceptedResourceRoles() {
     return this.get('acceptedResourceRoles');
   }

--- a/plugins/services/src/js/structs/Service.js
+++ b/plugins/services/src/js/structs/Service.js
@@ -1,4 +1,3 @@
-import {cleanServiceJSON} from '../../../../../src/js/utils/CleanJSONUtil';
 import HealthStatus from '../constants/HealthStatus';
 import Item from '../../../../../src/js/structs/Item';
 
@@ -85,6 +84,6 @@ module.exports = class Service extends Item {
   }
 
   toJSON() {
-    return cleanServiceJSON(this.get());
+    return this.get();
   }
 };

--- a/plugins/services/src/js/structs/__tests__/Application-test.js
+++ b/plugins/services/src/js/structs/__tests__/Application-test.js
@@ -594,4 +594,14 @@ describe('Application', function () {
 
   });
 
+  describe('#getSpec', function () {
+
+    it('should clean-up JSON when getting the spec', function () {
+      const item = new Application({foo: 'bar', baz: 'qux', uris: []});
+      const spec = item.getSpec();
+      expect(JSON.stringify(spec)).toEqual('{"foo":"bar","baz":"qux"}');
+    });
+
+  });
+
 });

--- a/plugins/services/src/js/structs/__tests__/Service-test.js
+++ b/plugins/services/src/js/structs/__tests__/Service-test.js
@@ -38,11 +38,6 @@ describe('Service', function () {
       expect(JSON.stringify(item)).toEqual('{"foo":"bar","baz":"qux"}');
     });
 
-    it('should drop blacklisted keys', function () {
-      const item = new Service({foo: 'bar', baz: 'qux', uris: []});
-      expect(JSON.stringify(item)).toEqual('{"foo":"bar","baz":"qux"}');
-    });
-
   });
 
 });


### PR DESCRIPTION
This PR tries to move the `cleanServiceJSON` to the most appropriate place, in order for it to be called only when it makes sense and not every time.

Ideally, I would put it in `createServiceFromResponse` , but I thought that `Application` **can** contain additional ("state"?) information, but `ApplicationSpec` **should not**.