### PR TITLE
DCOS-12890: Allow .page-body-content to shrink

### DIFF
--- a/src/styles/layout/page-body/styles.less
+++ b/src/styles/layout/page-body/styles.less
@@ -2,4 +2,12 @@
   flex: 1 1 auto;
   overflow: hidden;
   position: relative;
+
+  &-content {
+
+    &,
+    .flex-item-shrink-1 {
+      min-height: 0;
+    }
+  }
 }


### PR DESCRIPTION
This PR sets the `min-height` property on `.page-body-content` and any `.flex-item-shrink-1` children to allow them to shrink as needed.

In the screenshots, note the log viewer is expanding beyond the viewport's boundaries in the "Before" screenshot, then notice that it's respecting the available space in the "After" screenshot.

Before:
![](https://cl.ly/050d0h2o2X2q/Screen%20Shot%202017-02-09%20at%2011.45.55%20AM.png)

After:
![](https://cl.ly/2t0e1I2B2h0W/Screen%20Shot%202017-02-09%20at%2011.50.10%20AM.png)