### PR TITLE
DCOS-10182: Adding deprecation warning for `uris`

### DIFF
--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -52,7 +52,8 @@ const APP_ERROR_VALIDATORS = [
   AppValidators.App,
   MarathonAppValidators.containsCmdArgsOrContainer,
   MarathonAppValidators.complyWithResidencyRules,
-  MarathonAppValidators.complyWithIpAddressRules
+  MarathonAppValidators.complyWithIpAddressRules,
+  MarathonAppValidators.mustNotContainUris
 ];
 
 const POD_ERROR_VALIDATORS = [

--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -137,6 +137,22 @@ const MarathonAppValidators = {
 
     // No errors
     return [];
+  },
+
+  /**
+   * @param {Object} app - The data to validate
+   * @returns {Array} Returns an array with validation errors
+   */
+  mustNotContainUris(app) {
+    if (ValidatorUtil.isDefined(app.uris)) {
+      const message = '`uris` are deprecated. Please use `fetch` instead';
+
+      return [
+        {path: ['uris'], message}
+      ];
+    }
+
+    return [];
   }
 };
 

--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -144,7 +144,8 @@ const MarathonAppValidators = {
    * @returns {Array} Returns an array with validation errors
    */
   mustNotContainUris(app) {
-    if (ValidatorUtil.isDefined(app.uris)) {
+    if (ValidatorUtil.isDefined(app.uris) &&
+        ValidatorUtil.isDefined(app.fetch)) {
       const message = '`uris` are deprecated. Please use `fetch` instead';
 
       return [


### PR DESCRIPTION
This PR introduces a validator that emits an error when `uris` and `fetch` is defined, prompting the users to use `fetch` in favour of `uris`.