### PR TITLE
[1 of 2] DCOS-12713: Emitting xhr object in action error handlers

### DIFF
--- a/plugins/services/src/js/events/MarathonActions.js
+++ b/plugins/services/src/js/events/MarathonActions.js
@@ -303,10 +303,11 @@ var MarathonActions = {
               });
               resolve();
             },
-            error(e) {
+            error(xhr) {
               AppDispatcher.handleServerAction({
                 type: REQUEST_MARATHON_GROUPS_ERROR,
-                data: e.message
+                data: xhr.message,
+                xhr
               });
               reject();
             },
@@ -334,10 +335,11 @@ var MarathonActions = {
               });
               resolve();
             },
-            error(e) {
+            error(xhr) {
               AppDispatcher.handleServerAction({
                 type: REQUEST_MARATHON_DEPLOYMENTS_ERROR,
-                data: e.message
+                data: xhr.message,
+                xhr
               });
               reject();
             },
@@ -364,7 +366,8 @@ var MarathonActions = {
       error(xhr) {
         AppDispatcher.handleServerAction({
           type: REQUEST_MARATHON_SERVICE_VERSION_ERROR,
-          data: RequestUtil.getErrorFromXHR(xhr)
+          data: RequestUtil.getErrorFromXHR(xhr),
+          xhr
         });
       }
     });
@@ -383,7 +386,8 @@ var MarathonActions = {
       error(xhr) {
         AppDispatcher.handleServerAction({
           type: REQUEST_MARATHON_SERVICE_VERSIONS_ERROR,
-          data: RequestUtil.getErrorFromXHR(xhr)
+          data: RequestUtil.getErrorFromXHR(xhr),
+          xhr
         });
       }
     });
@@ -401,7 +405,8 @@ var MarathonActions = {
       error(xhr) {
         AppDispatcher.handleServerAction({
           type: REQUEST_MARATHON_INSTANCE_INFO_ERROR,
-          data: RequestUtil.getErrorFromXHR(xhr)
+          data: RequestUtil.getErrorFromXHR(xhr),
+          xhr
         });
       }
     });
@@ -422,10 +427,11 @@ var MarathonActions = {
               });
               resolve();
             },
-            error(e) {
+            error(xhr) {
               AppDispatcher.handleServerAction({
                 type: REQUEST_MARATHON_QUEUE_ERROR,
-                data: e.message
+                data: xhr.message,
+                xhr
               });
               reject();
             },
@@ -456,7 +462,8 @@ var MarathonActions = {
           data: {
             originalDeploymentID: deploymentID,
             error: RequestUtil.parseResponseBody(xhr)
-          }
+          },
+          xhr
         });
       }
     });
@@ -487,7 +494,8 @@ var MarathonActions = {
       error(xhr) {
         AppDispatcher.handleServerAction({
           type: REQUEST_MARATHON_TASK_KILL_ERROR,
-          data: RequestUtil.parseResponseBody(xhr)
+          data: RequestUtil.parseResponseBody(xhr),
+          xhr
         });
       }
     });
@@ -513,7 +521,8 @@ var MarathonActions = {
       error(xhr) {
         AppDispatcher.handleServerAction({
           type: REQUEST_MARATHON_POD_INSTANCE_KILL_ERROR,
-          data: RequestUtil.parseResponseBody(xhr)
+          data: RequestUtil.parseResponseBody(xhr),
+          xhr
         });
       }
     });

--- a/plugins/services/src/js/events/MesosLogActions.js
+++ b/plugins/services/src/js/events/MesosLogActions.js
@@ -22,7 +22,8 @@ const MesosLogActions = {
           type: ActionTypes.REQUEST_MESOS_LOG_OFFSET_ERROR,
           data: RequestUtil.getErrorFromXHR(xhr),
           path,
-          slaveID
+          slaveID,
+          xhr
         });
       }
     });
@@ -44,7 +45,8 @@ const MesosLogActions = {
           type: ActionTypes.REQUEST_MESOS_LOG_ERROR,
           data: RequestUtil.getErrorFromXHR(xhr),
           path,
-          slaveID
+          slaveID,
+          xhr
         });
       }
     });
@@ -66,7 +68,8 @@ const MesosLogActions = {
           type: ActionTypes.REQUEST_PREVIOUS_MESOS_LOG_ERROR,
           data: RequestUtil.getErrorFromXHR(xhr),
           path,
-          slaveID
+          slaveID,
+          xhr
         });
       }
     });

--- a/plugins/services/src/js/events/TaskDirectoryActions.js
+++ b/plugins/services/src/js/events/TaskDirectoryActions.js
@@ -57,7 +57,8 @@ var TaskDirectoryActions = {
               type: REQUEST_NODE_STATE_ERROR,
               data: xhr.message,
               task,
-              node
+              node,
+              xhr
             });
             reject();
           }
@@ -97,7 +98,8 @@ var TaskDirectoryActions = {
         AppDispatcher.handleServerAction({
           type: REQUEST_TASK_DIRECTORY_ERROR,
           data: xhr.message,
-          task
+          task,
+          xhr
         });
       }
     });

--- a/plugins/services/src/js/events/__tests__/MarathonActions-test.js
+++ b/plugins/services/src/js/events/__tests__/MarathonActions-test.js
@@ -66,6 +66,22 @@ describe('MarathonActions', function () {
       this.configuration.error({message: 'error'});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
   describe('#deleteGroup', function () {
@@ -115,6 +131,22 @@ describe('MarathonActions', function () {
       });
 
       this.configuration.error({message: 'error', response: '{}'});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
   });
@@ -177,6 +209,22 @@ describe('MarathonActions', function () {
       this.configuration.error({message: 'error', response: '{}'});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
   describe('#createService', function () {
@@ -235,6 +283,22 @@ describe('MarathonActions', function () {
         this.configuration.error({message: 'error', response: '{}'});
       });
 
+      it('dispatches the xhr when unsuccessful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.xhr).toEqual({
+            foo: 'bar',
+            responseJSON: {description: 'baz'}
+          });
+        });
+
+        this.configuration.error({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
     });
 
     describe('pod', function () {
@@ -291,6 +355,22 @@ describe('MarathonActions', function () {
         this.configuration.error({message: 'error', response: '{}'});
       });
 
+      it('dispatches the xhr when unsuccessful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.xhr).toEqual({
+            foo: 'bar',
+            responseJSON: {description: 'baz'}
+          });
+        });
+
+        this.configuration.error({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
     });
 
   });
@@ -343,6 +423,22 @@ describe('MarathonActions', function () {
         this.configuration.error({message: 'error', response: '{}'});
       });
 
+      it('dispatches the xhr when unsuccessful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.xhr).toEqual({
+            foo: 'bar',
+            responseJSON: {description: 'baz'}
+          });
+        });
+
+        this.configuration.error({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
     });
 
     describe('pod', function () {
@@ -389,6 +485,22 @@ describe('MarathonActions', function () {
         });
 
         this.configuration.error({message: 'error', response: '{}'});
+      });
+
+      it('dispatches the xhr when unsuccessful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.xhr).toEqual({
+            foo: 'bar',
+            responseJSON: {description: 'baz'}
+          });
+        });
+
+        this.configuration.error({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
       });
 
     });
@@ -455,6 +567,22 @@ describe('MarathonActions', function () {
         this.configuration.error({message: 'error', response: '{}'});
       });
 
+      it('dispatches the xhr when unsuccessful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.xhr).toEqual({
+            foo: 'bar',
+            responseJSON: {description: 'baz'}
+          });
+        });
+
+        this.configuration.error({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
     });
 
     describe('pods', function () {
@@ -512,6 +640,22 @@ describe('MarathonActions', function () {
         });
 
         this.configuration.error({message: 'error', response: '{}'});
+      });
+
+      it('dispatches the xhr when unsuccessful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.xhr).toEqual({
+            foo: 'bar',
+            responseJSON: {description: 'baz'}
+          });
+        });
+
+        this.configuration.error({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
       });
 
     });
@@ -573,6 +717,22 @@ describe('MarathonActions', function () {
         this.configuration.error({message: 'error', response: '{}'});
       });
 
+      it('dispatches the xhr when unsuccessful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.xhr).toEqual({
+            foo: 'bar',
+            responseJSON: {description: 'baz'}
+          });
+        });
+
+        this.configuration.error({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
     });
 
     describe('pods', function () {
@@ -628,6 +788,22 @@ describe('MarathonActions', function () {
         this.configuration.error({message: 'error', response: '{}'});
       });
 
+      it('dispatches the xhr when unsuccessful', function () {
+        var id = AppDispatcher.register(function (payload) {
+          var action = payload.action;
+          AppDispatcher.unregister(id);
+          expect(action.xhr).toEqual({
+            foo: 'bar',
+            responseJSON: {description: 'baz'}
+          });
+        });
+
+        this.configuration.error({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
     });
   });
 
@@ -674,6 +850,22 @@ describe('MarathonActions', function () {
       this.configuration.error({message: 'error'});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
   describe('#fetchGroups', function () {
@@ -717,6 +909,22 @@ describe('MarathonActions', function () {
       });
 
       this.configuration.error({message: 'error'});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
   });
@@ -770,6 +978,22 @@ describe('MarathonActions', function () {
       this.configuration.error({message: 'error'});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
   describe('#fetchServiceVersion', function () {
@@ -821,6 +1045,22 @@ describe('MarathonActions', function () {
       this.configuration.error({message: 'error'});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
   describe('#fetchServiceVersions', function () {
@@ -869,6 +1109,22 @@ describe('MarathonActions', function () {
       this.configuration.error({message: 'error'});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
   describe('#fetchMarathonInstanceInfo', function () {
@@ -913,6 +1169,22 @@ describe('MarathonActions', function () {
       });
 
       this.configuration.error({message: 'error'});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
   });
@@ -1003,6 +1275,22 @@ describe('MarathonActions', function () {
       });
     });
 
+    it('emits the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
   describe('#killTasks', function () {
@@ -1074,6 +1362,22 @@ describe('MarathonActions', function () {
 
       this.configuration.error({
         responseText: JSON.stringify({message: 'A helpful error message.'})
+      });
+    });
+
+    it('emits the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
       });
     });
 

--- a/plugins/services/src/js/events/__tests__/MesosLogActions-test.js
+++ b/plugins/services/src/js/events/__tests__/MesosLogActions-test.js
@@ -71,6 +71,22 @@ describe('MesosLogActions', function () {
       this.configuration.error({});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
   describe('#fetchLog', function () {
@@ -130,6 +146,22 @@ describe('MesosLogActions', function () {
       });
 
       this.configuration.error({});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
   });
@@ -195,6 +227,22 @@ describe('MesosLogActions', function () {
       });
 
       this.configuration.error({});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
   });

--- a/plugins/services/src/js/events/__tests__/TaskDirectoryActions-test.js
+++ b/plugins/services/src/js/events/__tests__/TaskDirectoryActions-test.js
@@ -77,6 +77,22 @@ describe('TaskDirectoryActions', function () {
       this.configuration.error({message: 'foo'});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
   describe('#fetchDirectory', function () {
@@ -128,6 +144,22 @@ describe('TaskDirectoryActions', function () {
       });
 
       this.configuration.error({message: 'foo'});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
   });

--- a/src/js/events/AuthActions.js
+++ b/src/js/events/AuthActions.js
@@ -46,7 +46,8 @@ const AuthActions = {
       error(xhr) {
         AppDispatcher.handleServerAction({
           type: REQUEST_LOGOUT_ERROR,
-          data: RequestUtil.getErrorFromXHR(xhr)
+          data: RequestUtil.getErrorFromXHR(xhr),
+          xhr
         });
       }
     });

--- a/src/js/events/ConfigActions.js
+++ b/src/js/events/ConfigActions.js
@@ -21,10 +21,11 @@ const ConfigActions = {
           data: response
         });
       },
-      error(e) {
+      error(xhr) {
         AppDispatcher.handleServerAction({
           type: ActionTypes.REQUEST_CONFIG_ERROR,
-          data: e.message
+          data: xhr.message,
+          xhr
         });
       }
     });
@@ -39,9 +40,10 @@ const ConfigActions = {
           data: response
         });
       },
-      error() {
+      error(xhr) {
         AppDispatcher.handleServerAction({
-          type: ActionTypes.REQUEST_CLUSTER_CCID_ERROR
+          type: ActionTypes.REQUEST_CLUSTER_CCID_ERROR,
+          xhr
         });
       }
     });

--- a/src/js/events/CosmosPackagesActions.js
+++ b/src/js/events/CosmosPackagesActions.js
@@ -60,7 +60,8 @@ const CosmosPackagesActions = {
         AppDispatcher.handleServerAction({
           type: REQUEST_COSMOS_PACKAGES_SEARCH_ERROR,
           data: RequestUtil.parseResponseBody(xhr),
-          query
+          query,
+          xhr
         });
       }
     });
@@ -112,7 +113,8 @@ const CosmosPackagesActions = {
           type: REQUEST_COSMOS_PACKAGES_LIST_ERROR,
           data: RequestUtil.getErrorFromXHR(xhr),
           packageName,
-          appId
+          appId,
+          xhr
         });
       }
     });
@@ -142,7 +144,8 @@ const CosmosPackagesActions = {
           type: REQUEST_COSMOS_PACKAGE_DESCRIBE_ERROR,
           data: RequestUtil.getErrorFromXHR(xhr),
           packageName,
-          packageVersion
+          packageVersion,
+          xhr
         });
       }
     });
@@ -168,7 +171,8 @@ const CosmosPackagesActions = {
           type: REQUEST_COSMOS_PACKAGE_INSTALL_ERROR,
           data: RequestUtil.parseResponseBody(xhr),
           packageName,
-          packageVersion
+          packageVersion,
+          xhr
         });
       }
     });
@@ -196,7 +200,8 @@ const CosmosPackagesActions = {
           data: RequestUtil.parseResponseBody(xhr),
           packageName,
           packageVersion,
-          appId
+          appId,
+          xhr
         });
       }
     });
@@ -218,7 +223,8 @@ const CosmosPackagesActions = {
       error(xhr) {
         AppDispatcher.handleServerAction({
           type: REQUEST_COSMOS_REPOSITORIES_LIST_ERROR,
-          data: RequestUtil.getErrorFromXHR(xhr)
+          data: RequestUtil.getErrorFromXHR(xhr),
+          xhr
         });
       }
     });
@@ -244,7 +250,8 @@ const CosmosPackagesActions = {
           type: REQUEST_COSMOS_REPOSITORY_ADD_ERROR,
           data: RequestUtil.getErrorFromXHR(xhr),
           name,
-          uri
+          uri,
+          xhr
         });
       }
     });
@@ -270,7 +277,8 @@ const CosmosPackagesActions = {
           type: REQUEST_COSMOS_REPOSITORY_DELETE_ERROR,
           data: RequestUtil.getErrorFromXHR(xhr),
           name,
-          uri
+          uri,
+          xhr
         });
       }
     });

--- a/src/js/events/MesosSummaryActions.js
+++ b/src/js/events/MesosSummaryActions.js
@@ -85,10 +85,11 @@ function requestFromMesos(resolve, reject) {
       });
       resolve();
     },
-    error(e) {
+    error(xhr) {
       AppDispatcher.handleServerAction({
         type: REQUEST_SUMMARY_ERROR,
-        data: e.message
+        data: xhr.message,
+        xhr
       });
       reject();
     },

--- a/src/js/events/MetadataActions.js
+++ b/src/js/events/MetadataActions.js
@@ -19,10 +19,11 @@ var MetadataActions = {
           data: response
         });
       },
-      error(e) {
+      error(xhr) {
         AppDispatcher.handleServerAction({
           type: ActionTypes.REQUEST_DCOS_BUILD_INFO_ERROR,
-          data: e.message
+          data: xhr.message,
+          xhr
         });
       }
     });

--- a/src/js/events/MetronomeActions.js
+++ b/src/js/events/MetronomeActions.js
@@ -49,15 +49,6 @@ const MetronomeActions = {
     Config.getRefreshRate(),
     function (resolve, reject) {
       return function () {
-
-        const handleError = function (e) {
-          AppDispatcher.handleServerAction({
-            type: REQUEST_METRONOME_JOBS_ERROR,
-            data: e.message
-          });
-          reject();
-        };
-
         RequestUtil.json({
           url: `${Config.metronomeAPI}/v1/jobs`,
           data: [
@@ -74,10 +65,21 @@ const MetronomeActions = {
               });
               resolve();
             } catch (error) {
-              handleError(error);
+              AppDispatcher.handleServerAction({
+                type: REQUEST_METRONOME_JOBS_ERROR,
+                data: error
+              });
+              reject();
             }
           },
-          error: handleError,
+          error(xhr) {
+            AppDispatcher.handleServerAction({
+              type: REQUEST_METRONOME_JOBS_ERROR,
+              data: xhr.message,
+              xhr
+            });
+            reject();
+          },
           hangingRequestCallback() {
             AppDispatcher.handleServerAction({
               type: REQUEST_METRONOME_JOBS_ONGOING

--- a/src/js/events/NodeHealthActions.js
+++ b/src/js/events/NodeHealthActions.js
@@ -27,7 +27,8 @@ const NodeHealthActions = {
       error(xhr) {
         AppDispatcher.handleServerAction({
           type: REQUEST_HEALTH_NODES_ERROR,
-          data: RequestUtil.getErrorFromXHR(xhr)
+          data: RequestUtil.getErrorFromXHR(xhr),
+          xhr
         });
       }
     });
@@ -47,7 +48,8 @@ const NodeHealthActions = {
         AppDispatcher.handleServerAction({
           type: REQUEST_HEALTH_NODE_ERROR,
           data: RequestUtil.getErrorFromXHR(xhr),
-          nodeID
+          nodeID,
+          xhr
         });
       }
     });
@@ -67,7 +69,8 @@ const NodeHealthActions = {
         AppDispatcher.handleServerAction({
           type: REQUEST_HEALTH_NODE_UNITS_ERROR,
           data: RequestUtil.getErrorFromXHR(xhr),
-          nodeID
+          nodeID,
+          xhr
         });
       }
     });
@@ -89,7 +92,8 @@ const NodeHealthActions = {
           type: REQUEST_HEALTH_NODE_UNIT_ERROR,
           data: RequestUtil.getErrorFromXHR(xhr),
           nodeID,
-          unitID
+          unitID,
+          xhr
         });
       }
     });

--- a/src/js/events/SystemLogActions.js
+++ b/src/js/events/SystemLogActions.js
@@ -202,7 +202,8 @@ const SystemLogActions = {
       error(xhr) {
         AppDispatcher.handleServerAction({
           type: REQUEST_SYSTEM_LOG_STREAM_TYPES_ERROR,
-          data: RequestUtil.getErrorFromXHR(xhr)
+          data: RequestUtil.getErrorFromXHR(xhr),
+          xhr
         });
       }
     });

--- a/src/js/events/UnitHealthActions.js
+++ b/src/js/events/UnitHealthActions.js
@@ -27,7 +27,8 @@ const UnitHealthActions = {
       error(xhr) {
         AppDispatcher.handleServerAction({
           type: REQUEST_HEALTH_UNITS_ERROR,
-          data: RequestUtil.getErrorFromXHR(xhr)
+          data: RequestUtil.getErrorFromXHR(xhr),
+          xhr
         });
       }
     });
@@ -47,7 +48,8 @@ const UnitHealthActions = {
         AppDispatcher.handleServerAction({
           type: REQUEST_HEALTH_UNIT_ERROR,
           data: RequestUtil.getErrorFromXHR(xhr),
-          unitID
+          unitID,
+          xhr
         });
       }
     });
@@ -67,7 +69,8 @@ const UnitHealthActions = {
         AppDispatcher.handleServerAction({
           type: REQUEST_HEALTH_UNIT_NODES_ERROR,
           data: RequestUtil.getErrorFromXHR(xhr),
-          unitID
+          unitID,
+          xhr
         });
       }
     });
@@ -89,7 +92,8 @@ const UnitHealthActions = {
           type: REQUEST_HEALTH_UNIT_NODE_ERROR,
           data: RequestUtil.getErrorFromXHR(xhr),
           unitID,
-          nodeID
+          nodeID,
+          xhr
         });
       }
     });

--- a/src/js/events/UsersActions.js
+++ b/src/js/events/UsersActions.js
@@ -25,7 +25,8 @@ const UsersActions = {
       error(xhr) {
         AppDispatcher.handleServerAction({
           type: REQUEST_USERS_ERROR,
-          data: RequestUtil.getErrorFromXHR(xhr)
+          data: RequestUtil.getErrorFromXHR(xhr),
+          xhr
         });
       }
     });
@@ -77,7 +78,8 @@ const UsersActions = {
         AppDispatcher.handleServerAction({
           type: REQUEST_USER_DELETE_ERROR,
           data: RequestUtil.getErrorFromXHR(xhr),
-          userID
+          userID,
+          xhr
         });
       }
     });

--- a/src/js/events/VirtualNetworksActions.js
+++ b/src/js/events/VirtualNetworksActions.js
@@ -26,7 +26,8 @@ const VirtualNetworksActions = {
       error(xhr) {
         AppDispatcher.handleServerAction({
           type: REQUEST_VIRTUAL_NETWORKS_ERROR,
-          data: RequestUtil.getErrorFromXHR(xhr)
+          data: RequestUtil.getErrorFromXHR(xhr),
+          xhr
         });
       }
     });

--- a/src/js/events/__tests__/AuthActions-test.js
+++ b/src/js/events/__tests__/AuthActions-test.js
@@ -135,6 +135,22 @@ describe('AuthActions', function () {
       this.configuration.error({responseJSON: {description: 'bar'}});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
 });

--- a/src/js/events/__tests__/ConfigActions-test.js
+++ b/src/js/events/__tests__/ConfigActions-test.js
@@ -55,6 +55,22 @@ describe('ConfigActions', function () {
       this.configuration.error();
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
 });

--- a/src/js/events/__tests__/CosmosPackagesActions-test.js
+++ b/src/js/events/__tests__/CosmosPackagesActions-test.js
@@ -61,6 +61,22 @@ describe('CosmosPackagesActions', function () {
       this.configuration.error({responseJSON: {description: 'bar'}});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
     it('calls #json from the RequestUtil', function () {
       expect(RequestUtil.json).toHaveBeenCalled();
     });
@@ -154,6 +170,22 @@ describe('CosmosPackagesActions', function () {
       this.configuration.error({responseJSON: {description: 'bar'}});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
     it('calls #json from the RequestUtil', function () {
       expect(RequestUtil.json).toHaveBeenCalled();
     });
@@ -229,6 +261,22 @@ describe('CosmosPackagesActions', function () {
       });
 
       this.configuration.error({responseJSON: {description: 'bar'}});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
     it('calls #json from the RequestUtil', function () {
@@ -315,6 +363,22 @@ describe('CosmosPackagesActions', function () {
       this.configuration.error({responseJSON: 'bar'});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
     it('calls #json from the RequestUtil', function () {
       expect(RequestUtil.json).toHaveBeenCalled();
     });
@@ -395,6 +459,22 @@ describe('CosmosPackagesActions', function () {
       });
 
       this.configuration.error({responseJSON: 'bar'});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
     it('calls #json from the RequestUtil', function () {
@@ -478,6 +558,22 @@ describe('CosmosPackagesActions', function () {
       this.configuration.error({responseJSON: {description: 'bar'}});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
     it('calls #json from the RequestUtil', function () {
       expect(RequestUtil.json).toHaveBeenCalled();
     });
@@ -543,6 +639,22 @@ describe('CosmosPackagesActions', function () {
       });
 
       this.configuration.error({responseJSON: {description: 'bar'}});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
     it('calls #json from the RequestUtil', function () {
@@ -618,6 +730,22 @@ describe('CosmosPackagesActions', function () {
       });
 
       this.configuration.error({responseJSON: {description: 'bar'}});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
     it('calls #json from the RequestUtil', function () {

--- a/src/js/events/__tests__/MetronomeActions-test.js
+++ b/src/js/events/__tests__/MetronomeActions-test.js
@@ -51,6 +51,22 @@ describe('MetronomeActions', function () {
       this.configuration.error({message: 'error'});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
   describe('#fetchJobs', function () {
@@ -88,6 +104,22 @@ describe('MetronomeActions', function () {
       });
 
       this.configuration.error({message: 'error'});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
   });
@@ -133,6 +165,22 @@ describe('MetronomeActions', function () {
       });
 
       this.configuration.error({message: 'error'});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
   });
@@ -185,6 +233,22 @@ describe('MetronomeActions', function () {
       this.configuration.error({message: 'error'});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
   describe('#updateJob', function () {
@@ -224,6 +288,22 @@ describe('MetronomeActions', function () {
       });
 
       this.configuration.error({message: 'error'});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
   });
@@ -277,6 +357,22 @@ describe('MetronomeActions', function () {
       this.configuration.error({message: 'error'});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
   describe('#stopJobRun', function () {
@@ -324,6 +420,22 @@ describe('MetronomeActions', function () {
       });
 
       this.configuration.error({message: 'error'});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
   });
@@ -377,6 +489,22 @@ describe('MetronomeActions', function () {
       });
 
       this.configuration.error({message: 'error'});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
   });

--- a/src/js/events/__tests__/NodeHealthActions-test.js
+++ b/src/js/events/__tests__/NodeHealthActions-test.js
@@ -48,6 +48,22 @@ describe('NodeHealthActions', function () {
       this.configuration.error({responseJSON: {description: 'bar'}});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
   describe('#fetchNode', function () {
@@ -87,6 +103,22 @@ describe('NodeHealthActions', function () {
       });
 
       this.configuration.error({responseJSON: {description: 'bar'}});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
   });
@@ -132,6 +164,22 @@ describe('NodeHealthActions', function () {
       this.configuration.error({responseJSON: {description: 'bar'}});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
   describe('#fetchNodeUnit', function () {
@@ -174,6 +222,22 @@ describe('NodeHealthActions', function () {
       });
 
       this.configuration.error({responseJSON: {description: 'bar'}});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
   });

--- a/src/js/events/__tests__/SystemLogActions-test.js
+++ b/src/js/events/__tests__/SystemLogActions-test.js
@@ -385,6 +385,22 @@ describe('SystemLogActions', function () {
       });
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
 });

--- a/src/js/events/__tests__/UnitHealthActions-test.js
+++ b/src/js/events/__tests__/UnitHealthActions-test.js
@@ -49,6 +49,22 @@ describe('UnitHealthActions', function () {
       this.configuration.error({responseJSON: {description: 'bar'}});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
   describe('#fetchUnit', function () {
@@ -88,6 +104,22 @@ describe('UnitHealthActions', function () {
       });
 
       this.configuration.error({responseJSON: {description: 'bar'}});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
   });
@@ -133,6 +165,22 @@ describe('UnitHealthActions', function () {
       this.configuration.error({responseJSON: {description: 'bar'}});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
   describe('#fetchUnitNode', function () {
@@ -175,6 +223,22 @@ describe('UnitHealthActions', function () {
       });
 
       this.configuration.error({responseJSON: {description: 'bar'}});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
   });

--- a/src/js/events/__tests__/UsersActions-test.js
+++ b/src/js/events/__tests__/UsersActions-test.js
@@ -40,6 +40,22 @@ describe('UsersActions', function () {
       this.configuration.error({responseJSON: {description: 'bar'}});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
     it('calls #json from the RequestUtil', function () {
       expect(RequestUtil.json).toHaveBeenCalled();
     });
@@ -222,6 +238,22 @@ describe('UsersActions', function () {
       });
 
       this.configuration.error({responseJSON: {description: 'bar'}});
+    });
+
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
     });
 
   });

--- a/src/js/events/__tests__/VirtualNetworksActions-test.js
+++ b/src/js/events/__tests__/VirtualNetworksActions-test.js
@@ -66,6 +66,22 @@ describe('VirtualNetworksActions', function () {
       this.configuration.error({responseJSON: {description: 'bar'}});
     });
 
+    it('dispatches the xhr when unsuccessful', function () {
+      var id = AppDispatcher.register(function (payload) {
+        var action = payload.action;
+        AppDispatcher.unregister(id);
+        expect(action.xhr).toEqual({
+          foo: 'bar',
+          responseJSON: {description: 'baz'}
+        });
+      });
+
+      this.configuration.error({
+        foo: 'bar',
+        responseJSON: {description: 'baz'}
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
This is part 1 of several PRs.

This PR alters action files and their associated tests to ensure the xhr object is emitted in action error handlers.

The goal is to allow `<RequestErrorMsg />` to customize the error message based on xhr properties.