### PR TITLE
Be more specific on the required versions of node and npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-Node 4.x and NPM 3.x (and above) are **required**. We suggest using [nvm](https://github.com/creationix/nvm) or [n](https://github.com/tj/n) to keep multiple Node versions on your system.
+Node 4.4.x and NPM 3.9.x (and above) are **required**. We suggest using [nvm](https://github.com/creationix/nvm) or [n](https://github.com/tj/n) to keep multiple Node versions on your system.
 
 
 


### PR DESCRIPTION
That one appeared during the on-site session. In README we ask for node 4.x and npm 3.x but we test for 4.4.x and 3.9.x respectively. Since node 4.7.2 and npm 3.10.10 are available our README requirement is wrong.