### PR TITLE
DCOS-13362: [1/7] Error Normalisation: Introduce MarathonErrorUtil

### DIFF
--- a/plugins/services/src/js/utils/MarathonErrorUtil.js
+++ b/plugins/services/src/js/utils/MarathonErrorUtil.js
@@ -1,0 +1,121 @@
+import ValidatorUtil from '../../../../../src/js/utils/ValidatorUtil';
+
+const MarathonErrorUtil = {
+
+  /**
+   * Try to guess an error type from it's contents
+   *
+   * @param {String} message - The marathon error string
+   * @returns {String} Returns the message type
+   */
+  /* eslint-disable no-unused-vars */
+  getErrorType(message) {
+  /* eslint-enable no-unused-vars */
+
+    // TODO: This will be implemented on the next PR
+    return 'MARATHON_ERROR';
+
+  },
+
+  /**
+   * Parses errros from the given input format into the common error format
+   * used internally
+   *
+   * For reference, marathon responds an error according to the exception that
+   * occurred and it's translated with the following checks:
+   *
+   * https://github.com/mesosphere/marathon/blob/master/src/main/scala/mesosphere/marathon/api/MarathonExceptionMapper.scala#L63
+   *
+   * @param {Object|String} error - The marathon error(s) to process
+   * @returns {Array} Returns an array of error objects
+   */
+  parseErrors(error) {
+    if (error == null) {
+      return [];
+    }
+
+    // `error` could be a string, if the error has no details
+    if (typeof error === 'string') {
+      return [
+        {
+          path: [],
+          message: error,
+          type: MarathonErrorUtil.getErrorType(error),
+          variables: {}
+        }
+      ];
+    }
+
+    // `details` can be missing
+    if (!error.details) {
+      if (!error.message) {
+        return [];
+      }
+
+      return [
+        {
+          path: [],
+          message: error.message,
+          type: MarathonErrorUtil.getErrorType(error.message),
+          variables: {}
+        }
+      ];
+    }
+
+    // `details` can be a string
+    if (typeof error.details === 'string') {
+      return [
+        {
+          path: [],
+          message: error.details,
+          type: MarathonErrorUtil.getErrorType(error.details),
+          variables: {}
+        }
+      ];
+
+    }
+
+    // `details` can be an array of errors
+    return error.details.reduce(function (memo, {errors, path}) {
+
+      // Convert marathon path components to a dot-separated string
+      // and then split it into an array
+      //
+      // A marathon path looks like: /container(0)/containerPath
+      //
+      const pathString = path
+        .replace(/\//g, '.')
+        .replace(/\((\d+)\)/g, (_, id) => `.${id}`)
+        .slice(1);
+
+      // Don't create array with empty first item when we have an empty path
+      let pathComponents = [];
+      if (pathString !== '') {
+        pathComponents = pathString
+          .split('.')
+          .map(function (component) {
+            if (ValidatorUtil.isNumber(component)) {
+              return Number(component);
+            }
+
+            return component;
+          });
+      }
+
+      // For every error, create the correct message
+      return errors.reduce(function (memo, errorMessage) {
+        memo.push({
+          path: pathComponents,
+          message: errorMessage,
+          type: MarathonErrorUtil.getErrorType(errorMessage),
+          variables: {}
+        });
+
+        return memo;
+      }, memo);
+    }, []);
+  }
+
+};
+
+module.exports = MarathonErrorUtil;

--- a/plugins/services/src/js/utils/MarathonErrorUtil.js
+++ b/plugins/services/src/js/utils/MarathonErrorUtil.js
@@ -8,9 +8,8 @@ const MarathonErrorUtil = {
    * @param {String} message - The marathon error string
    * @returns {String} Returns the message type
    */
-  /* eslint-disable no-unused-vars */
+  // eslint-disable-next-line no-unused-vars
   getErrorType(message) {
-  /* eslint-enable no-unused-vars */
 
     // TODO: This will be implemented on the next PR
     return 'MARATHON_ERROR';
@@ -46,12 +45,13 @@ const MarathonErrorUtil = {
       ];
     }
 
-    // `details` can be missing
-    if (!error.details) {
-      if (!error.message) {
-        return [];
-      }
+    // Both `details` and `errors` can be missing
+    if (!error.details && !error.message) {
+      return [];
+    }
 
+    // Only `details` can be missing
+    if (!error.details && error.message) {
       return [
         {
           path: [],
@@ -84,15 +84,14 @@ const MarathonErrorUtil = {
       // A marathon path looks like: /container(0)/containerPath
       //
       const pathString = path
-        .replace(/\//g, '.')
-        .replace(/\((\d+)\)/g, (_, id) => `.${id}`)
+        .replace(/\((\d+)\)/g, (_, id) => `/${id}`)
         .slice(1);
 
       // Don't create array with empty first item when we have an empty path
       let pathComponents = [];
       if (pathString !== '') {
         pathComponents = pathString
-          .split('.')
+          .split('/')
           .map(function (component) {
             if (ValidatorUtil.isNumber(component)) {
               return Number(component);

--- a/plugins/services/src/js/utils/__tests__/MarathonErrorUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/MarathonErrorUtil-test.js
@@ -1,0 +1,123 @@
+jest.dontMock('../MarathonErrorUtil');
+
+const MarathonErrorUtil = require('../MarathonErrorUtil');
+
+describe('MarathonErrorUtil', function () {
+
+  describe('#parseErrors', function () {
+
+    it('should properly process string-only errors', function () {
+      const marathonError = 'Some error';
+
+      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([
+        {
+          path: [],
+          message: 'Some error',
+          type: 'MARATHON_ERROR',
+          variables: {}
+        }
+      ]);
+    });
+
+    it('should properly handle object errors with message-only', function () {
+      const marathonError = {
+        message: 'Some error'
+      };
+
+      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([
+        {
+          path: [],
+          message: 'Some error',
+          type: 'MARATHON_ERROR',
+          variables: {}
+        }
+      ]);
+    });
+
+    it('should properly handle object errors with string details', function () {
+      const marathonError = {
+        message: 'Some error',
+        details: 'Some error details'
+      };
+
+      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([
+        {
+          path: [],
+          message: 'Some error details',
+          type: 'MARATHON_ERROR',
+          variables: {}
+        }
+      ]);
+    });
+
+    it('should properly handle object errors with array details', function () {
+      const marathonError = {
+        message: 'Some error',
+        details: [
+          {
+            errors: ['First Error', 'Second Error'],
+            path: '/'
+          }
+        ]
+      };
+
+      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([
+        {
+          path: [],
+          message: 'First Error',
+          type: 'MARATHON_ERROR',
+          variables: {}
+        },
+        {
+          path: [],
+          message: 'Second Error',
+          type: 'MARATHON_ERROR',
+          variables: {}
+        }
+      ]);
+    });
+
+    it('should properly translate marathon paths without index', function () {
+      const marathonError = {
+        message: 'Some error',
+        details: [
+          {
+            errors: ['First Error'],
+            path: '/some/property'
+          }
+        ]
+      };
+
+      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([
+        {
+          path: ['some', 'property'],
+          message: 'First Error',
+          type: 'MARATHON_ERROR',
+          variables: {}
+        }
+      ]);
+    });
+
+    it('should properly translate marathon paths with index', function () {
+      const marathonError = {
+        message: 'Some error',
+        details: [
+          {
+            errors: ['First Error'],
+            path: '/some/indexed(3)/property'
+          }
+        ]
+      };
+
+      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([
+        {
+          path: ['some', 'indexed', 3, 'property'],
+          message: 'First Error',
+          type: 'MARATHON_ERROR',
+          variables: {}
+        }
+      ]);
+    });
+  });
+
+});


### PR DESCRIPTION
This utility exposes the `MarathonErrorUtil.parseErrors` function that normalises whatever marathon error response into an internal representation of an array of error messages.

_This PR implements the `Marathon Error Parsing` task in the spec document: https://docs.google.com/document/d/1kwdPxBo3UlRZvMxLLIUqSZqLlUJitEuIAWderUgWY1c/edit#heading=h.thdpdh4mx6uj_