### PR TITLE
DCOS-13282: Force text wrapping in configuration-map-labels

### DIFF
--- a/src/styles/components/configuration-map/styles.less
+++ b/src/styles/components/configuration-map/styles.less
@@ -54,6 +54,24 @@
       }
     }
 
+    &,
+    &-table {
+
+      &-label {
+
+        &,
+        & > * {
+          overflow-wrap: break-word;
+          word-break: break-all;
+        }
+
+        code,
+        pre {
+          white-space: pre-wrap;
+        }
+      }
+    }
+
     &-label {
       color: @neutral;
       flex: 0 0 @configuration-map-label-width;


### PR DESCRIPTION
This PR forces text to overwrap in the `.configuration-map-label` and `.configuration-map-table-label` classes.

Before:
![](https://cl.ly/0o27450l1j1w/Screen%20Shot%202017-01-18%20at%2010.28.07%20AM.png)

After:
![](https://cl.ly/1l3n0o0v1S3k/Screen%20Shot%202017-01-18%20at%2010.25.24%20AM.png)