### PR TITLE
Fix nested icon styling

### DIFF
--- a/src/styles/components/icons/styles.less
+++ b/src/styles/components/icons/styles.less
@@ -95,13 +95,6 @@
     button & {
       flex: 0 0 auto;
     }
-
-    .icon {
-      left: 50%;
-      position: absolute;
-      top: 50%;
-      transform: translate(-50%, -50%);
-    }
   }
 
   & when (@icon-tiny-enabled) {


### PR DESCRIPTION
This PR fixes a bug that I introduced in this PR: https://github.com/dcos/dcos-ui/pull/1782

I wrote the CSS for a situation that I ended up not using, and the style I created is overly generic for its intended purpose anyway.

Before:
![](https://cl.ly/2b081E3O2W07/Screen%20Shot%202017-01-24%20at%2010.52.16%20AM.png)

After:
![](https://cl.ly/3k1K400r0h0M/Screen%20Shot%202017-01-24%20at%2010.57.20%20AM.png)