### PR TITLE
Fix jobs tooltip styles

### DIFF
--- a/src/styles/components/tooltip/styles.less
+++ b/src/styles/components/tooltip/styles.less
@@ -17,6 +17,13 @@
       padding: @tooltip-padding-vertical @tooltip-padding-horizontal;
       transition: translateZ(0);
 
+      // Provides an extra level of specificity to override cnvs defaults
+      &,
+      p {
+        color: @white;
+        font-size: @tooltip-font-size;
+      }
+
       &:after {
         border-color: @tooltip-background-color;
       }


### PR DESCRIPTION
Before, note overlarge font and unreadable grey colour:
![](https://d3vv6lp55qjaqc.cloudfront.net/items/04332t3q1C0V0V1E0n2c/Image%202017-01-05%20at%205.12.32%20PM.png?X-CloudApp-Visitor-Id=1905462&v=f8648d86)

After:
![](https://d3vv6lp55qjaqc.cloudfront.net/items/1F1I0I1g3Q200K2o3n0I/Screen%20Recording%202017-01-20%20at%2006.12%20PM.gif?X-CloudApp-Visitor-Id=1905462&v=e15fcf9a)