### PR TITLE
DCOS-12628: Allow tcp & udp simultaneously for multi container

### DIFF
--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -208,24 +208,22 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
           Protocol
         </FieldLabel>
         <FormRow>
-          <FormGroup className="column-auto" key="protocol-tcp">
-            <FieldLabel matchInputHeight={true}>
-              <FieldInput
-                checked={endpoint.protocol === 'tcp'}
-                name={`containers.${containerIndex}.endpoints.${index}.protocol`}
-                type="radio"
-                value="tcp" />
-              TCP
-            </FieldLabel>
-          </FormGroup>
           <FormGroup className="column-auto" key="protocol-udp">
             <FieldLabel matchInputHeight={true}>
               <FieldInput
-                checked={endpoint.protocol === 'udp'}
-                name={`containers.${containerIndex}.endpoints.${index}.protocol`}
-                type="radio"
-                value="udp" />
+                checked={endpoint.protocol.udp}
+                name={`containers.${containerIndex}.endpoints.${index}.protocol.udp`}
+                type="checkbox" />
               UDP
+            </FieldLabel>
+          </FormGroup>
+          <FormGroup className="column-auto" key="protocol-tcp">
+            <FieldLabel matchInputHeight={true}>
+              <FieldInput
+                checked={endpoint.protocol.tcp}
+                name={`containers.${containerIndex}.endpoints.${index}.protocol.tcp`}
+                type="checkbox" />
+              TCP
             </FieldLabel>
           </FormGroup>
         </FormRow>

--- a/plugins/services/src/js/reducers/serviceForm/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/Containers.js
@@ -18,6 +18,7 @@ import {
   FormReducer as multiContainerHealthFormReducer
 } from './MultiContainerHealthChecks';
 import {isEmpty} from '../../../../../../src/js/utils/ValidatorUtil';
+import {PROTOCOLS} from '../../constants/PortDefinitionConstants';
 import Networking from '../../../../../../src/js/constants/Networking';
 import VipLabelUtil from '../../utils/VipLabelUtil';
 
@@ -240,38 +241,22 @@ function containersParser(state) {
               'labels'
             ], item.labels));
           }
-          if (endpoint.protocol) {
-            endpoint.protocol.forEach(function (protocol) {
-              memo.push(new Transaction(
-                [
-                  'containers',
-                  index,
-                  'endpoints',
-                  endpointIndex,
-                  'protocol',
-                  protocol
-                ],
-                true
-              ));
-            });
-          }
         }
 
-        if (networkMode === HOST.toLowerCase() && endpoint.protocol) {
-          endpoint.protocol.forEach(function (protocol) {
-            memo.push(new Transaction(
-              [
-                'containers',
-                index,
-                'endpoints',
-                endpointIndex,
-                'protocol',
-                protocol
-              ],
-              true
-            ));
-          });
-        }
+        const protocols = endpoint.protocol || [];
+        PROTOCOLS.forEach((protocol) => {
+          memo.push(new Transaction(
+            [
+              'containers',
+              index,
+              'endpoints',
+              endpointIndex,
+              'protocol',
+              protocol
+            ],
+            protocols.includes(protocol), SET
+          ));
+        });
       });
     }
 

--- a/plugins/services/src/js/reducers/serviceForm/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/Containers.js
@@ -240,22 +240,24 @@ function containersParser(state) {
               'labels'
             ], item.labels));
           }
-          endpoint.protocol.forEach(function (protocol) {
-            memo.push(new Transaction(
-              [
-                'containers',
-                index,
-                'endpoints',
-                endpointIndex,
-                'protocol',
-                protocol
-              ],
-              true
-            ));
-          });
+          if (endpoint.protocol) {
+            endpoint.protocol.forEach(function (protocol) {
+              memo.push(new Transaction(
+                [
+                  'containers',
+                  index,
+                  'endpoints',
+                  endpointIndex,
+                  'protocol',
+                  protocol
+                ],
+                true
+              ));
+            });
+          }
         }
 
-        if (networkMode === HOST.toLowerCase()) {
+        if (networkMode === HOST.toLowerCase() && endpoint.protocol) {
           endpoint.protocol.forEach(function (protocol) {
             memo.push(new Transaction(
               [

--- a/plugins/services/src/js/reducers/serviceForm/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/Containers.js
@@ -21,6 +21,8 @@ import {isEmpty} from '../../../../../../src/js/utils/ValidatorUtil';
 import Networking from '../../../../../../src/js/constants/Networking';
 import VipLabelUtil from '../../utils/VipLabelUtil';
 
+const {CONTAINER, HOST} = Networking.type;
+
 const containerReducer = combineReducers({
   cpus: simpleReducer('resources.cpus'),
   mem: simpleReducer('resources.mem'),
@@ -67,7 +69,7 @@ function mapEndpoints(endpoints = [], networkType, appState) {
       hostPort = 0;
     }
 
-    if (networkType === Networking.type.CONTAINER) {
+    if (networkType === CONTAINER) {
       const vipLabel = `VIP_${index}`;
 
       labels = VipLabelUtil.generateVipLabel(
@@ -209,7 +211,7 @@ function containersParser(state) {
           )
         ]);
 
-        if (networkMode === Networking.type.CONTAINER.toLowerCase()) {
+        if (networkMode === CONTAINER.toLowerCase()) {
           memo.push(new Transaction(
             ['containers', index, 'endpoints', endpointIndex, 'containerPort'],
             endpoint.containerPort
@@ -253,7 +255,7 @@ function containersParser(state) {
           });
         }
 
-        if (networkMode === Networking.type.HOST.toLowerCase()) {
+        if (networkMode === HOST.toLowerCase()) {
           endpoint.protocol.forEach(function (protocol) {
             memo.push(new Transaction(
               [
@@ -299,7 +301,7 @@ module.exports = {
     const [base, index, field, secondIndex, name, subField] = path;
 
     if (this.networkType == null) {
-      this.networkType = Networking.type.HOST;
+      this.networkType = HOST;
     }
 
     if (this.appState == null) {

--- a/plugins/services/src/js/reducers/serviceForm/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/Containers.js
@@ -180,6 +180,11 @@ function containersParser(state) {
 
     if (item.endpoints != null && item.endpoints.length !== 0) {
       item.endpoints.forEach((endpoint, endpointIndex) => {
+        const networkMode = findNestedPropertyInObject(
+          state,
+          'state.networks.0.mode'
+        );
+
         memo = memo.concat([
           new Transaction(
             ['containers', index, 'endpoints'],
@@ -204,8 +209,7 @@ function containersParser(state) {
           )
         ]);
 
-        if (state.networks && state.networks[0] &&
-          state.networks[0].mode === Networking.type.CONTAINER.toLowerCase()) {
+        if (networkMode === Networking.type.CONTAINER.toLowerCase()) {
           memo.push(new Transaction(
             ['containers', index, 'endpoints', endpointIndex, 'containerPort'],
             endpoint.containerPort
@@ -249,8 +253,7 @@ function containersParser(state) {
           });
         }
 
-        if (state.networks && state.networks[0] &&
-          state.networks[0].mode === Networking.type.HOST.toLowerCase()) {
+        if (networkMode === Networking.type.HOST.toLowerCase()) {
           endpoint.protocol.forEach(function (protocol) {
             memo.push(new Transaction(
               [

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
@@ -183,8 +183,9 @@ describe('Containers', function () {
                 0,
                 'endpoints',
                 0,
-                'protocol'
-              ], 'udp'));
+                'protocol',
+                'udp'
+              ], true));
 
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
@@ -199,6 +200,7 @@ describe('Containers', function () {
                   name: null,
                   hostPort: 0,
                   protocol: [
+                    'tcp',
                     'udp'
                   ]
                 }
@@ -227,8 +229,9 @@ describe('Containers', function () {
                 0,
                 'endpoints',
                 0,
-                'protocol'
-              ], 'foo'));
+                'protocol',
+                'foo'
+              ], true));
 
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
@@ -243,6 +246,7 @@ describe('Containers', function () {
                   name: null,
                   hostPort: 0,
                   protocol: [
+                    'tcp',
                     'foo'
                   ]
                 }
@@ -422,8 +426,9 @@ describe('Containers', function () {
                 0,
                 'endpoints',
                 0,
-                'protocol'
-              ], 'udp'));
+                'protocol',
+                'udp'
+              ], true));
 
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
@@ -440,6 +445,7 @@ describe('Containers', function () {
                   labels: null,
                   hostPort: 0,
                   protocol: [
+                    'tcp',
                     'udp'
                   ]
                 }
@@ -468,8 +474,9 @@ describe('Containers', function () {
                 0,
                 'endpoints',
                 0,
-                'protocol'
-              ], 'foo'));
+                'protocol',
+                'foo'
+              ], true));
 
           expect(batch.reduce(Containers.JSONReducer.bind({})))
           .toEqual([
@@ -486,6 +493,7 @@ describe('Containers', function () {
                   labels: null,
                   hostPort: 0,
                   protocol: [
+                    'tcp',
                     'foo'
                   ]
                 }
@@ -887,7 +895,10 @@ describe('Containers', function () {
                   name: null,
                   loadBalanced: false,
                   vip: null,
-                  protocol: 'tcp',
+                  protocol: {
+                    tcp: true,
+                    udp: false
+                  },
                   servicePort: null,
                   containerPort: null
                 }
@@ -933,7 +944,10 @@ describe('Containers', function () {
                   name: 'foo',
                   loadBalanced: false,
                   vip: null,
-                  protocol: 'tcp',
+                  protocol: {
+                    tcp: true,
+                    udp: false
+                  },
                   servicePort: null,
                   containerPort: null
                 }
@@ -997,7 +1011,10 @@ describe('Containers', function () {
                   name: 'foo',
                   loadBalanced: false,
                   vip: null,
-                  protocol: 'tcp',
+                  protocol: {
+                    tcp: true,
+                    udp: false
+                  },
                   servicePort: null,
                   containerPort: null
                 }
@@ -1026,8 +1043,9 @@ describe('Containers', function () {
                 0,
                 'endpoints',
                 0,
-                'protocol'
-              ], 'udp'));
+                'protocol',
+                'udp'
+              ], true));
 
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
@@ -1045,7 +1063,10 @@ describe('Containers', function () {
                   name: null,
                   loadBalanced: false,
                   vip: null,
-                  protocol: 'udp',
+                  protocol: {
+                    tcp: true,
+                    udp: true
+                  },
                   servicePort: null,
                   containerPort: null
                 }
@@ -1074,8 +1095,9 @@ describe('Containers', function () {
                 0,
                 'endpoints',
                 0,
-                'protocol'
-              ], 'foo'));
+                'protocol',
+                'foo'
+              ], true));
 
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
@@ -1093,7 +1115,11 @@ describe('Containers', function () {
                   name: null,
                   loadBalanced: false,
                   vip: null,
-                  protocol: 'foo',
+                  protocol: {
+                    tcp: true,
+                    udp: false,
+                    foo: true
+                  },
                   servicePort: null,
                   containerPort: null
                 }
@@ -1136,7 +1162,10 @@ describe('Containers', function () {
                   name: null,
                   loadBalanced: false,
                   vip: null,
-                  protocol: 'tcp',
+                  protocol: {
+                    tcp: true,
+                    udp: false
+                  },
                   servicePort: null,
                   containerPort: null
                 }
@@ -1184,7 +1213,10 @@ describe('Containers', function () {
                   name: 'foo',
                   loadBalanced: false,
                   vip: null,
-                  protocol: 'tcp',
+                  protocol: {
+                    tcp: true,
+                    udp: false
+                  },
                   servicePort: null,
                   containerPort: null
                 }
@@ -1250,7 +1282,10 @@ describe('Containers', function () {
                   name: 'foo',
                   loadBalanced: false,
                   vip: null,
-                  protocol: 'tcp',
+                  protocol: {
+                    tcp: true,
+                    udp: false
+                  },
                   servicePort: null,
                   containerPort: null
                 }
@@ -1280,8 +1315,9 @@ describe('Containers', function () {
                 0,
                 'endpoints',
                 0,
-                'protocol'
-              ], 'udp'));
+                'protocol',
+                'udp'
+              ], true));
 
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
@@ -1299,7 +1335,10 @@ describe('Containers', function () {
                   name: null,
                   loadBalanced: false,
                   vip: null,
-                  protocol: 'udp',
+                  protocol: {
+                    tcp: true,
+                    udp: true
+                  },
                   servicePort: null,
                   containerPort: null
                 }
@@ -1328,8 +1367,9 @@ describe('Containers', function () {
                 0,
                 'endpoints',
                 0,
-                'protocol'
-              ], 'foo'));
+                'protocol',
+                'foo'
+              ], true));
 
           expect(batch.reduce(Containers.FormReducer.bind({})))
           .toEqual([
@@ -1347,7 +1387,11 @@ describe('Containers', function () {
                   name: null,
                   loadBalanced: false,
                   vip: null,
-                  protocol: 'foo',
+                  protocol: {
+                    foo: true,
+                    tcp: true,
+                    udp: false
+                  },
                   servicePort: null,
                   containerPort: null
                 }
@@ -1395,7 +1439,10 @@ describe('Containers', function () {
                   name: null,
                   loadBalanced: false,
                   vip: null,
-                  protocol: 'tcp',
+                  protocol: {
+                    tcp: true,
+                    udp: false
+                  },
                   servicePort: null,
                   containerPort: 8080
                 }
@@ -1453,7 +1500,10 @@ describe('Containers', function () {
                   name: null,
                   loadBalanced: true,
                   vip: null,
-                  protocol: 'tcp',
+                  protocol: {
+                    tcp: true,
+                    udp: false
+                  },
                   servicePort: null,
                   containerPort: 8080
                 }
@@ -1520,7 +1570,10 @@ describe('Containers', function () {
                   name: null,
                   loadBalanced: true,
                   vip: '1.3.3.7:8080',
-                  protocol: 'tcp',
+                  protocol: {
+                    tcp: true,
+                    udp: false
+                  },
                   servicePort: null,
                   containerPort: 8080
                 }
@@ -1580,7 +1633,10 @@ describe('Containers', function () {
                   name: null,
                   loadBalanced: true,
                   vip: null,
-                  protocol: 'tcp',
+                  protocol: {
+                    tcp: true,
+                    udp: false
+                  },
                   servicePort: null,
                   containerPort: 8080
                 }
@@ -1650,7 +1706,10 @@ describe('Containers', function () {
                   loadBalanced: true,
                   containerPort: 8080,
                   vip: '1.3.3.7:8080',
-                  protocol: 'tcp',
+                  protocol: {
+                    tcp: true,
+                    udp: false
+                  },
                   servicePort: null
                 }
               ]


### PR DESCRIPTION
This PR adds support for multiple values in protocol array field. To achieve it I replaced radio buttons with checkboxes and changed underlying data format and logic. I also changed the order of checkboxes, so that single and multi container forms match.

As Mesos doesn't restrict any specific values in the array, nor does the Marathon, I also enhanced this logic. So that @philipnrmn could use GOPHER :) 

Depends on the Single-container version: #1820 

<img width="937" alt="screen shot 2017-01-19 at 16 30 41" src="https://cloud.githubusercontent.com/assets/186223/22112806/a3dae55c-de64-11e6-9f0f-16c6c5afc7fd.png">
