### PR TITLE
DCOS-11968: Service Health checks visual improvements

### DIFF
--- a/plugins/services/src/js/components/ConfigurationMapDurationValue.js
+++ b/plugins/services/src/js/components/ConfigurationMapDurationValue.js
@@ -29,11 +29,15 @@ class ConfigurationMapDurationValue extends React.Component {
     const valueInMs = value * multiplicants[units];
     const components = DateUtil.msToMultiplicants(valueInMs, multiplicants);
 
+    const hasNoComponents = components.length === 0;
+    const hasOnlyUnitComponent = (components.length === 1)
+      && (components[0].split(' ')[1] === units);
+
     // Check if components are redundant
-    if ((components.length === 1) && (components[0].split(' ')[1] === units)) {
+    if (hasNoComponents || hasOnlyUnitComponent) {
       return (
         <ConfigurationMapValue>
-          {`${value} ${units}`}
+          {value} {units}
         </ConfigurationMapValue>
       );
     }
@@ -41,7 +45,7 @@ class ConfigurationMapDurationValue extends React.Component {
     // Otherwise show the value and it's components
     return (
       <ConfigurationMapValue>
-        {`${value} ${units} (${components.join(', ')})`}
+        {value} {units} ({components.join(', ')})
       </ConfigurationMapValue>
     );
   }

--- a/plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js
@@ -15,18 +15,11 @@ import {COMMAND, MESOS_HTTP, MESOS_HTTPS} from '../constants/HealthCheckProtocol
 import Util from '../../../../../src/js/utils/Util';
 
 function renderDuration(prop, row) {
-  const value = row[prop];
-
-  if (!value || value === 0) {
-    return (
-      <ConfigurationMapValue>
-        {getDisplayValue(value)}
-      </ConfigurationMapValue>
-    );
-  }
+  const value = row[prop] || null;
 
   return (
     <ConfigurationMapDurationValue
+      defaultValue={<em>Not Configured</em>}
       units="sec"
       value={value} />
   );

--- a/plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js
@@ -6,11 +6,31 @@ import {
   getColumnHeadingFn,
   getDisplayValue
 } from '../utils/ServiceConfigDisplayUtil';
-import ConfigurationMapEditAction from '../components/ConfigurationMapEditAction';
 import ConfigurationMapDurationValue from '../components/ConfigurationMapDurationValue';
+import ConfigurationMapEditAction from '../components/ConfigurationMapEditAction';
+import ConfigurationMapHeading from '../../../../../src/js/components/ConfigurationMapHeading';
+import ConfigurationMapValue from '../../../../../src/js/components/ConfigurationMapValue';
 import ServiceConfigBaseSectionDisplay from './ServiceConfigBaseSectionDisplay';
 import {COMMAND, MESOS_HTTP, MESOS_HTTPS} from '../constants/HealthCheckProtocols';
 import Util from '../../../../../src/js/utils/Util';
+
+function renderDuration(prop, row) {
+  const value = row[prop];
+
+  if (!value || value === 0) {
+    return (
+      <ConfigurationMapValue>
+        {getDisplayValue(value)}
+      </ConfigurationMapValue>
+    );
+  }
+
+  return (
+    <ConfigurationMapDurationValue
+      units="sec"
+      value={value} />
+  );
+}
 
 class ServiceHealthChecksConfigSection extends ServiceConfigBaseSectionDisplay {
   /**
@@ -33,20 +53,27 @@ class ServiceHealthChecksConfigSection extends ServiceConfigBaseSectionDisplay {
       values: [
         {
           key: 'healthChecks',
-          heading: 'Health Checks',
-          headingLevel: 1
-        },
-        {
-          key: 'healthChecks',
-          heading: 'Service Endpoint Health Checks',
-          headingLevel: 2
+          render(healthChecks) {
+            if (healthChecks.length === 0) {
+              return null;
+            }
+
+            return (
+              <ConfigurationMapHeading
+                key="service-health-checks-heading"
+                level={1}>
+
+                Health Checks
+              </ConfigurationMapHeading>
+            );
+          }
         },
         {
           key: 'healthChecks',
           render(healthChecks) {
             const serviceEndpointHealthChecks = healthChecks.filter(
               (healthCheck) => {
-                return [MESOS_HTTP, MESOS_HTTPS, COMMAND].includes(healthCheck.protocol);
+                return [MESOS_HTTP, MESOS_HTTPS].includes(healthCheck.protocol);
               }
             );
 
@@ -55,7 +82,11 @@ class ServiceHealthChecksConfigSection extends ServiceConfigBaseSectionDisplay {
                 heading: getColumnHeadingFn('Protocol'),
                 prop: 'protocol',
                 render(prop, row) {
-                  return getDisplayValue(row[prop]);
+                  return (
+                    <ConfigurationMapValue>
+                      {getDisplayValue(row[prop])}
+                    </ConfigurationMapValue>
+                  );
                 },
                 className: getColumnClassNameFn(),
                 sortable: true
@@ -65,7 +96,11 @@ class ServiceHealthChecksConfigSection extends ServiceConfigBaseSectionDisplay {
                 prop: 'path',
                 className: getColumnClassNameFn(),
                 render(prop, row) {
-                  return getDisplayValue(row[prop]);
+                  return (
+                    <ConfigurationMapValue>
+                      {getDisplayValue(row[prop])}
+                    </ConfigurationMapValue>
+                  );
                 },
                 sortable: true
               },
@@ -73,39 +108,21 @@ class ServiceHealthChecksConfigSection extends ServiceConfigBaseSectionDisplay {
                 heading: getColumnHeadingFn('Grace Period'),
                 prop: 'gracePeriodSeconds',
                 className: getColumnClassNameFn(),
-                render(prop, row) {
-                  return (
-                    <ConfigurationMapDurationValue
-                      units="sec"
-                      value={row[prop]} />
-                  );
-                },
+                render: renderDuration,
                 sortable: true
               },
               {
                 heading: getColumnHeadingFn('Interval'),
                 prop: 'intervalSeconds',
                 className: getColumnClassNameFn(),
-                render(prop, row) {
-                  return (
-                    <ConfigurationMapDurationValue
-                      units="sec"
-                      value={row[prop]} />
-                  );
-                },
+                render: renderDuration,
                 sortable: true
               },
               {
                 heading: getColumnHeadingFn('Timeout'),
                 prop: 'timeoutSeconds',
                 className: getColumnClassNameFn(),
-                render(prop, row) {
-                  return (
-                    <ConfigurationMapDurationValue
-                      units="sec"
-                      value={row[prop]} />
-                  );
-                },
+                render: renderDuration,
                 sortable: true
               },
               {
@@ -113,7 +130,11 @@ class ServiceHealthChecksConfigSection extends ServiceConfigBaseSectionDisplay {
                 heading: getColumnHeadingFn('Max Failures'),
                 prop: 'maxConsecutiveFailures',
                 render(prop, row) {
-                  return getDisplayValue(row[prop]);
+                  return (
+                    <ConfigurationMapValue>
+                      {getDisplayValue(row[prop])}
+                    </ConfigurationMapValue>
+                  );
                 },
                 sortable: true
               }
@@ -134,18 +155,24 @@ class ServiceHealthChecksConfigSection extends ServiceConfigBaseSectionDisplay {
               });
             }
 
-            return (
+            if (serviceEndpointHealthChecks.length === 0) {
+              return null;
+            }
+
+            return [
+              <ConfigurationMapHeading
+                key="service-endpoint-health-checks-heading"
+                level={2}>
+
+                Service Endpoint Health Checks
+              </ConfigurationMapHeading>,
               <Table
                 key="service-endpoint-health-checks"
                 className="table table-simple table-align-top table-break-word table-fixed-layout flush-bottom"
                 columns={columns}
                 data={serviceEndpointHealthChecks} />
-            );
+            ];
           }
-        },
-        {
-          heading: 'Command Health Checks',
-          headingLevel: 2
         },
         {
           key: 'healthChecks',
@@ -166,9 +193,11 @@ class ServiceHealthChecksConfigSection extends ServiceConfigBaseSectionDisplay {
                   }
 
                   return (
-                    <pre className="flush transparent wrap">
-                      {value}
-                    </pre>
+                    <ConfigurationMapValue>
+                      <pre className="flush transparent wrap">
+                        {value}
+                      </pre>
+                    </ConfigurationMapValue>
                   );
                 },
                 className: getColumnClassNameFn(),
@@ -178,39 +207,21 @@ class ServiceHealthChecksConfigSection extends ServiceConfigBaseSectionDisplay {
                 heading: getColumnHeadingFn('Grace Period'),
                 prop: 'gracePeriodSeconds',
                 className: getColumnClassNameFn(),
-                render(prop, row) {
-                  return (
-                    <ConfigurationMapDurationValue
-                      units="sec"
-                      value={row[prop]} />
-                  );
-                },
+                render: renderDuration,
                 sortable: true
               },
               {
                 heading: getColumnHeadingFn('Interval'),
                 prop: 'intervalSeconds',
                 className: getColumnClassNameFn(),
-                render(prop, row) {
-                  return (
-                    <ConfigurationMapDurationValue
-                      units="sec"
-                      value={row[prop]} />
-                  );
-                },
+                render: renderDuration,
                 sortable: true
               },
               {
                 heading: getColumnHeadingFn('Timeout'),
                 prop: 'timeoutSeconds',
                 className: getColumnClassNameFn(),
-                render(prop, row) {
-                  return (
-                    <ConfigurationMapDurationValue
-                      units="sec"
-                      value={row[prop]} />
-                  );
-                },
+                render: renderDuration,
                 sortable: true
               },
               {
@@ -218,7 +229,11 @@ class ServiceHealthChecksConfigSection extends ServiceConfigBaseSectionDisplay {
                 heading: getColumnHeadingFn('Max Failures'),
                 prop: 'maxConsecutiveFailures',
                 render(prop, row) {
-                  return getDisplayValue(row[prop]);
+                  return (
+                    <ConfigurationMapValue>
+                      {getDisplayValue(row[prop])}
+                    </ConfigurationMapValue>
+                  );
                 },
                 sortable: true
               }
@@ -239,13 +254,24 @@ class ServiceHealthChecksConfigSection extends ServiceConfigBaseSectionDisplay {
               });
             }
 
-            return (
+            if (commandHealthChecks.length === 0) {
+              return null;
+            }
+
+            return [
+              <ConfigurationMapHeading
+                key="command-health-checks-heading"
+                level={2}>
+
+                Command Health Checks
+              </ConfigurationMapHeading>,
               <Table
                 key="command-health-checks"
                 className="table table-simple table-align-top table-break-word table-fixed-layout flush-bottom"
                 columns={columns}
-                data={commandHealthChecks} />
-            );
+                data={commandHealthChecks}
+              />
+            ];
           }
         }
       ]


### PR DESCRIPTION
* Removed COMMAND from the endpoint health checks section
* Hide the whole section if there's no healthchecks
* Hide respective sections if there's no respective health checks
* Fix various visual quirks

Before, jumping values, `0 sec ()`:
![screen shot 2017-02-14 at 15 10 24](https://cloud.githubusercontent.com/assets/186223/22934519/8f3d5e20-f2cf-11e6-9175-83c3aa17f121.png)

After:
![screen shot 2017-02-14 at 15 51 06](https://cloud.githubusercontent.com/assets/186223/22934538/9c68ff50-f2cf-11e6-8d3f-b40dd96fd18d.png)


**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
