### PR TITLE
DCOS-13109: Fix Load balanced checkbox for USER network

### DIFF
--- a/plugins/services/src/js/utils/ServiceConfigUtil.js
+++ b/plugins/services/src/js/utils/ServiceConfigUtil.js
@@ -3,10 +3,16 @@ import Networking from '../../../../../src/js/constants/Networking';
 
 const ServiceConfigUtil = {
 
+  matchVIPLabel(str) {
+    return Networking.VIP_LABEL_REGEX.test(str);
+  },
+
+  findVIPLabel(labels = {}) {
+    return Object.keys(labels).find(ServiceConfigUtil.matchVIPLabel);
+  },
+
   hasVIPLabel(labels = {}) {
-    return Object.keys(labels).find(function (key) {
-      return /^VIP_[0-9]+$/.test(key);
-    });
+    return !!ServiceConfigUtil.findVIPLabel(labels);
   },
 
   buildHostName(id, port) {

--- a/plugins/services/src/js/utils/__tests__/ServiceConfigUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceConfigUtil-test.js
@@ -3,6 +3,39 @@ jest.dontMock('../ServiceConfigUtil');
 const ServiceConfigUtil = require('../ServiceConfigUtil');
 
 describe('ServiceConfigUtil', function () {
+
+  describe('#matchVIPLabel', function () {
+
+    it('returns true', function () {
+      expect(
+        ServiceConfigUtil.matchVIPLabel('VIP_1')
+      ).toBeTruthy();
+    });
+
+    it('returns false', function () {
+      expect(
+        ServiceConfigUtil.matchVIPLabel('LABEL')
+      ).toBeFalsy();
+    });
+
+  });
+
+  describe('#findVIPLabel', function () {
+
+    it('returns label', function () {
+      expect(
+        ServiceConfigUtil.findVIPLabel({VIP_1: ''})
+      ).toEqual('VIP_1');
+    });
+
+    it('returns undefined', function () {
+      expect(
+        ServiceConfigUtil.findVIPLabel({LABEL: ''})
+      ).toEqual(undefined);
+    });
+
+  });
+
   describe('#hasVIPLabel', function () {
 
     it('returns true', function () {

--- a/src/js/constants/Networking.js
+++ b/src/js/constants/Networking.js
@@ -5,7 +5,8 @@ const Networking = {
     HOST: 'HOST',
     USER: 'USER'
   },
-  L4LB_ADDRESS: '.marathon.l4lb.thisdcos.directory'
+  L4LB_ADDRESS: '.marathon.l4lb.thisdcos.directory',
+  VIP_LABEL_REGEX: /^VIP_[0-9]+$/
 };
 
 module.exports = Networking;


### PR DESCRIPTION
This PR addresses the issue of the load balanced checkbox not removing VIP label from the app definition. It also keeps all non-VIP labels there as it is what we want to do according to the documentation.