### PR TITLE
Bug: Fix page header tab alignment

### DIFF
--- a/src/styles/components/menu-tabbed/styles.less
+++ b/src/styles/components/menu-tabbed/styles.less
@@ -62,8 +62,10 @@
     }
 
     .menu-tabbed-item-label {
+      overflow: hidden;
       padding-bottom: @menu-tabbed-vertical-item-link-padding-bottom;
       padding-top: @menu-tabbed-vertical-item-link-padding-top;
+      text-overflow: ellipsis;
 
       &:after {
         bottom: 0;
@@ -108,11 +110,9 @@
     cursor: pointer;
     display: block;
     font-weight: @menu-tabbed-item-link-font-weight;
-    overflow: hidden;
     padding-bottom: @menu-tabbed-horizontal-item-link-padding-bottom;
     position: relative;
     text-decoration: @menu-tabbed-item-link-text-decoration;
-    text-overflow: ellipsis;
 
     &:hover {
       color: @menu-tabbed-item-link-hover-color;


### PR DESCRIPTION
This PR fixes a bug I introduced in #1870. These overflow properties should only be applied to vertical tabs.

Before:
![](https://cl.ly/3D052Y043i0i/Screen%20Shot%202017-02-01%20at%203.59.02%20PM.png)

After:
![](https://cl.ly/1o1N0m1z1E0T/Screen%20Shot%202017-02-01%20at%203.57.24%20PM.png)