### PR TITLE
DCOS-12581: Create and implement AddButton component

### DIFF
--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -5,6 +5,7 @@ import {Tooltip} from 'reactjs-components';
 import {FormReducer as ContainerReducer} from '../../reducers/serviceForm/Container';
 import {FormReducer as ContainersReducer} from '../../reducers/serviceForm/Containers';
 import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
+import AddButton from '../../../../../../src/js/components/form/AddButton';
 import AdvancedSection from '../../../../../../src/js/components/form/AdvancedSection';
 import AdvancedSectionContent from '../../../../../../src/js/components/form/AdvancedSectionContent';
 import AdvancedSectionLabel from '../../../../../../src/js/components/form/AdvancedSectionLabel';
@@ -293,14 +294,13 @@ class ContainerServiceFormSection extends Component {
         {this.getArtifactsInputs()}
         <FormRow>
           <FormGroup className="column-12">
-            <a
-              className="button button-primary-link button-flush"
+            <AddButton
               onClick={this.props.onAddItem.bind(
                 this,
                 {value: artifacts.length, path: artifactsPath}
               )}>
-              <Icon color="purple" id="plus" size="tiny" /> Add Artifact
-            </a>
+              Add Artifact
+            </AddButton>
           </FormGroup>
         </FormRow>
       </AdvancedSectionContent>

--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -52,7 +52,9 @@ class EnvironmentFormSection extends Component {
           </FormGroup>
           <FormGroup className="flex flex-item-align-end column-2 flush-left">
             <DeleteRowButton
-              onClick={this.props.onRemoveItem.bind(this, {value: key, path: 'env'})}/>
+              onClick={this.props.onRemoveItem.bind(
+                this, {value: key, path: 'env'}
+              )} />
           </FormGroup>
         </FormRow>
       );
@@ -94,7 +96,9 @@ class EnvironmentFormSection extends Component {
           </FormGroup>
           <FormGroup className="flex flex-item-align-end column-2 flush-left">
             <DeleteRowButton
-              onClick={this.props.onRemoveItem.bind(this, {value: key, path: 'labels'})}/>
+              onClick={this.props.onRemoveItem.bind(
+                this, {value: key, path: 'labels'}
+              )} />
           </FormGroup>
         </FormRow>
       );
@@ -145,7 +149,9 @@ class EnvironmentFormSection extends Component {
         <FormRow>
           <FormGroup className="column-12">
             <AddButton
-              onClick={this.props.onAddItem.bind(this, {value: data.env.length, path: 'env'})}>
+              onClick={this.props.onAddItem.bind(
+                this, {value: data.env.length, path: 'env'}
+              )}>
               Add Environment Variable
             </AddButton>
           </FormGroup>
@@ -168,7 +174,9 @@ class EnvironmentFormSection extends Component {
         <FormRow>
           <FormGroup className="column-12">
             <AddButton
-              onClick={this.props.onAddItem.bind(this, {value: data.labels.length, path: 'labels'})}>
+              onClick={this.props.onAddItem.bind(
+                this, {value: data.labels.length, path: 'labels'}
+              )}>
               Add Label
             </AddButton>
           </FormGroup>

--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -4,6 +4,7 @@ import React, {Component} from 'react';
 
 import {FormReducer as env} from '../../reducers/serviceForm/EnvironmentVariables';
 import {FormReducer as labels} from '../../reducers/serviceForm/Labels';
+import AddButton from '../../../../../../src/js/components/form/AddButton';
 import DeleteRowButton from '../../../../../../src/js/components/form/DeleteRowButton';
 import FieldError from '../../../../../../src/js/components/form/FieldError';
 import FieldInput from '../../../../../../src/js/components/form/FieldInput';
@@ -143,11 +144,10 @@ class EnvironmentFormSection extends Component {
         {this.getEnvironmentLines(data.env)}
         <FormRow>
           <FormGroup className="column-12">
-            <a
-              className="button button-primary-link button-flush"
+            <AddButton
               onClick={this.props.onAddItem.bind(this, {value: data.env.length, path: 'env'})}>
-              <Icon color="purple" id="plus" size="tiny" /> Add Environment Variable
-            </a>
+              Add Environment Variable
+            </AddButton>
           </FormGroup>
         </FormRow>
         <h2 className="short-bottom">
@@ -167,11 +167,10 @@ class EnvironmentFormSection extends Component {
         {this.getLabelsLines(data.labels)}
         <FormRow>
           <FormGroup className="column-12">
-            <a
-              className="button button-primary-link button-flush"
+            <AddButton
               onClick={this.props.onAddItem.bind(this, {value: data.labels.length, path: 'labels'})}>
-              <Icon color="purple" id="plus" size="tiny" /> Add Label
-            </a>
+              Add Label
+            </AddButton>
           </FormGroup>
         </FormRow>
         <MountService.Mount

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -3,6 +3,7 @@ import {Confirm, Tooltip} from 'reactjs-components';
 
 import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
 import {pluralize} from '../../../../../../src/js/utils/StringUtil';
+import AddButton from '../../../../../../src/js/components/form/AddButton';
 import AdvancedSection from '../../../../../../src/js/components/form/AdvancedSection';
 import AdvancedSectionContent from '../../../../../../src/js/components/form/AdvancedSectionContent';
 import AdvancedSectionLabel from '../../../../../../src/js/components/form/AdvancedSectionLabel';
@@ -144,14 +145,12 @@ class GeneralServiceFormSection extends Component {
 
     return (
       <div>
-        <a
-          className="button button-primary-link button-flush"
-          onClick={this.props.onAddItem.bind(
+        <AddButton onClick={this.props.onAddItem.bind(
             this,
             {value: 0, path: 'containers'}
           )}>
-          <Icon color="purple" id="plus" size="tiny" /> Add Container
-        </a>
+          Add Container
+        </AddButton>
       </div>
     );
   }
@@ -483,11 +482,9 @@ class GeneralServiceFormSection extends Component {
             {this.getPlacementConstraints(data.constraints)}
             <FormRow>
               <FormGroup className="column-12">
-                <a
-                  className="button button-primary-link button-flush"
-                  onClick={this.props.onAddItem.bind(this, {value: data.constraints.length, path: 'constraints'})}>
-                  <Icon color="purple" id="plus" size="tiny" /> Add Placement Constraint
-                </a>
+                <AddButton onClick={this.props.onAddItem.bind(this, {value: data.constraints.length, path: 'constraints'})}>
+                  Add Placement Constraint
+                </AddButton>
               </FormGroup>
             </FormRow>
           </AdvancedSectionContent>

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -509,7 +509,8 @@ class GeneralServiceFormSection extends Component {
           showHeader={true}>
           <p>
             {'Adding another container will automatically put multiple containers into a Pod definition. Your containers will be co-located on the same node and scale together. '}
-            <a href={MetadataStore.buildDocsURI('/usage/pods/')}
+            <a
+              href={MetadataStore.buildDocsURI('/usage/pods/')}
               target="_blank">
               More information
             </a>.

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -482,7 +482,9 @@ class GeneralServiceFormSection extends Component {
             {this.getPlacementConstraints(data.constraints)}
             <FormRow>
               <FormGroup className="column-12">
-                <AddButton onClick={this.props.onAddItem.bind(this, {value: data.constraints.length, path: 'constraints'})}>
+                <AddButton onClick={this.props.onAddItem.bind(
+                    this, {value: data.constraints.length, path: 'constraints'}
+                  )}>
                   Add Placement Constraint
                 </AddButton>
               </FormGroup>
@@ -507,7 +509,10 @@ class GeneralServiceFormSection extends Component {
           showHeader={true}>
           <p>
             {'Adding another container will automatically put multiple containers into a Pod definition. Your containers will be co-located on the same node and scale together. '}
-            <a href={MetadataStore.buildDocsURI('/usage/pods/')} target="_blank">More information</a>.
+            <a href={MetadataStore.buildDocsURI('/usage/pods/')}
+              target="_blank">
+              More information
+            </a>.
           </p>
           <p>Are you sure you would like to continue and create a Pod? Any data you have already entered will be lost.</p>
         </Confirm>

--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import Objektiv from 'objektiv';
 
+import AddButton from '../../../../../../src/js/components/form/AddButton';
 import AdvancedSection from '../../../../../../src/js/components/form/AdvancedSection';
 import AdvancedSectionContent from '../../../../../../src/js/components/form/AdvancedSectionContent';
 import AdvancedSectionLabel from '../../../../../../src/js/components/form/AdvancedSectionLabel';
@@ -14,8 +15,6 @@ import FormGroupContainer from '../../../../../../src/js/components/form/FormGro
 import FormRow from '../../../../../../src/js/components/form/FormRow';
 import {MESOS_HTTP, MESOS_HTTPS, COMMAND} from '../../constants/HealthCheckProtocols';
 import HealthCheckUtil from '../../utils/HealthCheckUtil';
-import Icon from '../../../../../../src/js/components/Icon';
-
 import {FormReducer as healthChecks} from '../../reducers/serviceForm/HealthChecks';
 
 const errorsLens = Objektiv.attr('healthChecks', []);
@@ -233,10 +232,9 @@ class HealthChecksFormSection extends Component {
         {this.getHealthChecksLines(data.healthChecks)}
         <FormRow>
           <FormGroup className="column-12">
-            <a className="button button-primary-link button-flush"
-              onClick={this.props.onAddItem.bind(this, {value: data.healthChecks.length, path: 'healthChecks'})}>
-              <Icon color="purple" id="plus" size="tiny" /> Add Health Check
-            </a>
+            <AddButton onClick={this.props.onAddItem.bind(this, {value: data.healthChecks.length, path: 'healthChecks'})}>
+              Add Health Check
+            </AddButton>
           </FormGroup>
         </FormRow>
       </div>

--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -21,8 +21,9 @@ const errorsLens = Objektiv.attr('healthChecks', []);
 
 class HealthChecksFormSection extends Component {
   getAdvancedSettings(healthCheck, key) {
-    if (healthCheck.protocol !== COMMAND && healthCheck.protocol !== MESOS_HTTP &&
-      healthCheck.protocol !== MESOS_HTTPS) {
+    if (healthCheck.protocol !== COMMAND
+      && healthCheck.protocol !== MESOS_HTTP
+      && healthCheck.protocol !== MESOS_HTTPS) {
       return null;
     }
 
@@ -120,7 +121,8 @@ class HealthChecksFormSection extends Component {
   }
 
   getHTTPFields(healthCheck, key) {
-    if (healthCheck.protocol !== MESOS_HTTP && healthCheck.protocol !== MESOS_HTTPS) {
+    if (healthCheck.protocol !== MESOS_HTTP
+      && healthCheck.protocol !== MESOS_HTTPS) {
       return null;
     }
 
@@ -232,7 +234,9 @@ class HealthChecksFormSection extends Component {
         {this.getHealthChecksLines(data.healthChecks)}
         <FormRow>
           <FormGroup className="column-12">
-            <AddButton onClick={this.props.onAddItem.bind(this, {value: data.healthChecks.length, path: 'healthChecks'})}>
+            <AddButton onClick={this.props.onAddItem.bind(
+                this, {value: data.healthChecks.length, path: 'healthChecks'}
+              )}>
               Add Health Check
             </AddButton>
           </FormGroup>

--- a/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import Objektiv from 'objektiv';
 
+import AddButton from '../../../../../../src/js/components/form/AddButton';
 import AdvancedSection from '../../../../../../src/js/components/form/AdvancedSection';
 import AdvancedSectionContent from '../../../../../../src/js/components/form/AdvancedSectionContent';
 import AdvancedSectionLabel from '../../../../../../src/js/components/form/AdvancedSectionLabel';
@@ -12,8 +13,8 @@ import FieldSelect from '../../../../../../src/js/components/form/FieldSelect';
 import FormGroup from '../../../../../../src/js/components/form/FormGroup';
 import FormGroupContainer from '../../../../../../src/js/components/form/FormGroupContainer';
 import FormRow from '../../../../../../src/js/components/form/FormRow';
-import {HTTP, TCP, COMMAND} from '../../constants/HealthCheckProtocols';
 import Icon from '../../../../../../src/js/components/Icon';
+import {HTTP, TCP, COMMAND} from '../../constants/HealthCheckProtocols';
 
 class MultiContainerHealthChecksFormSection extends Component {
   getAdvancedSettings(healthCheck, path, errorsLens) {
@@ -199,10 +200,11 @@ class MultiContainerHealthChecksFormSection extends Component {
     if (healthCheck == null) {
       return (
         <div>
-          <a className="button button-primary-link button-flush"
-            onClick={this.props.onAddItem.bind(this, {path, value: index})}>
-            <Icon color="purple" id="plus" size="tiny" /> Add Health Check
-          </a>
+          <AddButton onClick={this.props.onAddItem.bind(
+              this, {path, value: index})
+            }>
+            Add Health Check
+          </AddButton>
         </div>
       );
     }

--- a/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
@@ -260,7 +260,8 @@ class MultiContainerHealthChecksFormSection extends Component {
           </h2>
           <p>
             {'Please '}
-            <a onClick={handleTabChange.bind(null, 'services')}
+            <a
+              onClick={handleTabChange.bind(null, 'services')}
               className="clickable">
               add a container
             </a>

--- a/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
@@ -199,8 +199,7 @@ class MultiContainerHealthChecksFormSection extends Component {
     if (healthCheck == null) {
       return (
         <div>
-          <a
-            className="button button-primary-link button-flush"
+          <a className="button button-primary-link button-flush"
             onClick={this.props.onAddItem.bind(this, {path, value: index})}>
             <Icon color="purple" id="plus" size="tiny" /> Add Health Check
           </a>

--- a/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
@@ -258,8 +258,13 @@ class MultiContainerHealthChecksFormSection extends Component {
           <h2 className="flush-top short-bottom">
             Health Checks
           </h2>
-          <p className="flush-bottom">
-            Please <a onClick={handleTabChange.bind(null, 'services')} className="clickable">add a container</a> before configuring health checks.
+          <p>
+            {'Please '}
+            <a onClick={handleTabChange.bind(null, 'services')}
+              className="clickable">
+              add a container
+            </a>
+            {' before configuring health checks.'}
           </p>
         </div>
       );

--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -88,7 +88,8 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
     const tooltipContent = (
       <span>
         {`This host port will be accessible as an environment variable called '$PORT${index}'. `}
-        <a href="https://mesosphere.github.io/marathon/docs/ports.html" about="_blank">
+        <a href="https://mesosphere.github.io/marathon/docs/ports.html"
+          target="_blank">
           More information
         </a>
       </span>
@@ -254,8 +255,16 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
             {value: index, path: `containers.${containerIndex}.endpoints`}
           )}>
           <FormRow key="port-name-group">
-            {this.getContainerPortField(endpoint, network, index, containerIndex, errors)}
-            <FormGroup className="column-6" key="endpoint-name" showError={Boolean(nameError)}>
+            {this.getContainerPortField(
+              endpoint,
+              network,
+              index,
+              containerIndex,
+              errors
+            )}
+            <FormGroup className="column-6"
+              key="endpoint-name"
+              showError={Boolean(nameError)}>
               <FieldLabel>
                 Service Endpoint Name
               </FieldLabel>
@@ -270,7 +279,12 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
             {this.getHostPortFields(endpoint, index, containerIndex)}
             {this.getProtocolField(endpoint, index, containerIndex)}
           </FormRow>
-          {this.getLoadBalancedServiceAddressField(endpoint, network, index, containerIndex)}
+          {this.getLoadBalancedServiceAddressField(
+            endpoint,
+            network,
+            index,
+            containerIndex
+          )}
         </FormGroupContainer>
       );
     });
@@ -357,7 +371,8 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
     const tooltipContent = (
       <span>
         {'Choose BRIDGE, HOST, or USER networking. Refer to the '}
-        <a href="https://mesosphere.github.io/marathon/docs/ports.html" target="_blank">
+        <a href="https://mesosphere.github.io/marathon/docs/ports.html"
+          target="_blank">
           ports documentation
         </a> for more information.
       </span>

--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -88,7 +88,8 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
     const tooltipContent = (
       <span>
         {`This host port will be accessible as an environment variable called '$PORT${index}'. `}
-        <a href="https://mesosphere.github.io/marathon/docs/ports.html"
+        <a
+          href="https://mesosphere.github.io/marathon/docs/ports.html"
           target="_blank">
           More information
         </a>
@@ -262,7 +263,8 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
               containerIndex,
               errors
             )}
-            <FormGroup className="column-6"
+            <FormGroup
+              className="column-6"
               key="endpoint-name"
               showError={Boolean(nameError)}>
               <FieldLabel>
@@ -371,7 +373,8 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
     const tooltipContent = (
       <span>
         {'Choose BRIDGE, HOST, or USER networking. Refer to the '}
-        <a href="https://mesosphere.github.io/marathon/docs/ports.html"
+        <a
+          href="https://mesosphere.github.io/marathon/docs/ports.html"
           target="_blank">
           ports documentation
         </a> for more information.

--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -5,6 +5,7 @@ import {StoreMixin} from 'mesosphere-shared-reactjs';
 
 import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
 import {FormReducer as networks} from '../../reducers/serviceForm/MultiContainerNetwork';
+import AddButton from '../../../../../../src/js/components/form/AddButton';
 import FieldError from '../../../../../../src/js/components/form/FieldError';
 import FieldHelp from '../../../../../../src/js/components/form/FieldHelp';
 import FieldInput from '../../../../../../src/js/components/form/FieldInput';
@@ -288,23 +289,16 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
             {` ${container.name}`}
           </h3>
           {this.getServiceContainerEndpoints(endpoints, index)}
-          <div key="add-button">
-            <button
-              type="button"
-              onBlur={(event) => {
-                event.stopPropagation();
-              }}
-              className="button button-primary-link button-flush"
-              onClick={this.props.onAddItem.bind(
-                  this,
-                {
-                  value: endpoints.length,
-                  path: `containers.${index}.endpoints`
-                }
-                )}>
-              <Icon color="purple" id="plus" size="tiny"/> Add Service
-              Endpoint
-            </button>
+          <div>
+            <AddButton onClick={this.props.onAddItem.bind(
+              this,
+              {
+                value: endpoints.length,
+                path: `containers.${index}.endpoints`
+              }
+            )}>
+              Add Service Endpoint
+            </AddButton>
           </div>
         </div>
       );

--- a/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
@@ -126,7 +126,12 @@ class MultiContainerVolumesFormSection extends Component {
         <div>
           {this.getHeadline()}
           <p>
-            Please <a onClick={handleTabChange.bind(null, 'services')} className="clickable">add a container</a> before configuring Volumes.
+            {'Please '}
+            <a onClick={handleTabChange.bind(null, 'services')}
+              className="clickable">
+              add a container
+            </a>
+            {' before configuring Volumes.'}
           </p>
         </div>
       );

--- a/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
@@ -127,7 +127,8 @@ class MultiContainerVolumesFormSection extends Component {
           {this.getHeadline()}
           <p>
             {'Please '}
-            <a onClick={handleTabChange.bind(null, 'services')}
+            <a
+              onClick={handleTabChange.bind(null, 'services')}
               className="clickable">
               add a container
             </a>

--- a/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
@@ -3,15 +3,16 @@ import React, {Component} from 'react';
 import Objektiv from 'objektiv';
 
 import {getContainerNameWithIcon} from '../../utils/ServiceConfigDisplayUtil';
+import AddButton from '../../../../../../src/js/components/form/AddButton';
 import FieldError from '../../../../../../src/js/components/form/FieldError';
 import FieldInput from '../../../../../../src/js/components/form/FieldInput';
 import FieldLabel from '../../../../../../src/js/components/form/FieldLabel';
 import FormGroup from '../../../../../../src/js/components/form/FormGroup';
 import FormGroupContainer from '../../../../../../src/js/components/form/FormGroupContainer';
 import FormRow from '../../../../../../src/js/components/form/FormRow';
+import Icon from '../../../../../../src/js/components/Icon';
 import MetadataStore from '../../../../../../src/js/stores/MetadataStore';
 import {FormReducer as volumeMounts} from '../../reducers/serviceForm/MultiContainerVolumes';
-import Icon from '../../../../../../src/js/components/Icon';
 
 const errorsLens = Objektiv.attr('container', {}).attr('volumes', []);
 
@@ -145,12 +146,11 @@ class MultiContainerVolumesFormSection extends Component {
         </p>
         {this.getVolumesMountLines(data.volumeMounts, data.volumeMounts)}
         <div>
-          <a
-            className="button button-primary-link button-flush"
-            onClick={this.props.onAddItem.bind(this,
-              {value: data.volumeMounts.length, path: 'volumeMounts'})}>
-            <Icon color="purple" id="plus" size="tiny" /> Add Ephemeral Volume
-          </a>
+          <AddButton onClick={this.props.onAddItem.bind(
+              this, {value: data.volumeMounts.length, path: 'volumeMounts'}
+            )}>
+            Add Ephemeral Volume
+          </AddButton>
         </div>
       </div>
     );

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -66,7 +66,8 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     const tooltipContent = (
       <span>
         {`This host port will be accessible as an environment variable called '$PORT${index}'. `}
-        <a href="https://mesosphere.github.io/marathon/docs/ports.html"
+        <a
+          href="https://mesosphere.github.io/marathon/docs/ports.html"
           target="_blank">
           More information
         </a>
@@ -482,7 +483,8 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     const tooltipContent = (
       <span>
         {'Choose BRIDGE, HOST, or USER networking. Refer to the '}
-        <a href="https://mesosphere.github.io/marathon/docs/ports.html"
+        <a
+          href="https://mesosphere.github.io/marathon/docs/ports.html"
           target="_blank">
           ports documentation
         </a> for more information.

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -66,7 +66,8 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     const tooltipContent = (
       <span>
         {`This host port will be accessible as an environment variable called '$PORT${index}'. `}
-        <a href="https://mesosphere.github.io/marathon/docs/ports.html" about="_blank">
+        <a href="https://mesosphere.github.io/marathon/docs/ports.html"
+          target="_blank">
           More information
         </a>
       </span>
@@ -114,7 +115,15 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     ];
   }
 
-  getLoadBalancedServiceAddressField({containerPort, hostPort, loadBalanced, vip}, index) {
+  getLoadBalancedServiceAddressField(
+      {
+        containerPort,
+        hostPort,
+        loadBalanced,
+        vip
+      },
+      index
+    ) {
     const {errors} = this.props;
     const loadBalancedError = findNestedPropertyInObject(
       errors,
@@ -303,7 +312,12 @@ class NetworkingFormSection extends mixin(StoreMixin) {
             {value: index, path: 'portDefinitions'}
           )}>
           <FormRow>
-            {this.getContainerPortField(portDefinition, networkType, errors, index)}
+            {this.getContainerPortField(
+              portDefinition,
+              networkType,
+              errors,
+              index
+            )}
             <FormGroup className="column-6" showError={Boolean(nameError)}>
               <FieldLabel>
                 Service Endpoint Name
@@ -468,7 +482,8 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     const tooltipContent = (
       <span>
         {'Choose BRIDGE, HOST, or USER networking. Refer to the '}
-        <a href="https://mesosphere.github.io/marathon/docs/ports.html" target="_blank">
+        <a href="https://mesosphere.github.io/marathon/docs/ports.html"
+          target="_blank">
           ports documentation
         </a> for more information.
       </span>

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -6,6 +6,7 @@ import {StoreMixin} from 'mesosphere-shared-reactjs';
 import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
 import {FormReducer as portDefinitionsReducer} from '../../reducers/serviceForm/PortDefinitions';
 import {SET} from '../../../../../../src/js/constants/TransactionTypes';
+import AddButton from '../../../../../../src/js/components/form/AddButton';
 import ContainerConstants from '../../constants/ContainerConstants';
 import FieldError from '../../../../../../src/js/components/form/FieldError';
 import FieldHelp from '../../../../../../src/js/components/form/FieldHelp';
@@ -443,19 +444,15 @@ class NetworkingFormSection extends mixin(StoreMixin) {
         {this.getServiceEndpoints()}
         <FormRow key="service-endpoints-add-button">
           <FormGroup className="column-12">
-            <button
-              type="button"
-              onBlur={(event) => { event.stopPropagation(); }}
-              className="button button-primary-link button-flush"
-              onClick={this.props.onAddItem.bind(
-                this,
-                {
-                  value: portDefinitions.length,
-                  path: 'portDefinitions'
-                }
-              )}>
-              <Icon color="purple" id="plus" size="tiny" /> Add Service Endpoint
-            </button>
+            <AddButton onClick={this.props.onAddItem.bind(
+              this,
+              {
+                value: portDefinitions.length,
+                path: 'portDefinitions'
+              }
+            )}>
+              Add Service Endpoint
+            </AddButton>
           </FormGroup>
         </FormRow>
       </div>

--- a/plugins/services/src/js/components/forms/VolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/VolumesFormSection.js
@@ -35,7 +35,9 @@ class VolumesFormSection extends Component {
     const tooltipContent = (
       <span>
         {'The path where your application will read and write data. This must be a single-level path relative to the container. '}
-        <a href={MetadataStore.buildDocsURI('/usage/storage/persistent-volume/')} target="_blank">
+        <a
+          href={MetadataStore.buildDocsURI('/usage/storage/persistent-volume/')}
+          target="_blank">
           More information
         </a>.
       </span>
@@ -91,7 +93,8 @@ class VolumesFormSection extends Component {
     const tooltipContent = (
       <span>
         {'If you are using the Mesos containerizer, this must be a single-level path relative to the container. '}
-        <a href={MetadataStore.buildDocsURI('/usage/storage/external-storage/')} target="_blank">
+        <a href={MetadataStore.buildDocsURI('/usage/storage/external-storage/')}
+          target="_blank">
           More information
         </a>.
       </span>
@@ -186,7 +189,8 @@ class VolumesFormSection extends Component {
               required={false}
               showError={Boolean(typeError)}>
               <FieldLabel>Volume Type</FieldLabel>
-              <FieldSelect name={`localVolumes.${key}.type`} value={volume.type}>
+              <FieldSelect name={`localVolumes.${key}.type`}
+                value={volume.type}>
                 <option>Select...</option>
                 {this.getHostOption(dockerImage)}
                 <option value="PERSISTENT">Persistent Volume</option>
@@ -204,7 +208,8 @@ class VolumesFormSection extends Component {
    * getExternalVolumesLines
    *
    * @param  {Object} data
-   * @param  {Number} offset as we have two independent sections that are 0 based we need to add an offset to the second one
+   * @param  {Number} offset as we have two independent sections that are 0
+   *                  based we need to add an offset to the second one
    * @return {Array} elements
    */
   getExternalVolumesLines(data, offset) {
@@ -333,7 +338,10 @@ class VolumesFormSection extends Component {
             More information
           </a>.
         </p>
-        {this.getExternalVolumesLines(data.externalVolumes, data.localVolumes.length)}
+        {this.getExternalVolumesLines(
+          data.externalVolumes,
+          data.localVolumes.length
+        )}
         <FormRow>
           <FormGroup className="column-12">
             <AddButton onClick={this.props.onAddItem.bind(

--- a/plugins/services/src/js/components/forms/VolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/VolumesFormSection.js
@@ -4,6 +4,7 @@ import Objektiv from 'objektiv';
 
 import {FormReducer as externalVolumes} from '../../reducers/serviceForm/ExternalVolumes';
 import {FormReducer as localVolumes} from '../../reducers/serviceForm/LocalVolumes';
+import AddButton from '../../../../../../src/js/components/form/AddButton';
 import FieldError from '../../../../../../src/js/components/form/FieldError';
 import FieldInput from '../../../../../../src/js/components/form/FieldInput';
 import FieldLabel from '../../../../../../src/js/components/form/FieldLabel';
@@ -315,11 +316,11 @@ class VolumesFormSection extends Component {
         </p>
         {this.getLocalVolumesLines(data.localVolumes)}
         <div>
-          <a
-            className="button button-primary-link button-flush"
-            onClick={this.props.onAddItem.bind(this, {value: data.localVolumes.length, path: 'localVolumes'})}>
-            <Icon color="purple" id="plus" size="tiny" /> Add Local Volume
-          </a>
+          <AddButton onClick={this.props.onAddItem.bind(
+              this, {value: data.localVolumes.length, path: 'localVolumes'}
+            )}>
+            Add Local Volume
+          </AddButton>
         </div>
         <h3 className="short-bottom">
           External Volumes Variables
@@ -335,11 +336,11 @@ class VolumesFormSection extends Component {
         {this.getExternalVolumesLines(data.externalVolumes, data.localVolumes.length)}
         <FormRow>
           <FormGroup className="column-12">
-            <a
-              className="button button-primary-link button-flush"
-              onClick={this.props.onAddItem.bind(this, {value: data.localVolumes.length, path: 'externalVolumes'})}>
-              <Icon color="purple" id="plus" size="tiny" /> Add External Volume
-            </a>
+            <AddButton onClick={this.props.onAddItem.bind(
+                this, {value: data.localVolumes.length, path: 'externalVolumes'}
+              )}>
+              Add External Volume
+            </AddButton>
           </FormGroup>
         </FormRow>
       </div>

--- a/plugins/services/src/js/components/forms/VolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/VolumesFormSection.js
@@ -93,7 +93,8 @@ class VolumesFormSection extends Component {
     const tooltipContent = (
       <span>
         {'If you are using the Mesos containerizer, this must be a single-level path relative to the container. '}
-        <a href={MetadataStore.buildDocsURI('/usage/storage/external-storage/')}
+        <a
+          href={MetadataStore.buildDocsURI('/usage/storage/external-storage/')}
           target="_blank">
           More information
         </a>.
@@ -189,7 +190,8 @@ class VolumesFormSection extends Component {
               required={false}
               showError={Boolean(typeError)}>
               <FieldLabel>Volume Type</FieldLabel>
-              <FieldSelect name={`localVolumes.${key}.type`}
+              <FieldSelect
+                name={`localVolumes.${key}.type`}
                 value={volume.type}>
                 <option>Select...</option>
                 {this.getHostOption(dockerImage)}

--- a/src/js/components/form/AddButton.js
+++ b/src/js/components/form/AddButton.js
@@ -1,0 +1,34 @@
+import classNames from 'classnames/dedupe';
+import React from 'react';
+
+import Icon from '../Icon';
+
+function AddButton({children, className, icon, onClick}) {
+  const classes = classNames(
+    'button button-primary-link button-flush text-no-transform', className
+  );
+
+  return (
+    <a className={classes} onClick={onClick}>
+      {icon}
+      {children}
+    </a>
+  );
+};
+
+AddButton.defaultProps = {
+  icon: <Icon color="purple" id="plus" size="tiny" />
+};
+
+AddButton.propTypes = {
+  children: React.PropTypes.node,
+  onClick: React.PropTypes.func,
+  className: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ]),
+  icon: React.PropTypes.node
+};
+
+module.exports = AddButton;

--- a/src/js/components/form/AddButton.js
+++ b/src/js/components/form/AddButton.js
@@ -5,7 +5,7 @@ import Icon from '../Icon';
 
 function AddButton({children, className, icon, onClick}) {
   const classes = classNames(
-    'button button-primary-link button-flush text-no-transform', className
+    'button button-primary-link button-flush', className
   );
 
   return (

--- a/src/js/components/form/AdvancedSectionLabel.js
+++ b/src/js/components/form/AdvancedSectionLabel.js
@@ -15,7 +15,7 @@ function getStateIndicator(isExpanded) {
 
 const AdvancedSectionLabel = ({className, children, isExpanded, onClick}) => {
   const classes = classNames(
-    'advanced-section-label clickable button button-primary-link button-flush text-no-transform',
+    'advanced-section-label clickable button button-primary-link button-flush',
     className
   );
 

--- a/src/js/components/form/AdvancedSectionLabel.js
+++ b/src/js/components/form/AdvancedSectionLabel.js
@@ -14,7 +14,10 @@ function getStateIndicator(isExpanded) {
 }
 
 const AdvancedSectionLabel = ({className, children, isExpanded, onClick}) => {
-  const classes = classNames('advanced-section-label clickable', className);
+  const classes = classNames(
+    'advanced-section-label clickable button button-primary-link button-flush text-no-transform',
+    className
+  );
 
   return (
     <a className={classes} onClick={onClick}>

--- a/src/js/components/form/index.js
+++ b/src/js/components/form/index.js
@@ -1,3 +1,4 @@
+import AddButton from './AddButton';
 import AdvancedSection from './AdvancedSection';
 import AdvancedSectionContainer from './AdvancedSectionContent';
 import AdvancedSectionLabel from './AdvancedSectionLabel';
@@ -13,6 +14,7 @@ import FormGroupContainer from './FormGroupContainer';
 import FormRow from './FormRow';
 
 module.exports = {
+  AddButton,
   AdvancedSection,
   AdvancedSectionContainer,
   AdvancedSectionLabel,

--- a/src/styles/components/advanced-section/styles.less
+++ b/src/styles/components/advanced-section/styles.less
@@ -13,10 +13,6 @@
       &:hover {
         text-decoration: none;
       }
-
-      .icon {
-        margin-right: @advanced-section-icon-margin-right;
-      }
     }
   }
 }
@@ -30,13 +26,6 @@
 
       &-content {
         margin-top: @advanced-section-content-margin-top-screen-small;
-      }
-
-      &-label {
-
-        .icon {
-          margin-right: @advanced-section-icon-margin-right-screen-small;
-        }
       }
     }
   }
@@ -52,13 +41,6 @@
       &-content {
         margin-top: @advanced-section-content-margin-top-screen-medium;
       }
-
-      &-label {
-
-        .icon {
-          margin-right: @advanced-section-icon-margin-right-screen-medium;
-        }
-      }
     }
   }
 }
@@ -73,13 +55,6 @@
       &-content {
         margin-top: @advanced-section-content-margin-top-screen-large;
       }
-
-      &-label {
-
-        .icon {
-          margin-right: @advanced-section-icon-margin-right-screen-large;
-        }
-      }
     }
   }
 }
@@ -93,13 +68,6 @@
 
       &-content {
         margin-top: @advanced-section-content-margin-top-screen-jumbo;
-      }
-
-      &-label {
-
-        .icon {
-          margin-right: @advanced-section-icon-margin-right-screen-jumbo;
-        }
       }
     }
   }

--- a/src/styles/components/advanced-section/variables.less
+++ b/src/styles/components/advanced-section/variables.less
@@ -6,12 +6,6 @@
 @advanced-section-margin-top-screen-large: @base-spacing-unit-screen-large * 3/4;
 @advanced-section-margin-top-screen-jumbo: @base-spacing-unit-screen-jumbo * 3/4;
 
-@advanced-section-icon-margin-right: @base-spacing-unit * 1/4;
-@advanced-section-icon-margin-right-screen-small: @base-spacing-unit-screen-small * 1/4;
-@advanced-section-icon-margin-right-screen-medium: @base-spacing-unit-screen-medium * 1/4;
-@advanced-section-icon-margin-right-screen-large: @base-spacing-unit-screen-large * 1/4;
-@advanced-section-icon-margin-right-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/4;
-
 @advanced-section-content-margin-top: @pod-margin-top * @pod-short-margin-top-scale;
 @advanced-section-content-margin-top-screen-small: @pod-margin-top-screen-small * @pod-short-margin-top-scale;
 @advanced-section-content-margin-top-screen-medium: @pod-margin-top-screen-medium * @pod-short-margin-top-scale;


### PR DESCRIPTION
This PR introduces an `AddButton` component for forms which produces the proper classnames. It's meant to be implemented on any form that has an `Add` button for duplicable field sets.

It also fixes the inconsistency between the `AdvancedSectionLabel` component and the `AddButton` component.

![](https://cl.ly/3K3f1z0P0e0p/Screen%20Shot%202017-01-17%20at%204.43.52%20PM.png)