### PR TITLE
DCOS-11160: Adjust the DCOSStore data received flags

### DIFF
--- a/foundation-ui/stores/__tests__/DCOSStore-test.js
+++ b/foundation-ui/stores/__tests__/DCOSStore-test.js
@@ -97,7 +97,7 @@ describe('DCOSStore', function () {
       ]}));
       spyOn(NotificationStore, 'addNotification');
       // DCOSStore is a singleton, need to reset it manually
-      DCOSStore.data.dataProcessed = false;
+      DCOSStore.data.marathon.dataReceived = false;
     });
 
     describe('when the groups endpoint is not populated', function () {

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailTaskTab.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailTaskTab.js
@@ -38,9 +38,9 @@ class NodeDetailTaskTab extends React.Component {
   onStoreChange() {
     // Throttle updates from DCOSStore
     if (Date.now() - this.state.lastUpdate > 1000
-      || (!!DCOSStore.dataProcessed && this.state.isLoading)) {
+      || (!!DCOSStore.serviceDataReceived && this.state.isLoading)) {
       this.setState({
-        isLoading: !(!!DCOSStore.dataProcessed),
+        isLoading: !(!!DCOSStore.serviceDataReceived),
         lastUpdate: Date.now()
       });
     }

--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -193,10 +193,10 @@ class ServicesContainer extends React.Component {
   onStoreChange() {
     // Throttle updates from DCOSStore
     if (Date.now() - this.state.lastUpdate > 1000
-      || (!!DCOSStore.dataProcessed && this.state.isLoading)) {
+      || (!!DCOSStore.serviceDataReceived && this.state.isLoading)) {
 
       this.setState({
-        isLoading: !(!!DCOSStore.dataProcessed),
+        isLoading: !(!!DCOSStore.serviceDataReceived),
         lastUpdate: Date.now()
       });
     }

--- a/plugins/services/src/js/containers/volume-detail/ServiceVolumeContainer.js
+++ b/plugins/services/src/js/containers/volume-detail/ServiceVolumeContainer.js
@@ -16,7 +16,7 @@ class ServiceVolumeContainer extends React.Component {
     super(...arguments);
 
     this.state = {
-      isLoading: !(!!DCOSStore.dataProcessed),
+      isLoading: !(!!DCOSStore.serviceDataReceived),
       lastUpdate: 0
     };
 
@@ -36,10 +36,10 @@ class ServiceVolumeContainer extends React.Component {
   onStoreChange() {
     // Throttle updates from DCOSStore
     if (Date.now() - this.state.lastUpdate > 1000
-      || (!!DCOSStore.dataProcessed && this.state.isLoading)) {
+      || (!!DCOSStore.serviceDataReceived && this.state.isLoading)) {
 
       this.setState({
-        isLoading: !(!!DCOSStore.dataProcessed),
+        isLoading: !(!!DCOSStore.serviceDataReceived),
         lastUpdate: Date.now()
       });
     }

--- a/plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.js
+++ b/plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.js
@@ -16,7 +16,7 @@ class TaskVolumeContainer extends React.Component {
     super(...arguments);
 
     this.state = {
-      isLoading: !(!!DCOSStore.dataProcessed),
+      isLoading: !(!!DCOSStore.serviceDataReceived),
       lastUpdate: 0
     };
 
@@ -36,10 +36,10 @@ class TaskVolumeContainer extends React.Component {
   onStoreChange() {
     // Throttle updates from DCOSStore
     if (Date.now() - this.state.lastUpdate > 1000
-      || (!!DCOSStore.dataProcessed && this.state.isLoading)) {
+      || (!!DCOSStore.serviceDataReceived && this.state.isLoading)) {
 
       this.setState({
-        isLoading: !(!!DCOSStore.dataProcessed),
+        isLoading: !(!!DCOSStore.serviceDataReceived),
         lastUpdate: Date.now()
       });
     }

--- a/plugins/services/src/js/pages/__tests__/DeploymentsTab-test.js
+++ b/plugins/services/src/js/pages/__tests__/DeploymentsTab-test.js
@@ -43,7 +43,7 @@ describe('DeploymentsTab', function () {
         }
       ]
     });
-    DCOSStore.dataProcessed = true;
+    DCOSStore.serviceDataReceived = true;
     DCOSStore.deploymentsList = deployments;
     this.container = global.document.createElement('div');
     this.instance = ReactDOM.render(

--- a/plugins/services/src/js/pages/services/DeploymentsTab.js
+++ b/plugins/services/src/js/pages/services/DeploymentsTab.js
@@ -420,7 +420,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
 
   render() {
     const deployments = DCOSStore.deploymentsList.getItems();
-    const loading = !DCOSStore.dataProcessed;
+    const loading = !DCOSStore.serviceDataReceived;
 
     if (loading) {
       return this.renderLoading();

--- a/src/js/pages/DashboardPage.js
+++ b/src/js/pages/DashboardPage.js
@@ -211,7 +211,7 @@ var DashboardPage = React.createClass({
               footer={this.getViewAllServicesBtn()}
               footerClass="text-align-center">
               <ServiceList
-                healthProcessed={DCOSStore.dataProcessed}
+                healthProcessed={DCOSStore.serviceDataReceived}
                 services={this.getServicesList()} />
             </Panel>
           </div>

--- a/src/js/pages/__tests__/JobsTab-test.js
+++ b/src/js/pages/__tests__/JobsTab-test.js
@@ -25,7 +25,7 @@ describe('JobsTab', function () {
     DCOSStore.jobTree = new JobTree(MetronomeUtil.parseJobs([{
       id: '/test'
     }]));
-    DCOSStore.dataProcessed = true;
+    DCOSStore.jobDataReceived = true;
     this.container = global.document.createElement('div');
   });
 
@@ -47,7 +47,7 @@ describe('JobsTab', function () {
     });
 
     it('renders loading screen', function () {
-      DCOSStore.dataProcessed = false;
+      DCOSStore.jobDataReceived = false;
       var instance = ReactDOM.render(
         JestUtil.stubRouterContext(JobsTab, {params: {id: '/'}}),
         this.container

--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -183,7 +183,7 @@ class JobsTab extends mixin(StoreMixin) {
 
   getContents(item, modal) {
     // Render loading screen
-    if (!DCOSStore.dataProcessed) {
+    if (!DCOSStore.jobDataReceived) {
       return (
         <Page>
           <Page.Header breadcrumbs={<JobsBreadcrumbs/>} />


### PR DESCRIPTION
---
ℹ️   _This PR basically cherry-picks a DC/OS UI 1.8 fix (#1303) into master, which wasn't forwarded earlier due to the planned GraphQL refactoring._

---

Rename `dataProcessed` to `serviceDataReceived` and introduce a new job specific data received getter to entangle the Job and Service data received/processed behavior. This changes will make sure that we don't block the Job table rendering in case we didn't get any Service data,
which in some cases resulted in an unusable UI.

Closes DCOS-11160