### PR TITLE
DCOS-13017: Prevent labels in forms from wrapping to multiple lines

### DIFF
--- a/src/js/components/form/FieldLabel.js
+++ b/src/js/components/form/FieldLabel.js
@@ -13,6 +13,7 @@ const FieldLabel = (props) => {
     }
   });
   const classes = classNames(
+    'form-control-label',
     {'form-control-toggle form-control-toggle-custom': isToggle},
     className
   );

--- a/src/styles/components/form-elements/styles.less
+++ b/src/styles/components/form-elements/styles.less
@@ -38,6 +38,12 @@
     }
   }
 
+  .form-control-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   // TODO: Remove this when the full screen Create Service is implemented.
   .form-control-force-narrow {
 


### PR DESCRIPTION
This PR adds a class to prevent text in labels from overflowing.

I decided not to do this globally for all `labels` because it might not always be desirable (e.g. in the `ToggleButton`, the `overflow: hidden` property clips the toggle indicator). So this is implemented only on elements that make use of `FieldLabel`, which ideally will be all form fields in the future.

Before (look at `Grace Period (s)`):
![](https://cl.ly/193V1f0E2V1h/Screen%20Shot%202017-01-24%20at%202.40.55%20PM.png)

After (look at `Grace Period (s)`):
![](https://cl.ly/0Y2q2m3P2s0o/Screen%20Shot%202017-01-24%20at%202.37.15%20PM.png)