### PR TITLE
DCOS-13246: Disabling portMapping when using MESOS + Virtual Network

### DIFF
--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -404,16 +404,19 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     const {portDefinitions, container, networkType} = this.props.data;
     const type = findNestedPropertyInObject(container, 'type');
     const isMesosRuntime = !type || type === NONE;
+    const isUniversalContainerizer = !type || type === MESOS;
     const isUserNetwork = networkType && networkType.startsWith(USER);
 
     // Mesos Runtime doesn't support Service Endpoints for the USER network
-    if (isMesosRuntime && isUserNetwork) {
+    if ((isMesosRuntime || isUniversalContainerizer) && isUserNetwork) {
+      const tooltipMessage = `Service Endpoints are not available in the ${ContainerConstants.labelMap[type]}`;
+
       return (
         <div>
           <h3 className="short-bottom muted" key="service-endpoints-header">
             {'Service Endpoints '}
             <Tooltip
-              content="Service Endpoints are not available in the Mesos Runtime"
+              content={tooltipMessage}
               maxWidth={500}
               scrollContainer=".gm-scroll-view"
               wrapText={true}>

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -406,9 +406,11 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     const isMesosRuntime = !type || type === NONE;
     const isUniversalContainerizer = !type || type === MESOS;
     const isUserNetwork = networkType && networkType.startsWith(USER);
+    const isBridgeNetwork = networkType && networkType.startsWith(BRIDGE);
 
     // Mesos Runtime doesn't support Service Endpoints for the USER network
-    if ((isMesosRuntime || isUniversalContainerizer) && isUserNetwork) {
+    if ((isMesosRuntime || isUniversalContainerizer) &&
+        (isUserNetwork || isBridgeNetwork)) {
       const tooltipMessage = `Service Endpoints are not available in the ${ContainerConstants.labelMap[type]}`;
 
       return (

--- a/plugins/services/src/js/reducers/serviceForm/Docker.js
+++ b/plugins/services/src/js/reducers/serviceForm/Docker.js
@@ -5,7 +5,7 @@ import ContainerConstants from '../../constants/ContainerConstants';
 import Networking from '../../../../../../src/js/constants/Networking';
 import networkingReducer from './Networking';
 
-const {DOCKER} = ContainerConstants.type;
+const {DOCKER, NONE} = ContainerConstants.type;
 
 const {BRIDGE, HOST, USER} = Networking.type;
 
@@ -31,7 +31,19 @@ module.exports = combineReducers({
   forcePullImage: getContainerSettingsReducer('forcePullImage'),
   image: simpleReducer('container.docker.image', ''),
   network(state, {type, path = [], value}) {
+    if (!this.containerType) {
+      this.containerType = NONE;
+    }
+
     const joinedPath = path.join('.');
+    if (type === SET && joinedPath === 'container.type') {
+      this.containerType = value;
+    }
+
+    // Universal containerizer does not support network
+    if (this.containerType !== DOCKER) {
+      return null;
+    }
 
     if (type === SET && joinedPath === 'container.docker.network') {
       return Networking.type[value.split('.')[0]];
@@ -40,15 +52,22 @@ module.exports = combineReducers({
     return state;
   },
   portMappings(state, action) {
-    const {path = [], value} = action;
+    const {path = [], value, type} = action;
     if (!this.appState) {
       this.appState = {
         id: '',
         networkType: HOST
       };
     }
+    if (!this.containerType) {
+      this.containerType = NONE;
+    }
 
     const joinedPath = path.join('.');
+    if (type === SET && joinedPath === 'container.type') {
+      this.containerType = value;
+    }
+
     if (joinedPath === 'container.docker.network' && Boolean(value)) {
       this.appState.networkType = value.split('.')[0];
     }
@@ -60,6 +79,11 @@ module.exports = combineReducers({
     // Apply networkingReducer to retrieve updated local state
     // Store the change no matter what network type we have
     this.portDefinitions = networkingReducer(this.portDefinitions, action);
+
+    // Universal containerizer does not support portMappings
+    if (this.containerType !== DOCKER) {
+      return null;
+    }
 
     // We only want portMappings for networks of type BRIDGE or USER
     if (this.appState.networkType !== BRIDGE &&

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -17,7 +17,7 @@ describe('Container', function () {
             forcePullImage: null,
             image: '',
             privileged: null,
-            network: undefined,
+            network: null,
             portMappings: null
           }
         });
@@ -72,7 +72,7 @@ describe('Container', function () {
       )).toEqual({type: 'MESOS', docker: {image: 'foo',
         forcePullImage: null,
         privileged: null,
-        network: undefined,
+        network: null,
         portMappings: null
       }});
     });
@@ -197,7 +197,7 @@ describe('Container', function () {
           forcePullImage: null,
           image: '',
           privileged: null,
-          network: undefined,
+          network: null,
           portMappings: null
         }
       });
@@ -222,7 +222,7 @@ describe('Container', function () {
         docker: {
           forcePullImage: null,
           image: 'foo',
-          network: undefined,
+          network: null,
           portMappings: null,
           privileged: null
         }
@@ -249,7 +249,7 @@ describe('Container', function () {
         docker: {
           forcePullImage: true,
           image: 'foo',
-          network: undefined,
+          network: null,
           portMappings: null,
           privileged: null
         }
@@ -305,7 +305,7 @@ describe('Container', function () {
         forcePullImage: null,
         image: '',
         privileged: null,
-        network: undefined,
+        network: null,
         portMappings: null
       }});
     });
@@ -314,12 +314,14 @@ describe('Container', function () {
 
       it('should create default portDefinition configurations', function () {
         let batch = new Batch();
+        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
         batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
         batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
+            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
@@ -334,6 +336,7 @@ describe('Container', function () {
 
       it('shouldn\'t include hostPort or protocol when not enabled', function () {
         let batch = new Batch();
+        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
         batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
         // This is default
         // batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], false));
@@ -343,6 +346,7 @@ describe('Container', function () {
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
+            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
@@ -357,6 +361,7 @@ describe('Container', function () {
 
       it('should include hostPort or protocol when not enabled for BRIDGE', function () {
         let batch = new Batch();
+        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
         batch = batch.add(new Transaction(['container', 'docker', 'network'], BRIDGE, SET));
         // This is default
         // batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], false));
@@ -368,6 +373,7 @@ describe('Container', function () {
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
+            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
@@ -382,12 +388,14 @@ describe('Container', function () {
 
       it('should create default portDefinition configurations', function () {
         let batch = new Batch();
+        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
         batch = batch.add(new Transaction(['container', 'docker', 'network'], BRIDGE, SET));
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
         batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
+            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
@@ -410,7 +418,7 @@ describe('Container', function () {
               forcePullImage: null,
               image: '',
               privileged: null,
-              network: undefined,
+              network: null,
               portMappings: null
             }
           });
@@ -418,16 +426,18 @@ describe('Container', function () {
 
       it('shouldn\'t create portMappings for HOST', function () {
         let batch = new Batch();
+        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
         batch = batch.add(new Transaction(['container', 'docker', 'network'], HOST, SET));
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
         batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual({docker: {network: HOST, forcePullImage: null, image: '', privileged: null, portMappings: null}});
+          .toEqual({docker: {network: HOST, forcePullImage: null, image: '', privileged: null, portMappings: null}, type: 'DOCKER'});
       });
 
       it('should create two default portDefinition configurations', function () {
         let batch = new Batch();
+        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
         batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
         batch = batch.add(new Transaction(['portDefinitions'], 1, ADD_ITEM));
@@ -436,6 +446,7 @@ describe('Container', function () {
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
+            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
@@ -451,6 +462,7 @@ describe('Container', function () {
 
       it('should set the name value', function () {
         let batch = new Batch();
+        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
         batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
         batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
@@ -458,6 +470,7 @@ describe('Container', function () {
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
+            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
@@ -472,6 +485,7 @@ describe('Container', function () {
 
       it('should set the port value', function () {
         let batch = new Batch();
+        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
         batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
         batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
@@ -480,6 +494,7 @@ describe('Container', function () {
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
+            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
@@ -494,6 +509,7 @@ describe('Container', function () {
 
       it('should default port value to 0 if automaticPort', function () {
         let batch = new Batch();
+        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
         batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
         batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
@@ -503,6 +519,7 @@ describe('Container', function () {
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
+            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
@@ -517,6 +534,7 @@ describe('Container', function () {
 
       it('should set the protocol value', function () {
         let batch = new Batch();
+        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
         batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
         batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
@@ -525,6 +543,7 @@ describe('Container', function () {
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
+            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
@@ -539,6 +558,7 @@ describe('Container', function () {
 
       it('should add the labels key if the portDefinition is load balanced', function () {
         let batch = new Batch();
+        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
         batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
         batch = batch.add(new Transaction(['portDefinitions'], 1, ADD_ITEM));
@@ -548,6 +568,7 @@ describe('Container', function () {
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
+            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
@@ -563,6 +584,7 @@ describe('Container', function () {
 
       it('should add the index of the portDefinition to the VIP keys', function () {
         let batch = new Batch();
+        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
         batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
         batch = batch.add(new Transaction(['portDefinitions'], 1, ADD_ITEM));
@@ -573,6 +595,7 @@ describe('Container', function () {
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
+            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
@@ -588,6 +611,7 @@ describe('Container', function () {
 
       it('should add the port to the VIP string', function () {
         let batch = new Batch();
+        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
         batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
@@ -599,6 +623,7 @@ describe('Container', function () {
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
+            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
@@ -614,6 +639,7 @@ describe('Container', function () {
 
       it('should add the app ID to the VIP string when it is defined', function () {
         let batch = new Batch();
+        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
         batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
@@ -625,6 +651,7 @@ describe('Container', function () {
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
+            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
@@ -640,6 +667,7 @@ describe('Container', function () {
 
       it('should store portDefinitions even if network is HOST when recorded', function () {
         let batch = new Batch();
+        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
         batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
@@ -651,6 +679,7 @@ describe('Container', function () {
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
+            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
@@ -660,6 +689,26 @@ describe('Container', function () {
                 {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', servicePort: null},
                 {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', labels: {'VIP_1': 'foo:0'}, servicePort: null}
               ]
+            }
+          });
+      });
+
+      it('should\'t create portMappings when container.type is MESOS', function () {
+        let batch = new Batch();
+        batch = batch.add(new Transaction(['container', 'type'], 'MESOS', SET));
+        batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
+        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+        batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+
+        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+          .toEqual({
+            type: 'MESOS',
+            docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
+              network: null,
+              portMappings: null
             }
           });
       });


### PR DESCRIPTION
Apparently mesos does not support MESOS containerizer and the `portMapping` property to be present in the `docker` object. This PR ensures this does not happen