### PR TITLE
DCOS-13661: Forbid destructuring in methods

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,8 @@
   "plugins": [
     "jsx-max-len",
     "react",
-    "compat"
+    "compat",
+    "destructuring"
   ],
 
   "globals": {
@@ -40,9 +41,14 @@
     "d3": true
   },
 
-  "extends": "airbnb",
+  "extends": [
+    "airbnb",
+    "plugin:destructuring/recommended"
+  ],
 
   "rules": {
+    "destructuring/no-rename": "off",
+    "destructuring/in-params": "off",
     "compat/compat": "error",
     "arrow-parens": ["error", "always"],
     "eqeqeq": ["error", "smart"],

--- a/foundation-ui/mount/Mount.js
+++ b/foundation-ui/mount/Mount.js
@@ -40,7 +40,9 @@ class Mount extends React.Component {
     MountService.addListener(CHANGE, this.onMountServiceChange);
   }
 
-  componentWillReceiveProps({type}) {
+  componentWillReceiveProps(nextProps) {
+    const {type} = nextProps;
+
     if (this.props.type === type) {
       return;
     }

--- a/foundation-ui/stores/DCOSStore.js
+++ b/foundation-ui/stores/DCOSStore.js
@@ -273,7 +273,8 @@ class DCOSStore extends EventEmitter {
     this.emit(DCOS_CHANGE);
   }
 
-  onMarathonServiceVersionChange({serviceID, versionID, version}) {
+  onMarathonServiceVersionChange(event) {
+    const {serviceID, versionID, version} = event;
     const {marathon:{versions}} = this.data;
     let currentVersions = versions.get(serviceID);
 
@@ -287,7 +288,8 @@ class DCOSStore extends EventEmitter {
     this.emit(DCOS_CHANGE);
   }
 
-  onMarathonServiceVersionsChange({serviceID, versions:nextVersions}) {
+  onMarathonServiceVersionsChange(event) {
+    let {serviceID, versions:nextVersions} = event;
     const {marathon:{versions}} = this.data;
     const currentVersions = versions.get(serviceID);
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2469,6 +2469,11 @@
         }
       }
     },
+    "eslint-plugin-destructuring": {
+      "version": "2.1.0",
+      "from": "eslint-plugin-destructuring@2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-destructuring/-/eslint-plugin-destructuring-2.1.0.tgz"
+    },
     "eslint-plugin-import": {
       "version": "1.13.0",
       "from": "eslint-plugin-import@1.13.0",
@@ -5455,6 +5460,11 @@
       "version": "3.2.0",
       "from": "lodash.words@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.2.0.tgz"
+    },
+    "lodash.zipobject": {
+      "version": "4.1.3",
+      "from": "lodash.zipobject@>=4.1.3 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.zipobject/-/lodash.zipobject-4.1.3.tgz"
     },
     "log-symbols": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "eslint-plugin-jsx-a11y": "2.1.0",
     "eslint-plugin-jsx-max-len": "1.0.0",
     "eslint-plugin-react": "6.9.0",
+    "eslint-plugin-destructuring": "2.1.0",
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.8.5",
     "glob": "7.0.5",

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -26,7 +26,8 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
     ];
   }
 
-  componentWillReceiveProps({location: {query}}) {
+  componentWillReceiveProps(nextProps) {
+    const {location: {query}} = nextProps;
     const filters = {
       health: query.filterHealth || 'all',
       name: query.searchString || '',

--- a/plugins/services/src/js/components/dsl/FuzzyTextDSLSection.js
+++ b/plugins/services/src/js/components/dsl/FuzzyTextDSLSection.js
@@ -32,7 +32,8 @@ class FuzzyTextDSLSection extends React.Component {
     });
   }
 
-  componentWillReceiveProps({expression}) {
+  componentWillReceiveProps(nextProps) {
+    const {expression} = nextProps;
     const data = DSLUtil.getPartValues(expression, EXPRESSION_PARTS);
     this.setState({data});
   }

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -120,7 +120,12 @@ class NetworkingFormSection extends mixin(StoreMixin) {
   }
 
   getLoadBalancedServiceAddressField(portDefinition, index) {
-    const {containerPort, hostPort, loadBalanced, vip} = portDefinition;
+    const {
+      containerPort,
+      hostPort,
+      loadBalanced,
+      vip
+    } = portDefinition;
     const {errors} = this.props;
     let vipPortError = null;
     let loadBalancedError = findNestedPropertyInObject(

--- a/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
+++ b/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
@@ -31,7 +31,8 @@ class CreateServiceJsonOnly extends React.Component {
   /**
    * @override
    */
-  componentWillReceiveProps({service}) {
+  componentWillReceiveProps(nextProps) {
+    const {service} = nextProps;
     const prevJSON = ServiceUtil.getServiceJSON(this.props.service);
     const nextJSON = ServiceUtil.getServiceJSON(service);
     // Make sure to not set state unless the service has actually changed

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -198,7 +198,8 @@ class NewCreateServiceModal extends Component {
     this.setState({service, serviceConfig: service.getSpec()});
   }
 
-  handleGoBack({tabViewID}) {
+  handleGoBack(event) {
+    const {tabViewID} = event;
     const {location} = this.props;
     const {
       serviceFormActive,
@@ -292,7 +293,8 @@ class NewCreateServiceModal extends Component {
     this.setState({serviceFormErrors: errors});
   }
 
-  handleServiceSelection({route, type}) {
+  handleServiceSelection(event) {
+    const {route, type} = event;
     const {params} = this.props;
     const baseID = getBaseID(decodeURIComponent(params.id || '/'));
 

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -237,7 +237,8 @@ class NewCreateServiceModalForm extends Component {
     });
   }
 
-  handleAddItem({value, path}) {
+  handleAddItem(event) {
+    const {value, path} = event;
     let {batch} = this.state;
 
     batch = batch.add(
@@ -247,7 +248,8 @@ class NewCreateServiceModalForm extends Component {
     this.setState({batch, appConfig: this.getAppConfig(batch)});
   }
 
-  handleRemoveItem({value, path}) {
+  handleRemoveItem(event) {
+    const {value, path} = event;
     let {batch} = this.state;
 
     batch = batch.add(

--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
@@ -302,7 +302,8 @@ class PodInstancesTable extends React.Component {
     );
   }
 
-  renderColumnID(prop, {id: taskID, name: taskName}, rowOptions = {}) {
+  renderColumnID(prop, col, rowOptions = {}) {
+    const {id: taskID, name: taskName} = col;
     if (!rowOptions.isParent) {
       const id = encodeURIComponent(this.props.pod.getId());
 

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
@@ -13,7 +13,8 @@ class ServiceConfigurationContainer extends React.Component {
     DCOSStore.fetchServiceVersions(service.getId());
   }
 
-  componentWillReceiveProps({service:nextService}) {
+  componentWillReceiveProps(nextProps) {
+    const {service:nextService} = nextProps;
     const {service} = this.props;
 
     if (service.getVersion() !== nextService.getVersion()) {

--- a/plugins/services/src/js/containers/services/SidebarLabelsFilter.js
+++ b/plugins/services/src/js/containers/services/SidebarLabelsFilter.js
@@ -158,7 +158,8 @@ class SidebarLabelsFilters extends React.Component {
     );
   }
 
-  handleActionSelection({key, value}) {
+  handleActionSelection(event) {
+    const {key, value} = event;
     const {selectedLabels} = this.state;
     const nextSelectedLabels = selectedLabels.slice();
 

--- a/plugins/services/src/js/stores/MarathonStore.js
+++ b/plugins/services/src/js/stores/MarathonStore.js
@@ -551,7 +551,8 @@ class MarathonStore extends GetSetBaseStore {
     // Handle ongoing request here.
   }
 
-  processMarathonServiceVersions({serviceID, versions}) {
+  processMarathonServiceVersions(service) {
+    let {serviceID, versions} = service;
     versions = versions.reduce(function (map, version) {
       return map.set(version);
     }, new Map());
@@ -563,7 +564,8 @@ class MarathonStore extends GetSetBaseStore {
     this.emit(MARATHON_SERVICE_VERSIONS_ERROR);
   }
 
-  processMarathonServiceVersion({serviceID, version, versionID}) {
+  processMarathonServiceVersion(service) {
+    const {serviceID, version, versionID} = service;
     // TODO (orlandohohmeier): Convert version into typed version struct
     this.emit(MARATHON_SERVICE_VERSION_CHANGE, {serviceID, versionID, version});
   }

--- a/src/js/components/DSLFormWithExpressionUpdates.js
+++ b/src/js/components/DSLFormWithExpressionUpdates.js
@@ -29,7 +29,8 @@ class DSLFormWithExpressionUpdates extends React.Component {
     });
   }
 
-  handleFormBlur({target}) {
+  handleFormBlur(event) {
+    const {target} = event;
     const {onChange, parts} = this.props;
     let {value} = target;
 
@@ -59,8 +60,11 @@ class DSLFormWithExpressionUpdates extends React.Component {
 
   /**
    * Handle a change to the form
+   *
+   * @param {Object} event
    */
-  handleFormChange({target}) {
+  handleFormChange(event) {
+    const {target} = event;
     const {onChange, parts} = this.props;
     let {value} = target;
 

--- a/src/js/components/DSLInputField.js
+++ b/src/js/components/DSLInputField.js
@@ -95,9 +95,9 @@ class DSLInputField extends React.Component {
    *
    * @param {SyntheticEvent} event - The change event
    */
-  handleChange({target}) {
+  handleChange(event) {
     this.setState({
-      expression: new DSLExpression(target.value)
+      expression: new DSLExpression(event.target.value)
     });
 
     this.handleDebounceUpdate();

--- a/src/js/components/modals/JobFormModal.js
+++ b/src/js/components/modals/JobFormModal.js
@@ -267,8 +267,8 @@ class JobFormModal extends mixin(StoreMixin) {
     }
   }
 
-  handleFormChange({model}) {
-    if (!model) {
+  handleFormChange(event) {
+    if (!event.model) {
       return;
     }
 

--- a/src/js/pages/jobs/JobDetailPage.js
+++ b/src/js/pages/jobs/JobDetailPage.js
@@ -90,7 +90,8 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
     MetronomeStore.stopJobDetailMonitor(this.props.params.id);
   }
 
-  onMetronomeStoreJobDeleteError(id, {message:errorMsg}) {
+  onMetronomeStoreJobDeleteError(id, error) {
+    const {message:errorMsg} = error;
     if (id !== this.props.params.id || errorMsg == null) {
       return;
     }

--- a/src/js/pages/jobs/JobsTable.js
+++ b/src/js/pages/jobs/JobsTable.js
@@ -217,7 +217,8 @@ class JobsTable extends React.Component {
     );
   }
 
-  renderStatusColumn(prop, {[prop]:statusKey, isGroup}) {
+  renderStatusColumn(prop, col) {
+    const {[prop]:statusKey, isGroup} = col;
     if (isGroup) {
       return null;
     }


### PR DESCRIPTION
As we've agreed that we want to keep our class interface as clear as possible it is beneficial to have a name for a param and you can always destructure it in a method body.

It is still okay to destructure in params in higher order functions and in standalone functions.