### PR TITLE
DCOS-13159: Bug fix: Placement constraints

### DIFF
--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -232,15 +232,11 @@ class GeneralServiceFormSection extends Component {
         </h3>
         <p>Constraints control where apps run to allow optimization for either fault tolerance or locality.</p>
         {this.getPlacementConstraintsFields(data.constraints)}
-        <FormRow>
-          <FormGroup
-            className="column-12"
-            showError={constraintsErrors != null && !Array.isArray(constraintsErrors)}>
-            <FieldError>
-              {constraintsErrors}
-            </FieldError>
-          </FormGroup>
-        </FormRow>
+        <FormGroup showError={constraintsErrors != null && !Array.isArray(constraintsErrors)}>
+          <FieldError>
+            {constraintsErrors}
+          </FieldError>
+        </FormGroup>
         <FormRow>
           <FormGroup className="column-12">
             <AddButton onClick={this.props.onAddItem.bind(

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -294,7 +294,7 @@ class NewCreateServiceModal extends Component {
         activeTab: tabViewID,
         apiErrors,
         serviceReviewActive: false,
-        showAllErrors: false
+        showAllErrors: true
       });
 
       return;

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -583,26 +583,22 @@ class NewCreateServiceModal extends Component {
         MultiContainerNetworkingFormSection
       ];
 
-      const isPod = serviceSpec instanceof PodSpec;
-
       let jsonParserReducers = combineParsers(
         Hooks.applyFilter('serviceCreateJsonParserReducers', JSONParser)
       );
 
-      if (isPod) {
+      let jsonConfigReducers = combineReducers(
+        Hooks.applyFilter('serviceJsonConfigReducers', JSONAppReducers)
+      );
+
+      if (serviceSpec instanceof PodSpec) {
         jsonParserReducers = combineParsers(
           Hooks.applyFilter(
             'serviceCreateJsonParserReducers',
             JSONMultiContainerParser
           )
         );
-      }
 
-      let jsonConfigReducers = combineReducers(
-        Hooks.applyFilter('serviceJsonConfigReducers', JSONAppReducers)
-      );
-
-      if (isPod) {
         jsonConfigReducers = combineReducers(
           Hooks.applyFilter(
             'serviceJsonConfigReducers',

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -44,6 +44,7 @@ import Util from '../../../../../../src/js/utils/Util';
 import GeneralServiceFormSection from '../forms/GeneralServiceFormSection';
 import HealthChecksFormSection from '../forms/HealthChecksFormSection';
 import JSONAppReducers from '../../reducers/JSONAppReducers';
+import JSONMultiContainerParser from '../../reducers/JSONMultiContainerParser';
 import JSONMultiContainerReducers from '../../reducers/JSONMultiContainerReducers';
 import JSONParser from '../../reducers/JSONParser';
 import ModalHeading from '../../../../../../src/js/components/modals/ModalHeading';
@@ -85,6 +86,9 @@ const APP_VALIDATORS = [
   MarathonAppValidators.complyWithResidencyRules,
   MarathonAppValidators.complyWithIpAddressRules,
   MarathonAppValidators.mustContainImageOnDocker,
+  MarathonAppValidators.validateConstraints,
+  MarathonAppValidators.containerVolmesPath,
+  MarathonAppValidators.mustNotContainUris,
   VipLabelsValidators.mustContainPort
 ];
 
@@ -579,11 +583,20 @@ class NewCreateServiceModal extends Component {
         MultiContainerNetworkingFormSection
       ];
 
-      const jsonParserReducers = combineParsers(
+      const isPod = serviceSpec instanceof PodSpec;
+
+      let jsonParserReducers = combineParsers(
         Hooks.applyFilter('serviceCreateJsonParserReducers', JSONParser)
       );
 
-      const isPod = serviceSpec instanceof PodSpec;
+      if (isPod) {
+        jsonParserReducers = combineParsers(
+          Hooks.applyFilter(
+            'serviceCreateJsonParserReducers',
+            JSONMultiContainerParser
+          )
+        );
+      }
 
       let jsonConfigReducers = combineReducers(
         Hooks.applyFilter('serviceJsonConfigReducers', JSONAppReducers)
@@ -591,7 +604,10 @@ class NewCreateServiceModal extends Component {
 
       if (isPod) {
         jsonConfigReducers = combineReducers(
-          Hooks.applyFilter('serviceJsonConfigReducers', JSONMultiContainerReducers)
+          Hooks.applyFilter(
+            'serviceJsonConfigReducers',
+            JSONMultiContainerReducers
+          )
         );
       }
 

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -117,9 +117,14 @@ class NewCreateServiceModalForm extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     const {editingFieldPath, appConfig} = this.state;
+    const {onChange, service} = this.props;
 
-    if ((editingFieldPath === null) && (prevState.editingFieldPath !== null)) {
-      this.props.onChange(new this.props.service.constructor(appConfig));
+    const shouldUpdate = (editingFieldPath === null) && (
+      prevState.editingFieldPath !== null ||
+      !deepEqual(appConfig, prevState.appConfig)
+    );
+    if (shouldUpdate) {
+      onChange(new service.constructor(appConfig));
     }
   }
 

--- a/plugins/services/src/js/constants/OperatorTypes.js
+++ b/plugins/services/src/js/constants/OperatorTypes.js
@@ -1,21 +1,33 @@
 const OperatorTypes = {
   UNIQUE: {
-    requiresValue: false
+    requiresValue: false,
+    requiresEmptyValue: true,
+    stringNumberValue: false
   },
   CLUSTER: {
-    requiresValue: true
+    requiresValue: true,
+    requiresEmptyValue: false,
+    stringNumberValue: false
   },
   GROUP_BY: {
-    requiresValue: false
+    requiresValue: false,
+    requiresEmptyValue: false,
+    stringNumberValue: true
   },
   LIKE: {
-    requiresValue: true
+    requiresValue: true,
+    requiresEmptyValue: false,
+    stringNumberValue: false
   },
   UNLIKE: {
-    requiresValue: true
+    requiresValue: true,
+    requiresEmptyValue: false,
+    stringNumberValue: false
   },
   MAX_PER: {
-    requiresValue: true
+    requiresValue: true,
+    requiresEmptyValue: false,
+    stringNumberValue: true
   }
 };
 

--- a/plugins/services/src/js/constants/OperatorTypes.js
+++ b/plugins/services/src/js/constants/OperatorTypes.js
@@ -1,27 +1,21 @@
 const OperatorTypes = {
-  types: {
-    UNIQUE: 'UNIQUE',
-    CLUSTER: 'CLUSTER',
-    GROUP_BY: 'GROUP_BY',
-    LIKE: 'LIKE',
-    UNLIKE: 'UNLIKE',
-    MAX_PER: 'MAX_PER'
+  UNIQUE: {
+    requiresValue: false
   },
-  isRequired: {
-    UNIQUE: false,
-    CLUSTER: true,
-    GROUP_BY: false,
-    LIKE: true,
-    UNLIKE: true,
-    MAX_PER: true
+  CLUSTER: {
+    requiresValue: true
   },
-  hasThirdField: {
-    UNIQUE: false,
-    CLUSTER: true,
-    GROUP_BY: false,
-    LIKE: true,
-    UNLIKE: true,
-    MAX_PER: true
+  GROUP_BY: {
+    requiresValue: false
+  },
+  LIKE: {
+    requiresValue: true
+  },
+  UNLIKE: {
+    requiresValue: true
+  },
+  MAX_PER: {
+    requiresValue: true
   }
 };
 

--- a/plugins/services/src/js/constants/OperatorTypes.js
+++ b/plugins/services/src/js/constants/OperatorTypes.js
@@ -1,10 +1,28 @@
 const OperatorTypes = {
-  UNIQUE: 'UNIQUE',
-  CLUSTER: 'CLUSTER',
-  GROUP_BY: 'GROUP_BY',
-  LIKE: 'LIKE',
-  UNLIKE: 'UNLIKE',
-  MAX_PER: 'MAX_PER'
+  types: {
+    UNIQUE: 'UNIQUE',
+    CLUSTER: 'CLUSTER',
+    GROUP_BY: 'GROUP_BY',
+    LIKE: 'LIKE',
+    UNLIKE: 'UNLIKE',
+    MAX_PER: 'MAX_PER'
+  },
+  isRequired: {
+    UNIQUE: false,
+    CLUSTER: true,
+    GROUP_BY: false,
+    LIKE: true,
+    UNLIKE: true,
+    MAX_PER: true
+  },
+  hasThirdField: {
+    UNIQUE: false,
+    CLUSTER: true,
+    GROUP_BY: false,
+    LIKE: true,
+    UNLIKE: true,
+    MAX_PER: true
+  }
 };
 
 module.exports = OperatorTypes;

--- a/plugins/services/src/js/reducers/JSONMultiContainerParser.js
+++ b/plugins/services/src/js/reducers/JSONMultiContainerParser.js
@@ -1,0 +1,43 @@
+import {JSONParser as container} from './serviceForm/Container';
+import {JSONParser as constraints} from './serviceForm/MultiContainerConstraints';
+import {JSONParser as fetch} from './serviceForm/Artifacts';
+import {JSONParser as environmentVariables} from './serviceForm/EnvironmentVariables';
+import {JSONParser as externalVolumes} from './serviceForm/ExternalVolumes';
+import {JSONParser as healthChecks} from './serviceForm/HealthChecks';
+import {JSONParser as labels} from './serviceForm/Labels';
+import {JSONParser as localVolumes} from './serviceForm/LocalVolumes';
+import {JSONParser as portDefinitions} from './serviceForm/PortDefinitions';
+import {JSONParser as portMappings} from './serviceForm/PortMappings';
+import {JSONParser as residency} from './serviceForm/Residency';
+import {JSONParser as scaling} from './serviceForm/MultiContainerScaling';
+import {JSONParser as network} from './serviceForm/Network';
+import {JSONParser as multiContainerNetwork} from './serviceForm/MultiContainerNetwork';
+import {JSONParser as volumeMounts} from './serviceForm/MultiContainerVolumes';
+import {simpleParser} from '../../../../../src/js/utils/ParserUtil';
+import {JSONParser as containers} from './serviceForm/Containers';
+
+module.exports = [
+  simpleParser(['id']),
+  simpleParser(['instances']),
+  simpleParser(['cpus']),
+  simpleParser(['mem']),
+  simpleParser(['disk']),
+  simpleParser(['gpus']),
+  simpleParser(['cmd']),
+  container,
+  containers,
+  network,
+  multiContainerNetwork,
+  volumeMounts,
+  portDefinitions,
+  portMappings, // Note: must come after portDefinitions, as it uses its information!
+  environmentVariables,
+  labels,
+  scaling,
+  healthChecks,
+  localVolumes,
+  externalVolumes,
+  constraints,
+  residency,
+  fetch
+];

--- a/plugins/services/src/js/reducers/JSONMultiContainerReducers.js
+++ b/plugins/services/src/js/reducers/JSONMultiContainerReducers.js
@@ -1,4 +1,4 @@
-import {JSONReducer as scheduling} from './serviceForm/MultiContainerConstraints';
+import {JSONReducer as constraints} from './serviceForm/MultiContainerConstraints';
 import {JSONReducer as containers} from './serviceForm/Containers';
 import {JSONReducer as env} from './serviceForm/EnvironmentVariables';
 import {JSONReducer as fetch} from './serviceForm/Artifacts';
@@ -17,7 +17,13 @@ module.exports = {
   env,
   scaling,
   labels,
-  scheduling,
+  scheduling(state, transaction) {
+    return {
+      placement: {
+        constraints: constraints.bind(this)(state, transaction)
+      }
+    };
+  },
   fetch,
   volumes,
   networks,

--- a/plugins/services/src/js/reducers/JSONMultiContainerReducers.js
+++ b/plugins/services/src/js/reducers/JSONMultiContainerReducers.js
@@ -1,4 +1,4 @@
-import {JSONReducer as constraints} from './serviceForm/Constraints';
+import {JSONReducer as scheduling} from './serviceForm/MultiContainerConstraints';
 import {JSONReducer as containers} from './serviceForm/Containers';
 import {JSONReducer as env} from './serviceForm/EnvironmentVariables';
 import {JSONReducer as fetch} from './serviceForm/Artifacts';
@@ -17,7 +17,7 @@ module.exports = {
   env,
   scaling,
   labels,
-  constraints,
+  scheduling,
   fetch,
   volumes,
   networks,

--- a/plugins/services/src/js/reducers/serviceForm/Constraints.js
+++ b/plugins/services/src/js/reducers/serviceForm/Constraints.js
@@ -31,9 +31,15 @@ module.exports = {
     }
 
     return JSONParser(
-      constraints.map(function ([fieldName, operator, value]) {
-        return {fieldName, operator, value};
-      })
+      constraints.reduce(function (memo, constraint) {
+        if (!Array.isArray(constraint)) {
+          return memo;
+        }
+        const [fieldName, operator, value] = constraint;
+        memo.push({fieldName, operator, value});
+
+        return memo;
+      }, [])
     );
   }
 };

--- a/plugins/services/src/js/reducers/serviceForm/Constraints.js
+++ b/plugins/services/src/js/reducers/serviceForm/Constraints.js
@@ -1,118 +1,39 @@
-import {
-  ADD_ITEM,
-  REMOVE_ITEM,
-  SET
-} from '../../../../../../src/js/constants/TransactionTypes';
 import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
 import {isEmpty} from '../../../../../../src/js/utils/ValidatorUtil';
-import Transaction from '../../../../../../src/js/structs/Transaction';
-import {hasThirdField} from '../../constants/OperatorTypes';
-
-const CONSTRAINT_FIELDS = ['fieldName', 'operator', 'value'];
-
-function getJson(constraints) {
-  return constraints.filter((item = {}) => {
-    return !isEmpty(item.fieldName) && !isEmpty(item.operator);
-  }).map(({fieldName, operator, value}) => {
-    const normalizedOperator = operator.toUpperCase();
-
-    if (!isEmpty(value)) {
-      return [fieldName, normalizedOperator, value];
-    }
-
-    return [fieldName, normalizedOperator];
-  });
-}
-
-function processTransaction(state, {type, path, value}) {
-  const [fieldName, index, name] = path;
-
-  if (fieldName !== 'constraints') {
-    return state;
-  }
-
-  let newState = state.slice();
-
-  if (type === ADD_ITEM) {
-    newState.push({fieldName: null, operator: null, value: null});
-  }
-  if (type === REMOVE_ITEM) {
-    newState = newState.filter((item, index) => {
-      return index !== value;
-    });
-  }
-  if (type === SET && CONSTRAINT_FIELDS.includes(name)) {
-    newState[index][name] = value;
-  }
-
-  if (name === 'operator' && !hasThirdField[value]) {
-    newState[index].value = null;
-  }
-
-  return newState;
-}
+import {
+  FormReducer,
+  JSONParser,
+  JSONReducer
+} from './common/Constraints';
 
 module.exports = {
-  JSONReducer(state, {type, path, value}) {
-    if (path == null) {
-      return state;
-    }
-    if (this.constraints == null) {
-      this.constraints = [];
-    }
+  FormReducer,
+  JSONReducer(state, transaction) {
+    const constraints = JSONReducer.bind(this)(state, transaction);
 
-    this.constraints = processTransaction(
-      this.constraints,
-      {type, path, value}
-    );
+    return constraints.map(function ({fieldName, operator, value}) {
+      if (!isEmpty(value)) {
+        return [fieldName, operator, value];
+      }
 
-    return getJson(this.constraints);
+      return [fieldName, operator];
+    });
   },
 
   JSONParser(state) {
-    const constraints = findNestedPropertyInObject(state, 'constraints');
+    const constraints = findNestedPropertyInObject(
+      state,
+      'constraints'
+    ) || [];
 
-    // Ignore non-array constraints
     if (!Array.isArray(constraints)) {
       return [];
     }
 
-    return state.constraints.reduce(function (memo, item, index) {
-      if (!Array.isArray(item)) {
-        return memo;
-      }
-
-      const [fieldName, operator, value] = item;
-      memo.push(new Transaction(['constraints'], index, ADD_ITEM));
-      memo.push(new Transaction([
-        'constraints',
-        index,
-        'fieldName'
-      ], fieldName, SET));
-      memo.push(new Transaction([
-        'constraints',
-        index,
-        'operator'
-      ], operator, SET));
-
-      // Skip if value is not set
-      if (value != null) {
-        memo.push(new Transaction([
-          'constraints',
-          index,
-          'value'
-        ], value, SET));
-      }
-
-      return memo;
-    }, []);
-  },
-
-  FormReducer(state = [], {type, path, value}) {
-    if (path == null || !Array.isArray(state)) {
-      return state;
-    }
-
-    return processTransaction(state, {type, path, value});
+    return JSONParser(
+      constraints.map(function ([fieldName, operator, value]) {
+        return {fieldName, operator, value};
+      })
+    );
   }
 };

--- a/plugins/services/src/js/reducers/serviceForm/Constraints.js
+++ b/plugins/services/src/js/reducers/serviceForm/Constraints.js
@@ -3,6 +3,7 @@ import {
   REMOVE_ITEM,
   SET
 } from '../../../../../../src/js/constants/TransactionTypes';
+import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
 import {isEmpty} from '../../../../../../src/js/utils/ValidatorUtil';
 import Transaction from '../../../../../../src/js/structs/Transaction';
 import {hasThirdField} from '../../constants/OperatorTypes';
@@ -69,7 +70,10 @@ module.exports = {
   },
 
   JSONParser(state) {
-    if (state.constraints == null) {
+    const constraints = findNestedPropertyInObject(state, 'constraints');
+
+    // Ignore non-array constraints
+    if (!Array.isArray(constraints)) {
       return [];
     }
 
@@ -90,23 +94,25 @@ module.exports = {
         index,
         'operator'
       ], operator, SET));
-      memo.push(new Transaction([
-        'constraints',
-        index,
-        'value'
-      ], value, SET));
+
+      // Skip if value is not set
+      if (value != null) {
+        memo.push(new Transaction([
+          'constraints',
+          index,
+          'value'
+        ], value, SET));
+      }
 
       return memo;
     }, []);
   },
 
   FormReducer(state = [], {type, path, value}) {
-    if (path == null) {
+    if (path == null || !Array.isArray(state)) {
       return state;
     }
 
-    state = processTransaction(state, {type, path, value});
-
-    return state;
+    return processTransaction(state, {type, path, value});
   }
 };

--- a/plugins/services/src/js/reducers/serviceForm/MultiContainerConstraints.js
+++ b/plugins/services/src/js/reducers/serviceForm/MultiContainerConstraints.js
@@ -1,73 +1,23 @@
-import {
-  ADD_ITEM,
-  REMOVE_ITEM,
-  SET
-} from '../../../../../../src/js/constants/TransactionTypes';
 import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
 import {isEmpty} from '../../../../../../src/js/utils/ValidatorUtil';
-import Transaction from '../../../../../../src/js/structs/Transaction';
-import {hasThirdField} from '../../constants/OperatorTypes';
-
-const CONSTRAINT_FIELDS = ['fieldName', 'operator', 'value'];
-
-function getJson(constraints) {
-  return constraints.filter((item = {}) => {
-    return !isEmpty(item.fieldName) && !isEmpty(item.operator);
-  }).map(({fieldName, operator, value}) => {
-    const normalizedOperator = operator.toUpperCase();
-
-    if (!isEmpty(value)) {
-      return {fieldName, operator: normalizedOperator, value};
-    }
-
-    return {fieldName, operator: normalizedOperator};
-  });
-}
-
-function processTransaction(state, {type, path, value}) {
-  const [fieldName, index, name] = path;
-
-  if (fieldName !== 'constraints') {
-    return state;
-  }
-
-  let newState = state.slice();
-
-  if (type === ADD_ITEM) {
-    newState.push({fieldName: null, operator: null, value: null});
-  }
-  if (type === REMOVE_ITEM) {
-    newState = newState.filter((item, index) => {
-      return index !== value;
-    });
-  }
-  if (type === SET && CONSTRAINT_FIELDS.includes(name)) {
-    newState[index][name] = value;
-  }
-
-  if (name === 'operator' && !hasThirdField[value]) {
-    newState[index].value = null;
-  }
-
-  return newState;
-}
+import {
+  FormReducer,
+  JSONParser,
+  JSONReducer
+} from './common/Constraints';
 
 module.exports = {
-  JSONReducer(state, {type, path, value}) {
-    if (path == null) {
-      return state;
-    }
-    if (this.constraints == null) {
-      this.constraints = [];
-    }
+  FormReducer,
+  JSONReducer(state, transaction) {
+    const constraints = JSONReducer.bind(this)(state, transaction);
 
-    this.constraints = processTransaction(
-      this.constraints,
-      {type, path, value}
-    );
+    return constraints.map(function ({fieldName, operator, value}) {
+      if (!isEmpty(value)) {
+        return {fieldName, operator, value};
+      }
 
-    // Will be applied in the `scheduling` object
-    return {placement: {constraints: getJson(this.constraints)}};
+      return {fieldName, operator};
+    });
   },
 
   JSONParser(state) {
@@ -75,47 +25,7 @@ module.exports = {
       state,
       'scheduling.placement.constraints'
     );
-    // Ignore non-array constraints
-    if (!Array.isArray(constraints)) {
-      return [];
-    }
 
-    return constraints.reduce(function (memo, item, index) {
-      if (typeof item !== 'object') {
-        return memo;
-      }
-
-      const {fieldName, operator, value} = item;
-      memo.push(new Transaction(['constraints'], index, ADD_ITEM));
-      memo.push(new Transaction([
-        'constraints',
-        index,
-        'fieldName'
-      ], fieldName, SET));
-      memo.push(new Transaction([
-        'constraints',
-        index,
-        'operator'
-      ], operator, SET));
-
-      // Skip if value is not set
-      if (value != null) {
-        memo.push(new Transaction([
-          'constraints',
-          index,
-          'value'
-        ], value, SET));
-      }
-
-      return memo;
-    }, []);
-  },
-
-  FormReducer(state = [], {type, path, value}) {
-    if (path == null) {
-      return state;
-    }
-
-    return processTransaction(state, {type, path, value});
+    return JSONParser(constraints);
   }
 };

--- a/plugins/services/src/js/reducers/serviceForm/MultiContainerConstraints.js
+++ b/plugins/services/src/js/reducers/serviceForm/MultiContainerConstraints.js
@@ -75,7 +75,8 @@ module.exports = {
       state,
       'scheduling.placement.constraints'
     );
-    if (constraints == null) {
+    // Ignore non-array constraints
+    if (!Array.isArray(constraints)) {
       return [];
     }
 
@@ -96,11 +97,15 @@ module.exports = {
         index,
         'operator'
       ], operator, SET));
-      memo.push(new Transaction([
-        'constraints',
-        index,
-        'value'
-      ], value, SET));
+
+      // Skip if value is not set
+      if (value != null) {
+        memo.push(new Transaction([
+          'constraints',
+          index,
+          'value'
+        ], value, SET));
+      }
 
       return memo;
     }, []);
@@ -111,8 +116,6 @@ module.exports = {
       return state;
     }
 
-    state = processTransaction(state, {type, path, value});
-
-    return state;
+    return processTransaction(state, {type, path, value});
   }
 };

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Constraints-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Constraints-test.js
@@ -47,7 +47,13 @@ describe('Constraints', function () {
 
     it('ignores non-array constraints', function () {
       expect(Constraints.JSONParser({
-        constraints: {}
+        constraints: {fieldName: 'hostname', operator: 'JOIN', value: 'param'}
+      })).toEqual([]);
+    });
+
+    it('ignores non-array constraint items', function () {
+      expect(Constraints.JSONParser({
+        constraints: [{fieldName: 'hostname', operator: 'JOIN', value: 'param'}]
       })).toEqual([]);
     });
 

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Constraints-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Constraints-test.js
@@ -19,15 +19,28 @@ describe('Constraints', function () {
         .toEqual([['hostname', 'JOIN', 'param']]);
     });
 
-    it('skips optional value', function () {
+    it('skips value required to be empty after operator was set', function () {
       const batch = new Batch([
         new Transaction(['constraints'], 0, ADD_ITEM),
         new Transaction(['constraints', 0, 'fieldName'], 'hostname', SET),
-        new Transaction(['constraints', 0, 'operator'], 'JOIN', SET)
+        new Transaction(['constraints', 0, 'operator'], 'UNIQUE', SET),
+        new Transaction(['constraints', 0, 'value'], 'foo', SET)
       ]);
 
       expect(batch.reduce(Constraints.JSONReducer.bind({}), []))
-        .toEqual([['hostname', 'JOIN']]);
+        .toEqual([['hostname', 'UNIQUE']]);
+    });
+
+    it('skips value required to be empty before operator was set', function () {
+      const batch = new Batch([
+        new Transaction(['constraints'], 0, ADD_ITEM),
+        new Transaction(['constraints', 0, 'fieldName'], 'hostname', SET),
+        new Transaction(['constraints', 0, 'value'], 'foo', SET),
+        new Transaction(['constraints', 0, 'operator'], 'UNIQUE', SET)
+      ]);
+
+      expect(batch.reduce(Constraints.JSONReducer.bind({}), []))
+        .toEqual([['hostname', 'UNIQUE']]);
     });
 
   });

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Constraints-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Constraints-test.js
@@ -10,7 +10,7 @@ describe('Constraints', function () {
     it('emits correct JSON', function () {
       const batch = new Batch([
         new Transaction(['constraints'], 0, ADD_ITEM),
-        new Transaction(['constraints', 0, 'field'], 'hostname', SET),
+        new Transaction(['constraints', 0, 'fieldName'], 'hostname', SET),
         new Transaction(['constraints', 0, 'operator'], 'JOIN', SET),
         new Transaction(['constraints', 0, 'value'], 'param', SET)
       ]);
@@ -22,7 +22,7 @@ describe('Constraints', function () {
     it('skips optional value', function () {
       const batch = new Batch([
         new Transaction(['constraints'], 0, ADD_ITEM),
-        new Transaction(['constraints', 0, 'field'], 'hostname', SET),
+        new Transaction(['constraints', 0, 'fieldName'], 'hostname', SET),
         new Transaction(['constraints', 0, 'operator'], 'JOIN', SET)
       ]);
 

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/MulitContainerConstraints-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/MulitContainerConstraints-test.js
@@ -18,9 +18,9 @@ describe('MultiContainerConstraints', function () {
       // Doesn't expect 'scheduling' in the beginning as this object is passed
       // to the 'scheduling' key on the appConfig
       expect(batch.reduce(MultiContainerConstraints.JSONReducer.bind({}), []))
-        .toEqual({placement: {constraints: [
+        .toEqual([
           {fieldName: 'hostname', operator: 'JOIN', value: 'param'}
-        ]}});
+        ]);
     });
 
     it('skips optional value', function () {
@@ -33,9 +33,9 @@ describe('MultiContainerConstraints', function () {
       // Doesn't expect 'scheduling' in the beginning as this object is passed
       // to the 'scheduling' key on the appConfig
       expect(batch.reduce(MultiContainerConstraints.JSONReducer.bind({}), []))
-        .toEqual({placement: {constraints: [
+        .toEqual([
           {fieldName: 'hostname', operator: 'JOIN'}
-        ]}});
+        ]);
     });
 
   });

--- a/plugins/services/src/js/reducers/serviceForm/common/Constraints.js
+++ b/plugins/services/src/js/reducers/serviceForm/common/Constraints.js
@@ -1,0 +1,111 @@
+import {
+  ADD_ITEM,
+  REMOVE_ITEM,
+  SET
+} from '../../../../../../../src/js/constants/TransactionTypes';
+import Transaction from '../../../../../../../src/js/structs/Transaction';
+import {hasThirdField} from '../../../constants/OperatorTypes';
+import {isEmpty} from '../../../../../../../src/js/utils/ValidatorUtil';
+
+const CONSTRAINT_FIELDS = ['fieldName', 'operator', 'value'];
+
+function processTransaction(state, {type, path, value}) {
+  const [fieldName, index, name] = path;
+
+  if (fieldName !== 'constraints') {
+    return state;
+  }
+
+  let newState = state.slice();
+
+  if (type === ADD_ITEM) {
+    newState.push({fieldName: null, operator: null, value: null});
+  }
+  if (type === REMOVE_ITEM) {
+    newState = newState.filter((item, index) => {
+      return index !== value;
+    });
+  }
+  if (type === SET && CONSTRAINT_FIELDS.includes(name)) {
+    newState[index][name] = value;
+  }
+
+  if (name === 'operator' && !hasThirdField[value]) {
+    newState[index].value = null;
+  }
+
+  return newState;
+}
+
+module.exports = {
+  JSONParser(constraints) {
+    // Ignore non-array constraints
+    if (!Array.isArray(constraints)) {
+      return [];
+    }
+
+    return constraints.reduce(function (memo, item, index) {
+      if (typeof item !== 'object') {
+        return memo;
+      }
+
+      const {fieldName, operator, value} = item;
+      memo.push(new Transaction(['constraints'], index, ADD_ITEM));
+      memo.push(new Transaction([
+        'constraints',
+        index,
+        'fieldName'
+      ], fieldName, SET));
+      memo.push(new Transaction([
+        'constraints',
+        index,
+        'operator'
+      ], operator, SET));
+
+      // Skip if value is not set
+      if (value != null) {
+        memo.push(new Transaction([
+          'constraints',
+          index,
+          'value'
+        ], value, SET));
+      }
+
+      return memo;
+    }, []);
+  },
+
+  JSONReducer(state, {type, path, value}) {
+    if (path == null) {
+      return state;
+    }
+    if (this.constraints == null) {
+      this.constraints = [];
+    }
+
+    this.constraints = processTransaction(
+      this.constraints,
+      {type, path, value}
+    );
+
+    return this.constraints
+      .filter(function (item = {}) {
+        return !isEmpty(item.fieldName) && !isEmpty(item.operator);
+      })
+      .map(function ({fieldName, operator, value}) {
+        return {
+          fieldName,
+          value,
+          operator: operator.toUpperCase()
+        };
+      });
+  },
+
+  FormReducer(state = [], {type, path, value}) {
+    if (path == null || !Array.isArray(state)) {
+      return state;
+    }
+
+    return processTransaction(state, {type, path, value});
+  }
+};

--- a/plugins/services/src/js/reducers/serviceForm/common/Constraints.js
+++ b/plugins/services/src/js/reducers/serviceForm/common/Constraints.js
@@ -4,7 +4,7 @@ import {
   SET
 } from '../../../../../../../src/js/constants/TransactionTypes';
 import Transaction from '../../../../../../../src/js/structs/Transaction';
-import {hasThirdField} from '../../../constants/OperatorTypes';
+import PlacementConstraintsUtil from '../../../utils/PlacementConstraintsUtil';
 import {isEmpty} from '../../../../../../../src/js/utils/ValidatorUtil';
 
 const CONSTRAINT_FIELDS = ['fieldName', 'operator', 'value'];
@@ -30,7 +30,7 @@ function processTransaction(state, {type, path, value}) {
     newState[index][name] = value;
   }
 
-  if (name === 'operator' && !hasThirdField[value]) {
+  if (name === 'operator' && !PlacementConstraintsUtil.requiresValue(value)) {
     newState[index].value = null;
   }
 

--- a/plugins/services/src/js/reducers/serviceForm/common/Constraints.js
+++ b/plugins/services/src/js/reducers/serviceForm/common/Constraints.js
@@ -4,7 +4,7 @@ import {
   SET
 } from '../../../../../../../src/js/constants/TransactionTypes';
 import Transaction from '../../../../../../../src/js/structs/Transaction';
-import PlacementConstraintsUtil from '../../../utils/PlacementConstraintsUtil';
+import {requiresEmptyValue} from '../../../utils/PlacementConstraintsUtil';
 import {isEmpty} from '../../../../../../../src/js/utils/ValidatorUtil';
 
 const CONSTRAINT_FIELDS = ['fieldName', 'operator', 'value'];
@@ -26,11 +26,12 @@ function processTransaction(state, {type, path, value}) {
       return index !== value;
     });
   }
-  if (type === SET && CONSTRAINT_FIELDS.includes(name)) {
+  if (type === SET && CONSTRAINT_FIELDS.includes(name) &&
+    !requiresEmptyValue(newState[index].operator)) {
     newState[index][name] = value;
   }
 
-  if (name === 'operator' && !PlacementConstraintsUtil.requiresValue(value)) {
+  if (name === 'operator' && requiresEmptyValue(value)) {
     newState[index].value = null;
   }
 

--- a/plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js
@@ -31,7 +31,7 @@ class PodPlacementConstraintsConfigSection extends React.Component {
     ) || [];
 
     return constraints.map(function ({fieldName, operator, value}) {
-      if (!PlacementConstraintsUtil.requiresValue(operator)) {
+      if (PlacementConstraintsUtil.requiresEmptyValue(operator)) {
         value = <em>Not Applicable</em>;
       }
 

--- a/plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js
@@ -4,12 +4,13 @@ import {findNestedPropertyInObject} from '../../../../../src/js/utils/Util';
 import ConfigurationMapTable from '../components/ConfigurationMapTable.js';
 import ConfigurationMapHeading from '../../../../../src/js/components/ConfigurationMapHeading';
 import ConfigurationMapSection from '../../../../../src/js/components/ConfigurationMapSection';
+import {hasThirdField} from '../constants/OperatorTypes';
 
 class PodPlacementConstraintsConfigSection extends React.Component {
   getColumns() {
     return [
       {
-        heading: 'Label',
+        heading: 'Field Name',
         prop: 'fieldName'
       },
       {
@@ -18,22 +19,32 @@ class PodPlacementConstraintsConfigSection extends React.Component {
       },
       {
         heading: 'Value',
-        prop: 'value',
-        hideIfempty: true
+        prop: 'value'
       }
     ];
   }
 
-  render() {
-    const {onEditClick} = this.props;
+  getConstraints() {
     const constraints = findNestedPropertyInObject(
       this.props.appConfig,
       'scheduling.placement.constraints'
-    );
+    ) || [];
 
+    return constraints.map(function ({fieldName, operator, value}) {
+      if (!hasThirdField[operator]) {
+        value = <em>Not Applicable</em>;
+      }
+
+      return {fieldName, operator, value};
+    });
+  }
+
+  render() {
+    const {onEditClick} = this.props;
+    const constraints = this.getConstraints();
     // Since we are stateless component we will need to return something for react
     // so we are using the `<noscript>` tag as placeholder.
-    if (!constraints || !constraints.length) {
+    if (!constraints.length) {
       return <noscript />;
     }
 
@@ -45,7 +56,6 @@ class PodPlacementConstraintsConfigSection extends React.Component {
         <ConfigurationMapSection>
           <ConfigurationMapTable
             columns={this.getColumns()}
-            columnDefaults={{hideIfempty: true}}
             data={constraints}
             onEditClick={onEditClick}
             tabViewID="services" />

--- a/plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import {findNestedPropertyInObject} from '../../../../../src/js/utils/Util';
-import ConfigurationMapTable from '../components/ConfigurationMapTable.js';
+import ConfigurationMapTable from '../components/ConfigurationMapTable';
 import ConfigurationMapHeading from '../../../../../src/js/components/ConfigurationMapHeading';
 import ConfigurationMapSection from '../../../../../src/js/components/ConfigurationMapSection';
-import {hasThirdField} from '../constants/OperatorTypes';
+import PlacementConstraintsUtil from '../utils/PlacementConstraintsUtil';
 
 class PodPlacementConstraintsConfigSection extends React.Component {
   getColumns() {
@@ -31,7 +31,7 @@ class PodPlacementConstraintsConfigSection extends React.Component {
     ) || [];
 
     return constraints.map(function ({fieldName, operator, value}) {
-      if (!hasThirdField[operator]) {
+      if (!PlacementConstraintsUtil.requiresValue(operator)) {
         value = <em>Not Applicable</em>;
       }
 

--- a/plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.js
@@ -1,109 +1,74 @@
 import React from 'react';
-import {Table} from 'reactjs-components';
 
-import ConfigurationMapEditAction from '../components/ConfigurationMapEditAction';
-import ServiceConfigBaseSectionDisplay from './ServiceConfigBaseSectionDisplay';
-import ServiceConfigDisplayUtil from '../utils/ServiceConfigDisplayUtil';
+import ConfigurationMapTable from '../components/ConfigurationMapTable.js';
+import ConfigurationMapHeading from '../../../../../src/js/components/ConfigurationMapHeading';
+import ConfigurationMapSection from '../../../../../src/js/components/ConfigurationMapSection';
+import {hasThirdField} from '../constants/OperatorTypes';
 
-class ServicePlacementConstraintsConfigSection extends ServiceConfigBaseSectionDisplay {
-  /**
-  * @override
-  */
-  shouldExcludeItem() {
-    return this.props.appConfig.constraints == null ||
-      this.props.appConfig.constraints.length === 0;
+class ServicePlacementConstraintsConfigSection extends React.Component {
+  getColumns() {
+    return [
+      {
+        heading: 'Field Name',
+        prop: 'fieldName'
+      },
+      {
+        heading: 'Operator',
+        prop: 'operator'
+      },
+      {
+        heading: 'Value',
+        prop: 'value'
+      }
+    ];
   }
 
-  /**
-   * @override
-   */
-  getDefinition() {
+  getConstraints() {
+    const {constraints = []} = this.props.appConfig;
+
+    return constraints.map(function ([fieldName, operator, value]) {
+      if (!hasThirdField[operator]) {
+        value = <em>Not Applicable</em>;
+      }
+
+      return {fieldName, operator, value};
+    });
+  }
+
+  render() {
     const {onEditClick} = this.props;
+    const constraints = this.getConstraints();
 
-    return {
-      tabViewID: 'services',
-      values: [
-        {
-          key: 'constraints',
-          heading: 'Placement Constraints',
-          headingLevel: 2
-        },
-        {
-          key: 'constraints',
-          render(data) {
-            const columns = [
-              {
-                heading: ServiceConfigDisplayUtil.getColumnHeadingFn('Field Name'),
-                prop: 'field',
-                render(prop, row) {
-                  const value = row[prop];
+    // Since we are stateless component we will need to return something for react
+    // so we are using the `<noscript>` tag as placeholder.
+    if (!constraints.length) {
+      return <noscript />;
+    }
 
-                  return ServiceConfigDisplayUtil.getDisplayValue(value);
-                },
-                className: ServiceConfigDisplayUtil.getColumnClassNameFn(
-                  'configuration-map-table-label'
-                ),
-                sortable: true
-              },
-              {
-                heading: ServiceConfigDisplayUtil.getColumnHeadingFn('Operator'),
-                prop: 'operator',
-                render(prop, row) {
-                  const value = row[prop];
-
-                  return ServiceConfigDisplayUtil.getDisplayValue(value);
-                },
-                className: ServiceConfigDisplayUtil.getColumnClassNameFn(
-                  'configuration-map-table-value'
-                ),
-                sortable: true
-              },
-              {
-                heading: ServiceConfigDisplayUtil.getColumnHeadingFn('Value'),
-                prop: 'value',
-                render(prop, row) {
-                  const value = row[prop];
-
-                  return ServiceConfigDisplayUtil.getDisplayValue(value);
-                },
-                className: ServiceConfigDisplayUtil.getColumnClassNameFn(
-                  'configuration-map-table-value'
-                ),
-                sortable: true
-              }
-            ];
-
-            if (onEditClick) {
-              columns.push({
-                heading() { return null; },
-                className: 'configuration-map-action',
-                prop: 'edit',
-                render() {
-                  return (
-                    <ConfigurationMapEditAction
-                      onEditClick={onEditClick}
-                      tabViewID="services" />
-                  );
-                }
-              });
-            }
-
-            const mappedData = data.map((item) => {
-              return {field: item[0], operator: item[1], value: item[2]};
-            });
-
-            return (
-              <Table
-                key="constraints-table"
-                className="table table-simple table-align-top table-break-word table-fixed-layout flush-bottom"
-                columns={columns}
-                data={mappedData} />
-            );
-          }
-        }
-      ]
-    };
+    return (
+      <div>
+        <ConfigurationMapHeading level={3}>
+          Placement Constraints
+        </ConfigurationMapHeading>
+        <ConfigurationMapSection>
+          <ConfigurationMapTable
+            columns={this.getColumns()}
+            data={constraints}
+            onEditClick={onEditClick}
+            tabViewID="services" />
+        </ConfigurationMapSection>
+      </div>
+    );
   }
-}
+};
+
+ServicePlacementConstraintsConfigSection.defaultProps = {
+  appConfig: {}
+};
+
+ServicePlacementConstraintsConfigSection.propTypes = {
+  appConfig: React.PropTypes.object,
+  onEditClick: React.PropTypes.func
+};
 
 module.exports = ServicePlacementConstraintsConfigSection;

--- a/plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.js
@@ -27,7 +27,7 @@ class ServicePlacementConstraintsConfigSection extends React.Component {
     const {constraints = []} = this.props.appConfig;
 
     return constraints.map(function ([fieldName, operator, value]) {
-      if (!PlacementConstraintsUtil.requiresValue(operator)) {
+      if (PlacementConstraintsUtil.requiresEmptyValue(operator)) {
         value = <em>Not Applicable</em>;
       }
 

--- a/plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import ConfigurationMapTable from '../components/ConfigurationMapTable.js';
+import ConfigurationMapTable from '../components/ConfigurationMapTable';
 import ConfigurationMapHeading from '../../../../../src/js/components/ConfigurationMapHeading';
 import ConfigurationMapSection from '../../../../../src/js/components/ConfigurationMapSection';
-import {hasThirdField} from '../constants/OperatorTypes';
+import PlacementConstraintsUtil from '../utils/PlacementConstraintsUtil';
 
 class ServicePlacementConstraintsConfigSection extends React.Component {
   getColumns() {
@@ -27,7 +27,7 @@ class ServicePlacementConstraintsConfigSection extends React.Component {
     const {constraints = []} = this.props.appConfig;
 
     return constraints.map(function ([fieldName, operator, value]) {
-      if (!hasThirdField[operator]) {
+      if (!PlacementConstraintsUtil.requiresValue(operator)) {
         value = <em>Not Applicable</em>;
       }
 

--- a/plugins/services/src/js/utils/DeclinedOffersUtil.js
+++ b/plugins/services/src/js/utils/DeclinedOffersUtil.js
@@ -138,7 +138,16 @@ const DeclinedOffersUtil = {
       },
       constraints: {
         requested: requestedResources.constraints.map((constraint = []) => {
-          return constraint.join(':');
+          if (Array.isArray(constraint)) {
+            return constraint.join(':');
+          }
+
+          // pod
+          const {fieldName, operator, value} = constraint;
+
+          return [fieldName, operator, value].filter(function (value) {
+            return value && value !== '';
+          }).join(':');
         }).join(', ') || UNAVAILABLE_TEXT,
         offers: constraintOfferSummary.processed,
         matched: constraintOfferSummary.processed

--- a/plugins/services/src/js/utils/PlacementConstraintsUtil.js
+++ b/plugins/services/src/js/utils/PlacementConstraintsUtil.js
@@ -5,5 +5,17 @@ module.exports = {
     const constraintType = OperatorTypes[operator] || {};
 
     return constraintType.requiresValue;
+  },
+
+  stringNumberValue(operator) {
+    const constraintType = OperatorTypes[operator] || {};
+
+    return constraintType.stringNumberValue;
+  },
+
+  requiresEmptyValue(operator) {
+    const constraintType = OperatorTypes[operator] || {};
+
+    return constraintType.requiresEmptyValue;
   }
 };

--- a/plugins/services/src/js/utils/PlacementConstraintsUtil.js
+++ b/plugins/services/src/js/utils/PlacementConstraintsUtil.js
@@ -1,0 +1,9 @@
+import OperatorTypes from '../constants/OperatorTypes';
+
+module.exports = {
+  requiresValue(operator) {
+    const constraintType = OperatorTypes[operator] || {};
+
+    return constraintType.requiresValue;
+  }
+};

--- a/plugins/services/src/js/utils/__tests__/DeclinedOffersUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/DeclinedOffersUtil-test.js
@@ -149,7 +149,10 @@ describe('DeclinedOffersUtil', function () {
           scheduling: {
             placement: {
               acceptedResourceRoles: ['foo', 'bar'],
-              constraints: [['foo.constraint.1', 'foo.constraint.2', 'foo.constraint.3']]
+              constraints: [
+                {fieldName: 'hostname', operator: 'LIKE', value: 'hostname'},
+                {fieldName: 'hostname', operator: 'UNIQUE'}
+              ]
             }
           }
         },
@@ -213,7 +216,7 @@ describe('DeclinedOffersUtil', function () {
           matched: 123
         },
         constraints: {
-          requested: 'foo.constraint.1:foo.constraint.2:foo.constraint.3',
+          requested: 'hostname:LIKE:hostname, hostname:UNIQUE',
           offers: 123,
           matched: 123
         },

--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -2,7 +2,7 @@ import ContainerConstants from '../constants/ContainerConstants';
 import ValidatorUtil from '../../../../../src/js/utils/ValidatorUtil';
 import {findNestedPropertyInObject} from '../../../../../src/js/utils/Util';
 import {PROP_CONFLICT, PROP_DEPRECATED, PROP_MISSING_ALL, PROP_MISSING_ONE} from '../constants/ServiceErrorTypes';
-import OperatorTypes from '../constants/OperatorTypes';
+import PlacementConstraintsUtil from '../utils/PlacementConstraintsUtil';
 
 const {DOCKER} = ContainerConstants.type;
 
@@ -265,8 +265,11 @@ const MarathonAppValidators = {
       }
 
       const [_fieldName, operator, value] = constraint;
+      const isValueRequiredAndEmpty =
+        PlacementConstraintsUtil.requiresValue(operator) &&
+        ValidatorUtil.isEmpty(value);
 
-      if (OperatorTypes.isRequired[operator] && ValidatorUtil.isEmpty(value)) {
+      if (isValueRequiredAndEmpty) {
         errors.push({
           path: ['constraints', index, 'value'],
           message: message.replace('{{operator}}', operator),

--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -244,7 +244,8 @@ const MarathonAppValidators = {
       // No errors
       return [{
         path: ['constraints'],
-        message: 'constrains needs to be an array of 2 or 3 element arrays'
+        message: 'constrains needs to be an array of 2 or 3 element arrays',
+        type: 'TYPE_NOT_ARRAY'
       }];
     }
 
@@ -256,7 +257,8 @@ const MarathonAppValidators = {
       if (!Array.isArray(constraint)) {
         errors.push({
           path: ['constraints', index],
-          message: 'Must be an array'
+          message: 'Must be an array',
+          type: 'TYPE_NOT_ARRAY'
         });
 
         return errors;

--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -239,7 +239,7 @@ const MarathonAppValidators = {
   },
 
   validateConstraints(app) {
-    const constraints = findNestedPropertyInObject(app, 'constraints');
+    const constraints = findNestedPropertyInObject(app, 'constraints') || [];
     if (constraints != null && !Array.isArray(constraints)) {
       // No errors
       return [{

--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -249,6 +249,7 @@ const MarathonAppValidators = {
     }
 
     const isRequiredMessage = 'You must specify a value for operator {{operator}}';
+    const isRequiredEmptyMessage = 'Value must be empty for operator {{operator}}';
     const isStringNumberMessage = 'Must only contain characters between 0-9 for operator {{operator}}';
     const variables = {name: 'value'};
 
@@ -274,6 +275,19 @@ const MarathonAppValidators = {
           path: ['constraints', index, 'value'],
           message: isRequiredMessage.replace('{{operator}}', operator),
           type: PROP_MISSING_ONE,
+          variables
+        });
+      }
+      const isValueDefinedAndRequiredEmpty = (
+        PlacementConstraintsUtil.requiresEmptyValue(operator) &&
+        value != null
+      );
+
+      if (isValueDefinedAndRequiredEmpty) {
+        errors.push({
+          path: ['constraints', index, 'value'],
+          message: isRequiredEmptyMessage.replace('{{operator}}', operator),
+          type: SYNTAX_ERROR,
           variables
         });
       }

--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -252,7 +252,18 @@ const MarathonAppValidators = {
     const type = PROP_MISSING_ONE;
     const variables = {name: 'value'};
 
-    return constraints.reduce((errors, [fieldName, operator, value], index) => {
+    return constraints.reduce((errors, constraint, index) => {
+      if (!Array.isArray(constraint)) {
+        errors.push({
+          path: ['constraints', index],
+          message: 'Must be an array'
+        });
+
+        return errors;
+      }
+
+      const [_fieldName, operator, value] = constraint;
+
       if (OperatorTypes.isRequired[operator] && ValidatorUtil.isEmpty(value)) {
         errors.push({
           path: ['constraints', index, 'value'],

--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -279,8 +279,7 @@ const MarathonAppValidators = {
       }
       const isValueNotAStringNumberWhenRequired = (
         PlacementConstraintsUtil.stringNumberValue(operator) &&
-        typeof value === 'string' &&
-        isNaN(parseInt(value, 10))
+        !ValidatorUtil.isStringInteger(value)
       );
 
       if (isValueNotAStringNumberWhenRequired) {

--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -2,6 +2,7 @@ import ContainerConstants from '../constants/ContainerConstants';
 import ValidatorUtil from '../../../../../src/js/utils/ValidatorUtil';
 import {findNestedPropertyInObject} from '../../../../../src/js/utils/Util';
 import {PROP_CONFLICT, PROP_DEPRECATED, PROP_MISSING_ALL, PROP_MISSING_ONE} from '../constants/ServiceErrorTypes';
+import OperatorTypes from '../constants/OperatorTypes';
 
 const {DOCKER} = ContainerConstants.type;
 
@@ -235,6 +236,34 @@ const MarathonAppValidators = {
 
     // No errors
     return [];
+  },
+
+  validateConstraints(app) {
+    const constraints = findNestedPropertyInObject(app, 'constraints');
+    if (constraints != null && !Array.isArray(constraints)) {
+      // No errors
+      return [{
+        path: ['constraints'],
+        message: 'constrains needs to be an array of 2 or 3 element arrays'
+      }];
+    }
+
+    const message = 'You must specify a value for operator {{operator}}';
+    const type = PROP_MISSING_ONE;
+    const variables = {name: 'value'};
+
+    return constraints.reduce((errors, [fieldName, operator, value], index) => {
+      if (OperatorTypes.isRequired[operator] && ValidatorUtil.isEmpty(value)) {
+        errors.push({
+          path: ['constraints', index, 'value'],
+          message: message.replace('{{operator}}', operator),
+          type,
+          variables
+        });
+      }
+
+      return errors;
+    }, []);
   }
 };
 

--- a/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
@@ -1,6 +1,6 @@
 jest.unmock('../MarathonAppValidators');
 const MarathonAppValidators = require('../MarathonAppValidators');
-const {PROP_MISSING_ONE} = require('../../constants/ServiceErrorTypes');
+const {PROP_MISSING_ONE, SYNTAX_ERROR} = require('../../constants/ServiceErrorTypes');
 
 const APPCONTAINERID_ERRORS = [
   {
@@ -411,6 +411,37 @@ describe('MarathonAppValidators', function () {
         type: PROP_MISSING_ONE,
         variables: {name: 'value'}
       }]);
+    });
+
+    it('returns an error when wrong characters are applied', function () {
+      const spec = {
+        constraints: [
+          [
+            'CPUS',
+            'MAX_PER',
+            'foo'
+          ]
+        ]
+      };
+      expect(MarathonAppValidators.validateConstraints(spec)).toEqual([{
+        path: ['constraints', 0, 'value'],
+        message: 'Must only contain characters between 0-9 for operator MAX_PER',
+        type: SYNTAX_ERROR,
+        variables: {name: 'value'}
+      }]);
+    });
+
+    it('accepts number strings for number-string fields', function () {
+      const spec = {
+        constraints: [
+          [
+            'CPUS',
+            'MAX_PER',
+            '2'
+          ]
+        ]
+      };
+      expect(MarathonAppValidators.validateConstraints(spec)).toEqual([]);
     });
   });
 });

--- a/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
@@ -378,7 +378,8 @@ describe('MarathonAppValidators', function () {
       };
       expect(MarathonAppValidators.validateConstraints(spec)).toEqual([{
         path: ['constraints'],
-        message: 'constrains needs to be an array of 2 or 3 element arrays'
+        message: 'constrains needs to be an array of 2 or 3 element arrays',
+        type: 'TYPE_NOT_ARRAY'
       }]);
     });
 
@@ -390,7 +391,8 @@ describe('MarathonAppValidators', function () {
       };
       expect(MarathonAppValidators.validateConstraints(spec)).toEqual([{
         path: ['constraints', 0],
-        message: 'Must be an array'
+        message: 'Must be an array',
+        type: 'TYPE_NOT_ARRAY'
       }]);
     });
 

--- a/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
@@ -413,6 +413,24 @@ describe('MarathonAppValidators', function () {
       }]);
     });
 
+    it('returns an error when empty parameter is required', function () {
+      const spec = {
+        constraints: [
+          [
+            'CPUS',
+            'UNIQUE',
+            'foo'
+          ]
+        ]
+      };
+      expect(MarathonAppValidators.validateConstraints(spec)).toEqual([{
+        path: ['constraints', 0, 'value'],
+        message: 'Value must be empty for operator UNIQUE',
+        type: SYNTAX_ERROR,
+        variables: {name: 'value'}
+      }]);
+    });
+
     it('returns an error when wrong characters are applied', function () {
       const spec = {
         constraints: [

--- a/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
@@ -401,14 +401,32 @@ describe('MarathonAppValidators', function () {
         constraints: [
           [
             'CPUS',
-            'MAX_PER'
+            'LIKE'
           ]
         ]
       };
       expect(MarathonAppValidators.validateConstraints(spec)).toEqual([{
         path: ['constraints', 0, 'value'],
-        message: 'You must specify a value for operator MAX_PER',
+        message: 'You must specify a value for operator LIKE',
         type: PROP_MISSING_ONE,
+        variables: {name: 'value'}
+      }]);
+    });
+
+    it('returns an error when wrong characters are applied', function () {
+      const spec = {
+        constraints: [
+          [
+            'CPUS',
+            'GROUP_BY',
+            '2foo'
+          ]
+        ]
+      };
+      expect(MarathonAppValidators.validateConstraints(spec)).toEqual([{
+        path: ['constraints', 0, 'value'],
+        message: 'Must only contain characters between 0-9 for operator GROUP_BY',
+        type: SYNTAX_ERROR,
         variables: {name: 'value'}
       }]);
     });

--- a/src/js/components/form/AdvancedSection.js
+++ b/src/js/components/form/AdvancedSection.js
@@ -7,12 +7,10 @@ import AdvancedSectionLabel from './AdvancedSectionLabel';
 const METHODS_TO_BIND = ['handleHeadingClick'];
 
 class AdvancedSection extends React.Component {
-  constructor() {
+  constructor(props) {
     super(...arguments);
 
-    this.state = {
-      isExpanded: false
-    };
+    this.state = {isExpanded: props.initialIsExpanded === true};
 
     METHODS_TO_BIND.forEach((method) => {
       this[method] = this[method].bind(this);
@@ -55,6 +53,7 @@ class AdvancedSection extends React.Component {
 }
 
 AdvancedSection.propTypes = {
+  initialIsExpanded: React.PropTypes.bool,
   children: React.PropTypes.node,
   className: React.PropTypes.oneOfType([
     React.PropTypes.array,

--- a/src/js/utils/ValidatorUtil.js
+++ b/src/js/utils/ValidatorUtil.js
@@ -50,6 +50,10 @@ var ValidatorUtil = {
     const number = parseFloat(value);
 
     return ValidatorUtil.isNumber(value) && number >= min && number <= max;
+  },
+
+  isStringInteger(value) {
+    return typeof value === 'string' && /^([0-9]+)$/.test(value);
   }
 };
 

--- a/src/js/utils/__tests__/ValidatorUtil-test.js
+++ b/src/js/utils/__tests__/ValidatorUtil-test.js
@@ -270,4 +270,47 @@ describe('ValidatorUtil', function () {
 
   });
 
+  describe('#isStringInteger', function () {
+    it('should properly handle empty strings', function () {
+      expect(ValidatorUtil.isStringInteger('')).toBe(false);
+    });
+
+    it('should properly handle undefined values', function () {
+      expect(ValidatorUtil.isStringInteger()).toBe(false);
+    });
+
+    it('should properly handle null values', function () {
+      expect(ValidatorUtil.isStringInteger(null)).toBe(false);
+    });
+
+    it('should properly handle wrong value types', function () {
+      expect(ValidatorUtil.isStringInteger('not a number 666')).toBe(false);
+      expect(ValidatorUtil.isStringInteger('2a+1')).toBe(false);
+      expect(ValidatorUtil.isStringInteger('2a1')).toBe(false);
+      expect(ValidatorUtil.isStringInteger('0.0001')).toBe(false);
+      expect(ValidatorUtil.isStringInteger(-.1)).toBe(false);
+      expect(ValidatorUtil.isStringInteger('-.1')).toBe(false);
+      expect(ValidatorUtil.isStringInteger('2e+1')).toBe(false);
+      expect(ValidatorUtil.isStringInteger('2e1')).toBe(false);
+      expect(ValidatorUtil.isStringInteger('1.23')).toBe(false);
+    });
+
+    it('should handle integer string inputs', function () {
+      expect(ValidatorUtil.isStringInteger('2')).toBe(true);
+      expect(ValidatorUtil.isStringInteger('123')).toBe(true);
+    });
+
+    it('should disregard any value is in a number', function () {
+      expect(ValidatorUtil.isStringInteger(0.1)).toBe(false);
+      expect(ValidatorUtil.isStringInteger(2.2)).toBe(false);
+      expect(ValidatorUtil.isStringInteger(-.3)).toBe(false);
+      expect(ValidatorUtil.isStringInteger(0)).toBe(false);
+      expect(ValidatorUtil.isStringInteger(1)).toBe(false);
+      expect(ValidatorUtil.isStringInteger(2)).toBe(false);
+      expect(ValidatorUtil.isStringInteger(2e+1)).toBe(false);
+      expect(ValidatorUtil.isStringInteger(2e1)).toBe(false);
+    });
+
+  });
+
 });


### PR DESCRIPTION
Placement constraints was not working for pods and had a few issues.

This PR makes the placement constraints work for pods again with a separate reducer for this (there is a unique items issue that @wavesoft is working on separately). It also introduces form validation for placement constraints and displays `Not Applicable` in the ServiceConfigDisplay for `value`s that are empty.

NB: I encountered an error while working on this that was introduced here: https://github.com/dcos/dcos-ui/commit/31630d08344f2a2d00f2534a9333e084fc459a76

Before:
![](https://cl.ly/270S3P0Q1k2m/Image%202017-01-31%20at%2016.03.45.png)

After:
![](https://cl.ly/0v1R001j3O1b/Image%202017-01-31%20at%2016.32.54.png)