### PR TITLE
Duplicable row delete button improvements

### DIFF
--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React, {Component} from 'react';
 import {Confirm, Tooltip} from 'reactjs-components';
 
@@ -220,6 +221,11 @@ class GeneralServiceFormSection extends Component {
         );
       }
 
+      const deleteRowButtonClassNames = classNames(
+        'column-2 flush-left',
+        {'form-group-without-top-label': padDeleteButton}
+      );
+
       return (
         <FormRow key={index}>
           <FormGroup
@@ -276,10 +282,7 @@ class GeneralServiceFormSection extends Component {
             </FieldError>
           </FormGroup>
 
-          <FormGroup className={{
-            'column-2 flush-left': true,
-            'form-group-without-top-label': padDeleteButton
-          }}>
+          <FormGroup className={deleteRowButtonClassNames}>
             <DeleteRowButton
               onClick={this.props.onRemoveItem.bind(this,
                 {value: index, path: 'constraints'})} />

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -195,6 +195,7 @@ class GeneralServiceFormSection extends Component {
       let fieldLabel = null;
       let operatorLabel = null;
       let parameterLabel = null;
+      let padDeleteButton = false;
       const showParameterField = ![GROUP_BY, UNIQUE]
         .includes(constraint.operator);
       const paramterIsRequired = [LIKE, MAX_PER_OPERATOR]
@@ -209,6 +210,7 @@ class GeneralServiceFormSection extends Component {
           'Operator',
           'Operators specify where your app will run.'
         );
+        padDeleteButton = true;
       }
       if (index === 0 && showParameterLabel) {
         parameterLabel = this.getConstraintField(
@@ -274,7 +276,10 @@ class GeneralServiceFormSection extends Component {
             </FieldError>
           </FormGroup>
 
-          <FormGroup className="flex flex-item-align-end column-2 flush-left">
+          <FormGroup className={{
+            'column-2 flush-left': true,
+            'form-group-without-top-label': padDeleteButton
+          }}>
             <DeleteRowButton
               onClick={this.props.onRemoveItem.bind(this,
                 {value: index, path: 'constraints'})} />

--- a/src/js/components/form/DeleteRowButton.js
+++ b/src/js/components/form/DeleteRowButton.js
@@ -10,7 +10,7 @@ const DeleteRowButton = ({onClick}) => {
       maxWidth={300}
       scrollContainer=".gm-scroll-view"
       wrapText={true}>
-      <a className="button button-link button-flush"
+      <a className="button button-link"
         onClick={onClick}>
         <Icon id="close" family="tiny" size="tiny" />
       </a>

--- a/src/js/components/form/FormGroupContainer.js
+++ b/src/js/components/form/FormGroupContainer.js
@@ -9,7 +9,6 @@ const FormGroupContainer = (props) => {
     removeButton = (
       <div className="form-group-container-action-button-group">
         <Tooltip content="Delete"
-          interactive={true}
           maxWidth={300}
           scrollContainer=".gm-scroll-view"
           wrapText={true}>

--- a/src/js/components/form/FormGroupContainer.js
+++ b/src/js/components/form/FormGroupContainer.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Tooltip} from 'reactjs-components';
 
 import Icon from '../Icon';
 
@@ -7,10 +8,16 @@ const FormGroupContainer = (props) => {
   if (props.onRemove != null) {
     removeButton = (
       <div className="form-group-container-action-button-group">
-        <a className="button button-primary-link"
-          onClick={props.onRemove}>
-          <Icon id="close" color="grey" size="tiny" family="tiny"/>
-        </a>
+        <Tooltip content="Delete"
+          interactive={true}
+          maxWidth={300}
+          scrollContainer=".gm-scroll-view"
+          wrapText={true}>
+          <a className="button button-primary-link"
+            onClick={props.onRemove}>
+            <Icon id="close" color="grey" size="tiny" family="tiny"/>
+          </a>
+        </Tooltip>
       </div>
     );
   }

--- a/src/styles/components/form-elements/form-row/styles.less
+++ b/src/styles/components/form-elements/form-row/styles.less
@@ -14,6 +14,11 @@
       margin-bottom: 0;
     }
   }
+
+  // Add top-padding equivalent to a label
+  .form-group-without-top-label {
+    padding-top: 1.82rem;
+  }
 }
 
 & when (@form-row-enabled) and (@layout-screen-small-enabled) {

--- a/src/styles/components/form-elements/form-row/styles.less
+++ b/src/styles/components/form-elements/form-row/styles.less
@@ -17,7 +17,7 @@
 
   // Add top-padding equivalent to a label
   .form-group-without-top-label {
-    padding-top: 1.82rem;
+    padding-top: @label-line-height + @label-margin-bottom;
   }
 }
 
@@ -46,6 +46,10 @@
         margin-top: @form-row-margin-top-screen-medium;
       }
     }
+
+    .form-group-without-top-label {
+      padding-top: @label-line-height + @label-margin-bottom-screen-medium;
+    }
   }
 }
 
@@ -59,6 +63,10 @@
       & + .form-row {
         margin-top: @form-row-margin-top-screen-large;
       }
+    }
+
+    .form-group-without-top-label {
+      padding-top: @label-line-height + @label-margin-bottom-screen-large;
     }
   }
 }


### PR DESCRIPTION
This PR
 - vertically centres the delete icons on duplicable rows in the service create
form
 - adds a 'delete' tooltip to form group containers in the service create form

Before centering the delete icons:
![](https://d3vv6lp55qjaqc.cloudfront.net/items/3z0G1F0o2E3F3t1e2u2o/image-2017-01-12-13-45-05-665.png?X-CloudApp-Visitor-Id=1905462&v=68c3d97b)

Before adding tooltips to the group containers:
https://cl.ly/0V46200O1L08