### PR TITLE
DCOS-12595: Move sidebar dock icon outside navigation list scroll container

### DIFF
--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -375,20 +375,20 @@ var Sidebar = React.createClass({
             {this.getSidebarHeader()}
           </header>
           <GeminiScrollbar autoshow={true}
-            className="flex-item-grow-1 flex-item-shrink-1 gm-scrollbar-container-flex gm-scrollbar-container-flex-view"
+            className="flex-item-grow-1 flex-item-shrink-1 gm-scrollbar-container-flex gm-scrollbar-container-flex-view inverse"
             ref={(ref) => this.geminiRef = ref}>
             <div className="sidebar-content-wrapper">
               <div className="sidebar-sections pod pod-narrow">
                 {this.getNavigationSections()}
               </div>
-              <div className="sidebar-dock-container pod pod-short pod-narrow flush-top">
-                <Icon className="sidebar-dock-trigger"
-                  size="mini"
-                  id={dockIconID}
-                  onClick={this.toggleSidebarDocking} />
-              </div>
             </div>
           </GeminiScrollbar>
+          <div className="sidebar-dock-container">
+            <Icon className="sidebar-dock-trigger"
+              size="mini"
+              id={dockIconID}
+              onClick={this.toggleSidebarDocking} />
+          </div>
         </div>
       </div>
     );

--- a/src/styles/layout/sidebar/styles.less
+++ b/src/styles/layout/sidebar/styles.less
@@ -267,9 +267,11 @@
   }
 
   .sidebar-dock-container {
+    border-top: 1px solid @sidebar-dock-container-border-color;
     display: flex;
     flex: 0 0 auto;
     justify-content: flex-end;
+    padding: @sidebar-dock-container-padding-vertical @sidebar-dock-container-padding-horizontal;
   }
 
   .sidebar-dock-trigger {
@@ -347,6 +349,10 @@
             }
           }
         }
+      }
+
+      .sidebar-dock-container {
+        padding: @sidebar-dock-container-padding-vertical-screen-small @sidebar-dock-container-padding-horizontal-screen-small;
       }
     }
   }
@@ -444,6 +450,10 @@
       .sidebar-dock-trigger {
         display: block;
       }
+
+      .sidebar-dock-container {
+        padding: @sidebar-dock-container-padding-vertical-screen-medium @sidebar-dock-container-padding-horizontal-screen-medium;
+      }
     }
   }
 }
@@ -525,6 +535,10 @@
           }
         }
       }
+
+      .sidebar-dock-container {
+        padding: @sidebar-dock-container-padding-vertical-screen-large @sidebar-dock-container-padding-horizontal-screen-large;
+      }
     }
   }
 }
@@ -605,6 +619,10 @@
             }
           }
         }
+      }
+
+      .sidebar-dock-container {
+        padding: @sidebar-dock-container-padding-vertical-screen-jumbo @sidebar-dock-container-padding-horizontal-screen-jumbo;
       }
     }
   }

--- a/src/styles/layout/sidebar/variables.less
+++ b/src/styles/layout/sidebar/variables.less
@@ -382,3 +382,21 @@
 @sidebar-submenu-item-link-padding-right-screen-medium: -@sidebar-submenu-item-link-margin-right-screen-medium;
 @sidebar-submenu-item-link-padding-right-screen-large: -@sidebar-submenu-item-link-margin-right-screen-large;
 @sidebar-submenu-item-link-padding-right-screen-jumbo: -@sidebar-submenu-item-link-margin-right-screen-jumbo;
+
+/*
+ * Sidebar Dock
+ */
+
+@sidebar-dock-container-padding-vertical: @pod-margin-top * @pod-short-margin-top-scale;
+@sidebar-dock-container-padding-vertical-screen-small: @pod-margin-top-screen-small * @pod-short-margin-top-scale;
+@sidebar-dock-container-padding-vertical-screen-medium: @pod-margin-top-screen-medium * @pod-short-margin-top-scale;
+@sidebar-dock-container-padding-vertical-screen-large: @pod-margin-top-screen-large * @pod-short-margin-top-scale;
+@sidebar-dock-container-padding-vertical-screen-jumbo: @pod-margin-top-screen-jumbo * @pod-short-margin-top-scale;
+
+@sidebar-dock-container-padding-horizontal: @pod-margin-left * @pod-narrow-margin-left-scale;
+@sidebar-dock-container-padding-horizontal-screen-small: @pod-margin-left-screen-small * @pod-narrow-margin-left-scale;
+@sidebar-dock-container-padding-horizontal-screen-medium: @pod-margin-left-screen-medium * @pod-narrow-margin-left-scale;
+@sidebar-dock-container-padding-horizontal-screen-large: @pod-margin-left-screen-large * @pod-narrow-margin-left-scale;
+@sidebar-dock-container-padding-horizontal-screen-jumbo: @pod-margin-left-screen-jumbo * @pod-narrow-margin-left-scale;
+
+@sidebar-dock-container-border-color: color-lighten(@neutral, -50);


### PR DESCRIPTION
This PR makes the sidebar dock icon visible at all times by moving it outside of the sidebar's navigation scroll container.

It also adds the `inverse` class on the sidebar's scroll container to properly style the scrollbars on the dark background. (not sure how I missed this before)

Before:
![](https://cl.ly/0w2H0x1j411m/Screen%20Recording%202017-01-17%20at%2003.54%20PM.gif)

After:
![](https://cl.ly/04033F0a2t29/Screen%20Recording%202017-01-17%20at%2003.53%20PM.gif)