### PR TITLE
[Service Modal Routes 2a of 3] DCOS-12423: Show marathon errors in service config display 

### DIFF
--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -5,21 +5,21 @@ import React, {PropTypes, Component} from 'react';
 import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
 import {getContainerNameWithIcon} from '../../utils/ServiceConfigDisplayUtil';
 import {pluralize} from '../../../../../../src/js/utils/StringUtil';
-import Alert from '../../../../../../src/js/components/Alert';
 import Batch from '../../../../../../src/js/structs/Batch';
 import ContainerServiceFormSection from '../forms/ContainerServiceFormSection';
 import CreateServiceModalFormUtil from '../../utils/CreateServiceModalFormUtil';
 import DataValidatorUtil from '../../../../../../src/js/utils/DataValidatorUtil';
 import EnvironmentFormSection from '../forms/EnvironmentFormSection';
 import ErrorMessageUtil from '../../../../../../src/js/utils/ErrorMessageUtil';
+import ErrorsAlert from '../../../../../../src/js/components/ErrorsAlert';
 import FluidGeminiScrollbar from '../../../../../../src/js/components/FluidGeminiScrollbar';
 import GeneralServiceFormSection from '../forms/GeneralServiceFormSection';
 import HealthChecksFormSection from '../forms/HealthChecksFormSection';
 import JSONEditor from '../../../../../../src/js/components/JSONEditor';
-import NetworkingFormSection from '../forms/NetworkingFormSection';
 import MultiContainerHealthChecksFormSection from '../forms/MultiContainerHealthChecksFormSection';
 import MultiContainerNetworkingFormSection from '../forms/MultiContainerNetworkingFormSection';
 import MultiContainerVolumesFormSection from '../forms/MultiContainerVolumesFormSection';
+import NetworkingFormSection from '../forms/NetworkingFormSection';
 import ServiceErrorMessages from '../../constants/ServiceErrorMessages';
 import ServiceErrorPathMapping from '../../constants/ServiceErrorPathMapping';
 import ServiceUtil from '../../utils/ServiceUtil';
@@ -277,44 +277,8 @@ class NewCreateServiceModalForm extends Component {
 
   getErrors() {
     return ErrorMessageUtil.translateErrorMessages(
-      this.props.errors, ServiceErrorMessages
-    );
-  }
-
-  getErrorsAlertComponent() {
-    const {showAllErrors} = this.props;
-    let showErrors = this.getErrors();
-
-    if (!showAllErrors) {
-      showErrors = showErrors.filter(function (error) {
-        return error.path.length === 0;
-      });
-    }
-
-    if (showErrors.length === 0) {
-      return null;
-    }
-
-    const errorItems = showErrors.map((error, index) => {
-      const message = ErrorMessageUtil.getUnanchoredErrorMessage(
-        error, ServiceErrorPathMapping);
-
-      return (
-        <li key={index} className="short">
-          {message}
-        </li>
-      );
-    });
-
-    return (
-      <Alert>
-        <strong>There is an error with your configuration</strong>
-        <div className="pod pod-narrower-left pod-shorter-top flush-bottom">
-          <ul className="short flush-bottom">
-            {errorItems}
-          </ul>
-        </div>
-      </Alert>
+      this.props.errors,
+      ServiceErrorMessages
     );
   }
 
@@ -337,9 +301,8 @@ class NewCreateServiceModalForm extends Component {
   }
 
   getContainerContent(data, errors) {
-    const {service} = this.props;
+    const {service, showAllErrors} = this.props;
     const {containers} = data;
-    const errorsAlertComponent = this.getErrorsAlertComponent();
 
     if (containers == null) {
       return [];
@@ -348,7 +311,10 @@ class NewCreateServiceModalForm extends Component {
     return containers.map((item, index) => {
       return (
         <TabView key={index} id={`container${index}`}>
-          {errorsAlertComponent}
+          <ErrorsAlert
+            errors={this.getErrors()}
+            pathMapping={ServiceErrorPathMapping}
+            showAllErrors={showAllErrors} />
           <h2 className="flush-top short-bottom">
             Container
           </h2>
@@ -392,12 +358,16 @@ class NewCreateServiceModalForm extends Component {
   }
 
   getSectionContent(data, errorMap) {
-    const errorsAlertComponent = this.getErrorsAlertComponent();
+    const {showAllErrors} = this.props;
+    const errors = this.getErrors();
 
     if (this.state.isPod) {
       return [
         <TabView id="networking" key="multinetworking">
-          {errorsAlertComponent}
+          <ErrorsAlert
+            errors={errors}
+            pathMapping={ServiceErrorPathMapping}
+            showAllErrors={showAllErrors} />
           <MultiContainerNetworkingFormSection
             data={data}
             errors={errorMap}
@@ -405,7 +375,10 @@ class NewCreateServiceModalForm extends Component {
             onAddItem={this.handleAddItem} />
         </TabView>,
         <TabView id="volumes" key="multivolumes">
-          {errorsAlertComponent}
+          <ErrorsAlert
+            errors={errors}
+            pathMapping={ServiceErrorPathMapping}
+            showAllErrors={showAllErrors} />
           <MultiContainerVolumesFormSection
             data={data}
             errors={errorMap}
@@ -414,7 +387,10 @@ class NewCreateServiceModalForm extends Component {
             onAddItem={this.handleAddItem} />
         </TabView>,
         <TabView id="healthChecks" key="multihealthChecks">
-          {errorsAlertComponent}
+          <ErrorsAlert
+            errors={errors}
+            pathMapping={ServiceErrorPathMapping}
+            showAllErrors={showAllErrors} />
           <MultiContainerHealthChecksFormSection
             data={data}
             errors={errorMap}
@@ -423,7 +399,10 @@ class NewCreateServiceModalForm extends Component {
             onAddItem={this.handleAddItem} />
         </TabView>,
         <TabView id="environment" key="multienvironment">
-          {errorsAlertComponent}
+          <ErrorsAlert
+            errors={errors}
+            pathMapping={ServiceErrorPathMapping}
+            showAllErrors={showAllErrors} />
           <EnvironmentFormSection
             mountType="CreateService:MultiContainerEnvironmentFormSection"
             data={data}
@@ -436,7 +415,10 @@ class NewCreateServiceModalForm extends Component {
 
     return [
       <TabView id="networking" key="networking">
-        {errorsAlertComponent}
+        <ErrorsAlert
+          errors={errors}
+          pathMapping={ServiceErrorPathMapping}
+          showAllErrors={showAllErrors} />
         <NetworkingFormSection
           data={data}
           errors={errorMap}
@@ -444,7 +426,10 @@ class NewCreateServiceModalForm extends Component {
           onAddItem={this.handleAddItem} />
       </TabView>,
       <TabView id="volumes" key="volumes">
-        {errorsAlertComponent}
+        <ErrorsAlert
+          errors={errors}
+          pathMapping={ServiceErrorPathMapping}
+          showAllErrors={showAllErrors} />
         <VolumesFormSection
           data={data}
           errors={errorMap}
@@ -452,7 +437,10 @@ class NewCreateServiceModalForm extends Component {
           onAddItem={this.handleAddItem} />
       </TabView>,
       <TabView id="healthChecks" key="healthChecks">
-        {errorsAlertComponent}
+        <ErrorsAlert
+          errors={errors}
+          pathMapping={ServiceErrorPathMapping}
+          showAllErrors={showAllErrors} />
         <HealthChecksFormSection
           data={data}
           errors={errorMap}
@@ -460,7 +448,10 @@ class NewCreateServiceModalForm extends Component {
           onAddItem={this.handleAddItem} />
       </TabView>,
       <TabView id="environment" key="environment">
-        {errorsAlertComponent}
+        <ErrorsAlert
+          errors={errors}
+          pathMapping={ServiceErrorPathMapping}
+          showAllErrors={showAllErrors} />
         <EnvironmentFormSection
           mountType="CreateService:EnvironmentFormSection"
           data={data}
@@ -500,7 +491,15 @@ class NewCreateServiceModalForm extends Component {
 
   render() {
     const {appConfig, batch} = this.state;
-    const {activeTab, handleTabChange, isJSONModeActive, isEdit, onConvertToPod, service} = this.props;
+    const {
+      activeTab,
+      handleTabChange,
+      isEdit,
+      isJSONModeActive,
+      onConvertToPod,
+      service,
+      showAllErrors
+    } = this.props;
     const data = batch.reduce(this.props.inputConfigReducers, {});
     const unmutedErrors = this.getUnmutedErrors();
     const errors = this.getErrors();
@@ -514,7 +513,6 @@ class NewCreateServiceModalForm extends Component {
     });
 
     const errorMap = DataValidatorUtil.errorArrayToMap(unmutedErrors);
-    const errorsAlertComponent = this.getErrorsAlertComponent();
     const serviceLabel = pluralize('Service', findNestedPropertyInObject(
       appConfig,
       'containers.length'
@@ -545,7 +543,10 @@ class NewCreateServiceModalForm extends Component {
                   </TabButtonList>
                   <TabViewList>
                     <TabView id="services">
-                      {errorsAlertComponent}
+                      <ErrorsAlert
+                        errors={errors}
+                        pathMapping={ServiceErrorPathMapping}
+                        showAllErrors={showAllErrors} />
                       <GeneralServiceFormSection
                         errors={errorMap}
                         data={data}

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -314,7 +314,7 @@ class NewCreateServiceModalForm extends Component {
           <ErrorsAlert
             errors={this.getErrors()}
             pathMapping={ServiceErrorPathMapping}
-            showAllErrors={showAllErrors} />
+            hideTopLevelErrors={!showAllErrors} />
           <h2 className="flush-top short-bottom">
             Container
           </h2>
@@ -367,7 +367,7 @@ class NewCreateServiceModalForm extends Component {
           <ErrorsAlert
             errors={errors}
             pathMapping={ServiceErrorPathMapping}
-            showAllErrors={showAllErrors} />
+            hideTopLevelErrors={!showAllErrors} />
           <MultiContainerNetworkingFormSection
             data={data}
             errors={errorMap}
@@ -378,7 +378,7 @@ class NewCreateServiceModalForm extends Component {
           <ErrorsAlert
             errors={errors}
             pathMapping={ServiceErrorPathMapping}
-            showAllErrors={showAllErrors} />
+            hideTopLevelErrors={!showAllErrors} />
           <MultiContainerVolumesFormSection
             data={data}
             errors={errorMap}
@@ -390,7 +390,7 @@ class NewCreateServiceModalForm extends Component {
           <ErrorsAlert
             errors={errors}
             pathMapping={ServiceErrorPathMapping}
-            showAllErrors={showAllErrors} />
+            hideTopLevelErrors={!showAllErrors} />
           <MultiContainerHealthChecksFormSection
             data={data}
             errors={errorMap}
@@ -402,7 +402,7 @@ class NewCreateServiceModalForm extends Component {
           <ErrorsAlert
             errors={errors}
             pathMapping={ServiceErrorPathMapping}
-            showAllErrors={showAllErrors} />
+            hideTopLevelErrors={!showAllErrors} />
           <EnvironmentFormSection
             mountType="CreateService:MultiContainerEnvironmentFormSection"
             data={data}
@@ -418,7 +418,7 @@ class NewCreateServiceModalForm extends Component {
         <ErrorsAlert
           errors={errors}
           pathMapping={ServiceErrorPathMapping}
-          showAllErrors={showAllErrors} />
+          hideTopLevelErrors={!showAllErrors} />
         <NetworkingFormSection
           data={data}
           errors={errorMap}
@@ -429,7 +429,7 @@ class NewCreateServiceModalForm extends Component {
         <ErrorsAlert
           errors={errors}
           pathMapping={ServiceErrorPathMapping}
-          showAllErrors={showAllErrors} />
+          hideTopLevelErrors={!showAllErrors} />
         <VolumesFormSection
           data={data}
           errors={errorMap}
@@ -440,7 +440,7 @@ class NewCreateServiceModalForm extends Component {
         <ErrorsAlert
           errors={errors}
           pathMapping={ServiceErrorPathMapping}
-          showAllErrors={showAllErrors} />
+          hideTopLevelErrors={!showAllErrors} />
         <HealthChecksFormSection
           data={data}
           errors={errorMap}
@@ -451,7 +451,7 @@ class NewCreateServiceModalForm extends Component {
         <ErrorsAlert
           errors={errors}
           pathMapping={ServiceErrorPathMapping}
-          showAllErrors={showAllErrors} />
+          hideTopLevelErrors={!showAllErrors} />
         <EnvironmentFormSection
           mountType="CreateService:EnvironmentFormSection"
           data={data}
@@ -546,7 +546,7 @@ class NewCreateServiceModalForm extends Component {
                       <ErrorsAlert
                         errors={errors}
                         pathMapping={ServiceErrorPathMapping}
-                        showAllErrors={showAllErrors} />
+                        hideTopLevelErrors={!showAllErrors} />
                       <GeneralServiceFormSection
                         errors={errorMap}
                         data={data}

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -11,7 +11,10 @@ import Icon from '../../../../../../src/js/components/Icon';
 import Loader from '../../../../../../src/js/components/Loader';
 import ServiceConfigDisplay from '../../service-configuration/ServiceConfigDisplay';
 import Service from '../../structs/Service';
-import ServiceUtil from '../../utils/ServiceUtil';
+import {
+  getDefinitionFromSpec,
+  getErrorsMap
+} from '../../utils/ServiceUtil';
 
 const METHODS_TO_BIND = [
   'handleApplyButtonClick',
@@ -64,11 +67,9 @@ class ServiceConfiguration extends mixin(StoreMixin) {
 
     const serviceConfiguration = service.getVersions().get(selectedVersionID);
 
-    onEditClick(service,
-      ServiceUtil.getDefinitionFromSpec(
-          new ApplicationSpec(serviceConfiguration)
-      )
-    );
+    onEditClick(service, getDefinitionFromSpec(
+      new ApplicationSpec(serviceConfiguration)
+    ));
   }
 
   handleEditButtonClick() {
@@ -187,7 +188,7 @@ class ServiceConfiguration extends mixin(StoreMixin) {
   }
 
   render() {
-    const {service} = this.props;
+    const {errors, onClearError, service} = this.props;
     const {selectedVersionID} = this.state;
     const config = service.getVersions().get(selectedVersionID);
     let content = null;
@@ -196,7 +197,10 @@ class ServiceConfiguration extends mixin(StoreMixin) {
       content = <Loader />;
     } else {
       content = (
-        <ServiceConfigDisplay appConfig={config} />
+        <ServiceConfigDisplay
+          appConfig={config}
+          clearError={onClearError}
+          errors={getErrorsMap(errors)} />
       );
     }
 
@@ -215,7 +219,9 @@ ServiceConfiguration.contextTypes = {
 };
 
 ServiceConfiguration.propTypes = {
+  onClearError: React.PropTypes.func,
   onEditClick: React.PropTypes.func.isRequired,
+  errors: React.PropTypes.object,
   service: React.PropTypes.instanceOf(Service).isRequired
 };
 

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -185,7 +185,7 @@ class ServiceConfiguration extends mixin(StoreMixin) {
   }
 
   render() {
-    const {errors, onClearError, service} = this.props;
+    const {errors, service} = this.props;
     const {selectedVersionID} = this.state;
     const config = service.getVersions().get(selectedVersionID);
     let content = null;
@@ -193,12 +193,7 @@ class ServiceConfiguration extends mixin(StoreMixin) {
     if (config == null) {
       content = <Loader />;
     } else {
-      content = (
-        <ServiceConfigDisplay
-          appConfig={config}
-          clearError={onClearError}
-          errors={errors} />
-      );
+      content = <ServiceConfigDisplay appConfig={config} errors={errors} />;
     }
 
     return (
@@ -215,8 +210,11 @@ ServiceConfiguration.contextTypes = {
   router: routerShape
 };
 
+ServiceConfiguration.defaultProps = {
+  errors: []
+};
+
 ServiceConfiguration.propTypes = {
-  onClearError: React.PropTypes.func,
   onEditClick: React.PropTypes.func.isRequired,
   errors: React.PropTypes.array,
   service: React.PropTypes.instanceOf(Service).isRequired

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -11,10 +11,7 @@ import Icon from '../../../../../../src/js/components/Icon';
 import Loader from '../../../../../../src/js/components/Loader';
 import ServiceConfigDisplay from '../../service-configuration/ServiceConfigDisplay';
 import Service from '../../structs/Service';
-import {
-  getDefinitionFromSpec,
-  getErrorsMap
-} from '../../utils/ServiceUtil';
+import {getDefinitionFromSpec} from '../../utils/ServiceUtil';
 
 const METHODS_TO_BIND = [
   'handleApplyButtonClick',
@@ -200,7 +197,7 @@ class ServiceConfiguration extends mixin(StoreMixin) {
         <ServiceConfigDisplay
           appConfig={config}
           clearError={onClearError}
-          errors={getErrorsMap(errors)} />
+          errors={errors} />
       );
     }
 
@@ -221,7 +218,7 @@ ServiceConfiguration.contextTypes = {
 ServiceConfiguration.propTypes = {
   onClearError: React.PropTypes.func,
   onEditClick: React.PropTypes.func.isRequired,
-  errors: React.PropTypes.object,
+  errors: React.PropTypes.array,
   service: React.PropTypes.instanceOf(Service).isRequired
 };
 

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
@@ -23,7 +23,7 @@ class ServiceConfigurationContainer extends React.Component {
   }
 
   render() {
-    const {onEditClick, service} = this.props;
+    const {onClearError, errors, onEditClick, service} = this.props;
 
     // Wait till we've loaded the versions
     if (!service.getVersions().size) {
@@ -32,6 +32,8 @@ class ServiceConfigurationContainer extends React.Component {
 
     return (
       <ServiceConfiguration
+        onClearError={onClearError}
+        errors={errors}
         onEditClick={onEditClick}
         service={service} />
     );
@@ -39,7 +41,9 @@ class ServiceConfigurationContainer extends React.Component {
 }
 
 ServiceConfigurationContainer.propTypes = {
+  onClearError: React.PropTypes.func,
   onEditClick: React.PropTypes.func.isRequired,
+  errors: React.PropTypes.object,
   service: React.PropTypes.instanceOf(Service).isRequired
 };
 

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
@@ -43,7 +43,7 @@ class ServiceConfigurationContainer extends React.Component {
 ServiceConfigurationContainer.propTypes = {
   onClearError: React.PropTypes.func,
   onEditClick: React.PropTypes.func.isRequired,
-  errors: React.PropTypes.object,
+  errors: React.PropTypes.array,
   service: React.PropTypes.instanceOf(Service).isRequired
 };
 

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
@@ -23,7 +23,7 @@ class ServiceConfigurationContainer extends React.Component {
   }
 
   render() {
-    const {onClearError, errors, onEditClick, service} = this.props;
+    const {errors, onEditClick, service} = this.props;
 
     // Wait till we've loaded the versions
     if (!service.getVersions().size) {
@@ -32,7 +32,6 @@ class ServiceConfigurationContainer extends React.Component {
 
     return (
       <ServiceConfiguration
-        onClearError={onClearError}
         errors={errors}
         onEditClick={onEditClick}
         service={service} />
@@ -40,8 +39,11 @@ class ServiceConfigurationContainer extends React.Component {
   }
 }
 
+ServiceConfigurationContainer.defaultProps = {
+  errors: []
+};
+
 ServiceConfigurationContainer.propTypes = {
-  onClearError: React.PropTypes.func,
   onEditClick: React.PropTypes.func.isRequired,
   errors: React.PropTypes.array,
   service: React.PropTypes.instanceOf(Service).isRequired

--- a/plugins/services/src/js/containers/service-configuration/__tests__/ServiceConfigurationContainer-test.js
+++ b/plugins/services/src/js/containers/service-configuration/__tests__/ServiceConfigurationContainer-test.js
@@ -1,5 +1,6 @@
 jest.dontMock('../ServiceConfigurationContainer');
 jest.dontMock('../../../service-configuration/ServiceConfigDisplay');
+jest.dontMock('../../../../../../../src/js/components/ErrorsAlert');
 jest.dontMock('../../../../../../../src/js/components/ConfigurationMap');
 
 /* eslint-disable no-unused-vars */

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -4,6 +4,7 @@ import {routerShape} from 'react-router';
 
 import ActionKeys from '../../constants/ActionKeys';
 import Page from '../../../../../../src/js/components/Page';
+import MarathonErrorUtil from '../../utils/MarathonErrorUtil';
 import ServiceBreadcrumbs from '../../components/ServiceBreadcrumbs';
 import Service from '../../structs/Service';
 import ServiceActionItem from '../../constants/ServiceActionItem';
@@ -95,7 +96,7 @@ class ServiceDetail extends mixin(TabsMixin) {
 
     return (
       <ServiceConfigurationContainer
-        errors={errors[ActionKeys.SERVICE_EDIT]}
+        errors={MarathonErrorUtil.parseErrors(errors[ActionKeys.SERVICE_EDIT])}
         onClearError={this.handleEditClearError}
         onEditClick={actions.editService}
         service={service} />

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -234,6 +234,7 @@ class ServiceDetail extends mixin(TabsMixin) {
 }
 
 ServiceDetail.contextTypes = {
+  clearError() {},
   modalHandlers: PropTypes.shape({
     scaleService: PropTypes.func,
     restartService: PropTypes.func,

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -2,6 +2,7 @@ import mixin from 'reactjs-mixin';
 import React, {PropTypes} from 'react';
 import {routerShape} from 'react-router';
 
+import ActionKeys from '../../constants/ActionKeys';
 import Page from '../../../../../../src/js/components/Page';
 import ServiceBreadcrumbs from '../../components/ServiceBreadcrumbs';
 import Service from '../../structs/Service';
@@ -13,6 +14,7 @@ import TabsMixin from '../../../../../../src/js/mixins/TabsMixin';
 import VolumeTable from '../../components/VolumeTable';
 
 const METHODS_TO_BIND = [
+  'handleEditClearError',
   'onActionsItemSelection'
 ];
 
@@ -43,6 +45,10 @@ class ServiceDetail extends mixin(TabsMixin) {
   componentWillUpdate() {
     super.componentWillUpdate(...arguments);
     this.checkForVolumes();
+  }
+
+  handleEditClearError() {
+    this.props.clearError(ActionKeys.SERVICE_EDIT);
   }
 
   onActionsItemSelection(actionItem) {
@@ -85,10 +91,12 @@ class ServiceDetail extends mixin(TabsMixin) {
   }
 
   renderConfigurationTabView() {
-    const {actions, service} = this.props;
+    const {actions, errors, service} = this.props;
 
     return (
       <ServiceConfigurationContainer
+        errors={errors[ActionKeys.SERVICE_EDIT]}
+        onClearError={this.handleEditClearError}
         onEditClick={actions.editService}
         service={service} />
     );
@@ -236,6 +244,8 @@ ServiceDetail.contextTypes = {
 
 ServiceDetail.propTypes = {
   actions: PropTypes.object.isRequired,
+  clearError: PropTypes.func,
+  errors: PropTypes.object.isRequired,
   params: PropTypes.object.isRequired,
   service: PropTypes.instanceOf(Service),
   children: PropTypes.node

--- a/plugins/services/src/js/containers/service-detail/__tests__/ServiceDetail-test.js
+++ b/plugins/services/src/js/containers/service-detail/__tests__/ServiceDetail-test.js
@@ -73,6 +73,7 @@ describe('ServiceDetail', function () {
         ServiceDetail,
         {
           actions: {editService() {}},
+          errors: {},
           params: {},
           service
         },

--- a/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
+++ b/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import {MountService} from 'foundation-ui';
 
-import Alert from '../../../../../src/js/components/Alert';
+import ErrorsAlert from '../../../../../src/js/components/ErrorsAlert';
 import ConfigurationMap from '../../../../../src/js/components/ConfigurationMap';
-import ErrorMessageUtil from '../../../../../src/js/utils/ErrorMessageUtil';
+import {translateErrorMessages} from '../../../../../src/js/utils/ErrorMessageUtil';
 import PodContainersConfigSection from './PodContainersConfigSection';
 import PodEnvironmentVariablesConfigSection from './PodEnvironmentVariablesConfigSection';
 import PodGeneralConfigSection from './PodGeneralConfigSection';
@@ -15,6 +15,7 @@ import PodSpec from '../structs/PodSpec';
 import PodStorageConfigSection from './PodStorageConfigSection';
 import ServiceEnvironmentVariablesConfigSection from './ServiceEnvironmentVariablesConfigSection';
 import ServiceErrorMessages from '../constants/ServiceErrorMessages';
+import ServiceErrorPathMapping from '../constants/ServiceErrorPathMapping';
 import ServiceGeneralConfigSection from './ServiceGeneralConfigSection';
 import ServiceHealthChecksConfigSection from './ServiceHealthChecksConfigSection';
 import ServiceLabelsConfigSection from './ServiceLabelsConfigSection';
@@ -75,49 +76,23 @@ class ServiceConfigDisplay extends React.Component {
   }
 
   getErrors() {
-    return ErrorMessageUtil.translateErrorMessages(
-      this.props.errors, ServiceErrorMessages
-    );
-  }
-
-  getRootErrors() {
-    const errors = this.getErrors();
-
-    if (errors.length === 0) {
-      return null;
-    }
-
-    const errorItems = errors.map((error, index) => {
-      const prefix = error.path.length ? `${error.path.join('.')}:` : '';
-
-      return (
-        <li key={index} className="short">
-          {`${prefix} ${error.message}`}
-        </li>
-      );
-    });
-
-    return (
-      <Alert>
-        <strong>There is an error with your configuration</strong>
-        <div className="pod pod-narrower-left pod-shorter-top flush-bottom">
-          <ul className="short flush-bottom">
-            {errorItems}
-          </ul>
-        </div>
-      </Alert>
-    );
+    return translateErrorMessages(this.props.errors, ServiceErrorMessages);
   }
 
   render() {
     const {appConfig, onEditClick} = this.props;
+    const errorsAlert = (
+      <ErrorsAlert
+        errors={this.getErrors()}
+        pathMapping={ServiceErrorPathMapping} />
+    );
 
     return (
       <ConfigurationMap>
-        {this.getRootErrors()}
+        {errorsAlert}
         <MountService.Mount
           appConfig={appConfig}
-          errors={this.getRootErrors()}
+          errors={errorsAlert}
           onEditClick={onEditClick}
           type={this.getMountType()} />
       </ConfigurationMap>

--- a/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
+++ b/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
@@ -107,7 +107,7 @@ ServiceConfigDisplay.defaultProps = {
 ServiceConfigDisplay.propTypes = {
   appConfig: React.PropTypes.object.isRequired,
   errors: React.PropTypes.array,
-  onEditClick: React.PropTypes.func
+  onEditClick: React.PropTypes.func.isRequired
 };
 
 module.exports = ServiceConfigDisplay;

--- a/plugins/services/src/js/utils/MarathonErrorUtil.js
+++ b/plugins/services/src/js/utils/MarathonErrorUtil.js
@@ -50,12 +50,14 @@ const MarathonErrorUtil = {
     }
 
     // Both `details` and `errors` can be missing
-    if (!error.details && !error.message) {
+    if (ValidatorUtil.isEmpty(error.details) &&
+      ValidatorUtil.isEmpty(error.message)) {
       return [];
     }
 
     // Only `details` can be missing
-    if (!error.details && error.message) {
+    if (ValidatorUtil.isEmpty(error.details) &&
+      !ValidatorUtil.isEmpty(error.message)) {
       return [
         {
           path: [],
@@ -76,7 +78,10 @@ const MarathonErrorUtil = {
           variables: {}
         }
       ];
+    }
 
+    if (!Array.isArray(error.details)) {
+      return [];
     }
 
     // `details` can be an array of errors

--- a/plugins/services/src/js/utils/ServiceUtil.js
+++ b/plugins/services/src/js/utils/ServiceUtil.js
@@ -469,9 +469,9 @@ const ServiceUtil = {
 
     // Only compare the service specs as everything else is status data
     return deepEqual(
-        serviceA.getSpec(),
-        serviceB.getSpec()
-      );
+      serviceA.getSpec(),
+      serviceB.getSpec()
+    );
   },
 
   getBaseID(serviceID) {
@@ -484,6 +484,30 @@ const ServiceUtil = {
     // return value of `getId` would be `/` so in most cases we want to append a
     // `/` so that the user can begin typing the `id` of their application.
     return serviceID.replace(/^(\/.+)$/, '$1/');
+  },
+
+  getErrorsMap(errors) {
+    const errorsMap = new Map();
+    if (errors) {
+      const {message} = errors;
+      errorsMap.set('/', [message]);
+
+      if (errors.details) {
+        errors.details.forEach(function (item) {
+          const existingMessages = errorsMap.get(item.path);
+
+          let messages = item.errors;
+
+          if (existingMessages) {
+            messages = messages.concat(existingMessages);
+          }
+
+          errorsMap.set(item.path, messages);
+        });
+      }
+    }
+
+    return errorsMap;
   },
 
   getDefinitionFromSpec(spec) {

--- a/plugins/services/src/js/utils/ServiceUtil.js
+++ b/plugins/services/src/js/utils/ServiceUtil.js
@@ -486,30 +486,6 @@ const ServiceUtil = {
     return serviceID.replace(/^(\/.+)$/, '$1/');
   },
 
-  getErrorsMap(errors) {
-    const errorsMap = new Map();
-    if (errors) {
-      const {message} = errors;
-      errorsMap.set('/', [message]);
-
-      if (errors.details) {
-        errors.details.forEach(function (item) {
-          const existingMessages = errorsMap.get(item.path);
-
-          let messages = item.errors;
-
-          if (existingMessages) {
-            messages = messages.concat(existingMessages);
-          }
-
-          errorsMap.set(item.path, messages);
-        });
-      }
-    }
-
-    return errorsMap;
-  },
-
   getDefinitionFromSpec(spec) {
     const definition = spec.toJSON();
 

--- a/plugins/services/src/js/utils/__tests__/MarathonErrorUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/MarathonErrorUtil-test.js
@@ -119,6 +119,89 @@ describe('MarathonErrorUtil', function () {
         }
       ]);
     });
+
+    it('should be able to translate messages with no details', function () {
+      const marathonError = {message: 'Some error'};
+
+      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([
+        {
+          path: [],
+          message: 'Some error',
+          type: ServiceErrorTypes.GENERIC,
+          variables: {}
+        }
+      ]);
+    });
+
+    it('should handle a message value of null as empty', function () {
+      // TODO (JIRA DCOS_OSS-653): We should include these with a generic error
+      const marathonError = {message: null};
+
+      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([]);
+    });
+
+    it('should handle a message value of empty object as empty', function () {
+      // TODO (JIRA DCOS_OSS-653): We should include these with a generic error
+      const marathonError = {message: {}};
+
+      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([]);
+    });
+
+    it('should handle a message value of empty array as empty', function () {
+      // TODO (JIRA DCOS_OSS-653): We should include these with a generic error
+      const marathonError = {message: []};
+
+      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([]);
+    });
+
+    it('should handle a details value of null as empty', function () {
+      // TODO (JIRA DCOS_OSS-653): We should include these with a generic error
+      const marathonError = {message: 'Some error', details: null};
+
+      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([
+        {
+          path: [],
+          message: 'Some error',
+          type: ServiceErrorTypes.GENERIC,
+          variables: {}
+        }
+      ]);
+    });
+
+    it('should handle a details value of empty object as empty', function () {
+      // TODO (JIRA DCOS_OSS-653): We should include these with a generic error
+      const marathonError = {message: 'Some error', details: {}};
+
+      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([
+        {
+          path: [],
+          message: 'Some error',
+          type: ServiceErrorTypes.GENERIC,
+          variables: {}
+        }
+      ]);
+    });
+
+    it('should handle a details value of empty array as empty', function () {
+      // TODO (JIRA DCOS_OSS-653): We should include these with a generic error
+      const marathonError = {message: 'Some error', details: []};
+
+      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([
+        {
+          path: [],
+          message: 'Some error',
+          type: ServiceErrorTypes.GENERIC,
+          variables: {}
+        }
+      ]);
+    });
+
+    it('should discard details value of object', function () {
+      // TODO (JIRA DCOS_OSS-653): We should include these with a generic error
+      const marathonError = {message: 'Some error', details: {foo: 'bar'}};
+
+      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([]);
+    });
   });
 
 });

--- a/src/js/components/ErrorsAlert.js
+++ b/src/js/components/ErrorsAlert.js
@@ -4,10 +4,10 @@ import Alert from './Alert';
 import {getUnanchoredErrorMessage} from '../utils/ErrorMessageUtil';
 
 const ErrorsAlert = function (props) {
-  const {errors, showAllErrors, pathMapping} = props;
+  const {errors, hideTopLevelErrors, pathMapping} = props;
   let showErrors = errors;
 
-  if (!showAllErrors) {
+  if (hideTopLevelErrors) {
     showErrors = showErrors.filter(function (error) {
       return error.path.length === 0;
     });
@@ -41,13 +41,13 @@ const ErrorsAlert = function (props) {
 
 ErrorsAlert.defaultProps = {
   errors: [],
-  showAllErrors: true,
+  hideTopLevelErrors: false,
   pathMapping: []
 };
 
 ErrorsAlert.propTypes = {
   errors: React.PropTypes.array,
-  showAllErrors: React.PropTypes.bool,
+  hideTopLevelErrors: React.PropTypes.bool,
   pathMapping: React.PropTypes.array
 };
 

--- a/src/js/components/ErrorsAlert.js
+++ b/src/js/components/ErrorsAlert.js
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import Alert from './Alert';
+import {getUnanchoredErrorMessage} from '../utils/ErrorMessageUtil';
+
+const ErrorsAlert = function (props) {
+  const {errors, showAllErrors, pathMapping} = props;
+  let showErrors = errors;
+
+  if (!showAllErrors) {
+    showErrors = showErrors.filter(function (error) {
+      return error.path.length === 0;
+    });
+  }
+
+  if (showErrors.length === 0) {
+    return <noscript />;
+  }
+
+  const errorItems = showErrors.map((error, index) => {
+    const message = getUnanchoredErrorMessage(error, pathMapping);
+
+    return (
+      <li key={index} className="short">
+        {message}
+      </li>
+    );
+  });
+
+  return (
+    <Alert>
+      <strong>There is an error with your configuration</strong>
+      <div className="pod pod-narrower-left pod-shorter-top flush-bottom">
+        <ul className="short flush-bottom">
+          {errorItems}
+        </ul>
+      </div>
+    </Alert>
+  );
+};
+
+ErrorsAlert.defaultProps = {
+  errors: [],
+  showAllErrors: true,
+  pathMapping: []
+};
+
+ErrorsAlert.propTypes = {
+  errors: React.PropTypes.array,
+  showAllErrors: React.PropTypes.bool,
+  pathMapping: React.PropTypes.array
+};
+
+module.exports = ErrorsAlert;

--- a/src/js/utils/ErrorMessageUtil.js
+++ b/src/js/utils/ErrorMessageUtil.js
@@ -12,22 +12,22 @@ const ErrorMessageUtil = {
    * @returns {String} Returns the composed error string
    */
   getUnanchoredErrorMessage(error, pathTranslationRules) {
-    const pathString = error.path.join('.');
+    const {message, path = []} = error;
+    const pathString = path.join('.');
     const rule = pathTranslationRules.find(function (rule) {
       return rule.match.exec(pathString);
     });
 
     if (!rule && !pathString) {
-      return error.message;
+      return message;
     }
     if (!rule) {
-      return `${pathString}: ${error.message}`;
+      return `${pathString}: ${message}`;
     }
 
     // We need to make the first letter of the error message lowercase
     // in order to compose a proper sentence with the resolved path name.
-    const errorMessage = error.message[0].toLowerCase() +
-      error.message.substr(1);
+    const errorMessage = message[0].toLowerCase() + message.substr(1);
 
     return `${rule.name} ${errorMessage}`;
   },
@@ -42,7 +42,7 @@ const ErrorMessageUtil = {
    */
   translateErrorMessages(errors, translationRules) {
     return errors.map(function (error) {
-      const {path, type, variables} = error;
+      const {path = [], type, variables} = error;
       const pathString = path.join('.');
 
       const rule = translationRules.find(function (rule) {
@@ -67,7 +67,6 @@ const ErrorMessageUtil = {
       };
     });
   }
-
 };
 
 module.exports = ErrorMessageUtil;

--- a/src/js/utils/__tests__/ErrorMessageUtil-test.js
+++ b/src/js/utils/__tests__/ErrorMessageUtil-test.js
@@ -176,7 +176,6 @@ describe('ErrorMessageUtil', function () {
             variables: {}
           }
         ]);
-
     });
 
     it('should correctly replace variables', function () {
@@ -209,6 +208,28 @@ describe('ErrorMessageUtil', function () {
             }
           }
         ]);
+    });
+
+    it('should be able to handle errors with no path', function () {
+      const errorInput = [{message: 'message'}];
+      const translationRules = [];
+
+      const translatedErrors = ErrorMessageUtil.translateErrorMessages(
+        errorInput,
+        translationRules
+      );
+      expect(translatedErrors).toEqual([{message: 'message'}]);
+    });
+
+    it('should be able to handle errors with null messages', function () {
+      const errorInput = [{message: null}];
+      const translationRules = [];
+
+      const translatedErrors = ErrorMessageUtil.translateErrorMessages(
+        errorInput,
+        translationRules
+      );
+      expect(translatedErrors).toEqual([{message: null}]);
     });
   });
 });


### PR DESCRIPTION
~~Service Modal Routes 1 of 3: https://github.com/dcos/dcos-ui/pull/1828~~ Merged!
Service Modal Routes 2a of 3: https://github.com/dcos/dcos-ui/pull/1853
Service Modal Routes 2b of 3: https://github.com/dcos/dcos-ui/pull/1871

This PR ensures that we do display marathon errors on the service configuration page, when they emerge.

![](https://cl.ly/2m0O3Q0S052y/Image%202017-02-21%20at%2015.23.41.png)
![](https://cl.ly/0y042H0Q0C0c/Image%202017-02-21%20at%2015.49.21.png)
![](https://cl.ly/3Z0t0i1n3x0m/Image%202017-02-21%20at%2015.50.37.png)

~~Diff for review can be found here: https://github.com/dcos/dcos-ui/compare/mlunoe/feature/DCOS-12423-add-routes-for-the-new-create-service-modal...mlunoe/feature/DCOS-12423-add-routes-for-the-new-create-service-modal-2?expand=1~~ Merged!