### PR TITLE
[1 of 3: Mobile Page Header Navigation] DCOS-12558: Create page header navigation dropdown menu

### DIFF
--- a/src/js/components/PageHeaderNavigationDropdown.js
+++ b/src/js/components/PageHeaderNavigationDropdown.js
@@ -1,0 +1,88 @@
+import {Dropdown} from 'reactjs-components';
+import React from 'react';
+
+import Icon from './Icon';
+
+class PageHeaderNavigationDropdown extends React.Component {
+  getActiveItemID() {
+    const {items} = this.props;
+    const activeTab = items.find(function (item) {
+      return item.isActive;
+    });
+
+    if (activeTab) {
+      return activeTab.id;
+    }
+
+    if (items.length > 0) {
+      return activeTab[0].id;
+    }
+  }
+
+  getItems() {
+    return this.props.items.map(function (item) {
+      const {label} = item;
+
+      return Object.assign({}, item, {
+        html: label,
+        selectedHtml: (
+          <div className="page-header-navigation-dropdown-active-item">
+            <span className="page-header-navigation-dropdown-label">
+              {label}
+            </span>
+            <span className="page-header-navigation-dropdown-caret">
+              <Icon id="caret-down"
+                color="light-grey"
+                family="tiny"
+                size="tiny" />
+            </span>
+          </div>
+        )
+      });
+    });
+  }
+
+  render() {
+    const {handleNavigationItemSelection} = this.props;
+    const dropdownItems = this.getItems();
+
+    if (dropdownItems.length === 0) {
+      return null;
+    }
+
+    return (
+      <Dropdown
+        buttonClassName="page-header-navigation-dropdown-button button button-transparent"
+        dropdownMenuClassName="page-header-navigation-dropdown-menu dropdown-menu"
+        dropdownMenuListClassName="dropdown-menu-list"
+        dropdownMenuListItemClassName="clickable"
+        items={this.getItems()}
+        onItemSelection={handleNavigationItemSelection}
+        persistentID={this.getActiveItemID()}
+        scrollContainer=".gm-scroll-view"
+        scrollContainerParentSelector=".gm-prevented"
+        transition={true}
+        transitionName="dropdown-menu"
+        wrapperClassName="page-header-navigation-dropdown dropdown" />
+    );
+  }
+}
+
+PageHeaderNavigationDropdown.defaultProps = {
+  items: []
+};
+
+PageHeaderNavigationDropdown.propTypes = {
+  items: React.PropTypes.arrayOf(
+    React.PropTypes.shape({
+      id: React.PropTypes.oneOfType([
+        React.PropTypes.number,
+        React.PropTypes.string
+      ]).isRequired,
+      isActive: React.PropTypes.bool.isRequired,
+      label: React.PropTypes.node.isRequired
+    })
+  )
+};
+
+module.exports = PageHeaderNavigationDropdown;

--- a/src/js/components/PageHeaderTabs.js
+++ b/src/js/components/PageHeaderTabs.js
@@ -46,7 +46,7 @@ class PageHeaderTabs extends React.Component {
         </a>
       );
 
-      if (callback == null) {
+      if (callback == null && routePath != null) {
         link = (
           <Link
             className={linkClasses}

--- a/src/js/components/PageHeaderTabs.js
+++ b/src/js/components/PageHeaderTabs.js
@@ -15,7 +15,9 @@ class PageHeaderTabs extends React.Component {
     });
   }
 
-  handleNavigationItemSelection({callback, routePath}) {
+  handleNavigationItemSelection(navItem) {
+    const {callback, routePath} = navItem;
+
     if (callback != null) {
       callback();
     }

--- a/src/js/components/PageHeaderTabs.js
+++ b/src/js/components/PageHeaderTabs.js
@@ -1,9 +1,8 @@
 import classNames from 'classnames';
-import {Dropdown} from 'reactjs-components';
 import {Link, routerShape} from 'react-router';
 import React from 'react';
 
-import Icon from './Icon';
+import PageHeaderNavigationDropdown from './PageHeaderNavigationDropdown';
 
 const METHODS_TO_BIND = ['handleNavigationItemSelection'];
 
@@ -60,60 +59,28 @@ class PageHeaderTabs extends React.Component {
     );
   }
 
-  getDropdown() {
-    let activeID = null;
-    const {props: {tabs}} = this;
+  getNavigationDropdownItems() {
+    const {tabs} = this.props;
 
-    if (!tabs || tabs.length === 0) {
-      return null;
+    if (tabs == null) {
+      return [];
     }
 
-    const dropdownItems = tabs.map((tab, index) => {
+    return tabs.map((tab, index) => {
       const {callback, isActive, label, routePath} = tab;
       // We add 1 to index for the ID to avoid an ID of 0, due to coercion in
       // the Dropdown component.
       const id = index + 1;
 
-      if (isActive || (routePath != null && this.isRouteActive(routePath))) {
-        activeID = id;
-      }
-
       return {
-        html: label,
+        label,
         id,
+        isActive: isActive || (routePath != null
+          && this.isRouteActive(routePath)),
         callback,
-        routePath,
-        selectedHtml: (
-          <div className="page-header-navigation-dropdown-active-item">
-            <span className="page-header-navigation-dropdown-label">
-              {label}
-            </span>
-            <span className="page-header-navigation-dropdown-caret">
-              <Icon id="caret-down"
-                color="light-grey"
-                family="tiny"
-                size="tiny" />
-            </span>
-          </div>
-        )
+        routePath
       };
     });
-
-    return (
-      <Dropdown
-        buttonClassName="page-header-navigation-dropdown-button button button-transparent"
-        dropdownMenuClassName="page-header-navigation-dropdown-menu dropdown-menu"
-        dropdownMenuListClassName="dropdown-menu-list"
-        dropdownMenuListItemClassName="clickable"
-        items={dropdownItems}
-        onItemSelection={this.handleNavigationItemSelection}
-        persistentID={activeID}
-        scrollContainer=".gm-scroll-view"
-        scrollContainerParentSelector=".gm-prevented"
-        transition={true}
-        transitionName="dropdown-menu"
-        wrapperClassName="page-header-navigation-dropdown dropdown" />
-    );
   }
 
   handleNavigationItemSelection({callback, routePath}) {
@@ -134,7 +101,9 @@ class PageHeaderTabs extends React.Component {
     return (
       <div className="page-header-navigation">
         {this.getTabs()}
-        {this.getDropdown()}
+        <PageHeaderNavigationDropdown
+          handleNavigationItemSelection={this.handleNavigationItemSelection}
+          items={this.getNavigationDropdownItems()} />
       </div>
     );
   }

--- a/src/js/components/PageHeaderTabs.js
+++ b/src/js/components/PageHeaderTabs.js
@@ -15,6 +15,16 @@ class PageHeaderTabs extends React.Component {
     });
   }
 
+  handleNavigationItemSelection({callback, routePath}) {
+    if (callback != null) {
+      callback();
+    }
+
+    if (routePath != null) {
+      this.context.router.push(routePath);
+    }
+  }
+
   getTabs() {
     const {props: {tabs}} = this;
 
@@ -81,16 +91,6 @@ class PageHeaderTabs extends React.Component {
         routePath
       };
     });
-  }
-
-  handleNavigationItemSelection({callback, routePath}) {
-    if (callback != null) {
-      callback();
-    }
-
-    if (routePath != null) {
-      this.context.router.push(routePath);
-    }
   }
 
   isRouteActive(route) {

--- a/src/js/components/PageHeaderTabs.js
+++ b/src/js/components/PageHeaderTabs.js
@@ -1,19 +1,32 @@
-import classNames from 'classnames/dedupe';
-import {Link} from 'react-router';
+import classNames from 'classnames';
+import {Dropdown} from 'reactjs-components';
+import {Link, routerShape} from 'react-router';
 import React from 'react';
 
+import Icon from './Icon';
+
+const METHODS_TO_BIND = ['handleNavigationItemSelection'];
+
 class PageHeaderTabs extends React.Component {
-  render() {
+  constructor() {
+    super(...arguments);
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  getTabs() {
     const {props: {tabs}} = this;
 
     const tabElements = tabs.map(function (tab, index) {
-      const {isActive, callback} = tab;
+      const {isActive, callback, label, routePath} = tab;
       const classes = classNames('menu-tabbed-item', {active: isActive});
       const linkClasses = classNames('menu-tabbed-item-label', {active: isActive});
 
       const innerLinkSpan = (
         <span className="menu-tabbed-item-label-text">
-          {tab.label}
+          {label}
         </span>
       );
       let link = (
@@ -22,11 +35,11 @@ class PageHeaderTabs extends React.Component {
         </a>
       );
 
-      if (tab.callback == null) {
+      if (callback == null) {
         link = (
           <Link
             className={linkClasses}
-            to={tab.routePath}
+            to={routePath}
             activeClassName="active">
             {innerLinkSpan}
           </Link>
@@ -41,14 +54,95 @@ class PageHeaderTabs extends React.Component {
     });
 
     return (
+      <ul className="page-header-navigation-tabs menu-tabbed">
+        {tabElements}
+      </ul>
+    );
+  }
+
+  getDropdown() {
+    let activeID = null;
+    const {props: {tabs}} = this;
+
+    if (!tabs || tabs.length === 0) {
+      return null;
+    }
+
+    const dropdownItems = tabs.map((tab, index) => {
+      const {callback, isActive, label, routePath} = tab;
+      // We add 1 to index for the ID to avoid an ID of 0, due to coercion in
+      // the Dropdown component.
+      const id = index + 1;
+
+      if (isActive || (routePath != null && this.isRouteActive(routePath))) {
+        activeID = id;
+      }
+
+      return {
+        html: label,
+        id,
+        callback,
+        routePath,
+        selectedHtml: (
+          <div className="page-header-navigation-dropdown-active-item">
+            <span className="page-header-navigation-dropdown-label">
+              {label}
+            </span>
+            <span className="page-header-navigation-dropdown-caret">
+              <Icon id="caret-down"
+                color="light-grey"
+                family="tiny"
+                size="tiny" />
+            </span>
+          </div>
+        )
+      };
+    });
+
+    return (
+      <Dropdown
+        buttonClassName="page-header-navigation-dropdown-button button button-transparent"
+        dropdownMenuClassName="page-header-navigation-dropdown-menu dropdown-menu"
+        dropdownMenuListClassName="dropdown-menu-list"
+        dropdownMenuListItemClassName="clickable"
+        items={dropdownItems}
+        onItemSelection={this.handleNavigationItemSelection}
+        persistentID={activeID}
+        scrollContainer=".gm-scroll-view"
+        scrollContainerParentSelector=".gm-prevented"
+        transition={true}
+        transitionName="dropdown-menu"
+        wrapperClassName="page-header-navigation-dropdown dropdown" />
+    );
+  }
+
+  handleNavigationItemSelection({callback, routePath}) {
+    if (callback != null) {
+      callback();
+    }
+
+    if (routePath != null) {
+      this.context.router.push(routePath);
+    }
+  }
+
+  isRouteActive(route) {
+    return this.context.router.isActive(route);
+  }
+
+  render() {
+    return (
       <div className="page-header-navigation">
-        <ul className="menu-tabbed">
-          {tabElements}
-        </ul>
+        {this.getTabs()}
+        {this.getDropdown()}
       </div>
     );
   }
 }
+
+PageHeaderTabs.contextTypes = {
+  router: routerShape
+};
 
 PageHeaderTabs.defaultProps = {
   tabs: []

--- a/src/js/components/PageHeaderTabs.js
+++ b/src/js/components/PageHeaderTabs.js
@@ -85,8 +85,7 @@ class PageHeaderTabs extends React.Component {
       return {
         label,
         id,
-        isActive: isActive || (routePath != null
-          && this.isRouteActive(routePath)),
+        isActive: isActive || this.isRouteActive(routePath),
         callback,
         routePath
       };
@@ -94,7 +93,7 @@ class PageHeaderTabs extends React.Component {
   }
 
   isRouteActive(route) {
-    return this.context.router.isActive(route);
+    return route != null && this.context.router.isActive(route);
   }
 
   render() {

--- a/src/styles/components/page-header/styles.less
+++ b/src/styles/components/page-header/styles.less
@@ -8,7 +8,7 @@
     position: relative;
 
     &:before {
-      background-color: color-lighten(@neutral, 80);
+      background-color: @page-header-border-color;
       bottom: 0;
       content: '';
       display: block;
@@ -159,6 +159,7 @@
     &-navigation {
       align-items: flex-start;
       display: flex;
+      flex: 1 1 auto;
 
       .menu-tabbed {
         margin-bottom: 0;
@@ -170,6 +171,74 @@
 
       & when not (@pod-margin-bottom = null) {
         margin-bottom: -@pod-margin-bottom;
+      }
+
+      &-tabs {
+        display: none;
+      }
+
+      &-dropdown {
+        border-top: 1px solid @page-header-navigation-dropdown-border-color;
+        display: block;
+        flex: 1 1 auto;
+        margin-left: @page-header-navigation-dropdown-margin-left;
+        margin-right: @page-header-navigation-dropdown-margin-right;
+
+        &-button {
+          border-radius: 0;
+          height: @page-header-dropdown-menu-button-height;
+          padding-left: @page-header-navigation-dropdown-padding-left;
+          padding-right: @page-header-navigation-dropdown-padding-right;
+          text-align: left;
+          text-transform: none;
+          width: 100%;
+
+          button& {
+            display: block;
+          }
+        }
+
+        &-menu .is-selected,
+        &-active-item {
+          color: @page-header-navigation-dropdown-item-active-color;
+        }
+
+        &-menu {
+          border-radius: 0;
+          max-width: none;
+          width: 100%;
+
+          &.up {
+            box-shadow: 0 -1px 0 @page-header-navigation-dropdown-menu-border-color;
+            margin-bottom: @page-header-dropdown-menu-button-height * -1;
+          }
+
+          &.down {
+            box-shadow: 0 1px 0 @page-header-navigation-dropdown-menu-border-color;
+            margin-top: @page-header-dropdown-menu-button-height * -1;
+          }
+
+          li {
+            padding-left: @page-header-navigation-dropdown-padding-left;
+            padding-right: @page-header-navigation-dropdown-padding-right;
+          }
+        }
+
+        &-active-item {
+          display: flex;
+        }
+
+        &-label {
+          flex: 1 1 auto;
+        }
+
+        &-caret {
+          flex: 0 0 auto;
+
+          .icon {
+            display: block;
+          }
+        }
       }
     }
 
@@ -225,6 +294,33 @@
 
           & when not (@pod-margin-bottom-screen-small = null) {
             margin-bottom: -@pod-margin-bottom-screen-small;
+          }
+
+          &-dropdown {
+            margin-left: @page-header-navigation-dropdown-margin-left-screen-small;
+            margin-right: @page-header-navigation-dropdown-margin-right-screen-small;
+
+            &-button {
+              height: @page-header-dropdown-menu-button-height-screen-small;
+              padding-left: @page-header-navigation-dropdown-padding-left-screen-small;
+              padding-right: @page-header-navigation-dropdown-padding-right-screen-small;
+            }
+
+            &-menu {
+
+              &.up {
+                margin-bottom: @page-header-dropdown-menu-button-height-screen-small * -1;
+              }
+
+              &.down {
+                margin-top: @page-header-dropdown-menu-button-height-screen-small * -1;
+              }
+
+              li {
+                padding-left: @page-header-navigation-dropdown-padding-left-screen-small;
+                padding-right: @page-header-navigation-dropdown-padding-right-screen-small;
+              }
+            }
           }
         }
       }
@@ -286,6 +382,14 @@
 
           & when not (@pod-margin-bottom-screen-medium = null) {
             margin-bottom: -@pod-margin-bottom-screen-medium;
+          }
+
+          &-tabs {
+            display: block;
+          }
+
+          &-dropdown {
+            display: none;
           }
         }
       }

--- a/src/styles/components/page-header/styles.less
+++ b/src/styles/components/page-header/styles.less
@@ -219,8 +219,14 @@
           }
 
           li {
-            padding-left: @page-header-navigation-dropdown-padding-left;
-            padding-right: @page-header-navigation-dropdown-padding-right;
+            height: @page-header-dropdown-menu-button-height;
+            line-height: @page-header-dropdown-menu-button-height;
+            padding: @page-header-navigation-dropdown-padding-top @page-header-navigation-dropdown-padding-right @page-header-navigation-dropdown-padding-bottom @page-header-navigation-dropdown-padding-left;
+          }
+
+          .dropdown-menu-items {
+            padding-bottom: 0;
+            padding-top: 0;
           }
         }
 
@@ -317,8 +323,9 @@
               }
 
               li {
-                padding-left: @page-header-navigation-dropdown-padding-left-screen-small;
-                padding-right: @page-header-navigation-dropdown-padding-right-screen-small;
+                height: @page-header-dropdown-menu-button-height-screen-small;
+                line-height: @page-header-dropdown-menu-button-height-screen-small;
+                padding: @page-header-navigation-dropdown-padding-top-screen-small @page-header-navigation-dropdown-padding-right-screen-small @page-header-navigation-dropdown-padding-bottom-screen-small @page-header-navigation-dropdown-padding-left-screen-small;
               }
             }
           }

--- a/src/styles/components/page-header/variables.less
+++ b/src/styles/components/page-header/variables.less
@@ -132,8 +132,8 @@
 
 /* Page Header Navigation Dropdown */
 
-@page-header-dropdown-menu-button-height: @base-spacing-unit * 1.5;
-@page-header-dropdown-menu-button-height-screen-small: @base-spacing-unit-screen-small * 1.5;
+@page-header-dropdown-menu-button-height: @button-height + @base-spacing-unit / 3;
+@page-header-dropdown-menu-button-height-screen-small: @button-height + @base-spacing-unit-screen-small / 3;
 
 @page-header-navigation-dropdown-border-color: color-lighten(@page-header-border-color, 40);
 @page-header-navigation-dropdown-item-active-color: @purple;
@@ -144,10 +144,16 @@
 @page-header-navigation-dropdown-margin-right: @pod-margin-right * -1;
 @page-header-navigation-dropdown-margin-right-screen-small: @pod-margin-right-screen-small * -1;
 
-@page-header-navigation-dropdown-padding-left: @page-header-navigation-dropdown-margin-left * -1;
-@page-header-navigation-dropdown-padding-left-screen-small: @page-header-navigation-dropdown-margin-left-screen-small * -1;
+@page-header-navigation-dropdown-padding-top: 0;
+@page-header-navigation-dropdown-padding-top-screen-small: 0;
 
 @page-header-navigation-dropdown-padding-right: @page-header-navigation-dropdown-margin-right * -1;
 @page-header-navigation-dropdown-padding-right-screen-small: @page-header-navigation-dropdown-margin-right-screen-small * -1;
+
+@page-header-navigation-dropdown-padding-bottom: 0;
+@page-header-navigation-dropdown-padding-bottom-screen-small: 0;
+
+@page-header-navigation-dropdown-padding-left: @page-header-navigation-dropdown-margin-left * -1;
+@page-header-navigation-dropdown-padding-left-screen-small: @page-header-navigation-dropdown-margin-left-screen-small * -1;
 
 @page-header-navigation-dropdown-menu-border-color: fade(@neutral, 20%);

--- a/src/styles/components/page-header/variables.less
+++ b/src/styles/components/page-header/variables.less
@@ -1,5 +1,7 @@
 @page-header-enabled: true;
 
+@page-header-border-color: color-lighten(@neutral, 80);
+
 /*
  * Responsive Scaling
  */
@@ -127,3 +129,25 @@
 @page-header-breadcrumb-item-icon-container-padding-left-screen-medium: @icon-small-width + @base-spacing-unit-screen-medium * 1/4;
 @page-header-breadcrumb-item-icon-container-padding-left-screen-large: @icon-small-width + @base-spacing-unit-screen-large * 1/4;
 @page-header-breadcrumb-item-icon-container-padding-left-screen-jumbo: @icon-small-width + @base-spacing-unit-screen-jumbo * 1/4;
+
+/* Page Header Navigation Dropdown */
+
+@page-header-dropdown-menu-button-height: @base-spacing-unit * 1.5;
+@page-header-dropdown-menu-button-height-screen-small: @base-spacing-unit-screen-small * 1.5;
+
+@page-header-navigation-dropdown-border-color: color-lighten(@page-header-border-color, 40);
+@page-header-navigation-dropdown-item-active-color: @purple;
+
+@page-header-navigation-dropdown-margin-left: @pod-margin-left * -1;
+@page-header-navigation-dropdown-margin-left-screen-small: @pod-margin-left-screen-small * -1;
+
+@page-header-navigation-dropdown-margin-right: @pod-margin-right * -1;
+@page-header-navigation-dropdown-margin-right-screen-small: @pod-margin-right-screen-small * -1;
+
+@page-header-navigation-dropdown-padding-left: @page-header-navigation-dropdown-margin-left * -1;
+@page-header-navigation-dropdown-padding-left-screen-small: @page-header-navigation-dropdown-margin-left-screen-small * -1;
+
+@page-header-navigation-dropdown-padding-right: @page-header-navigation-dropdown-margin-right * -1;
+@page-header-navigation-dropdown-padding-right-screen-small: @page-header-navigation-dropdown-margin-right-screen-small * -1;
+
+@page-header-navigation-dropdown-menu-border-color: fade(@neutral, 20%);


### PR DESCRIPTION
1 of 3: #1850 
2 of 3: #1872 — [diff between 1 and 2](https://github.com/dcos/dcos-ui/compare/john/DCOS-12558/mobile-page-header-navigation...john/feature/separate-page-header-navigation-styles?expand=1)
3 of 3: #1873 — [diff between 2 and 3](https://github.com/dcos/dcos-ui/commit/83fb381a92b8c2369ac59f3193783ef9c51d63b1)

This PR implements a dropdown menu for the page header navigation at viewports narrower than `768px` (the medium breakpoint).

![](https://cl.ly/0c2P3n2n2l0u/Screen%20Recording%202017-01-25%20at%2010.52%20AM.gif)