### PR TITLE
DCOS-13362: [5/7] Error Normalisation: Show errors only when needed

### DIFF
--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -410,9 +410,7 @@ class NewCreateServiceModal extends Component {
    * @returns {Array} - An array of error objects
    */
   getAllErrors() {
-    const {apiErrors} = this.state;
-
-    return apiErrors.concat(this.getFormErrors());
+    return this.state.apiErrors.concat(this.getFormErrors());
   }
 
   getHeader() {

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -205,11 +205,18 @@ class NewCreateServiceModal extends Component {
     } = this.state;
 
     if (serviceReviewActive) {
+      // Remove the 'Application is deploying' error when we havigate back
+      // since it's not related to the form
+      const apiErrors = this.state.apiErrors.filter(function (error) {
+        return error.type !== ServiceErrorTypes.SERVICE_DEPLOYING;
+      });
+
       // Just hide review screen. Form or JSON mode will be
       // activated automatically depending on their last state
       this.setState({
-        serviceReviewActive: false,
-        activeTab: tabViewID
+        activeTab: tabViewID,
+        apiErrors,
+        serviceReviewActive: false
       });
 
       return;
@@ -248,7 +255,10 @@ class NewCreateServiceModal extends Component {
   }
 
   handleClearError() {
-    this.setState({apiErrors: []});
+    this.setState({
+      apiErrors: [],
+      showAllErrors: false
+    });
   }
 
   handleClose() {
@@ -269,7 +279,11 @@ class NewCreateServiceModal extends Component {
   }
 
   handleServiceChange(newService) {
-    this.setState({serviceConfig: newService});
+    this.setState({
+      apiErrors: [],
+      serviceConfig: newService,
+      showAllErrors: false
+    });
   }
 
   handleServiceErrorsChange(errors) {
@@ -324,6 +338,8 @@ class NewCreateServiceModal extends Component {
     const errors = this.getAllErrors();
     if (errors.length === 0) {
       this.setState({serviceReviewActive: true});
+    } else {
+      this.setState({showAllErrors: true});
     }
   }
 
@@ -438,7 +454,6 @@ class NewCreateServiceModal extends Component {
             <ServiceConfigDisplay
               onEditClick={this.handleGoBack}
               appConfig={serviceConfig}
-              clearError={this.handleClearError}
               errors={this.getAllErrors()} />
           </div>
         </div>
@@ -454,6 +469,7 @@ class NewCreateServiceModal extends Component {
 
     if (serviceFormActive) {
       const {location} = this.props;
+      const {showAllErrors} = this.state;
 
       const SECTIONS = [
         ContainerServiceFormSection,
@@ -496,15 +512,16 @@ class NewCreateServiceModal extends Component {
           jsonConfigReducers={jsonConfigReducers}
           handleTabChange={this.handleTabChange}
           inputConfigReducers={inputConfigReducers}
+          isEdit={this.isLocationEdit(location)}
           isJSONModeActive={isJSONModeActive}
           ref={(ref) => {
             return this.createComponent = ref;
           }}
-          service={serviceConfig}
           onChange={this.handleServiceChange}
           onConvertToPod={this.handleConvertToPod}
           onErrorsChange={this.handleServiceErrorsChange}
-          isEdit={this.isLocationEdit(location)} />
+          service={serviceConfig}
+          showAllErrors={showAllErrors} />
       );
     }
 
@@ -557,7 +574,7 @@ class NewCreateServiceModal extends Component {
     }
 
     if (serviceFormActive) {
-      const errors = this.getAllErrors();
+      // const errors = this.getAllErrors();
 
       return [
         {
@@ -575,20 +592,22 @@ class NewCreateServiceModal extends Component {
         {
           className: 'button-primary flush-vertical',
           clickHandler: this.handleServiceReview,
-          disabled: errors.length !== 0,
+          disabled: false,
+          // disabled: errors.length !== 0,
           label: 'Review & Run'
         }
       ];
     }
 
     if (serviceJsonActive) {
-      const errors = this.getAllErrors();
+      // const errors = this.getAllErrors();
 
       return [
         {
           className: 'button-primary flush-vertical',
           clickHandler: this.handleServiceReview,
-          disabled: errors.length !== 0,
+          disabled: false,
+          // disabled: errors.length !== 0,
           label: 'Review & Run'
         }
       ];
@@ -628,7 +647,8 @@ class NewCreateServiceModal extends Component {
       serviceJsonActive: false,
       servicePickerActive: !isEdit, // Switch directly to form/json if edit
       serviceReviewActive: false,
-      serviceFormHasErrors: false
+      serviceFormHasErrors: false,
+      showAllErrors: false
     };
 
     // Only add change listener if we didn't receive our service in first try

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -216,7 +216,8 @@ class NewCreateServiceModal extends Component {
       this.setState({
         activeTab: tabViewID,
         apiErrors,
-        serviceReviewActive: false
+        serviceReviewActive: false,
+        showAllErrors: false
       });
 
       return;
@@ -280,9 +281,7 @@ class NewCreateServiceModal extends Component {
 
   handleServiceChange(newService) {
     this.setState({
-      apiErrors: [],
-      serviceConfig: newService,
-      showAllErrors: false
+      serviceConfig: newService
     });
   }
 
@@ -298,33 +297,42 @@ class NewCreateServiceModal extends Component {
       case 'app':
         this.setState({
           activeTab: null,
+          apiErrors: [],
+          serviceFormErrors: [],
           servicePickerActive: false,
           serviceFormActive: true,
           serviceConfig: new ApplicationSpec(
             Object.assign({id: baseID}, DEFAULT_APP_SPEC)
-          )
+          ),
+          showAllErrors: false
         });
         break;
 
       case 'pod':
         this.setState({
           activeTab: null,
+          apiErrors: [],
+          serviceFormErrors: [],
           servicePickerActive: false,
           serviceFormActive: true,
           serviceConfig: new PodSpec(
             Object.assign({id: baseID}, DEFAULT_POD_SPEC)
-          )
+          ),
+          showAllErrors: false
         });
         break;
 
       case 'json':
         this.setState({
           activeTab: null,
+          apiErrors: [],
+          serviceFormErrors: [],
           servicePickerActive: false,
           serviceJsonActive: true,
           serviceConfig: new ApplicationSpec(
             Object.assign({id: baseID}, DEFAULT_APP_SPEC)
-          )
+          ),
+          showAllErrors: false
         });
         break;
 
@@ -335,11 +343,16 @@ class NewCreateServiceModal extends Component {
   }
 
   handleServiceReview() {
-    const errors = this.getAllErrors();
+    const errors = this.getFormErrors();
     if (errors.length === 0) {
-      this.setState({serviceReviewActive: true});
+      this.setState({
+        apiErrors: [],
+        serviceReviewActive: true
+      });
     } else {
-      this.setState({showAllErrors: true});
+      this.setState({
+        showAllErrors: true
+      });
     }
   }
 
@@ -366,8 +379,8 @@ class NewCreateServiceModal extends Component {
    *
    * @returns {Array} - An array of error objects
    */
-  getAllErrors() {
-    const {apiErrors, serviceFormErrors, serviceConfig} = this.state;
+  getFormErrors() {
+    const {serviceFormErrors, serviceConfig} = this.state;
     let validationErrors = [];
 
     // Validate Application or Pod according to the contents
@@ -387,11 +400,19 @@ class NewCreateServiceModal extends Component {
       );
     }
 
-    // Combine all errors
-    return apiErrors.concat(
-      serviceFormErrors,
-      validationErrors
-    );
+    return validationErrors.concat(serviceFormErrors);
+  }
+
+  /**
+   * This function combines the errors received from marathon and the errors
+   * produced by the form into a unified error array
+   *
+   * @returns {Array} - An array of error objects
+   */
+  getAllErrors() {
+    const {apiErrors} = this.state;
+
+    return apiErrors.concat(this.getFormErrors());
   }
 
   getHeader() {
@@ -574,8 +595,6 @@ class NewCreateServiceModal extends Component {
     }
 
     if (serviceFormActive) {
-      // const errors = this.getAllErrors();
-
       return [
         {
           node: (
@@ -593,21 +612,17 @@ class NewCreateServiceModal extends Component {
           className: 'button-primary flush-vertical',
           clickHandler: this.handleServiceReview,
           disabled: false,
-          // disabled: errors.length !== 0,
           label: 'Review & Run'
         }
       ];
     }
 
     if (serviceJsonActive) {
-      // const errors = this.getAllErrors();
-
       return [
         {
           className: 'button-primary flush-vertical',
           clickHandler: this.handleServiceReview,
           disabled: false,
-          // disabled: errors.length !== 0,
           label: 'Review & Run'
         }
       ];

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -471,7 +471,7 @@ class NewCreateServiceModalForm extends Component {
 
       // Never mute fields in the CONSTANTLY_UNMUTED_ERRORS fields
       const isUnmuted = CONSTANTLY_UNMUTED_ERRORS.some(function (rule) {
-        return rule.exec(errorPath);
+        return rule.test(errorPath);
       });
 
       return isUnmuted || showAllErrors || editedFieldPaths.includes(errorPath);

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -35,6 +35,7 @@ const METHODS_TO_BIND = [
   'handleFormChange',
   'handleFormBlur',
   'handleJSONChange',
+  'handleJSONPropertyChange',
   'handleAddItem',
   'handleRemoveItem',
   'getNewStateForJSON'
@@ -49,11 +50,17 @@ class NewCreateServiceModalForm extends Component {
   constructor() {
     super(...arguments);
 
+    // Hint: When you add something to the state, make sure to update the
+    //       shouldComponentUpdate function, since we are trying to reduce
+    //       the number of updates as much as possible.
+
     this.state = Object.assign(
       {
         appConfig: null,
         batch: new Batch(),
         baseConfig: {},
+        editedFieldPaths: [],
+        editingFieldPath: null,
         isPod: false,
         jsonReducer() {},
         jsonParser() {}
@@ -90,13 +97,23 @@ class NewCreateServiceModalForm extends Component {
     this.props.onConvertToPod(this.getAppConfig());
   }
 
-  componentDidUpdate() {
-    this.props.onChange(new this.props.service.constructor(this.state.appConfig));
+  componentDidUpdate(prevProps, prevState) {
+    const {editingFieldPath} = this.state;
+
+    if ((editingFieldPath === null) &&
+       !deepEqual(this.state.appConfig, prevState.appConfig)) {
+      this.props.onChange(new this.props.service.constructor(this.state.appConfig));
+    }
   }
 
   shouldComponentUpdate(nextProps, nextState) {
     // Update if json state changed
     if (this.props.isJSONModeActive !== nextProps.isJSONModeActive) {
+      return true;
+    }
+
+    // Update if showAllErrors changed
+    if (this.props.showAllErrors !== nextProps.showAllErrors) {
       return true;
     }
 
@@ -121,6 +138,7 @@ class NewCreateServiceModalForm extends Component {
     // Otherwise update if the state has changed
     return (this.state.baseConfig !== nextState.baseConfig) ||
       (this.state.batch !== nextState.batch) ||
+      (this.state.editingFieldPath !== nextState.editingFieldPath) ||
       (this.props.activeTab !== nextProps.activeTab) ||
       (!deepEqual(this.props.errors, nextProps.errors));
   }
@@ -151,11 +169,38 @@ class NewCreateServiceModalForm extends Component {
     this.setState(this.getNewStateForJSON(jsonObject));
   }
 
+  handleJSONPropertyChange(path) {
+    const {editedFieldPaths} = this.state;
+    const pathStr = path.join('.');
+    if (path.length === 0) {
+      return;
+    }
+
+    if (!editedFieldPaths.includes(pathStr)) {
+      this.setState({
+        editedFieldPaths: editedFieldPaths.concat([pathStr])
+      });
+    }
+  }
+
   handleFormBlur(event) {
+    const {editedFieldPaths, batch} = this.state;
     const fieldName = event.target.getAttribute('name');
+    const newState = {
+      editingFieldPath: null,
+      appConfig: this.getAppConfig(batch)
+    };
+
     if (!fieldName) {
       return;
     }
+
+    // Keep track of which fields have changed
+    if (!editedFieldPaths.includes(fieldName)) {
+      newState.editedFieldPaths = editedFieldPaths.concat([fieldName]);
+    }
+
+    this.setState(newState);
   }
 
   handleFormChange(event) {
@@ -173,9 +218,8 @@ class NewCreateServiceModalForm extends Component {
     batch = batch.add(new Transaction(path, value));
 
     this.setState({
-      // Render the new appconfig
-      appConfig: this.getAppConfig(batch),
-      batch
+      batch,
+      editingFieldPath: fieldName
     });
   }
 
@@ -210,12 +254,17 @@ class NewCreateServiceModalForm extends Component {
     return CreateServiceModalFormUtil.applyPatch(baseConfig, patch);
   }
 
-  getRootErrors() {
-    const errors = this.props.errors.filter(function (error) {
-      return error.path.length === 0;
-    });
+  getErrorsAlertComponent() {
+    const {errors, showAllErrors} = this.props;
+    let showErrors = errors;
 
-    if (errors.length === 0) {
+    if (!showAllErrors) {
+      showErrors = showErrors.filter(function (error) {
+        return error.path.length === 0;
+      });
+    }
+
+    if (showErrors.length === 0) {
       return null;
     }
 
@@ -262,7 +311,7 @@ class NewCreateServiceModalForm extends Component {
   getContainerContent(data, errors) {
     const {service} = this.props;
     const {containers} = data;
-    const rootErrorComponent = this.getRootErrors();
+    const errorsAlertComponent = this.getErrorsAlertComponent();
 
     if (containers == null) {
       return [];
@@ -271,7 +320,7 @@ class NewCreateServiceModalForm extends Component {
     return containers.map((item, index) => {
       return (
         <TabView key={index} id={`container${index}`}>
-          {rootErrorComponent}
+          {errorsAlertComponent}
           <ContainerServiceFormSection
             data={data}
             errors={errors}
@@ -309,12 +358,12 @@ class NewCreateServiceModalForm extends Component {
   }
 
   getSectionContent(data, errorMap) {
-    const rootErrorComponent = this.getRootErrors();
+    const errorsAlertComponent = this.getErrorsAlertComponent();
 
     if (this.state.isPod) {
       return [
         <TabView id="networking" key="multinetworking">
-          {rootErrorComponent}
+          {errorsAlertComponent}
           <MultiContainerNetworkingFormSection
             data={data}
             errors={errorMap}
@@ -322,7 +371,7 @@ class NewCreateServiceModalForm extends Component {
             onAddItem={this.handleAddItem} />
         </TabView>,
         <TabView id="volumes" key="multivolumes">
-          {rootErrorComponent}
+          {errorsAlertComponent}
           <MultiContainerVolumesFormSection
             data={data}
             errors={errorMap}
@@ -331,7 +380,7 @@ class NewCreateServiceModalForm extends Component {
             onAddItem={this.handleAddItem} />
         </TabView>,
         <TabView id="healthChecks" key="multihealthChecks">
-          {rootErrorComponent}
+          {errorsAlertComponent}
           <MultiContainerHealthChecksFormSection
             data={data}
             errors={errorMap}
@@ -340,7 +389,7 @@ class NewCreateServiceModalForm extends Component {
             onAddItem={this.handleAddItem} />
         </TabView>,
         <TabView id="environment" key="multienvironment">
-          {rootErrorComponent}
+          {errorsAlertComponent}
           <EnvironmentFormSection
             mountType="CreateService:MultiContainerEnvironmentFormSection"
             data={data}
@@ -353,7 +402,7 @@ class NewCreateServiceModalForm extends Component {
 
     return [
       <TabView id="networking" key="networking">
-        {rootErrorComponent}
+        {errorsAlertComponent}
         <NetworkingFormSection
           data={data}
           errors={errorMap}
@@ -361,7 +410,7 @@ class NewCreateServiceModalForm extends Component {
           onAddItem={this.handleAddItem} />
       </TabView>,
       <TabView id="volumes" key="volumes">
-        {rootErrorComponent}
+        {errorsAlertComponent}
         <VolumesFormSection
           data={data}
           errors={errorMap}
@@ -369,7 +418,7 @@ class NewCreateServiceModalForm extends Component {
           onAddItem={this.handleAddItem} />
       </TabView>,
       <TabView id="healthChecks" key="healthChecks">
-        {rootErrorComponent}
+        {errorsAlertComponent}
         <HealthChecksFormSection
           data={data}
           errors={errorMap}
@@ -377,7 +426,7 @@ class NewCreateServiceModalForm extends Component {
           onAddItem={this.handleAddItem} />
       </TabView>,
       <TabView id="environment" key="environment">
-        {rootErrorComponent}
+        {errorsAlertComponent}
         <EnvironmentFormSection
           mountType="CreateService:EnvironmentFormSection"
           data={data}
@@ -388,10 +437,33 @@ class NewCreateServiceModalForm extends Component {
     ];
   }
 
+  /**
+   * This function filters the error list in order to keep only the
+   * errors that should be displayed to the UI.
+   *
+   * @returns {Array} - Returns an array of errors that passed the filter
+   */
+  getUnmutedErrors() {
+    const {errors, showAllErrors} = this.props;
+    const {editedFieldPaths, editingFieldPath} = this.state;
+
+    return errors.filter(function (error) {
+      const errorPath = error.path.join('.');
+
+      // Always mute the error on the field we are editing
+      if ((editingFieldPath != null) && (errorPath === editingFieldPath)) {
+        return false;
+      }
+
+      return showAllErrors || editedFieldPaths.includes(errorPath);
+    });
+  }
+
   render() {
     const {appConfig, batch} = this.state;
     const {activeTab, errors, handleTabChange, isJSONModeActive, isEdit, onConvertToPod, service} = this.props;
     const data = batch.reduce(this.props.inputConfigReducers, {});
+    const unmutedErrors = this.getUnmutedErrors();
 
     const jsonEditorPlaceholderClasses = classNames(
       'modal-full-screen-side-panel-placeholder',
@@ -401,12 +473,16 @@ class NewCreateServiceModalForm extends Component {
       'is-visible': isJSONModeActive
     });
 
-    const errorMap = DataValidatorUtil.errorArrayToMap(errors);
-    const rootErrorComponent = this.getRootErrors();
+    const errorMap = DataValidatorUtil.errorArrayToMap(unmutedErrors);
+    const errorsAlertComponent = this.getErrorsAlertComponent();
     const serviceLabel = pluralize('Service', findNestedPropertyInObject(
       appConfig,
       'containers.length'
     ) || 1);
+
+    console.log('errorMap=', errorMap);
+    console.log('unmutedErrors=', unmutedErrors);
+    console.log('errors=', errors);
 
     return (
       <div className="flex flex-item-grow-1">
@@ -433,7 +509,7 @@ class NewCreateServiceModalForm extends Component {
                   </TabButtonList>
                   <TabViewList>
                     <TabView id="services">
-                      {rootErrorComponent}
+                      {errorsAlertComponent}
                       <GeneralServiceFormSection
                         errors={errorMap}
                         data={data}
@@ -457,6 +533,7 @@ class NewCreateServiceModalForm extends Component {
           <JSONEditor
             errors={errors}
             onChange={this.handleJSONChange}
+            onPropertyChange={this.handleJSONPropertyChange}
             showGutter={true}
             showPrintMargin={false}
             theme="monokai"
@@ -474,7 +551,8 @@ NewCreateServiceModalForm.defaultProps = {
   handleTabChange() {},
   isJSONModeActive: false,
   onChange() {},
-  onErrorStateChange() {}
+  onErrorStateChange() {},
+  showAllErrors: false
 };
 
 NewCreateServiceModalForm.propTypes = {
@@ -484,7 +562,8 @@ NewCreateServiceModalForm.propTypes = {
   isJSONModeActive: PropTypes.bool,
   onChange: PropTypes.func,
   onErrorStateChange: PropTypes.func,
-  service: PropTypes.object
+  service: PropTypes.object,
+  showAllErrors: PropTypes.bool
 };
 
 module.exports = NewCreateServiceModalForm;

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -46,6 +46,20 @@ const KEY_VALUE_FIELDS = [
   'labels'
 ];
 
+/**
+ * Since the form input fields operate on a different path than the one in the
+ * data, it's not always possible to figure out which error paths to unmute when
+ * the field is edited. Therefore, form fields that do not map 1:1 with the data
+ * are opted out from the error muting feature.
+ *
+ * TODO: This should be removed when DCOS-13524 is completed
+ */
+const CONSTANTLY_UNMUTED_ERRORS = [
+  /^constraints\.[0-9]+\./,
+  /^portDefinitions\.[0-9]+\./,
+  /^localVolumes\.[0-9]+\./
+];
+
 class NewCreateServiceModalForm extends Component {
   constructor() {
     super(...arguments);
@@ -455,7 +469,12 @@ class NewCreateServiceModalForm extends Component {
         return false;
       }
 
-      return showAllErrors || editedFieldPaths.includes(errorPath);
+      // Never mute fields in the CONSTANTLY_UNMUTED_ERRORS fields
+      const isUnmuted = CONSTANTLY_UNMUTED_ERRORS.some(function (rule) {
+        return rule.exec(errorPath);
+      });
+
+      return isUnmuted || showAllErrors || editedFieldPaths.includes(errorPath);
     });
   }
 
@@ -479,10 +498,6 @@ class NewCreateServiceModalForm extends Component {
       appConfig,
       'containers.length'
     ) || 1);
-
-    console.log('errorMap=', errorMap);
-    console.log('unmutedErrors=', unmutedErrors);
-    console.log('errors=', errors);
 
     return (
       <div className="flex flex-item-grow-1">

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -112,11 +112,11 @@ class NewCreateServiceModalForm extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const {editingFieldPath} = this.state;
+    const {editingFieldPath, appConfig} = this.state;
 
     if ((editingFieldPath === null) &&
-       !deepEqual(this.state.appConfig, prevState.appConfig)) {
-      this.props.onChange(new this.props.service.constructor(this.state.appConfig));
+       !deepEqual(appConfig, prevState.appConfig)) {
+      this.props.onChange(new this.props.service.constructor(appConfig));
     }
   }
 

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -282,7 +282,7 @@ class NewCreateServiceModalForm extends Component {
       return null;
     }
 
-    const errorItems = errors.map((error, index) => {
+    const errorItems = showErrors.map((error, index) => {
       const prefix = error.path.length ? `${error.path.join('.')}:` : '';
 
       return (

--- a/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
+++ b/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
@@ -64,10 +64,6 @@ DEFAULT_DISPLAY_COMPONENTS.forEach(({MOUNT_TYPE, COMPONENTS}) => {
 });
 
 class ServiceConfigDisplay extends React.Component {
-  componentWillUnmount() {
-    this.props.clearError();
-  }
-
   getMountType() {
     if (this.props.appConfig instanceof PodSpec) {
       return 'CreateService:ServiceConfigDisplay:Pod';
@@ -122,13 +118,11 @@ class ServiceConfigDisplay extends React.Component {
 }
 
 ServiceConfigDisplay.defaultProps = {
-  clearError() {},
   errors: []
 };
 
 ServiceConfigDisplay.propTypes = {
   appConfig: React.PropTypes.object.isRequired,
-  clearError: React.PropTypes.func,
   errors: React.PropTypes.array,
   onEditClick: React.PropTypes.func
 };


### PR DESCRIPTION
---
⚠️  ~~This PR depends on #1834 - ( [See the diff](https://github.com/dcos/dcos-ui/compare/ic/feat/error-message-refactoring-4...ic/feat/error-message-refactoring-5?expand=1) )~~

---
 
![new-form-errors mov](https://cloud.githubusercontent.com/assets/883486/22157342/a15984fe-df37-11e6-996c-11ab8ab5a15c.gif)

This commit introduces a series of changes in order to show errors
in the most optimal way. In a bit more detail:

- Marathon errors now persist after the review screen, back to the form, until the user has edited the form.
- The "Review & Run" button is now always enabled, even if there are errors in the form.
- NewCreateServiceModalForm tracks which fields the user has edited and shows real-time validation errors only on them. The rest of the errors are muted.
- When the user clicks "Review & Run", a showAllErrors= bypass flag is set and forces the form to display all errors. Not only in-line, next to the fields, but also to the alert on top.
- When the user edits a field with error the validation is temporarily disabled until the user blurs away.
- When the form is changed, the showAllErrors= bypass flag is reset, along with all marathon errors and it returns on it's normal behaviour.

_This PR implements a logic described in the spec document: https://docs.google.com/document/d/1kwdPxBo3UlRZvMxLLIUqSZqLlUJitEuIAWderUgWY1c/edit#heading=h.thdpdh4mx6uj_

Closes DCOS-12422