### PR TITLE
DCOS-12589: Apply tooltips to disabled fields

### DIFF
--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -430,21 +430,19 @@ class NetworkingFormSection extends mixin(StoreMixin) {
       const tooltipMessage = `Service Endpoints are not available in the ${ContainerConstants.labelMap[type]}`;
 
       return (
-        <div>
+        <Tooltip
+          content={tooltipMessage}
+          maxWidth={500}
+          scrollContainer=".gm-scroll-view"
+          wrapperClassName="tooltip-wrapper tooltip-block-wrapper"
+          wrapText={true}>
           <h3 className="short-bottom muted" key="service-endpoints-header">
-            {'Service Endpoints '}
-            <Tooltip
-              content={tooltipMessage}
-              maxWidth={500}
-              scrollContainer=".gm-scroll-view"
-              wrapText={true}>
-              <Icon color="grey" id="lock" size="mini" />
-            </Tooltip>
+            Service Endpoints
           </h3>
           <p key="service-endpoints-description" className="muted">
             DC/OS can automatically generate a Service Address to connect to each of your load balanced endpoints.
           </p>
-        </div>
+        </Tooltip>
       );
     }
 

--- a/src/styles/components/form-elements/form-control-toggle/styles.less
+++ b/src/styles/components/form-elements/form-control-toggle/styles.less
@@ -1,0 +1,9 @@
+& when (@form-control-toggle-enabled) {
+
+  .form-control-toggle {
+
+    &.disabled {
+      cursor: not-allowed;
+    }
+  }
+}

--- a/src/styles/components/form-elements/form-control-toggle/variables.less
+++ b/src/styles/components/form-elements/form-control-toggle/variables.less
@@ -1,0 +1,1 @@
+@form-control-toggle-enabled: true;

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -273,6 +273,11 @@
 @import 'components/form-elements/variables.less';
 @import 'components/form-elements/styles.less';
 
+// Form Elements: Form Control Toggle
+
+@import 'components/form-elements/form-control-toggle/variables.less';
+@import 'components/form-elements/form-control-toggle/styles.less';
+
 // Form Elements: Form Group
 
 @import 'components/form-elements/form-group/variables.less';


### PR DESCRIPTION
This PR moves the disabled tooltip notification to the disabled fields, rather than a lock icon near the disabled field.

Before:
![](https://cl.ly/1G2B3K3K0V2n/Screen%20Shot%202017-02-01%20at%203.15.46%20PM.png)

After:
![](https://cl.ly/3e2p2J113Y0c/Screen%20Shot%202017-02-01%20at%203.00.16%20PM.png)

![](https://cl.ly/2o431f1z1L17/Screen%20Shot%202017-02-01%20at%203.00.22%20PM.png)
_In the above example, a bug in the `Tooltip` prevents us from aligning the tooltip with the left edge of the checkbox. This needs to be fixed in `reactjs-components`._