### PR TITLE
DCOS-13362: [2/7] Error Normalisation : Adapt MarathonAppValidators

### DIFF
--- a/plugins/services/src/js/constants/ServiceErrorTypes.js
+++ b/plugins/services/src/js/constants/ServiceErrorTypes.js
@@ -1,0 +1,47 @@
+const ServiceErrorTypes = {
+
+  /**
+   * Two or more properties are present in the configuration that are are
+   * conflicting to eachother.
+   *
+   * Expected variables:
+   * {
+   *   "feature1": "first conflicting feature",
+   *   "feature2": "second conflicting feature"
+   * }
+   */
+  PROP_CONFLICT: 'PROP_CONFLICT',
+
+  /**
+   * The specified property is part of a deprecated API
+   *
+   * Expected variables:
+   * {
+   *   "name": "property name"
+   * }
+   */
+  PROP_DEPRECATED: 'PROP_DEPRECATED',
+
+  /**
+   * All of the specified properties must be specified
+   *
+   * Expected variables:
+   * {
+   *    "names": "prop1, prop2, prop3, ..."
+   * }
+   */
+  PROP_MISSING_ALL: 'PROP_MISSING_ALL',
+
+  /**
+   * At least one of the specified properties must be specified
+   *
+   * Expected variables:
+   * {
+   *    "names": "prop1, prop2, prop3, ..."
+   * }
+   */
+  PROP_MISSING_ONE: 'PROP_MISSING_ONE'
+
+};
+
+module.exports = ServiceErrorTypes;

--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -22,10 +22,12 @@ const MarathonAppValidators = {
     // Dont accept both `args` and `cmd`
     if (hasCmd && hasArgs) {
       const notBothMessage = 'Please specify only one of `cmd` or `args`';
+      const type = 'MARATHON_APP_ONE_OF_CMD_ARGS';
+      const variables = {};
 
       return [
-        {path: ['cmd'], message: notBothMessage},
-        {path: ['args'], message: notBothMessage}
+        {path: ['cmd'], message: notBothMessage, type, variables},
+        {path: ['args'], message: notBothMessage, type, variables}
       ];
     }
 
@@ -53,7 +55,9 @@ const MarathonAppValidators = {
           return [
             {
               path: ['container', 'appc', 'id'],
-              message: 'AppContainer id should start with \'sha512-\''
+              message: 'AppContainer id should start with \'sha512-\'',
+              type: 'MARATHON_APP_APPCONTAINER_ID',
+              variables: {}
             }
           ];
         }
@@ -66,11 +70,13 @@ const MarathonAppValidators = {
     // Create one error for every field, instead of showing the error
     // to the root.
     const message = 'You must specify a command, an argument or a container';
+    const type = 'MARATHON_APP_CMD_OR_IMAGE';
+    const variables = {};
 
     return [
-      {path: ['cmd'], message},
-      {path: ['args'], message},
-      {path: ['container', 'docker', 'image'], message}
+      {path: ['cmd'], message, type, variables},
+      {path: ['args'], message, type, variables},
+      {path: ['container', 'docker', 'image'], message, type, variables}
     ];
   },
 
@@ -91,10 +97,12 @@ const MarathonAppValidators = {
     if (hasAppResidency !== hasPersistentVolumes) {
       const message = 'AppDefinition must contain persistent volumes and ' +
         'define residency';
+      const type = 'MARATHON_APP_RESIDENCY_RULES';
+      const variables = {};
 
       return [
-        {path: ['residency'], message},
-        {path: ['container', 'volumes'], message}
+        {path: ['residency'], message, type, variables},
+        {path: ['container', 'volumes'], message, type, variables}
       ];
     }
 
@@ -127,11 +135,13 @@ const MarathonAppValidators = {
     if (/^(BRIDGE|USER)$/.exec(app.container.docker.network)) {
       const message = 'ipAddress/discovery is not allowed for Docker ' +
         'containers using BRIDGE or USER networks';
+      const type = 'MARATHON_APP_IP_ADDRESS_RULES';
+      const variables = {};
 
       return [
-        {path: ['ipAddress'], message},
-        {path: ['discoveryInfo'], message},
-        {path: ['container', 'docker', 'network'], message}
+        {path: ['ipAddress'], message, type, variables},
+        {path: ['discoveryInfo'], message, type, variables},
+        {path: ['container', 'docker', 'network'], message, type, variables}
       ];
     }
 
@@ -147,9 +157,11 @@ const MarathonAppValidators = {
     if (ValidatorUtil.isDefined(app.uris) &&
         ValidatorUtil.isDefined(app.fetch)) {
       const message = '`uris` are deprecated. Please use `fetch` instead';
+      const type = 'MARATHON_APP_URIS_DEPRECATED';
+      const variables = {};
 
       return [
-        {path: ['uris'], message}
+        {path: ['uris'], message, type, variables}
       ];
     }
 

--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -1,5 +1,6 @@
 import ValidatorUtil from '../../../../../src/js/utils/ValidatorUtil';
 import {findNestedPropertyInObject} from '../../../../../src/js/utils/Util';
+import {PROP_CONFLICT, PROP_DEPRECATED, PROP_MISSING_ALL, PROP_MISSING_ONE} from '../constants/ServiceErrorTypes';
 
 const MarathonAppValidators = {
 
@@ -22,8 +23,11 @@ const MarathonAppValidators = {
     // Dont accept both `args` and `cmd`
     if (hasCmd && hasArgs) {
       const notBothMessage = 'Please specify only one of `cmd` or `args`';
-      const type = 'MARATHON_APP_ONE_OF_CMD_ARGS';
-      const variables = {};
+      const type = PROP_CONFLICT;
+      const variables = {
+        feature1: 'cmd',
+        feature2: 'args'
+      };
 
       return [
         {path: ['cmd'], message: notBothMessage, type, variables},
@@ -56,8 +60,10 @@ const MarathonAppValidators = {
             {
               path: ['container', 'appc', 'id'],
               message: 'AppContainer id should start with \'sha512-\'',
-              type: 'MARATHON_APP_APPCONTAINER_ID',
-              variables: {}
+              type: 'STRING_PATTERN',
+              variables: {
+                pattern: '^sha512-'
+              }
             }
           ];
         }
@@ -70,8 +76,10 @@ const MarathonAppValidators = {
     // Create one error for every field, instead of showing the error
     // to the root.
     const message = 'You must specify a command, an argument or a container';
-    const type = 'MARATHON_APP_CMD_OR_IMAGE';
-    const variables = {};
+    const type = PROP_MISSING_ONE;
+    const variables = {
+      names: 'cmd, args, container.docker.image'
+    };
 
     return [
       {path: ['cmd'], message, type, variables},
@@ -97,8 +105,10 @@ const MarathonAppValidators = {
     if (hasAppResidency !== hasPersistentVolumes) {
       const message = 'AppDefinition must contain persistent volumes and ' +
         'define residency';
-      const type = 'MARATHON_APP_RESIDENCY_RULES';
-      const variables = {};
+      const type = PROP_MISSING_ALL;
+      const variables = {
+        names: 'residency, container.volumes'
+      };
 
       return [
         {path: ['residency'], message, type, variables},
@@ -135,8 +145,11 @@ const MarathonAppValidators = {
     if (/^(BRIDGE|USER)$/.exec(app.container.docker.network)) {
       const message = 'ipAddress/discovery is not allowed for Docker ' +
         'containers using BRIDGE or USER networks';
-      const type = 'MARATHON_APP_IP_ADDRESS_RULES';
-      const variables = {};
+      const type = PROP_CONFLICT;
+      const variables = {
+        feature1: 'ipAddress or discoveryInfo',
+        feature2: 'container.docker.network'
+      };
 
       return [
         {path: ['ipAddress'], message, type, variables},
@@ -157,8 +170,10 @@ const MarathonAppValidators = {
     if (ValidatorUtil.isDefined(app.uris) &&
         ValidatorUtil.isDefined(app.fetch)) {
       const message = '`uris` are deprecated. Please use `fetch` instead';
-      const type = 'MARATHON_APP_URIS_DEPRECATED';
-      const variables = {};
+      const type = PROP_DEPRECATED;
+      const variables = {
+        name: 'uris'
+      };
 
       return [
         {path: ['uris'], message, type, variables}

--- a/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
@@ -1,44 +1,83 @@
 jest.unmock('../MarathonAppValidators');
 const MarathonAppValidators = require('../MarathonAppValidators');
 
+const APPCONTAINERID_ERRORS = [
+  {
+    path: ['container', 'appc', 'id'],
+    message: 'AppContainer id should start with \'sha512-\'',
+    type: 'MARATHON_APP_APPCONTAINER_ID',
+    variables: {}
+  }
+];
 const CMDORDOCKERIMAGE_ERRORS = [
   {
     path: ['cmd'],
-    message: 'You must specify a command, an argument or a container'
+    message: 'You must specify a command, an argument or a container',
+    type: 'MARATHON_APP_CMD_OR_IMAGE',
+    variables: {}
   },
   {
     path: ['args'],
-    message: 'You must specify a command, an argument or a container'
+    message: 'You must specify a command, an argument or a container',
+    type: 'MARATHON_APP_CMD_OR_IMAGE',
+    variables: {}
   },
   {
     path: ['container', 'docker', 'image'],
-    message: 'You must specify a command, an argument or a container'
+    message: 'You must specify a command, an argument or a container',
+    type: 'MARATHON_APP_CMD_OR_IMAGE',
+    variables: {}
   }
 ];
 
 const COMPLYWITHRESIDENCY_ERRORS = [
   {
     path: ['residency'],
-    message: 'AppDefinition must contain persistent volumes and define residency'
+    message: 'AppDefinition must contain persistent volumes and define residency',
+    type: 'MARATHON_APP_RESIDENCY_RULES',
+    variables: {}
   },
   {
     path: ['container', 'volumes'],
-    message: 'AppDefinition must contain persistent volumes and define residency'
+    message: 'AppDefinition must contain persistent volumes and define residency',
+    type: 'MARATHON_APP_RESIDENCY_RULES',
+    variables: {}
   }
 ];
 
 const COMPLYWITHIPADDRESS_ERRORS = [
   {
     path: ['ipAddress'],
-    message: 'ipAddress/discovery is not allowed for Docker containers using BRIDGE or USER networks'
+    message: 'ipAddress/discovery is not allowed for Docker containers using BRIDGE or USER networks',
+    type: 'MARATHON_APP_IP_ADDRESS_RULES',
+    variables: {}
   },
   {
     path: ['discoveryInfo'],
-    message: 'ipAddress/discovery is not allowed for Docker containers using BRIDGE or USER networks'
+    message: 'ipAddress/discovery is not allowed for Docker containers using BRIDGE or USER networks',
+    type: 'MARATHON_APP_IP_ADDRESS_RULES',
+    variables: {}
   },
   {
     path: ['container', 'docker', 'network'],
-    message: 'ipAddress/discovery is not allowed for Docker containers using BRIDGE or USER networks'
+    message: 'ipAddress/discovery is not allowed for Docker containers using BRIDGE or USER networks',
+    type: 'MARATHON_APP_IP_ADDRESS_RULES',
+    variables: {}
+  }
+];
+
+const NOTBOTHCMDARGS_ERRORS = [
+  {
+    path: ['cmd'],
+    message: 'Please specify only one of `cmd` or `args`',
+    type: 'MARATHON_APP_ONE_OF_CMD_ARGS',
+    variables: {}
+  },
+  {
+    path: ['args'],
+    message: 'Please specify only one of `cmd` or `args`',
+    type: 'MARATHON_APP_ONE_OF_CMD_ARGS',
+    variables: {}
   }
 ];
 
@@ -68,10 +107,7 @@ describe('MarathonAppValidators', function () {
     it('should return error if both `args` and `cmd` are defined', function () {
       const spec = {args: ['foo'], cmd: 'bar'};
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec))
-        .toEqual([
-          {path: ['cmd'], message: 'Please specify only one of `cmd` or `args`'},
-          {path: ['args'], message: 'Please specify only one of `cmd` or `args`'}
-        ]);
+        .toEqual(NOTBOTHCMDARGS_ERRORS);
     });
 
     it('should return all errors if neither is defined', function () {
@@ -125,12 +161,7 @@ describe('MarathonAppValidators', function () {
     it('should return errors if `container.appc.id` does not start with "sha512-"', function () {
       const spec = {container: {appc: {image: 'foo', id: 'sha256-test'}}};
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec))
-        .toEqual([
-          {
-            path: ['container', 'appc', 'id'],
-            message: 'AppContainer id should start with \'sha512-\''
-          }
-        ]);
+        .toEqual(APPCONTAINERID_ERRORS);
     });
 
     it('should not return errors if `container.appc` correctly defined', function () {

--- a/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
@@ -5,28 +5,36 @@ const APPCONTAINERID_ERRORS = [
   {
     path: ['container', 'appc', 'id'],
     message: 'AppContainer id should start with \'sha512-\'',
-    type: 'MARATHON_APP_APPCONTAINER_ID',
-    variables: {}
+    type: 'STRING_PATTERN',
+    variables: {
+      pattern: '^sha512-'
+    }
   }
 ];
 const CMDORDOCKERIMAGE_ERRORS = [
   {
     path: ['cmd'],
     message: 'You must specify a command, an argument or a container',
-    type: 'MARATHON_APP_CMD_OR_IMAGE',
-    variables: {}
+    type: 'PROP_MISSING_ONE',
+    variables: {
+      names: 'cmd, args, container.docker.image'
+    }
   },
   {
     path: ['args'],
     message: 'You must specify a command, an argument or a container',
-    type: 'MARATHON_APP_CMD_OR_IMAGE',
-    variables: {}
+    type: 'PROP_MISSING_ONE',
+    variables: {
+      names: 'cmd, args, container.docker.image'
+    }
   },
   {
     path: ['container', 'docker', 'image'],
     message: 'You must specify a command, an argument or a container',
-    type: 'MARATHON_APP_CMD_OR_IMAGE',
-    variables: {}
+    type: 'PROP_MISSING_ONE',
+    variables: {
+      names: 'cmd, args, container.docker.image'
+    }
   }
 ];
 
@@ -34,14 +42,18 @@ const COMPLYWITHRESIDENCY_ERRORS = [
   {
     path: ['residency'],
     message: 'AppDefinition must contain persistent volumes and define residency',
-    type: 'MARATHON_APP_RESIDENCY_RULES',
-    variables: {}
+    type: 'PROP_MISSING_ALL',
+    variables: {
+      names: 'residency, container.volumes'
+    }
   },
   {
     path: ['container', 'volumes'],
     message: 'AppDefinition must contain persistent volumes and define residency',
-    type: 'MARATHON_APP_RESIDENCY_RULES',
-    variables: {}
+    type: 'PROP_MISSING_ALL',
+    variables: {
+      names: 'residency, container.volumes'
+    }
   }
 ];
 
@@ -49,20 +61,29 @@ const COMPLYWITHIPADDRESS_ERRORS = [
   {
     path: ['ipAddress'],
     message: 'ipAddress/discovery is not allowed for Docker containers using BRIDGE or USER networks',
-    type: 'MARATHON_APP_IP_ADDRESS_RULES',
-    variables: {}
+    type: 'PROP_CONFLICT',
+    variables: {
+      feature1: 'ipAddress or discoveryInfo',
+      feature2: 'container.docker.network'
+    }
   },
   {
     path: ['discoveryInfo'],
     message: 'ipAddress/discovery is not allowed for Docker containers using BRIDGE or USER networks',
-    type: 'MARATHON_APP_IP_ADDRESS_RULES',
-    variables: {}
+    type: 'PROP_CONFLICT',
+    variables: {
+      feature1: 'ipAddress or discoveryInfo',
+      feature2: 'container.docker.network'
+    }
   },
   {
     path: ['container', 'docker', 'network'],
     message: 'ipAddress/discovery is not allowed for Docker containers using BRIDGE or USER networks',
-    type: 'MARATHON_APP_IP_ADDRESS_RULES',
-    variables: {}
+    type: 'PROP_CONFLICT',
+    variables: {
+      feature1: 'ipAddress or discoveryInfo',
+      feature2: 'container.docker.network'
+    }
   }
 ];
 
@@ -70,14 +91,20 @@ const NOTBOTHCMDARGS_ERRORS = [
   {
     path: ['cmd'],
     message: 'Please specify only one of `cmd` or `args`',
-    type: 'MARATHON_APP_ONE_OF_CMD_ARGS',
-    variables: {}
+    type: 'PROP_CONFLICT',
+    variables: {
+      feature1: 'cmd',
+      feature2: 'args'
+    }
   },
   {
     path: ['args'],
     message: 'Please specify only one of `cmd` or `args`',
-    type: 'MARATHON_APP_ONE_OF_CMD_ARGS',
-    variables: {}
+    type: 'PROP_CONFLICT',
+    variables: {
+      feature1: 'cmd',
+      feature2: 'args'
+    }
   }
 ];
 


### PR DESCRIPTION
---
~⚠️  This PR depends on #1830 - ( [See the diff](https://github.com/dcos/dcos-ui/compare/ic/feat/error-message-refactoring-1...ic/feat/error-message-refactoring-2?expand=1) )~

---

This commit ensures that the response from MarathonAppValidators complies with the structured agreed in the spec document.

_This PR implements the `Normalize internal error structure` task in the spec document: https://docs.google.com/document/d/1kwdPxBo3UlRZvMxLLIUqSZqLlUJitEuIAWderUgWY1c/edit#heading=h.thdpdh4mx6uj_