### PR TITLE
DCOS-11559: Keep host ports when switching a container network to HOST

### DIFF
--- a/src/js/components/ServiceForm.js
+++ b/src/js/components/ServiceForm.js
@@ -373,6 +373,19 @@ class ServiceForm extends SchemaForm {
           return port;
         });
       }
+
+      let previousNetworkType = this.props.model.networking.networkType;
+      // When switching a container network from anything to HOST
+      // we want to keep portDefinitions[*].port which is equal to servicePort
+      if (model.networking.networkType === 'host'
+        && previousNetworkType !== 'host') {
+        model.networking.ports.map(function (port) {
+          port.lbPort = port.servicePort;
+
+          return port;
+        });
+      }
+
       let {dockerVolumesDefinition = null} = this.internalStorage_get();
       this.internalStorage_set({model, dockerVolumesDefinition});
 

--- a/src/js/components/ServiceForm.js
+++ b/src/js/components/ServiceForm.js
@@ -40,6 +40,8 @@ const FIELDS_TO_WATCH = {
   }
 };
 
+let networkTypeChanged = false;
+
 class ServiceForm extends SchemaForm {
   constructor() {
     super(...arguments);
@@ -97,6 +99,8 @@ class ServiceForm extends SchemaForm {
     let shouldUpdateDefinition = this.shouldUpdateDefinition(
       changes, eventType, fieldName
     );
+
+    networkTypeChanged = eventType === 'change' && fieldName === 'networkType';
 
     if (eventType === 'change' || shouldUpdateDefinition) {
       this.recalculateFormModelAndRender(shouldUpdateDefinition);
@@ -374,17 +378,16 @@ class ServiceForm extends SchemaForm {
         });
       }
 
-      let previousNetworkType = this.props.model.networking.networkType;
       // When switching a container network from anything to HOST
       // we want to keep portDefinitions[*].port which is equal to servicePort
-      if (model.networking.networkType === 'host'
-        && previousNetworkType !== 'host') {
+      if (model.networking.networkType === 'host' && networkTypeChanged) {
         model.networking.ports.map(function (port) {
-          port.lbPort = port.servicePort;
+          port.lbPort = port.servicePort || 0;
 
           return port;
         });
       }
+      networkTypeChanged = false;
 
       let {dockerVolumesDefinition = null} = this.internalStorage_get();
       this.internalStorage_set({model, dockerVolumesDefinition});

--- a/src/js/components/ServiceForm.js
+++ b/src/js/components/ServiceForm.js
@@ -40,8 +40,6 @@ const FIELDS_TO_WATCH = {
   }
 };
 
-let networkTypeChanged = false;
-
 class ServiceForm extends SchemaForm {
   constructor() {
     super(...arguments);
@@ -57,6 +55,8 @@ class ServiceForm extends SchemaForm {
         suppressUpdate: true
       }
     ]);
+
+    this.networkTypeChanged = false;
   }
 
   componentWillMount() {
@@ -100,7 +100,7 @@ class ServiceForm extends SchemaForm {
       changes, eventType, fieldName
     );
 
-    networkTypeChanged = eventType === 'change' && fieldName === 'networkType';
+    this.networkTypeChanged = eventType === 'change' && fieldName === 'networkType';
 
     if (eventType === 'change' || shouldUpdateDefinition) {
       this.recalculateFormModelAndRender(shouldUpdateDefinition);
@@ -380,14 +380,14 @@ class ServiceForm extends SchemaForm {
 
       // When switching a container network from anything to HOST
       // we want to keep portDefinitions[*].port which is equal to servicePort
-      if (model.networking.networkType === 'host' && networkTypeChanged) {
+      if (model.networking.networkType === 'host' && this.networkTypeChanged) {
         model.networking.ports.map(function (port) {
           port.lbPort = port.servicePort || 0;
 
           return port;
         });
       }
-      networkTypeChanged = false;
+      this.networkTypeChanged = false;
 
       let {dockerVolumesDefinition = null} = this.internalStorage_get();
       this.internalStorage_set({model, dockerVolumesDefinition});


### PR DESCRIPTION
⚠️  Some 1.8 codebase here, PR targets 1.8

---

When we have a container app with a Bridge network and want to go to HOST network the UI would just discard ports from `portDefinitions` and put `containerPort` instead which can result in a conflict.

This PR ensures that the UI, as requested, keeps host ports and discards container ports instead.
Since we don't have access to the `portDefinitions` field in the `ServiceForm` I'm using `servicePort` which is always equal to a `portDefinitions[*].port`