### PR TITLE
[Service Modal Routes 1 of 3] DCOS-12423: Adding routes to the service create modal

### DIFF
--- a/foundation-ui/stores/DCOSStore.js
+++ b/foundation-ui/stores/DCOSStore.js
@@ -45,9 +45,7 @@ class DCOSStore extends EventEmitter {
     PluginSDK.addStoreConfig({
       store: this,
       storeID: this.storeID,
-      events: {
-        change: DCOS_CHANGE
-      },
+      events: this.getEvents(),
       unmountWhen() {
         return true;
       },
@@ -74,6 +72,16 @@ class DCOSStore extends EventEmitter {
     };
 
     this.debouncedEvents = new Map();
+  }
+
+  getEvents() {
+    return {change: DCOS_CHANGE};
+  }
+
+  getTotalListenerCount() {
+    return Object.values(this.getEvents()).reduce((memo, name) => {
+      return memo + this.listeners(name).length;
+    }, 0);
   }
 
   getProxyListeners() {
@@ -340,7 +348,7 @@ class DCOSStore extends EventEmitter {
    */
   on(eventName, callback) {
     // Only add proxy listeners if not already listening
-    if (this.listeners().length === 0) {
+    if (this.getTotalListenerCount() === 0) {
       this.addProxyListeners();
     }
 
@@ -357,7 +365,7 @@ class DCOSStore extends EventEmitter {
   removeListener(eventName, callback) {
     super.removeListener(eventName, callback);
     // Remove proxy listeners if no one is listening
-    if (this.listeners().length === 0) {
+    if (this.getTotalListenerCount() === 0) {
       this.removeProxyListeners();
     }
 

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -74,12 +74,17 @@ class NewCreateServiceModal extends Component {
     const isEdit = location.pathname.includes('/edit');
     const serviceID = decodeURIComponent(params.id || '/');
     const service = isEdit ? DCOSStore.serviceTree.findItemById(serviceID) : null;
+    const isSpecificVersion = service instanceof Application && params.version;
     let serviceConfig = new Application(
       Object.assign({id: getBaseID(serviceID)}, DEFAULT_APP_SPEC)
     );
 
-    if (isEdit && service instanceof Service) {
+    if (isEdit && service instanceof Service && !isSpecificVersion) {
       serviceConfig = service.getSpec();
+    }
+
+    if (isEdit && isSpecificVersion) {
+      serviceConfig = service.getVersions().get(params.version);
     }
 
     this.state = {

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -197,6 +197,8 @@ class NewCreateServiceModal extends Component {
       MARATHON_SERVICE_EDIT_SUCCESS,
       this.onMarathonStoreServiceEditSuccess
     );
+
+    // Also remove DCOS change listener, if still subscribed
     DCOSStore.removeChangeListener(DCOS_CHANGE, this.handleStoreChange);
   }
 

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -71,7 +71,7 @@ class NewCreateServiceModal extends Component {
     super(...arguments);
 
     const {location, params} = this.props;
-    const isEdit = location.pathname.includes('/edit');
+    const isEdit = this.isLocationEdit(location);
     const serviceID = decodeURIComponent(params.id || '/');
     const service = isEdit ? DCOSStore.serviceTree.findItemById(serviceID) : null;
     const isSpecificVersion = service instanceof Application && params.version;
@@ -139,7 +139,7 @@ class NewCreateServiceModal extends Component {
       return;
     }
 
-    const isEdit = nextProps.location.pathname.includes('/edit');
+    const isEdit = this.isLocationEdit(nextProps.location);
     const serviceID = decodeURIComponent(nextProps.params.id || '/');
     const service = isEdit ? DCOSStore.serviceTree.findItemById(serviceID) : null;
     let serviceConfig = new Application(
@@ -261,7 +261,7 @@ class NewCreateServiceModal extends Component {
 
     // Close if picker is open, or if editing a service in the form
     if (servicePickerActive ||
-      (!serviceReviewActive && location.pathname.includes('/edit'))) {
+      (!serviceReviewActive && this.isLocationEdit(location))) {
       this.handleClose();
 
       return;
@@ -374,13 +374,17 @@ class NewCreateServiceModal extends Component {
     const {location} = this.props;
     const {service, serviceConfig} = this.state;
     const force = this.shouldForceSubmit();
-    if (location.pathname.includes('/edit') && service instanceof Service) {
+    if (this.isLocationEdit(location) && service instanceof Service) {
       MarathonActions.editService(service, serviceConfig, force);
     } else {
       MarathonActions.createService(serviceConfig, force);
     }
 
     this.setState({isPending: true});
+  }
+
+  isLocationEdit(location) {
+    return location.pathname.includes('/edit');
   }
 
   getHeader() {
@@ -406,7 +410,7 @@ class NewCreateServiceModal extends Component {
     const {service} = this.state;
     const serviceName = service ? `"${service.getName()}"` : 'Service';
 
-    if (location.pathname.includes('/edit')) {
+    if (this.isLocationEdit(location)) {
       title = `Edit ${serviceName}`;
     }
 
@@ -535,7 +539,7 @@ class NewCreateServiceModal extends Component {
           onChange={this.handleServiceChange}
           onConvertToPod={this.handleConvertToPod}
           onErrorStateChange={this.handleServiceErrorChange}
-          isEdit={location.pathname.includes('/edit')} />
+          isEdit={this.isLocationEdit(location)} />
       );
     }
 
@@ -631,7 +635,7 @@ class NewCreateServiceModal extends Component {
     } = this.state;
     let label = 'Back';
 
-    if (servicePickerActive || (location.pathname.includes('/edit') && !serviceReviewActive)) {
+    if (servicePickerActive || (this.isLocationEdit(location) && !serviceReviewActive)) {
       label = 'Cancel';
     }
 

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -544,7 +544,7 @@ class NewCreateServiceModal extends Component {
     }
 
     if (serviceJsonActive) {
-      // serviceConfig should be service
+      // TODO (DCOS-13561): serviceConfig should be service
 
       return (
         <CreateServiceJsonOnly

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -40,6 +40,7 @@ import NetworkingFormSection from '../forms/NetworkingFormSection';
 import NewCreateServiceModalForm from './NewCreateServiceModalForm';
 import NewCreateServiceModalServicePicker from './NewCreateServiceModalServicePicker';
 import ServiceConfigDisplay from '../../service-configuration/ServiceConfigDisplay';
+import {getBaseID} from '../../utils/ServiceUtil';
 import ToggleButton from '../../../../../../src/js/components/ToggleButton';
 import Util from '../../../../../../src/js/utils/Util';
 import VolumesFormSection from '../forms/VolumesFormSection';
@@ -74,7 +75,7 @@ class NewCreateServiceModal extends Component {
     const serviceID = decodeURIComponent(params.id || '/');
     const service = isEdit ? DCOSStore.serviceTree.findItemById(serviceID) : null;
     let serviceConfig = new Application(
-      Object.assign({id: serviceID}, DEFAULT_APP_SPEC)
+      Object.assign({id: getBaseID(serviceID)}, DEFAULT_APP_SPEC)
     );
 
     if (isEdit && service instanceof Service) {
@@ -137,7 +138,7 @@ class NewCreateServiceModal extends Component {
     const serviceID = decodeURIComponent(nextProps.params.id || '/');
     const service = isEdit ? DCOSStore.serviceTree.findItemById(serviceID) : null;
     let serviceConfig = new Application(
-      Object.assign({id: serviceID}, DEFAULT_APP_SPEC)
+      Object.assign({id: getBaseID(serviceID)}, DEFAULT_APP_SPEC)
     );
 
     if (isEdit && service instanceof Service) {
@@ -312,7 +313,7 @@ class NewCreateServiceModal extends Component {
 
   handleServiceSelection({route, type}) {
     const {params} = this.props;
-    const serviceID = decodeURIComponent(params.id || '/');
+    const baseID = getBaseID(decodeURIComponent(params.id || '/'));
 
     switch (type) {
       case 'app':
@@ -321,7 +322,7 @@ class NewCreateServiceModal extends Component {
           servicePickerActive: false,
           serviceFormActive: true,
           serviceConfig: new Application(
-            Object.assign({id: serviceID}, DEFAULT_APP_SPEC)
+            Object.assign({id: baseID}, DEFAULT_APP_SPEC)
           )
         });
         break;
@@ -332,7 +333,7 @@ class NewCreateServiceModal extends Component {
           servicePickerActive: false,
           serviceFormActive: true,
           serviceConfig: new PodSpec(
-            Object.assign({id: serviceID}, DEFAULT_POD_SPEC)
+            Object.assign({id: baseID}, DEFAULT_POD_SPEC)
           )
         });
         break;
@@ -343,7 +344,7 @@ class NewCreateServiceModal extends Component {
           servicePickerActive: false,
           serviceJsonActive: true,
           serviceConfig: new Application(
-            Object.assign({id: serviceID}, DEFAULT_APP_SPEC)
+            Object.assign({id: baseID}, DEFAULT_APP_SPEC)
           )
         });
         break;

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -296,9 +296,11 @@ class NewCreateServiceModal extends Component {
   }
 
   handleClose() {
+    // Start the animation of the modal by setting isOpen to false
     this.setState({isOpen: false}, () => {
-      // Navigate to parent after setState, so we get modal animation
-      this.context.router.goBack();
+      // Once state is set, start a timer for the length of the animation and
+      // navigate away once the animation is over.
+      setTimeout(this.context.router.goBack, 300);
     });
   }
 

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
-import React, {PropTypes, Component} from 'react';
 import deepEqual from 'deep-equal';
+import React, {PropTypes, Component} from 'react';
 
 import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
 import {getContainerNameWithIcon} from '../../utils/ServiceConfigDisplayUtil';
@@ -89,9 +89,6 @@ class NewCreateServiceModalForm extends Component {
     });
   }
 
-  /**
-   * @override
-   */
   componentWillReceiveProps(nextProps) {
     const prevJSON = ServiceUtil.getServiceJSON(this.props.service);
     const nextJSON = ServiceUtil.getServiceJSON(nextProps.service);
@@ -110,17 +107,11 @@ class NewCreateServiceModalForm extends Component {
     this.props.onConvertToPod(this.getAppConfig());
   }
 
-  /**
-   * @override
-   */
   componentDidUpdate() {
     this.props.onChange(new this.props.service.constructor(this.state.appConfig));
     this.props.onErrorStateChange(this.state.errorList.length !== 0);
   }
 
-  /**
-   * @override
-   */
   shouldComponentUpdate(nextProps, nextState) {
     // Update if json state changed
     if (this.props.isJSONModeActive !== nextProps.isJSONModeActive) {

--- a/plugins/services/src/js/components/modals/ServiceModals.js
+++ b/plugins/services/src/js/components/modals/ServiceModals.js
@@ -1,18 +1,15 @@
 import React, {PropTypes} from 'react';
 
 import ActionKeys from '../../constants/ActionKeys';
-import Application from '../../structs/Application';
 import ServiceTree from '../../structs/ServiceTree';
 
 import ServiceActionItem from '../../constants/ServiceActionItem';
 import ServiceDestroyModal from './ServiceDestroyModal';
-import NewCreateServiceModal from './NewCreateServiceModal';
 import ServiceGroupFormModal from './ServiceGroupFormModal';
 import ServiceRestartModal from './ServiceRestartModal';
 import ServiceScaleFormModal from './ServiceScaleFormModal';
 import ServiceSpecUtil from '../../utils/ServiceSpecUtil';
 import ServiceSuspendModal from './ServiceSuspendModal';
-import {DEFAULT_APP_SPEC} from '../../constants/DefaultApp';
 
 class ServiceModals extends React.Component {
   getGroupModal() {
@@ -36,87 +33,6 @@ class ServiceModals extends React.Component {
         errors={actionErrors[key]}
         parentGroupId={service.getId()}
         open={modalProps.id === ServiceActionItem.CREATE_GROUP}
-        onClose={() => onClose(key)} />
-    );
-  }
-
-  getCreateModal() {
-    const {
-      actionErrors,
-      clearError,
-      onClose,
-      modalProps,
-      pendingActions
-    } = this.props;
-
-    // The regular expression `/^(\/.+)$/` is looking for the beginning of the
-    // string and matches if the string starts with a `/` and does contain more
-    // characters after the slash. This is combined into a group and then
-    // replaced with the first group which is the complete string and a `/` is
-    // appended. This is needed because in most case a path like
-    // `/group/another-group` will be given by `getId` except on root then the
-    // return value of `getId` would be `/` so in most cases we want to append a
-    // `/` so that the user can begin typing the `id` of their application.
-    const {service} = modalProps;
-    const baseId = service.getId().replace(/^(\/.+)$/, '$1/');
-    const key = ActionKeys.SERVICE_CREATE;
-    const createService = (_, serviceSpec, force) => {
-      this.props.actions.createService(serviceSpec, force);
-    };
-
-    const newApp = new Application(
-      Object.assign(
-        {id: baseId},
-        DEFAULT_APP_SPEC
-      )
-    );
-
-    return (
-      <NewCreateServiceModal
-        clearError={() => clearError(key)}
-        errors={actionErrors[key]}
-        isEdit={false}
-        isPending={!!pendingActions[key]}
-        marathonAction={createService}
-        open={modalProps.id === ServiceActionItem.CREATE}
-        service={newApp}
-        onClose={() => onClose(key)} />
-    );
-  }
-
-  getEditModal() {
-    const {
-      actionErrors,
-      clearError,
-      onClose,
-      modalProps,
-      pendingActions
-    } = this.props;
-
-    const {service} = modalProps;
-    const isGroup = service instanceof ServiceTree;
-    const key = ActionKeys.SERVICE_EDIT;
-    const editService = (updatedService, serviceSpec, force) => {
-      this.props.actions.editService(updatedService, serviceSpec, force);
-    };
-
-    let serviceToEdit = service;
-
-    // Pass in a fake Application to keep the PropTypes happy when
-    // this modal isn't active.
-    if (isGroup && modalProps.id !== ServiceActionItem.EDIT) {
-      serviceToEdit = new Application({id: '/'});
-    }
-
-    return (
-      <NewCreateServiceModal
-        clearError={() => clearError(key)}
-        errors={actionErrors[key]}
-        isEdit={true}
-        isPending={!!pendingActions[key]}
-        marathonAction={editService}
-        open={modalProps.id === ServiceActionItem.EDIT}
-        service={serviceToEdit}
         onClose={() => onClose(key)} />
     );
   }
@@ -259,8 +175,6 @@ class ServiceModals extends React.Component {
     return (
       <div>
         {this.getGroupModal()}
-        {this.getCreateModal()}
-        {this.getEditModal()}
         {this.getDestroyModal()}
         {this.getRestartModal()}
         {this.getScaleModal()}
@@ -275,9 +189,7 @@ const actionPropTypes = PropTypes.shape({
   createGroup: PropTypes.func,
   deleteGroup: PropTypes.func,
   editGroup: PropTypes.func,
-  createService: PropTypes.func,
   deleteService: PropTypes.func,
-  editService: PropTypes.func,
   restartService: PropTypes.func
 }).isRequired;
 

--- a/plugins/services/src/js/containers/pod-detail/PodDetail.js
+++ b/plugins/services/src/js/containers/pod-detail/PodDetail.js
@@ -44,7 +44,9 @@ class PodDetail extends mixin(TabsMixin) {
 
   handleActionEdit() {
     const {pod} = this.props.pod;
-    this.context.modalHandlers.editService({pod});
+    this.context.router.push(
+      `/services/overview/${encodeURIComponent(pod.getId())}/edit`
+    );
   }
 
   handleActionScale() {
@@ -132,7 +134,7 @@ class PodDetail extends mixin(TabsMixin) {
   }
 
   render() {
-    const {modals, pod} = this.props;
+    const {children, pod} = this.props;
 
     const breadcrumbs = <ServiceBreadcrumbs serviceID={pod.id} />;
 
@@ -151,7 +153,7 @@ class PodDetail extends mixin(TabsMixin) {
             tabs={this.tabs_getUnroutedTabs()} />
         </Page.Header>
         {this.tabs_getTabView()}
-        {modals}
+        {children}
       </Page>
     );
   }
@@ -167,7 +169,7 @@ PodDetail.contextTypes = {
 };
 
 PodDetail.propTypes = {
-  modals: PropTypes.node,
+  children: PropTypes.node,
   pod: React.PropTypes.instanceOf(Pod)
 };
 

--- a/plugins/services/src/js/containers/pod-detail/PodDetail.js
+++ b/plugins/services/src/js/containers/pod-detail/PodDetail.js
@@ -45,7 +45,7 @@ class PodDetail extends mixin(TabsMixin) {
   handleActionEdit() {
     const {pod} = this.props.pod;
     this.context.router.push(
-      `/services/overview/${encodeURIComponent(pod.getId())}/edit`
+      `/services/overview/${encodeURIComponent(pod.getId())}/edit/`
     );
   }
 

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -3,6 +3,7 @@ import {DCOSStore} from 'foundation-ui';
 import {Dropdown, Tooltip} from 'reactjs-components';
 import mixin from 'reactjs-mixin';
 import React from 'react';
+import {routerShape} from 'react-router';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
 import ApplicationSpec from '../../structs/ApplicationSpec';
@@ -58,12 +59,12 @@ class ServiceConfiguration extends mixin(StoreMixin) {
   }
 
   handleApplyButtonClick() {
-    const {editService, service} = this.props;
+    const {onEditClick, service} = this.props;
     const {selectedVersionID} = this.state;
 
     const serviceConfiguration = service.getVersions().get(selectedVersionID);
 
-    editService(service,
+    onEditClick(service,
       ServiceUtil.getDefinitionFromSpec(
           new ApplicationSpec(serviceConfiguration)
       )
@@ -76,7 +77,10 @@ class ServiceConfiguration extends mixin(StoreMixin) {
 
     const service = ServiceUtil.createServiceFromResponse(serviceConfiguration);
 
-    this.context.modalHandlers.editService({service});
+    this.context.router.push(
+      `/services/overview/${encodeURIComponent(service.getId())}/edit`
+    );
+
   }
 
   handleVersionSelection(versionItem) {
@@ -194,7 +198,9 @@ class ServiceConfiguration extends mixin(StoreMixin) {
     if (config == null) {
       content = <Loader />;
     } else {
-      content = <ServiceConfigDisplay appConfig={config} />;
+      content = (
+        <ServiceConfigDisplay appConfig={config} />
+      );
     }
 
     return (
@@ -208,13 +214,11 @@ class ServiceConfiguration extends mixin(StoreMixin) {
 }
 
 ServiceConfiguration.contextTypes = {
-  modalHandlers: React.PropTypes.shape({
-    editService: React.PropTypes.func.isRequired
-  }).isRequired
+  router: routerShape
 };
 
 ServiceConfiguration.propTypes = {
-  editService: React.PropTypes.func.isRequired,
+  onEditClick: React.PropTypes.func.isRequired,
   service: React.PropTypes.instanceOf(Service).isRequired
 };
 

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -72,15 +72,12 @@ class ServiceConfiguration extends mixin(StoreMixin) {
   }
 
   handleEditButtonClick() {
-    const serviceConfiguration =
-      this.props.service.getVersions().get(this.state.selectedVersionID);
-
-    const service = ServiceUtil.createServiceFromResponse(serviceConfiguration);
+    const serviceID = encodeURIComponent(this.props.service.getId());
+    const {selectedVersionID} = this.state;
 
     this.context.router.push(
-      `/services/overview/${encodeURIComponent(service.getId())}/edit`
+      `/services/overview/${serviceID}/edit/${selectedVersionID}`
     );
-
   }
 
   handleVersionSelection(versionItem) {

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
@@ -1,6 +1,5 @@
 import {DCOSStore} from 'foundation-ui';
 import React from 'react';
-import {routerShape} from 'react-router';
 
 import Loader from '../../../../../../src/js/components/Loader';
 import Service from '../../structs/Service';
@@ -23,32 +22,23 @@ class ServiceConfigurationContainer extends React.Component {
   }
 
   render() {
-    const {service} = this.props;
+    const {onEditClick, service} = this.props;
 
     // Wait till we've loaded the versions
     if (!service.getVersions().size) {
       return <Loader />;
     }
 
-    const editService = () => {
-      this.context.router.push(
-        `/services/overview/${encodeURIComponent(service.getId())}/edit`
-      );
-    };
-
     return (
       <ServiceConfiguration
-        editService={editService}
+        onEditClick={onEditClick}
         service={service} />
     );
   }
 }
 
-ServiceConfigurationContainer.contextTypes = {
-  router: routerShape
-};
-
 ServiceConfigurationContainer.propTypes = {
+  onEditClick: React.PropTypes.func.isRequired,
   service: React.PropTypes.instanceOf(Service).isRequired
 };
 

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
@@ -1,5 +1,6 @@
 import {DCOSStore} from 'foundation-ui';
 import React from 'react';
+import {routerShape} from 'react-router';
 
 import Loader from '../../../../../../src/js/components/Loader';
 import Service from '../../structs/Service';
@@ -22,25 +23,32 @@ class ServiceConfigurationContainer extends React.Component {
   }
 
   render() {
-    const {actions, service} = this.props;
+    const {service} = this.props;
 
     // Wait till we've loaded the versions
     if (!service.getVersions().size) {
       return <Loader />;
     }
 
+    const editService = () => {
+      this.context.router.push(
+        `/services/overview/${encodeURIComponent(service.getId())}/edit`
+      );
+    };
+
     return (
       <ServiceConfiguration
-        editService={actions.editService}
+        editService={editService}
         service={service} />
     );
   }
 }
 
+ServiceConfigurationContainer.contextTypes = {
+  router: routerShape
+};
+
 ServiceConfigurationContainer.propTypes = {
-  actions: React.PropTypes.shape({
-    editService: React.PropTypes.func.isRequired
-  }).isRequired,
   service: React.PropTypes.instanceOf(Service).isRequired
 };
 

--- a/plugins/services/src/js/containers/service-configuration/__tests__/ServiceConfigurationContainer-test.js
+++ b/plugins/services/src/js/containers/service-configuration/__tests__/ServiceConfigurationContainer-test.js
@@ -29,11 +29,10 @@ describe('ServiceConfigurationContainer', function () {
   });
 
   beforeEach(function () {
-    const actions = {editService: () => {}};
     this.container = global.document.createElement('div');
     this.instance = ReactDOM.render(
       <ServiceConfigurationContainer
-        actions={actions}
+        onEditClick={function () {}}
         service={service} />,
       this.container
     );

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -46,10 +46,15 @@ class ServiceDetail extends mixin(TabsMixin) {
   }
 
   onActionsItemSelection(actionItem) {
-    const {modalHandlers} = this.context;
+    const {modalHandlers, router} = this.context;
     const {service} = this.props;
 
     switch (actionItem.id) {
+      case ServiceActionItem.EDIT:
+        router.push(
+          `/services/overview/${encodeURIComponent(service.getId())}/edit`
+        );
+        break;
       case ServiceActionItem.SCALE:
         modalHandlers.scaleService({service});
         break;
@@ -80,8 +85,12 @@ class ServiceDetail extends mixin(TabsMixin) {
   }
 
   renderConfigurationTabView() {
+    const {actions, service} = this.props;
+
     return (
-      <ServiceConfigurationContainer service={this.props.service} />
+      <ServiceConfigurationContainer
+        onEditClick={actions.editService}
+        service={service} />
     );
   }
 

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -52,7 +52,7 @@ class ServiceDetail extends mixin(TabsMixin) {
     switch (actionItem.id) {
       case ServiceActionItem.EDIT:
         router.push(
-          `/services/overview/${encodeURIComponent(service.getId())}/edit`
+          `/services/overview/${encodeURIComponent(service.getId())}/edit/`
         );
         break;
       case ServiceActionItem.SCALE:
@@ -129,7 +129,7 @@ class ServiceDetail extends mixin(TabsMixin) {
       label: 'Edit',
       onItemSelect() {
         router.push(
-          `/services/overview/${encodeURIComponent(service.getId())}/edit`
+          `/services/overview/${encodeURIComponent(service.getId())}/edit/`
         );
       }
     });

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -1,5 +1,6 @@
 import mixin from 'reactjs-mixin';
 import React, {PropTypes} from 'react';
+import {routerShape} from 'react-router';
 
 import Page from '../../../../../../src/js/components/Page';
 import ServiceBreadcrumbs from '../../components/ServiceBreadcrumbs';
@@ -49,9 +50,6 @@ class ServiceDetail extends mixin(TabsMixin) {
     const {service} = this.props;
 
     switch (actionItem.id) {
-      case ServiceActionItem.EDIT:
-        modalHandlers.editService({service});
-        break;
       case ServiceActionItem.SCALE:
         modalHandlers.scaleService({service});
         break;
@@ -83,9 +81,7 @@ class ServiceDetail extends mixin(TabsMixin) {
 
   renderConfigurationTabView() {
     return (
-      <ServiceConfigurationContainer
-        actions={this.props.actions}
-        service={this.props.service} />
+      <ServiceConfigurationContainer service={this.props.service} />
     );
   }
 
@@ -115,14 +111,18 @@ class ServiceDetail extends mixin(TabsMixin) {
 
   getActions() {
     const {service} = this.props;
-    const {modalHandlers} = this.context;
+    const {modalHandlers, router} = this.context;
     const instanceCount = service.getInstancesCount();
 
     const actions = [];
 
     actions.push({
       label: 'Edit',
-      onItemSelect: modalHandlers.editService
+      onItemSelect() {
+        router.push(
+          `/services/overview/${encodeURIComponent(service.getId())}/edit`
+        );
+      }
     });
 
     if (instanceCount > 0) {
@@ -199,7 +199,7 @@ class ServiceDetail extends mixin(TabsMixin) {
   }
 
   render() {
-    const {modals, service:{id}} = this.props;
+    const {children, service:{id}} = this.props;
     const breadcrumbs = <ServiceBreadcrumbs serviceID={id} />;
 
     return (
@@ -209,7 +209,7 @@ class ServiceDetail extends mixin(TabsMixin) {
           breadcrumbs={breadcrumbs}
           iconID="services" />
         {this.tabs_getTabView()}
-        {modals}
+        {children}
       </Page>
     );
   }
@@ -217,19 +217,19 @@ class ServiceDetail extends mixin(TabsMixin) {
 
 ServiceDetail.contextTypes = {
   modalHandlers: PropTypes.shape({
-    editService: PropTypes.func,
     scaleService: PropTypes.func,
     restartService: PropTypes.func,
     suspendService: PropTypes.func,
     deleteService: PropTypes.func
-  }).isRequired
+  }).isRequired,
+  router: routerShape
 };
 
 ServiceDetail.propTypes = {
   actions: PropTypes.object.isRequired,
   params: PropTypes.object.isRequired,
   service: PropTypes.instanceOf(Service),
-  modals: PropTypes.node
+  children: PropTypes.node
 };
 
 module.exports = ServiceDetail;

--- a/plugins/services/src/js/containers/service-detail/__tests__/ServiceDetail-test.js
+++ b/plugins/services/src/js/containers/service-detail/__tests__/ServiceDetail-test.js
@@ -69,7 +69,15 @@ describe('ServiceDetail', function () {
     this.container = global.document.createElement('div');
     this.wrapper = ReactDOM.render(
       JestUtil.stubRouterContext(
-        ServiceDetail, {service}, {}, contextTypes, context
+        ServiceDetail,
+        {
+          actions: {editService() {}},
+          params: {},
+          service
+        },
+        {},
+        contextTypes,
+        context
       ),
       this.container
     );

--- a/plugins/services/src/js/containers/services/ServiceTreeView.js
+++ b/plugins/services/src/js/containers/services/ServiceTreeView.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React, {PropTypes} from 'react';
+import {routerShape} from 'react-router';
 
 import EmptyServiceTree from './EmptyServiceTree';
 import ServiceBreadcrumbs from '../../components/ServiceBreadcrumbs';
@@ -62,7 +63,7 @@ class ServiceTreeView extends React.Component {
 
   render() {
     const {
-      modals,
+      children,
       filterExpression,
       isEmpty,
       serviceTree,
@@ -70,6 +71,11 @@ class ServiceTreeView extends React.Component {
     } = this.props;
 
     const {modalHandlers} = this.context;
+    const createService = () => {
+      this.context.router.push(
+        `/services/overview/${encodeURIComponent(serviceTree.id)}/create`
+      );
+    };
 
     if (isEmpty) {
       return (
@@ -77,8 +83,8 @@ class ServiceTreeView extends React.Component {
           <Page.Header breadcrumbs={<ServiceBreadcrumbs serviceID={serviceTree.id} />} />
           <EmptyServiceTree
             onCreateGroup={modalHandlers.createGroup}
-            onCreateService={modalHandlers.createService} />
-          {modals}
+            onCreateService={createService} />
+          {children}
         </Page>
       );
     }
@@ -88,7 +94,7 @@ class ServiceTreeView extends React.Component {
         <Page.Header
           breadcrumbs={<ServiceBreadcrumbs serviceID={serviceTree.id} />}
           actions={[{onItemSelect: modalHandlers.createGroup, label: 'Create Group'}]}
-          addButton={{onItemSelect: modalHandlers.createService, label: 'Run a Service'}}
+          addButton={{onItemSelect: createService, label: 'Run a Service'}}
           />
         <div>
           {this.getFilterBar()}
@@ -98,7 +104,7 @@ class ServiceTreeView extends React.Component {
             modalHandlers={modalHandlers}
             services={services} />
         </div>
-        {modals}
+        {children}
       </Page>
     );
   }
@@ -106,9 +112,9 @@ class ServiceTreeView extends React.Component {
 
 ServiceTreeView.contextTypes = {
   modalHandlers: PropTypes.shape({
-    createGroup: PropTypes.func,
-    createService: PropTypes.func
-  }).isRequired
+    createGroup: PropTypes.func
+  }).isRequired,
+  router: routerShape
 };
 
 ServiceTreeView.defaultProps = {
@@ -120,7 +126,7 @@ ServiceTreeView.propTypes = {
   filters: PropTypes.instanceOf(DSLFilterList).isRequired,
   filterExpression: PropTypes.instanceOf(DSLExpression).isRequired,
   isEmpty: PropTypes.bool,
-  modals: PropTypes.node,
+  children: PropTypes.node,
   onFilterExpressionChange: PropTypes.func,
   services: PropTypes.arrayOf(PropTypes.oneOfType([
     PropTypes.instanceOf(Service),

--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -53,6 +53,9 @@ import {
   REQUEST_MARATHON_SERVICE_DELETE_ERROR,
   REQUEST_MARATHON_SERVICE_DELETE_SUCCESS,
 
+  REQUEST_MARATHON_SERVICE_EDIT_ERROR,
+  REQUEST_MARATHON_SERVICE_EDIT_SUCCESS,
+
   REQUEST_MARATHON_SERVICE_RESTART_ERROR,
   REQUEST_MARATHON_SERVICE_RESTART_SUCCESS
 } from '../../constants/ActionTypes';
@@ -122,6 +125,7 @@ const METHODS_TO_BIND = [
   'deleteGroup',
   'editGroup',
   'deleteService',
+  'editService',
   'restartService',
   'onStoreChange'
 ];
@@ -224,6 +228,12 @@ class ServicesContainer extends React.Component {
     return MarathonActions.deleteService(...arguments);
   }
 
+  editService() {
+    this.setPendingAction(ActionKeys.SERVICE_EDIT);
+
+    return MarathonActions.editService(...arguments);
+  }
+
   restartService() {
     this.setPendingAction(ActionKeys.SERVICE_RESTART);
 
@@ -277,6 +287,13 @@ class ServicesContainer extends React.Component {
         break;
       case REQUEST_MARATHON_SERVICE_DELETE_SUCCESS:
         this.unsetPendingAction(ActionKeys.SERVICE_DELETE);
+        break;
+
+      case REQUEST_MARATHON_SERVICE_EDIT_ERROR:
+        this.unsetPendingAction(ActionKeys.SERVICE_EDIT, action.data);
+        break;
+      case REQUEST_MARATHON_SERVICE_EDIT_SUCCESS:
+        this.unsetPendingAction(ActionKeys.SERVICE_EDIT);
         break;
 
       case REQUEST_MARATHON_SERVICE_RESTART_ERROR:
@@ -371,6 +388,7 @@ class ServicesContainer extends React.Component {
       createGroup: () => set(ServiceActionItem.CREATE_GROUP),
       // All methods below work on ServiceTree and Service types
       deleteService: (props) => set(ServiceActionItem.DESTROY, props),
+      editService: (props) => set(ServiceActionItem.EDIT, props),
       restartService: (props) => set(ServiceActionItem.RESTART, props),
       scaleService: (props) => set(ServiceActionItem.SCALE, props),
       suspendService: (props) => set(ServiceActionItem.SUSPEND, props)
@@ -384,6 +402,7 @@ class ServicesContainer extends React.Component {
       deleteGroup: this.deleteGroup,
       editGroup: this.editGroup,
       deleteService: this.deleteService,
+      editService: this.editService,
       restartService: this.restartService
     };
   }
@@ -463,6 +482,8 @@ class ServicesContainer extends React.Component {
       return (
         <ServiceDetail
           actions={this.getActions()}
+          errors={this.state.actionErrors}
+          clearError={this.clearActionError}
           params={params}
           routes={routes}
           service={item}>
@@ -517,6 +538,7 @@ ServicesContainer.childContextTypes = {
   modalHandlers: PropTypes.shape({
     createGroup: PropTypes.func,
     deleteService: PropTypes.func,
+    editService: PropTypes.func,
     restartService: PropTypes.func,
     scaleService: PropTypes.func,
     suspendService: PropTypes.func

--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -50,14 +50,8 @@ import {
   REQUEST_MARATHON_GROUP_EDIT_ERROR,
   REQUEST_MARATHON_GROUP_EDIT_SUCCESS,
 
-  REQUEST_MARATHON_SERVICE_CREATE_ERROR,
-  REQUEST_MARATHON_SERVICE_CREATE_SUCCESS,
-
   REQUEST_MARATHON_SERVICE_DELETE_ERROR,
   REQUEST_MARATHON_SERVICE_DELETE_SUCCESS,
-
-  REQUEST_MARATHON_SERVICE_EDIT_ERROR,
-  REQUEST_MARATHON_SERVICE_EDIT_SUCCESS,
 
   REQUEST_MARATHON_SERVICE_RESTART_ERROR,
   REQUEST_MARATHON_SERVICE_RESTART_SUCCESS
@@ -127,9 +121,7 @@ const METHODS_TO_BIND = [
   'revertDeployment',
   'deleteGroup',
   'editGroup',
-  'createService',
   'deleteService',
-  'editService',
   'restartService',
   'onStoreChange'
 ];
@@ -226,22 +218,10 @@ class ServicesContainer extends React.Component {
     return MarathonActions.editGroup(...arguments);
   }
 
-  createService() {
-    this.setPendingAction(ActionKeys.SERVICE_CREATE);
-
-    return MarathonActions.createService(...arguments);
-  }
-
   deleteService() {
     this.setPendingAction(ActionKeys.SERVICE_DELETE);
 
     return MarathonActions.deleteService(...arguments);
-  }
-
-  editService() {
-    this.setPendingAction(ActionKeys.SERVICE_EDIT);
-
-    return MarathonActions.editService(...arguments);
   }
 
   restartService() {
@@ -292,25 +272,11 @@ class ServicesContainer extends React.Component {
         this.unsetPendingAction(ActionKeys.GROUP_EDIT);
         break;
 
-      case REQUEST_MARATHON_SERVICE_CREATE_ERROR:
-        this.unsetPendingAction(ActionKeys.SERVICE_CREATE, action.data);
-        break;
-      case REQUEST_MARATHON_SERVICE_CREATE_SUCCESS:
-        this.unsetPendingAction(ActionKeys.SERVICE_CREATE);
-        break;
-
       case REQUEST_MARATHON_SERVICE_DELETE_ERROR:
         this.unsetPendingAction(ActionKeys.SERVICE_DELETE, action.data);
         break;
       case REQUEST_MARATHON_SERVICE_DELETE_SUCCESS:
         this.unsetPendingAction(ActionKeys.SERVICE_DELETE);
-        break;
-
-      case REQUEST_MARATHON_SERVICE_EDIT_ERROR:
-        this.unsetPendingAction(ActionKeys.SERVICE_EDIT, action.data);
-        break;
-      case REQUEST_MARATHON_SERVICE_EDIT_SUCCESS:
-        this.unsetPendingAction(ActionKeys.SERVICE_EDIT);
         break;
 
       case REQUEST_MARATHON_SERVICE_RESTART_ERROR:
@@ -403,8 +369,6 @@ class ServicesContainer extends React.Component {
 
     return {
       createGroup: () => set(ServiceActionItem.CREATE_GROUP),
-      createService: () => set(ServiceActionItem.CREATE),
-      editService: (props) => set(ServiceActionItem.EDIT, props),
       // All methods below work on ServiceTree and Service types
       deleteService: (props) => set(ServiceActionItem.DESTROY, props),
       restartService: (props) => set(ServiceActionItem.RESTART, props),
@@ -419,9 +383,7 @@ class ServicesContainer extends React.Component {
       createGroup: this.createGroup,
       deleteGroup: this.deleteGroup,
       editGroup: this.editGroup,
-      createService: this.createService,
       deleteService: this.deleteService,
-      editService: this.editService,
       restartService: this.restartService
     };
   }
@@ -450,6 +412,7 @@ class ServicesContainer extends React.Component {
       return this.props.children;
     }
 
+    const {children, params, routes} = this.props;
     const {
       fetchErrors,
       filterExpression,
@@ -489,8 +452,10 @@ class ServicesContainer extends React.Component {
       return (
         <PodDetail
           actions={this.getActions()}
-          pod={item}
-          modals={this.getModals(item)} />
+          pod={item}>
+          {this.getModals(item)}
+          {children}
+        </PodDetail>
       );
     }
 
@@ -498,10 +463,12 @@ class ServicesContainer extends React.Component {
       return (
         <ServiceDetail
           actions={this.getActions()}
-          params={this.props.params}
-          routes={this.props.routes}
-          service={item}
-          modals={this.getModals(item)} />
+          params={params}
+          routes={routes}
+          service={item}>
+          {this.getModals(item)}
+          {children}
+        </ServiceDetail>
       );
     }
 
@@ -522,12 +489,14 @@ class ServicesContainer extends React.Component {
           filters={SERVICE_FILTERS}
           filterExpression={filterExpression}
           isEmpty={isEmpty}
-          modals={this.getModals(item)}
           onFilterExpressionChange={this.handleFilterExpressionChange}
-          params={this.props.params}
-          routes={this.props.routes}
+          params={params}
+          routes={routes}
           services={filteredServices.getItems()}
-          serviceTree={item} />
+          serviceTree={item}>
+          {this.getModals(item)}
+          {children}
+        </ServiceTreeView>
       );
     }
 
@@ -547,8 +516,6 @@ class ServicesContainer extends React.Component {
 ServicesContainer.childContextTypes = {
   modalHandlers: PropTypes.shape({
     createGroup: PropTypes.func,
-    createService: PropTypes.func,
-    editService: PropTypes.func,
     deleteService: PropTypes.func,
     restartService: PropTypes.func,
     scaleService: PropTypes.func,

--- a/plugins/services/src/js/routes/services.js
+++ b/plugins/services/src/js/routes/services.js
@@ -98,7 +98,7 @@ const serviceRoutes = [
               },
               {
                 type: Route,
-                path: 'edit',
+                path: 'edit(/:version)',
                 component: NewCreateServiceModal,
                 buildBreadCrumb(params) {
                   return {

--- a/plugins/services/src/js/routes/services.js
+++ b/plugins/services/src/js/routes/services.js
@@ -5,6 +5,7 @@ import React from 'react';
 
 import DeploymentsTab from '../pages/services/DeploymentsTab';
 import ServicesContainer from '../containers/services/ServicesContainer';
+import NewCreateServiceModal from '../components/modals/NewCreateServiceModal';
 import ServicesPage from '../pages/ServicesPage';
 import ServiceTaskDetailPage from '../pages/task-details/ServiceTaskDetailPage';
 import ServiceVolumeContainer from '../containers/volume-detail/ServiceVolumeContainer';
@@ -65,10 +66,18 @@ const serviceRoutes = [
         children: [
           {
             type: Route,
+            path: 'create',
+            component: NewCreateServiceModal,
+            buildBreadCrumb() {
+              return {
+                parentCrumb: '/services/overview',
+                getCrumbs: buildServiceCrumbs
+              };
+            }
+          },
+          {
+            type: Route,
             path: ':id',
-            component({children}) {
-              return children;
-            },
             buildBreadCrumb() {
               return {
                 parentCrumb: '/services/overview',
@@ -76,6 +85,28 @@ const serviceRoutes = [
               };
             },
             children: [
+              {
+                type: Route,
+                path: 'create',
+                component: NewCreateServiceModal,
+                buildBreadCrumb(params) {
+                  return {
+                    parentCrumb: `/services/overview/${params.id}`,
+                    getCrumbs: buildServiceCrumbs
+                  };
+                }
+              },
+              {
+                type: Route,
+                path: 'edit',
+                component: NewCreateServiceModal,
+                buildBreadCrumb(params) {
+                  return {
+                    parentCrumb: `/services/overview/${params.id}`,
+                    getCrumbs: buildServiceCrumbs
+                  };
+                }
+              },
               // This route needs to be rendered outside of the tabs that are
               // rendered in the service-task-details route.
               {

--- a/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
+++ b/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
@@ -90,9 +90,11 @@ class ServiceConfigDisplay extends React.Component {
       );
     }
 
-    return messages.length > 0
-      ? <Alert>{messages}</Alert>
-      : null;
+    if (!messages.length) {
+      return null;
+    }
+
+    return <Alert>{messages}</Alert>;
   }
 
   render() {

--- a/plugins/services/src/js/structs/ServiceTree.js
+++ b/plugins/services/src/js/structs/ServiceTree.js
@@ -104,6 +104,10 @@ module.exports = class ServiceTree extends Tree {
    * @return {Service|ServiceTree} matching item
    */
   findItemById(id) {
+    if (this.getId() === id) {
+      return this;
+    }
+
     return this.findItem(function (item) {
       return item.getId() === id;
     });

--- a/plugins/services/src/js/utils/ServiceUtil.js
+++ b/plugins/services/src/js/utils/ServiceUtil.js
@@ -474,6 +474,18 @@ const ServiceUtil = {
       );
   },
 
+  getBaseID(serviceID) {
+    // The regular expression `/^(\/.+)$/` is looking for the beginning of the
+    // string and matches if the string starts with a `/` and does contain more
+    // characters after the slash. This is combined into a group and then
+    // replaced with the first group which is the complete string and a `/` is
+    // appended. This is needed because in most case a path like
+    // `/group/another-group` will be given by `getId` except on root then the
+    // return value of `getId` would be `/` so in most cases we want to append a
+    // `/` so that the user can begin typing the `id` of their application.
+    return serviceID.replace(/^(\/.+)$/, '$1/');
+  },
+
   getDefinitionFromSpec(spec) {
     const definition = spec.toJSON();
 

--- a/src/js/components/modals/FullScreenModal.js
+++ b/src/js/components/modals/FullScreenModal.js
@@ -18,7 +18,8 @@ class FullScreenModal extends React.Component {
     }
 
     return (
-      <Modal geminiClass={geminiClasses}
+      <Modal
+        geminiClass={geminiClasses}
         modalClass="modal modal-full-screen"
         modalHeight={modalHeight}
         showHeader={true}


### PR DESCRIPTION
Service Modal Routes 1 of 3: https://github.com/dcos/dcos-ui/pull/1828
Service Modal Routes 2a of 3: https://github.com/dcos/dcos-ui/pull/1853
Service Modal Routes 2b of 3: https://github.com/dcos/dcos-ui/pull/1871

Partly closes: DCOS-12423

Essentially this PR should not make a difference in functionality, other than the `NewCreateServiceModal` now is routed with `/create` and `/edit:version` routes.

One thing to note is that it is possible to go to a group route and then add `/edit` at the end, which will open the modal in an edit mode. It is possible to change the group into an application if it is empty, otherwise Marathon will complain and provide a reasonable error message:
![](https://cl.ly/3T1s2r1n0N22/Image%202017-01-19%20at%2017.50.41.png)

Since this is actually possible, I chose to leave it as is. Also, I don't expect many people will enter that route manually. If they do and feel like what happens is not what they expect we can create an issue and take it from there.

![](https://cl.ly/1V2F383M1F2g/Screen%20Recording%202017-01-19%20at%2018.05.gif)