### PR TITLE
Spelling: ReactUil -> ReactUtil

### DIFF
--- a/foundation-ui/utils/ReactUtil.js
+++ b/foundation-ui/utils/ReactUtil.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const ReactUil = {
+const ReactUtil = {
   /**
    * Wrap React elements
    *
@@ -31,4 +31,4 @@ const ReactUil = {
   }
 };
 
-module.exports = ReactUil;
+module.exports = ReactUtil;


### PR DESCRIPTION
Not a big deal, just spelling ReactUil -> ReactUtil