### PR TITLE
Prevent Mount component from wrapping singular registered child components

### DIFF
--- a/foundation-ui/mount/__tests__/Mount-test.js
+++ b/foundation-ui/mount/__tests__/Mount-test.js
@@ -148,8 +148,7 @@ describe('Mount', function () {
       </Mount>
     );
 
-    expect(renderer.getRenderOutput().props.children[0].props)
-        .toEqual({message:'hello world'});
+    expect(renderer.getRenderOutput().props).toEqual({message:'hello world'});
   });
 
 });

--- a/foundation-ui/utils/ReactUtil.js
+++ b/foundation-ui/utils/ReactUtil.js
@@ -15,6 +15,10 @@ const ReactUil = {
       return null;
     }
 
+    if (Array.isArray(elements) && elements.length === 1 && !alwaysWrap) {
+      return elements[0];
+    }
+
     if (React.isValidElement(elements) && !alwaysWrap) {
       return elements;
     }
@@ -24,4 +28,3 @@ const ReactUil = {
 };
 
 module.exports = ReactUil;
-

--- a/foundation-ui/utils/ReactUtil.js
+++ b/foundation-ui/utils/ReactUtil.js
@@ -4,6 +4,9 @@ const ReactUil = {
   /**
    * Wrap React elements
    *
+   * If elements is an array with a single element, it will not be wrapped
+   * unless alwaysWrap is true.
+   *
    * @param {Array.<ReactElement>|ReactElement} elements
    * @param  {function|String} wrapper component
    * @param {boolean} [alwaysWrap]

--- a/foundation-ui/utils/ReactUtil.js
+++ b/foundation-ui/utils/ReactUtil.js
@@ -18,7 +18,8 @@ const ReactUil = {
       return null;
     }
 
-    if (Array.isArray(elements) && elements.length === 1 && !alwaysWrap) {
+    if (Array.isArray(elements) && elements.length === 1
+      && React.isValidElement(elements[0]) && !alwaysWrap) {
       return elements[0];
     }
 

--- a/foundation-ui/utils/__tests__/ReactUtil-test.js
+++ b/foundation-ui/utils/__tests__/ReactUtil-test.js
@@ -40,4 +40,18 @@ describe('ReactUtil', function () {
     expect(elements).toEqual(null);
   });
 
+  it('should not wrap elements if they are an array with a single item', function () {
+    const elements = ReactUtil.wrapElements([<span key={0}>test</span>], 'p');
+
+    expect(TestUtils.isElementOfType(elements, 'span')).toEqual(true);
+  });
+
+  it('should wrap elements if they are an array with a single item when alwaysWrap is true', function () {
+    const elements = ReactUtil.wrapElements(
+      [<span key={0}>test</span>], 'p', true
+    );
+
+    expect(TestUtils.isElementOfType(elements, 'p')).toEqual(true);
+  });
+
 });


### PR DESCRIPTION
This PR prevents `Mount` from wrapping a singular registered component component.

This is necessary for me to predictably render the grid of options in the create service modal. I'm fairly confident it's desirable everywhere because it doesn't force any component to be wrapped, unless there are more than 1 components to render, or the owner of `Mount` has explicitly declared it.

cc @orlandohohmeier I discussed this offline with @mlunoe, but it would be nice if you could review this as well.