### PR TITLE
[DCOS-12416] Use ConfigurationMap in VirtualNetworkDetailsTab

### DIFF
--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js
@@ -1,22 +1,37 @@
 import React from 'react';
 
 import ConfigurationMap from '../../../components/ConfigurationMap';
-import HashMapDisplay from '../../../components/HashMapDisplay';
+import ConfigurationMapLabel from '../../../components/ConfigurationMapLabel';
+import ConfigurationMapRow from '../../../components/ConfigurationMapRow';
+import ConfigurationMapSection from '../../../components/ConfigurationMapSection';
+import ConfigurationMapValue from '../../../components/ConfigurationMapValue';
 import Overlay from '../../../structs/Overlay';
 
 class VirtualNetworkDetailsTab extends React.Component {
   render() {
     const {overlay} = this.props;
 
-    const details = {
-      Name: overlay.getName(),
-      'IP Subnet': overlay.getSubnet()
-    };
-
     return (
       <div className="container">
         <ConfigurationMap>
-          <HashMapDisplay hash={details} />
+          <ConfigurationMapSection>
+            <ConfigurationMapRow>
+              <ConfigurationMapLabel>
+                Name
+              </ConfigurationMapLabel>
+              <ConfigurationMapValue>
+                {overlay.getName()}
+              </ConfigurationMapValue>
+            </ConfigurationMapRow>
+            <ConfigurationMapRow>
+              <ConfigurationMapLabel>
+                IP Subnet
+              </ConfigurationMapLabel>
+              <ConfigurationMapValue>
+                {overlay.getSubnet()}
+              </ConfigurationMapValue>
+            </ConfigurationMapRow>
+          </ConfigurationMapSection>
         </ConfigurationMap>
       </div>
     );


### PR DESCRIPTION
This PR implements the `ConfigurationMap` components in place of the `HashMapDisplay` component.