### PR TITLE
DCOS-13456: Fix fluid gemini scrollbar stylesheet handling

### DIFF
--- a/src/js/components/FluidGeminiScrollbar.js
+++ b/src/js/components/FluidGeminiScrollbar.js
@@ -30,7 +30,7 @@ import Util from '../utils/Util';
  */
 
 let componentMountCount = 0;
-let stylesheetRef = null;
+let styleElement = null;
 
 class FluidGeminiScrollbar extends React.Component {
   constructor() {
@@ -56,16 +56,16 @@ class FluidGeminiScrollbar extends React.Component {
           }
         `;
 
-        stylesheetRef = global.document.createElement('style');
-        stylesheetRef.type = 'text/css';
+        styleElement = global.document.createElement('style');
+        styleElement.type = 'text/css';
 
-        if (stylesheetRef.styleSheet) {
-          stylesheetRef.styleSheet.cssText = cssString;
+        if (styleElement.styleSheet) {
+          styleElement.styleSheet.cssText = cssString;
         } else {
-          stylesheetRef.appendChild(global.document.createTextNode(cssString));
+          styleElement.appendChild(global.document.createTextNode(cssString));
         }
 
-        head.appendChild(stylesheetRef);
+        head.appendChild(styleElement);
       }
     }
 
@@ -77,8 +77,8 @@ class FluidGeminiScrollbar extends React.Component {
     componentMountCount--;
 
     // If this is the last mounted instance, remove the stylesheet.
-    if (componentMountCount === 0 && stylesheetRef != null) {
-      stylesheetRef.remove();
+    if (componentMountCount === 0 && styleElement != null) {
+      styleElement.remove();
     }
   }
 

--- a/src/js/components/FluidGeminiScrollbar.js
+++ b/src/js/components/FluidGeminiScrollbar.js
@@ -29,7 +29,7 @@ import Util from '../utils/Util';
  *
  */
 
-let fluidContainerCount = 0;
+let componentMountCount = 0;
 let stylesheetRef = null;
 
 class FluidGeminiScrollbar extends React.Component {
@@ -43,7 +43,7 @@ class FluidGeminiScrollbar extends React.Component {
     // If the browser's scrollbar width is larger than zero and this is the
     // first instance of the component, then add the stylesheet to the
     // document's head.
-    if (fluidContainerCount === 0) {
+    if (componentMountCount === 0) {
       const scrollbarWidth = ScrollbarUtil.getScrollbarWidth();
 
       if (scrollbarWidth > 0) {
@@ -70,14 +70,14 @@ class FluidGeminiScrollbar extends React.Component {
     }
 
     // Keep track of the number of mounted instances.
-    fluidContainerCount++;
+    componentMountCount++;
   }
 
   componentWillUnmount() {
-    fluidContainerCount--;
+    componentMountCount--;
 
     // If this is the last mounted instance, remove the stylesheet.
-    if (fluidContainerCount === 0 && stylesheetRef != null) {
+    if (componentMountCount === 0 && stylesheetRef != null) {
       stylesheetRef.remove();
     }
   }

--- a/src/js/components/FluidGeminiScrollbar.js
+++ b/src/js/components/FluidGeminiScrollbar.js
@@ -73,12 +73,19 @@ class FluidGeminiScrollbar extends React.Component {
     componentMountCount++;
   }
 
+  /**
+   * Handle component will unmount and remove the gemini style sheet if it's the
+   * last mounted {FluidGeminiScrollbar} instance.
+   */
   componentWillUnmount() {
-    componentMountCount--;
+    if (--componentMountCount === 0) {
+      return;
+    }
 
-    // If this is the last mounted instance, remove the stylesheet.
-    if (componentMountCount === 0 && styleElement != null) {
-      styleElement.remove();
+    if (styleElement instanceof Element &&
+        styleElement.parentNode instanceof Node) {
+
+      styleElement.parentNode.removeChild(styleElement);
     }
   }
 

--- a/src/js/components/FluidGeminiScrollbar.js
+++ b/src/js/components/FluidGeminiScrollbar.js
@@ -43,8 +43,11 @@ class FluidGeminiScrollbar extends React.Component {
     // If the browser's scrollbar width is larger than zero and this is the
     // first instance of the component, then add the stylesheet to the
     // document's head.
-    if (componentMountCount === 0) {
+    if (componentMountCount <= 0) {
       const scrollbarWidth = ScrollbarUtil.getScrollbarWidth();
+
+      // Reset component mount counter
+      componentMountCount = 0;
 
       if (scrollbarWidth > 0) {
         const head = global.document.head
@@ -78,7 +81,7 @@ class FluidGeminiScrollbar extends React.Component {
    * last mounted {FluidGeminiScrollbar} instance.
    */
   componentWillUnmount() {
-    if (--componentMountCount === 0) {
+    if (--componentMountCount > 0) {
       return;
     }
 


### PR DESCRIPTION
Change the `componentWillUnmount` method to use `Node.prototype.removeChild` as `ChildNode.prototype.remove` is still experimental and not supported by the Internet Explorer.

Closes DCOS-13456