### PR TITLE
DCOS-12454: Use 2x2 grid in Service Create Picker

### DIFF
--- a/foundation-ui/mount/Mount.js
+++ b/foundation-ui/mount/Mount.js
@@ -102,7 +102,7 @@ Mount.propTypes = {
   limit: PropTypes.number,
   children: PropTypes.element,
   type: PropTypes.string.isRequired,
-  wrapper: PropTypes.node
+  wrapper: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
 };
 
 module.exports = Mount;

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
-import React, {Component, PropTypes} from 'react';
 import {Hooks} from 'PluginSDK';
+import React, {Component, PropTypes} from 'react';
+import {routerShape} from 'react-router';
 
 import Application from '../../structs/Application';
 import PodSpec from '../../structs/PodSpec';
@@ -331,7 +332,8 @@ class NewServiceFormModal extends Component {
     if (servicePickerActive) {
       return (
         <NewCreateServiceModalServicePicker
-          onServiceSelect={this.handleServiceSelection} />
+          onServiceSelect={this.handleServiceSelection}
+          router={this.context.router} />
       );
     }
 
@@ -539,6 +541,10 @@ class NewServiceFormModal extends Component {
     );
   }
 }
+
+NewServiceFormModal.contextTypes = {
+  router: routerShape
+};
 
 NewServiceFormModal.propTypes = {
   clearError: PropTypes.func.isRequired,

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalServicePicker.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalServicePicker.js
@@ -1,3 +1,4 @@
+import {MountService} from 'foundation-ui';
 /* eslint-disable no-unused-vars */
 import React from 'react';
 /* eslint-enable no-unused-vars */
@@ -70,9 +71,11 @@ class NewCreateServiceModalServicePicker extends React.Component {
         <h4 className="short flush-top">
           Run your own Service
         </h4>
-        <p className="lead tall">
-          Create a containerized service or run a command in one of two ways: use our form to be guided through the correct configuration, or enter your JSON configuration directly.
-        </p>
+        <MountService.Mount type="CreateService:ServicePicker:IntroductoryText">
+          <p className="lead tall">
+            Create a containerized service or run a command in one of two ways: use our form to be guided through the correct configuration, or enter your JSON configuration directly.
+          </p>
+        </MountService.Mount>
         {this.getCustomServiceGrid()}
       </div>
     );

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalServicePicker.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalServicePicker.js
@@ -2,146 +2,88 @@ import {MountService} from 'foundation-ui';
 /* eslint-disable no-unused-vars */
 import React from 'react';
 /* eslint-enable no-unused-vars */
+import {routerShape} from 'react-router';
 
 import defaultServiceImage from '../../../img/icon-service-default-medium@2x.png';
 import jsonServiceImage from '../../../img/service-image-json-medium@2x.png';
-import CosmosPackagesStore from '../../../../../../src/js/stores/CosmosPackagesStore';
+import CreateServiceModalServicePickerOption from '../../../../../../src/js/components/CreateServiceModalServicePickerOption';
+import CreateServiceModalServicePickerOptionWrapper from '../../../../../../src/js/components/CreateServiceModalServicePickerOptionWrapper';
 import Image from '../../../../../../src/js/components/Image';
-import Panel from '../../../../../../src/js/components/Panel';
+
+const METHODS_TO_BIND = ['handleServiceSelect'];
 
 class NewCreateServiceModalServicePicker extends React.Component {
   constructor() {
     super(...arguments);
 
-    this.state = {
-    };
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
   }
 
   handleServiceSelect(service) {
     this.props.onServiceSelect(service);
   }
 
-  getCustomServiceGrid() {
-    let customOptions = [{
-      icon: (
-        <Image fallbackSrc={defaultServiceImage} src={defaultServiceImage} />
-      ),
-      label: 'Use the Form',
-      type: 'app'
-    }, {
-      icon: (
-        <Image fallbackSrc={defaultServiceImage} src={defaultServiceImage} />
-      ),
-      label: 'Use the Form to create a MultiContainer',
-      type: 'pod'
-    }, {
-      icon: (
-        <Image fallbackSrc={jsonServiceImage} src={jsonServiceImage} />
-      ),
-      label: 'Enter JSON',
-      type: 'json'
-    }].map((item, index) => {
-      return this.getServiceOption(
-        this.getServiceOptionIconWrapper(item.icon),
-        item.label,
-        index,
-        item
-      );
-    });
-
-    return (
-      <div className="create-service-modal-service-picker-options panel-grid row">
-        {customOptions}
-      </div>
-    );
-  }
-
-  getPackageIcon(cosmosPackage) {
-    return (
-      <Image
-        fallbackSrc={defaultServiceImage}
-        src={cosmosPackage.getIcons()['icon-medium']} />
-    );
-  }
-
-  getServiceDeployOptions() {
-    // TODO: Implement the correct copy when received. DCOS-11807
-    return (
-      <div className="create-service-modal-service-picker container text-align-center">
-        <h4 className="short flush-top">
-          Run your own Service
-        </h4>
-        <MountService.Mount type="CreateService:ServicePicker:IntroductoryText">
-          <p className="lead tall">
-            Create a containerized service or run a command in one of two ways: use our form to be guided through the correct configuration, or enter your JSON configuration directly.
-          </p>
-        </MountService.Mount>
-        {this.getCustomServiceGrid()}
-      </div>
-    );
-  }
-
-  getServiceOption(icon, title, index, service) {
-    return (
-      <div className="create-service-modal-service-picker-option panel-grid-item column-12 column-small-4 column-large-3"
-        key={index}>
-        <Panel className="panel-interactive clickable"
-          contentClass={[
-            'horizontal-center panel-cell-short flush-top',
-            {
-              'panel-cell-shorter': false
-            }
-          ]}
-          heading={icon}
-          headingClass={[
-            'panel-cell-borderless horizontal-center panel-cell-short',
-            {
-              'panel-cell-light': false,
-              'panel-cell-shorter': false
-            }
-          ]}
-          onClick={this.handleServiceSelect.bind(this, service)}>
-          <h5 className="flush text-align-center">
-            {title}
-          </h5>
-        </Panel>
-      </div>
-    );
-  }
-
-  getServiceOptionIconWrapper(icon) {
-    return (
-      <div className="icon icon-jumbo icon-image-container icon-app-container icon-default-white">
-        {icon}
-      </div>
-    );
-  }
-
-  getUniversePackagesGrid() {
-    const packages = CosmosPackagesStore.getAvailablePackages();
-    let packagesGrid = packages.getItems().map((cosmosPackage, index) => {
-      return this.getServiceOption(
-        this.getServiceOptionIconWrapper(this.getPackageIcon(cosmosPackage)),
-        cosmosPackage.getName(),
-        index,
-        cosmosPackage
-      );
-    });
-
-    return (
-      <div className="panel-grid row">
-        {packagesGrid}
-      </div>
-    );
-  }
-
   render() {
-    return this.getServiceDeployOptions();
+    return (
+      <div className="create-service-modal-service-picker container">
+        <div className="create-service-modal-service-picker-options panel-grid row">
+          <CreateServiceModalServicePickerOptionWrapper>
+            <CreateServiceModalServicePickerOption
+              icon={(
+                <div className="icon icon-jumbo icon-image-container icon-app-container icon-default-white">
+                  <Image fallbackSrc={defaultServiceImage}
+                    src={defaultServiceImage} />
+                </div>
+              )}
+              offset={true}
+              onOptionSelect={
+                this.handleServiceSelect.bind(null, {type: 'app'})
+              }
+              title="Single Container" />
+          </CreateServiceModalServicePickerOptionWrapper>
+          <CreateServiceModalServicePickerOptionWrapper>
+            <CreateServiceModalServicePickerOption
+              icon={(
+                <div className="icon icon-jumbo icon-image-container icon-app-container icon-default-white">
+                  <Image fallbackSrc={defaultServiceImage}
+                    src={defaultServiceImage} />
+                </div>
+              )}
+              onOptionSelect={
+                this.handleServiceSelect.bind(null, {type: 'pod'})
+              }
+              title="Multi-container (Pod)"
+              />
+          </CreateServiceModalServicePickerOptionWrapper>
+          <CreateServiceModalServicePickerOptionWrapper>
+            <CreateServiceModalServicePickerOption
+              icon={(
+                <div className="icon icon-jumbo icon-image-container icon-app-container icon-default-white">
+                  <Image fallbackSrc={defaultServiceImage}
+                    src={jsonServiceImage} />
+                </div>
+              )}
+              onOptionSelect={
+                this.handleServiceSelect.bind(null, {type: 'json'})
+              }
+              title="JSON Configuration" />
+          </CreateServiceModalServicePickerOptionWrapper>
+          <MountService.Mount
+            type="CreateService:ServicePicker:GridOptions"
+            onOptionSelect={this.handleServiceSelect}
+            redirect={(route) => this.props.router.push(route)}
+            wrapper={CreateServiceModalServicePickerOptionWrapper} />
+        </div>
+      </div>
+    );
   }
 }
 
 NewCreateServiceModalServicePicker.propTypes = {
-  onServiceSelect: React.PropTypes.func
+  onServiceSelect: React.PropTypes.func,
+  router: routerShape
 };
 
 module.exports = NewCreateServiceModalServicePicker;

--- a/src/js/components/CreateServiceModalServicePickerOption.js
+++ b/src/js/components/CreateServiceModalServicePickerOption.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import Panel from './Panel';
+
+function CreateServiceModalServicePickerOption({icon, title, onOptionSelect}) {
+  return (
+    <Panel className="panel-interactive clickable"
+      contentClass={[
+        'horizontal-center panel-cell flush-top',
+        {
+          'panel-cell-short': false,
+          'panel-cell-shorter': false
+        }
+      ]}
+      heading={icon}
+      headingClass={[
+        'panel-cell-borderless horizontal-center panel-cell',
+        {
+          'panel-cell-light': false,
+          'panel-cell-shorter': false
+        }
+      ]}
+      onClick={onOptionSelect}>
+      <h5 className="flush text-align-center">
+        {title}
+      </h5>
+    </Panel>
+  );
+}
+
+module.exports = CreateServiceModalServicePickerOption;

--- a/src/js/components/CreateServiceModalServicePickerOptionWrapper.js
+++ b/src/js/components/CreateServiceModalServicePickerOptionWrapper.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function ServicePickerOptionWrapper({children}) {
+  return (
+    <div className="create-service-modal-service-picker-option panel-grid-item column-12 column-small-6">
+      {children}
+    </div>
+  );
+}
+
+module.exports = ServicePickerOptionWrapper;

--- a/src/js/pages/UniversePage.js
+++ b/src/js/pages/UniversePage.js
@@ -1,6 +1,20 @@
+import {MountService} from 'foundation-ui';
 import React from 'react';
 
 import Icon from '../components/Icon';
+
+const IntroductoryText = () => {
+  return (
+    <p className="lead tall">
+      Create a containerized service or run a command in one of two ways: use our form to be guided through the correct configuration, or enter your JSON configuration directly. You may also <a href="#/universe">browse the package repository</a>.
+    </p>
+  );
+};
+
+MountService.MountService.registerComponent(
+  IntroductoryText,
+  'CreateService:ServicePicker:IntroductoryText'
+);
 
 class UniversePage extends React.Component {
   render() {

--- a/src/js/pages/UniversePage.js
+++ b/src/js/pages/UniversePage.js
@@ -1,19 +1,12 @@
 import {MountService} from 'foundation-ui';
 import React from 'react';
 
+import CreateServiceModalUniversePanelOption from './universe/CreateServiceModalUniversePanelOption';
 import Icon from '../components/Icon';
 
-const IntroductoryText = () => {
-  return (
-    <p className="lead tall">
-      Create a containerized service or run a command in one of two ways: use our form to be guided through the correct configuration, or enter your JSON configuration directly. You may also <a href="#/universe">browse the package repository</a>.
-    </p>
-  );
-};
-
 MountService.MountService.registerComponent(
-  IntroductoryText,
-  'CreateService:ServicePicker:IntroductoryText'
+  CreateServiceModalUniversePanelOption,
+  'CreateService:ServicePicker:GridOptions'
 );
 
 class UniversePage extends React.Component {

--- a/src/js/pages/universe/CreateServiceModalUniversePanelOption.js
+++ b/src/js/pages/universe/CreateServiceModalUniversePanelOption.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import CreateServiceModalServicePickerOption from '../../components/CreateServiceModalServicePickerOption';
+import Icon from '../../components/Icon';
+
+function CreateServicePickerUniverseOption({redirect}) {
+  return (
+    <CreateServiceModalServicePickerOption
+      icon={(
+        <div className="icon icon-jumbo icon-image-container icon-app-container icon-background-neutral">
+          <Icon id="packages-inverse" size="large" family="product" color="white" />
+        </div>
+      )}
+      onOptionSelect={function () {
+        redirect('universe');
+      }}
+      title="Install a Package" />
+  );
+}
+
+module.exports = CreateServicePickerUniverseOption;

--- a/src/styles/components/icons/styles.less
+++ b/src/styles/components/icons/styles.less
@@ -1,6 +1,7 @@
 & when (@icon-enabled) {
 
   .icon {
+    position: relative;
 
     svg {
       display: block;
@@ -53,6 +54,13 @@
       }
     }
 
+    &-background {
+
+      &-neutral {
+        background-color: @neutral;
+      }
+    }
+
     &-default-white {
       background-color: @icon-default-background-white;
     }
@@ -93,6 +101,13 @@
     .button &,
     button & {
       flex: 0 0 auto;
+    }
+
+    .icon {
+      left: 50%;
+      position: absolute;
+      top: 50%;
+      transform: translate(-50%, -50%);
     }
   }
 

--- a/src/styles/views/create-service-modal/styles.less
+++ b/src/styles/views/create-service-modal/styles.less
@@ -1,18 +1,23 @@
 & when (@create-services-modal-enabled) {
 
   .create-service-modal-service-picker {
+    align-items: center;
     display: flex;
     flex-direction: column;
     justify-content: center;
-  }
 
-  .create-service-modal-service-picker-options {
-    display: flex;
-    justify-content: center;
-  }
+    &-options {
+      display: flex;
+      justify-content: center;
+    }
 
-  .create-service-modal-service-picker-option {
-    flex: 0 0 auto;
+    &-option {
+      flex: 0 0 auto;
+
+      .panel-content {
+        justify-content: center;
+      }
+    }
   }
 
   // TODO: Remove this custom margin and rely on the FormSection component to
@@ -46,6 +51,13 @@
 & when (@create-services-modal-enabled) and (@layout-screen-small-enabled) {
 
   @media (min-width: @layout-screen-small-min-width) {
+
+    .create-service-modal-service-picker {
+
+      &-options {
+        max-width: 500px;
+      }
+    }
 
     .artifacts-section {
       margin-top: @base-spacing-unit-screen-small * 3/4;


### PR DESCRIPTION
_Includes the changes from #1774 (changes the `Mount` `propTypes`)._

This PR changes the service create picker to a 2x2 grid of options. It also implements the `Mount` component to display the `Universe` grid option.

@rcorral said I should definitely not pass around the router context in order to redirect to the Universe page, but I don't see any other way to do it. If anyone has a better idea, please let me know!

This is still a `hold merge` until the JSON icon is fixed. ping @leemunroe 

![](https://cl.ly/2e1G020v3n0J/Screen%20Shot%202017-01-12%20at%2010.21.50%20AM.png)