### PR TITLE
[1 of 3: User Account Menu] DCOS-12462: Extend ClipboardTrigger functionality

### DIFF
--- a/src/js/components/ClipboardTrigger.js
+++ b/src/js/components/ClipboardTrigger.js
@@ -46,22 +46,24 @@ class ClipboardTrigger extends React.Component {
   getTriggerContent() {
     const {children, className} = this.props;
 
+    let childNode = (
+      <Icon
+        id="clipboard"
+        size="mini"
+        className={`clickable icon-clipboard ${className}`}
+        color="purple" />
+    );
+
     if (children != null) {
-      return (
-        <span className={className} onMouseEnter={this.handleCopyIconMouseEnter}
-          ref="copyButton">
-          {children}
-        </span>
-      );
+      childNode = children;
     }
 
     return (
-      <span onMouseEnter={this.handleCopyIconMouseEnter} ref="copyButton">
-        <Icon
-          id="clipboard"
-          size="mini"
-          className={`clickable icon-clipboard ${className}`}
-          color="purple" />
+      <span
+        className={className}
+        onMouseEnter={this.handleCopyIconMouseEnter}
+        ref="copyButton">
+        {childNode}
       </span>
     );
   }
@@ -80,13 +82,10 @@ class ClipboardTrigger extends React.Component {
 
   render() {
     const {copiedText, tooltipContent, useTooltip} = this.props;
+    const {hasCopiedToClipboard} = this.state;
 
     if (useTooltip) {
-      let text = tooltipContent;
-
-      if (this.state.hasCopiedToClipboard) {
-        text = copiedText;
-      }
+      const text = hasCopiedToClipboard ? copiedText : tooltipContent;
 
       return (
         <Tooltip position="bottom" content={text}>

--- a/src/js/components/ClipboardTrigger.js
+++ b/src/js/components/ClipboardTrigger.js
@@ -56,13 +56,13 @@ class ClipboardTrigger extends React.Component {
     }
 
     return (
-      <Icon
-        id="clipboard"
-        size="mini"
-        className={`clickable icon-clipboard ${className}`}
-        color="purple"
-        onMouseEnter={this.handleCopyIconMouseEnter}
-        ref="copyButton" />
+      <span onMouseEnter={this.handleCopyIconMouseEnter} ref="copyButton">
+        <Icon
+          id="clipboard"
+          size="mini"
+          className={`clickable icon-clipboard ${className}`}
+          color="purple" />
+      </span>
     );
   }
 

--- a/src/js/components/ClipboardTrigger.js
+++ b/src/js/components/ClipboardTrigger.js
@@ -1,4 +1,3 @@
-import browserInfo from 'browser-info';
 import Clipboard from 'clipboard';
 import React, {PropTypes} from 'react';
 import ReactDOM from 'react-dom';
@@ -44,8 +43,35 @@ class ClipboardTrigger extends React.Component {
     }
   }
 
+  getTriggerContent() {
+    const {children, className} = this.props;
+
+    if (children != null) {
+      return (
+        <span className={className} onMouseEnter={this.handleCopyIconMouseEnter}
+          ref="copyButton">
+          {children}
+        </span>
+      );
+    }
+
+    return (
+      <Icon
+        id="clipboard"
+        size="mini"
+        className={`clickable icon-clipboard ${className}`}
+        color="purple"
+        onMouseEnter={this.handleCopyIconMouseEnter}
+        ref="copyButton" />
+    );
+  }
+
   handleCopy() {
     this.setState({hasCopiedToClipboard: true});
+
+    if (this.props.onTextCopy) {
+      this.props.onTextCopy();
+    }
   }
 
   handleCopyIconMouseEnter() {
@@ -53,30 +79,23 @@ class ClipboardTrigger extends React.Component {
   }
 
   render() {
-    if (/safari/i.test(browserInfo().name)) {
-      return null;
+    const {copiedText, tooltipContent, useTooltip} = this.props;
+
+    if (useTooltip) {
+      let text = tooltipContent;
+
+      if (this.state.hasCopiedToClipboard) {
+        text = copiedText;
+      }
+
+      return (
+        <Tooltip position="bottom" content={text}>
+          {this.getTriggerContent()}
+        </Tooltip>
+      );
     }
 
-    const {copiedText, tooltipContent} = this.props;
-    const clipboardIcon = (
-      <Icon
-        id="clipboard"
-        size="mini"
-        className="clickable icon-clipboard"
-        color="purple"
-        onMouseEnter={this.handleCopyIconMouseEnter} />
-    );
-    let text = tooltipContent;
-
-    if (this.state.hasCopiedToClipboard) {
-      text = copiedText;
-    }
-
-    return (
-      <Tooltip position="bottom" content={text} ref="copyButton">
-        {clipboardIcon}
-      </Tooltip>
-    );
+    return this.getTriggerContent();
   }
 }
 
@@ -86,9 +105,13 @@ ClipboardTrigger.defaultProps = {
 };
 
 ClipboardTrigger.propTypes = {
-  copiedText: PropTypes.string,
-  copyText: PropTypes.string,
-  tooltipContent: PropTypes.string
+  children: PropTypes.node,
+  className: PropTypes.string,
+  copiedText: PropTypes.node,
+  copyText: PropTypes.node,
+  onTextCopy: PropTypes.func,
+  tooltipContent: PropTypes.node,
+  useTooltip: PropTypes.bool
 };
 
 module.exports = ClipboardTrigger;


### PR DESCRIPTION
1 of 3: #1822 
2 of 3: #1826 — [diff between 1 and 2](https://github.com/dcos/dcos-ui/compare/john/feature/extend-clipboard-trigger...john/DCOS-12462/new-user-account-menu-components?expand=1)
3 of 3: #1827  — [diff between 2 and 3](https://github.com/dcos/dcos-ui/compare/john/DCOS-12462/new-user-account-menu-components...john/DCOS-12462/sidebar-user-account-menu?expand=1)

This PR extends the functionality of the `ClipboardTrigger` component. It allows custom trigger buttons instead of just the clipboard icon and adds an optional `onTextCopy` callback.

I also removed the Safari exclusion because Safari 10 supports the Clipboard API. As of December 2016, Safari 10 is at 2.92% global usage while Safari 9.0 + 9.1 is at 1.37% combined (and dropping quickly: http://gs.statcounter.com/#desktop-browser_version_partially_combined-ww-monthly-201512-201612).