### PR TITLE
[1 of 2: Fix form label wrapping] Introduce FormGroupHeading components

### DIFF
--- a/src/js/components/form/FormGroup.js
+++ b/src/js/components/form/FormGroup.js
@@ -5,14 +5,14 @@ import FieldError from './FieldError';
 import {omit} from '../../utils/Util';
 
 const FormGroup = (props) => {
-  const {children, className, errorClassName, showError, required} = props;
+  const {children, className, errorClassName, showError} = props;
 
   const clonedChildren = React.Children.map(children, (child) => {
-    if (child == null || (!showError && child.type === FieldError)) {
+    if (child != null && !showError && child.type === FieldError) {
       return null;
     }
 
-    return React.cloneElement(child, {required});
+    return child;
   });
 
   const classes = classNames(
@@ -44,9 +44,6 @@ FormGroup.propTypes = {
   children: React.PropTypes.node,
   // Optional boolean to display error
   showError: React.PropTypes.bool,
-
-  // Optional boolean to make field required
-  required: React.PropTypes.bool,
 
   // Classes
   className: classPropType,

--- a/src/js/components/form/FormGroupHeading.js
+++ b/src/js/components/form/FormGroupHeading.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 import FormGroupHeadingContent from './FormGroupHeadingContent';
 
-function getModifiedChildren(children) {
+function injectAsteriskNode(children) {
   const asteriskNode = (
     <FormGroupHeadingContent className="text-danger" key="asterisk">
       *
@@ -21,7 +21,7 @@ function FormGroupHeading({className, children, required}) {
 
   return (
     <div className={classes}>
-      {required ? getModifiedChildren(children) : children}
+      {required ? injectAsteriskNode(children) : children}
     </div>
   );
 }

--- a/src/js/components/form/FormGroupHeading.js
+++ b/src/js/components/form/FormGroupHeading.js
@@ -1,0 +1,56 @@
+import classNames from 'classnames';
+import React from 'react';
+
+import FormGroupHeadingContent from './FormGroupHeadingContent';
+
+function getChildren(children, required) {
+  if (!required) {
+    return children;
+  }
+
+  // We add the required field indicator after the first child.
+  return React.Children.toArray(children).reduce(
+    function (accumulator, child, index) {
+      accumulator.push(child);
+
+      if (index === 0) {
+        accumulator.push(
+          <FormGroupHeadingContent
+            className="text-danger"
+            key={`${index}-asterisk`}>
+            *
+          </FormGroupHeadingContent>
+        );
+      }
+
+      return accumulator;
+    },
+    []
+  );
+}
+
+function FormGroupHeading({className, children, required}) {
+  const classes = classNames('form-group-heading', className);
+
+  return (
+    <div className={classes}>
+      {getChildren(children, required)}
+    </div>
+  );
+}
+
+FormGroupHeading.defaultProps = {
+  required: false
+};
+
+FormGroupHeading.propTypes = {
+  children: React.PropTypes.node.isRequired,
+  className: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ]),
+  required: React.PropTypes.bool
+};
+
+module.exports = FormGroupHeading;

--- a/src/js/components/form/FormGroupHeading.js
+++ b/src/js/components/form/FormGroupHeading.js
@@ -3,30 +3,17 @@ import React from 'react';
 
 import FormGroupHeadingContent from './FormGroupHeadingContent';
 
-function getChildren(children, required) {
-  if (!required) {
-    return children;
-  }
-
-  // We add the required field indicator after the first child.
-  return React.Children.toArray(children).reduce(
-    function (accumulator, child, index) {
-      accumulator.push(child);
-
-      if (index === 0) {
-        accumulator.push(
-          <FormGroupHeadingContent
-            className="text-danger"
-            key={`${index}-asterisk`}>
-            *
-          </FormGroupHeadingContent>
-        );
-      }
-
-      return accumulator;
-    },
-    []
+function getModifiedChildren(children) {
+  const asteriskNode = (
+    <FormGroupHeadingContent className="text-danger" key="asterisk">
+      *
+    </FormGroupHeadingContent>
   );
+  const nextChildren = React.Children.toArray(children);
+
+  nextChildren.splice(1, 0, asteriskNode);
+
+  return nextChildren;
 }
 
 function FormGroupHeading({className, children, required}) {
@@ -34,7 +21,7 @@ function FormGroupHeading({className, children, required}) {
 
   return (
     <div className={classes}>
-      {getChildren(children, required)}
+      {required ? getModifiedChildren(children) : children}
     </div>
   );
 }

--- a/src/js/components/form/FormGroupHeadingContent.js
+++ b/src/js/components/form/FormGroupHeadingContent.js
@@ -1,0 +1,54 @@
+import classNames from 'classnames';
+import React from 'react';
+
+import Config from '../../config/Config';
+
+function getTitle(children) {
+  if (typeof children === 'string') {
+    return children;
+  }
+
+  if (Config.environment === 'development') {
+    console.warn('Primary FormGroupHeadingContent elements should be given ' +
+      'a title attribute.');
+  }
+
+  return null;
+}
+
+function FormGroupHeadingContent({className, children, primary, title}) {
+  if (children == null) {
+    return <noscript />;
+  }
+
+  const classes = classNames('form-group-heading-content', className, {
+    'form-group-heading-content-primary': primary
+  });
+
+  if (primary && !title) {
+    title = getTitle(children);
+  }
+
+  return (
+    <div className={classes} title={title}>
+      {children}
+    </div>
+  );
+}
+
+FormGroupHeadingContent.defaultProps = {
+  primary: false
+};
+
+FormGroupHeadingContent.propTypes = {
+  children: React.PropTypes.node,
+  className: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ]),
+  primary: React.PropTypes.bool,
+  title: React.PropTypes.string
+};
+
+module.exports = FormGroupHeadingContent;

--- a/src/js/components/form/index.js
+++ b/src/js/components/form/index.js
@@ -11,6 +11,8 @@ import FieldSelect from './FieldSelect';
 import FieldTextarea from './FieldTextarea';
 import FormGroup from './FormGroup';
 import FormGroupContainer from './FormGroupContainer';
+import FormGroupHeading from './FormGroupHeading';
+import FormGroupHeadingContent from './FormGroupHeadingContent';
 import FormRow from './FormRow';
 
 module.exports = {
@@ -27,5 +29,7 @@ module.exports = {
   FieldTextarea,
   FormGroup,
   FormGroupContainer,
+  FormGroupHeading,
+  FormGroupHeadingContent,
   FormRow
 };

--- a/src/styles/components/form-elements/form-group/styles.less
+++ b/src/styles/components/form-elements/form-group/styles.less
@@ -9,5 +9,91 @@
         margin-bottom: 0;
       }
     }
+
+    &-heading {
+      align-items: center;
+      display: flex;
+
+      &-content {
+        flex: 0 0 auto;
+        margin-left: @form-group-heading-content-margin-left;
+
+        &:first-child {
+          margin-left: 0;
+        }
+
+        &-primary {
+          flex: 0 1 auto;
+          min-width: 0;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+      }
+    }
+  }
+}
+
+& when (@form-group-enabled) and (@layout-screen-small-enabled) {
+
+  @media (min-width: @layout-screen-small-min-width) {
+
+    .form-group {
+
+      &-heading {
+
+        &-content {
+          margin-left: @form-group-heading-content-margin-left-screen-small;
+        }
+      }
+    }
+  }
+}
+
+& when (@form-group-enabled) and (@layout-screen-medium-enabled) {
+
+  @media (min-width: @layout-screen-medium-min-width) {
+
+    .form-group {
+
+      &-heading {
+
+        &-content {
+          margin-left: @form-group-heading-content-margin-left-screen-medium;
+        }
+      }
+    }
+  }
+}
+
+& when (@form-group-enabled) and (@layout-screen-large-enabled) {
+
+  @media (min-width: @layout-screen-large-min-width) {
+
+    .form-group {
+
+      &-heading {
+
+        &-content {
+          margin-left: @form-group-heading-content-margin-left-screen-large;
+        }
+      }
+    }
+  }
+}
+
+& when (@form-group-enabled) and (@layout-screen-jumbo-enabled) {
+
+  @media (min-width: @layout-screen-jumbo-min-width) {
+
+    .form-group {
+
+      &-heading {
+
+        &-content {
+          margin-left: @form-group-heading-content-margin-left-screen-jumbo;
+        }
+      }
+    }
   }
 }

--- a/src/styles/components/form-elements/form-group/variables.less
+++ b/src/styles/components/form-elements/form-group/variables.less
@@ -1,1 +1,7 @@
 @form-group-enabled: true;
+
+@form-group-heading-content-margin-left: @base-spacing-unit * 1/4;
+@form-group-heading-content-margin-left-screen-small: @base-spacing-unit-screen-small * 1/4;
+@form-group-heading-content-margin-left-screen-medium: @base-spacing-unit-screen-medium * 1/4;
+@form-group-heading-content-margin-left-screen-large: @base-spacing-unit-screen-large * 1/4;
+@form-group-heading-content-margin-left-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/4;

--- a/src/styles/components/form-elements/form-row/styles.less
+++ b/src/styles/components/form-elements/form-row/styles.less
@@ -11,7 +11,11 @@
     }
 
     &:last-child {
-      margin-bottom: 0;
+
+      &,
+      .form-group {
+        margin-bottom: 0;
+      }
     }
   }
 }

--- a/src/styles/components/menu-tabbed/styles.less
+++ b/src/styles/components/menu-tabbed/styles.less
@@ -6,6 +6,7 @@
 
     .menu-tabbed-view-container {
       flex: 1 1 auto;
+      min-width: 0;
     }
   }
 

--- a/src/styles/views/create-service-modal/styles.less
+++ b/src/styles/views/create-service-modal/styles.less
@@ -30,6 +30,7 @@
 
       .menu-tabbed-container {
         flex: 1 1 auto;
+        min-width: 0;
       }
 
       .menu-tabbed-vertical {


### PR DESCRIPTION
1 of 2: #1886 
2 of 2: #1887

This PR introduces two components: `FormGroupHeading` and `FormGroupHeadingContent`.

`FormGroupHeading` is now responsible for applying the required indicator (`*`) to the fields. This was previously handled by `FormGroup`, so that logic has been removed.

`FormGroupHeading` can take any number of `FormGroupHeadingContent` elements and will render them on a single line. Setting `primary={true}` on a `FormGroupHeadingContent` element allows that element to shrink and for its content to be truncated.

Example usage:
```jsx
<FormGroupHeading>
  <FormGroupHeadingContent primary={true}>
    I am a piece of content that is reasonably long.
  </FormGroupHeadingContent>
  <FormGroupHeadingContent>
    <Tooltip ... />
  </FormGroupHeadingContent>
</FormGroupHeading>
```

In this example, the tooltip will always be directly adjacent to the string. If the viewport is too narrow, the string will be truncated while the tooltip remains visible.