### PR TITLE
DCOS-13481: Feature (service form): allow GPUs for Mesos runtime

### DIFF
--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -21,7 +21,7 @@ import Icon from '../../../../../../src/js/components/Icon';
 import MetadataStore from '../../../../../../src/js/stores/MetadataStore';
 import PodSpec from '../../structs/PodSpec';
 
-const {DOCKER, NONE, MESOS} = ContainerConstants.type;
+const {DOCKER, NONE} = ContainerConstants.type;
 
 const containerSettings = {
   privileged: {
@@ -71,6 +71,13 @@ class ContainerServiceFormSection extends Component {
     }
 
     return appPaths[fieldName].replace('{basePath}', basePath);
+  }
+
+  isGpusDisabled() {
+    const {data, path} = this.props;
+    const typePath = this.getFieldPath(path, 'type');
+
+    return findNestedPropertyInObject(data, typePath) === DOCKER;
   }
 
   getArtifactsLabel() {
@@ -151,11 +158,7 @@ class ContainerServiceFormSection extends Component {
   }
 
   getGPUSLabel() {
-    const {data, path} = this.props;
-    const typePath = this.getFieldPath(path, 'type');
-    const disabled = findNestedPropertyInObject(data, typePath) !== MESOS;
-
-    if (disabled) {
+    if (this.isGpusDisabled()) {
       return (
         <FieldLabel className="text-no-transform">
           {'GPUs '}
@@ -184,11 +187,9 @@ class ContainerServiceFormSection extends Component {
       return null;
     }
 
-    const typePath = this.getFieldPath(path, 'type');
-    const containerType = findNestedPropertyInObject(data, typePath);
     const gpusPath = this.getFieldPath(path, 'gpus');
     const gpusErrors = findNestedPropertyInObject(errors, gpusPath);
-    const gpusDisabled = containerType !== MESOS;
+    const gpusDisabled = this.isGpusDisabled();
 
     return (
       <FormGroup


### PR DESCRIPTION
This PR unblocks GPUs field for Mesos Runtime as it is the same thing as UCR and confirmed to support GPUs as well.

as GPUs field is still under the Container section we might want to reconsider its location in the form @leemunroe 

![screen shot 2017-01-31 at 16 32 27](https://cloud.githubusercontent.com/assets/186223/22471545/f05b49ae-e7d2-11e6-9bc1-8ef8b4c553fd.png)
