### PR TITLE
Fix sidebar scrollbar bug

### DIFF
--- a/src/styles/components/user-account-dropdown/variables.less
+++ b/src/styles/components/user-account-dropdown/variables.less
@@ -71,11 +71,11 @@
 @user-account-dropdown-menu-primary-padding-right-screen-large: @base-spacing-unit-screen-large * 1/4;
 @user-account-dropdown-menu-primary-padding-right-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/4;
 
-@user-account-dropdown-menu-primary-margin-bottom: @base-spacing-unit * 1/8;
-@user-account-dropdown-menu-primary-margin-bottom-screen-small: @base-spacing-unit-screen-small * 1/8;
-@user-account-dropdown-menu-primary-margin-bottom-screen-medium: @base-spacing-unit-screen-medium * 1/8;
-@user-account-dropdown-menu-primary-margin-bottom-screen-large: @base-spacing-unit-screen-large * 1/8;
-@user-account-dropdown-menu-primary-margin-bottom-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/8;
+@user-account-dropdown-menu-primary-margin-bottom: round(@base-spacing-unit * 1/8);
+@user-account-dropdown-menu-primary-margin-bottom-screen-small: round(@base-spacing-unit-screen-small * 1/8);
+@user-account-dropdown-menu-primary-margin-bottom-screen-medium: round(@base-spacing-unit-screen-medium * 1/8);
+@user-account-dropdown-menu-primary-margin-bottom-screen-large: round(@base-spacing-unit-screen-large * 1/8);
+@user-account-dropdown-menu-primary-margin-bottom-screen-jumbo: round(@base-spacing-unit-screen-jumbo * 1/8);
 
 @user-account-dropdown-menu-copy-text-margin-left: @base-spacing-unit * 1/4;
 @user-account-dropdown-menu-copy-text-margin-left-screen-small: @base-spacing-unit-screen-small * 1/4;


### PR DESCRIPTION
This PR rounds one of the variables in the user account menu because it was resulting the component's height ending in a half pixel. This in turn causes Gemini to be off by one pixel when it calculates its own height.

Before (note the height of the user account dropdown button is `63.5px`, and the 1px sliver of native scrollbar at the bottom of the scroll panel):
![](https://d3vv6lp55qjaqc.cloudfront.net/items/0t0026120R2d3H1S450y/%5B0fc443c3f66b9c1035a741cf0de59ffd%5D_Screen%2520Shot%25202017-02-06%2520at%252010.21.45%2520AM.png)

After:
![](https://d3vv6lp55qjaqc.cloudfront.net/items/1c1p2o2f1j0Q0k0F202B/%5B2a5f931ce9b2a9d78726a6b81b9f5aa7%5D_Screen%2520Shot%25202017-02-06%2520at%252010.22.11%2520AM.png)