### PR TITLE
DCOS-12565: Add chosen route to expandedItems at mount

### DIFF
--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -53,8 +53,7 @@ var Sidebar = React.createClass({
   },
 
   componentWillMount() {
-    const {pathname} = this.props.location;
-    const pathnameSegments = pathname.split('/');
+    const pathnameSegments = this.props.location.pathname.split('/');
 
     // If the user loaded the UI from a route other than `/`, we want to display
     // it in its expanded state.

--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -52,6 +52,17 @@ var Sidebar = React.createClass({
     return {expandedItems: []};
   },
 
+  componentWillMount() {
+    const {pathname} = this.props.location;
+    const pathnameSegments = pathname.split('/');
+
+    // If the user loaded the UI from a route other than `/`, we want to display
+    // it in its expanded state.
+    if (pathnameSegments.length > 1) {
+      this.setState({expandedItems: [`/${pathnameSegments[1]}`]});
+    }
+  },
+
   componentDidMount() {
     NavigationService.on(NAVIGATION_CHANGE, this.onNavigationChange);
 


### PR DESCRIPTION
Previously, if you loaded the UI at a route other than `/`, and that route was a nested item (e.g. `/universe/packages`), the sidebar would not show the parent item as expanded.

Now, the Sidebar adds the parent route to `state.expandedItems` in `componentWillMount` so it will be expanded when it renders.