### PR TITLE
DCOS-8852: Remove word-wrap logs

### DIFF
--- a/plugins/services/src/js/components/LogView.js
+++ b/plugins/services/src/js/components/LogView.js
@@ -226,8 +226,7 @@ class LogView extends React.Component {
       <pre
         className="flex-item-grow-1 flush-bottom prettyprint"
         ref={(ref) => { this.logContainer = ref; }}
-        onScroll={this.handleLogContainerScroll}
-        style={{wordWrap: 'break-word', whiteSpace: 'pre-wrap'}}>
+        onScroll={this.handleLogContainerScroll}>
         {this.getLogPrepend()}
         <Highlight
           matchClass="highlight"

--- a/plugins/services/src/js/components/LogView.js
+++ b/plugins/services/src/js/components/LogView.js
@@ -262,7 +262,7 @@ class LogView extends React.Component {
   getLogPrepend() {
     if (this.props.hasLoadedTop) {
       return (
-        <div className="text-align-center vertical-center">
+        <div className="text-muted">
           (AT BEGINNING OF FILE)
         </div>
       );


### PR DESCRIPTION
This PR removes word wrapping from logs.
Before:
![](https://cl.ly/1N1y1U1m1U1R/Image%202017-01-17%20at%2012.02.45.png)

After:
![](https://cl.ly/38032a2X1A35/Screen%20Recording%202017-01-17%20at%2011.56.gif)