### PR TITLE
DCOS-12247: Fix for flipping runtime type Mesos to UCR

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/Container.js
+++ b/plugins/services/src/js/reducers/serviceForm/Container.js
@@ -207,7 +207,12 @@ module.exports = {
 
   JSONParser: combineParsers([
     function (state) {
+      const image = findNestedPropertyInObject(state, 'container.docker.image');
       let value = findNestedPropertyInObject(state, 'container.type');
+
+      if (value === MESOS && !image) {
+        value = NONE;
+      }
 
       if (value == null) {
         value = NONE;

--- a/plugins/services/src/js/reducers/serviceForm/Container.js
+++ b/plugins/services/src/js/reducers/serviceForm/Container.js
@@ -210,7 +210,7 @@ module.exports = {
       let value = findNestedPropertyInObject(state, 'container.type');
 
       if (value == null) {
-        value = 'NONE';
+        value = NONE;
       }
 
       return new Transaction(['container', 'type'], value);

--- a/plugins/services/src/js/reducers/serviceForm/Residency.js
+++ b/plugins/services/src/js/reducers/serviceForm/Residency.js
@@ -35,6 +35,8 @@ module.exports = {
           relaunchEscalationTimeoutSeconds: 10,
           taskLostBehavior: 'WAIT_FOREVER'
         };
+      } else if (!hasLocalVolumes) {
+        return;
       } else {
         return this.residency;
       }


### PR DESCRIPTION
This PR fixes the situation when a Mesos app with local volumes will be switched to UCR as you edit JSON.

I added additional check into parser so that it looks not only for `container.type === MESOS` but also for `container.docker.image` not to be empty.

In addition to that I added a fix that remove Residency as we remove the last localVolume.

Please refer to the original issue https://mesosphere.atlassian.net/browse/DCOS-12247 to come up with a test plan.