### PR TITLE
DCOS-13362: [3/7] Error Normalisation: Handling empty paths in DataValidatorUtil

### DIFF
--- a/src/js/utils/DataValidatorUtil.js
+++ b/src/js/utils/DataValidatorUtil.js
@@ -48,6 +48,12 @@ const DataValidatorUtil = {
    */
   errorArrayToMap(errors) {
     return errors.reduce(function (errorMap, error) {
+
+      // We cannot place root errors in the map
+      if (error.path.length === 0) {
+        return errorMap;
+      }
+
       const lens = path2lens(error.path);
       let message = error.message;
       const prevMessage = lens.get(errorMap);

--- a/src/js/utils/__tests__/DataValidatorUtil-test.js
+++ b/src/js/utils/__tests__/DataValidatorUtil-test.js
@@ -40,6 +40,14 @@ describe('DataValidatorUtil', function () {
       expect(obj).toEqual({a: {b: 'Foo, Bar'}});
     });
 
+    it('should correctly handle errors with empty paths', function () {
+      var obj = DataValidatorUtil.errorArrayToMap([
+        {path: [], message: 'Foo'},
+        {path: ['a', 'b'], message: 'Bar'}
+      ]);
+      expect(obj).toEqual({a: {b: 'Bar'}});
+    });
+
   });
 
   describe('#updateOnlyOnPath', function () {


### PR DESCRIPTION
---
⚠️  This PR depends on #1832 - ( [See the diff](https://github.com/dcos/dcos-ui/compare/ic/feat/error-message-refactoring-2...ic/feat/error-message-refactoring-3?expand=1) )

---
 
This commit ensures that DataValidatorUtil.errorArrayToMap will behave properly when fed an empty path to the error message. Currently there were some issues in the way the functional lenses were setting the path.

_This PR implements the `Normalize internal error structure` task in the spec document: https://docs.google.com/document/d/1kwdPxBo3UlRZvMxLLIUqSZqLlUJitEuIAWderUgWY1c/edit#heading=h.thdpdh4mx6uj_

Closes DCOS-13223