### PR TITLE
Clean up z-index variable assignments

### DIFF
--- a/src/styles/components/charts/styles.less
+++ b/src/styles/components/charts/styles.less
@@ -292,11 +292,6 @@
     }
   }
 
-  .dropdown-chart-details {
-    position: relative;
-    z-index: @z-index-dropdown-chart-details;
-  }
-
   .dygraph-chart-wrapper {
 
     .dot {

--- a/src/styles/components/nodes-grid-view/styles.less
+++ b/src/styles/components/nodes-grid-view/styles.less
@@ -5,7 +5,6 @@
     display: flex;
     flex-direction: row;
     position: relative;
-    z-index: @z-index-nodes-grid;
 
     .nodes-grid-legend {
       display: flex;

--- a/src/styles/components/scrollbar/styles.less
+++ b/src/styles/components/scrollbar/styles.less
@@ -5,7 +5,7 @@
     border-radius: 4px;
     bottom: 3px;
     right: 3px;
-    z-index: @gemini-scrollbar-handle;
+    z-index: @z-index-gemini-scrollbar-handle;
 
     &.-vertical {
       top: 3px;

--- a/src/styles/components/tooltip/styles.less
+++ b/src/styles/components/tooltip/styles.less
@@ -102,5 +102,5 @@
   position: absolute;
   right: @base-spacing-unit;
   top: @base-spacing-unit;
-  z-index: 100;
+  z-index: @z-index-json-editor-help-tooltip;
 }

--- a/src/styles/layout/header/styles.less
+++ b/src/styles/layout/header/styles.less
@@ -6,7 +6,6 @@
   background: color-lighten(@neutral, -50);
   position: relative;
   width: 100%;
-  z-index: @z-index-header;
 
   // Header Subtitle Action
   .header-subtitle-action {

--- a/src/styles/variables/variables-z-index.less
+++ b/src/styles/variables/variables-z-index.less
@@ -20,7 +20,7 @@
 @z-index-side-panel-expand-button: @z-index-side-panel + 10;
 @z-index-sidebar: @z-index-modal - 1;
 @z-index-sidebar-overlay: @z-index-sidebar - 1;
-@z-index-tooltip: @z-index-modal + 1;
+@z-index-tooltip: @z-index-dropdown + 1;
 // The error message comes in 'body' and 'modal' varieties
 @z-index-errormsg-floater-modal: @z-index-modal + 1;
 // This has to be at least 10000 to render above gemini.

--- a/src/styles/variables/variables-z-index.less
+++ b/src/styles/variables/variables-z-index.less
@@ -1,28 +1,33 @@
-// TODO: Audit these variables and all z-index properties, some are not being
-// used properly.
+@z-index-modal: 1000;
+
+@z-index-auth-providers-modal-divider: 0;
+@z-index-auth-providers-modal-divider-content: @z-index-auth-providers-modal-divider + 1;
+
 @z-index-dropdown: @z-index-modal + 1;
-@z-index-dropdown-chart-details: @z-index-side-panel + 20;
-@z-index-dygraph-chart: @z-index-side-panel + 10;
-@z-index-dygraph-hover-label: 100;
-@gemini-scrollbar-handle: @z-index-header-tabs + 1;
-@z-index-form-group-container-action-button-group: 1;
-@z-index-header: 1000;
-@z-index-header-border: 1;
-@z-index-header-tabs: @z-index-header-border + 1;
-@z-index-modal-side-panel: @z-index-header-tabs + 1;
-@z-index-menu-tabbed-item-active-indicator: @z-index-header-tabs + 1;
-@z-index-nodes-grid: 2;
-@z-index-overlay: @z-index-side-panel + 10;
-@z-index-overlay-header: @z-index-side-panel + 2;
-@z-index-page-navigation-sidebar-toggle: 100;
-@z-index-side-panel: 2000;
-@z-index-side-panel-container: @z-index-side-panel + 4;
-@z-index-side-panel-expand-button: @z-index-side-panel + 10;
-@z-index-sidebar: @z-index-modal - 1;
-@z-index-sidebar-overlay: @z-index-sidebar - 1;
-@z-index-tooltip: @z-index-dropdown + 1;
+
+@z-index-dygraph-chart: @z-index-dropdown - 1;
+@z-index-dygraph-hover-label: @z-index-dropdown + 1;
+
 // The error message comes in 'body' and 'modal' varieties
 @z-index-errormsg-floater-modal: @z-index-modal + 1;
-// This has to be at least 10000 to render above gemini.
-@z-index-user-account-menu-dropdown: 10000;
-@z-index-user-dropdown-menu: @z-index-modal + 1;
+
+@z-index-form-group-container-action-button-group: 1;
+
+@z-index-gemini-scrollbar-handle: @z-index-header-tabs + 1;
+
+@z-index-header-border: 1;
+@z-index-header-tabs: @z-index-header-border + 1;
+
+@z-index-json-editor-help-tooltip: @z-index-modal - 1;
+
+@z-index-menu-tabbed-item-active-indicator: @z-index-header-tabs + 1;
+
+@z-index-modal-side-panel: @z-index-header-tabs + 1;
+
+@z-index-overlay-header: @z-index-overlay + 1;
+@z-index-overlay: @z-index-dropdown + 1;
+
+@z-index-sidebar-overlay: @z-index-sidebar - 1;
+@z-index-sidebar: @z-index-modal - 1;
+
+@z-index-tooltip: @z-index-dropdown + 1;

--- a/src/styles/vendor/cnvs/layout/variables.less
+++ b/src/styles/vendor/cnvs/layout/variables.less
@@ -34,16 +34,6 @@
 @base-spacing-unit-screen-jumbo: 28px;
 
 /*
- * Z-Index
- */
-
-@z-index-page: 1000;
-@z-index-header: 2000;
-@z-index-dropdown-menu: 3000;
-@z-index-tooltip: 4000;
-@z-index-modal: 5000;
-
-/*
  * Styling
  */
 


### PR DESCRIPTION
Includes the single-line commit from #1838 

This PR removes unused `z-index` variables and consolidates their assignment. It also moves all rogue `z-index` property assignments that weren't using a variable (except one in `service-sidebar` which needs to be removed entirely).