### PR TITLE
DCOS-13340: Update service status warning logic

### DIFF
--- a/plugins/services/src/js/containers/pod-debug/PodDebugContainer.js
+++ b/plugins/services/src/js/containers/pod-debug/PodDebugContainer.js
@@ -39,7 +39,7 @@ class PodDebugTabView extends React.Component {
     const {pod} = this.props;
     const queue = pod.getQueue();
 
-    if (!DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(queue)
+    if (!DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(pod)
       || queue.declinedOffers.offers == null) {
       return null;
     }
@@ -142,12 +142,13 @@ class PodDebugTabView extends React.Component {
   }
 
   getRecentOfferSummary() {
-    const queue = this.props.pod.getQueue();
+    const {pod} = this.props;
+    const queue = pod.getQueue();
     let introText = null;
     let mainContent = null;
     let offerCount = null;
 
-    if (!DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(queue)
+    if (!DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(pod)
       || queue.declinedOffers.summary == null) {
       introText = 'Offers will appear here when your service is deploying or waiting for resources.';
     } else {

--- a/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
+++ b/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
@@ -118,7 +118,7 @@ class ServiceDebugContainer extends React.Component {
       } else {
         introText = 'Rejected offer analysis is not currently supported.';
       }
-    } else if (!DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(queue)
+    } else if (!DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(service)
       || queue.declinedOffers.summary == null) {
       introText = 'Offers will appear here when your service is deploying or waiting for resources.';
     } else {
@@ -159,7 +159,7 @@ class ServiceDebugContainer extends React.Component {
 
     const queue = service.getQueue();
 
-    if (!DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(queue)
+    if (!DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(service)
       || queue.declinedOffers.offers == null) {
       return null;
     }

--- a/plugins/services/src/js/utils/DeclinedOffersUtil.js
+++ b/plugins/services/src/js/utils/DeclinedOffersUtil.js
@@ -1,5 +1,6 @@
 import DateUtil from '../../../../../src/js/utils/DateUtil';
 import DeclinedOffersReasons from '../constants/DeclinedOffersReasons';
+import ServiceStatus from '../constants/ServiceStatus';
 import Util from '../../../../../src/js/utils/Util';
 
 const DEPLOYMENT_WARNING_DELAY_MS = 1000 * 60 * 5;
@@ -220,8 +221,25 @@ const DeclinedOffersUtil = {
       ) || queue.since;
   },
 
-  shouldDisplayDeclinedOffersWarning(queue) {
-    if (queue == null) {
+  shouldDisplayDeclinedOffersWarning(item) {
+    const queue = item.getQueue();
+    const lastUsedOffer = DateUtil.strToMs(
+      Util.findNestedPropertyInObject(
+        queue, 'processedOffersSummary.lastUsedOfferAt'
+      ) || 0
+    );
+    const lastUnusedOffer = DateUtil.strToMs(
+      Util.findNestedPropertyInObject(
+        queue, 'processedOffersSummary.lastUnusedOfferAt'
+      ) || 0
+    );
+
+    // We don't display the declined offers debug info if the app is not in the
+    // deployment queue, or if the app's status is delayed, or if the app has
+    // matched an offer more recently than unmatched.
+    if (queue == null
+      || item.getServiceStatus() === ServiceStatus.DELAYED
+      || lastUsedOffer >= lastUnusedOffer) {
       return false;
     }
 


### PR DESCRIPTION
This PR prevents showing any declined offer information for a task whose status is `delayed`.

It also adds a warning for apps which have been in the launch queue for over 30 minutes, as discussed in https://mesosphere.atlassian.net/browse/DCOS-13340