### PR TITLE
[Service Modal Routes 2b of 3] DCOS-12423: Add confirm modals when navigating away from route

### DIFF
--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -96,15 +96,17 @@ class NewCreateServiceModal extends Component {
   constructor() {
     super(...arguments);
 
-    const {route} = this.props;
-    const {router} = this.context;
+    this.state = this.getResetState(this.props);
 
     METHODS_TO_BIND.forEach((method) => {
       this[method] = this[method].bind(this);
     });
+  }
 
-    this.state = this.getResetState(this.props);
-
+  componentDidMount() {
+    const {location, route} = this.props;
+    const {service} = this.state;
+    const {router} = this.context;
     // Add store change listeners the traditional way as React Router is
     // not able to pass down correct props if we are using StoreMixin
     MarathonStore.addChangeListener(
@@ -128,6 +130,11 @@ class NewCreateServiceModal extends Component {
       route,
       this.handleRouterWillLeave
     );
+
+    // Only add change listener if we didn't receive our service in first try
+    if (!service && this.isLocationEdit(location)) {
+      DCOSStore.addChangeListener(DCOS_CHANGE, this.handleStoreChange);
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -262,7 +269,6 @@ class NewCreateServiceModal extends Component {
 
   handleGoBack(event) {
     const {tabViewID} = event;
-    const {location} = this.props;
     const {
       hasChangesApplied,
       serviceFormActive,
@@ -734,11 +740,6 @@ class NewCreateServiceModal extends Component {
       serviceFormHasErrors: false,
       showAllErrors: false
     };
-
-    // Only add change listener if we didn't receive our service in first try
-    if (!service && isEdit) {
-      DCOSStore.addChangeListener(DCOS_CHANGE, this.handleStoreChange);
-    }
 
     return newState;
   }

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -202,17 +202,13 @@ class NewCreateServiceModal extends Component {
     // If we are not about to close the modal and not on the review screen,
     // confirm before navigating away
     if (isOpen && hasChangesApplied && !serviceReviewActive) {
-      this.handleClose(true);
+      this.handleOpenConfirm();
 
       // Cancel route change, if it is already open
       return false;
     }
 
     return true;
-  }
-
-  handleCloseConfirmModal() {
-    this.setState({isConfirmOpen: false});
   }
 
   handleConfirmGoBack() {
@@ -297,7 +293,7 @@ class NewCreateServiceModal extends Component {
     // Close if editing a service in the form, but confirm before
     // if changes has been applied to the form
     if (serviceFormActive && hasChangesApplied) {
-      this.handleClose(true);
+      this.handleOpenConfirm();
 
       return;
     }
@@ -316,17 +312,21 @@ class NewCreateServiceModal extends Component {
     });
   }
 
-  handleClose(showConfirm = false) {
-    if (showConfirm) {
-      this.setState({isConfirmOpen: true});
-    } else {
-      // Start the animation of the modal by setting isOpen to false
-      this.setState({isConfirmOpen: false, isOpen: false}, () => {
-        // Once state is set, start a timer for the length of the animation and
-        // navigate away once the animation is over.
-        setTimeout(this.context.router.goBack, 300);
-      });
-    }
+  handleOpenConfirm() {
+    this.setState({isConfirmOpen: true});
+  }
+
+  handleCloseConfirmModal() {
+    this.setState({isConfirmOpen: false});
+  }
+
+  handleClose() {
+    // Start the animation of the modal by setting isOpen to false
+    this.setState({isConfirmOpen: false, isOpen: false}, () => {
+      // Once state is set, start a timer for the length of the animation and
+      // navigate away once the animation is over.
+      setTimeout(this.context.router.goBack, 300);
+    });
   }
 
   handleConvertToPod() {
@@ -767,15 +767,19 @@ class NewCreateServiceModal extends Component {
       serviceReviewActive
     } = this.state;
     let useGemini = false;
-
     if (servicePickerActive || serviceReviewActive) {
       useGemini = true;
+    }
+
+    let closeAction = this.handleClose;
+    if (hasChangesApplied) {
+      closeAction = this.handleOpenConfirm;
     }
 
     return (
       <FullScreenModal
         header={this.getHeader()}
-        onClose={this.handleClose.bind(this, hasChangesApplied)}
+        onClose={closeAction}
         useGemini={useGemini}
         open={isOpen}
         {...Util.omit(props, Object.keys(NewCreateServiceModal.propTypes))}>

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -786,12 +786,12 @@ class NewCreateServiceModal extends Component {
         {this.getModalContent()}
         <Confirm
           closeByBackdropClick={true}
-          header={<ModalHeading>Discard Current Changes</ModalHeading>}
+          header={<ModalHeading>Discard Changes?</ModalHeading>}
           open={this.state.isConfirmOpen}
           onClose={this.handleCloseConfirmModal}
           leftButtonText="Cancel"
           leftButtonCallback={this.handleCloseConfirmModal}
-          rightButtonText="Continue"
+          rightButtonText="Discard"
           rightButtonClassName="button button-danger"
           rightButtonCallback={this.handleConfirmGoBack}
           showHeader={true}>

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -124,7 +124,10 @@ class NewCreateServiceModal extends Component {
       this.onMarathonStoreServiceEditSuccess
     );
 
-    router.setRouteLeaveHook(route, this.handleRouterWillLeave);
+    this.unregisterLeaveHook = router.setRouteLeaveHook(
+      route,
+      this.handleRouterWillLeave
+    );
   }
 
   componentWillReceiveProps(nextProps) {
@@ -164,6 +167,9 @@ class NewCreateServiceModal extends Component {
       MARATHON_SERVICE_EDIT_SUCCESS,
       this.onMarathonStoreServiceEditSuccess
     );
+
+    // Clean up router leave hook
+    this.unregisterLeaveHook();
 
     // Also remove DCOS change listener, if still subscribed
     DCOSStore.removeChangeListener(DCOS_CHANGE, this.handleStoreChange);

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -21,6 +21,11 @@ describe('Service Actions', function () {
       clickHeaderAction('Edit');
     });
 
+    it('navigates to the correct route', function () {
+      cy.location().its('hash')
+        .should('include', '#/services/overview/%2Fcassandra-healthy/edit');
+    });
+
     it('opens the correct service edit modal', function () {
       cy.get('.modal .menu-tabbed-view input[name="id"]')
         .should('to.have.value', '/cassandra-healthy');
@@ -47,6 +52,44 @@ describe('Service Actions', function () {
         .contains('Cancel')
         .click();
       cy.get('.modal').should('to.have.length', 0);
+    });
+
+    it('opens confirm after edits', function () {
+      cy.get('.modal .menu-tabbed-view input[name="cpus"]')
+        .type('5'); // Edit the cpus field
+      cy.get('.modal .modal-header .button')
+        .contains('Cancel')
+        .click();
+
+      cy.get('.confirm-modal').should('to.have.length', 1);
+    });
+
+    it('closes both confirm and edit modal after confirmation', function () {
+      cy.get('.modal .menu-tabbed-view input[name="cpus"]')
+        .type('5'); // Edit the cpus field
+      cy.get('.modal .modal-header .button')
+        .contains('Cancel')
+        .click();
+      cy.get('.confirm-modal .button')
+        .contains('Continue')
+        .click();
+
+      cy.get('.confirm-modal').should('to.have.length', 0);
+      cy.get('.modal').should('to.have.length', 0);
+    });
+
+    it('it stays in the edit modal after cancelling confirmation', function () {
+      cy.get('.modal .menu-tabbed-view input[name="cpus"]')
+        .type('5'); // Edit the cpus field
+      cy.get('.modal .modal-header .button')
+        .contains('Cancel')
+        .click();
+      cy.get('.confirm-modal .button')
+        .contains('Cancel')
+        .click();
+
+      cy.get('.confirm-modal').should('to.have.length', 0);
+      cy.get('.modal').should('to.have.length', 1);
     });
   });
 

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -35,7 +35,7 @@ describe('Service Actions', function () {
       cy
         .route({
           method: 'PUT',
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: []
         });
       cy.get('.modal .modal-header .button')
@@ -71,7 +71,7 @@ describe('Service Actions', function () {
         .contains('Cancel')
         .click();
       cy.get('.confirm-modal .button')
-        .contains('Continue')
+        .contains('Discard')
         .click();
 
       cy.get('.confirm-modal').should('to.have.length', 0);
@@ -203,7 +203,7 @@ describe('Service Actions', function () {
       cy
         .route({
           method: 'PUT',
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: []
         });
       cy.get('.modal-footer .button-collection .button-primary')
@@ -215,7 +215,7 @@ describe('Service Actions', function () {
       cy
         .route({
           method: 'PUT',
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: []
         });
       cy.get('.modal-footer .button-collection .button-primary').click();
@@ -227,7 +227,7 @@ describe('Service Actions', function () {
         .route({
           method: 'PUT',
           status: 409,
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: {
             message: 'App is locked by one or more deployments.'
           }
@@ -242,7 +242,7 @@ describe('Service Actions', function () {
         .route({
           method: 'PUT',
           status: 403,
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: {
             message: 'Not Authorized to perform this action!'
           }
@@ -256,7 +256,7 @@ describe('Service Actions', function () {
       cy
         .route({
           method: 'PUT',
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: [],
           delay: SERVER_RESPONSE_DELAY
         });
@@ -287,7 +287,7 @@ describe('Service Actions', function () {
       cy
         .route({
           method: 'PUT',
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: []
         });
       cy.get('.confirm-modal .button-collection .button-primary')
@@ -299,7 +299,7 @@ describe('Service Actions', function () {
       cy
         .route({
           method: 'PUT',
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: []
         });
       cy.get('.confirm-modal .button-collection .button-primary').click();
@@ -311,7 +311,7 @@ describe('Service Actions', function () {
         .route({
           method: 'PUT',
           status: 409,
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: {
             message: 'App is locked by one or more deployments.'
           }
@@ -326,7 +326,7 @@ describe('Service Actions', function () {
         .route({
           method: 'PUT',
           status: 403,
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: {
             message: 'Not Authorized to perform this action!'
           }
@@ -340,7 +340,7 @@ describe('Service Actions', function () {
       cy
         .route({
           method: 'PUT',
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: [],
           delay: SERVER_RESPONSE_DELAY
         });


### PR DESCRIPTION
~~Service Modal Routes 1 of 3: https://github.com/dcos/dcos-ui/pull/1828~~ Merged!
Service Modal Routes 2a of 3: https://github.com/dcos/dcos-ui/pull/1853
Service Modal Routes 2b of 3: https://github.com/dcos/dcos-ui/pull/1871

This PR adds a confirm modal to route changes from service create/edit modal and when navigating away if there are any changes to the form.

![](https://cl.ly/341g400o2O1f/Image%202017-01-31%20at%2012.55.03.png)

Diff for review can be found here: https://github.com/dcos/dcos-ui/compare/mlunoe/feature/DCOS-12423-add-routes-for-the-new-create-service-modal...mlunoe/feature/DCOS-12423-add-confirm-modals-when-navigating-away-from-route?expand=1