### PR TITLE
DCOS-12573: Remove .button-large classes from UI

### DIFF
--- a/src/js/components/modals/IdentifyModal.js
+++ b/src/js/components/modals/IdentifyModal.js
@@ -46,7 +46,7 @@ var IdentifyModal = React.createClass({
   getFooter() {
     return (
       <div className="button-collection button-collection-align-horizontal-center flush-bottom">
-        <button className="button button-primary button-large button-wide-below-screen-mini"
+        <button className="button button-primary button-wide-below-screen-mini"
           onClick={this.handleSubmit}>
           Try {Config.productName}
         </button>

--- a/src/js/components/modals/InstallPackageModal.js
+++ b/src/js/components/modals/InstallPackageModal.js
@@ -396,13 +396,13 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
       <div className="modal-footer">
         <div className="button-collection flush-bottom">
           <button
-            className="button button-large"
+            className="button"
             onClick={this.handleChangeTab.bind(this, 'defaultInstall')}>
             Back
           </button>
           <button
             disabled={!cosmosPackage || pendingRequest || hasFormErrors}
-            className="button button-large button-success"
+            className="button button-success"
             onClick={this.handleChangeTab.bind(this, 'reviewAdvancedConfig')}>
             Review and Install
           </button>
@@ -433,13 +433,13 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
         <div className="modal-footer">
           <div className="button-collection flush-bottom">
             <button
-              className="button button-large"
+              className="button"
               onClick={this.handleChangeTab.bind(this, 'advancedInstall')}>
               Back
             </button>
             <button
               disabled={!cosmosPackage || pendingRequest}
-              className="button button-success button-large"
+              className="button button-success"
               onClick={this.handleInstallPackage}>
               {buttonText}
             </button>

--- a/src/js/components/modals/JobFormModal.js
+++ b/src/js/components/modals/JobFormModal.js
@@ -400,12 +400,12 @@ class JobFormModal extends mixin(StoreMixin) {
     return (
       <div className="button-collection flush-bottom">
         <button
-          className="button button-large"
+          className="button"
           onClick={this.handleCancel}>
           Cancel
         </button>
         <button
-          className="button button-large button-success"
+          className="button button-success"
           onClick={this.handleSubmit}>
           {submitLabel}
         </button>


### PR DESCRIPTION
This PR removes the `.button-large` classes from the UI.

After this PR, they'll only exist in `ServiceFormModal` (which needs to be removed in a separate PR :fire:) and some of the `/styles/` components, which are there intentionally.