### PR TITLE
Bug: Fix .expanding-table's "row" misalignment

### DIFF
--- a/src/styles/components/expanding-table/styles.less
+++ b/src/styles/components/expanding-table/styles.less
@@ -5,6 +5,13 @@
     td {
       line-height: 1.8rem;
       white-space: nowrap;
+
+      // All children in an expanding table's cell needs to have the same
+      // line-height to maintain the illusion of expanding one table row into
+      // many.
+      * {
+        line-height: inherit;
+      }
     }
   }
 


### PR DESCRIPTION
This PR forces `line-height` inheritance on all children of `.expanding-table td`s. This is necessary to maintain proper alignment among the expanded "rows" in each cell (I was tempted to add an `!important` here but opted not to...).

Before:
![](https://cl.ly/2g073W0P040N/Screen%20Shot%202017-02-01%20at%204.25.02%20PM.png)

After:
![](https://cl.ly/1g3J3X140m0M/Screen%20Shot%202017-02-01%20at%204.23.53%20PM.png)