### PR TITLE
Fix service form volume handling

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/Container.js
+++ b/plugins/services/src/js/reducers/serviceForm/Container.js
@@ -154,10 +154,6 @@ module.exports = {
       delete newState.docker;
     }
 
-    if (ValidatorUtil.isEmpty(newState.volumes)) {
-      delete newState.volumes;
-    }
-
     if (ValidatorUtil.isEmpty(newState.type)) {
       delete newState.type;
     }

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -27,54 +27,65 @@ describe('Container', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
       batch = batch.add(
-          new Transaction(['container', 'docker', 'image'], 'foo', SET)
+        new Transaction(['container', 'docker', 'image'], 'foo', SET)
       );
 
       expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-        .toEqual({type: 'DOCKER', docker: {
-          image: 'foo',
-          forcePullImage: null,
-          privileged: null,
-          network: undefined,
-          portMappings: null
-        }});
+        .toEqual({
+          docker: {
+            image: 'foo',
+            forcePullImage: null,
+            privileged: null,
+            network: undefined,
+            portMappings: null
+          },
+          type: 'DOCKER'
+        });
     });
 
     it('creates new container info when there is nothing', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
       batch = batch.add(
-          new Transaction(['container', 'docker', 'image'], 'foo', SET)
+        new Transaction(['container', 'docker', 'image'], 'foo', SET)
       );
       batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
 
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({type: 'DOCKER', docker: {image: 'foo',
-        forcePullImage: null,
-        privileged: null,
-        network: undefined,
-        portMappings: null
-      }});
+      )).toEqual({
+        docker: {
+          image: 'foo',
+          forcePullImage: null,
+          privileged: null,
+          network: undefined,
+          portMappings: null
+        },
+        type: 'DOCKER'
+      });
     });
 
     it('keeps top-level container info with type switch', function () {
       let batch = new Batch();
       batch = batch.add(
-          new Transaction(['container', 'docker', 'image'], 'foo', SET)
+        new Transaction(['container', 'docker', 'image'], 'foo', SET)
       );
       batch = batch.add(new Transaction(['container', 'type'], 'MESOS', SET));
 
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({type: 'MESOS', docker: {image: 'foo',
-        forcePullImage: null,
-        privileged: null,
-        network: null,
-        portMappings: null
-      }});
+      )).toEqual({
+        docker: {
+          image: 'foo',
+          forcePullImage: null,
+          privileged: null,
+          network: null,
+          portMappings: null
+        },
+        type: 'MESOS'
+      });
     });
 
     it('sets privileged correctly', function () {
@@ -84,24 +95,29 @@ describe('Container', function () {
         new Transaction(['container', 'docker', 'privileged'], true, SET)
       );
       batch = batch.add(
-          new Transaction(['container', 'docker', 'image'], 'foo', SET)
+        new Transaction(['container', 'docker', 'image'], 'foo', SET)
       );
 
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({type: 'DOCKER', docker: {image: 'foo', privileged: true,
-        forcePullImage: null,
-        network: undefined,
-        portMappings: null
-      }});
+      )).toEqual({
+        docker: {
+          image: 'foo',
+          privileged: true,
+          forcePullImage: null,
+          network: undefined,
+          portMappings: null
+        },
+        type: 'DOCKER'
+      });
     });
 
     it('sets privileged correctly to false', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
       batch = batch.add(
-          new Transaction(['container', 'docker', 'image'], 'foo', SET)
+        new Transaction(['container', 'docker', 'image'], 'foo', SET)
       );
       batch = batch.add(
         new Transaction(['container', 'docker', 'privileged'], false, SET)
@@ -110,18 +126,23 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({type: 'DOCKER', docker: {image: 'foo', privileged: false,
-        forcePullImage: null,
-        network: undefined,
-        portMappings: null
-      }});
+      )).toEqual({
+        docker: {
+          image: 'foo',
+          privileged: false,
+          forcePullImage: null,
+          network: undefined,
+          portMappings: null
+        },
+        type: 'DOCKER'
+      });
     });
 
     it('doesn\'t set privileged if path doesn\'t match type', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
       batch = batch.add(
-          new Transaction(['container', 'docker', 'image'], 'foo', SET)
+        new Transaction(['container', 'docker', 'image'], 'foo', SET)
       );
       batch = batch.add(
         new Transaction(['container', 'foo', 'privileged'], true, SET)
@@ -130,19 +151,23 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({type: 'DOCKER', docker: {image: 'foo',
-        forcePullImage: null,
-        privileged: null,
-        network: undefined,
-        portMappings: null
-      }});
+      )).toEqual({
+        docker: {
+          image: 'foo',
+          forcePullImage: null,
+          privileged: null,
+          network: undefined,
+          portMappings: null
+        },
+        type: 'DOCKER'
+      });
     });
 
     it('sets forcePullImage correctly', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
       batch = batch.add(
-          new Transaction(['container', 'docker', 'image'], 'foo', SET)
+        new Transaction(['container', 'docker', 'image'], 'foo', SET)
       );
       batch = batch.add(
         new Transaction(['container', 'docker', 'forcePullImage'], true, SET)
@@ -151,11 +176,16 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({type: 'DOCKER', docker: {image: 'foo', forcePullImage: true,
-        privileged: null,
-        network: undefined,
-        portMappings: null
-      }});
+      )).toEqual({
+        docker: {
+          image: 'foo',
+          forcePullImage: true,
+          privileged: null,
+          network: undefined,
+          portMappings: null
+        },
+        type: 'DOCKER'
+      });
     });
 
     it('sets forcePullImage correctly to false', function () {
@@ -171,16 +201,16 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-        )).toEqual({
-          type: 'DOCKER',
-          docker: {
-            image: 'foo',
-            forcePullImage: false,
-            privileged: null,
-            network: undefined,
-            portMappings: null
-          }
-        });
+      )).toEqual({
+        docker: {
+          image: 'foo',
+          forcePullImage: false,
+          privileged: null,
+          network: undefined,
+          portMappings: null
+        },
+        type: 'DOCKER'
+      });
     });
 
     it('doesn\'t set forcePullImage if path doesn\'t match type', function () {
@@ -211,21 +241,21 @@ describe('Container', function () {
       );
       batch = batch.add(new Transaction(['container', 'type'], 'MESOS', SET));
       batch = batch.add(
-          new Transaction(['container', 'docker', 'image'], 'foo', SET)
+        new Transaction(['container', 'docker', 'image'], 'foo', SET)
       );
 
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
       )).toEqual({
-        type: 'MESOS',
         docker: {
           forcePullImage: null,
           image: 'foo',
           network: null,
           portMappings: null,
           privileged: null
-        }
+        },
+        type: 'MESOS'
       });
     });
 
@@ -237,7 +267,7 @@ describe('Container', function () {
       );
       batch = batch.add(new Transaction(['container', 'type'], 'MESOS', SET));
       batch = batch.add(
-          new Transaction(['container', 'docker', 'image'], 'foo', SET)
+        new Transaction(['container', 'docker', 'image'], 'foo', SET)
       );
       batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
 
@@ -245,14 +275,14 @@ describe('Container', function () {
         Container.JSONReducer.bind({}),
         {}
       )).toEqual({
-        type: 'DOCKER',
         docker: {
           forcePullImage: true,
           image: 'foo',
           network: null,
           portMappings: null,
           privileged: null
-        }
+        },
+        type: 'DOCKER'
       });
     });
 
@@ -266,12 +296,16 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({type: 'DOCKER', docker: {image: 'foo',
-        forcePullImage: null,
-        privileged: null,
-        network: undefined,
-        portMappings: null
-      }});
+      )).toEqual({
+        docker: {
+          image: 'foo',
+          forcePullImage: null,
+          privileged: null,
+          network: undefined,
+          portMappings: null
+        },
+        type: 'DOCKER'
+      });
     });
 
     it('changes image value correctly', function () {
@@ -284,12 +318,16 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({type: 'DOCKER', docker: {image: 'bar',
-        forcePullImage: null,
-        privileged: null,
-        network: undefined,
-        portMappings: null
-      }});
+      )).toEqual({
+        docker: {
+          image: 'bar',
+          forcePullImage: null,
+          privileged: null,
+          network: undefined,
+          portMappings: null
+        },
+        type: 'DOCKER'
+      });
     });
 
     it('doesn\'t set image if path doesn\'t match type', function () {
@@ -301,13 +339,15 @@ describe('Container', function () {
       expect(batch.reduce(
         Container.JSONReducer.bind({}),
         {}
-      )).toEqual({ docker: {
-        forcePullImage: null,
-        image: '',
-        privileged: null,
-        network: null,
-        portMappings: null
-      }});
+      )).toEqual({
+        docker: {
+          forcePullImage: null,
+          image: '',
+          privileged: null,
+          network: null,
+          portMappings: null
+        }
+      });
     });
 
     describe('PortMappings', function () {
@@ -321,16 +361,23 @@ describe('Container', function () {
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
-            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
               privileged: null,
               network: USER,
               portMappings: [
-                {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', servicePort: null}
+                {
+                  containerPort: 0,
+                  hostPort: 0,
+                  labels: null,
+                  name: null,
+                  protocol: 'tcp',
+                  servicePort: null
+                }
               ]
-            }
+            },
+            type: 'DOCKER'
           });
       });
 
@@ -346,16 +393,23 @@ describe('Container', function () {
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
-            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
               privileged: null,
               network: USER,
               portMappings: [
-                {containerPort: 0, hostPort: null, labels: null, name: null, protocol: null, servicePort: null}
+                {
+                  containerPort: 0,
+                  hostPort: null,
+                  labels: null,
+                  name: null,
+                  protocol: null,
+                  servicePort: null
+                }
               ]
-            }
+            },
+            type: 'DOCKER'
           });
       });
 
@@ -364,7 +418,7 @@ describe('Container', function () {
         batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
         batch = batch.add(new Transaction(['container', 'docker', 'network'], BRIDGE, SET));
         // This is default
-        // batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], false));
+        // batch = batch.add(new Transaction(['portDefinitions', 0,'portMapping'], false));
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
         batch = batch.add(new Transaction(['portDefinitions', 0, 'protocol', 'tcp'], false));
         batch = batch.add(new Transaction(['portDefinitions', 0, 'protocol', 'udp'], true));
@@ -373,16 +427,23 @@ describe('Container', function () {
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
-            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
               privileged: null,
               network: BRIDGE,
               portMappings: [
-                {containerPort: 0, hostPort: 100, labels: null, name: null, protocol: 'udp', servicePort: null}
+                {
+                  containerPort: 0,
+                  hostPort: 100,
+                  labels: null,
+                  name: null,
+                  protocol: 'udp',
+                  servicePort: null
+                }
               ]
-            }
+            },
+            type: 'DOCKER',
           });
       });
 
@@ -395,322 +456,451 @@ describe('Container', function () {
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
-            type: 'DOCKER',
             docker: {
               forcePullImage: null,
               image: '',
               privileged: null,
               network: BRIDGE,
               portMappings: [
-                {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', servicePort: null}
+                {
+                  containerPort: 0,
+                  hostPort: 0,
+                  labels: null,
+                  name: null,
+                  protocol: 'tcp',
+                  servicePort: null
+                }
               ]
-            }
+            },
+            type: 'DOCKER'
           });
-      });
 
-      it('shouldn\'t create portMappings by default', function () {
-        let batch = new Batch();
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+        it('shouldn\'t create portMappings by default', function () {
+          let batch = new Batch();
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual({
-            docker: {
-              forcePullImage: null,
-              image: '',
-              privileged: null,
-              network: null,
-              portMappings: null
-            }
-          });
-      });
+          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+            .toEqual({
+              docker: {
+                forcePullImage: null,
+                image: '',
+                privileged: null,
+                network: null,
+                portMappings: null
+              }
+            });
+        });
 
-      it('shouldn\'t create portMappings for HOST', function () {
-        let batch = new Batch();
-        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-        batch = batch.add(new Transaction(['container', 'docker', 'network'], HOST, SET));
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+        it('shouldn\'t create portMappings for HOST', function () {
+          let batch = new Batch();
+          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
+          batch = batch.add(new Transaction(['container', 'docker', 'network'], HOST, SET));
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual({docker: {network: HOST, forcePullImage: null, image: '', privileged: null, portMappings: null}, type: 'DOCKER'});
-      });
+          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+            .toEqual({
+              docker: {
+                network: HOST,
+                forcePullImage: null,
+                image: '',
+                privileged: null,
+                portMappings: null
+              },
+              type: 'DOCKER'
+            });
+        });
 
-      it('should create two default portDefinition configurations', function () {
-        let batch = new Batch();
-        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-        batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions'], 1, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
+        it('should create two default portDefinition configurations', function () {
+          let batch = new Batch();
+          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
+          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions'], 1, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+          batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual({
-            type: 'DOCKER',
-            docker: {
-              forcePullImage: null,
-              image: '',
-              privileged: null,
-              network: USER,
-              portMappings: [
-                {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', servicePort: null},
-                {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', servicePort: null}
-              ]
-            }
-          });
-      });
+          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+            .toEqual({
+              docker: {
+                forcePullImage: null,
+                image: '',
+                privileged: null,
+                network: USER,
+                portMappings: [
+                  {
+                    containerPort: 0,
+                    hostPort: 0,
+                    labels: null,
+                    name: null,
+                    protocol: 'tcp',
+                    servicePort: null
+                  },
+                  {
+                    containerPort: 0,
+                    hostPort: 0,
+                    labels: null,
+                    name: null,
+                    protocol: 'tcp',
+                    servicePort: null
+                  }
+                ]
+              },
+              type: 'DOCKER'
+            });
+        });
 
-      it('should set the name value', function () {
-        let batch = new Batch();
-        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-        batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'name'], 'foo'));
+        it('should set the name value', function () {
+          let batch = new Batch();
+          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
+          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'name'], 'foo'));
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual({
-            type: 'DOCKER',
-            docker: {
-              forcePullImage: null,
-              image: '',
-              privileged: null,
-              network: USER,
-              portMappings: [
-                {containerPort: 0, hostPort: 0, labels: null, name: 'foo', protocol: 'tcp', servicePort: null}
-              ]
-            }
-          });
-      });
+          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+            .toEqual({
+              docker: {
+                forcePullImage: null,
+                image: '',
+                privileged: null,
+                network: USER,
+                portMappings: [
+                  {
+                    containerPort: 0,
+                    hostPort: 0,
+                    labels: null,
+                    name: 'foo',
+                    protocol: 'tcp',
+                    servicePort: null
+                  }
+                ]
+              },
+              type: 'DOCKER'
+            });
+        });
 
-      it('should set the port value', function () {
-        let batch = new Batch();
-        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-        batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'automaticPort'], false));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'hostPort'], 100));
+        it('should set the port value', function () {
+          let batch = new Batch();
+          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
+          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'automaticPort'], false));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'hostPort'], 100));
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual({
-            type: 'DOCKER',
-            docker: {
-              forcePullImage: null,
-              image: '',
-              privileged: null,
-              network: USER,
-              portMappings: [
-                {containerPort: 0, hostPort: 100, labels: null, name: null, protocol: 'tcp', servicePort: null}
-              ]
-            }
-          });
-      });
+          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+            .toEqual({
+              docker: {
+                forcePullImage: null,
+                image: '',
+                privileged: null,
+                network: USER,
+                portMappings: [
+                  {
+                    containerPort: 0,
+                    hostPort: 100,
+                    labels: null,
+                    name: null,
+                    protocol: 'tcp',
+                    servicePort: null
+                  }
+                ]
+              },
+              type: 'DOCKER'
+            });
+        });
 
-      it('should default port value to 0 if automaticPort', function () {
-        let batch = new Batch();
-        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-        batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-        // This is default behavior
-        // batch = batch.add(new Transaction(['portDefinitions', 0, 'automaticPort'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'hostPort'], 100));
+        it('should default port value to 0 if automaticPort', function () {
+          let batch = new Batch();
+          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
+          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+          // This is default behavior
+          // batch = batch.add(new Transaction(['portDefinitions', 0, 'automaticPort'], true));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'hostPort'], 100));
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual({
-            type: 'DOCKER',
-            docker: {
-              forcePullImage: null,
-              image: '',
-              privileged: null,
-              network: USER,
-              portMappings: [
-                {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', servicePort: null}
-              ]
-            }
-          });
-      });
+          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+            .toEqual({
+              docker: {
+                forcePullImage: null,
+                image: '',
+                privileged: null,
+                network: USER,
+                portMappings: [
+                  {
+                    containerPort: 0,
+                    hostPort: 0,
+                    labels: null,
+                    name: null,
+                    protocol: 'tcp',
+                    servicePort: null
+                  }
+                ]
+              },
+              type: 'DOCKER'
+            });
+        });
 
-      it('should set the protocol value', function () {
-        let batch = new Batch();
-        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-        batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'protocol', 'tcp'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'protocol', 'udp'], true));
+        it('should set the protocol value', function () {
+          let batch = new Batch();
+          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
+          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'protocol', 'tcp'], true));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'protocol', 'udp'], true));
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual({
-            type: 'DOCKER',
-            docker: {
-              forcePullImage: null,
-              image: '',
-              privileged: null,
-              network: USER,
-              portMappings: [
-                {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'udp,tcp', servicePort: null}
-              ]
-            }
-          });
-      });
+          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+            .toEqual({
+              docker: {
+                forcePullImage: null,
+                image: '',
+                privileged: null,
+                network: USER,
+                portMappings: [
+                  {
+                    containerPort: 0,
+                    hostPort: 0,
+                    labels: null,
+                    name: null,
+                    protocol: 'udp,tcp',
+                    servicePort: null
+                  }
+                ]
+              },
+              type: 'DOCKER'
+            });
+        });
 
-      it('should add the labels key if the portDefinition is load balanced', function () {
-        let batch = new Batch();
-        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-        batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions'], 1, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 1, 'loadBalanced'], true));
+        it('should add the labels key if the portDefinition is load balanced', function () {
+          let batch = new Batch();
+          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
+          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions'], 1, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+          batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
+          batch = batch.add(new Transaction(['portDefinitions', 1, 'loadBalanced'], true));
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual({
-            type: 'DOCKER',
-            docker: {
-              forcePullImage: null,
-              image: '',
-              privileged: null,
-              network: USER,
-              portMappings: [
-                {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', servicePort: null},
-                {containerPort: 0, hostPort: 0, labels: {'VIP_1': ':0'}, name: null, protocol: 'tcp', servicePort: null}
-              ]
-            }
-          });
-      });
+          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+            .toEqual({
+              docker: {
+                forcePullImage: null,
+                image: '',
+                privileged: null,
+                network: USER,
+                portMappings: [
+                  {
+                    containerPort: 0,
+                    hostPort: 0,
+                    labels: null,
+                    name: null,
+                    protocol: 'tcp',
+                    servicePort: null
+                  },
+                  {
+                    containerPort: 0,
+                    hostPort: 0,
+                    labels: {'VIP_1': ':0'},
+                    name: null,
+                    protocol: 'tcp',
+                    servicePort: null
+                  }
+                ]
+              },
+              type: 'DOCKER'
+            });
+        });
 
-      it('should add the index of the portDefinition to the VIP keys', function () {
-        let batch = new Batch();
-        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-        batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions'], 1, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'loadBalanced'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 1, 'loadBalanced'], true));
+        it('should add the index of the portDefinition to the VIP keys', function () {
+          let batch = new Batch();
+          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
+          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions'], 1, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+          batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'loadBalanced'], true));
+          batch = batch.add(new Transaction(['portDefinitions', 1, 'loadBalanced'], true));
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual({
-            type: 'DOCKER',
-            docker: {
-              forcePullImage: null,
-              image: '',
-              privileged: null,
-              network: USER,
-              portMappings: [
-                {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', labels: {VIP_0: ':0'}, servicePort: null},
-                {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', labels: {VIP_1: ':0'}, servicePort: null}
-              ]
-            }
-          });
-      });
+          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+            .toEqual({
+              docker: {
+                forcePullImage: null,
+                image: '',
+                privileged: null,
+                network: USER,
+                portMappings: [
+                  {
+                    containerPort: 0,
+                    hostPort: 0,
+                    name: null,
+                    protocol: 'tcp',
+                    labels: {VIP_0: ':0'},
+                    servicePort: null
+                  },
+                  {
+                    containerPort: 0,
+                    hostPort: 0,
+                    name: null,
+                    protocol: 'tcp',
+                    labels: {VIP_1: ':0'},
+                    servicePort: null
+                  }
+                ]
+              },
+              type: 'DOCKER',
+            });
+        });
 
-      it('should add the port to the VIP string', function () {
-        let batch = new Batch();
-        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-        batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'automaticPort'], false));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'hostPort'], 300));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'loadBalanced'], true));
+        it('should add the port to the VIP string', function () {
+          let batch = new Batch();
+          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
+          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+          batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'automaticPort'], false));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'hostPort'], 300));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'loadBalanced'], true));
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual({
-            type: 'DOCKER',
-            docker: {
-              forcePullImage: null,
-              image: '',
-              privileged: null,
-              network: USER,
-              portMappings: [
-                {containerPort: 0, hostPort: 300, name: null, protocol: 'tcp', labels: {VIP_0: ':300'}, servicePort: null},
-                {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', servicePort: null}
-              ]
-            }
-          });
-      });
+          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+            .toEqual({
+              docker: {
+                forcePullImage: null,
+                image: '',
+                privileged: null,
+                network: USER,
+                portMappings: [
+                  {
+                    containerPort: 0,
+                    hostPort: 300,
+                    name: null,
+                    protocol: 'tcp',
+                    labels: {VIP_0: ':300'},
+                    servicePort: null
+                  },
+                  {
+                    containerPort: 0,
+                    hostPort: 0,
+                    labels: null,
+                    name: null,
+                    protocol: 'tcp',
+                    servicePort: null
+                  }
+                ]
+              },
+              type: 'DOCKER'
+            });
+        });
 
-      it('should add the app ID to the VIP string when it is defined', function () {
-        let batch = new Batch();
-        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-        batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'automaticPort'], false));
-        batch = batch.add(new Transaction(['portDefinitions', 1, 'loadBalanced'], true));
-        batch = batch.add(new Transaction(['id'], 'foo'));
+        it('should add the app ID to the VIP string when it is defined', function () {
+          let batch = new Batch();
+          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
+          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+          batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'automaticPort'], false));
+          batch = batch.add(new Transaction(['portDefinitions', 1, 'loadBalanced'], true));
+          batch = batch.add(new Transaction(['id'], 'foo'));
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual({
-            type: 'DOCKER',
-            docker: {
-              forcePullImage: null,
-              image: '',
-              privileged: null,
-              network: USER,
-              portMappings: [
-                {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', servicePort: null},
-                {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', labels: {'VIP_1': 'foo:0'}, servicePort: null}
-              ]
-            }
-          });
-      });
+          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+            .toEqual({
+              docker: {
+                forcePullImage: null,
+                image: '',
+                privileged: null,
+                network: USER,
+                portMappings: [
+                  {
+                    containerPort: 0,
+                    hostPort: 0,
+                    labels: null,
+                    name: null,
+                    protocol: 'tcp',
+                    servicePort: null
+                  },
+                  {
+                    containerPort: 0,
+                    hostPort: 0,
+                    name: null,
+                    protocol: 'tcp',
+                    labels: {'VIP_1': 'foo:0'},
+                    servicePort: null
+                  }
+                ]
+              },
+              type: 'DOCKER'
+            });
+        });
 
-      it('should store portDefinitions even if network is HOST when recorded', function () {
-        let batch = new Batch();
-        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'automaticPort'], false));
-        batch = batch.add(new Transaction(['portDefinitions', 1, 'loadBalanced'], true));
-        batch = batch.add(new Transaction(['id'], 'foo'));
-        batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
+        it('should store portDefinitions even if network is HOST when recorded', function () {
+          let batch = new Batch();
+          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+          batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'automaticPort'], false));
+          batch = batch.add(new Transaction(['portDefinitions', 1, 'loadBalanced'], true));
+          batch = batch.add(new Transaction(['id'], 'foo'));
+          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual({
-            type: 'DOCKER',
-            docker: {
-              forcePullImage: null,
-              image: '',
-              privileged: null,
-              network: USER,
-              portMappings: [
-                {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', servicePort: null},
-                {containerPort: 0, hostPort: 0, labels: null, name: null, protocol: 'tcp', labels: {'VIP_1': 'foo:0'}, servicePort: null}
-              ]
-            }
-          });
-      });
+          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+            .toEqual({
+              docker: {
+                forcePullImage: null,
+                image: '',
+                privileged: null,
+                network: USER,
+                portMappings: [
+                  {
+                    containerPort: 0,
+                    hostPort: 0,
+                    labels: null,
+                    name: null,
+                    protocol: 'tcp',
+                    servicePort: null
+                  },
+                  {
+                    containerPort: 0,
+                    hostPort: 0,
+                    name: null,
+                    protocol: 'tcp',
+                    labels: {'VIP_1': 'foo:0'},
+                    servicePort: null
+                  }
+                ]
+              },
+              type: 'DOCKER'
+            });
+        });
 
-      it('should\'t create portMappings when container.type is MESOS', function () {
-        let batch = new Batch();
-        batch = batch.add(new Transaction(['container', 'type'], 'MESOS', SET));
-        batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+        it('should\'t create portMappings when container.type is MESOS', function () {
+          let batch = new Batch();
+          batch = batch.add(new Transaction(['container', 'type'], 'MESOS', SET));
+          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual({
-            type: 'MESOS',
-            docker: {
-              forcePullImage: null,
-              image: '',
-              privileged: null,
-              network: null,
-              portMappings: null
-            }
-          });
+          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+            .toEqual({
+              docker: {
+                forcePullImage: null,
+                image: '',
+                privileged: null,
+                network: null,
+                portMappings: null
+              },
+              type: 'MESOS'
+            });
+        });
+
       });
 
     });

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -1,8 +1,10 @@
 const Container = require('../Container');
 const Batch = require('../../../../../../../src/js/structs/Batch');
 const Transaction = require('../../../../../../../src/js/structs/Transaction');
-const {ADD_ITEM, SET} = require('../../../../../../../src/js/constants/TransactionTypes');
-const {type: {BRIDGE, HOST, USER}} = require('../../../../../../../src/js/constants/Networking');
+const {ADD_ITEM, SET} =
+  require('../../../../../../../src/js/constants/TransactionTypes');
+const {type: {BRIDGE, HOST, USER}} =
+  require('../../../../../../../src/js/constants/Networking');
 
 describe('Container', function () {
 
@@ -354,10 +356,16 @@ describe('Container', function () {
 
       it('should create default portDefinition configurations', function () {
         let batch = new Batch();
-        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-        batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
+        batch = batch.add(
+          new Transaction(['container', 'type'], 'DOCKER', SET)
+        );
+        batch = batch.add(
+          new Transaction(['container', 'docker', 'network'], USER, SET)
+        );
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+        batch = batch.add(
+          new Transaction(['portDefinitions', 0, 'portMapping'], true)
+        );
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
@@ -381,78 +389,112 @@ describe('Container', function () {
           });
       });
 
-      it('shouldn\'t include hostPort or protocol when not enabled', function () {
-        let batch = new Batch();
-        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-        batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-        // This is default
-        // batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], false));
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'protocol', 'udp'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'hostPort'], 100));
+      it('shouldn\'t include hostPort or protocol when not enabled',
+        function () {
+          let batch = new Batch();
+          batch = batch.add(
+            new Transaction(['container', 'type'], 'DOCKER', SET)
+          );
+          batch = batch.add(
+            new Transaction(['container', 'docker', 'network'], USER, SET)
+          );
+          // This is default
+          // batch = batch.add(
+          //   new Transaction(['portDefinitions', 0, 'portMapping'], false)
+          // );
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'protocol', 'udp'], true)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'hostPort'], 100)
+          );
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual({
-            docker: {
-              forcePullImage: null,
-              image: '',
-              privileged: null,
-              network: USER,
-              portMappings: [
-                {
-                  containerPort: 0,
-                  hostPort: null,
-                  labels: null,
-                  name: null,
-                  protocol: null,
-                  servicePort: null
-                }
-              ]
-            },
-            type: 'DOCKER'
-          });
-      });
+          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+            .toEqual({
+              docker: {
+                forcePullImage: null,
+                image: '',
+                privileged: null,
+                network: USER,
+                portMappings: [
+                  {
+                    containerPort: 0,
+                    hostPort: null,
+                    labels: null,
+                    name: null,
+                    protocol: null,
+                    servicePort: null
+                  }
+                ]
+              },
+              type: 'DOCKER'
+            });
+        }
+      );
 
-      it('should include hostPort or protocol when not enabled for BRIDGE', function () {
-        let batch = new Batch();
-        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-        batch = batch.add(new Transaction(['container', 'docker', 'network'], BRIDGE, SET));
-        // This is default
-        // batch = batch.add(new Transaction(['portDefinitions', 0,'portMapping'], false));
-        batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'protocol', 'tcp'], false));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'protocol', 'udp'], true));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'automaticPort'], false));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'hostPort'], 100));
+      it('should include hostPort or protocol when not enabled for BRIDGE',
+        function () {
+          let batch = new Batch();
+          batch = batch.add(
+            new Transaction(['container', 'type'], 'DOCKER', SET)
+          );
+          batch = batch.add(
+            new Transaction(['container', 'docker', 'network'], BRIDGE, SET)
+          );
+          // This is default
+          // batch = batch.add(
+          //   new Transaction(['portDefinitions',0,'portMapping'], false)
+          // );
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'protocol', 'tcp'], false)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'protocol', 'udp'], true)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'automaticPort'], false)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'hostPort'], 100)
+          );
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-          .toEqual({
-            docker: {
-              forcePullImage: null,
-              image: '',
-              privileged: null,
-              network: BRIDGE,
-              portMappings: [
-                {
-                  containerPort: 0,
-                  hostPort: 100,
-                  labels: null,
-                  name: null,
-                  protocol: 'udp',
-                  servicePort: null
-                }
-              ]
-            },
-            type: 'DOCKER',
-          });
-      });
+          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+            .toEqual({
+              docker: {
+                forcePullImage: null,
+                image: '',
+                privileged: null,
+                network: BRIDGE,
+                portMappings: [
+                  {
+                    containerPort: 0,
+                    hostPort: 100,
+                    labels: null,
+                    name: null,
+                    protocol: 'udp',
+                    servicePort: null
+                  }
+                ]
+              },
+              type: 'DOCKER'
+            });
+        }
+      );
 
       it('should create default portDefinition configurations', function () {
         let batch = new Batch();
-        batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-        batch = batch.add(new Transaction(['container', 'docker', 'network'], BRIDGE, SET));
+        batch = batch.add(
+          new Transaction(['container', 'type'], 'DOCKER', SET)
+        );
+        batch = batch.add(
+          new Transaction(['container', 'docker', 'network'], BRIDGE, SET)
+        );
         batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+        batch = batch.add(
+          new Transaction(['portDefinitions', 0, 'portMapping'], true)
+        );
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {}))
           .toEqual({
@@ -493,10 +535,18 @@ describe('Container', function () {
 
         it('shouldn\'t create portMappings for HOST', function () {
           let batch = new Batch();
-          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-          batch = batch.add(new Transaction(['container', 'docker', 'network'], HOST, SET));
-          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+          batch = batch.add(
+            new Transaction(['container', 'type'], 'DOCKER', SET)
+          );
+          batch = batch.add(
+            new Transaction(['container', 'docker', 'network'], HOST, SET)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions'], 0, ADD_ITEM)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'portMapping'], true)
+          );
 
           expect(batch.reduce(Container.JSONReducer.bind({}), {}))
             .toEqual({
@@ -511,52 +561,76 @@ describe('Container', function () {
             });
         });
 
-        it('should create two default portDefinition configurations', function () {
-          let batch = new Batch();
-          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions'], 1, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-          batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
+        it('should create two default portDefinition configurations',
+          function () {
+            let batch = new Batch();
+            batch = batch.add(
+              new Transaction(['container', 'type'], 'DOCKER', SET)
+            );
+            batch = batch.add(
+              new Transaction(['container', 'docker', 'network'], USER, SET)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions'], 0, ADD_ITEM)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions'], 1, ADD_ITEM)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 0, 'portMapping'], true)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 1, 'portMapping'], true)
+            );
 
-          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-            .toEqual({
-              docker: {
-                forcePullImage: null,
-                image: '',
-                privileged: null,
-                network: USER,
-                portMappings: [
-                  {
-                    containerPort: 0,
-                    hostPort: 0,
-                    labels: null,
-                    name: null,
-                    protocol: 'tcp',
-                    servicePort: null
-                  },
-                  {
-                    containerPort: 0,
-                    hostPort: 0,
-                    labels: null,
-                    name: null,
-                    protocol: 'tcp',
-                    servicePort: null
-                  }
-                ]
-              },
-              type: 'DOCKER'
-            });
-        });
+            expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+              .toEqual({
+                docker: {
+                  forcePullImage: null,
+                  image: '',
+                  privileged: null,
+                  network: USER,
+                  portMappings: [
+                    {
+                      containerPort: 0,
+                      hostPort: 0,
+                      labels: null,
+                      name: null,
+                      protocol: 'tcp',
+                      servicePort: null
+                    },
+                    {
+                      containerPort: 0,
+                      hostPort: 0,
+                      labels: null,
+                      name: null,
+                      protocol: 'tcp',
+                      servicePort: null
+                    }
+                  ]
+                },
+                type: 'DOCKER'
+              });
+          }
+        );
 
         it('should set the name value', function () {
           let batch = new Batch();
-          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'name'], 'foo'));
+          batch = batch.add(
+            new Transaction(['container', 'type'], 'DOCKER', SET)
+          );
+          batch = batch.add(
+            new Transaction(['container', 'docker', 'network'], USER, SET)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions'], 0, ADD_ITEM)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'portMapping'], true)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'name'], 'foo')
+          );
 
           expect(batch.reduce(Container.JSONReducer.bind({}), {}))
             .toEqual({
@@ -582,12 +656,24 @@ describe('Container', function () {
 
         it('should set the port value', function () {
           let batch = new Batch();
-          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'automaticPort'], false));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'hostPort'], 100));
+          batch = batch.add(
+            new Transaction(['container', 'type'], 'DOCKER', SET)
+          );
+          batch = batch.add(
+            new Transaction(['container', 'docker', 'network'], USER, SET)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions'], 0, ADD_ITEM)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'portMapping'], true)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'automaticPort'], false)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'hostPort'], 100)
+          );
 
           expect(batch.reduce(Container.JSONReducer.bind({}), {}))
             .toEqual({
@@ -613,13 +699,24 @@ describe('Container', function () {
 
         it('should default port value to 0 if automaticPort', function () {
           let batch = new Batch();
-          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+          batch = batch.add(
+            new Transaction(['container', 'type'], 'DOCKER', SET)
+          );
+          batch = batch.add(
+            new Transaction(['container', 'docker', 'network'], USER, SET)
+          );
+          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'portMapping'], true)
+          );
           // This is default behavior
-          // batch = batch.add(new Transaction(['portDefinitions', 0, 'automaticPort'], true));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'hostPort'], 100));
+          // batch = batch.add(
+          //  new Transaction(['portDefinitions', 0, 'automaticPort'], true)
+          // );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'hostPort'], 100)
+          );
 
           expect(batch.reduce(Container.JSONReducer.bind({}), {}))
             .toEqual({
@@ -645,12 +742,24 @@ describe('Container', function () {
 
         it('should set the protocol value', function () {
           let batch = new Batch();
-          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'protocol', 'tcp'], true));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'protocol', 'udp'], true));
+          batch = batch.add(
+            new Transaction(['container', 'type'], 'DOCKER', SET)
+          );
+          batch = batch.add(
+            new Transaction(['container', 'docker', 'network'], USER, SET)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions'], 0, ADD_ITEM)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'portMapping'], true)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'protocol', 'tcp'], true)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'protocol', 'udp'], true)
+          );
 
           expect(batch.reduce(Container.JSONReducer.bind({}), {}))
             .toEqual({
@@ -674,98 +783,150 @@ describe('Container', function () {
             });
         });
 
-        it('should add the labels key if the portDefinition is load balanced', function () {
-          let batch = new Batch();
-          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions'], 1, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-          batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
-          batch = batch.add(new Transaction(['portDefinitions', 1, 'loadBalanced'], true));
+        it('should add the labels key if the portDefinition is load balanced',
+          function () {
+            let batch = new Batch();
+            batch = batch.add(
+              new Transaction(['container', 'type'], 'DOCKER', SET)
+            );
+            batch = batch.add(
+              new Transaction(['container', 'docker', 'network'], USER, SET)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions'], 0, ADD_ITEM)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions'], 1, ADD_ITEM)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 0, 'portMapping'], true)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 1, 'portMapping'], true)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 1, 'loadBalanced'], true)
+            );
 
-          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-            .toEqual({
-              docker: {
-                forcePullImage: null,
-                image: '',
-                privileged: null,
-                network: USER,
-                portMappings: [
-                  {
-                    containerPort: 0,
-                    hostPort: 0,
-                    labels: null,
-                    name: null,
-                    protocol: 'tcp',
-                    servicePort: null
-                  },
-                  {
-                    containerPort: 0,
-                    hostPort: 0,
-                    labels: {'VIP_1': ':0'},
-                    name: null,
-                    protocol: 'tcp',
-                    servicePort: null
-                  }
-                ]
-              },
-              type: 'DOCKER'
-            });
-        });
+            expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+              .toEqual({
+                docker: {
+                  forcePullImage: null,
+                  image: '',
+                  privileged: null,
+                  network: USER,
+                  portMappings: [
+                    {
+                      containerPort: 0,
+                      hostPort: 0,
+                      labels: null,
+                      name: null,
+                      protocol: 'tcp',
+                      servicePort: null
+                    },
+                    {
+                      containerPort: 0,
+                      hostPort: 0,
+                      labels: {'VIP_1': ':0'},
+                      name: null,
+                      protocol: 'tcp',
+                      servicePort: null
+                    }
+                  ]
+                },
+                type: 'DOCKER'
+              });
+          }
+        );
 
-        it('should add the index of the portDefinition to the VIP keys', function () {
-          let batch = new Batch();
-          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions'], 1, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-          batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'loadBalanced'], true));
-          batch = batch.add(new Transaction(['portDefinitions', 1, 'loadBalanced'], true));
+        it('should add the index of the portDefinition to the VIP keys',
+          function () {
+            let batch = new Batch();
+            batch = batch.add(
+              new Transaction(['container', 'type'], 'DOCKER', SET)
+            );
+            batch = batch.add(
+              new Transaction(['container', 'docker', 'network'], USER, SET)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions'], 0, ADD_ITEM)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions'], 1, ADD_ITEM)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 0, 'portMapping'], true)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 1, 'portMapping'], true)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 0, 'loadBalanced'], true)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 1, 'loadBalanced'], true)
+            );
 
-          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-            .toEqual({
-              docker: {
-                forcePullImage: null,
-                image: '',
-                privileged: null,
-                network: USER,
-                portMappings: [
-                  {
-                    containerPort: 0,
-                    hostPort: 0,
-                    name: null,
-                    protocol: 'tcp',
-                    labels: {VIP_0: ':0'},
-                    servicePort: null
-                  },
-                  {
-                    containerPort: 0,
-                    hostPort: 0,
-                    name: null,
-                    protocol: 'tcp',
-                    labels: {VIP_1: ':0'},
-                    servicePort: null
-                  }
-                ]
-              },
-              type: 'DOCKER',
-            });
-        });
+            expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+              .toEqual({
+                docker: {
+                  forcePullImage: null,
+                  image: '',
+                  privileged: null,
+                  network: USER,
+                  portMappings: [
+                    {
+                      containerPort: 0,
+                      hostPort: 0,
+                      name: null,
+                      protocol: 'tcp',
+                      labels: {VIP_0: ':0'},
+                      servicePort: null
+                    },
+                    {
+                      containerPort: 0,
+                      hostPort: 0,
+                      name: null,
+                      protocol: 'tcp',
+                      labels: {VIP_1: ':0'},
+                      servicePort: null
+                    }
+                  ]
+                },
+                type: 'DOCKER'
+              });
+          }
+        );
 
         it('should add the port to the VIP string', function () {
           let batch = new Batch();
-          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-          batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'automaticPort'], false));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'hostPort'], 300));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'loadBalanced'], true));
+          batch = batch.add(
+            new Transaction(['container', 'type'], 'DOCKER', SET)
+          );
+          batch = batch.add(
+            new Transaction(['container', 'docker', 'network'], USER, SET)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions'], 0, ADD_ITEM)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions'], 0, ADD_ITEM)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'portMapping'], true)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 1, 'portMapping'], true)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'automaticPort'], false)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'hostPort'], 300)
+          );
+          batch = batch.add(
+            new Transaction(['portDefinitions', 0, 'loadBalanced'], true)
+          );
 
           expect(batch.reduce(Container.JSONReducer.bind({}), {}))
             .toEqual({
@@ -797,109 +958,159 @@ describe('Container', function () {
             });
         });
 
-        it('should add the app ID to the VIP string when it is defined', function () {
-          let batch = new Batch();
-          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-          batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'automaticPort'], false));
-          batch = batch.add(new Transaction(['portDefinitions', 1, 'loadBalanced'], true));
-          batch = batch.add(new Transaction(['id'], 'foo'));
+        it('should add the app ID to the VIP string when it is defined',
+          function () {
+            let batch = new Batch();
+            batch = batch.add(
+              new Transaction(['container', 'type'], 'DOCKER', SET)
+            );
+            batch = batch.add(
+              new Transaction(['container', 'docker', 'network'], USER, SET)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions'], 0, ADD_ITEM)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions'], 0, ADD_ITEM)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 0, 'portMapping'], true)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 1, 'portMapping'], true)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 0, 'automaticPort'], false)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 1, 'loadBalanced'], true)
+            );
+            batch = batch.add(
+              new Transaction(['id'], 'foo')
+            );
 
-          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-            .toEqual({
-              docker: {
-                forcePullImage: null,
-                image: '',
-                privileged: null,
-                network: USER,
-                portMappings: [
-                  {
-                    containerPort: 0,
-                    hostPort: 0,
-                    labels: null,
-                    name: null,
-                    protocol: 'tcp',
-                    servicePort: null
-                  },
-                  {
-                    containerPort: 0,
-                    hostPort: 0,
-                    name: null,
-                    protocol: 'tcp',
-                    labels: {'VIP_1': 'foo:0'},
-                    servicePort: null
-                  }
-                ]
-              },
-              type: 'DOCKER'
-            });
-        });
+            expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+              .toEqual({
+                docker: {
+                  forcePullImage: null,
+                  image: '',
+                  privileged: null,
+                  network: USER,
+                  portMappings: [
+                    {
+                      containerPort: 0,
+                      hostPort: 0,
+                      labels: null,
+                      name: null,
+                      protocol: 'tcp',
+                      servicePort: null
+                    },
+                    {
+                      containerPort: 0,
+                      hostPort: 0,
+                      name: null,
+                      protocol: 'tcp',
+                      labels: {'VIP_1': 'foo:0'},
+                      servicePort: null
+                    }
+                  ]
+                },
+                type: 'DOCKER'
+              });
+          }
+        );
 
-        it('should store portDefinitions even if network is HOST when recorded', function () {
-          let batch = new Batch();
-          batch = batch.add(new Transaction(['container', 'type'], 'DOCKER', SET));
-          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
-          batch = batch.add(new Transaction(['portDefinitions', 1, 'portMapping'], true));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'automaticPort'], false));
-          batch = batch.add(new Transaction(['portDefinitions', 1, 'loadBalanced'], true));
-          batch = batch.add(new Transaction(['id'], 'foo'));
-          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
+        it('should store portDefinitions even if network is HOST when recorded',
+          function () {
+            let batch = new Batch();
+            batch = batch.add(
+              new Transaction(['container', 'type'], 'DOCKER', SET)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions'], 0, ADD_ITEM)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions'], 0, ADD_ITEM)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 0, 'portMapping'], true)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 1, 'portMapping'], true)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 0, 'automaticPort'], false)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 1, 'loadBalanced'], true)
+            );
+            batch = batch.add(
+              new Transaction(['id'], 'foo')
+            );
+            batch = batch.add(
+              new Transaction(['container', 'docker', 'network'], USER, SET)
+            );
 
-          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-            .toEqual({
-              docker: {
-                forcePullImage: null,
-                image: '',
-                privileged: null,
-                network: USER,
-                portMappings: [
-                  {
-                    containerPort: 0,
-                    hostPort: 0,
-                    labels: null,
-                    name: null,
-                    protocol: 'tcp',
-                    servicePort: null
-                  },
-                  {
-                    containerPort: 0,
-                    hostPort: 0,
-                    name: null,
-                    protocol: 'tcp',
-                    labels: {'VIP_1': 'foo:0'},
-                    servicePort: null
-                  }
-                ]
-              },
-              type: 'DOCKER'
-            });
-        });
+            expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+              .toEqual({
+                docker: {
+                  forcePullImage: null,
+                  image: '',
+                  privileged: null,
+                  network: USER,
+                  portMappings: [
+                    {
+                      containerPort: 0,
+                      hostPort: 0,
+                      labels: null,
+                      name: null,
+                      protocol: 'tcp',
+                      servicePort: null
+                    },
+                    {
+                      containerPort: 0,
+                      hostPort: 0,
+                      name: null,
+                      protocol: 'tcp',
+                      labels: {'VIP_1': 'foo:0'},
+                      servicePort: null
+                    }
+                  ]
+                },
+                type: 'DOCKER'
+              });
+          }
+        );
 
-        it('should\'t create portMappings when container.type is MESOS', function () {
-          let batch = new Batch();
-          batch = batch.add(new Transaction(['container', 'type'], 'MESOS', SET));
-          batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
-          batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(['portDefinitions', 0, 'portMapping'], true));
+        it('should\'t create portMappings when container.type is MESOS',
+          function () {
+            let batch = new Batch();
+            batch = batch.add(
+              new Transaction(['container', 'type'], 'MESOS', SET)
+            );
+            batch = batch.add(
+              new Transaction(['container', 'docker', 'network'], USER, SET)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions'], 0, ADD_ITEM)
+            );
+            batch = batch.add(
+              new Transaction(['portDefinitions', 0, 'portMapping'], true)
+            );
 
-          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
-            .toEqual({
-              docker: {
-                forcePullImage: null,
-                image: '',
-                privileged: null,
-                network: null,
-                portMappings: null
-              },
-              type: 'MESOS'
-            });
-        });
+            expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+              .toEqual({
+                docker: {
+                  forcePullImage: null,
+                  image: '',
+                  privileged: null,
+                  network: null,
+                  portMappings: null
+                },
+                type: 'MESOS'
+              });
+          }
+        );
 
       });
 

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -1,7 +1,7 @@
 const Container = require('../Container');
 const Batch = require('../../../../../../../src/js/structs/Batch');
 const Transaction = require('../../../../../../../src/js/structs/Transaction');
-const {ADD_ITEM, SET} =
+const {ADD_ITEM, SET, REMOVE_ITEM} =
   require('../../../../../../../src/js/constants/TransactionTypes');
 const {type: {BRIDGE, HOST, USER}} =
   require('../../../../../../../src/js/constants/Networking');
@@ -21,7 +21,8 @@ describe('Container', function () {
             privileged: null,
             network: null,
             portMappings: null
-          }
+          },
+          volumes: []
         });
     });
 
@@ -41,7 +42,8 @@ describe('Container', function () {
             network: undefined,
             portMappings: null
           },
-          type: 'DOCKER'
+          type: 'DOCKER',
+          volumes: []
         });
     });
 
@@ -64,7 +66,8 @@ describe('Container', function () {
           network: undefined,
           portMappings: null
         },
-        type: 'DOCKER'
+        type: 'DOCKER',
+        volumes: []
       });
     });
 
@@ -86,7 +89,8 @@ describe('Container', function () {
           network: null,
           portMappings: null
         },
-        type: 'MESOS'
+        type: 'MESOS',
+        volumes: []
       });
     });
 
@@ -111,7 +115,8 @@ describe('Container', function () {
           network: undefined,
           portMappings: null
         },
-        type: 'DOCKER'
+        type: 'DOCKER',
+        volumes: []
       });
     });
 
@@ -136,7 +141,8 @@ describe('Container', function () {
           network: undefined,
           portMappings: null
         },
-        type: 'DOCKER'
+        type: 'DOCKER',
+        volumes: []
       });
     });
 
@@ -161,7 +167,8 @@ describe('Container', function () {
           network: undefined,
           portMappings: null
         },
-        type: 'DOCKER'
+        type: 'DOCKER',
+        volumes: []
       });
     });
 
@@ -186,7 +193,8 @@ describe('Container', function () {
           network: undefined,
           portMappings: null
         },
-        type: 'DOCKER'
+        type: 'DOCKER',
+        volumes: []
       });
     });
 
@@ -211,7 +219,8 @@ describe('Container', function () {
           network: undefined,
           portMappings: null
         },
-        type: 'DOCKER'
+        type: 'DOCKER',
+        volumes: []
       });
     });
 
@@ -231,7 +240,8 @@ describe('Container', function () {
           privileged: null,
           network: null,
           portMappings: null
-        }
+        },
+        volumes: []
       });
     });
 
@@ -257,7 +267,8 @@ describe('Container', function () {
           portMappings: null,
           privileged: null
         },
-        type: 'MESOS'
+        type: 'MESOS',
+        volumes: []
       });
     });
 
@@ -284,7 +295,8 @@ describe('Container', function () {
           portMappings: null,
           privileged: null
         },
-        type: 'DOCKER'
+        type: 'DOCKER',
+        volumes: []
       });
     });
 
@@ -306,7 +318,8 @@ describe('Container', function () {
           network: undefined,
           portMappings: null
         },
-        type: 'DOCKER'
+        type: 'DOCKER',
+        volumes: []
       });
     });
 
@@ -328,7 +341,8 @@ describe('Container', function () {
           network: undefined,
           portMappings: null
         },
-        type: 'DOCKER'
+        type: 'DOCKER',
+        volumes: []
       });
     });
 
@@ -348,7 +362,8 @@ describe('Container', function () {
           privileged: null,
           network: null,
           portMappings: null
-        }
+        },
+        volumes: []
       });
     });
 
@@ -385,7 +400,8 @@ describe('Container', function () {
                 }
               ]
             },
-            type: 'DOCKER'
+            type: 'DOCKER',
+            volumes: []
           });
       });
 
@@ -428,7 +444,8 @@ describe('Container', function () {
                   }
                 ]
               },
-              type: 'DOCKER'
+              type: 'DOCKER',
+              volumes: []
             });
         }
       );
@@ -478,7 +495,8 @@ describe('Container', function () {
                   }
                 ]
               },
-              type: 'DOCKER'
+              type: 'DOCKER',
+              volumes: []
             });
         }
       );
@@ -514,7 +532,8 @@ describe('Container', function () {
                 }
               ]
             },
-            type: 'DOCKER'
+            type: 'DOCKER',
+            volumes: []
           });
 
         it('shouldn\'t create portMappings by default', function () {
@@ -529,7 +548,8 @@ describe('Container', function () {
                 privileged: null,
                 network: null,
                 portMappings: null
-              }
+              },
+              volumes: []
             });
         });
 
@@ -557,7 +577,8 @@ describe('Container', function () {
                 privileged: null,
                 portMappings: null
               },
-              type: 'DOCKER'
+              type: 'DOCKER',
+              volumes: []
             });
         });
 
@@ -609,7 +630,8 @@ describe('Container', function () {
                     }
                   ]
                 },
-                type: 'DOCKER'
+                type: 'DOCKER',
+                volumes: []
               });
           }
         );
@@ -650,7 +672,8 @@ describe('Container', function () {
                   }
                 ]
               },
-              type: 'DOCKER'
+              type: 'DOCKER',
+              volumes: []
             });
         });
 
@@ -693,7 +716,8 @@ describe('Container', function () {
                   }
                 ]
               },
-              type: 'DOCKER'
+              type: 'DOCKER',
+              volumes: []
             });
         });
 
@@ -736,7 +760,8 @@ describe('Container', function () {
                   }
                 ]
               },
-              type: 'DOCKER'
+              type: 'DOCKER',
+              volumes: []
             });
         });
 
@@ -779,7 +804,8 @@ describe('Container', function () {
                   }
                 ]
               },
-              type: 'DOCKER'
+              type: 'DOCKER',
+              volumes: []
             });
         });
 
@@ -834,7 +860,8 @@ describe('Container', function () {
                     }
                   ]
                 },
-                type: 'DOCKER'
+                type: 'DOCKER',
+                volumes: []
               });
           }
         );
@@ -893,7 +920,8 @@ describe('Container', function () {
                     }
                   ]
                 },
-                type: 'DOCKER'
+                type: 'DOCKER',
+                volumes: []
               });
           }
         );
@@ -954,7 +982,8 @@ describe('Container', function () {
                   }
                 ]
               },
-              type: 'DOCKER'
+              type: 'DOCKER',
+              volumes: []
             });
         });
 
@@ -1015,7 +1044,8 @@ describe('Container', function () {
                     }
                   ]
                 },
-                type: 'DOCKER'
+                type: 'DOCKER',
+                volumes: []
               });
           }
         );
@@ -1077,7 +1107,8 @@ describe('Container', function () {
                     }
                   ]
                 },
-                type: 'DOCKER'
+                type: 'DOCKER',
+                volumes: []
               });
           }
         );
@@ -1107,12 +1138,158 @@ describe('Container', function () {
                   network: null,
                   portMappings: null
                 },
-                type: 'MESOS'
+                type: 'MESOS',
+                volumes: []
               });
           }
         );
 
       });
+
+    });
+
+    describe('Volumes', function () {
+
+      it('should return an empty array if no volumes are set', function () {
+        const batch = new Batch();
+
+        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+          .toEqual({
+            docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
+              network: null,
+              portMappings: null
+            },
+            volumes: []
+          });
+      });
+
+      it('should return a local volume', function () {
+        let batch = new Batch();
+
+        batch = batch.add(new Transaction(['localVolumes'], 0, ADD_ITEM));
+        batch = batch.add(
+          new Transaction(['localVolumes', 0, 'type'], 'PERSISTENT', SET)
+        );
+
+        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+          .toEqual({
+            docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
+              network: null,
+              portMappings: null
+            },
+            type: 'MESOS',
+            volumes: [{
+              containerPath: null,
+              persistent: {
+                size: null
+              },
+              mode: 'RW'
+            }]
+          });
+      });
+
+      it('should return an external volume', function () {
+        let batch = new Batch();
+
+        batch = batch.add(new Transaction(['externalVolumes'], 0, ADD_ITEM));
+
+        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+          .toEqual({
+            docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
+              network: null,
+              portMappings: null
+            },
+            type: 'MESOS',
+            volumes: [{
+              containerPath: null,
+              external: {
+                name: null,
+                provider: 'dvdi',
+                options: {
+                  'dvdi/driver': 'rexray'
+                }
+              },
+              mode: 'RW'
+            }]
+          });
+      });
+
+      it('should return a local and an external volume', function () {
+        let batch = new Batch();
+
+        batch = batch.add(new Transaction(['externalVolumes'], 0, ADD_ITEM));
+        batch = batch.add(new Transaction(['localVolumes'], 0, ADD_ITEM));
+        batch = batch.add(new Transaction(['localVolumes', 0, 'type'], 'PERSISTENT', SET));
+
+        expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+          .toEqual({
+            docker: {
+              forcePullImage: null,
+              image: '',
+              privileged: null,
+              network: null,
+              portMappings: null
+            },
+            type: 'MESOS',
+            volumes: [
+              {
+                containerPath: null,
+                persistent: {
+                  size: null
+                },
+                mode: 'RW'
+              },
+              {
+                containerPath: null,
+                external: {
+                  name: null,
+                  provider: 'dvdi',
+                  options: {
+                    'dvdi/driver': 'rexray'
+                  }
+                },
+                mode: 'RW'
+              }
+            ]
+          });
+      });
+
+      it('should return an empty array if all volumes have been removed',
+        function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['localVolumes'], 0, ADD_ITEM));
+          batch = batch.add(
+            new Transaction(['localVolumes', 0, 'type'], 'PERSISTENT', SET)
+          );
+          batch = batch.add(new Transaction(['externalVolumes'], 0, ADD_ITEM));
+          batch = batch.add(
+            new Transaction(['externalVolumes'], 0, REMOVE_ITEM)
+          );
+          batch = batch.add(new Transaction(['localVolumes'], 0, REMOVE_ITEM));
+
+          expect(batch.reduce(Container.JSONReducer.bind({}), {}))
+            .toEqual({
+              docker: {
+                forcePullImage: null,
+                image: '',
+                privileged: null,
+                network: null,
+                portMappings: null
+              },
+              volumes: []
+            });
+        }
+      );
 
     });
 


### PR DESCRIPTION
Change the container JSON reducer to always output volumes as omitting empty volumes results in wrong patch updates. This change fixes issues with wrong JSON after a volumes was removed.