### PR TITLE
DCOS-12567: Fix RepositoriesTab: left align filter input

### DIFF
--- a/src/js/pages/system/RepositoriesTab.js
+++ b/src/js/pages/system/RepositoriesTab.js
@@ -106,7 +106,7 @@ class RepositoriesTab extends mixin(StoreMixin) {
 
     return (
       <div>
-        <FilterBar rightAlignLastNChildren={1}>
+        <FilterBar>
           <FilterInputText
             className="flush-bottom"
             placeholder="Search"


### PR DESCRIPTION
This PR removes `rightAlignLastNChildren` prop that effectively aligns filter to the left side

http://0.0.0.0:4200/#/settings/repositories