### PR TITLE
DCOS-11890: Fix the string to hostname util

### DIFF
--- a/plugins/services/src/js/utils/HostUtil.js
+++ b/plugins/services/src/js/utils/HostUtil.js
@@ -1,32 +1,80 @@
 const HostUtil = {
+
+  /**
+   * Util to "transform" a string to a valid hostname following the RFC-952
+   * standard. It mirrors the `dcos/mesos_state` implementation.
+   * The util  will remove empty labels and use the string to label util
+   * to ensure that labels don't include invalid characters and don't exceed
+   * the character limit.
+   *
+   * @param {string} string
+   * @return {string} hostname
+   */
   stringToHostname(string) {
-    const HOSTNAME_MAX_LENGTH = 63;
+    if (string == null) {
+
+      return null;
+    }
+
+    return string
+      .split('.')
+      .filter(function (string) {
+        return string !== '';
+      })
+      .map(HostUtil.stringToLabel)
+      .join('.');
+  },
+
+  /**
+   * Util to "convert" a given string to a RFC-952 compliant DNS label.
+   * It mirrors the respective `dcos/mesos_state` implementation.
+   * The util  will strip invalid characters and ensures that the label don't
+   * exceed the character limit.
+   *
+   * @param {string} string
+   * @return {string} label
+   */
+  stringToLabel(string) {
+    const LABEL_MAX_LENGTH = 63;
 
     if (string == null) {
-      return string;
+      return '';
     }
 
-    // Strip or convert illegal characters
-    let host = string.toLowerCase().replace(/[_\.]/g, '-').replace(/[^a-z0-9-]/g, '');
+    string = string.toLowerCase();
 
-    // Strip symbols from beginning
-    while (host.startsWith('-')) {
-      host = host.slice(1);
+    // Strip all invalid character including leading and trailing dashes
+    // or replace them with dashes.
+    string = string.replace(/(_)|^-+|-+$|[^a-z0-9-]/g, function (match, p1) {
+
+      // Replace underscores (first capture group) with dashes
+      if (p1 != null) {
+        return '-';
+      }
+
+      // Strip any other invalid character
+      return '';
+    });
+
+    // Trim labels if they exceed the allowed max length
+    if (string.length > LABEL_MAX_LENGTH) {
+
+      // Remove all dashes and groups of dashes that have an offset larger or
+      // equal to the allowed max length before trimming the label to ensure
+      // that no label ends with a dash.
+      string = string.replace(/[-]+/g, function (match, offset) {
+        if (offset + match.length >= LABEL_MAX_LENGTH) {
+          return '';
+        }
+
+        return match;
+      });
+
+      // Trim the label to the allowed max length
+      string = string.slice(0, LABEL_MAX_LENGTH);
     }
 
-    // Strip symbols from middle if greater than max length
-    while (host.length > HOSTNAME_MAX_LENGTH && host.charAt(HOSTNAME_MAX_LENGTH - 1) === '-') {
-      host = host.slice(0, HOSTNAME_MAX_LENGTH - 1).concat(host.slice(HOSTNAME_MAX_LENGTH));
-    }
-
-    host = host.slice(0, HOSTNAME_MAX_LENGTH);
-
-    // Strip symbols from end
-    while (host.endsWith('-')) {
-      host = host.slice(0, host.length - 1);
-    }
-
-    return host.slice(0, HOSTNAME_MAX_LENGTH);
+    return string;
   }
 };
 

--- a/plugins/services/src/js/utils/__tests__/HostUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/HostUtil-test.js
@@ -6,26 +6,87 @@ describe('HostUtil', function () {
 
   describe('#stringToHostname', function () {
 
+    it('should omit dots at the start', function () {
+      const result = HostUtil.stringToHostname('.fdgsf.4abc123');
+
+      expect(result).toEqual('fdgsf.4abc123');
+    });
+
+    it('should omit dots at the end', function () {
+      const result = HostUtil.stringToHostname('fdgsf.4abc123.');
+
+      expect(result).toEqual('fdgsf.4abc123');
+    });
+
+    it('should omit duplicated dots', function () {
+      const result = HostUtil.stringToHostname('fdgsf..4abc123');
+
+      expect(result).toEqual('fdgsf.4abc123');
+    });
+
+    it('should not replace dots midway', function () {
+      const result = HostUtil.stringToHostname('fdgsf.4abc123');
+
+      expect(result).toEqual('fdgsf.4abc123');
+    });
+
+    it('should allow 63 char labels', function () {
+      const hostname = [
+        '010203040506070809010111213141516171819202122232425262728293031',
+        '010203040506070809010111213141516171819202122232425262728293031'
+      ].join('.');
+
+      expect(HostUtil.stringToHostname(hostname)).toEqual(hostname);
+    });
+
+    it('should not alter valid strings', function () {
+      const result = HostUtil.stringToHostname('0-0');
+
+      expect(result).toEqual('0-0');
+    });
+
+  });
+
+  describe('#stringToLabel', function () {
+
     it('should strip invalid chars', function () {
-      const result = HostUtil.stringToHostname('fd%gsf---gs7-f$gs--d7fddg-123');
+      const result = HostUtil.stringToLabel('fd%gsf---gs7-f$gs--d7fddg-123');
 
       expect(result).toEqual('fdgsf---gs7-fgs--d7fddg-123');
     });
 
+    it('should replace underscores', function () {
+      const result = HostUtil.stringToLabel('fdgsf_4abc123');
+
+      expect(result).toEqual('fdgsf-4abc123');
+    });
+
+    it('should omit slashes', function () {
+      const result = HostUtil.stringToLabel('fdgsf/4abc123');
+
+      expect(result).toEqual('fdgsf4abc123');
+    });
+
+    it('should omit dots', function () {
+      const result = HostUtil.stringToLabel('.fdgsf.4abc123.');
+
+      expect(result).toEqual('fdgsf4abc123');
+    });
+
     it('should strip invalid chars from the start', function () {
-      const result = HostUtil.stringToHostname('-@4abc123');
+      const result = HostUtil.stringToLabel('-@4abc123');
 
       expect(result).toEqual('4abc123');
     });
 
     it('should strip invalid chars from the end', function () {
-      const result = HostUtil.stringToHostname('4abc123.');
+      const result = HostUtil.stringToLabel('4abc123-');
 
       expect(result).toEqual('4abc123');
     });
 
     it('should strip invalid chars from the start and end', function () {
-      const result = HostUtil.stringToHostname(
+      const result = HostUtil.stringToLabel(
         '##fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789-'
       );
 
@@ -34,20 +95,14 @@ describe('HostUtil', function () {
       );
     });
 
-    it('should return valid hostnames', function () {
-      const result = HostUtil.stringToHostname('0-0');
-
-      expect(result).toEqual('0-0');
-    });
-
     it('should allow dashes within the hostname', function () {
-      const result = HostUtil.stringToHostname('89fdgsf---gs7-fgs--d7fddg-123');
+      const result = HostUtil.stringToLabel('89fdgsf---gs7-fgs--d7fddg-123');
 
       expect(result).toEqual('89fdgsf---gs7-fgs--d7fddg-123');
     });
 
     it('should strip invalid chars and trim string to 63 chars', function () {
-      const result = HostUtil.stringToHostname(
+      const result = HostUtil.stringToLabel(
         'fd%gsf---gs7-f$gs--d7fddg123456789012345678901234567890123456789-123'
       );
 
@@ -56,8 +111,18 @@ describe('HostUtil', function () {
       );
     });
 
+    it('should trim string to 63 chars', function () {
+      const result = HostUtil.stringToLabel(
+        '0102030405060708090101112131415161718192021222324252627282930313233'
+      );
+
+      expect(result).toEqual(
+        '010203040506070809010111213141516171819202122232425262728293031'
+      );
+    });
+
     it('should strip invalid chars from start and trim string', function () {
-      const result = HostUtil.stringToHostname(
+      const result = HostUtil.stringToLabel(
         '%%fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789---123'
       );
 
@@ -67,7 +132,7 @@ describe('HostUtil', function () {
     });
 
     it('should strip dashes from the end and trim string', function () {
-      const result = HostUtil.stringToHostname(
+      const result = HostUtil.stringToLabel(
         '%%fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789---123'
       );
 
@@ -76,18 +141,27 @@ describe('HostUtil', function () {
       );
     });
 
+    it('should strip all dashes that exceed the char limit', function () {
+      const result = HostUtil.stringToLabel(
+        'a--------------------------------------------------------------------b'
+      );
+
+      expect(result).toEqual('ab');
+
+    });
+
     it('should not alter valid hostnames', function () {
-      const result = HostUtil.stringToHostname(
-        'a--------------------------------------------------------------b'
+      const result = HostUtil.stringToLabel(
+        'a-----------------------------------------------b'
       );
 
       expect(result).toEqual(
-        'a-------------------------------------------------------------b'
+        'a-----------------------------------------------b'
       );
     });
 
     it('should lowercase the string', function () {
-      const result = HostUtil.stringToHostname('XYZ');
+      const result = HostUtil.stringToLabel('XYZ');
 
       expect(result).toEqual('xyz');
     });

--- a/plugins/services/src/js/utils/__tests__/HostUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/HostUtil-test.js
@@ -7,61 +7,61 @@ describe('HostUtil', function () {
   describe('#stringToHostname', function () {
 
     it('should strip out invalid characters from the middle', function () {
-      var result = HostUtil.stringToHostname('fd%gsf---gs7-f$gs--d7fddg-123');
+      const result = HostUtil.stringToHostname('fd%gsf---gs7-f$gs--d7fddg-123');
 
       expect(result).toEqual('fdgsf---gs7-fgs--d7fddg-123');
     });
 
     it('should strip out invalid characters from the start', function () {
-      var result = HostUtil.stringToHostname('-@4abc123');
+      const result = HostUtil.stringToHostname('-@4abc123');
 
       expect(result).toEqual('4abc123');
     });
 
     it('should strip out invalid characters from the end', function () {
-      var result = HostUtil.stringToHostname('4abc123.');
+      const result = HostUtil.stringToHostname('4abc123.');
 
       expect(result).toEqual('4abc123');
     });
 
     it('should strip invalid characters from the start and end', function () {
-      var result = HostUtil.stringToHostname('##fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789-');
+      const result = HostUtil.stringToHostname('##fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789-');
 
       expect(result).toEqual('fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789');
     });
 
     it('should return valid hostnames', function () {
-      var result = HostUtil.stringToHostname('0-0');
+      const result = HostUtil.stringToHostname('0-0');
 
       expect(result).toEqual('0-0');
     });
 
     it('should allow dashes within the hostname', function () {
-      var result = HostUtil.stringToHostname('89fdgsf---gs7-fgs--d7fddg-123');
+      const result = HostUtil.stringToHostname('89fdgsf---gs7-fgs--d7fddg-123');
 
       expect(result).toEqual('89fdgsf---gs7-fgs--d7fddg-123');
     });
 
     it('should strip invalid characters and trim to 63 characters and remove invalid end characters', function () {
-      var result = HostUtil.stringToHostname('fd%gsf---gs7-f$gs--d7fddg123456789012345678901234567890123456789-123');
+      const result = HostUtil.stringToHostname('fd%gsf---gs7-f$gs--d7fddg123456789012345678901234567890123456789-123');
 
       expect(result).toEqual('fdgsf---gs7-fgs--d7fddg1234567890123456789012345678901234567891');
     });
 
     it('should strip invalid start characters and trim to 63 characters and remove invalid end characters', function () {
-      var result = HostUtil.stringToHostname('%%fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789---123');
+      const result = HostUtil.stringToHostname('%%fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789---123');
 
       expect(result).toEqual('fdgsf---gs7-fgs--d7fddg1234567890123456789012345678901234567891');
     });
 
     it('should return valid strings', function () {
-      var result = HostUtil.stringToHostname('a--------------------------------------------------------------b');
+      const result = HostUtil.stringToHostname('a--------------------------------------------------------------b');
 
       expect(result).toEqual('a-------------------------------------------------------------b');
     });
 
     it('should lowercase the string', function () {
-      var result = HostUtil.stringToHostname('XYZ');
+      const result = HostUtil.stringToHostname('XYZ');
 
       expect(result).toEqual('xyz');
     });

--- a/plugins/services/src/js/utils/__tests__/HostUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/HostUtil-test.js
@@ -6,28 +6,32 @@ describe('HostUtil', function () {
 
   describe('#stringToHostname', function () {
 
-    it('should strip out invalid characters from the middle', function () {
+    it('should strip invalid chars', function () {
       const result = HostUtil.stringToHostname('fd%gsf---gs7-f$gs--d7fddg-123');
 
       expect(result).toEqual('fdgsf---gs7-fgs--d7fddg-123');
     });
 
-    it('should strip out invalid characters from the start', function () {
+    it('should strip invalid chars from the start', function () {
       const result = HostUtil.stringToHostname('-@4abc123');
 
       expect(result).toEqual('4abc123');
     });
 
-    it('should strip out invalid characters from the end', function () {
+    it('should strip invalid chars from the end', function () {
       const result = HostUtil.stringToHostname('4abc123.');
 
       expect(result).toEqual('4abc123');
     });
 
-    it('should strip invalid characters from the start and end', function () {
-      const result = HostUtil.stringToHostname('##fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789-');
+    it('should strip invalid chars from the start and end', function () {
+      const result = HostUtil.stringToHostname(
+        '##fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789-'
+      );
 
-      expect(result).toEqual('fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789');
+      expect(result).toEqual(
+        'fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789'
+      );
     });
 
     it('should return valid hostnames', function () {
@@ -42,22 +46,44 @@ describe('HostUtil', function () {
       expect(result).toEqual('89fdgsf---gs7-fgs--d7fddg-123');
     });
 
-    it('should strip invalid characters and trim to 63 characters and remove invalid end characters', function () {
-      const result = HostUtil.stringToHostname('fd%gsf---gs7-f$gs--d7fddg123456789012345678901234567890123456789-123');
+    it('should strip invalid chars and trim string to 63 chars', function () {
+      const result = HostUtil.stringToHostname(
+        'fd%gsf---gs7-f$gs--d7fddg123456789012345678901234567890123456789-123'
+      );
 
-      expect(result).toEqual('fdgsf---gs7-fgs--d7fddg1234567890123456789012345678901234567891');
+      expect(result).toEqual(
+        'fdgsf---gs7-fgs--d7fddg1234567890123456789012345678901234567891'
+      );
     });
 
-    it('should strip invalid start characters and trim to 63 characters and remove invalid end characters', function () {
-      const result = HostUtil.stringToHostname('%%fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789---123');
+    it('should strip invalid chars from start and trim string', function () {
+      const result = HostUtil.stringToHostname(
+        '%%fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789---123'
+      );
 
-      expect(result).toEqual('fdgsf---gs7-fgs--d7fddg1234567890123456789012345678901234567891');
+      expect(result).toEqual(
+        'fdgsf---gs7-fgs--d7fddg1234567890123456789012345678901234567891'
+      );
     });
 
-    it('should return valid strings', function () {
-      const result = HostUtil.stringToHostname('a--------------------------------------------------------------b');
+    it('should strip dashes from the end and trim string', function () {
+      const result = HostUtil.stringToHostname(
+        '%%fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789---123'
+      );
 
-      expect(result).toEqual('a-------------------------------------------------------------b');
+      expect(result).toEqual(
+        'fdgsf---gs7-fgs--d7fddg1234567890123456789012345678901234567891'
+      );
+    });
+
+    it('should not alter valid hostnames', function () {
+      const result = HostUtil.stringToHostname(
+        'a--------------------------------------------------------------b'
+      );
+
+      expect(result).toEqual(
+        'a-------------------------------------------------------------b'
+      );
     });
 
     it('should lowercase the string', function () {


### PR DESCRIPTION
Introduce a new `stringToLabel` util and change the way the `stringToHostname` util works to align them with the respective DC/OS component. The new implementation follows RFC-952 and mirrors the `dcos/mesos_state`  implementation.

Please see dcos/mesos_state#22 as well as dcos/mesos_state#21 for improved/added test cases which illustrate how `dcos/mesos_state` is transform strings.

Closes DCOS-11890