### PR TITLE
[2 of 3: User Account Menu] DCOS-12462: Create new user account menu components

### DIFF
--- a/src/js/components/UserAccountDropdownTrigger.js
+++ b/src/js/components/UserAccountDropdownTrigger.js
@@ -1,0 +1,66 @@
+import mixin from 'reactjs-mixin';
+import React from 'react';
+import {StoreMixin} from 'mesosphere-shared-reactjs';
+
+import Icon from './Icon';
+
+class UserAccountDropdownTrigger extends mixin(StoreMixin) {
+  constructor() {
+    super(...arguments);
+
+    this.store_listeners = [
+      {
+        name: 'metadata',
+        events: ['success'],
+        listenAlways: false
+      }
+    ];
+  }
+
+  componentDidUpdate() {
+    if (this.props.onUpdate) {
+      this.props.onUpdate();
+    }
+  }
+
+  render() {
+    let {primaryContent, secondaryContent = null} = this.props;
+
+    // Promote secondary content to primary content in the event that secondary
+    // is the only available content.
+    if (!primaryContent && secondaryContent) {
+      primaryContent = secondaryContent;
+      secondaryContent = null;
+    } else if (secondaryContent) {
+      secondaryContent = (
+        <div className="cluster-header-secondary">
+          {secondaryContent}
+        </div>
+      );
+    }
+
+    return (
+      <div className="cluster-header">
+        <div className="cluster-header-primary-wrapper">
+          <h5 className="cluster-header-primary inverse text-overflow flush">
+            {primaryContent}
+          </h5>
+          <Icon family="tiny" id="triangle-down" key="caret" size="tiny" />
+        </div>
+        {secondaryContent}
+      </div>
+    );
+  }
+}
+
+UserAccountDropdownTrigger.defaultProps = {
+  showCaret: false
+};
+
+UserAccountDropdownTrigger.propTypes = {
+  clusterName: React.PropTypes.node,
+  onUpdate: React.PropTypes.func,
+  showCaret: React.PropTypes.bool
+};
+
+module.exports = UserAccountDropdownTrigger;

--- a/src/styles/components/dropdown-menus/styles.less
+++ b/src/styles/components/dropdown-menus/styles.less
@@ -111,22 +111,23 @@
 
   .dropdown-menu-list {
 
-    li.clickable {
-      cursor: pointer;
-    }
+    li {
 
-    .dropdown-menu-section-header {
-      margin-top: @base-spacing-unit * 1/2;
-      padding: @dropdown-menu-header-padding-top @dropdown-menu-header-padding-right @dropdown-menu-header-padding-bottom @dropdown-menu-header-padding-left;
-
-      &:first-child {
-        margin-top: 0;
+      &.clickable {
+        cursor: pointer;
       }
 
-      label {
-        color: @dropdown-menu-header-color;
-        font-size: @dropdown-menu-header-font-size;
-        margin: 0;
+      &:first-child {
+
+        &.hidden {
+
+          & + li {
+
+            &.dropdown-menu-section-header {
+              margin-top: 0;
+            }
+          }
+        }
       }
     }
   }
@@ -138,6 +139,29 @@
   .dropdown-menu-up-leave {
     z-index: @z-index-dropdown;
   }
+
+  .dropdown-menu-section-header {
+
+    li& {
+      margin-top: @dropdown-menu-header-margin-top;
+      padding: @dropdown-menu-header-padding-vertical @dropdown-menu-header-padding-horizontal;
+
+      &:first-child {
+        margin-top: 0;
+      }
+    }
+
+    label {
+      color: @dropdown-menu-header-color;
+      font-size: @dropdown-menu-header-font-size;
+      margin: 0;
+    }
+  }
+
+  .dropdown-menu-item-padding-surrogate {
+    &:extend(.dropdown-menu-list li all);
+    display: block;
+  }
 }
 
 & when (@dropdown-menu-enabled) and (@layout-screen-small-enabled) {
@@ -145,7 +169,11 @@
   @media (min-width: @layout-screen-small-min-width) {
 
     .dropdown-menu-section-header {
-      margin-top: @base-spacing-unit-screen-small * 1/2;
+
+      li& {
+        margin-top: @dropdown-menu-header-margin-top-screen-small;
+        padding: @dropdown-menu-header-padding-vertical-screen-small @dropdown-menu-header-padding-horizontal-screen-small;
+      }
     }
   }
 }
@@ -155,8 +183,11 @@
   @media (min-width: @layout-screen-medium-min-width) {
 
     .dropdown-menu-section-header {
-      margin-top: @base-spacing-unit-screen-medium * 1/2;
-      padding: @dropdown-menu-header-padding-top-screen-medium @dropdown-menu-header-padding-right-screen-medium @dropdown-menu-header-padding-bottom-screen-medium @dropdown-menu-header-padding-left-screen-medium;
+
+      li& {
+        margin-top: @dropdown-menu-header-margin-top-screen-medium;
+        padding: @dropdown-menu-header-padding-vertical-screen-medium @dropdown-menu-header-padding-horizontal-screen-medium;
+      }
     }
   }
 }
@@ -166,8 +197,11 @@
   @media (min-width: @layout-screen-large-min-width) {
 
     .dropdown-menu-section-header {
-      margin-top: @base-spacing-unit-screen-large * 1/2;
-      padding: @dropdown-menu-header-padding-top-screen-large @dropdown-menu-header-padding-right-screen-large @dropdown-menu-header-padding-bottom-screen-large @dropdown-menu-header-padding-left-screen-large;
+
+      li& {
+        margin-top: @dropdown-menu-header-margin-top-screen-large;
+        padding: @dropdown-menu-header-padding-vertical-screen-large @dropdown-menu-header-padding-horizontal-screen-large;
+      }
     }
   }
 }
@@ -177,7 +211,11 @@
   @media (min-width: @layout-screen-jumbo-min-width) {
 
     .dropdown-menu-section-header {
-      margin-top: @base-spacing-unit-screen-jumbo * 1/2;
+
+      li& {
+        margin-top: @dropdown-menu-header-margin-top-screen-jumbo;
+        padding: @dropdown-menu-header-padding-vertical-screen-jumbo @dropdown-menu-header-padding-horizontal-screen-jumbo;
+      }
     }
   }
 }

--- a/src/styles/components/dropdown-menus/variables.less
+++ b/src/styles/components/dropdown-menus/variables.less
@@ -1,1 +1,20 @@
 @dropdown-menu-enabled: true;
+
+@dropdown-menu-header-margin-top: @base-spacing-unit * 1/2;
+@dropdown-menu-header-margin-top-screen-small: @base-spacing-unit-screen-small * 1/2;
+@dropdown-menu-header-margin-top-screen-medium: @base-spacing-unit-screen-medium * 1/2;
+@dropdown-menu-header-margin-top-screen-large: @base-spacing-unit-screen-large * 1/2;
+@dropdown-menu-header-margin-top-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/2;
+
+@dropdown-menu-header-padding-vertical: 0;
+@dropdown-menu-header-padding-vertical-screen-small: 0;
+@dropdown-menu-header-padding-vertical-screen-medium: 0;
+@dropdown-menu-header-padding-vertical-screen-large: 0;
+@dropdown-menu-header-padding-vertical-screen-jumbo: 0;
+
+@dropdown-menu-header-padding-horizontal: @dropdown-menu-header-padding-right;
+@dropdown-menu-header-padding-horizontal-screen-small: @dropdown-menu-header-padding-horizontal;
+@dropdown-menu-header-padding-horizontal-screen-medium: @dropdown-menu-header-padding-right-screen-medium;
+@dropdown-menu-header-padding-horizontal-screen-large: @dropdown-menu-header-padding-right-screen-large;
+@dropdown-menu-header-padding-horizontal-screen-jumbo: @dropdown-menu-header-padding-horizontal-screen-large;
+

--- a/src/styles/components/user-account-dropdown/styles.less
+++ b/src/styles/components/user-account-dropdown/styles.less
@@ -2,6 +2,13 @@
 
   .user-account-dropdown {
     display: flex;
+
+    &-list {
+
+      .dropdown-menu-items {
+        padding-top: @user-account-dropdown-menu-padding-top;
+      }
+    }
   }
 
   .user-account-dropdown-button {
@@ -21,15 +28,9 @@
       border: none;
     }
 
-    &:hover {
-
-      .icon {
-        fill: color-lighten(@button-color, 15);
-      }
-    }
-
     .cluster-header {
       align-items: stretch;
+      color: @white;
       // This !important overrides an awful CNVS !important tag.
       // https://github.com/mesosphere/canvas/issues/24
       display: flex !important;
@@ -37,28 +38,39 @@
       flex-direction: column;
       min-width: 0;
       text-align: left;
-    }
 
-    .cluster-header-name {
-      align-items: center;
-      display: flex;
-      flex: 1 1 auto;
-    }
+      &-primary {
+        flex: 0 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        padding-right: @user-account-dropdown-menu-primary-padding-right;
 
-    .header-title {
-      flex: 0 1 auto;
-      min-width: 0;
-      overflow: hidden;
-      padding-right: @base-spacing-unit * 1/2;
+        &-wrapper {
+          align-items: center;
+          display: flex;
+          flex: 1 1 auto;
+
+          & + .cluster-header {
+
+            &-secondary {
+              margin-top: @user-account-dropdown-menu-primary-margin-bottom;
+            }
+          }
+        }
+      }
+
+      &-secondary {
+        font-size: 0.75rem;
+        font-weight: 400;
+      }
     }
 
     .icon {
-      fill: @button-color;
+      fill: @white;
       flex: 0 0 auto;
       transition: fill 0.2s, transform 0.2s;
 
       .open & {
-        fill: color-lighten(@button-color, 15);
         transform: rotate(180deg);
       }
     }
@@ -66,6 +78,31 @@
 
   .user-account-dropdown-menu {
     margin-left: @pod-margin-left * @pod-narrow-margin-left-scale;
+
+    &-public-ip {
+
+      li& {
+        padding: 0;
+      }
+
+      &:hover {
+
+        .user-account-dropdown-menu {
+
+          &-copy-text {
+            visibility: visible;
+          }
+        }
+      }
+    }
+
+    &-copy-text {
+      color: @purple;
+      display: inline-block;
+      margin-left: @user-account-dropdown-menu-copy-text-margin-left;
+      text-decoration: underline;
+      visibility: hidden;
+    }
   }
 }
 
@@ -75,10 +112,31 @@
 
     .user-account-dropdown-button {
       padding: @pod-margin-top-screen-small * @pod-short-margin-top-scale @pod-margin-right-screen-small * @pod-narrow-margin-right-scale @pod-margin-bottom-screen-small * @pod-short-margin-bottom-scale @pod-margin-left-screen-small * @pod-narrow-margin-left-scale;
+
+      .cluster-header {
+
+        &-primary {
+
+          &-wrapper {
+            padding-right: @user-account-dropdown-menu-primary-padding-right-screen-small;
+
+            & + .cluster-header {
+
+              &-secondary {
+                margin-top: @user-account-dropdown-menu-primary-margin-bottom-screen-small;
+              }
+            }
+          }
+        }
+      }
     }
 
     .user-account-dropdown-menu {
       margin-left: @pod-margin-left-screen-small * @pod-narrow-margin-left-scale;
+
+      &-copy-text {
+        margin-left: @user-account-dropdown-menu-copy-text-margin-left-screen-small;
+      }
     }
   }
 }
@@ -89,10 +147,31 @@
 
     .user-account-dropdown-button {
       padding: @pod-margin-top-screen-medium * @pod-short-margin-top-scale @pod-margin-right-screen-medium * @pod-narrow-margin-right-scale @pod-margin-bottom-screen-medium * @pod-short-margin-bottom-scale @pod-margin-left-screen-medium * @pod-narrow-margin-left-scale;
+
+      .cluster-header {
+
+        &-primary {
+
+          &-wrapper {
+            padding-right: @user-account-dropdown-menu-primary-padding-right-screen-medium;
+
+            & + .cluster-header {
+
+              &-secondary {
+                margin-top: @user-account-dropdown-menu-primary-margin-bottom-screen-medium;
+              }
+            }
+          }
+        }
+      }
     }
 
     .user-account-dropdown-menu {
       margin-left: @pod-margin-left-screen-medium * @pod-narrow-margin-left-scale;
+
+      &-copy-text {
+        margin-left: @user-account-dropdown-menu-copy-text-margin-left-screen-medium;
+      }
     }
   }
 }
@@ -103,10 +182,31 @@
 
     .user-account-dropdown-button {
       padding: @pod-margin-top-screen-large * @pod-short-margin-top-scale @pod-margin-right-screen-large * @pod-narrow-margin-right-scale @pod-margin-bottom-screen-large * @pod-short-margin-bottom-scale @pod-margin-left-screen-large * @pod-narrow-margin-left-scale;
+
+      .cluster-header {
+
+        &-primary {
+
+          &-wrapper {
+            padding-right: @user-account-dropdown-menu-primary-padding-right-screen-large;
+
+            & + .cluster-header {
+
+              &-secondary {
+                margin-top: @user-account-dropdown-menu-primary-margin-bottom-screen-large;
+              }
+            }
+          }
+        }
+      }
     }
 
     .user-account-dropdown-menu {
       margin-left: @pod-margin-left-screen-large * @pod-narrow-margin-left-scale;
+
+      &-copy-text {
+        margin-left: @user-account-dropdown-menu-copy-text-margin-left-screen-large;
+      }
     }
   }
 }
@@ -117,10 +217,31 @@
 
     .user-account-dropdown-button {
       padding: @pod-margin-top-screen-jumbo * @pod-short-margin-top-scale @pod-margin-right-screen-jumbo * @pod-narrow-margin-right-scale @pod-margin-bottom-screen-jumbo * @pod-short-margin-bottom-scale @pod-margin-left-screen-jumbo * @pod-narrow-margin-left-scale;
+
+      .cluster-header {
+
+        &-primary {
+
+          &-wrapper {
+            padding-right: @user-account-dropdown-menu-primary-padding-right-screen-jumbo;
+
+            & + .cluster-header {
+
+              &-secondary {
+                margin-top: @user-account-dropdown-menu-primary-margin-bottom-screen-jumbo;
+              }
+            }
+          }
+        }
+      }
     }
 
     .user-account-dropdown-menu {
       margin-left: @pod-margin-left-screen-jumbo * @pod-narrow-margin-left-scale;
+
+      &-copy-text {
+        margin-left: @user-account-dropdown-menu-copy-text-margin-left-screen-jumbo;
+      }
     }
   }
 }

--- a/src/styles/components/user-account-dropdown/variables.less
+++ b/src/styles/components/user-account-dropdown/variables.less
@@ -1,5 +1,7 @@
 @user-dropdown-menu-enabled: true;
 
+@user-account-dropdown-menu-padding-top: 1rem;
+
 // TODO: Remove the small and jumbo media queries;
 @user-account-menu-button-height: calc(@button-height ~' - ' @body-line-height ~' + ' @icon-large-width);
 @user-account-menu-button-height-screen-small: @user-account-menu-button-height;
@@ -62,3 +64,21 @@
 @user-account-menu-height-screen-medium: @user-account-menu-items * (@user-account-menu-list-item-line-height-screen-medium + @user-account-menu-list-item-padding-vertical-screen-medium * 2) + @user-account-slider-list-padding-vertical-screen-medium * 2;
 @user-account-menu-height-screen-large: @user-account-menu-items * (@user-account-menu-list-item-line-height-screen-large + @user-account-menu-list-item-padding-vertical-screen-large * 2) + @user-account-slider-list-padding-vertical-screen-large * 2;
 @user-account-menu-height-screen-jumbo: @user-account-menu-items * (@user-account-menu-list-item-line-height-screen-jumbo + @user-account-menu-list-item-padding-vertical-screen-jumbo * 2) + @user-account-slider-list-padding-vertical-screen-jumbo * 2;
+
+@user-account-dropdown-menu-primary-padding-right: @base-spacing-unit * 1/4;
+@user-account-dropdown-menu-primary-padding-right-screen-small: @base-spacing-unit-screen-small * 1/4;
+@user-account-dropdown-menu-primary-padding-right-screen-medium: @base-spacing-unit-screen-medium * 1/4;
+@user-account-dropdown-menu-primary-padding-right-screen-large: @base-spacing-unit-screen-large * 1/4;
+@user-account-dropdown-menu-primary-padding-right-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/4;
+
+@user-account-dropdown-menu-primary-margin-bottom: @base-spacing-unit * 1/8;
+@user-account-dropdown-menu-primary-margin-bottom-screen-small: @base-spacing-unit-screen-small * 1/8;
+@user-account-dropdown-menu-primary-margin-bottom-screen-medium: @base-spacing-unit-screen-medium * 1/8;
+@user-account-dropdown-menu-primary-margin-bottom-screen-large: @base-spacing-unit-screen-large * 1/8;
+@user-account-dropdown-menu-primary-margin-bottom-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/8;
+
+@user-account-dropdown-menu-copy-text-margin-left: @base-spacing-unit * 1/4;
+@user-account-dropdown-menu-copy-text-margin-left-screen-small: @base-spacing-unit-screen-small * 1/4;
+@user-account-dropdown-menu-copy-text-margin-left-screen-medium: @base-spacing-unit-screen-medium * 1/4;
+@user-account-dropdown-menu-copy-text-margin-left-screen-large: @base-spacing-unit-screen-large * 1/4;
+@user-account-dropdown-menu-copy-text-margin-left-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/4;


### PR DESCRIPTION
1 of 3: #1822 
2 of 3: #1826 — [diff between 1 and 2](https://github.com/dcos/dcos-ui/compare/john/feature/extend-clipboard-trigger...john/DCOS-12462/new-user-account-menu-components?expand=1)
3 of 3: #1827  — [diff between 2 and 3](https://github.com/dcos/dcos-ui/compare/john/DCOS-12462/new-user-account-menu-components...john/DCOS-12462/sidebar-user-account-menu?expand=1)

This PR introduces a new component, `UserAccountDropdownTrigger`, which will be used to trigger the new user account menu. It also updates the styling of the dropdown itself.

This doesn't make any changes that you can see in the UI immediately; that will come in a follow-up PR.

Here's a sneak peak:
![](https://d3vv6lp55qjaqc.cloudfront.net/items/0M260R0o2L082y012p0B/Screen%20Shot%202017-01-19%20at%203.19.27%20PM.png?X-CloudApp-Visitor-Id=1972842)