### PR TITLE
Fix .form-control:disabled color

### DIFF
--- a/src/styles/components/form-elements/styles.less
+++ b/src/styles/components/form-elements/styles.less
@@ -48,6 +48,16 @@
     }
   }
 
+  // TODO: Remove this when the fix hits CNVS:
+  // https://github.com/mesosphere/cnvs/issues/76
+  .form-control {
+
+    &:disabled,
+    &.disabled {
+      color: color-lighten(@neutral, 50);
+    }
+  }
+
   .form-colon {
     bottom: 0.8rem;
     left: 100%;


### PR DESCRIPTION
This PR sets a contrasting foreground color for disabled fields.

This should be fixed in CNVS ([here's the issue](https://github.com/mesosphere/cnvs/issues/76)). cc @ashenden 

Before:
![](https://cl.ly/2o2J190W0E0A/Screen%20Shot%202017-01-31%20at%209.36.26%20AM.png)

After:
![](https://cl.ly/0x3a373H050s/Screen%20Shot%202017-01-31%20at%209.35.26%20AM.png)