### PR TITLE
Fix create service modal's navigation divider

### DIFF
--- a/src/styles/views/create-service-modal/styles.less
+++ b/src/styles/views/create-service-modal/styles.less
@@ -118,7 +118,7 @@
 
             &:after {
               bottom: -@modal-full-screen-body-padding-vertical-screen-medium;
-              top: @modal-full-screen-body-padding-vertical-screen-medium;
+              top: -@modal-full-screen-body-padding-vertical-screen-medium;
             }
           }
         }


### PR DESCRIPTION
Fixes a missing `-` to negate the variable's value. This only occurred at the `medium` breakpoint.

Before:
![](https://cl.ly/3K163t1c1t2L/Screen%20Shot%202017-01-20%20at%2010.35.42%20AM.png)

After:
![](https://cl.ly/223G413i1v3T/Screen%20Shot%202017-01-20%20at%2010.36.43%20AM.png)