### PR TITLE
Fix table link styling

### DIFF
--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -100,6 +100,7 @@
     text-decoration: none;
 
     &:hover {
+      color: @table-cell-highlight-color;
       text-decoration: underline;
     }
   }


### PR DESCRIPTION
This PR fixes the purple `:hover` color for table cell links.

Before:
![](https://cl.ly/2u0U3n461d3R/Screen%20Shot%202017-01-24%20at%2010.50.52%20AM.png)

After:
![](https://cl.ly/3D322j150k0W/Screen%20Shot%202017-01-24%20at%2010.49.13%20AM.png)