### PR TITLE
DCOS-13238: Ensuring Job.getSchedules always returns an array

### DIFF
--- a/src/js/structs/Job.js
+++ b/src/js/structs/Job.js
@@ -102,7 +102,13 @@ module.exports = class Job extends Item {
   }
 
   getSchedules() {
-    return this.get('schedules') || [];
+    const schedules = this.get('schedules');
+
+    if (!Array.isArray(schedules)) {
+      return [];
+    }
+
+    return schedules;
   }
 
   getScheduleStatus() {


### PR DESCRIPTION
This PR fixes a bug that occurs if somebody pastes a wrongly-formatted job spec, that uses `schedules: { }` instead of `schedules: [ {} ]`.

For example, as seen [here](https://dcos.io/docs/1.9/usage/jobs/getting-started/):
```json
 {
     "id": "myjob",
     "description": "A job that sleeps regularly",
     "run": {
         "cmd": "sleep 20000",
         "cpus": 0.01,
         "mem": 32,
         "disk": 0
     },
     "schedules": {
         "id": "sleep-schedule",
         "enabled": true,
         "cron": "20 0 * * *",
         "concurrencyPolicy": "ALLOW"
     }
 }
```