### PR TITLE
Change CPU default from 1 to 0.1 for service create

### DIFF
--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -452,7 +452,7 @@ class ContainerServiceFormSection extends Component {
             <FieldLabel className="text-no-transform">CPUs</FieldLabel>
             <FieldInput
               min="0.001"
-              name="cpus"
+              name={cpusPath}
               step="any"
               type="number"
               value={findNestedPropertyInObject(data, cpusPath)} />

--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -453,7 +453,7 @@ class ContainerServiceFormSection extends Component {
             <FieldInput
               min="0.001"
               name="cpus"
-              step="0.1"
+              step="any"
               type="number"
               value={findNestedPropertyInObject(data, cpusPath)} />
             <FieldError>{cpusErrors}</FieldError>

--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -452,8 +452,8 @@ class ContainerServiceFormSection extends Component {
             <FieldLabel className="text-no-transform">CPUs</FieldLabel>
             <FieldInput
               min="0.001"
-              name={cpusPath}
-              step="any"
+              name="cpus"
+              step="0.1"
               type="number"
               value={findNestedPropertyInObject(data, cpusPath)} />
             <FieldError>{cpusErrors}</FieldError>

--- a/plugins/services/src/js/constants/DefaultApp.js
+++ b/plugins/services/src/js/constants/DefaultApp.js
@@ -1,4 +1,4 @@
-const DEFAULT_APP_RESOURCES = {cpus: 1, mem: 128};
+const DEFAULT_APP_RESOURCES = {cpus: 0.1, mem: 128};
 const DEFAULT_APP_SPEC = Object.assign({instances: 1}, DEFAULT_APP_RESOURCES);
 
 module.exports = {

--- a/plugins/services/src/js/constants/DefaultPod.js
+++ b/plugins/services/src/js/constants/DefaultPod.js
@@ -1,4 +1,4 @@
-const DEFAULT_POD_RESOURCES = {cpus: 1, mem: 128};
+const DEFAULT_POD_RESOURCES = {cpus: 0.1, mem: 128};
 const DEFAULT_POD_SCALING = {kind: 'fixed', instances: 1};
 const DEFAULT_POD_CONTAINER =
   {name: 'container-1', resources: DEFAULT_POD_RESOURCES};

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
@@ -828,7 +828,7 @@ describe('Containers', function () {
             endpoints: [],
             name: 'container-1',
             resources: {
-              cpus: 1,
+              cpus: 0.1,
               mem: 128
             }
           }]);
@@ -1744,7 +1744,7 @@ describe('Containers', function () {
             ],
             name: 'container-1',
             resources: {
-              cpus: 1,
+              cpus: 0.1,
               mem: 128
             }
           }]);

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
@@ -43,7 +43,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -85,7 +85,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -147,7 +147,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -192,7 +192,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -238,7 +238,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -278,7 +278,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -324,7 +324,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -388,7 +388,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -435,7 +435,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -483,7 +483,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -530,7 +530,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -586,7 +586,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -653,7 +653,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -713,7 +713,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -782,7 +782,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -884,7 +884,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -933,7 +933,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -1000,7 +1000,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -1052,7 +1052,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -1104,7 +1104,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -1151,7 +1151,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -1202,7 +1202,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -1271,7 +1271,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -1324,7 +1324,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -1376,7 +1376,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -1428,7 +1428,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -1489,7 +1489,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -1559,7 +1559,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -1622,7 +1622,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [
@@ -1694,7 +1694,7 @@ describe('Containers', function () {
             {
               name: 'container-1',
               resources: {
-                cpus: 1,
+                cpus: 0.1,
                 mem: 128
               },
               endpoints: [

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -118,7 +118,7 @@ describe('Service Form Modal', function () {
 
     it('contains right cpus default value', function () {
       getFormValue('cpus')
-        .should('to.have.value', '1');
+        .should('to.have.value', '0.1');
     });
 
     it('contains right mem default value', function () {
@@ -135,7 +135,7 @@ describe('Service Form Modal', function () {
       openServiceModal();
       openServiceJSON();
       cy.get('.ace_content').should(function (nodeList) {
-        expect(nodeList[0].textContent).to.contain('"cpus": 1');
+        expect(nodeList[0].textContent).to.contain('"cpus": 0.1');
         expect(nodeList[0].textContent).to.contain('"instances": 1');
         expect(nodeList[0].textContent).to.contain('"mem": 128');
       });


### PR DESCRIPTION
This changes the default value for CPU from 1 to 0.1. Users find themselves deploying demo apps with the defaults then quickly run out of resources. This will help with that, as well as educating the user that fractional values are allowed.

![image](https://cloud.githubusercontent.com/assets/15963/22392159/50c0f350-e4ab-11e6-8586-dc6f4a665e04.png)
