### PR TITLE
DCOS-12594: Give tooltips a higher z-index than dropdowns

### DIFF
--- a/src/styles/variables/variables-z-index.less
+++ b/src/styles/variables/variables-z-index.less
@@ -20,7 +20,7 @@
 @z-index-side-panel-expand-button: @z-index-side-panel + 10;
 @z-index-sidebar: @z-index-modal - 1;
 @z-index-sidebar-overlay: @z-index-sidebar - 1;
-@z-index-tooltip: @z-index-modal + 1;
+@z-index-tooltip: @z-index-dropdown + 1;
 // The error message comes in 'body' and 'modal' varieties
 @z-index-errormsg-floater-modal: @z-index-modal + 1;
 // This has to be at least 10000 to render above gemini.


### PR DESCRIPTION
Tooltips will now render above dropdown menus.

![](https://cl.ly/0d2w3G0V3N2A/Screen%20Shot%202017-01-20%20at%209.18.58%20AM.png)