### PR TITLE
Bug: Fix word wrapping in configuration map

### DIFF
--- a/src/styles/components/configuration-map/styles.less
+++ b/src/styles/components/configuration-map/styles.less
@@ -44,6 +44,11 @@
       word-wrap: break-word;
     }
 
+    &-label,
+    &-value {
+      overflow: hidden;
+    }
+
     // We need specificity here to override table styles
     &-action,
     td&-action {
@@ -69,6 +74,7 @@
         code,
         pre {
           white-space: pre-wrap;
+          word-break: break-all;
         }
       }
     }


### PR DESCRIPTION
I thought I corrected this yesterday, but apparently not...

Before:
![](https://cl.ly/1Q2c2H3s3T1V/Screen%20Shot%202017-02-02%20at%201.38.57%20PM.png)

After:
![](https://cl.ly/240r0F1J022m/Screen%20Shot%202017-02-02%20at%201.41.36%20PM.png)