### PR TITLE
DCOS-12703: Display correct service address across the UI

### DIFF
--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -5,17 +5,17 @@ import {StoreMixin} from 'mesosphere-shared-reactjs';
 
 import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
 import {FormReducer as networks} from '../../reducers/serviceForm/MultiContainerNetwork';
+import FieldError from '../../../../../../src/js/components/form/FieldError';
 import FieldHelp from '../../../../../../src/js/components/form/FieldHelp';
 import FieldInput from '../../../../../../src/js/components/form/FieldInput';
 import FieldLabel from '../../../../../../src/js/components/form/FieldLabel';
-import FieldError from '../../../../../../src/js/components/form/FieldError';
 import FieldSelect from '../../../../../../src/js/components/form/FieldSelect';
 import FormGroup from '../../../../../../src/js/components/form/FormGroup';
 import FormGroupContainer from '../../../../../../src/js/components/form/FormGroupContainer';
 import FormRow from '../../../../../../src/js/components/form/FormRow';
-import HostUtil from '../../utils/HostUtil';
 import Icon from '../../../../../../src/js/components/Icon';
 import Networking from '../../../../../../src/js/constants/Networking';
+import ServiceConfigUtil from '../../utils/ServiceConfigUtil';
 import VirtualNetworksStore from '../../../../../../src/js/stores/VirtualNetworksStore';
 
 const {CONTAINER, HOST} = Networking.type;
@@ -146,18 +146,19 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
       errors,
       `containers.${containerIndex}.endpoints.${index}.labels`
     );
+
     let address = vip;
     if (address == null) {
-      const hostname = HostUtil.stringToHostname(this.props.data.id);
       let port = '';
       if (hostPort != null && hostPort !== '') {
-        port = `:${hostPort}`;
+        port = hostPort;
       }
       if (containerPort != null && containerPort !== '') {
-        port = `:${containerPort}`;
+        port = containerPort;
       }
+      port = port || 0;
 
-      address = `${hostname}${Networking.L4LB_ADDRESS}${port}`;
+      address = `${this.props.data.id}:${port}`;
     }
 
     return [
@@ -187,7 +188,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
         </FormGroup>
         <FormGroup className="column-auto flush-left" key="address">
           <span>
-            {address}
+            {ServiceConfigUtil.buildHostNameFromVipLabel(address)}
           </span>
         </FormGroup>
       </div>

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -3,21 +3,21 @@ import {Tooltip} from 'reactjs-components';
 import mixin from 'reactjs-mixin';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
+import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
+import {FormReducer as portDefinitionsReducer} from '../../reducers/serviceForm/PortDefinitions';
+import {SET} from '../../../../../../src/js/constants/TransactionTypes';
+import ContainerConstants from '../../constants/ContainerConstants';
+import FieldError from '../../../../../../src/js/components/form/FieldError';
 import FieldHelp from '../../../../../../src/js/components/form/FieldHelp';
 import FieldInput from '../../../../../../src/js/components/form/FieldInput';
 import FieldLabel from '../../../../../../src/js/components/form/FieldLabel';
-import FieldError from '../../../../../../src/js/components/form/FieldError';
 import FieldSelect from '../../../../../../src/js/components/form/FieldSelect';
-import FormRow from '../../../../../../src/js/components/form/FormRow';
-import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
-import {SET} from '../../../../../../src/js/constants/TransactionTypes';
 import FormGroup from '../../../../../../src/js/components/form/FormGroup';
 import FormGroupContainer from '../../../../../../src/js/components/form/FormGroupContainer';
-import {FormReducer as portDefinitionsReducer} from '../../reducers/serviceForm/PortDefinitions';
-import HostUtil from '../../utils/HostUtil';
+import FormRow from '../../../../../../src/js/components/form/FormRow';
 import Icon from '../../../../../../src/js/components/Icon';
 import Networking from '../../../../../../src/js/constants/Networking';
-import ContainerConstants from '../../constants/ContainerConstants';
+import ServiceConfigUtil from '../../utils/ServiceConfigUtil';
 import VirtualNetworksStore from '../../../../../../src/js/stores/VirtualNetworksStore';
 
 const {BRIDGE, HOST, USER} = Networking.type;
@@ -125,16 +125,16 @@ class NetworkingFormSection extends mixin(StoreMixin) {
 
     let address = vip;
     if (address == null) {
-      const hostname = HostUtil.stringToHostname(this.props.data.id);
       let port = '';
       if (hostPort != null && hostPort !== '') {
-        port = `:${hostPort}`;
+        port = hostPort;
       }
       if (containerPort != null && containerPort !== '') {
-        port = `:${containerPort}`;
+        port = containerPort;
       }
+      port = port || 0;
 
-      address = `${hostname}${Networking.L4LB_ADDRESS}${port}`;
+      address = `${this.props.data.id}:${port}`;
     }
 
     return [
@@ -163,7 +163,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
         </FormGroup>
         <FormGroup className="column-auto flush-left">
           <span>
-            {address}
+            {ServiceConfigUtil.buildHostNameFromVipLabel(address)}
           </span>
         </FormGroup>
       </FormRow>

--- a/plugins/services/src/js/reducers/serviceForm/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/Containers.js
@@ -213,7 +213,7 @@ function containersParser(state) {
               'loadBalanced'
             ], true));
 
-            if (!vip.startsWith(state.id)) {
+            if (!vip.startsWith(`${state.id}:`)) {
               memo.push(new Transaction([
                 'containers', index, 'endpoints', endpointIndex,
                 'vip'

--- a/plugins/services/src/js/reducers/serviceForm/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/Containers.js
@@ -17,8 +17,9 @@ import {
   JSONSegmentParser as multiContainerHealthCheckParser,
   FormReducer as multiContainerHealthFormReducer
 } from './MultiContainerHealthChecks';
-import Networking from '../../../../../../src/js/constants/Networking';
 import {isEmpty} from '../../../../../../src/js/utils/ValidatorUtil';
+import Networking from '../../../../../../src/js/constants/Networking';
+import VipLabelUtil from '../../utils/VipLabelUtil';
 
 const containerReducer = combineReducers({
   cpus: simpleReducer('resources.cpus'),
@@ -52,9 +53,7 @@ function mapEndpoints(endpoints = [], networkType, appState) {
       containerPort,
       automaticPort,
       protocol,
-      vip,
-      labels,
-      loadBalanced
+      labels
     } = endpoint;
 
     if (automaticPort) {
@@ -62,15 +61,14 @@ function mapEndpoints(endpoints = [], networkType, appState) {
     }
 
     if (networkType === Networking.type.CONTAINER) {
-      if (loadBalanced) {
-        if (vip == null) {
-          vip = `${appState.id}:${containerPort}`;
-        }
+      const vipLabel = `VIP_${index}`;
 
-        labels = Object.assign({}, labels, {
-          [`VIP_${index}`]: vip
-        });
-      }
+      labels = VipLabelUtil.generateVipLabel(
+        appState.id,
+        endpoint,
+        vipLabel,
+        containerPort
+      );
 
       return {
         name,

--- a/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
+++ b/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
@@ -7,6 +7,7 @@ import Networking from '../../../../../../src/js/constants/Networking';
 import networkingReducer from './Networking';
 import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
 import {PROTOCOLS} from '../../constants/PortDefinitionConstants';
+import VipLabelUtil from '../../utils/VipLabelUtil';
 
 const {HOST} = Networking.type;
 
@@ -55,30 +56,26 @@ module.exports = {
 
     // Create JSON port definitions from state
     return this.portDefinitions.map((portDefinition, index) => {
+      const {name} = portDefinition;
+      const vipLabel = `VIP_${index}`;
       const hostPort = Number(portDefinition.hostPort) || 0;
       const protocol = PROTOCOLS.filter(function (protocol) {
         return portDefinition.protocol[protocol];
       }).join(',');
-      const newPortDefinition = {
+
+      const labels = VipLabelUtil.generateVipLabel(
+        this.appState.id,
+        portDefinition,
+        vipLabel,
+        hostPort
+      );
+
+      return {
+        labels,
+        name,
         protocol,
-        name: portDefinition.name,
         port: hostPort
       };
-
-      // Only set labels if port mapping is load balanced
-      if (portDefinition.loadBalanced) {
-        let vip = portDefinition.vip;
-
-        if (portDefinition.vip == null) {
-          vip = `${this.appState.id}:${hostPort}`;
-        }
-
-        newPortDefinition.labels = Object.assign({}, newPortDefinition.labels, {
-          [`VIP_${index}`]: vip
-        });
-      }
-
-      return newPortDefinition;
     });
   },
 

--- a/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
+++ b/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
@@ -149,7 +149,7 @@ module.exports = {
           'loadBalanced'
         ], true, SET));
 
-        if (!vip.startsWith(state.id)) {
+        if (!vip.startsWith(`${state.id}:`)) {
           memo.push(new Transaction([
             'portDefinitions',
             index,

--- a/plugins/services/src/js/reducers/serviceForm/PortMappings.js
+++ b/plugins/services/src/js/reducers/serviceForm/PortMappings.js
@@ -135,7 +135,7 @@ module.exports = {
           'loadBalanced'
         ], true, SET));
 
-        if (!vip.startsWith(state.id)) {
+        if (!vip.startsWith(`${state.id}:`)) {
           memo.push(new Transaction([
             'portDefinitions',
             index,

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
@@ -12,7 +12,7 @@ describe('PortDefinitions', function () {
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}),
           {}))
-      .toEqual([{name: null, port: 0, protocol: 'tcp'}]);
+      .toEqual([{name: null, port: 0, protocol: 'tcp', labels: null}]);
     });
 
     it('Should return null if networkType is not HOST', function () {
@@ -40,7 +40,7 @@ describe('PortDefinitions', function () {
       batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {}))
-        .toEqual([{name: null, port: 0, protocol: 'tcp'}]);
+        .toEqual([{name: null, port: 0, protocol: 'tcp', labels: null}]);
     });
 
     it('should create default portDefinition configurations for BRIDGE network', function () {
@@ -68,8 +68,8 @@ describe('PortDefinitions', function () {
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {}))
         .toEqual([
-          {name: null, port: 0, protocol: 'tcp'},
-          {name: null, port: 0, protocol: 'tcp'}
+          {name: null, port: 0, protocol: 'tcp', labels: null},
+          {name: null, port: 0, protocol: 'tcp', labels: null}
         ]);
     });
 
@@ -80,7 +80,7 @@ describe('PortDefinitions', function () {
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {}))
         .toEqual([
-          {name: 'foo', port: 0, protocol: 'tcp'}
+          {name: 'foo', port: 0, protocol: 'tcp', labels: null}
         ]);
     });
 
@@ -92,7 +92,7 @@ describe('PortDefinitions', function () {
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {}))
         .toEqual([
-          {name: null, port: 100, protocol: 'tcp'}
+          {name: null, port: 100, protocol: 'tcp', labels: null}
         ]);
     });
 
@@ -105,7 +105,7 @@ describe('PortDefinitions', function () {
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {}))
         .toEqual([
-          {name: null, port: 0, protocol: 'tcp'}
+          {name: null, port: 0, protocol: 'tcp', labels: null}
         ]);
     });
 
@@ -117,7 +117,7 @@ describe('PortDefinitions', function () {
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {}))
         .toEqual([
-          {name: null, port: 0, protocol: 'udp'}
+          {name: null, port: 0, protocol: 'udp', labels: null}
         ]);
     });
 
@@ -141,7 +141,7 @@ describe('PortDefinitions', function () {
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {}))
         .toEqual([
-          {name: null, port: 0, protocol: 'tcp'},
+          {name: null, port: 0, protocol: 'tcp', labels: null},
           {name: null, port: 0, protocol: 'tcp', labels: {'VIP_1': ':0'}}
         ]);
     });
@@ -171,7 +171,7 @@ describe('PortDefinitions', function () {
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {}))
         .toEqual([
           {name: null, port: 300, protocol: 'tcp', labels: {VIP_0: ':300'}},
-          {name: null, port: 0, protocol: 'tcp'}
+          {name: null, port: 0, protocol: 'tcp', labels: null}
         ]);
     });
 
@@ -185,7 +185,7 @@ describe('PortDefinitions', function () {
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {}))
         .toEqual([
-          {name: null, port: 0, protocol: 'tcp'},
+          {name: null, port: 0, protocol: 'tcp', labels: null},
           {name: null, port: 0, protocol: 'tcp', labels: {'VIP_1': 'foo:0'}}
         ]);
     });
@@ -202,7 +202,7 @@ describe('PortDefinitions', function () {
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {}))
         .toEqual([
-          {name: null, port: 0, protocol: 'tcp'},
+          {name: null, port: 0, protocol: 'tcp', labels: null},
           {name: null, port: 0, protocol: 'tcp', labels: {'VIP_1': 'foo:0'}}
         ]);
     });

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
@@ -129,7 +129,7 @@ describe('PortDefinitions', function () {
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {}))
         .toEqual([
-          {name: null, port: 0, protocol: 'udp,tcp'}
+          {name: null, port: 0, protocol: 'udp,tcp', labels: null}
         ]);
     });
 

--- a/plugins/services/src/js/service-configuration/PodNetworkConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodNetworkConfigSection.js
@@ -7,8 +7,8 @@ import ConfigurationMapLabel from '../../../../../src/js/components/Configuratio
 import ConfigurationMapRow from '../../../../../src/js/components/ConfigurationMapRow';
 import ConfigurationMapSection from '../../../../../src/js/components/ConfigurationMapSection';
 import ServiceConfigDisplayUtil from '../utils/ServiceConfigDisplayUtil';
+import ServiceConfigUtil from '../utils/ServiceConfigUtil';
 import ConfigurationMapValueWithDefault from '../components/ConfigurationMapValueWithDefault';
-import Networking from '../../../../../src/js/constants/Networking';
 
 const NETWORK_MODE_NAME = {
   'container': 'Container',
@@ -60,9 +60,10 @@ class PodNetworkConfigSection extends React.Component {
       return memo.concat(
         endpoints.map(({containerPort, labels={}, name, protocol}) => {
           const lbAddress = Object.keys(labels).reduce((memo, label) => {
-            if (label.startsWith('VIP_')) {
-              const [prefix, port] = labels[label].split(':');
-              memo.push(`${prefix}.${Networking.L4LB_ADDRESS}:${port}`);
+            if (ServiceConfigUtil.matchVIPLabel(label)) {
+              memo.push(
+                ServiceConfigUtil.buildHostNameFromVipLabel(labels[label])
+              );
             }
 
             return memo;

--- a/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
@@ -132,15 +132,12 @@ class ServiceNetworkingConfigSection extends ServiceConfigBaseSectionDisplay {
                 prop: '',
                 className: getColumnClassNameFn(),
                 render(prop, row) {
-                  const portKey = networkType === Networking.type.HOST ?
-                    'port' :
-                    'containerPort';
+                  const {port, labels} = row;
+                  const vipLabel = ServiceConfigUtil.findVIPLabel(labels);
 
-                  const {[portKey]: port, labels} = row;
-
-                  if (labels && ServiceConfigUtil.hasVIPLabel(labels)) {
-                    return ServiceConfigUtil.buildHostName(
-                      appDefinition.id,
+                  if (vipLabel) {
+                    return ServiceConfigUtil.buildHostNameFromVipLabel(
+                      labels[vipLabel],
                       port
                     );
                   }

--- a/plugins/services/src/js/utils/ServiceConfigUtil.js
+++ b/plugins/services/src/js/utils/ServiceConfigUtil.js
@@ -19,6 +19,25 @@ const ServiceConfigUtil = {
     const hostname = HostUtil.stringToHostname(id);
 
     return `${hostname}${Networking.L4LB_ADDRESS}:${port}`;
+  },
+
+  buildHostNameFromVipLabel(label, port) {
+    const [ipOrName, labelPort] = label.split(':');
+
+    // Sometimes we don't know the port yet
+    port = port || '<assigned port>';
+
+    // 0 means randomly assigned port
+    port = labelPort === '0' ? port : labelPort;
+
+    // it seems to be an IP address
+    if (/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/.test(ipOrName)) {
+      return `${ipOrName}:${port}`;
+    }
+
+    const hostname = HostUtil.stringToHostname(ipOrName);
+
+    return `${hostname}${Networking.L4LB_ADDRESS}:${port}`;
   }
 
 };

--- a/plugins/services/src/js/utils/VipLabelUtil.js
+++ b/plugins/services/src/js/utils/VipLabelUtil.js
@@ -1,0 +1,22 @@
+const VipLabelUtil = {
+  generateVipLabel(appId, portDefinition, vipLabel, vipPort) {
+    const {labels, loadBalanced, vip} = portDefinition;
+
+    // Only set VIP labels if port mapping is load balanced
+    if (loadBalanced) {
+      let vipValue = vip;
+
+      if (vipValue == null) {
+        vipValue = `${appId}:${vipPort}`;
+      }
+
+      return Object.assign({}, labels, {[vipLabel]: vipValue});
+    } else if (labels) {
+      return Object.assign({}, labels, {[vipLabel]: undefined});
+    }
+
+    return labels;
+  }
+};
+
+module.exports = VipLabelUtil;

--- a/plugins/services/src/js/utils/__tests__/ServiceConfigUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceConfigUtil-test.js
@@ -61,4 +61,31 @@ describe('ServiceConfigUtil', function () {
 
   });
 
+  describe('#buildHostNameFromVipLabel', function () {
+    it('builds correct hostname', function () {
+      expect(
+        ServiceConfigUtil.buildHostNameFromVipLabel('/some-app:8080')
+      ).toEqual('some-app.marathon.l4lb.thisdcos.directory:8080');
+    });
+
+    it('builds correct hostname for an IP address', function () {
+      expect(
+        ServiceConfigUtil.buildHostNameFromVipLabel('192.168.0.1:9091')
+      ).toEqual('192.168.0.1:9091');
+    });
+
+    it('correctly displays <random port>', function () {
+      expect(
+        ServiceConfigUtil.buildHostNameFromVipLabel('192.168.0.1:0', undefined)
+      ).toEqual('192.168.0.1:<assigned port>');
+    });
+
+    it('correctly uses desired port', function () {
+      expect(
+        ServiceConfigUtil.buildHostNameFromVipLabel('192.168.0.1:0', 9070)
+      ).toEqual('192.168.0.1:9070');
+    });
+
+  });
+
 });

--- a/plugins/services/src/js/utils/__tests__/VipLabelUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/VipLabelUtil-test.js
@@ -1,0 +1,83 @@
+jest.dontMock('../VipLabelUtil');
+
+const VipLabelUtil = require('../VipLabelUtil');
+
+const appID = '/some-app';
+const vipLabel = 'VIP_0';
+const vipPort = 7070;
+
+describe('VipLabelUtil', function () {
+
+  describe('#generateVipLabel', function () {
+
+    describe('when port is not load balanced', function () {
+
+      describe('when there is a vip label', function () {
+
+        it('deletes vip label from labels', function () {
+          var portDefinition = {
+            loadBalanced: false,
+            labels: {
+              [vipLabel]: 'viplabel:9090'
+            }
+          };
+          var result = VipLabelUtil.generateVipLabel(appID, portDefinition, vipLabel, vipPort);
+
+          expect(result).toEqual({});
+        });
+
+      });
+
+      describe('when there is no vip labels', function () {
+
+        it('returns labels unchanged', function () {
+          var portDefinition = {
+            loadBalanced: false,
+            labels: {
+              otherLabel: 'value'
+            }
+          };
+          var result = VipLabelUtil.generateVipLabel(appID, portDefinition, vipLabel, vipPort);
+
+          expect(result).toEqual({ otherLabel: 'value' });
+        });
+
+      });
+
+    });
+
+    describe('when port is load balanced', function () {
+
+      describe('when no vip has been given', function () {
+
+        it('generates VIP', function () {
+          var portDefinition = {
+            loadBalanced: true,
+            vip: undefined
+          };
+          var result = VipLabelUtil.generateVipLabel(appID, portDefinition, vipLabel, vipPort);
+
+          expect(result).toEqual({ VIP_0: '/some-app:7070' });
+        });
+
+      });
+
+      describe('when vip has been given', function () {
+
+        it('generates VIP', function () {
+          var portDefinition = {
+            loadBalanced: true,
+            vip: 'service-address:9091'
+          };
+          var result = VipLabelUtil.generateVipLabel(appID, portDefinition, vipLabel, vipPort);
+
+          expect(result).toEqual({ VIP_0: 'service-address:9091' });
+        });
+
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
This PR ensures we display a consistent and hopefully correct value for a service address across the UI.

To make it possible:
- VIP label generation function has been extracted
- Multi and Single container network forms have been changed
- Multi and Single container config review screens have been changed

Additionally I've made more strict the rule of checking if a VIP has been changed by a user, yet there's an outstanding issue I decided to extract https://mesosphere.atlassian.net/browse/DCOS-13394