### PR TITLE
Fix service actions tests

### DIFF
--- a/tests/_support/index.js
+++ b/tests/_support/index.js
@@ -11,18 +11,18 @@ Cypress.addParentCommand('configureCluster', function (configuration) {
         Cypress.env('CLUSTER_URL') + '/acs/api/v1/auth/login',
         {password: 'deleteme', uid: 'bootstrapuser'}
       )
-      .then(function (response) {
-        var cookies = response.headers['set-cookie'];
-        cookies.forEach(function (cookie) {
-          var sessionID = cookie.split('=')[0];
-          // Set cookies for cypress
-          Cypress.Cookies.set(sessionID, response.body.token);
-          // Set cookies for application
-          cy.window().then(function (win) {
-            win.document.cookie = cookie;
+        .then(function (response) {
+          var cookies = response.headers['set-cookie'];
+          cookies.forEach(function (cookie) {
+            var sessionID = cookie.split('=')[0];
+            // Set cookies for cypress
+            Cypress.Cookies.set(sessionID, response.body.token);
+            // Set cookies for application
+            cy.window().then(function (win) {
+              win.document.cookie = cookie;
+            });
           });
         });
-      });
     }
 
     return;
@@ -31,149 +31,203 @@ Cypress.addParentCommand('configureCluster', function (configuration) {
   cy.chain().server();
 
   if (configuration.mesos === '1-task-healthy') {
-    cy
-      .route(/service\/marathon\/v2\/apps/, 'fx:marathon-1-task/app')
-      .route(/service\/marathon\/v2\/apps\/\/sleep\/versions/,
-        'fx:marathon-1-task/versions')
-      .route(/service\/marathon\/v2\/apps\/\/sleep\/versions\/2015\-08\-28T01:26:14\.620Z/,
-        'fx:marathon-1-task/app-version-1')
-      .route(/service\/marathon\/v2\/apps\/\/sleep\/versions\/2015\-02\-28T05:12:12\.221Z/,
-        'fx:marathon-1-task/app-version-2')
-      .route(/service\/marathon\/v2\/groups/, 'fx:marathon-1-task/groups')
-      .route(/service\/marathon\/v2\/deployments/, 'fx:marathon-1-task/deployments')
-      .route(/metronome\/v1\/jobs/, 'fx:metronome/jobs')
-      .route(/dcos-version/, 'fx:dcos/dcos-version')
-      .route(/history\/minute/, 'fx:marathon-1-task/history-minute')
-      .route(/history\/last/, 'fx:marathon-1-task/summary')
-      .route(/state-summary/, 'fx:marathon-1-task/summary')
-      .route(/state/, 'fx:marathon-1-task/state')
-      .route(/overlay-master\/state/, 'fx:mesos/overlay-master');
+    cy.route(/service\/marathon\/v2\/apps/, 'fx:marathon-1-task/app')
+      .as('marathon/apps');
+    cy.route(/service\/marathon\/v2\/apps\/\/sleep\/versions/,
+      'fx:marathon-1-task/versions')
+      .as('marathon/apps/sleep/versions');
+    cy.route(/service\/marathon\/v2\/apps\/\/sleep\/versions\/2015\-08\-28T01:26:14\.620Z/,
+      'fx:marathon-1-task/app-version-1')
+      .as('marathon/apps/sleep/versions/app-version-1');
+    cy.route(/service\/marathon\/v2\/apps\/\/sleep\/versions\/2015\-02\-28T05:12:12\.221Z/,
+      'fx:marathon-1-task/app-version-2')
+      .as('marathon/apps/sleep/versions/app-version-2');
+    cy.route(/service\/marathon\/v2\/groups/, 'fx:marathon-1-task/groups')
+      .as('marathon/groups');
+    cy.route(/service\/marathon\/v2\/deployments/,
+      'fx:marathon-1-task/deployments')
+      .as('marathon/deployments');
+    cy.route(/metronome\/v1\/jobs/, 'fx:metronome/jobs')
+      .as('metronome/jobs');
+    cy.route(/dcos-version/, 'fx:dcos/dcos-version')
+      .as('dcos-version');
+    cy.route(/history\/minute/, 'fx:marathon-1-task/history-minute')
+      .as('history/minute');
+    cy.route(/history\/last/, 'fx:marathon-1-task/summary')
+      .as('marathon-1-task/summary');
+    cy.route(/state-summary/, 'fx:marathon-1-task/summary')
+      .as('state-summary');
+    cy.route(/state/, 'fx:marathon-1-task/state')
+      .as('state');
+    cy.route(/overlay-master\/state/, 'fx:mesos/overlay-master')
+      .as('overlay-master/state');
   }
   if (configuration.mesos === '1-empty-group') {
-    cy
-      .route(/marathon\/v2\/groups/, 'fx:marathon-1-group/groups');
+    cy.route(/marathon\/v2\/groups/, 'fx:marathon-1-group/groups')
+      .as('marathon/groups');
   }
 
   if (configuration.mesos === '1-for-each-health') {
-    cy
-      .route(/service\/marathon\/v2\/apps/, 'fx:1-app-for-each-health/app')
-      .route(/service\/marathon\/v2\/groups/, 'fx:1-app-for-each-health/groups')
-      .route(/service\/marathon\/v2\/deployments/, 'fx:marathon-1-task/deployments')
-      .route(/metronome\/v1\/jobs/, 'fx:metronome/jobs')
-      .route(/dcos-version/, 'fx:dcos/dcos-version')
-      .route(/history\/last/, 'fx:1-app-for-each-health/summary')
-      .route(/state-summary/, 'fx:1-app-for-each-health/summary')
-      .route(/state/, 'fx:1-app-for-each-health/summary')
-      .route(/overlay-master\/state/, 'fx:mesos/overlay-master');
+    cy.route(/service\/marathon\/v2\/apps/, 'fx:1-app-for-each-health/app')
+      .as('marathon/apps');
+    cy.route(/service\/marathon\/v2\/groups/, 'fx:1-app-for-each-health/groups')
+      .as('marathon/groups');
+    cy.route(/service\/marathon\/v2\/deployments/, 'fx:marathon-1-task/deployments')
+      .as('marathon/deployments');
+    cy.route(/metronome\/v1\/jobs/, 'fx:metronome/jobs')
+      .as('metronome/jobs');
+    cy.route(/dcos-version/, 'fx:dcos/dcos-version')
+      .as('dcos-version');
+    cy.route(/history\/last/, 'fx:1-app-for-each-health/summary')
+      .as('history/last');
+    cy.route(/state-summary/, 'fx:1-app-for-each-health/summary')
+      .as('state-summary');
+    cy.route(/state/, 'fx:1-app-for-each-health/summary')
+      .as('state');
+    cy.route(/overlay-master\/state/, 'fx:mesos/overlay-master')
+      .as('overlay-master/state');
   }
 
   if (configuration.mesos === '1-service-with-executor-task') {
-    cy
-      .route(/service\/marathon\/v2\/apps/, 'fx:1-service-with-executor-task/app')
-      .route(/service\/marathon\/v2\/groups/, 'fx:1-service-with-executor-task/app')
-      .route(/service\/marathon\/v2\/deployments/, 'fx:marathon-1-task/deployments')
-      .route(/metronome\/v1\/jobs/, 'fx:metronome/jobs')
-      .route(/agent\/(.*)?\/files\/(.*)?\/runs\/(.*)?/, 'fx:1-service-with-executor-task/browse')
-      .route(/dcos-version/, 'fx:dcos/dcos-version')
-      .route(/history\/minute/, 'fx:1-service-with-executor-task/history-minute')
-      .route(/history\/last/, 'fx:1-service-with-executor-task/summary')
-      .route(/master\/state/, 'fx:1-service-with-executor-task/state')
-      .route(/state-summary/, 'fx:1-service-with-executor-task/summary')
-      .route(/agent\/.*\/slave\(1\)\/state/, 'fx:1-service-with-executor-task/slave-state');
+    cy.route(/service\/marathon\/v2\/apps/, 'fx:1-service-with-executor-task/app')
+      .as('marathon/apps');
+    cy.route(/service\/marathon\/v2\/groups/, 'fx:1-service-with-executor-task/app')
+      .as('marathon/groups');
+    cy.route(/service\/marathon\/v2\/deployments/, 'fx:marathon-1-task/deployments')
+      .as('marathon/deployments');
+    cy.route(/metronome\/v1\/jobs/, 'fx:metronome/jobs')
+      .as('metronome/jobs');
+    cy.route(/agent\/(.*)?\/files\/(.*)?\/runs\/(.*)?/, 'fx:1-service-with-executor-task/browse')
+      .as('agent/files/runs/browse');
+    cy.route(/dcos-version/, 'fx:dcos/dcos-version')
+      .as('dcos-version');
+    cy.route(/history\/minute/, 'fx:1-service-with-executor-task/history-minute')
+      .as('1-service-with-executor-task/history-minute');
+    cy.route(/history\/last/, 'fx:1-service-with-executor-task/summary')
+      .as('1-service-with-executor-task/summary');
+    cy.route(/master\/state/, 'fx:1-service-with-executor-task/state')
+      .as('1-service-with-executor-task/state');
+    cy.route(/state-summary/, 'fx:1-service-with-executor-task/summary')
+      .as('1-service-with-executor-task/summary');
+    cy.route(/agent\/.*\/slave\(1\)\/state/, 'fx:1-service-with-executor-task/slave-state')
+      .as('1-service-with-executor-task/slave-state');
   }
 
   if (configuration.mesos === '1-task-with-volumes') {
-    cy
-      .route(/marathon\/v2\/apps/, 'fx:marathon-1-task/app')
-      .route(/marathon\/v2\/groups/, 'fx:marathon-1-task-with-volumes/groups')
-      .route(/marathon\/v2\/deployments/, 'fx:marathon-1-task/deployments')
-      .route(/dcos-version/, 'fx:dcos/dcos-version')
-      .route(/history\/minute/, 'fx:marathon-1-task/history-minute')
-      .route(/history\/last/, 'fx:marathon-1-task/summary')
-      .route(/state-summary/, 'fx:marathon-1-task/summary')
-      .route(/state/, 'fx:marathon-1-task/state');
+    cy.route(/marathon\/v2\/apps/, 'fx:marathon-1-task/app')
+      .as('marathon-1-task/app');
+    cy.route(/marathon\/v2\/groups/, 'fx:marathon-1-task-with-volumes/groups')
+      .as('marathon-1-task-with-volumes/groups');
+    cy.route(/marathon\/v2\/deployments/, 'fx:marathon-1-task/deployments')
+      .as('marathon-1-task/deployments');
+    cy.route(/dcos-version/, 'fx:dcos/dcos-version')
+      .as('dcos-version');
+    cy.route(/history\/minute/, 'fx:marathon-1-task/history-minute')
+      .as('history/minute');
+    cy.route(/history\/last/, 'fx:marathon-1-task/summary')
+      .as('history/last');
+    cy.route(/state-summary/, 'fx:marathon-1-task/summary')
+      .as('state-summary');
+    cy.route(/state/, 'fx:marathon-1-task/state')
+      .as('state');
   }
 
   if (configuration.mesos === 'healthy-tasks-in-mesos-and-marathon') {
-    cy
-      .route(/marathon\/v2\/groups/, 'fx:healthy-tasks-in-mesos-and-marathon/groups')
-      .route(/history\/last/, 'fx:healthy-tasks-in-mesos-and-marathon/summary')
-      .route(/state-summary/, 'fx:healthy-tasks-in-mesos-and-marathon/summary')
-      .route(/state/, 'fx:healthy-tasks-in-mesos-and-marathon/state');
+    cy.route(/marathon\/v2\/groups/, 'fx:healthy-tasks-in-mesos-and-marathon/groups')
+      .as('marathon/groups');
+    cy.route(/history\/last/, 'fx:healthy-tasks-in-mesos-and-marathon/summary')
+      .as('history/last');
+    cy.route(/state-summary/, 'fx:healthy-tasks-in-mesos-and-marathon/summary')
+      .as('state-summary');
+    cy.route(/state/, 'fx:healthy-tasks-in-mesos-and-marathon/state')
+      .as('state');
   }
 
   if (configuration.deployments === 'one-deployment') {
-    cy
-      .route(/marathon\/v2\/deployments/, 'fx:deployments/one-deployment')
-      .route(/service\/marathon\/v2\/groups/, 'fx:marathon-1-group/kafka');
+    cy.route(/marathon\/v2\/deployments/, 'fx:deployments/one-deployment')
+      .as('marathon/deployments');
+    cy.route(/service\/marathon\/v2\/groups/, 'fx:marathon-1-group/kafka')
+      .as('marathon/groups');
   }
 
   if (configuration.networkVIPSummaries) {
-    cy
-      .route(/networking\/api\/v1\/summary/,
-        'fx:networking/networking-vip-summaries');
+    cy.route(/networking\/api\/v1\/summary/,
+      'fx:networking/networking-vip-summaries')
+      .as('networking/summary');
   }
 
   if (configuration.universePackages) {
-    cy
-      // Packages
-      .route({
-        method: 'POST',
-        url: /package\/describe/,
-        status: 200,
-        response: 'fx:cosmos/package-describe'
-      })
-      .route({
-        method: 'POST',
-        url: /package\/list/,
-        status: 200,
-        response: 'fx:cosmos/packages-list'
-      })
-      .route({
-        method: 'POST',
-        url: /package\/search/,
-        status: 200,
-        response: 'fx:cosmos/packages-search'
-      })
-      // Repositories
-      .route({
-        method: 'POST',
-        url: /repository\/list/,
-        status: 200,
-        response: 'fx:cosmos/repositories-list'
-      })
-      .route({
-        method: 'POST',
-        url: /repository\/add/,
-        status: 200,
-        response: 'fx:cosmos/repositories-list'
-      })
-      .route({
-        method: 'POST',
-        url: /repository\/delete/,
-        status: 200,
-        response: 'fx:cosmos/repositories-list'
-      });
+    // Packages
+    cy.route({
+      method: 'POST',
+      url: /package\/describe/,
+      status: 200,
+      response: 'fx:cosmos/package-describe'
+    }).as('package/describe');
+    cy.route({
+      method: 'POST',
+      url: /package\/list/,
+      status: 200,
+      response: 'fx:cosmos/packages-list'
+    }).as('package/list');
+    cy.route({
+      method: 'POST',
+      url: /package\/search/,
+      status: 200,
+      response: 'fx:cosmos/packages-search'
+    }).as('package/search');
+    // Repositories
+    cy.route({
+      method: 'POST',
+      url: /repository\/list/,
+      status: 200,
+      response: 'fx:cosmos/repositories-list'
+    }).as('repository/list');
+    cy.route({
+      method: 'POST',
+      url: /repository\/add/,
+      status: 200,
+      response: 'fx:cosmos/repositories-list'
+    }).as('repository/add');
+    cy.route({
+      method: 'POST',
+      url: /repository\/delete/,
+      status: 200,
+      response: 'fx:cosmos/repositories-list'
+    }).as('repository/delete');
   }
 
   if (configuration.componentHealth) {
-    cy
-      .route(/system\/health\/v1\/units/, 'fx:unit-health/units')
-      .route(/system\/health\/v1\/units\/dcos-mesos-dns\.service/, 'fx:unit-health/unit')
-      .route(/system\/health\/v1\/units\/dcos-mesos-dns\.service\/nodes/, 'fx:unit-health/unit-nodes')
-      .route(/system\/health\/v1\/units\/dcos-mesos-dns\.service\/nodes\/10\.10\.0\.236/, 'fx:unit-health/unit-node');
+    cy.route(/system\/health\/v1\/units/, 'fx:unit-health/units')
+      .as('system/health/units');
+    cy.route(/system\/health\/v1\/units\/dcos-mesos-dns\.service/,
+      'fx:unit-health/unit')
+      .as('system/health/units/dcos-mesos-dns');
+    cy.route(/system\/health\/v1\/units\/dcos-mesos-dns\.service\/nodes/,
+      'fx:unit-health/unit-nodes')
+      .as('system/health/units/dcos-mesos-dns/nodes');
+    cy.route(/system\/health\/v1\/units\/dcos-mesos-dns\.service\/nodes\/10\.10\.0\.236/,
+      'fx:unit-health/unit-node')
+      .as('system/health/units/dcos-mesos-dns/nodes/node');
   }
 
   if (configuration.nodeHealth) {
-    cy
-      .route(/system\/health\/v1\/nodes(\?_timestamp=[0-9]+)?$/, 'fx:unit-health/nodes')
-      .route(/system\/health\/v1\/nodes\/172\.17\.8\.101/, 'fx:unit-health/node')
-      .route(/system\/health\/v1\/nodes\/(.*)\/units/, 'fx:unit-health/node-units')
-      .route(/system\/health\/v1\/nodes\/172\.17\.8\.101\/nodes\/REPLACE/, 'fx:unit-health/node-unit');
+    cy.route(/system\/health\/v1\/nodes(\?_timestamp=[0-9]+)?$/,
+      'fx:unit-health/nodes')
+      .as('system/health/nodes');
+    cy.route(/system\/health\/v1\/nodes\/172\.17\.8\.101/,
+      'fx:unit-health/node')
+      .as('system/health/nodes/node');
+    cy.route(/system\/health\/v1\/nodes\/(.*)\/units/,
+      'fx:unit-health/node-units')
+      .as('system/health/nodes/units');
+    cy.route(/system\/health\/v1\/nodes\/172\.17\.8\.101\/nodes\/REPLACE/,
+      'fx:unit-health/node-unit');
   }
 
   if (configuration.jobDetails) {
-    cy.route(/jobs\/(.*)/, 'fx:metronome/job');
+    cy.route(/jobs\/(.*)/, 'fx:metronome/job')
+      .as('metronome/job');
   }
 
   // The app won't load until plugins are loaded
@@ -181,7 +235,8 @@ Cypress.addParentCommand('configureCluster', function (configuration) {
   cy.route(/ui-config/, 'fx:config/' + pluginsFixture + '.json');
 
   // Metadata
-  cy.route(/metadata(\?_timestamp=[0-9]+)?$/, 'fx:dcos/metadata');
+  cy.route(/metadata(\?_timestamp=[0-9]+)?$/, 'fx:dcos/metadata')
+    .as('dcos/metadata');
 });
 
 Cypress.addParentCommand('clusterCleanup', function (fn) {

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -2,6 +2,7 @@ describe('Service Actions', function () {
 
   function clickHeaderAction(actionText) {
     cy.get('.page-header-actions .dropdown').click();
+
     cy.get('.dropdown-menu-items').contains(actionText).click();
   }
 
@@ -11,7 +12,8 @@ describe('Service Actions', function () {
       nodeHealth: true
     });
 
-    cy.visitUrl({url: '/services/overview/%2Fcassandra-healthy'});
+    cy.visitUrl({url: '/services/overview/%2Fcassandra-healthy'})
+      .wait(['@marathon/groups', '@marathon/deployments', '@state']);
   });
 
   context('Edit Action', function () {
@@ -29,9 +31,9 @@ describe('Service Actions', function () {
         .route({
           method: 'PUT',
           url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
-          response: [],
-          delay: 0
+          response: []
         });
+
       cy.get('.modal .modal-header .button')
         .contains('Review & Run')
         .click();
@@ -59,7 +61,8 @@ describe('Service Actions', function () {
           nodeHealth: true
         });
 
-        cy.visitUrl({url: '/services/overview/%2Fsleep'});
+        cy.visitUrl({url: '/services/overview/%2Fsleep'})
+          .wait(['@marathon/groups', '@marathon/deployments', '@state']);
         clickHeaderAction('Destroy');
       });
 
@@ -73,12 +76,11 @@ describe('Service Actions', function () {
           .route({
             method: 'DELETE',
             url: /marathon\/v2\/apps\/\/sleep/,
-            response: [],
-            delay: 0
+            response: []
           });
         cy.get('.confirm-modal .button-collection .button-danger')
-          .as('primaryButton').click();
-        cy.get('@primaryButton').should('have.class', 'disabled');
+          .click()
+          .should('have.class', 'disabled');
       });
 
       it('closes dialog on successful API request', function () {
@@ -86,8 +88,7 @@ describe('Service Actions', function () {
           .route({
             method: 'DELETE',
             url: /marathon\/v2\/apps\/\/sleep/,
-            response: [],
-            delay: 0
+            response: []
           });
         cy.get('.confirm-modal .button-collection .button-danger').click();
         cy.get('.confirm-modal').should('to.have.length', 0);
@@ -101,6 +102,7 @@ describe('Service Actions', function () {
             url: /marathon\/v2\/apps\/\/sleep/,
             response: {message: 'App is locked by one or more deployments.'}
           });
+
         cy.get('.confirm-modal .button-collection .button-danger').click();
         cy.get('.modal-body .text-danger')
           .should('to.have.text', 'App is locked by one or more deployments.');
@@ -114,6 +116,7 @@ describe('Service Actions', function () {
             url: /marathon\/v2\/apps\/\/sleep/,
             response: {message: 'Not Authorized to perform this action!'}
           });
+
         cy.get('.confirm-modal .button-collection .button-danger').click();
         cy.get('.modal-body .text-danger')
           .should('to.have.text', 'Not Authorized to perform this action!');
@@ -128,13 +131,14 @@ describe('Service Actions', function () {
             response: {
               message: {message: 'Not Authorized to perform this action!'}
             },
-            delay: 100
-          });
+            delay:100
+          }).as('marathon/apps/sleep:deleteService');
+
         cy.get('.confirm-modal .button-collection .button-danger')
-          .as('dangerButton').click();
-        cy.get('@dangerButton').should('have.class', 'disabled');
-        cy
-          .wait(100)
+          .as('dangerButton').click()
+          .should('have.class', 'disabled');
+
+        cy.wait('@marathon/apps/sleep:deleteService')
           .get('@dangerButton').should('not.have.class', 'disabled');
       });
 
@@ -164,12 +168,11 @@ describe('Service Actions', function () {
         .route({
           method: 'PUT',
           url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
-          response: [],
-          delay: 0
+          response: []
         });
       cy.get('.modal-footer .button-collection .button-primary')
-        .as('primaryButton').click();
-      cy.get('@primaryButton').should('have.class', 'disabled');
+        .click()
+        .should('have.class', 'disabled');
     });
 
     it('closes dialog on successful API request', function () {
@@ -177,8 +180,7 @@ describe('Service Actions', function () {
         .route({
           method: 'PUT',
           url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
-          response: [],
-          delay: 0
+          response: []
         });
       cy.get('.modal-footer .button-collection .button-primary').click();
       cy.get('.modal-body').should('to.have.length', 0);
@@ -220,12 +222,15 @@ describe('Service Actions', function () {
           method: 'PUT',
           url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
           response: [],
-          delay: 50
-        });
+          delay:100
+        }).as('marathon/apps/cassandra-healthy:scaleService');
+
       cy.get('.modal-footer .button-collection .button-primary')
-        .as('primaryButton').click();
-      cy.get('@primaryButton').should('have.class', 'disabled');
-      cy.wait(100).get('@primaryButton').should('not.have.class', 'disabled');
+        .as('primaryButton').click()
+        .should('have.class', 'disabled');
+
+      cy.wait('@marathon/apps/cassandra-healthy:scaleService')
+        .get('@primaryButton').should('not.have.class', 'disabled');
     });
 
     it('closes dialog on secondary button click', function () {
@@ -250,12 +255,12 @@ describe('Service Actions', function () {
         .route({
           method: 'PUT',
           url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
-          response: [],
-          delay: 0
+          response: []
         });
+
       cy.get('.confirm-modal .button-collection .button-primary')
-        .as('primaryButton').click();
-      cy.get('@primaryButton').should('have.class', 'disabled');
+        .click()
+        .should('have.class', 'disabled');
     });
 
     it('closes dialog on successful API request', function () {
@@ -263,8 +268,7 @@ describe('Service Actions', function () {
         .route({
           method: 'PUT',
           url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
-          response: [],
-          delay: 0
+          response: []
         });
       cy.get('.confirm-modal .button-collection .button-primary').click();
       cy.get('.confirm-modal').should('to.have.length', 0);
@@ -306,12 +310,15 @@ describe('Service Actions', function () {
           method: 'PUT',
           url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
           response: [],
-          delay: 50
-        });
+          delay:100
+        }).as('marathon/apps/cassandra-healthy:suspendService');
+
       cy.get('.confirm-modal .button-collection .button-primary')
-        .as('primaryButton').click();
-      cy.get('@primaryButton').should('have.class', 'disabled');
-      cy.wait(100).get('@primaryButton').should('not.have.class', 'disabled');
+        .as('primaryButton').click()
+        .should('have.class', 'disabled');
+
+      cy.wait('@marathon/apps/cassandra-healthy:suspendService')
+        .get('@primaryButton').should('not.have.class', 'disabled');
     });
 
     it('closes dialog on secondary button click', function () {


### PR DESCRIPTION
Provide an alias for all "default" routes to enable tests to wait for the respective responses and refactor the service action test using the aliases instead of arbitrary timeouts. These changes will resolve the service action test reliability issues.