### PR TITLE
Fix package installation modal loading state

### DIFF
--- a/src/js/components/modals/InstallPackageModal.js
+++ b/src/js/components/modals/InstallPackageModal.js
@@ -125,17 +125,16 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
 
   onCosmosPackagesStoreDescriptionSuccess() {
     const cosmosPackage = CosmosPackagesStore.getPackageDetails();
-    if (!SchemaUtil.validateSchema(cosmosPackage.getConfig())) {
-      this.setState({schemaIncorrect: true});
-
-      return;
-    }
+    const schemaIncorrect = !SchemaUtil.validateSchema(
+      cosmosPackage.getConfig()
+    );
 
     this.internalStorage_update({
-      hasError: false,
+      hasError: schemaIncorrect,
       isLoading: false
     });
-    this.setState({schemaIncorrect: false});
+
+    this.setState({schemaIncorrect});
   }
 
   onCosmosPackagesStoreInstallError(installError) {
@@ -557,16 +556,16 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
     const {isLoading} = this.internalStorage_get();
     const cosmosPackage = CosmosPackagesStore.getPackageDetails();
 
+    if (isLoading || !cosmosPackage) {
+      return this.getLoadingScreen();
+    }
+
     if (cosmosPackage && cosmosPackage.isCLIOnly()) {
       return this.getCLIPackageInfo(cosmosPackage);
     }
 
     if (schemaIncorrect) {
       return this.getIncorrectSchemaWarning(cosmosPackage);
-    }
-
-    if (isLoading || !cosmosPackage) {
-      return this.getLoadingScreen();
     }
 
     let name = cosmosPackage.getName();


### PR DESCRIPTION
Previously, when a CLI-only package was selected in the package page, selecting a regular package would result in the CLI-only warning appearing until the new modal content loaded in. This was due to a combination of the CosmosStore holding state based on the UI, and the isLoading state in the modal not properly being reflected. See this [moving picture](https://cl.ly/373R341y1l1q) for the bug in action. 