### PR TITLE
DCOS-12974: Use smaller container icon

### DIFF
--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -395,7 +395,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
             <FieldError>{networkError}</FieldError>
           </FormGroup>
         </FormRow>
-        <h3 className="flush-top short-bottom">
+        <h3 className="short-bottom">
           Service Endpoints
         </h3>
         <p>

--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -285,7 +285,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
       return (
         <div key={index}>
           <h3 className="short-bottom">
-            <Icon id="container" size="medium" color="purple" />
+            <Icon id="container" size="mini" color="purple" />
             {` ${container.name}`}
           </h3>
           {this.getServiceContainerEndpoints(endpoints, index)}

--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -74,7 +74,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
     let placeholder;
     let value = endpoint.hostPort;
     const {errors} = this.props;
-    let hostPortError = findNestedPropertyInObject(
+    const hostPortError = findNestedPropertyInObject(
       errors,
       `containers.${containerIndex}.endpoints.${index}.port`
     );
@@ -84,7 +84,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
       value = null;
     }
 
-    let tooltipContent = (
+    const tooltipContent = (
       <span>
         {`This host port will be accessible as an environment variable called '$PORT${index}'. `}
         <a href="https://mesosphere.github.io/marathon/docs/ports.html" about="_blank">
@@ -196,7 +196,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
 
   getProtocolField(endpoint, index, containerIndex) {
     const {errors} = this.props;
-    let protocolError = findNestedPropertyInObject(
+    const protocolError = findNestedPropertyInObject(
       errors,
       `containers.${containerIndex}.endpoints.${index}.protocol`
     );
@@ -325,7 +325,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
         <option
           key={index}
           value={virtualNetwork.value}>
-        {virtualNetwork.text}
+          {virtualNetwork.text}
         </option>
       );
     });
@@ -356,12 +356,12 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
   }
 
   render() {
-    let networkError = findNestedPropertyInObject(
+    const networkError = findNestedPropertyInObject(
       this.props.errors,
       'container.docker.network'
     );
 
-    let tooltipContent = (
+    const tooltipContent = (
       <span>
         {'Choose BRIDGE, HOST, or USER networking. Refer to the '}
         <a href="https://mesosphere.github.io/marathon/docs/ports.html" target="_blank">


### PR DESCRIPTION
⚠️ There's no green light to 24x24 icon, due to the time lag. Yet I like how it looks and think that this will be the decision. Anyways please check the discussion before hitting that merge button https://mesosphere.atlassian.net/browse/DCOS-12974

---

This PR 
1. adds margin between the network type dropbox and the header
2. reduces size of the container icon

Before:
<img width="589" alt="screen shot 2017-01-19 at 10 44 44" src="https://cloud.githubusercontent.com/assets/186223/22101732/f27b07d0-de34-11e6-9974-61c77a5d4f79.png">

After:
<img width="622" alt="screen shot 2017-01-19 at 10 44 06" src="https://cloud.githubusercontent.com/assets/186223/22101739/f74a6eea-de34-11e6-8260-7f277ea8cc4d.png">
