### PR TITLE
DCOS-13519: Add vip port validation

### DIFF
--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -3,7 +3,10 @@ import {Tooltip} from 'reactjs-components';
 import mixin from 'reactjs-mixin';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
-import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
+import {
+  findNestedPropertyInObject,
+  isObject
+} from '../../../../../../src/js/utils/Util';
 import {FormReducer as networks} from '../../reducers/serviceForm/MultiContainerNetwork';
 import AddButton from '../../../../../../src/js/components/form/AddButton';
 import FieldError from '../../../../../../src/js/components/form/FieldError';
@@ -145,10 +148,14 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
 
     const {containerPort, hostPort, loadBalanced, vip} = endpoint;
     const {errors} = this.props;
-    const loadBalancedError = findNestedPropertyInObject(
+    let loadBalancedError = findNestedPropertyInObject(
       errors,
       `containers.${containerIndex}.endpoints.${index}.labels`
     );
+
+    if (isObject(loadBalancedError)) {
+      loadBalancedError = null;
+    }
 
     let address = vip;
     if (address == null) {

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -3,7 +3,10 @@ import {Tooltip} from 'reactjs-components';
 import mixin from 'reactjs-mixin';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
-import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
+import {
+  findNestedPropertyInObject,
+  isObject
+} from '../../../../../../src/js/utils/Util';
 import {FormReducer as portDefinitionsReducer} from '../../reducers/serviceForm/PortDefinitions';
 import {SET} from '../../../../../../src/js/constants/TransactionTypes';
 import AddButton from '../../../../../../src/js/components/form/AddButton';
@@ -119,13 +122,17 @@ class NetworkingFormSection extends mixin(StoreMixin) {
   getLoadBalancedServiceAddressField(portDefinition, index) {
     const {containerPort, hostPort, loadBalanced, vip} = portDefinition;
     const {errors} = this.props;
-    const loadBalancedError = findNestedPropertyInObject(
+    let loadBalancedError = findNestedPropertyInObject(
       errors,
       `portDefinitions.${index}.labels`
     ) || findNestedPropertyInObject(
       errors,
       `container.docker.portMappings.${index}.labels`
     );
+
+    if (isObject(loadBalancedError)) {
+      loadBalancedError = null;
+    }
 
     let address = vip;
     if (address == null) {

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -116,15 +116,8 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     ];
   }
 
-  getLoadBalancedServiceAddressField(
-      {
-        containerPort,
-        hostPort,
-        loadBalanced,
-        vip
-      },
-      index
-    ) {
+  getLoadBalancedServiceAddressField(portDefinition, index) {
+    const {containerPort, hostPort, loadBalanced, vip} = portDefinition;
     const {errors} = this.props;
     const loadBalancedError = findNestedPropertyInObject(
       errors,

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -122,6 +122,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
   getLoadBalancedServiceAddressField(portDefinition, index) {
     const {containerPort, hostPort, loadBalanced, vip} = portDefinition;
     const {errors} = this.props;
+    let vipPortError = null;
     let loadBalancedError = findNestedPropertyInObject(
       errors,
       `portDefinitions.${index}.labels`
@@ -131,6 +132,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     );
 
     if (isObject(loadBalancedError)) {
+      vipPortError = loadBalancedError[`VIP_${index}`];
       loadBalancedError = null;
     }
 
@@ -146,6 +148,15 @@ class NetworkingFormSection extends mixin(StoreMixin) {
       port = port || 0;
 
       address = `${this.props.data.id}:${port}`;
+    }
+
+    let hostName = null;
+    if (!Boolean(vipPortError)) {
+      hostName = (
+        <span>
+          {ServiceConfigUtil.buildHostNameFromVipLabel(address)}
+        </span>
+      );
     }
 
     return [
@@ -172,10 +183,11 @@ class NetworkingFormSection extends mixin(StoreMixin) {
           </FieldLabel>
           <FieldError>{loadBalancedError}</FieldError>
         </FormGroup>
-        <FormGroup className="column-auto flush-left">
-          <span>
-            {ServiceConfigUtil.buildHostNameFromVipLabel(address)}
-          </span>
+        <FormGroup
+          className="column-auto flush-left"
+          showError={Boolean(vipPortError)}>
+          {hostName}
+          <FieldError>{vipPortError}</FieldError>
         </FormGroup>
       </FormRow>
     ];

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -51,6 +51,7 @@ import NetworkingFormSection from '../forms/NetworkingFormSection';
 import {getBaseID, getServiceJSON} from '../../utils/ServiceUtil';
 import ServiceErrorTypes from '../../constants/ServiceErrorTypes';
 import VolumesFormSection from '../forms/VolumesFormSection';
+import VipLabelsValidators from '../../validators/VipLabelsValidators';
 import {combineParsers} from '../../../../../../src/js/utils/ParserUtil';
 import {combineReducers} from '../../../../../../src/js/utils/ReducerUtil';
 
@@ -77,11 +78,13 @@ const APP_VALIDATORS = [
   AppValidators.App,
   MarathonAppValidators.containsCmdArgsOrContainer,
   MarathonAppValidators.complyWithResidencyRules,
-  MarathonAppValidators.complyWithIpAddressRules
+  MarathonAppValidators.complyWithIpAddressRules,
+  VipLabelsValidators.mustContainPort
 ];
 
 const POD_VALIDATORS = [
-  PodValidators.Pod
+  PodValidators.Pod,
+  VipLabelsValidators.mustContainPort
 ];
 
 class NewCreateServiceModal extends Component {

--- a/plugins/services/src/js/utils/ServiceConfigUtil.js
+++ b/plugins/services/src/js/utils/ServiceConfigUtil.js
@@ -22,7 +22,7 @@ const ServiceConfigUtil = {
   },
 
   buildHostNameFromVipLabel(label, port) {
-    const [ipOrName, labelPort] = label.split(':');
+    const [ipOrName, labelPort = ''] = label.split(':');
 
     // Sometimes we don't know the port yet
     port = port || '<assigned port>';

--- a/plugins/services/src/js/validators/VipLabelsValidators.js
+++ b/plugins/services/src/js/validators/VipLabelsValidators.js
@@ -1,0 +1,53 @@
+import {isEmpty} from '../../../../../src/js/utils/ValidatorUtil';
+import ServiceConfigUtil from '../utils/ServiceConfigUtil';
+import {findNestedPropertyInObject} from '../../../../../src/js/utils/Util';
+import {VIP_LABEL_VALUE_REGEX} from '../../../../../src/js/constants/Networking';
+
+function checkServiceEndpoints(ports, pathPrefix) {
+  return ports.reduce(function (memo, port, index) {
+    const labels = port.labels || {};
+    const vipLabels = Object.keys(labels)
+      .filter(ServiceConfigUtil.matchVIPLabel);
+
+    vipLabels.forEach(function (label) {
+      if (!VIP_LABEL_VALUE_REGEX.test(labels[label])) {
+        memo.push({
+          path: pathPrefix.concat([index, 'labels', label]),
+          message: 'VIP label should be in the following format: <ip-address|name>:<port>'
+        });
+      }
+    });
+
+    return memo;
+  }, []);
+}
+
+const VipLabelsValidators = {
+  mustContainPort(app) {
+
+    // Single container app with HOST network
+    let ports = findNestedPropertyInObject(app, 'portDefinitions');
+    let pathPrefix = ['portDefinitions'];
+
+    // Single container app with BRIDGE or USER network
+    if (isEmpty(ports)) {
+      ports = findNestedPropertyInObject(app, 'container.docker.portMappings');
+      pathPrefix = ['container', 'docker', 'portMappings'];
+    }
+
+    if (!isEmpty(ports)) {
+      return checkServiceEndpoints(ports, pathPrefix);
+    }
+
+    // Multi container app
+    const containers = app.containers || [];
+
+    return containers.reduce(function (memo, {endpoints = []}, containerIndex) {
+      pathPrefix = ['containers', containerIndex, 'endpoints'];
+
+      return memo.concat(checkServiceEndpoints(endpoints, pathPrefix));
+    }, []);
+  }
+};
+
+module.exports = VipLabelsValidators;

--- a/plugins/services/src/js/validators/VipLabelsValidators.js
+++ b/plugins/services/src/js/validators/VipLabelsValidators.js
@@ -1,5 +1,6 @@
 import {isEmpty} from '../../../../../src/js/utils/ValidatorUtil';
 import ServiceConfigUtil from '../utils/ServiceConfigUtil';
+import NetworkValidatorUtil from '../../../../../src/js/utils/NetworkValidatorUtil';
 import {findNestedPropertyInObject} from '../../../../../src/js/utils/Util';
 import {VIP_LABEL_VALUE_REGEX} from '../../../../../src/js/constants/Networking';
 
@@ -10,10 +11,18 @@ function checkServiceEndpoints(ports, pathPrefix) {
       .filter(ServiceConfigUtil.matchVIPLabel);
 
     vipLabels.forEach(function (label) {
+      const [_address, vipPort] = labels[label].split(':');
+
       if (!VIP_LABEL_VALUE_REGEX.test(labels[label])) {
         memo.push({
           path: pathPrefix.concat([index, 'labels', label]),
-          message: 'VIP label should be in the following format: <ip-address|name>:<port>'
+          message: 'VIP label must be in the following format: <ip-addres|name>:<port>'
+        });
+      }
+      if (!NetworkValidatorUtil.isValidPort(vipPort)) {
+        memo.push({
+          path: pathPrefix.concat([index, 'labels', label]),
+          message: 'Port should be an integrer less than or equal to 65535'
         });
       }
     });

--- a/plugins/services/src/js/validators/VipLabelsValidators.js
+++ b/plugins/services/src/js/validators/VipLabelsValidators.js
@@ -1,39 +1,53 @@
 import {isEmpty} from '../../../../../src/js/utils/ValidatorUtil';
 import ServiceConfigUtil from '../utils/ServiceConfigUtil';
-import NetworkValidatorUtil from '../../../../../src/js/utils/NetworkValidatorUtil';
+import NetworkValidatorUtil
+  from '../../../../../src/js/utils/NetworkValidatorUtil';
 import {findNestedPropertyInObject} from '../../../../../src/js/utils/Util';
-import {VIP_LABEL_VALUE_REGEX} from '../../../../../src/js/constants/Networking';
+import {
+  VIP_LABEL_VALUE_REGEX
+} from '../../../../../src/js/constants/Networking';
 
 function checkServiceEndpoints(ports, pathPrefix) {
-  return ports.reduce(function (memo, port, index) {
-    const labels = port.labels || {};
-    const vipLabels = Object.keys(labels)
-      .filter(ServiceConfigUtil.matchVIPLabel);
+  return ports.reduce(
+    function (portsMemo, port, index) {
+      const labels = port.labels || {};
+      const vipLabels = Object.keys(labels).filter(
+        ServiceConfigUtil.matchVIPLabel
+      );
 
-    vipLabels.forEach(function (label) {
-      const [_address, vipPort] = labels[label].split(':');
+      const errors = vipLabels.reduce(
+        function (errorsMemo, label) {
+          const vipLabelMatch = VIP_LABEL_VALUE_REGEX.exec(labels[label]);
 
-      if (!VIP_LABEL_VALUE_REGEX.test(labels[label])) {
-        memo.push({
-          path: pathPrefix.concat([index, 'labels', label]),
-          message: 'VIP label must be in the following format: <ip-addres|name>:<port>'
-        });
-      }
-      if (!NetworkValidatorUtil.isValidPort(vipPort)) {
-        memo.push({
-          path: pathPrefix.concat([index, 'labels', label]),
-          message: 'Port should be an integrer less than or equal to 65535'
-        });
-      }
-    });
+          if (!vipLabelMatch) {
+            return errorsMemo.concat({
+              path: pathPrefix.concat([index, 'labels', label]),
+              message: 'VIP label must be in the following format: <ip-addres|name>:<port>'
+            });
+          }
 
-    return memo;
-  }, []);
+          const vipPort = vipLabelMatch[2];
+
+          if (!NetworkValidatorUtil.isValidPort(vipPort)) {
+            return errorsMemo.concat({
+              path: pathPrefix.concat([index, 'labels', label]),
+              message: 'Port should be an integrer less than or equal to 65535'
+            });
+          }
+
+          return errorsMemo;
+        },
+        []
+      );
+
+      return portsMemo.concat(errors);
+    },
+    []
+  );
 }
 
 const VipLabelsValidators = {
   mustContainPort(app) {
-
     // Single container app with HOST network
     let ports = findNestedPropertyInObject(app, 'portDefinitions');
     let pathPrefix = ['portDefinitions'];
@@ -51,11 +65,14 @@ const VipLabelsValidators = {
     // Multi container app
     const containers = app.containers || [];
 
-    return containers.reduce(function (memo, {endpoints = []}, containerIndex) {
-      pathPrefix = ['containers', containerIndex, 'endpoints'];
+    return containers.reduce(
+      function (memo, {endpoints = []}, containerIndex) {
+        pathPrefix = ['containers', containerIndex, 'endpoints'];
 
-      return memo.concat(checkServiceEndpoints(endpoints, pathPrefix));
-    }, []);
+        return memo.concat(checkServiceEndpoints(endpoints, pathPrefix));
+      },
+      []
+    );
   }
 };
 

--- a/plugins/services/src/js/validators/__tests__/VipLabelsValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/VipLabelsValidators-test.js
@@ -1,0 +1,116 @@
+jest.unmock('../VipLabelsValidators');
+const VipLabelsValidators = require('../VipLabelsValidators');
+
+const message = 'VIP label should be in the following format: <ip-address|name>:<port>';
+
+describe('VipLabelsValidators', function () {
+
+  describe('#mustContainPort', function () {
+
+    describe('with a Single container app', function () {
+      it('returns no errors if portDefinitions is empty', function () {
+        const spec = {portDefinitions: []};
+        expect(VipLabelsValidators.mustContainPort(spec)).toEqual([]);
+      });
+
+      it('returns no errors if portMappings is empty', function () {
+        const spec = {container: {docker: {portMappings: []}}};
+        expect(VipLabelsValidators.mustContainPort(spec)).toEqual([]);
+      });
+
+      it('returns no errors if VIP label is correct', function () {
+        const spec = {
+          portDefinitions: [
+            {labels: {VIP_0: 'endpoint-name:1000'}}
+          ]
+        };
+        expect(VipLabelsValidators.mustContainPort(spec)).toEqual([]);
+      });
+
+      it('returns no errors if VIP label is correct', function () {
+        const spec = {
+          container: {
+            docker: {
+              portMappings: [
+                {labels: {VIP_0: '0.0.0.0:1000'}}
+              ]
+            }
+          }
+        };
+        expect(VipLabelsValidators.mustContainPort(spec)).toEqual([]);
+      });
+
+      it('returns an error if VIP label is incorrect', function () {
+        const spec = {
+          portDefinitions: [
+            {labels: {VIP_0: 'endpoint-name'}}
+          ]
+        };
+        expect(VipLabelsValidators.mustContainPort(spec)).toEqual([
+          {
+            message,
+            path: ['portDefinitions', 0, 'labels', 'VIP_0']
+          }
+        ]);
+      });
+
+      it('returns an error if VIP label is incorrect', function () {
+        const spec = {
+          container: {
+            docker: {
+              portMappings: [
+                {labels: {VIP_0: '0.0.0.0:port'}}
+              ]
+            }
+          }
+        };
+        expect(VipLabelsValidators.mustContainPort(spec)).toEqual([
+          {
+            message,
+            path: ['container', 'docker', 'portMappings', 0, 'labels', 'VIP_0']
+          }
+        ]);
+      });
+
+    });
+
+    describe('with a Multi container app', function () {
+      it('returns no errors if endpoints is empty', function () {
+        const spec = {containers: [{endpoints: []}]};
+        expect(VipLabelsValidators.mustContainPort(spec)).toEqual([]);
+      });
+
+      it('returns no errors if VIP label is correct', function () {
+        const spec = {
+          containers: [
+            {
+              endpoints: [{labels: {VIP_0: '0.0.0.0:9090'}}]
+            }
+          ]
+        };
+        expect(VipLabelsValidators.mustContainPort(spec)).toEqual([]);
+      });
+
+      it('returns an error if VIP label is incorrect', function () {
+        const spec = {
+          containers: [
+            {
+              endpoints: [
+                {labels: {VIP_0: ':9090'}}
+              ]
+            }
+          ]
+        };
+        expect(VipLabelsValidators.mustContainPort(spec)).toEqual([
+          {
+            message,
+            path: ['containers', 0, 'endpoints', 0, 'labels', 'VIP_0']
+          }
+        ]);
+      });
+
+    });
+
+  });
+
+});

--- a/plugins/services/src/js/validators/__tests__/VipLabelsValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/VipLabelsValidators-test.js
@@ -1,8 +1,6 @@
 jest.unmock('../VipLabelsValidators');
 const VipLabelsValidators = require('../VipLabelsValidators');
 
-const message = 'VIP label should be in the following format: <ip-address|name>:<port>';
-
 describe('VipLabelsValidators', function () {
 
   describe('#mustContainPort', function () {
@@ -48,7 +46,11 @@ describe('VipLabelsValidators', function () {
         };
         expect(VipLabelsValidators.mustContainPort(spec)).toEqual([
           {
-            message,
+            message: 'VIP label must be in the following format: <ip-addres|name>:<port>',
+            path: ['portDefinitions', 0, 'labels', 'VIP_0']
+          },
+          {
+            message: 'Port should be an integrer less than or equal to 65535',
             path: ['portDefinitions', 0, 'labels', 'VIP_0']
           }
         ]);
@@ -66,7 +68,11 @@ describe('VipLabelsValidators', function () {
         };
         expect(VipLabelsValidators.mustContainPort(spec)).toEqual([
           {
-            message,
+            message: 'VIP label must be in the following format: <ip-addres|name>:<port>',
+            path: ['container', 'docker', 'portMappings', 0, 'labels', 'VIP_0']
+          },
+          {
+            message: 'Port should be an integrer less than or equal to 65535',
             path: ['container', 'docker', 'portMappings', 0, 'labels', 'VIP_0']
           }
         ]);
@@ -103,7 +109,7 @@ describe('VipLabelsValidators', function () {
         };
         expect(VipLabelsValidators.mustContainPort(spec)).toEqual([
           {
-            message,
+            message: 'VIP label must be in the following format: <ip-addres|name>:<port>',
             path: ['containers', 0, 'endpoints', 0, 'labels', 'VIP_0']
           }
         ]);

--- a/src/js/constants/Networking.js
+++ b/src/js/constants/Networking.js
@@ -6,7 +6,8 @@ const Networking = {
     USER: 'USER'
   },
   L4LB_ADDRESS: '.marathon.l4lb.thisdcos.directory',
-  VIP_LABEL_REGEX: /^VIP_[0-9]+$/
+  VIP_LABEL_REGEX: /^VIP_[0-9]+$/,
+  VIP_LABEL_VALUE_REGEX: /([\w\d_\-./]+):(\d+)/
 };
 
 module.exports = Networking;


### PR DESCRIPTION
This PR adds a custom validator for VIP labels

Why:

* because there's no other service in the stack that performs that validation but then Minuteman will fail not finding a port

This change addresses the need by:

* I introduced a new custom validator for single and multi container and added it to the form and JSON only editor

DCOS-13519 #close