### PR TITLE
DCOS-13075: Keep empty values on `docker` field

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/Container.js
+++ b/plugins/services/src/js/reducers/serviceForm/Container.js
@@ -80,15 +80,9 @@ const containerJSONReducer = combineReducers({
       this.containerType = value;
     }
 
-    if (!ValidatorUtil.isEmpty(this.internalState) && this.containerType !== NONE) {
-      const newState = Object.assign({}, this.internalState);
-      Object.keys(this.internalState).forEach((key) => {
-        if (ValidatorUtil.isEmpty(this.internalState[key])) {
-          delete newState[key];
-        }
-      });
-
-      return newState;
+    if (!ValidatorUtil.isEmpty(this.internalState) &&
+      this.containerType !== NONE) {
+      return Object.assign({}, this.internalState);
     }
   },
   volumes

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -12,7 +12,15 @@ describe('Container', function () {
       const batch = new Batch();
 
       expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-        .toEqual(null);
+        .toEqual({
+          docker: {
+            forcePullImage: null,
+            image: '',
+            privileged: null,
+            network: undefined,
+            portMappings: null
+          }
+        });
     });
 
     it('switches container name along with type', function () {
@@ -23,7 +31,13 @@ describe('Container', function () {
       );
 
       expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-        .toEqual({type: 'DOCKER', docker: {image: 'foo'}});
+        .toEqual({type: 'DOCKER', docker: {
+          image: 'foo',
+          forcePullImage: null,
+          privileged: null,
+          network: undefined,
+          portMappings: null
+        }});
     });
 
     it('creates new container info when there is nothing', function () {
@@ -37,7 +51,12 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({type: 'DOCKER', docker: {image: 'foo'}});
+      )).toEqual({type: 'DOCKER', docker: {image: 'foo',
+        forcePullImage: null,
+        privileged: null,
+        network: undefined,
+        portMappings: null
+      }});
     });
 
     it('keeps top-level container info with type switch', function () {
@@ -50,7 +69,12 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({type: 'MESOS', docker: {image: 'foo'}});
+      )).toEqual({type: 'MESOS', docker: {image: 'foo',
+        forcePullImage: null,
+        privileged: null,
+        network: undefined,
+        portMappings: null
+      }});
     });
 
     it('sets privileged correctly', function () {
@@ -66,7 +90,11 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({type: 'DOCKER', docker: {image: 'foo', privileged: true}});
+      )).toEqual({type: 'DOCKER', docker: {image: 'foo', privileged: true,
+        forcePullImage: null,
+        network: undefined,
+        portMappings: null
+      }});
     });
 
     it('sets privileged correctly to false', function () {
@@ -82,7 +110,11 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({type: 'DOCKER', docker: {image: 'foo', privileged: false}});
+      )).toEqual({type: 'DOCKER', docker: {image: 'foo', privileged: false,
+        forcePullImage: null,
+        network: undefined,
+        portMappings: null
+      }});
     });
 
     it('doesn\'t set privileged if path doesn\'t match type', function () {
@@ -98,7 +130,12 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({type: 'DOCKER', docker: {image: 'foo'}});
+      )).toEqual({type: 'DOCKER', docker: {image: 'foo',
+        forcePullImage: null,
+        privileged: null,
+        network: undefined,
+        portMappings: null
+      }});
     });
 
     it('sets forcePullImage correctly', function () {
@@ -114,7 +151,11 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({type: 'DOCKER', docker: {image: 'foo', forcePullImage: true}});
+      )).toEqual({type: 'DOCKER', docker: {image: 'foo', forcePullImage: true,
+        privileged: null,
+        network: undefined,
+        portMappings: null
+      }});
     });
 
     it('sets forcePullImage correctly to false', function () {
@@ -130,7 +171,16 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({type: 'DOCKER', docker: {image: 'foo', forcePullImage: false}});
+        )).toEqual({
+          type: 'DOCKER',
+          docker: {
+            image: 'foo',
+            forcePullImage: false,
+            privileged: null,
+            network: undefined,
+            portMappings: null
+          }
+        });
     });
 
     it('doesn\'t set forcePullImage if path doesn\'t match type', function () {
@@ -142,7 +192,13 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual(null);
+      )).toEqual({ docker: {
+        forcePullImage: null,
+        image: '',
+        privileged: null,
+        network: undefined,
+        portMappings: null
+      }});
     });
 
     it('sets image correctly', function () {
@@ -155,7 +211,12 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({type: 'DOCKER', docker: {image: 'foo'}});
+      )).toEqual({type: 'DOCKER', docker: {image: 'foo',
+        forcePullImage: null,
+        privileged: null,
+        network: undefined,
+        portMappings: null
+      }});
     });
 
     it('changes image value correctly', function () {
@@ -168,7 +229,12 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({type: 'DOCKER', docker: {image: 'bar'}});
+      )).toEqual({type: 'DOCKER', docker: {image: 'bar',
+        forcePullImage: null,
+        privileged: null,
+        network: undefined,
+        portMappings: null
+      }});
     });
 
     it('doesn\'t set image if path doesn\'t match type', function () {
@@ -180,7 +246,13 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual(null);
+      )).toEqual({ docker: {
+        forcePullImage: null,
+        image: '',
+        privileged: null,
+        network: undefined,
+        portMappings: null
+      }});
     });
 
     describe('PortMappings', function () {
@@ -194,6 +266,9 @@ describe('Container', function () {
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
             docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
               network: USER,
               portMappings: [
                 {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', servicePort: null}
@@ -214,6 +289,9 @@ describe('Container', function () {
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
             docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
               network: USER,
               portMappings: [
                 {containerPort: 0, hostPort: null, labels: null, name: null, protocol: null, servicePort: null}
@@ -235,6 +313,9 @@ describe('Container', function () {
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
             docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
               network: BRIDGE,
               portMappings: [
                 {containerPort: 0, hostPort: 100, labels: null, name: null, protocol: 'udp', servicePort: null}
@@ -252,6 +333,9 @@ describe('Container', function () {
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
             docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
               network: BRIDGE,
               portMappings: [
                 {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', servicePort: null}
@@ -265,7 +349,15 @@ describe('Container', function () {
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual(null);
+          .toEqual({
+            docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
+              network: undefined,
+              portMappings: null
+            }
+          });
       });
 
       it('shouldn\'t create portMappings for HOST', function () {
@@ -275,7 +367,7 @@ describe('Container', function () {
         batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual({docker: {network: HOST}});
+          .toEqual({docker: {network: HOST, forcePullImage: null, image: '', privileged: null, portMappings: null}});
       });
 
       it('should create two default portDefinition configurations', function () {
@@ -289,6 +381,9 @@ describe('Container', function () {
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
             docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
               network: USER,
               portMappings: [
                 {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', servicePort: null},
@@ -308,6 +403,9 @@ describe('Container', function () {
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
             docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
               network: USER,
               portMappings: [
                 {containerPort: 0, hostPort: 0, labels: null, name: 'foo', protocol: 'tcp', servicePort: null}
@@ -327,6 +425,9 @@ describe('Container', function () {
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
             docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
               network: USER,
               portMappings: [
                 {containerPort: 0, hostPort: 100, labels: null, name: null, protocol: 'tcp', servicePort: null}
@@ -347,6 +448,9 @@ describe('Container', function () {
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
             docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
               network: USER,
               portMappings: [
                 {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', servicePort: null}
@@ -365,6 +469,9 @@ describe('Container', function () {
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
             docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
               network: USER,
               portMappings: [
                 {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'udp', servicePort: null}
@@ -385,6 +492,9 @@ describe('Container', function () {
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
             docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
               network: USER,
               portMappings: [
                 {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', servicePort: null},
@@ -407,6 +517,9 @@ describe('Container', function () {
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
             docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
               network: USER,
               portMappings: [
                 {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', labels: {VIP_0: ':0'}, servicePort: null},
@@ -430,6 +543,9 @@ describe('Container', function () {
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
             docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
               network: USER,
               portMappings: [
                 {containerPort: 0, hostPort: 300, name: null, protocol: 'tcp', labels: {VIP_0: ':300'}, servicePort: null},
@@ -453,6 +569,9 @@ describe('Container', function () {
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
             docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
               network: USER,
               portMappings: [
                 {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', servicePort: null},
@@ -476,6 +595,9 @@ describe('Container', function () {
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
             docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
               network: USER,
               portMappings: [
                 {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', servicePort: null},


### PR DESCRIPTION
Why:

* otherwise these's no way applyPatch can delete portMappings. General idea that it's applyPatch's job to remove empty values, reducers should return all of them

DCOS-13075 #close