### PR TITLE
Fix Ace editor tooltip positioning

### DIFF
--- a/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
+++ b/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
@@ -114,12 +114,6 @@ class CreateServiceJsonOnly extends React.Component {
   render() {
     let {appConfig, errorList} = this.state;
 
-    // Note: The `transform` parameter is just a hack to properly align the
-    // error message.
-    let editorStyles = {
-      transform: 'translateX(0)'
-    };
-
     return (
       <div className="create-service-modal-json-only container">
         <div className="create-service-modal-json-only-introduction">
@@ -136,7 +130,6 @@ class CreateServiceJsonOnly extends React.Component {
             onErrorStateChange={this.handleJSONErrorStateChange}
             showGutter={true}
             showPrintMargin={false}
-            style={editorStyles}
             theme="monokai"
             value={appConfig} />
         </div>

--- a/src/styles/components/modal/full-screen/styles.less
+++ b/src/styles/components/modal/full-screen/styles.less
@@ -130,10 +130,11 @@
   .modal-full-screen-side-panel {
     height: 100%;
     position: absolute;
-    right: -100%;
+    right: @modal-full-screen-side-panel-width * -1;
     top: 0;
     transition: right 0.35s;
-    width: 100%;
+    width: @modal-full-screen-side-panel-width;
+    will-change: right;
     z-index: @z-index-modal-side-panel;
 
     &.is-visible {
@@ -235,7 +236,8 @@
     }
 
     .modal-full-screen-side-panel {
-      width: 400px;
+      right: @modal-full-screen-side-panel-width-screen-large * -1;
+      width: @modal-full-screen-side-panel-width-screen-large;
     }
 
     .modal-full-screen-side-panel-placeholder {
@@ -245,7 +247,7 @@
       width: 0;
 
       &.is-visible {
-        width: 400px;
+        width: @modal-full-screen-side-panel-width-screen-large;
       }
     }
   }
@@ -276,13 +278,14 @@
     }
 
     .modal-full-screen-side-panel {
-      width: 500px;
+      right: @modal-full-screen-side-panel-width-screen-jumbo * -1;
+      width: @modal-full-screen-side-panel-width-screen-jumbo;
     }
 
     .modal-full-screen-side-panel-placeholder {
 
       &.is-visible {
-        width: 500px;
+        width: @modal-full-screen-side-panel-width-screen-jumbo;
       }
     }
   }

--- a/src/styles/components/modal/full-screen/styles.less
+++ b/src/styles/components/modal/full-screen/styles.less
@@ -129,16 +129,15 @@
 
   .modal-full-screen-side-panel {
     height: 100%;
-    left: 0;
     position: absolute;
+    right: -100%;
     top: 0;
-    transform: translateX(100%);
-    transition: transform 0.35s;
+    transition: right 0.35s;
     width: 100%;
     z-index: @z-index-modal-side-panel;
 
     &.is-visible {
-      transform: translateX(0);
+      right: 0;
     }
   }
 
@@ -236,8 +235,6 @@
     }
 
     .modal-full-screen-side-panel {
-      left: auto;
-      right: 0;
       width: 400px;
     }
 

--- a/src/styles/components/modal/full-screen/variables.less
+++ b/src/styles/components/modal/full-screen/variables.less
@@ -18,3 +18,7 @@
 @modal-full-screen-body-padding-horizontal-screen-medium: @pod-margin-left-screen-medium;
 @modal-full-screen-body-padding-horizontal-screen-large: @pod-margin-left-screen-large;
 @modal-full-screen-body-padding-horizontal-screen-jumbo: @pod-margin-left-screen-jumbo;
+
+@modal-full-screen-side-panel-width: 100%;
+@modal-full-screen-side-panel-width-screen-large: 400px;
+@modal-full-screen-side-panel-width-screen-jumbo: 500px;


### PR DESCRIPTION
Change the fullscreen modal side panel positioning to use position `right` instead of transform `translateX` as `transform` creates a new stacking context and the containing block is changing the context which results in "wrong" positions.

For more details please see:
https://drafts.csswg.org/css-transforms-1/#transform-rendering

With this change in place we no longer need the hacks to correct the Ace editor tooltip position, as position fixed (used to position the tooltip) is working as expected.