### PR TITLE
DCOS-13439: Add schedule icon to Jobs breadcrumb

### DIFF
--- a/src/js/components/breadcrumbs/JobsBreadcrumbs.js
+++ b/src/js/components/breadcrumbs/JobsBreadcrumbs.js
@@ -1,9 +1,48 @@
 import {Link} from 'react-router';
+import prettycron from 'prettycron';
 import React from 'react';
+import {Tooltip} from 'reactjs-components';
 
+import Icon from '../Icon';
 import PageHeaderBreadcrumbs from '../../components/PageHeaderBreadcrumbs';
 
-const JobsBreadcrumbs = ({jobID, taskID, taskName, jobStatus}) => {
+function getJobStatus(jobStatus) {
+  if (jobStatus != null) {
+    return (
+      <div className="service-page-header-status page-header-breadcrumb-content-secondary muted">
+        {`(${jobStatus})`}
+      </div>
+    );
+  }
+
+  return null;
+}
+
+function getJobSchedule(jobSchedules) {
+  if (jobSchedules && jobSchedules.length !== 0) {
+    const schedule = jobSchedules[0];
+
+    if (schedule.enabled) {
+      return (
+        <Tooltip
+          wrapperClassName="tooltip-wrapper icon icon-margin-left"
+          content={prettycron.toString(schedule.cron)}
+          maxWidth={250}
+          wrapText={true}>
+          <Icon
+            color="grey"
+            id="repeat"
+            size="mini" />
+        </Tooltip>
+      );
+    }
+  }
+
+  return null;
+}
+
+const JobsBreadcrumbs = (props) => {
+  const {jobID, taskID, taskName, jobSchedules, jobStatus} = props;
   let aggregateIDs = '';
   const crumbs = [
     <Link to="/jobs">Jobs</Link>
@@ -14,22 +53,22 @@ const JobsBreadcrumbs = ({jobID, taskID, taskName, jobStatus}) => {
 
     const jobsCrumbs = ids.map(function (id, index) {
       let status;
+      let scheduleIcon;
+
       if (aggregateIDs !== '') {
         aggregateIDs += '.';
       }
       aggregateIDs += id;
 
-      if (index === ids.length - 1 && jobStatus != null) {
-        status = (
-          <div className="service-page-header-status page-header-breadcrumb-content-secondary muted">
-            {`(${jobStatus})`}
-          </div>
-        );
+      if (index === ids.length - 1) {
+        status = getJobStatus(jobStatus);
+        scheduleIcon = getJobSchedule(jobSchedules);
       }
 
       return (
         <div>
           <Link to={`/jobs/${aggregateIDs}`} key={index}>{id}</Link>
+          {scheduleIcon}
           {status}
         </div>
       );

--- a/src/js/pages/jobs/JobDetailPage.js
+++ b/src/js/pages/jobs/JobDetailPage.js
@@ -405,8 +405,13 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
 
     const job = MetronomeStore.getJob(this.props.params.id);
     const jobStatus = this.getJobStatus(job);
+    const jobSchedules = job.getSchedules();
+
     const breadcrumbs = (
-      <JobsBreadcrumbs jobID={job.getId()} jobStatus={jobStatus} />
+      <JobsBreadcrumbs
+        jobID={job.getId()}
+        jobSchedules={jobSchedules}
+        jobStatus={jobStatus} />
     );
 
     return (


### PR DESCRIPTION
This PR adds the schedule icon to the Jobs breadcrumb.
![](https://cl.ly/0P2O1B1M2z2V/Screen%20Shot%202017-02-01%20at%203.39.07%20PM.png)
![](https://cl.ly/0G1B400H0o02/Screen%20Shot%202017-02-01%20at%203.42.25%20PM.png)

cc @leemunroe 