### PR TITLE
DCOS-12461: [1/3] Unified error message handling

### DIFF
--- a/src/js/utils/ErrorMessagesUtil.js
+++ b/src/js/utils/ErrorMessagesUtil.js
@@ -35,7 +35,12 @@ const ErrorMessagesUtil = {
 
           // Replace tempalte variables in the error message
           return match.message.replace(TEMPLATE_VAR_REGEXP, function (match) {
-            return String(templateVars[match.slice(1, -1)] || '');
+            const value = templateVars[match.slice(1, -1)];
+            if (value === undefined) {
+              return '';
+            }
+
+            return String(value);
           });
         };
       })(errorMessageTests);

--- a/src/js/utils/ErrorMessagesUtil.js
+++ b/src/js/utils/ErrorMessagesUtil.js
@@ -1,5 +1,3 @@
-import {deepCopy} from './Util';
-
 const TEMPLATE_VAR_REGEXP = /\{([^\}]+)}/g;
 
 const ErrorMessagesUtil = {
@@ -12,102 +10,50 @@ const ErrorMessagesUtil = {
    * @returns {Object} Returns the errorMessages object
    */
   errorMessagesFromConfig(config) {
-    return Object.keys(config).reduce(function (memo, errorConstant) {
-      const errorMessageTests = config[errorConstant];
+    const typeGroups = config.reduce(function (memo, item) {
+      if (memo[item.type] == null) {
+        memo[item.type] = [];
+      }
 
-      // Create a function override for the RAML validator
-      // NOTE: We are creating a clojure for ensuring the correct
-      memo[errorConstant] = (function (errorMessageTests) {
-        return function (templateVars, path) {
-          const match = errorMessageTests.find(function (item) {
-            return item.regexp.exec(path.join('.'));
-          });
-
-          // We must never reach this case. If we did, we were not
-          // careful default when we populated the errors or the overrides
-          if (!match) {
-            if (process.env.NODE_ENV !== 'production') {
-              throw new TypeError(`No patch matched for error constant ${errorConstant}`);
-            }
-
-            return '';
-          }
-
-          // Replace tempalte variables in the error message
-          return match.message.replace(TEMPLATE_VAR_REGEXP, function (match) {
-            const value = templateVars[match.slice(1, -1)];
-            if (value === undefined) {
-              return '';
-            }
-
-            return String(value);
-          });
-        };
-      })(errorMessageTests);
+      memo[item.type].push(item);
 
       return memo;
     }, {});
-  },
 
-  /**
-   * This function extends a previously created error definition using
-   * `create` or `extends`, with the additional definitions given.
-   *
-   * @param {Object} messages - The error message configuration
-   * @param {Object} base - The base pre-processed error messages to extend
-   * @returns {Object} Returns the new pre-processed error messages
-   */
-  extend(messages, base) {
-    const newMessages = ErrorMessagesUtil.create(messages);
-    const baseClone = deepCopy(base);
+    return Object.keys(typeGroups).reduce(function (memo, errorType) {
+      const typeErrorMessages = typeGroups[errorType];
 
-    return Object.keys(newMessages).reduce(function (memo, errorConstant) {
-      if (memo[errorConstant] == null) {
-        memo[errorConstant] = [];
-      }
-
-      // Prepend new tests in order for the base tests to be called afterwards
-      memo[errorConstant] = newMessages[errorConstant]
-        .concat(memo[errorConstant]);
-
-      return memo;
-    }, baseClone);
-  },
-
-  /**
-   * Create a pre-processed error lookup table
-   *
-   * This function effectively transposes the 2D input table, by creating an
-   * object with error constants as keys, and an array of path matchers as
-   * values.
-   *
-   * @example <caption>Syntax of messages</caption>
-   * const Errors = ErrorMessagesUtil.createErrorMessages({
-   *    'some\.key\.regex': {
-   *      SOME_CONSTANT: 'Some error message in this constant'
-   *    }
-   *  })
-   * @param {Object} messages - The error message configuration
-   * @returns {Object} Returns the pre-processed error messages
-   */
-  create(messages) {
-    return Object.keys(messages).reduce(function (memo, keyRegexStr) {
-      const keyRegex = new RegExp(keyRegexStr);
-      const pathMessages = messages[keyRegexStr];
-
-      return Object.keys(pathMessages).reduce(function (memo, errorConstant) {
-        if (memo[errorConstant] == null) {
-          memo[errorConstant] = [];
-        }
-
-        // Keep track of error translation on this constant
-        memo[errorConstant].push({
-          regexp: keyRegex,
-          message: pathMessages[errorConstant]
+      // Create a function override for the RAML validator
+      // NOTE: We are creating a clojure for ensuring the correct
+      memo[errorType] = function (templateVars, path) {
+        const pathStr = path.join('.');
+        const match = typeErrorMessages.find(function (item) {
+          return item.path.exec(pathStr) &&
+            (item.type === errorType);
         });
 
-        return memo;
-      }, memo);
+        // We must never reach this case. If we did, we were not
+        // careful default when we populated the errors or the overrides
+        if (!match) {
+          if (process.env.NODE_ENV !== 'production') {
+            throw new TypeError(`No patch matched for error type ${errorType}`);
+          }
+
+          return '';
+        }
+
+        // Replace template variables in the error message
+        return match.message.replace(TEMPLATE_VAR_REGEXP, function (match) {
+          const value = templateVars[match.slice(1, -1)];
+          if (value === undefined) {
+            return '';
+          }
+
+          return String(value);
+        });
+      };
+
+      return memo;
     }, {});
   }
 

--- a/src/js/utils/ErrorMessagesUtil.js
+++ b/src/js/utils/ErrorMessagesUtil.js
@@ -1,0 +1,111 @@
+import {deepCopy} from './Util';
+
+const TEMPLATE_VAR_REGEXP = /\{([^\}]+)}/g;
+
+const ErrorMessagesUtil = {
+
+  /**
+   * Create an `errorMessage` table that can be passed to `RAMLValidator.clone`
+   * in order to provide custom error messages to RAML validator.
+   *
+   * @param {Object} config - The pre-processed error messages
+   * @returns {Object} Returns the errorMessages object
+   */
+  errorMessagesFromConfig(config) {
+    return Object.keys(config).reduce(function (memo, errorConstant) {
+      const errorMessageTests = config[errorConstant];
+
+      // Create a function override for the RAML validator
+      // NOTE: We are creating a clojure for ensuring the correct
+      memo[errorConstant] = (function (errorMessageTests) {
+        return function (templateVars, path) {
+          const match = errorMessageTests.find(function (item) {
+            return item.regexp.exec(path.join('.'));
+          });
+
+          // We must never reach this case. If we did, we were not
+          // careful default when we populated the errors or the overrides
+          if (!match) {
+            if (process.env.NODE_ENV !== 'production') {
+              throw new TypeError(`No patch matched for error constant ${errorConstant}`);
+            }
+
+            return '';
+          }
+
+          // Replace tempalte variables in the error message
+          return match.message.replace(TEMPLATE_VAR_REGEXP, function (match) {
+            return String(templateVars[match.slice(1, -1)] || '');
+          });
+        };
+      })(errorMessageTests);
+
+      return memo;
+    }, {});
+  },
+
+  /**
+   * This function extends a previously created error definition using
+   * `create` or `extends`, with the additional definitions given.
+   *
+   * @param {Object} messages - The error message configuration
+   * @param {Object} base - The base pre-processed error messages to extend
+   * @returns {Object} Returns the new pre-processed error messages
+   */
+  extend(messages, base) {
+    const newMessages = ErrorMessagesUtil.create(messages);
+    const baseClone = deepCopy(base);
+
+    return Object.keys(newMessages).reduce(function (memo, errorConstant) {
+      if (memo[errorConstant] == null) {
+        memo[errorConstant] = [];
+      }
+
+      // Prepend new tests in order for the base tests to be called afterwards
+      memo[errorConstant] = newMessages[errorConstant]
+        .concat(memo[errorConstant]);
+
+      return memo;
+    }, baseClone);
+  },
+
+  /**
+   * Create a pre-processed error lookup table
+   *
+   * This function effectively transposes the 2D input table, by creating an
+   * object with error constants as keys, and an array of path matchers as
+   * values.
+   *
+   * @example <caption>Syntax of messages</caption>
+   * const Errors = ErrorMessagesUtil.createErrorMessages({
+   *    'some\.key\.regex': {
+   *      SOME_CONSTANT: 'Some error message in this constant'
+   *    }
+   *  })
+   * @param {Object} messages - The error message configuration
+   * @returns {Object} Returns the pre-processed error messages
+   */
+  create(messages) {
+    return Object.keys(messages).reduce(function (memo, keyRegexStr) {
+      const keyRegex = new RegExp(keyRegexStr);
+      const pathMessages = messages[keyRegexStr];
+
+      return Object.keys(pathMessages).reduce(function (memo, errorConstant) {
+        if (memo[errorConstant] == null) {
+          memo[errorConstant] = [];
+        }
+
+        // Keep track of error translation on this constant
+        memo[errorConstant].push({
+          regexp: keyRegex,
+          message: pathMessages[errorConstant]
+        });
+
+        return memo;
+      }, memo);
+    }, {});
+  }
+
+};
+
+module.exports = ErrorMessagesUtil;

--- a/src/js/utils/ErrorMessagesUtil.js
+++ b/src/js/utils/ErrorMessagesUtil.js
@@ -24,7 +24,6 @@ const ErrorMessagesUtil = {
       const typeErrorMessages = typeGroups[errorType];
 
       // Create a function override for the RAML validator
-      // NOTE: We are creating a clojure for ensuring the correct
       memo[errorType] = function (templateVars, path) {
         const pathStr = path.join('.');
         const match = typeErrorMessages.find(function (item) {
@@ -33,7 +32,7 @@ const ErrorMessagesUtil = {
         });
 
         // We must never reach this case. If we did, we were not
-        // careful default when we populated the errors or the overrides
+        // careful when we defined the default errors or the overrides
         if (!match) {
           if (process.env.NODE_ENV !== 'production') {
             throw new TypeError(`No patch matched for error type ${errorType}`);

--- a/src/js/utils/__tests__/ErrorMessagesUtil-test.js
+++ b/src/js/utils/__tests__/ErrorMessagesUtil-test.js
@@ -1,0 +1,176 @@
+const ErrorMessagesUtil = require('../ErrorMessagesUtil');
+
+describe('ErrorMessagesUtil', function () {
+
+  describe('#create', function () {
+
+    it('should correctly transpose the data', function () {
+      const config = ErrorMessagesUtil.create({
+        'foo': {
+          CONSTANT_1: 'message1',
+          CONSTANT_2: 'message2'
+        }
+      });
+
+      expect(config).toEqual({
+        CONSTANT_1: [
+          {regexp: /foo/, message: 'message1'}
+        ],
+        CONSTANT_2: [
+          {regexp: /foo/, message: 'message2'}
+        ]
+      });
+    });
+
+    it('should stack error messages in correct order', function () {
+      const config = ErrorMessagesUtil.create({
+        'foo': {
+          CONSTANT_1: 'message1',
+          CONSTANT_2: 'message2'
+        },
+        'bar': {
+          CONSTANT_1: 'message3'
+        }
+      });
+
+      expect(config).toEqual({
+        CONSTANT_1: [
+          {regexp: /foo/, message: 'message1'},
+          {regexp: /bar/, message: 'message3'}
+        ],
+        CONSTANT_2: [
+          {regexp: /foo/, message: 'message2'}
+        ]
+      });
+    });
+
+  });
+
+  describe('#extend', function () {
+
+    it('should correctly create empty constants on the same path', function () {
+      const config = ErrorMessagesUtil.create({
+        'foo': {
+          CONSTANT_1: 'message1'
+        }
+      });
+
+      const extended = ErrorMessagesUtil.extend({
+        'foo': {
+          CONSTANT_2: 'message2'
+        }
+      }, config);
+
+      expect(extended).toEqual({
+        CONSTANT_1: [
+          {regexp: /foo/, message: 'message1'}
+        ],
+        CONSTANT_2: [
+          {regexp: /foo/, message: 'message2'}
+        ]
+      });
+    });
+
+    it('should correctly prepend new tests on existing constants', function () {
+      const config = ErrorMessagesUtil.create({
+        'foo': {
+          CONSTANT_1: 'message1'
+        }
+      });
+
+      const extended = ErrorMessagesUtil.extend({
+        'bar': {
+          CONSTANT_1: 'message2'
+        }
+      }, config);
+
+      expect(extended).toEqual({
+        CONSTANT_1: [
+          {regexp: /bar/, message: 'message2'},
+          {regexp: /foo/, message: 'message1'}
+        ]
+      });
+    });
+
+  });
+
+  describe('#errorMessagesFromConfig', function () {
+
+    it('should create a function for every constant', function () {
+      const config = ErrorMessagesUtil.create({
+        'foo': {
+          CONSTANT_1: 'message1',
+          CONSTANT_2: 'message2'
+        }
+      });
+      const errorMessages = ErrorMessagesUtil.errorMessagesFromConfig(config);
+
+      expect(Object.keys(errorMessages)).toEqual(['CONSTANT_1', 'CONSTANT_2']);
+      expect(Object.keys(errorMessages).map((key) => typeof errorMessages[key]))
+        .toEqual(['function', 'function']);
+    });
+
+    it('should create functions that correctly match path', function () {
+      const config = ErrorMessagesUtil.create({
+        'foo\\.bar': {
+          CONSTANT_1: 'message1'
+        },
+        '.*': {
+          CONSTANT_1: 'default'
+        }
+      });
+      const errorMessages = ErrorMessagesUtil.errorMessagesFromConfig(config);
+
+      expect(errorMessages.CONSTANT_1({}, ['foo', 'bar'])).toEqual('message1');
+      expect(errorMessages.CONSTANT_1({}, ['foo', 'baz'])).toEqual('default');
+    });
+
+    it('should correctly handle missing template vars', function () {
+      const config = ErrorMessagesUtil.create({
+        '.*': {
+          CONSTANT_1: 'default{missing}'
+        }
+      });
+      const errorMessages = ErrorMessagesUtil.errorMessagesFromConfig(config);
+
+      expect(errorMessages.CONSTANT_1({}, ['foo', 'bar'])).toEqual('default');
+    });
+
+    it('should create functions that correctly use templates vars', function () {
+      const config = ErrorMessagesUtil.create({
+        'foo\\.bar': {
+          CONSTANT_1: 'message1 {foo}'
+        },
+        '.*': {
+          CONSTANT_1: 'default {bar}'
+        }
+      });
+      const errorMessages = ErrorMessagesUtil.errorMessagesFromConfig(config);
+      const tpl = {
+        'foo': '1',
+        'bar': '2'
+      };
+
+      expect(errorMessages.CONSTANT_1(tpl, ['foo', 'bar'])).toEqual('message1 1');
+      expect(errorMessages.CONSTANT_1(tpl, ['foo', 'baz'])).toEqual('default 2');
+    });
+
+    it('should throw error if no path can be matched on a constant', function () {
+      const config = ErrorMessagesUtil.create({
+        'foo\\.bar': {
+          CONSTANT_1: 'message1 {foo}{missing}'
+        },
+        'no\\.baz': {
+          CONSTANT_1: 'default {bar}'
+        }
+      });
+      const errorMessages = ErrorMessagesUtil.errorMessagesFromConfig(config);
+
+      expect(function () {
+        errorMessages.CONSTANT_1({}, ['foo', 'baz']);
+      }).toThrow();
+    });
+
+  });
+
+});

--- a/src/js/utils/__tests__/ErrorMessagesUtil-test.js
+++ b/src/js/utils/__tests__/ErrorMessagesUtil-test.js
@@ -2,107 +2,13 @@ const ErrorMessagesUtil = require('../ErrorMessagesUtil');
 
 describe('ErrorMessagesUtil', function () {
 
-  describe('#create', function () {
-
-    it('should correctly transpose the data', function () {
-      const config = ErrorMessagesUtil.create({
-        'foo': {
-          CONSTANT_1: 'message1',
-          CONSTANT_2: 'message2'
-        }
-      });
-
-      expect(config).toEqual({
-        CONSTANT_1: [
-          {regexp: /foo/, message: 'message1'}
-        ],
-        CONSTANT_2: [
-          {regexp: /foo/, message: 'message2'}
-        ]
-      });
-    });
-
-    it('should stack error messages in correct order', function () {
-      const config = ErrorMessagesUtil.create({
-        'foo': {
-          CONSTANT_1: 'message1',
-          CONSTANT_2: 'message2'
-        },
-        'bar': {
-          CONSTANT_1: 'message3'
-        }
-      });
-
-      expect(config).toEqual({
-        CONSTANT_1: [
-          {regexp: /foo/, message: 'message1'},
-          {regexp: /bar/, message: 'message3'}
-        ],
-        CONSTANT_2: [
-          {regexp: /foo/, message: 'message2'}
-        ]
-      });
-    });
-
-  });
-
-  describe('#extend', function () {
-
-    it('should correctly create empty constants on the same path', function () {
-      const config = ErrorMessagesUtil.create({
-        'foo': {
-          CONSTANT_1: 'message1'
-        }
-      });
-
-      const extended = ErrorMessagesUtil.extend({
-        'foo': {
-          CONSTANT_2: 'message2'
-        }
-      }, config);
-
-      expect(extended).toEqual({
-        CONSTANT_1: [
-          {regexp: /foo/, message: 'message1'}
-        ],
-        CONSTANT_2: [
-          {regexp: /foo/, message: 'message2'}
-        ]
-      });
-    });
-
-    it('should correctly prepend new tests on existing constants', function () {
-      const config = ErrorMessagesUtil.create({
-        'foo': {
-          CONSTANT_1: 'message1'
-        }
-      });
-
-      const extended = ErrorMessagesUtil.extend({
-        'bar': {
-          CONSTANT_1: 'message2'
-        }
-      }, config);
-
-      expect(extended).toEqual({
-        CONSTANT_1: [
-          {regexp: /bar/, message: 'message2'},
-          {regexp: /foo/, message: 'message1'}
-        ]
-      });
-    });
-
-  });
-
   describe('#errorMessagesFromConfig', function () {
 
     it('should create a function for every constant', function () {
-      const config = ErrorMessagesUtil.create({
-        'foo': {
-          CONSTANT_1: 'message1',
-          CONSTANT_2: 'message2'
-        }
-      });
+      const config = [
+        {path: /^foo$/, type: 'CONSTANT_1', message: 'message1'},
+        {path: /^foo$/, type: 'CONSTANT_2', message: 'message2'}
+      ];
       const errorMessages = ErrorMessagesUtil.errorMessagesFromConfig(config);
 
       expect(Object.keys(errorMessages)).toEqual(['CONSTANT_1', 'CONSTANT_2']);
@@ -111,14 +17,10 @@ describe('ErrorMessagesUtil', function () {
     });
 
     it('should create functions that correctly match path', function () {
-      const config = ErrorMessagesUtil.create({
-        'foo\\.bar': {
-          CONSTANT_1: 'message1'
-        },
-        '.*': {
-          CONSTANT_1: 'default'
-        }
-      });
+      const config = [
+        {path: /^foo\.bar$/, type: 'CONSTANT_1', message: 'message1'},
+        {path: /.*/, type: 'CONSTANT_1', message: 'default'}
+      ];
       const errorMessages = ErrorMessagesUtil.errorMessagesFromConfig(config);
 
       expect(errorMessages.CONSTANT_1({}, ['foo', 'bar'])).toEqual('message1');
@@ -126,25 +28,19 @@ describe('ErrorMessagesUtil', function () {
     });
 
     it('should correctly handle missing template vars', function () {
-      const config = ErrorMessagesUtil.create({
-        '.*': {
-          CONSTANT_1: 'default{missing}'
-        }
-      });
+      const config = [
+        {path: /.*/, type: 'CONSTANT_1', message: 'default{missing}'}
+      ];
       const errorMessages = ErrorMessagesUtil.errorMessagesFromConfig(config);
 
       expect(errorMessages.CONSTANT_1({}, ['foo', 'bar'])).toEqual('default');
     });
 
     it('should create functions that correctly use templates vars', function () {
-      const config = ErrorMessagesUtil.create({
-        'foo\\.bar': {
-          CONSTANT_1: 'message1 {foo}'
-        },
-        '.*': {
-          CONSTANT_1: 'default {bar}'
-        }
-      });
+      const config = [
+        {path: /^foo\.bar$/, type: 'CONSTANT_1', message: 'message1 {foo}'},
+        {path: /.*/, type: 'CONSTANT_1', message: 'default {bar}'}
+      ];
       const errorMessages = ErrorMessagesUtil.errorMessagesFromConfig(config);
       const tpl = {
         'foo': '1',
@@ -156,14 +52,10 @@ describe('ErrorMessagesUtil', function () {
     });
 
     it('should throw error if no path can be matched on a constant', function () {
-      const config = ErrorMessagesUtil.create({
-        'foo\\.bar': {
-          CONSTANT_1: 'message1 {foo}{missing}'
-        },
-        'no\\.baz': {
-          CONSTANT_1: 'default {bar}'
-        }
-      });
+      const config = [
+        {path: /^foo\.bar$/, type: 'CONSTANT_1', message: 'message1 {foo}'},
+        {path: /^no\.baz$/, type: 'CONSTANT_1', message: 'default {bar}'}
+      ];
       const errorMessages = ErrorMessagesUtil.errorMessagesFromConfig(config);
 
       expect(function () {


### PR DESCRIPTION
This PR introduces the `ErrorMessageUtil` that is used to compose translation tables for error messages.

_Refer to #1795 for an example of such definition_