### PR TITLE
DCOS-13707: Safer alternative to parseInt for reducers

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/Containers.js
@@ -6,6 +6,7 @@ import {
 import Transaction from '../../../../../../src/js/structs/Transaction';
 import {
   combineReducers,
+  parseIntValue,
   simpleFloatReducer,
   simpleReducer
 } from '../../../../../../src/js/utils/ReducerUtil';
@@ -420,9 +421,8 @@ module.exports = {
         this.endpoints[index].endpoints[secondIndex][name] = value;
       }
       if (type === SET && numericalFiledNames.includes(name)) {
-        this.endpoints[index].endpoints[secondIndex][name] = parseInt(
-          value,
-          10
+        this.endpoints[index].endpoints[secondIndex][name] = parseIntValue(
+          value
         );
       }
     }
@@ -590,7 +590,7 @@ module.exports = {
         newState[index].endpoints[secondIndex][name] = value;
       }
       if (type === SET && numericalFiledNames.includes(name)) {
-        newState[index].endpoints[secondIndex][name] = parseInt(value, 10);
+        newState[index].endpoints[secondIndex][name] = parseIntValue(value);
       }
     }
 

--- a/plugins/services/src/js/reducers/serviceForm/HealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/HealthChecks.js
@@ -4,6 +4,7 @@ import {
   SET
 } from '../../../../../../src/js/constants/TransactionTypes';
 import {COMMAND, MESOS_HTTP, MESOS_HTTPS} from '../../constants/HealthCheckProtocols';
+import {parseIntValue} from '../../../../../../src/js/utils/ReducerUtil';
 import Util from '../../../../../../src/js/utils/Util';
 import Transaction from '../../../../../../src/js/structs/Transaction';
 
@@ -84,7 +85,7 @@ module.exports = {
           }
         }
         if (`healthChecks.${index}.portIndex` === joinedPath) {
-          this.healthChecks[index].portIndex = parseInt(value, 10);
+          this.healthChecks[index].portIndex = parseIntValue(value);
         }
         if (`healthChecks.${index}.command` === joinedPath) {
           this.healthChecks[index].command = value;
@@ -93,16 +94,16 @@ module.exports = {
           this.healthChecks[index].path = value;
         }
         if (`healthChecks.${index}.gracePeriodSeconds` === joinedPath) {
-          this.healthChecks[index].gracePeriodSeconds = parseInt(value, 10);
+          this.healthChecks[index].gracePeriodSeconds = parseIntValue(value);
         }
         if (`healthChecks.${index}.intervalSeconds` === joinedPath) {
-          this.healthChecks[index].intervalSeconds = parseInt(value, 10);
+          this.healthChecks[index].intervalSeconds = parseIntValue(value);
         }
         if (`healthChecks.${index}.timeoutSeconds` === joinedPath) {
-          this.healthChecks[index].timeoutSeconds = parseInt(value, 10);
+          this.healthChecks[index].timeoutSeconds = parseIntValue(value);
         }
         if (`healthChecks.${index}.maxConsecutiveFailures` === joinedPath) {
-          this.healthChecks[index].maxConsecutiveFailures = parseInt(value, 10);
+          this.healthChecks[index].maxConsecutiveFailures = parseIntValue(value);
         }
         if (`healthChecks.${index}.https` === joinedPath) {
           this.healthChecks[index].https = value;
@@ -221,7 +222,7 @@ module.exports = {
           }
         }
         if (`healthChecks.${index}.portIndex` === joinedPath) {
-          state[index].portIndex = parseInt(value, 10);
+          state[index].portIndex = parseIntValue(value);
         }
         if (`healthChecks.${index}.command` === joinedPath) {
           state[index].command = value;

--- a/plugins/services/src/js/reducers/serviceForm/MultiContainerHealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/MultiContainerHealthChecks.js
@@ -4,19 +4,10 @@ import {
   SET
 } from '../../../../../../src/js/constants/TransactionTypes';
 import {COMMAND, HTTP, HTTPS, TCP} from '../../constants/HealthCheckProtocols';
+import {parseIntValue} from '../../../../../../src/js/utils/ReducerUtil';
 import MesosCommandTypes from '../../constants/MesosCommandTypes';
 import Transaction from '../../../../../../src/js/structs/Transaction';
 import ValidatorUtil from '../../../../../../src/js/utils/ValidatorUtil';
-
-function parseIntOrNull(value) {
-  const intValue = parseInt(value);
-
-  if (Number.isNaN(intValue)) {
-    return null;
-  }
-
-  return intValue;
-}
 
 /**
  * JSON Parser Fragment for `HttpHealthCheck` type
@@ -307,23 +298,23 @@ const MultiContainerHealthChecks = {
         return reduceTcpHealthCheck(newState, field, value);
 
       case 'gracePeriodSeconds':
-        newState.gracePeriodSeconds = parseIntOrNull(value);
+        newState.gracePeriodSeconds = parseIntValue(value);
         break;
 
       case 'intervalSeconds':
-        newState.intervalSeconds = parseIntOrNull(value);
+        newState.intervalSeconds = parseIntValue(value);
         break;
 
       case 'maxConsecutiveFailures':
-        newState.maxConsecutiveFailures = parseIntOrNull(value);
+        newState.maxConsecutiveFailures = parseIntValue(value);
         break;
 
       case 'timeoutSeconds':
-        newState.timeoutSeconds = parseIntOrNull(value);
+        newState.timeoutSeconds = parseIntValue(value);
         break;
 
       case 'delaySeconds':
-        newState.delaySeconds = parseIntOrNull(value);
+        newState.delaySeconds = parseIntValue(value);
         break;
     }
 
@@ -366,35 +357,35 @@ const MultiContainerHealthChecks = {
     if (healthCheck.gracePeriodSeconds != null) {
       memo.push(new Transaction(
         path.concat(['gracePeriodSeconds']),
-        parseInt(healthCheck.gracePeriodSeconds),
+        parseIntValue(healthCheck.gracePeriodSeconds),
         SET
       ));
     }
     if (healthCheck.intervalSeconds != null) {
       memo.push(new Transaction(
         path.concat(['intervalSeconds']),
-        parseInt(healthCheck.intervalSeconds),
+        parseIntValue(healthCheck.intervalSeconds),
         SET
       ));
     }
     if (healthCheck.maxConsecutiveFailures != null) {
       memo.push(new Transaction(
         path.concat(['maxConsecutiveFailures']),
-        parseInt(healthCheck.maxConsecutiveFailures),
+        parseIntValue(healthCheck.maxConsecutiveFailures),
         SET
       ));
     }
     if (healthCheck.timeoutSeconds != null) {
       memo.push(new Transaction(
         path.concat(['timeoutSeconds']),
-        parseInt(healthCheck.timeoutSeconds),
+        parseIntValue(healthCheck.timeoutSeconds),
         SET
       ));
     }
     if (healthCheck.delaySeconds != null) {
       memo.push(new Transaction(
         path.concat(['delaySeconds']),
-        parseInt(healthCheck.delaySeconds),
+        parseIntValue(healthCheck.delaySeconds),
         SET
       ));
     }

--- a/plugins/services/src/js/reducers/serviceForm/Volumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/Volumes.js
@@ -1,3 +1,4 @@
+import {parseIntValue} from '../../../../../../src/js/utils/ReducerUtil';
 import {
   ADD_ITEM,
   REMOVE_ITEM,
@@ -51,10 +52,7 @@ module.exports = {
     const joinedPath = path.join('.');
 
     // Make sure to parse as integer when possible
-    const parsedValue = parseInt(value);
-    if (!isNaN(parsedValue)) {
-      value = parsedValue;
-    }
+    value = parseIntValue(value);
 
     if (joinedPath === 'container.docker.image') {
       this.docker = value !== '';
@@ -118,7 +116,7 @@ module.exports = {
         this.externalVolumes[index].containerPath = value;
       }
       if (type === SET && `externalVolumes.${index}.size` === joinedPath) {
-        this.externalVolumes[index].external.size = parseInt(value, 10);
+        this.externalVolumes[index].external.size = parseIntValue(value);
       }
       if (type === SET && `externalVolumes.${index}.mode` === joinedPath) {
         this.externalVolumes[index].mode = value;

--- a/src/js/utils/ReducerUtil.js
+++ b/src/js/utils/ReducerUtil.js
@@ -63,6 +63,21 @@ module.exports = {
     };
   },
 
+  /**
+   * Parse only integer values and passes-through any other types
+   *
+   * @param {any} value - The source value
+   * @returns {Number|any} - Returns a numerical value or the value itself
+   */
+  parseIntValue(value) {
+    const parsedValue = parseInt(value);
+    if (!isNaN(parsedValue)) {
+      return parsedValue;
+    }
+
+    return value;
+  },
+
   simpleReducer(needle, defaultState = '') {
     return function (state = defaultState, {path, type, value}) {
       if (type === TransactionTypes.SET && path.join('.') === needle) {

--- a/src/js/utils/__tests__/ReducerUtil-test.js
+++ b/src/js/utils/__tests__/ReducerUtil-test.js
@@ -234,6 +234,24 @@ describe('ReducerUtil', function () {
     });
   });
 
+  describe('#parseIntValue', function () {
+    it('should return the integer value parsed', function () {
+      expect(ReducerUtil.parseIntValue('10')).toEqual(10);
+    });
+
+    it('should return empty string as-is', function () {
+      expect(ReducerUtil.parseIntValue('')).toEqual('');
+    });
+
+    it('should return unparsable number string as-is', function () {
+      expect(ReducerUtil.parseIntValue('foo')).toEqual('foo');
+    });
+
+    it('should return numbers as-is', function () {
+      expect(ReducerUtil.parseIntValue(123)).toEqual(123);
+    });
+  });
+
   describe('#simpleReducer', function () {
     it('should return a function', function () {
       expect(typeof ReducerUtil.simpleReducer()).toBe('function');


### PR DESCRIPTION
In some places in the reducers we are using plain `parseInt` when we are processing a value. This results in some unwanted `NaN` values being collected to the output. 

This PR introduces the parseIntValue function that applies parseInt to the given value and it returns it's numerical representation only if it is indeed a number. Otherwise it passes through the value.

It allso replaces `parseInt(value, 10)` in all other places it was used