### PR TITLE
DCOS-13362: [4/7] Error Normalisation: Concentrate error handling

### DIFF
--- a/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
+++ b/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
@@ -4,6 +4,7 @@ import deepEqual from 'deep-equal';
 import ApplicationSpec from '../../structs/ApplicationSpec';
 import FieldHelp from '../../../../../../src/js/components/form/FieldHelp';
 import FieldLabel from '../../../../../../src/js/components/form/FieldLabel';
+import {SYNTAX_ERROR} from '../../constants/ServiceErrorTypes';
 import JSONEditor from '../../../../../../src/js/components/JSONEditor';
 import PodSpec from '../../structs/PodSpec';
 import ServiceUtil from '../../utils/ServiceUtil';
@@ -67,7 +68,7 @@ class CreateServiceJsonOnly extends React.Component {
   handleJSONErrorStateChange(errorState) {
     const {errors, onErrorsChange} = this.props;
     const hasJsonError = errors.some(function (error) {
-      return error.type === 'JSON_ERROR';
+      return error.type === SYNTAX_ERROR;
     });
 
     // Produce a JSON error if we have errors
@@ -75,7 +76,7 @@ class CreateServiceJsonOnly extends React.Component {
       onErrorsChange([
         {
           path: [],
-          type: 'JSON_ERROR',
+          type: SYNTAX_ERROR,
           variables: {},
           message: 'The input entered is not a valid JSON string'
         }

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -73,14 +73,14 @@ const METHODS_TO_BIND = [
   'onMarathonStoreServiceEditSuccess'
 ];
 
-const APP_ERROR_VALIDATORS = [
+const APP_VALIDATORS = [
   AppValidators.App,
   MarathonAppValidators.containsCmdArgsOrContainer,
   MarathonAppValidators.complyWithResidencyRules,
   MarathonAppValidators.complyWithIpAddressRules
 ];
 
-const POD_ERROR_VALIDATORS = [
+const POD_VALIDATORS = [
   PodValidators.Pod
 ];
 
@@ -360,14 +360,14 @@ class NewCreateServiceModal extends Component {
     if (serviceConfig instanceof ApplicationSpec) {
       validationErrors = DataValidatorUtil.validate(
         getServiceJSON(serviceConfig),
-        APP_ERROR_VALIDATORS
+        APP_VALIDATORS
       );
     }
 
     if (serviceConfig instanceof PodSpec) {
       validationErrors = DataValidatorUtil.validate(
         getServiceJSON(serviceConfig),
-        POD_ERROR_VALIDATORS
+        POD_VALIDATORS
       );
     }
 

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -372,8 +372,7 @@ class NewCreateServiceModal extends Component {
     }
 
     // Combine all errors
-    return [].concat(
-      apiErrors,
+    return apiErrors.concat(
       serviceFormErrors,
       validationErrors
     );

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -88,11 +88,11 @@ class NewCreateServiceModal extends Component {
   constructor() {
     super(...arguments);
 
-    this.state = this.getResetState(this.props);
-
     METHODS_TO_BIND.forEach((method) => {
       this[method] = this[method].bind(this);
     });
+
+    this.state = this.getResetState(this.props);
 
     // Add store change listeners the traditional way as React Router is
     // not able to pass down correct props if we are using StoreMixin

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -6,8 +6,6 @@ import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
 import {getContainerNameWithIcon} from '../../utils/ServiceConfigDisplayUtil';
 import {pluralize} from '../../../../../../src/js/utils/StringUtil';
 import Alert from '../../../../../../src/js/components/Alert';
-import AppValidators from '../../../../../../src/resources/raml/marathon/v2/types/app.raml';
-import PodValidators from '../../../../../../src/resources/raml/marathon/v2/types/pod.raml';
 import Batch from '../../../../../../src/js/structs/Batch';
 import ContainerServiceFormSection from '../forms/ContainerServiceFormSection';
 import CreateServiceModalFormUtil from '../../utils/CreateServiceModalFormUtil';
@@ -23,7 +21,6 @@ import MultiContainerNetworkingFormSection from '../forms/MultiContainerNetworki
 import MultiContainerVolumesFormSection from '../forms/MultiContainerVolumesFormSection';
 import ServiceUtil from '../../utils/ServiceUtil';
 import PodSpec from '../../structs/PodSpec';
-import MarathonAppValidators from '../../validators/MarathonAppValidators';
 import TabButton from '../../../../../../src/js/components/TabButton';
 import TabButtonList from '../../../../../../src/js/components/TabButtonList';
 import Tabs from '../../../../../../src/js/components/Tabs';
@@ -48,19 +45,6 @@ const KEY_VALUE_FIELDS = [
   'labels'
 ];
 
-const APP_ERROR_VALIDATORS = [
-  AppValidators.App,
-  MarathonAppValidators.containsCmdArgsOrContainer,
-  MarathonAppValidators.complyWithResidencyRules,
-  MarathonAppValidators.complyWithIpAddressRules,
-  MarathonAppValidators.containerVolmesPath,
-  MarathonAppValidators.mustNotContainUris
-];
-
-const POD_ERROR_VALIDATORS = [
-  PodValidators.Pod
-];
-
 class NewCreateServiceModalForm extends Component {
   constructor() {
     super(...arguments);
@@ -70,7 +54,6 @@ class NewCreateServiceModalForm extends Component {
         appConfig: null,
         batch: new Batch(),
         baseConfig: {},
-        errorList: [],
         isPod: false,
         jsonReducer() {},
         jsonParser() {}
@@ -109,7 +92,7 @@ class NewCreateServiceModalForm extends Component {
 
   componentDidUpdate() {
     this.props.onChange(new this.props.service.constructor(this.state.appConfig));
-    this.props.onErrorStateChange(this.state.errorList.length !== 0);
+    // this.props.onErrorStateChange(this.state.errorList.length !== 0);
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -137,10 +120,10 @@ class NewCreateServiceModalForm extends Component {
     }
 
     // Otherwise update if the state has changed
-    return (this.state.errorList !== nextState.errorList) ||
-      (this.state.baseConfig !== nextState.baseConfig) ||
+    return (this.state.baseConfig !== nextState.baseConfig) ||
       (this.state.batch !== nextState.batch) ||
-      (this.props.activeTab !== nextProps.activeTab);
+      (this.props.activeTab !== nextProps.activeTab) ||
+      (!deepEqual(this.props.errors, nextProps.errors));
   }
 
   getNewStateForJSON(baseConfig = {},
@@ -159,19 +142,6 @@ class NewCreateServiceModalForm extends Component {
       new Batch()
     );
 
-    let ERROR_VALIDATORS = APP_ERROR_VALIDATORS;
-
-    if (isPod) {
-      ERROR_VALIDATORS = POD_ERROR_VALIDATORS;
-    }
-
-    if (shouldValidate) {
-      newState.errorList = DataValidatorUtil.validate(
-        baseConfig,
-        ERROR_VALIDATORS
-      );
-    }
-
     // Update appConfig
     newState.appConfig = this.getAppConfig(newState.batch, baseConfig);
 
@@ -189,7 +159,7 @@ class NewCreateServiceModalForm extends Component {
     }
 
     // Run data validation on the raw data
-    this.validateCurrentState();
+    // this.validateCurrentState();
   }
 
   handleFormChange(event) {
@@ -209,12 +179,12 @@ class NewCreateServiceModalForm extends Component {
     this.setState({
       // Render the new appconfig
       appConfig: this.getAppConfig(batch),
-      batch,
-      // [Case F1] Reset errors only on the current field
-      errorList: DataValidatorUtil.stripErrorsOnPath(
-        this.state.errorList,
-        path
-      )
+      batch
+      // // [Case F1] Reset errors only on the current field
+      // errorList: DataValidatorUtil.stripErrorsOnPath(
+      //   this.state.errorList,
+      //   path
+      // )
     });
   }
 
@@ -238,13 +208,13 @@ class NewCreateServiceModalForm extends Component {
     this.setState({batch, appConfig: this.getAppConfig(batch)});
   }
 
-  validateCurrentState() {
-    const {errorList} = this.getNewStateForJSON(this.getAppConfig());
+  // validateCurrentState() {
+  //   const {errorList} = this.getNewStateForJSON(this.getAppConfig());
 
-    this.setState({errorList});
+  //   this.setState({errorList});
 
-    return Boolean(errorList.length);
-  }
+  //   return Boolean(errorList.length);
+  // }
 
   getAppConfig(batch = this.state.batch, baseConfig = this.state.baseConfig) {
     // Delete all key:value fields
@@ -257,22 +227,33 @@ class NewCreateServiceModalForm extends Component {
     return CreateServiceModalFormUtil.applyPatch(baseConfig, patch);
   }
 
-  getRootErrorMessage() {
-    const rootErrors = this.state.errorList.reduce(function (errors, error) {
-      if (error.path.length !== 0) {
-        return errors;
-      }
+  getRootErrors() {
+    const errors = this.props.errors.filter(function (error) {
+      return error.path.length === 0;
+    });
 
-      errors.push(<Alert>{error.message}</Alert>);
-
-      return errors;
-    }, []);
-
-    if (rootErrors.length === 0) {
+    if (errors.length === 0) {
       return null;
     }
 
-    return rootErrors;
+    return (
+      <Alert>
+        <strong>There is an error with your configuration</strong>
+        <div className="pod pod-narrower-left pod-shorter-top flush-bottom">
+          <ul className="list-unstyled short flush-bottom">
+            {errors.map((error, index) => {
+              const prefix = error.path.length ? `${error.path.join('.')}:` : '';
+
+              return (
+                <li key={index} className="short">
+                  {`\u2022 ${prefix} ${error.message}`}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </Alert>
+    );
   }
 
   getContainerList(data) {
@@ -296,7 +277,7 @@ class NewCreateServiceModalForm extends Component {
   getContainerContent(data, errors) {
     const {service} = this.props;
     const {containers} = data;
-    const rootErrorComponent = this.getRootErrorMessage();
+    const rootErrorComponent = this.getRootErrors();
 
     if (containers == null) {
       return [];
@@ -343,7 +324,7 @@ class NewCreateServiceModalForm extends Component {
   }
 
   getSectionContent(data, errorMap) {
-    const rootErrorComponent = this.getRootErrorMessage();
+    const rootErrorComponent = this.getRootErrors();
 
     if (this.state.isPod) {
       return [
@@ -423,8 +404,8 @@ class NewCreateServiceModalForm extends Component {
   }
 
   render() {
-    const {appConfig, batch, errorList} = this.state;
-    const {activeTab, handleTabChange, isJSONModeActive, isEdit, onConvertToPod, service} = this.props;
+    const {appConfig, batch} = this.state;
+    const {activeTab, errors, handleTabChange, isJSONModeActive, isEdit, onConvertToPod, service} = this.props;
     const data = batch.reduce(this.props.inputConfigReducers, {});
 
     const jsonEditorPlaceholderClasses = classNames(
@@ -435,8 +416,8 @@ class NewCreateServiceModalForm extends Component {
       'is-visible': isJSONModeActive
     });
 
-    const errorMap = DataValidatorUtil.errorArrayToMap(errorList);
-    const rootErrorComponent = this.getRootErrorMessage();
+    const errorMap = DataValidatorUtil.errorArrayToMap(errors);
+    const rootErrorComponent = this.getRootErrors();
     const serviceLabel = pluralize('Service', findNestedPropertyInObject(
       appConfig,
       'containers.length'
@@ -489,7 +470,7 @@ class NewCreateServiceModalForm extends Component {
         <div className={jsonEditorPlaceholderClasses} />
         <div className={jsonEditorClasses}>
           <JSONEditor
-            errors={errorList}
+            errors={errors}
             onChange={this.handleJSONChange}
             showGutter={true}
             showPrintMargin={false}
@@ -504,6 +485,7 @@ class NewCreateServiceModalForm extends Component {
 }
 
 NewCreateServiceModalForm.defaultProps = {
+  errors: [],
   handleTabChange() {},
   isJSONModeActive: false,
   onChange() {},
@@ -512,6 +494,7 @@ NewCreateServiceModalForm.defaultProps = {
 
 NewCreateServiceModalForm.propTypes = {
   activeTab: PropTypes.string,
+  errors: PropTypes.array,
   handleTabChange: PropTypes.func,
   isJSONModeActive: PropTypes.bool,
   onChange: PropTypes.func,

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -92,7 +92,6 @@ class NewCreateServiceModalForm extends Component {
 
   componentDidUpdate() {
     this.props.onChange(new this.props.service.constructor(this.state.appConfig));
-    // this.props.onErrorStateChange(this.state.errorList.length !== 0);
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -157,9 +156,6 @@ class NewCreateServiceModalForm extends Component {
     if (!fieldName) {
       return;
     }
-
-    // Run data validation on the raw data
-    // this.validateCurrentState();
   }
 
   handleFormChange(event) {
@@ -180,11 +176,6 @@ class NewCreateServiceModalForm extends Component {
       // Render the new appconfig
       appConfig: this.getAppConfig(batch),
       batch
-      // // [Case F1] Reset errors only on the current field
-      // errorList: DataValidatorUtil.stripErrorsOnPath(
-      //   this.state.errorList,
-      //   path
-      // )
     });
   }
 
@@ -208,14 +199,6 @@ class NewCreateServiceModalForm extends Component {
     this.setState({batch, appConfig: this.getAppConfig(batch)});
   }
 
-  // validateCurrentState() {
-  //   const {errorList} = this.getNewStateForJSON(this.getAppConfig());
-
-  //   this.setState({errorList});
-
-  //   return Boolean(errorList.length);
-  // }
-
   getAppConfig(batch = this.state.batch, baseConfig = this.state.baseConfig) {
     // Delete all key:value fields
     // Otherwise applyPatch will duplicate keys we're changing via the form
@@ -236,20 +219,22 @@ class NewCreateServiceModalForm extends Component {
       return null;
     }
 
+    const errorItems = errors.map((error, index) => {
+      const prefix = error.path.length ? `${error.path.join('.')}:` : '';
+
+      return (
+        <li key={index} className="short">
+          {`\u2022 ${prefix} ${error.message}`}
+        </li>
+      );
+    });
+
     return (
       <Alert>
         <strong>There is an error with your configuration</strong>
         <div className="pod pod-narrower-left pod-shorter-top flush-bottom">
           <ul className="list-unstyled short flush-bottom">
-            {errors.map((error, index) => {
-              const prefix = error.path.length ? `${error.path.join('.')}:` : '';
-
-              return (
-                <li key={index} className="short">
-                  {`\u2022 ${prefix} ${error.message}`}
-                </li>
-              );
-            })}
+            {errorItems}
           </ul>
         </div>
       </Alert>

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -224,7 +224,7 @@ class NewCreateServiceModalForm extends Component {
 
       return (
         <li key={index} className="short">
-          {`\u2022 ${prefix} ${error.message}`}
+          {`${prefix} ${error.message}`}
         </li>
       );
     });
@@ -233,7 +233,7 @@ class NewCreateServiceModalForm extends Component {
       <Alert>
         <strong>There is an error with your configuration</strong>
         <div className="pod pod-narrower-left pod-shorter-top flush-bottom">
-          <ul className="list-unstyled short flush-bottom">
+          <ul className="short flush-bottom">
             {errorItems}
           </ul>
         </div>

--- a/plugins/services/src/js/constants/ServiceErrorTypes.js
+++ b/plugins/services/src/js/constants/ServiceErrorTypes.js
@@ -47,10 +47,19 @@ const ServiceErrorTypes = {
    */
   PROP_MISSING_ONE: 'PROP_MISSING_ONE',
 
-  /**
+  /*
    * Service is locked for deployment
    */
-  SERVICE_DEPLOYING: 'SERVICE_DEPLOYING'
+  SERVICE_DEPLOYING: 'SERVICE_DEPLOYING',
+
+  /**
+   * The user input is syntactically incorrect and cannot be parsed
+   *
+   * Expected variables:
+   * {
+   * }
+   */
+  SYNTAX_ERROR: 'SYNTAX_ERROR'
 
 };
 

--- a/plugins/services/src/js/constants/ServiceErrorTypes.js
+++ b/plugins/services/src/js/constants/ServiceErrorTypes.js
@@ -1,6 +1,11 @@
 const ServiceErrorTypes = {
 
   /**
+   * A generic type of error without any detailed information
+   */
+  GENERIC: 'GENERIC',
+
+  /**
    * Two or more properties are present in the configuration that are are
    * conflicting to eachother.
    *
@@ -40,7 +45,12 @@ const ServiceErrorTypes = {
    *    "names": "prop1, prop2, prop3, ..."
    * }
    */
-  PROP_MISSING_ONE: 'PROP_MISSING_ONE'
+  PROP_MISSING_ONE: 'PROP_MISSING_ONE',
+
+  /**
+   * Service is locked for deployment
+   */
+  SERVICE_DEPLOYING: 'SERVICE_DEPLOYING'
 
 };
 

--- a/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
+++ b/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
@@ -88,7 +88,7 @@ class ServiceConfigDisplay extends React.Component {
 
       return (
         <li key={index} className="short">
-          {`\u2022 ${prefix} ${error.message}`}
+          {`${prefix} ${error.message}`}
         </li>
       );
     });
@@ -97,7 +97,7 @@ class ServiceConfigDisplay extends React.Component {
       <Alert>
         <strong>There is an error with your configuration</strong>
         <div className="pod pod-narrower-left pod-shorter-top flush-bottom">
-          <ul className="list-unstyled short flush-bottom">
+          <ul className="short flush-bottom">
             {errorItems}
           </ul>
         </div>

--- a/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
+++ b/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
@@ -77,24 +77,30 @@ class ServiceConfigDisplay extends React.Component {
   }
 
   getRootErrors() {
-    if (this.props.errors.size === 0) {
+    const {errors} = this.props;
+
+    if (errors.length === 0) {
       return null;
     }
 
-    let messages = [];
-    for (const [path, errors] of this.props.errors) {
-      messages = messages.concat(
-        errors.map((message, index) => {
-          return <div key={`${path}-${index}`}>{message}</div>;
-        })
-      );
-    }
+    return (
+      <Alert>
+        <strong>There is an error with your configuration</strong>
+        <div className="pod pod-narrower-left pod-shorter-top flush-bottom">
+          <ul className="list-unstyled short flush-bottom">
+            {errors.map((error, index) => {
+              const prefix = error.path.length ? `${error.path.join('.')}:` : '';
 
-    if (!messages.length) {
-      return null;
-    }
-
-    return <Alert>{messages}</Alert>;
+              return (
+                <li key={index} className="short">
+                  {`\u2022 ${prefix} ${error.message}`}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </Alert>
+    );
   }
 
   render() {
@@ -115,13 +121,13 @@ class ServiceConfigDisplay extends React.Component {
 
 ServiceConfigDisplay.defaultProps = {
   clearError() {},
-  errors: new Map()
+  errors: []
 };
 
 ServiceConfigDisplay.propTypes = {
   appConfig: React.PropTypes.object.isRequired,
   clearError: React.PropTypes.func,
-  errors: React.PropTypes.object,
+  errors: React.PropTypes.array,
   onEditClick: React.PropTypes.func
 };
 

--- a/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
+++ b/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
@@ -83,20 +83,22 @@ class ServiceConfigDisplay extends React.Component {
       return null;
     }
 
+    const errorItems = errors.map((error, index) => {
+      const prefix = error.path.length ? `${error.path.join('.')}:` : '';
+
+      return (
+        <li key={index} className="short">
+          {`\u2022 ${prefix} ${error.message}`}
+        </li>
+      );
+    });
+
     return (
       <Alert>
         <strong>There is an error with your configuration</strong>
         <div className="pod pod-narrower-left pod-shorter-top flush-bottom">
           <ul className="list-unstyled short flush-bottom">
-            {errors.map((error, index) => {
-              const prefix = error.path.length ? `${error.path.join('.')}:` : '';
-
-              return (
-                <li key={index} className="short">
-                  {`\u2022 ${prefix} ${error.message}`}
-                </li>
-              );
-            })}
+            {errorItems}
           </ul>
         </div>
       </Alert>

--- a/plugins/services/src/js/utils/MarathonErrorUtil.js
+++ b/plugins/services/src/js/utils/MarathonErrorUtil.js
@@ -13,7 +13,7 @@ const MarathonErrorUtil = {
   getErrorType(message) {
 
     // Check for 'service is deploying' error messages
-    if (/force=true/.exec(message)) {
+    if (/force=true/.test(message)) {
       return ServiceErrorTypes.SERVICE_DEPLOYING;
     }
 

--- a/plugins/services/src/js/utils/MarathonErrorUtil.js
+++ b/plugins/services/src/js/utils/MarathonErrorUtil.js
@@ -1,4 +1,5 @@
 import ValidatorUtil from '../../../../../src/js/utils/ValidatorUtil';
+import ServiceErrorTypes from '../constants/ServiceErrorTypes';
 
 const MarathonErrorUtil = {
 
@@ -11,9 +12,12 @@ const MarathonErrorUtil = {
   // eslint-disable-next-line no-unused-vars
   getErrorType(message) {
 
-    // TODO: This will be implemented on the next PR
-    return 'MARATHON_ERROR';
+    // Check for 'service is deploying' error messages
+    if (/force=true/.exec(message)) {
+      return ServiceErrorTypes.SERVICE_DEPLOYING;
+    }
 
+    return ServiceErrorTypes.GENERIC;
   },
 
   /**

--- a/plugins/services/src/js/utils/__tests__/MarathonErrorUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/MarathonErrorUtil-test.js
@@ -1,6 +1,7 @@
 jest.dontMock('../MarathonErrorUtil');
 
 const MarathonErrorUtil = require('../MarathonErrorUtil');
+const ServiceErrorTypes = require('../../constants/ServiceErrorTypes');
 
 describe('MarathonErrorUtil', function () {
 
@@ -13,7 +14,7 @@ describe('MarathonErrorUtil', function () {
         {
           path: [],
           message: 'Some error',
-          type: 'MARATHON_ERROR',
+          type: ServiceErrorTypes.GENERIC,
           variables: {}
         }
       ]);
@@ -28,7 +29,7 @@ describe('MarathonErrorUtil', function () {
         {
           path: [],
           message: 'Some error',
-          type: 'MARATHON_ERROR',
+          type: ServiceErrorTypes.GENERIC,
           variables: {}
         }
       ]);
@@ -44,7 +45,7 @@ describe('MarathonErrorUtil', function () {
         {
           path: [],
           message: 'Some error details',
-          type: 'MARATHON_ERROR',
+          type: ServiceErrorTypes.GENERIC,
           variables: {}
         }
       ]);
@@ -65,13 +66,13 @@ describe('MarathonErrorUtil', function () {
         {
           path: [],
           message: 'First Error',
-          type: 'MARATHON_ERROR',
+          type: ServiceErrorTypes.GENERIC,
           variables: {}
         },
         {
           path: [],
           message: 'Second Error',
-          type: 'MARATHON_ERROR',
+          type: ServiceErrorTypes.GENERIC,
           variables: {}
         }
       ]);
@@ -92,7 +93,7 @@ describe('MarathonErrorUtil', function () {
         {
           path: ['some', 'property'],
           message: 'First Error',
-          type: 'MARATHON_ERROR',
+          type: ServiceErrorTypes.GENERIC,
           variables: {}
         }
       ]);
@@ -113,7 +114,7 @@ describe('MarathonErrorUtil', function () {
         {
           path: ['some', 'indexed', 3, 'property'],
           message: 'First Error',
-          type: 'MARATHON_ERROR',
+          type: ServiceErrorTypes.GENERIC,
           variables: {}
         }
       ]);

--- a/src/styles/components/alert/styles.less
+++ b/src/styles/components/alert/styles.less
@@ -27,7 +27,8 @@
       color: @alert-success-foreground;
     }
 
-    a {
+    a,
+    li {
       color: inherit;
     }
   }


### PR DESCRIPTION
---
~⚠️  This PR depends on #1833 - ( [See the diff](https://github.com/dcos/dcos-ui/compare/ic/feat/error-message-refactoring-3...ic/feat/error-message-refactoring-4?expand=1) )~

~⚠️ This PR depends on https://github.com/dcos/dcos-ui/pull/1848 (raml-validator-loader v0.1.8)~

---
 
This commit includes the following:

- Adds NewCreateServiceModal.getAllErrors function that is collecting
  all errors, including validation and marathon errors
- Removes validation from NewCreateServiceModalForm & CreateServiceJsonOnly
- Fixes syling of the alert dialog in form and the review screen

**Note that this PR makes the error validation more "aggressive", meaning that you will instantly see an error when you edit a form field. This will be fixed on the next PR**

_This PR implements the `Normalize internal error structure` task in the spec document: https://docs.google.com/document/d/1kwdPxBo3UlRZvMxLLIUqSZqLlUJitEuIAWderUgWY1c/edit#heading=h.thdpdh4mx6uj_