### PR TITLE
DCOS-12560: Move column style properties to external stylesheet

### DIFF
--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -23,12 +23,19 @@ const StatusMapping = {
   'Running': 'running-state'
 };
 
+const columnClasses = {
+  name: 'service-table-column-name',
+  status: 'service-table-column-status',
+  cpus: 'service-table-column-cpus',
+  mem: 'service-table-column-mem',
+  disk: 'service-table-column-disk'
+};
+
 const METHODS_TO_BIND = [
   'onActionsItemSelection',
   'renderHeadline',
   'renderStats',
-  'renderStatus',
-  'renderStatsHeading'
+  'renderStatus'
 ];
 
 class ServicesTable extends React.Component {
@@ -258,29 +265,22 @@ class ServicesTable extends React.Component {
     );
   }
 
-  renderStatsHeading(prop, sortBy, row) {
+  getCellClasses(prop, sortBy, row) {
     const isHeader = row == null;
 
-    return classNames('flush-left text-align-right hidden-small-down', {
+    return classNames(columnClasses[prop], {
       'active': prop === sortBy.prop,
       'clickable': isHeader
     });
   }
 
   getColumns() {
-    const className = ResourceTableUtil.getClassName;
     const heading = ResourceTableUtil.renderHeading(ServiceTableHeaderLabels);
-    const {isFiltered} = this.props;
 
     return [
       {
-        className() {
-          return classNames([
-            className.apply(this, arguments),
-            {'table-cell-short': isFiltered}
-          ]);
-        },
-        headerClassName: className,
+        className: this.getCellClasses,
+        headerClassName: this.getCellClasses,
         prop: 'name',
         render: this.renderHeadline,
         sortable: true,
@@ -288,8 +288,8 @@ class ServicesTable extends React.Component {
         heading
       },
       {
-        className,
-        headerClassName: className,
+        className: this.getCellClasses,
+        headerClassName: this.getCellClasses,
         prop: 'status',
         helpText: (
           <span>
@@ -306,8 +306,8 @@ class ServicesTable extends React.Component {
         heading
       },
       {
-        className: this.renderStatsHeading,
-        headerClassName: this.renderStatsHeading,
+        className: this.getCellClasses,
+        headerClassName: this.getCellClasses,
         prop: 'cpus',
         render: this.renderStats,
         sortable: true,
@@ -315,8 +315,8 @@ class ServicesTable extends React.Component {
         heading
       },
       {
-        className: this.renderStatsHeading,
-        headerClassName: this.renderStatsHeading,
+        className: this.getCellClasses,
+        headerClassName: this.getCellClasses,
         prop: 'mem',
         render: this.renderStats,
         sortable: true,
@@ -324,8 +324,8 @@ class ServicesTable extends React.Component {
         heading
       },
       {
-        className: this.renderStatsHeading,
-        headerClassName: this.renderStatsHeading,
+        className: this.getCellClasses,
+        headerClassName: this.getCellClasses,
         prop: 'disk',
         render: this.renderStats,
         sortable: true,
@@ -338,11 +338,11 @@ class ServicesTable extends React.Component {
   getColGroup() {
     return (
       <colgroup>
-        <col />
-        <col className="status-bar-column"/>
-        <col className="hidden-small-down" style={{width: '65px'}} />
-        <col className="hidden-small-down" style={{width: '75px'}} />
-        <col className="hidden-small-down" style={{width: '65px'}} />
+        <col className={columnClasses.name} />
+        <col className={columnClasses.status} />
+        <col className={columnClasses.cpus} />
+        <col className={columnClasses.mem} />
+        <col className={columnClasses.disk} />
       </colgroup>
     );
   }

--- a/src/styles/components/service-table/styles.less
+++ b/src/styles/components/service-table/styles.less
@@ -3,14 +3,41 @@
   .service-table {
     table-layout: fixed;
 
+    &-column {
+
+      &-cpus,
+      &-mem,
+      &-disk {
+        display: none;
+
+        td&,
+        th& {
+          text-align: right;
+        }
+      }
+
+      &-mem,
+      &-disk {
+        width: 85px;
+      }
+
+      &-name {
+        width: auto;
+      }
+
+      &-status {
+        width: 144px;
+      }
+
+      &-cpus {
+        width: 65px;
+      }
+    }
+
     // We don't want the status bar to increase the height of the table row
     // when it wraps to two lines.
     .status-bar-wrapper {
       line-height: 1;
-    }
-
-    .status-bar-column {
-      width: @base-spacing-unit * 6;
     }
 
     .status-bar-indicator {
@@ -33,8 +60,11 @@
 
     .service-table {
 
-      .status-bar-column {
-        width: @base-spacing-unit * 8;
+      &-column {
+
+        &-status {
+          width: 160px;
+        }
       }
     }
 
@@ -50,8 +80,21 @@
 
     .service-table {
 
-      .status-bar-column {
-        width: @base-spacing-unit * 10;
+      &-column {
+
+        &-cpus,
+        &-mem,
+        &-disk {
+          display: table-cell;
+
+          col& {
+            display: table-column;
+          }
+        }
+
+        &-status {
+          width: 220px;
+        }
       }
 
       .status-bar-wrapper {
@@ -71,8 +114,11 @@
 
     .service-table {
 
-      .status-bar-column {
-        width: @base-spacing-unit * 11;
+      &-column {
+
+        &-status {
+          width: 264px;
+        }
       }
     }
 
@@ -88,8 +134,11 @@
 
     .service-table {
 
-      .status-bar-column {
-        width: @base-spacing-unit * 13;
+      &-column {
+
+        &-status {
+          width: 312px;
+        }
       }
     }
 


### PR DESCRIPTION
This PR moves the column width and visibility styles for the `ServicesTable` to its an external stylesheet, following the same pattern as other tables the UI.

It also:
* increases the width of the resources columns to prevent text wrapping
* removes the `@base-spacing-unit * x` math for the status column width and instead uses explicit pixel values