### PR TITLE
DCOS-13017: Extend FieldLabel's wrapping logic

### DIFF
--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-import {Tooltip} from 'reactjs-components';
 
 import {FormReducer as ContainerReducer} from '../../reducers/serviceForm/Container';
 import {FormReducer as ContainersReducer} from '../../reducers/serviceForm/Containers';
@@ -48,16 +47,8 @@ class ContainerServiceFormSection extends Component {
     );
 
     return (
-      <FieldLabel>
-        {'Artifact URI '}
-        <Tooltip
-          content={tooltipContent}
-          interactive={true}
-          maxWidth={300}
-          scrollContainer=".gm-scroll-view"
-          wrapText={true}>
-          <Icon color="grey" id="circle-question" size="mini" />
-        </Tooltip>
+      <FieldLabel tooltipContent={tooltipContent}>
+        Artifact URI
       </FieldLabel>
     );
   }
@@ -116,16 +107,12 @@ class ContainerServiceFormSection extends Component {
 
     if (disabled) {
       return (
-        <FieldLabel className="text-no-transform">
-          {'GPUs '}
-          <Tooltip
-            content="Docker Engine does not support GPU resources, please select Universal Container Runtime if you want to use GPU resources."
-            interactive={true}
-            maxWidth={300}
-            scrollContainer=".gm-scroll-view"
-            wrapText={true}>
-            <Icon color="grey" id="lock" size="mini" />
-          </Tooltip>
+        <FieldLabel
+          className="text-no-transform"
+          key="gpus-input-tooltip"
+          tooltipContent="Docker Engine does not support GPU resources, please select Universal Container Runtime if you want to use GPU resources."
+          tooltipIconID="lock">
+          GPUs
         </FieldLabel>
       );
     }
@@ -134,23 +121,6 @@ class ContainerServiceFormSection extends Component {
       <FieldLabel className="text-no-transform">
         GPUs
       </FieldLabel>
-    );
-  }
-
-  getTooltipIfContent(content) {
-    if (!content) {
-      return null;
-    }
-
-    return (
-      <Tooltip
-        content={content}
-        interactive={true}
-        maxWidth={300}
-        scrollContainer=".gm-scroll-view"
-        wrapText={true}>
-        <Icon color="grey" id="lock" size="mini" />
-      </Tooltip>
     );
   }
 
@@ -169,23 +139,28 @@ class ContainerServiceFormSection extends Component {
       );
 
       if (containerType === DOCKER) {
-        dockerOnly = '';
-      } else {
-        label = label + ' ';
+        dockerOnly = null;
       }
 
       return (
-        <FieldLabel key={index}>
-          <FieldInput
-            checked={containerType === DOCKER && Boolean(checked)}
-            name={`${path}.docker.${settingName}`}
-            type="checkbox"
-            disabled={containerType !== DOCKER}
-            value={settingName} />
-          {label}
-          {this.getTooltipIfContent(dockerOnly)}
-          <FieldHelp>{helpText}</FieldHelp>
-        </FieldLabel>
+        <FormRow>
+          <FormGroup className="column-12">
+            <FieldLabel key={index} wordWrap>
+              <FieldInput
+                checked={containerType === DOCKER && Boolean(checked)}
+                name={`${path}.docker.${settingName}`}
+                type="checkbox"
+                disabled={containerType !== DOCKER}
+                value={settingName} />
+              <FieldLabel
+                tooltipContent={dockerOnly}
+                tooltipIconID="lock">
+                {label}
+              </FieldLabel>
+              <FieldHelp>{helpText}</FieldHelp>
+            </FieldLabel>
+          </FormGroup>
+        </FormRow>
       );
     });
 
@@ -251,16 +226,8 @@ class ContainerServiceFormSection extends Component {
     );
 
     return (
-      <FieldLabel>
-        {'Command '}
-        <Tooltip
-          content={tooltipContent}
-          interactive={true}
-          wrapText={true}
-          maxWidth={300}
-          scrollContainer=".gm-scroll-view">
-          <Icon color="grey" id="circle-question" size="mini" />
-        </Tooltip>
+      <FieldLabel tooltipContent={tooltipContent}>
+        Command
       </FieldLabel>
     );
   }
@@ -290,16 +257,8 @@ class ContainerServiceFormSection extends Component {
     }
 
     return (
-      <FieldLabel>
-        {'Container Image '}
-        <Tooltip
-          content={tooltipContent}
-          interactive={true}
-          wrapText={true}
-          maxWidth={300}
-          scrollContainer=".gm-scroll-view">
-          <Icon color="grey" id={iconID} size="mini" />
-        </Tooltip>
+      <FieldLabel tooltipContent={tooltipContent} tooltipIconID={iconID} key="image-label">
+        Container Image
       </FieldLabel>
     );
   }

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -173,16 +173,8 @@ class GeneralServiceFormSection extends Component {
     );
 
     return (
-      <FieldLabel>
-        {`${name} `}
-        <Tooltip
-          content={tooltipContent}
-          interactive={true}
-          maxWidth={300}
-          scrollContainer=".gm-scroll-view"
-          wrapText={true}>
-          <Icon color="grey" id="circle-question" size="mini" />
-        </Tooltip>
+      <FieldLabel tooltipContent={tooltipContent}>
+        {name}
       </FieldLabel>
     );
   }
@@ -351,16 +343,22 @@ class GeneralServiceFormSection extends Component {
     return Object.keys(containerRuntimes).map((runtimeName, index) => {
       const {helpText, label} = containerRuntimes[runtimeName];
       let field = (
-        <FieldLabel className="text-align-left" key={index}>
-          <FieldInput
-            checked={Boolean(type === runtimeName)}
-            disabled={isDisabled[runtimeName]}
-            name="container.type"
-            type="radio"
-            value={runtimeName} />
-          {label}
-          <FieldHelp>{helpText}</FieldHelp>
-        </FieldLabel>
+        <FormRow>
+          <FormGroup className="column-12">
+            <FieldLabel className="text-align-left" key={index} wordWrap>
+              <FieldInput
+                checked={Boolean(type === runtimeName)}
+                disabled={isDisabled[runtimeName]}
+                name="container.type"
+                type="radio"
+                value={runtimeName} />
+              <FieldLabel>
+                {label}
+              </FieldLabel>
+              <FieldHelp>{helpText}</FieldHelp>
+            </FieldLabel>
+          </FormGroup>
+        </FormRow>
       );
 
       // Wrap field in tooltip if disabled and content populated
@@ -424,16 +422,8 @@ class GeneralServiceFormSection extends Component {
             className="column-9"
             required={true}
             showError={Boolean(errors.id)}>
-            <FieldLabel>
-              {'Service ID '}
-              <Tooltip
-                content={idTooltipContent}
-                interactive={true}
-                maxWidth={300}
-                scrollContainer=".gm-scroll-view"
-                wrapText={true}>
-                <Icon color="grey" id="circle-question" size="mini" />
-              </Tooltip>
+            <FieldLabel tooltipContent={idTooltipContent}>
+              Service ID
             </FieldLabel>
             <FieldInput
               name="id"

--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import {Tooltip} from 'reactjs-components';
 import mixin from 'reactjs-mixin';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
@@ -98,16 +97,8 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
         className="column-3"
         key="host-port"
         showError={Boolean(hostPortError)}>
-        <FieldLabel>
-          {'Host Port '}
-          <Tooltip
-            content={tooltipContent}
-            interactive={true}
-            maxWidth={300}
-            scrollContainer=".gm-scroll-view"
-            wrapText={true}>
-            <Icon color="grey" id="circle-question" size="mini" />
-          </Tooltip>
+        <FieldLabel tooltipContent={tooltipContent}>
+          Host Port
         </FieldLabel>
         <FieldInput
           disabled={endpoint.automaticPort}
@@ -163,7 +154,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
     return [
       <FormRow key="title">
         <FormGroup className="column-9">
-          <FieldLabel>
+          <FieldLabel wordWrap>
             Load Balanced Service Address
             <FieldHelp>
               Load balances the service internally (layer 4), and creates a service address. For external (layer 7) load balancing, create an external load balancer and attach this service.
@@ -380,16 +371,8 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
         </p>
         <FormRow>
           <FormGroup className="column-6" showError={Boolean(networkError)}>
-            <FieldLabel>
-              {'Network Type '}
-              <Tooltip
-                content={tooltipContent}
-                interactive={true}
-                maxWidth={300}
-                scrollContainer=".gm-scroll-view"
-                wrapText={true}>
-                <Icon color="grey" id="circle-question" size="mini" />
-              </Tooltip>
+            <FieldLabel tooltipContent={tooltipContent}>
+              Network Type
             </FieldLabel>
             {this.getTypeSelections()}
             <FieldError>{networkError}</FieldError>

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -76,16 +76,8 @@ class NetworkingFormSection extends mixin(StoreMixin) {
         className="column-3"
         key="host-port"
         showError={Boolean(hostPortError)}>
-        <FieldLabel>
-          {'Host Port '}
-          <Tooltip
-            content={tooltipContent}
-            interactive={true}
-            maxWidth={300}
-            scrollContainer=".gm-scroll-view"
-            wrapText={true}>
-            <Icon color="grey" id="circle-question" size="mini" />
-          </Tooltip>
+        <FieldLabel tooltipContent={tooltipContent}>
+          Host Port
         </FieldLabel>
         <FieldInput
           disabled={portDefinition.automaticPort}
@@ -140,7 +132,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     return [
       <FormRow key="title">
         <FormGroup className="column-9">
-          <FieldLabel>
+          <FieldLabel wordWrap>
             Load Balanced Service Address
             <FieldHelp>
               Load balances the service internally (layer 4), and creates a service address. For external (layer 7) load balancing, create an external load balancer and attach this service.
@@ -482,16 +474,8 @@ class NetworkingFormSection extends mixin(StoreMixin) {
         </p>
         <FormRow>
           <FormGroup className="column-6" showError={Boolean(networkError)}>
-            <FieldLabel>
-              {'Network Type '}
-              <Tooltip
-                content={tooltipContent}
-                interactive={true}
-                maxWidth={300}
-                scrollContainer=".gm-scroll-view"
-                wrapText={true}>
-                <Icon color="grey" id="circle-question" size="mini" />
-              </Tooltip>
+            <FieldLabel tooltipContent={tooltipContent}>
+              Network Type
             </FieldLabel>
             {this.getTypeSelections()}
             <FieldError>{networkError}</FieldError>

--- a/plugins/services/src/js/components/forms/PodContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/PodContainerServiceFormSection.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-import {Tooltip} from 'reactjs-components';
 
 import {FormReducer as ContainerReducer} from '../../reducers/serviceForm/Container';
 import {FormReducer as ContainersReducer} from '../../reducers/serviceForm/Containers';
@@ -32,16 +31,8 @@ class PodContainerServiceFormSection extends Component {
     );
 
     return (
-      <FieldLabel>
-        {'Artifact URI '}
-        <Tooltip
-          content={tooltipContent}
-          interactive={true}
-          maxWidth={300}
-          scrollContainer=".gm-scroll-view"
-          wrapText={true}>
-          <Icon color="grey" id="circle-question" size="mini" />
-        </Tooltip>
+      <FieldLabel tooltipContent={tooltipContent}>
+        Artifact URI
       </FieldLabel>
     );
   }
@@ -152,16 +143,8 @@ class PodContainerServiceFormSection extends Component {
     );
 
     return (
-      <FieldLabel>
-        {'Command '}
-        <Tooltip
-          content={tooltipContent}
-          interactive={true}
-          wrapText={true}
-          maxWidth={300}
-          scrollContainer=".gm-scroll-view">
-          <Icon color="grey" id="circle-question" size="mini" />
-        </Tooltip>
+      <FieldLabel tooltipContent={tooltipContent}>
+        Command
       </FieldLabel>
     );
   }
@@ -183,16 +166,8 @@ class PodContainerServiceFormSection extends Component {
     );
 
     return (
-      <FieldLabel>
-        {'Container Image '}
-        <Tooltip
-          content={tooltipContent}
-          interactive={true}
-          wrapText={true}
-          maxWidth={300}
-          scrollContainer=".gm-scroll-view">
-          <Icon color="grey" id="circle-question" size="mini" />
-        </Tooltip>
+      <FieldLabel tooltipContent={tooltipContent}>
+        Container Image
       </FieldLabel>
     );
   }

--- a/src/js/components/form/FieldLabel.js
+++ b/src/js/components/form/FieldLabel.js
@@ -13,6 +13,7 @@ const FieldLabel = (props) => {
     }
   });
   const classes = classNames(
+    'form-control-label',
     {'form-control-toggle form-control-toggle-custom': isToggle},
     className
   );

--- a/src/js/components/form/FieldLabel.js
+++ b/src/js/components/form/FieldLabel.js
@@ -1,33 +1,82 @@
 import classNames from 'classnames/dedupe';
 import React from 'react';
+import {Tooltip} from 'reactjs-components';
 
 import {findNestedPropertyInObject, omit} from '../../utils/Util';
+import Icon from '../Icon';
 
 const FieldLabel = (props) => {
-  const {children, className, matchInputHeight, required} = props;
+  const {
+    children,
+    className,
+    matchInputHeight,
+    required,
+    tooltipContent,
+    tooltipIconID,
+    wordWrap
+  } = props;
+
   let isToggle = false;
+
   React.Children.forEach(children, (child) => {
     const type = findNestedPropertyInObject(child, 'props.type');
     if (['radio', 'checkbox'].includes(type)) {
       isToggle = true;
     }
   });
+
   const classes = classNames(
     'form-control-label',
     {'form-control-toggle form-control-toggle-custom': isToggle},
     className
   );
+  const contentWrapperClasses = classNames(
+    'form-control-label-content-wrapper',
+    {'form-control-label-content-wrapper-no-wrap': !wordWrap && !isToggle}
+  );
 
+  let childNodes = children;
   let requiredNode;
+  let tooltipNode;
+
   if (required) {
-    requiredNode = <span className="text-danger"> *</span>;
+    requiredNode = (
+      <span className="form-control-label-content form-control-label-content-secondary text-danger">
+        *
+      </span>
+    );
+  }
+
+  if (!isToggle) {
+    childNodes = (
+      <span className="form-control-label-content form-control-label-content-primary">
+        {children}
+      </span>
+    );
+  }
+
+  if (tooltipContent != null) {
+    tooltipNode = (
+      <Tooltip
+        content={tooltipContent}
+        interactive={typeof tooltipContent !== 'string'}
+        maxWidth={300}
+        scrollContainer=".gm-scroll-view"
+        wrapperClassName="form-control-label-content form-control-label-content-secondary tooltip-wrapper"
+        wrapText={true}>
+        <Icon color="grey" id={tooltipIconID} size="mini" />
+      </Tooltip>
+    );
   }
 
   const label = (
     <label className={classes}
       {...omit(props, Object.keys(FieldLabel.propTypes))}>
-      {children}
-      {requiredNode}
+      <span className={contentWrapperClasses}>
+        {childNodes}
+        {tooltipNode}
+        {requiredNode}
+      </span>
     </label>
   );
 
@@ -42,19 +91,27 @@ const FieldLabel = (props) => {
   );
 };
 
+FieldLabel.defaultProps = {
+  tooltipIconID: 'circle-question',
+  wordWrap: false
+};
+
 FieldLabel.propTypes = {
   children: React.PropTypes.node,
   // Vertically center the element based on the height of input fields
   matchInputHeight: React.PropTypes.bool,
   // Optional boolean to show a required indicator
   required: React.PropTypes.bool,
+  tooltipIconID: React.PropTypes.string,
+  tooltipContent: React.PropTypes.node,
 
   // Classes
   className: React.PropTypes.oneOfType([
     React.PropTypes.array,
     React.PropTypes.object,
     React.PropTypes.string
-  ])
+  ]),
+  wordWrap: React.PropTypes.bool
 };
 
 module.exports = FieldLabel;

--- a/src/styles/components/form-elements/form-row/styles.less
+++ b/src/styles/components/form-elements/form-row/styles.less
@@ -12,6 +12,10 @@
 
     &:last-child {
       margin-bottom: 0;
+
+      .form-group {
+        margin-bottom: 0;
+      }
     }
   }
 }

--- a/src/styles/components/form-elements/styles.less
+++ b/src/styles/components/form-elements/styles.less
@@ -39,9 +39,47 @@
   }
 
   .form-control-label {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+
+    &-content {
+      margin-right: @base-spacing-unit * 1/4;
+
+      &:last-child {
+        margin-right: 0;
+      }
+
+      &-primary {
+        flex: 1 1 auto;
+      }
+
+      &-secondary {
+        flex: 0 0 auto;
+      }
+
+      &-wrapper {
+
+        &-no-wrap {
+          display: inline-flex;
+          max-width: 100%;
+
+          .form-control-label {
+
+            &-content {
+
+              &-primary {
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Remove bottom margin on labels.
+    .form-control-label {
+      margin-bottom: 0;
+    }
   }
 
   // TODO: Remove this when the full screen Create Service is implemented.
@@ -78,6 +116,13 @@
         margin-left: @base-spacing-unit-screen-small * 1/2;
       }
     }
+
+    .form-control-label {
+
+      &-content {
+        margin-right: @base-spacing-unit-screen-small * 1/4;
+      }
+    }
   }
 }
 
@@ -89,6 +134,13 @@
 
       & + .form-control-inline {
         margin-left: @base-spacing-unit-screen-medium * 1/2;
+      }
+    }
+
+    .form-control-label {
+
+      &-content {
+        margin-right: @base-spacing-unit-screen-medium * 1/4;
       }
     }
   }
@@ -108,6 +160,13 @@
         margin-left: @base-spacing-unit-screen-large * 1/2;
       }
     }
+
+    .form-control-label {
+
+      &-content {
+        margin-right: @base-spacing-unit-screen-large * 1/4;
+      }
+    }
   }
 }
 
@@ -119,6 +178,13 @@
 
       & + .form-control-inline {
         margin-left: @base-spacing-unit-screen-jumbo * 1/2;
+      }
+    }
+
+    .form-control-label {
+
+      &-content {
+        margin-right: @base-spacing-unit-screen-jumbo * 1/4;
       }
     }
   }

--- a/src/styles/components/form-elements/styles.less
+++ b/src/styles/components/form-elements/styles.less
@@ -38,6 +38,12 @@
     }
   }
 
+  .form-control-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   // TODO: Remove this when the full screen Create Service is implemented.
   .form-control-force-narrow {
 


### PR DESCRIPTION
This PR extends the `FieldLabel` component in the following ways:
* accepts a `tooltipContent` prop which will render the tooltip after the main content
* accepts a `tooltipIconID` prop to determine the tooltip icon to render (defaults to `circle-question`)
* accepts a `wordWrap` prop to control text wrapping (and if the text wraps, it doesn't get truncated) (defaults to `false`)

Ideally all field label tooltips should be applied in the same manner for consistency.

The following screenshot shows the scenarios that make these props useful:
![](https://cl.ly/2C2N1i3D0Y2v/Screen%20Shot%202017-01-26%20at%204.16.47%20PM.png)
* `Container Image` and `CPUs` labels are truncated but the tooltip & required indicators are visible (narrow widths applied for the screenshot, normally they don't truncate)
* The two checkboxes make use of the `wordWrap` property to prevent the text from being truncated. A nested `FieldLabel` wraps only the "primary" label and does not use the `wordWrap` property

I wrapped the toggle options in `FieldRow` and `FieldGroup` to give them the proper margin. I also edited the `FieldRow` styles to remove the bottom margin on all `FieldGroup`s which are children of `FieldRow` when it is the last child in its container.