### PR TITLE
Handle `null` cases in `updateLocalJsonState`

### DIFF
--- a/src/js/components/JSONEditor.js
+++ b/src/js/components/JSONEditor.js
@@ -278,7 +278,7 @@ class JSONEditor extends React.Component {
    * Get new JSON state (parsed value and meta data) from json text.
    *
    * @param {String} jsonText - The JSON buffer to extract metadata from
-   * @return {{
+   * @return {null | {
    *      jsonValue:object,
    *      jsonText:string,
    *      jsonMeta:object,
@@ -289,7 +289,7 @@ class JSONEditor extends React.Component {
     // Do not perform heavyweight calculations, such as `getObjectInformation`
     // if the json text hasn't really changed.
     if (this.jsonText === jsonText) {
-      return;
+      return null;
     }
 
     // Reset some properties
@@ -328,17 +328,21 @@ class JSONEditor extends React.Component {
    * want to re-do the processing when this will eventually trigger an update
    * to the `value` property with the same data.
    *
-   * @param {object} jsonSate
-   * @param {object} jsonSate.jsonValue
-   * @param {string} jsonSate.jsonText
-   * @param {object} jsonSate.jsonMeta
-   * @param {string} jsonSate.jsonError
+   * @param {object|null} jsonState
+   * @param {object} jsonState.jsonValue
+   * @param {string} jsonState.jsonText
+   * @param {object} jsonState.jsonMeta
+   * @param {string} jsonState.jsonError
    */
-  updateLocalJsonState(jsonSate) {
-    this.jsonText = jsonSate.jsonText;
-    this.jsonError = jsonSate.jsonError;
-    this.jsonValue = jsonSate.jsonValue;
-    this.jsonMeta = jsonSate.jsonMeta;
+  updateLocalJsonState(jsonState) {
+    if (jsonState == null) {
+      return;
+    }
+
+    this.jsonText = jsonState.jsonText;
+    this.jsonError = jsonState.jsonError;
+    this.jsonValue = jsonState.jsonValue;
+    this.jsonMeta = jsonState.jsonMeta;
 
     // Sync editor without a render cycle
     this.updateEditorState();

--- a/src/js/components/__tests__/JSONEditor-test.js
+++ b/src/js/components/__tests__/JSONEditor-test.js
@@ -130,4 +130,81 @@ describe('JSONEditor', function () {
 
   });
 
+  describe('#updateLocalJsonState', function () {
+    it('should accept `null` as an argument', function () {
+      const instance = ReactDOM.render((
+        <JSONEditor value={{}} />
+      ), this.container);
+
+      instance.updateLocalJsonState(null);
+
+      expect(instance.jsonText).toEqual('{}');
+      expect(instance.jsonValue).toEqual({});
+      expect(instance.jsonMeta).toEqual([]);
+      expect(instance.jsonError).toEqual(null);
+    });
+
+    it('should update all properties as given', function () {
+      const instance = ReactDOM.render((
+        <JSONEditor value={{}} />
+      ), this.container);
+
+      instance.updateLocalJsonState({
+        jsonText  : '[]',
+        jsonError : [{path: 'id', message: 'Required'}],
+        jsonValue : [],
+        jsonMeta  : [{path: 'id', line: 1}]
+      });
+
+      expect(instance.jsonText).toEqual('[]');
+      expect(instance.jsonValue).toEqual([]);
+      expect(instance.jsonMeta).toEqual([{path: 'id', line: 1}]);
+      expect(instance.jsonError).toEqual([{path: 'id', message: 'Required'}]);
+    });
+  });
+
+  describe('#getNewJsonState', function () {
+    it('should return `null` if the text has not changed', function () {
+      const instance = ReactDOM.render((
+        <JSONEditor value={{}} />
+      ), this.container);
+
+      expect(instance.getNewJsonState('{}')).toEqual(null);
+    });
+
+    it('should return errors if JSON is invalid', function () {
+      const instance = ReactDOM.render((
+        <JSONEditor value={{}} />
+      ), this.container);
+
+      expect(instance.getNewJsonState('{')).toEqual({
+        jsonError: 'SyntaxError: Unexpected end of input',
+        jsonMeta: [],
+        jsonText: '{',
+        jsonValue: {}
+      });
+    });
+
+    it('should return the correct state on new JSON', function () {
+      const instance = ReactDOM.render((
+        <JSONEditor value={{}} />
+      ), this.container);
+
+      expect(instance.getNewJsonState('[\n"foo"\n]')).toEqual({
+        jsonError: null,
+        jsonMeta: [
+          {
+            line: 2,
+            path: [0],
+            position: [2, 7],
+            type: 'literal',
+            value: 'foo'
+          }
+        ],
+        jsonText: '[\n"foo"\n]',
+        jsonValue: ['foo']
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
This PR fixes an issue with `JSONEditor` where `getNewJsonState` returns `undefined` and breaks `updateLocalJsonState`