### PR TITLE
[1 of 2: DCOS-12561] Page Header Breadcrumbs

### DIFF
--- a/plugins/services/src/js/components/HealthBar.js
+++ b/plugins/services/src/js/components/HealthBar.js
@@ -81,7 +81,7 @@ class HealthBar extends React.Component {
     return (
       <Tooltip interactive={true} content={this.renderToolTip()}>
         <StatusBar
-          className="status-bar-large"
+          className="status-bar--large"
           data={this.getMappedTasksSummary(tasksSummary)}
           scale={instancesCount}/>
       </Tooltip>

--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React from 'react';
 import {Link} from 'react-router';
 
@@ -35,9 +36,11 @@ function getHealthStatus(service) {
   }
 
   return (
-    <div className="service-page-header-status page-header-breadcrumb-content-secondary muted">
-      {`${serviceStatus} (${runningTasksCount} of ${instancesCount})`}
-      <ServiceStatusWarningWithDebugInformation item={service} />
+    <div className="page-header__breadcrumb-status page-header-breadcrumb-content-secondary muted">
+      <span className="page-header__breadcrumb-status__copy">
+        {`${serviceStatus} (${runningTasksCount} of ${instancesCount})`}
+        <ServiceStatusWarningWithDebugInformation item={service} />
+      </span>
       <HealthBar isDeploying={isDeploying}
         tasksSummary={tasksSummary}
         instancesCount={instancesCount}/>
@@ -57,10 +60,15 @@ const ServiceBreadcrumbs = ({serviceID, taskID, taskName}) => {
   if (serviceID != null && trimmedServiceID.length > 0) {
     const serviceCrumbs = ids.map(function (id, index) {
       let serviceIDNode = id;
+      const shouldShowStatusBar = index === ids.length - 1;
+      const linkClasses = classNames({'text-overflow': !shouldShowStatusBar});
+      const wrapperClasses = classNames({
+        'page-header-breadcrumb--has-status-bar': shouldShowStatusBar
+      });
       let breadcrumbHealth = null;
       let serviceImage = null;
 
-      if (index === ids.length - 1) {
+      if (shouldShowStatusBar) {
         const service = DCOSStore.serviceTree.findItemById(serviceID);
 
         breadcrumbHealth = getHealthStatus(service);
@@ -79,8 +87,13 @@ const ServiceBreadcrumbs = ({serviceID, taskID, taskName}) => {
       aggregateIDs += encodeURIComponent(`/${id}`);
 
       return (
-        <div>
-          <Link to={`/services/overview/${aggregateIDs}`} key={index}>
+        <div
+          className={wrapperClasses}
+          key={index}
+          dataTitle={decodeURIComponent(aggregateIDs)}>
+          <Link
+            className={linkClasses}
+            to={`/services/overview/${aggregateIDs}`}>
             {serviceIDNode}
           </Link>
           {breadcrumbHealth}
@@ -102,8 +115,12 @@ const ServiceBreadcrumbs = ({serviceID, taskID, taskName}) => {
     );
   }
 
-  return <PageHeaderBreadcrumbs iconID="services" breadcrumbs={crumbs} />;
-
+  return (
+    <PageHeaderBreadcrumbs
+      iconID="services"
+      iconRoute="/services"
+      breadcrumbs={crumbs} />
+  );
 };
 
 module.exports = ServiceBreadcrumbs;

--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {Link} from 'react-router';
 
 import {DCOSStore} from 'foundation-ui';
+import Breadcrumb from '../../../../../src/js/components/Breadcrumb';
 import HealthBar from './HealthBar';
 import PageHeaderBreadcrumbs from '../../../../../src/js/components/PageHeaderBreadcrumbs';
 import ServiceStatusWarningWithDebugInformation from './ServiceStatusWarningWithDebugInstruction';
@@ -54,7 +55,9 @@ const ServiceBreadcrumbs = ({serviceID, taskID, taskName}) => {
   let aggregateIDs = '';
 
   const crumbs = [
-    <Link to="/services" key={-1}>Services</Link>
+    <Breadcrumb key={-1} title="Services">
+      <Link to="/services">Services</Link>
+    </Breadcrumb>
   ];
 
   if (serviceID != null && trimmedServiceID.length > 0) {
@@ -87,17 +90,16 @@ const ServiceBreadcrumbs = ({serviceID, taskID, taskName}) => {
       aggregateIDs += encodeURIComponent(`/${id}`);
 
       return (
-        <div
-          className={wrapperClasses}
-          key={index}
-          dataTitle={decodeURIComponent(aggregateIDs)}>
-          <Link
-            className={linkClasses}
-            to={`/services/overview/${aggregateIDs}`}>
-            {serviceIDNode}
-          </Link>
-          {breadcrumbHealth}
-        </div>
+        <Breadcrumb key={index} title={ids.slice(0, index + 1).join('/')}>
+          <div className={wrapperClasses}>
+            <Link
+              className={linkClasses}
+              to={`/services/overview/${aggregateIDs}`}>
+              {serviceIDNode}
+            </Link>
+            {breadcrumbHealth}
+          </div>
+        </Breadcrumb>
       );
     });
 
@@ -107,11 +109,15 @@ const ServiceBreadcrumbs = ({serviceID, taskID, taskName}) => {
   if (taskID != null && taskName != null) {
     const encodedTaskID = encodeURIComponent(taskID);
     crumbs.push(
-      <Link
-        to={`/services/overview/${aggregateIDs}/tasks/${encodedTaskID}`}
-        index={taskID}>
-        {taskName}
-      </Link>
+      <Breadcrumb
+        key={trimmedServiceID.length + 1}
+        title={taskID}>
+        <Link
+          to={`/services/overview/${aggregateIDs}/tasks/${encodedTaskID}`}
+          index={taskID}>
+          {taskName}
+        </Link>
+      </Breadcrumb>
     );
   }
 

--- a/plugins/services/src/js/pages/services/DeploymentsTab.js
+++ b/plugins/services/src/js/pages/services/DeploymentsTab.js
@@ -229,7 +229,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
     ];
 
     return (
-      <StatusBar className="status-bar-large" data={data} />
+      <StatusBar className="status-bar--large" data={data} />
     );
   }
 

--- a/src/js/components/Breadcrumb.js
+++ b/src/js/components/Breadcrumb.js
@@ -1,10 +1,38 @@
+import classNames from 'classnames';
 import React from 'react';
 
-function Breadcrumb(props) {
-  return props.children;
+class Breadcrumb extends React.Component {
+  render() {
+    const {children, isCaret, isIcon} = this.props;
+
+    if (!children) {
+      return <noscript />;
+    }
+
+    const classes = classNames(
+      'breadcrumb',
+      {
+        'breadcrumb--is-caret': isCaret,
+        'breadcrumb--is-icon': isIcon
+      }
+    );
+
+    return (
+      <div className={classes}>
+        {children}
+      </div>
+    );
+  }
 }
 
+Breadcrumb.defaultProps = {
+  isCaret: false,
+  isIcon: false
+};
+
 Breadcrumb.propTypes = {
+  isCaret: React.PropTypes.bool,
+  isIcon: React.PropTypes.bool,
   title: React.PropTypes.string.isRequired
 };
 

--- a/src/js/components/Breadcrumb.js
+++ b/src/js/components/Breadcrumb.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function Breadcrumb(props) {
+  return props.children;
+}
+
+Breadcrumb.propTypes = {
+  title: React.PropTypes.string.isRequired
+};
+
+module.exports = Breadcrumb;

--- a/src/js/components/BreadcrumbCaret.js
+++ b/src/js/components/BreadcrumbCaret.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import Breadcrumb from './Breadcrumb';
+import Icon from './Icon';
+
+function BreadcrumbCaret() {
+  return (
+    <Breadcrumb isCaret={true} title="Caret">
+      <Icon color="light-grey" id="caret-right" size="mini" />
+    </Breadcrumb>
+  );
+}
+
+module.exports = BreadcrumbCaret;

--- a/src/js/components/BreadcrumbSupplementalContent.js
+++ b/src/js/components/BreadcrumbSupplementalContent.js
@@ -1,0 +1,33 @@
+import classNames from 'classnames';
+import React from 'react';
+
+class BreadcrumbSupplementalContent extends React.Component {
+  render() {
+    const {children, hasStatusBar} = this.props;
+
+    if (!children) {
+      return null;
+    }
+
+    const classes = classNames(
+      'breadcrumb__content breadcrumb__content--supplemental',
+      {'breadcrumb__content--has-status-bar': hasStatusBar}
+    );
+
+    return (
+      <div className={classes}>
+        {children}
+      </div>
+    );
+  }
+}
+
+BreadcrumbSupplementalContent.defaultProps = {
+  hasStatusBar: false
+};
+
+BreadcrumbSupplementalContent.propTypes = {
+  hasStatusBar: React.PropTypes.bool
+};
+
+module.exports = BreadcrumbSupplementalContent;

--- a/src/js/components/BreadcrumbTextContent.js
+++ b/src/js/components/BreadcrumbTextContent.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+class BreadcrumbTextContent extends React.Component {
+  render() {
+    if (!this.props.children) {
+      return <noscript />;
+    }
+
+    return (
+      <div className="breadcrumb__content breadcrumb__content--text">
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+BreadcrumbTextContent.propTypes = {
+  title: React.PropTypes.string
+};
+
+module.exports = BreadcrumbTextContent;

--- a/src/js/components/PageHeaderBreadcrumbs.js
+++ b/src/js/components/PageHeaderBreadcrumbs.js
@@ -1,30 +1,53 @@
+import {Link} from 'react-router';
 import React from 'react';
+import {Tooltip} from 'reactjs-components';
 
 import Icon from './Icon';
 
 class PageHeaderBreadcrumbs extends React.Component {
-
-  getCaret(index) {
+  getCaret(key) {
     return (
       <li className="page-header-breadcrumb page-header-breadcrumb-caret"
-        key={`caret-${index}`}>
+        key={`caret-${key}`}>
         <Icon color="light-grey" id="caret-right" size="mini" />
       </li>
     );
   }
 
   render() {
-    const {props: {iconID, breadcrumbs}} = this;
-
+    const {props: {breadcrumbs, iconID, iconRoute}} = this;
+    const breadcrumbCount = breadcrumbs.length;
     const containerIcon = (
       <li
         className="page-header-breadcrumb page-header-breadcrumb-icon"
         key="-1">
-        <Icon family="product" id={iconID} size="small" />
+        <Link to={iconRoute}>
+          <Icon family="product" id={iconID} size="small" />
+        </Link>
       </li>
     );
+    const shouldTruncateBreadcrumbs = breadcrumbCount > 3;
 
     const breadcrumbElements = breadcrumbs.reduce((memo, breadcrumb, index) => {
+      if (shouldTruncateBreadcrumbs && index === breadcrumbCount - 3) {
+        memo.push(
+          this.getCaret('first-caret'),
+          (
+            <Tooltip
+              content={breadcrumb.props.dataTitle}
+              key="breadcrumb-ellipsis"
+              wrapperClassName="page-header-breadcrumb page-header-breadcrumb--force-ellipsis h3">
+              {breadcrumb}
+            </Tooltip>
+          ),
+          this.getCaret(index)
+        );
+      }
+
+      if (shouldTruncateBreadcrumbs && index < breadcrumbCount - 2) {
+        return memo;
+      }
+
       memo.push(
         <li className="page-header-breadcrumb h3" key={index}>
           {breadcrumb}

--- a/src/js/components/PageHeaderBreadcrumbs.js
+++ b/src/js/components/PageHeaderBreadcrumbs.js
@@ -34,7 +34,7 @@ class PageHeaderBreadcrumbs extends React.Component {
           this.getCaret('first-caret'),
           (
             <Tooltip
-              content={breadcrumb.props.dataTitle}
+              content={breadcrumb.props.title}
               key="breadcrumb-ellipsis"
               wrapperClassName="page-header-breadcrumb page-header-breadcrumb--force-ellipsis h3">
               {breadcrumb}

--- a/src/js/components/PageHeaderBreadcrumbs.js
+++ b/src/js/components/PageHeaderBreadcrumbs.js
@@ -35,7 +35,7 @@ class PageHeaderBreadcrumbs extends React.Component {
 
       if (shouldTruncateBreadcrumbs && index === breadcrumbCount - 3) {
         memo.push(
-          this.getCaret('first-caret-forreal'),
+          this.getCaret('first-caret--truncated'),
           (
             <Tooltip
               content={breadcrumb.props.title}

--- a/src/js/components/PageHeaderBreadcrumbs.js
+++ b/src/js/components/PageHeaderBreadcrumbs.js
@@ -29,12 +29,17 @@ class PageHeaderBreadcrumbs extends React.Component {
     const shouldTruncateBreadcrumbs = breadcrumbCount > 3;
 
     const breadcrumbElements = breadcrumbs.reduce((memo, breadcrumb, index) => {
+      if (index === 0) {
+        memo.push(this.getCaret('first-caret'));
+      }
+
       if (shouldTruncateBreadcrumbs && index === breadcrumbCount - 3) {
         memo.push(
-          this.getCaret('first-caret'),
+          this.getCaret('first-caret-forreal'),
           (
             <Tooltip
               content={breadcrumb.props.title}
+              elementTag="li"
               key="breadcrumb-ellipsis"
               wrapperClassName="page-header-breadcrumb page-header-breadcrumb--force-ellipsis h3">
               {breadcrumb}

--- a/src/styles/components/page-header/breadcrumbs/styles.less
+++ b/src/styles/components/page-header/breadcrumbs/styles.less
@@ -33,6 +33,13 @@
       text-overflow: ellipsis;
       white-space: nowrap;
 
+      &:first-child {
+
+        & + .page-header-breadcrumb-caret {
+          display: block;
+        }
+      }
+
       &:last-child {
         display: block;
         flex: 1 1 auto;
@@ -194,6 +201,13 @@
         &-breadcrumb {
           display: block;
           margin-right: @page-header-breadcrumbs-margin-right-screen-medium;
+
+          &:first-child {
+
+            & + .page-header-breadcrumb-caret {
+              display: none;
+            }
+          }
 
           &-content-secondary {
             margin-left: @page-header-breadcrumbs-margin-right-screen-medium;

--- a/src/styles/components/page-header/breadcrumbs/styles.less
+++ b/src/styles/components/page-header/breadcrumbs/styles.less
@@ -23,6 +23,7 @@
       // Increase the shrink factor for all breadcrumbs (except the last one).
       // The last breadcrumb should shrink only when earlier breadcrumbs have
       // already shrunk.
+      display: none;
       flex: 0 5 auto;
       line-height: normal;
       margin: 0 @page-header-breadcrumbs-margin-right 0 0;
@@ -33,6 +34,7 @@
       white-space: nowrap;
 
       &:last-child {
+        display: block;
         flex: 1 1 auto;
         margin-right: 0;
         min-width: 0;
@@ -51,6 +53,7 @@
       }
 
       &-icon {
+        display: block;
         flex: 0 0 auto;
         margin-left: 0;
         margin-top: 0;
@@ -189,6 +192,7 @@
         }
 
         &-breadcrumb {
+          display: block;
           margin-right: @page-header-breadcrumbs-margin-right-screen-medium;
 
           &-content-secondary {

--- a/src/styles/components/page-header/breadcrumbs/styles.less
+++ b/src/styles/components/page-header/breadcrumbs/styles.less
@@ -1,0 +1,285 @@
+& when (@page-header-enabled) {
+
+  .page-header {
+
+    &-breadcrumbs {
+      align-items: center;
+      color: @page-header-breadcrumbs-color;
+      display: flex;
+      flex: 1 1 auto;
+      font-size: @page-header-breadcrumbs-font-size;
+      font-weight: @page-header-breadcrumbs-font-weight;
+      list-style: none;
+      margin-bottom: 0;
+      min-width: 0;
+
+      a {
+        color: @page-header-breadcrumbs-link-color;
+        text-decoration: none;
+      }
+    }
+
+    &-breadcrumb {
+      // Increase the shrink factor for all breadcrumbs (except the last one).
+      // The last breadcrumb should shrink only when earlier breadcrumbs have
+      // already shrunk.
+      flex: 0 5 auto;
+      line-height: normal;
+      margin: 0 @page-header-breadcrumbs-margin-right 0 0;
+      min-width: 1.2rem;
+      overflow: hidden;
+      padding: 0;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+
+      &:last-child {
+        flex: 1 1 auto;
+        margin-right: 0;
+        min-width: 0;
+      }
+
+      &:before {
+        display: none;
+      }
+
+      &--force-ellipsis {
+        width: 1.2rem;
+      }
+
+      &--has-status-bar {
+        display: flex;
+      }
+
+      &-icon {
+        flex: 0 0 auto;
+        margin-left: 0;
+        margin-top: 0;
+      }
+
+      &-caret {
+        flex: 0 0 auto;
+        min-width: auto;
+      }
+
+      &-item {
+
+        &-icon {
+          left: 0;
+          position: absolute;
+          top: 50%;
+          transform: translateY(-50%);
+
+          &-container {
+            padding-left: @page-header-breadcrumb-item-icon-container-padding-left;
+            position: relative;
+          }
+        }
+      }
+
+      .text-overflow {
+        display: block;
+      }
+
+      /* Styling Variants */
+
+      .emphasis {
+        color: @page-header-breadcrumbs-emphasis-color;
+        font-weight: @page-header-breadcrumbs-emphasis-font-weight;
+      }
+
+      .muted {
+        color: @page-header-breadcrumbs-muted-color;
+        font-weight: @page-header-breadcrumbs-muted-font-weight;
+      }
+
+      &.inverse {
+        color: @page-header-breadcrumbs-inverse-color;
+
+        .emphasis {
+          color: @page-header-breadcrumbs-inverse-emphasis-color;
+        }
+
+        .muted {
+          color: @page-header-breadcrumbs-inverse-muted-color;
+        }
+      }
+
+      &-content-secondary {
+        margin-left: @page-header-breadcrumbs-margin-right;
+      }
+    }
+
+    &__breadcrumb-status {
+      display: flex;
+      flex: 1 1 auto;
+      min-width: 0;
+
+      &__copy {
+        flex: 0 1 auto;
+      }
+
+      .tooltip-wrapper {
+        align-items: center;
+        display: flex;
+        flex: 0 1 @page-header-breadcrumb-status-bar-width;
+        margin-left: @page-header-breadcrumb-status-bar-margin-left;
+        min-width: @page-header-breadcrumb-status-bar-min-width;
+      }
+
+      .status-bar {
+        flex: 1 1 auto;
+        height: @page-header-breadcrumb-status-bar-height;
+        vertical-align: middle;
+        width: auto;
+      }
+    }
+  }
+}
+
+& when (@layout-screen-small-enabled) {
+
+  @media (min-width: @layout-screen-small-min-width) {
+
+    & when (@page-header-enabled) and (@page-header-screen-small-enabled) {
+
+      .page-header {
+
+        &__breadcrumb-status {
+
+          .tooltip-wrapper {
+            margin-left: @page-header-breadcrumb-status-bar-margin-left-screen-small;
+          }
+        }
+
+        &-breadcrumb {
+          margin-right: @page-header-breadcrumbs-margin-right-screen-small;
+
+          &-content-secondary {
+            margin-left: @page-header-breadcrumbs-margin-right-screen-small;
+          }
+
+          &-item {
+
+            &-icon {
+
+              &-container {
+                padding-left: @page-header-breadcrumb-item-icon-container-padding-left-screen-small;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+& when (@layout-screen-medium-enabled) {
+
+  @media (min-width: @layout-screen-medium-min-width) {
+
+    & when (@page-header-enabled) and (@page-header-screen-medium-enabled) {
+
+      .page-header {
+
+        &__breadcrumb-status {
+
+          .tooltip-wrapper {
+            margin-left: @page-header-breadcrumb-status-bar-margin-left-screen-medium;
+          }
+        }
+
+        &-breadcrumb {
+          margin-right: @page-header-breadcrumbs-margin-right-screen-medium;
+
+          &-content-secondary {
+            margin-left: @page-header-breadcrumbs-margin-right-screen-medium;
+          }
+
+          &-item {
+
+            &-icon {
+
+              &-container {
+                padding-left: @page-header-breadcrumb-item-icon-container-padding-left-screen-medium;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+& when (@layout-screen-large-enabled) {
+
+  @media (min-width: @layout-screen-large-min-width) {
+
+    & when (@page-header-enabled) and (@page-header-screen-large-enabled) {
+
+      .page-header {
+
+        &__breadcrumb-status {
+
+          .tooltip-wrapper {
+            margin-left: @page-header-breadcrumb-status-bar-margin-left-screen-large;
+          }
+        }
+
+        &-breadcrumb {
+          margin-right: @page-header-breadcrumbs-margin-right-screen-large;
+
+          &-content-secondary {
+            margin-left: @page-header-breadcrumbs-margin-right-screen-large;
+          }
+
+          &-item {
+
+            &-icon {
+
+              &-container {
+                padding-left: @page-header-breadcrumb-item-icon-container-padding-left-screen-large;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+& when (@layout-screen-jumbo-enabled) {
+
+  @media (min-width: @layout-screen-jumbo-min-width) {
+
+    & when (@page-header-enabled) and (@page-header-screen-jumbo-enabled) {
+
+      .page-header {
+
+        &__breadcrumb-status {
+
+          .tooltip-wrapper {
+            margin-left: @page-header-breadcrumb-status-bar-margin-left-screen-jumbo;
+          }
+        }
+
+        &-breadcrumb {
+          margin-right: @page-header-breadcrumbs-margin-right-screen-jumbo;
+
+          &-content-secondary {
+            margin-left: @page-header-breadcrumbs-margin-right-screen-jumbo;
+          }
+
+          &-item {
+
+            &-icon {
+
+              &-container {
+                padding-left: @page-header-breadcrumb-item-icon-container-padding-left-screen-jumbo;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/styles/components/page-header/breadcrumbs/styles.less
+++ b/src/styles/components/page-header/breadcrumbs/styles.less
@@ -1,146 +1,157 @@
 & when (@page-header-enabled) {
 
-  .page-header {
+  .breadcrumbs {
+    align-items: center;
+    color: @page-header-breadcrumbs-color;
+    display: flex;
+    flex: 1 1 auto;
+    font-size: @page-header-breadcrumbs-font-size;
+    font-weight: @page-header-breadcrumbs-font-weight;
+    list-style: none;
+    margin-bottom: 0;
+    min-width: 0;
 
-    &-breadcrumbs {
-      align-items: center;
-      color: @page-header-breadcrumbs-color;
+    a {
+      color: @page-header-breadcrumbs-link-color;
+      text-decoration: none;
+
+      &:focus,
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  .breadcrumb {
+    // Hide all breadcrumbs on mobile devices, except the first last.
+    display: none;
+    flex: 0 1 auto;
+    line-height: normal;
+    margin: 0 @page-header-breadcrumbs-margin-right 0 0;
+    overflow: hidden;
+    padding: 0;
+    white-space: nowrap;
+
+    &:first-child,
+    &:last-child {
       display: flex;
-      flex: 1 1 auto;
-      font-size: @page-header-breadcrumbs-font-size;
-      font-weight: @page-header-breadcrumbs-font-weight;
-      list-style: none;
-      margin-bottom: 0;
-      min-width: 0;
+    }
 
-      a {
-        color: @page-header-breadcrumbs-link-color;
-        text-decoration: none;
+    &:first-child {
+
+      & + .breadcrumb {
+
+        &--is-caret {
+          display: flex;
+        }
       }
     }
 
-    &-breadcrumb {
-      // Increase the shrink factor for all breadcrumbs (except the last one).
-      // The last breadcrumb should shrink only when earlier breadcrumbs have
-      // already shrunk.
-      display: none;
-      flex: 0 5 auto;
-      line-height: normal;
-      margin: 0 @page-header-breadcrumbs-margin-right 0 0;
+    &:last-child {
+      margin-right: 0;
+      min-width: 0;
+    }
+
+    &--is-caret,
+    &--is-icon {
+      flex: 0 0 auto;
+    }
+
+    &--force-ellipsis {
       min-width: 1.2rem;
-      overflow: hidden;
-      padding: 0;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+      position: relative;
+      width: 1.2rem;
 
-      &:first-child {
-
-        & + .page-header-breadcrumb-caret {
-          display: block;
-        }
-      }
-
-      &:last-child {
-        display: block;
-        flex: 1 1 auto;
+      .breadcrumb {
         margin-right: 0;
-        min-width: 0;
-      }
 
-      &:before {
-        display: none;
-      }
+        &__content {
 
-      &--force-ellipsis {
-        width: 1.2rem;
-      }
+          &--text {
 
-      &--has-status-bar {
-        display: flex;
-      }
+            // When we force an ellipsis, we still want the native click
+            // behavior, so we stretch the anchor tag to fill the breadcrumb
+            // and display the ellipsis in its place.
+            &:after {
+              content: '...';
+              display: block;
+              position: relative;
+              z-index: 1;
+            }
 
-      &-icon {
-        display: block;
-        flex: 0 0 auto;
-        margin-left: 0;
-        margin-top: 0;
-      }
-
-      &-caret {
-        flex: 0 0 auto;
-        min-width: auto;
-      }
-
-      &-item {
-
-        &-icon {
-          left: 0;
-          position: absolute;
-          top: 50%;
-          transform: translateY(-50%);
-
-          &-container {
-            padding-left: @page-header-breadcrumb-item-icon-container-padding-left;
-            position: relative;
+            a {
+              bottom: 0;
+              left: 0;
+              opacity: 0;
+              position: absolute;
+              right: 0;
+              top: 0;
+              z-index: 2;
+            }
           }
         }
       }
+    }
 
-      .text-overflow {
-        display: block;
+    &__content {
+      display: block;
+      flex: 0 0 auto;
+      margin-right: @page-header-breadcrumb-content-supplemental-margin-horizontal;
+      min-width: 1.2rem;
+
+      &:last-child {
+        margin-right: 0;
       }
 
-      /* Styling Variants */
-
-      .emphasis {
-        color: @page-header-breadcrumbs-emphasis-color;
-        font-weight: @page-header-breadcrumbs-emphasis-font-weight;
+      &--text {
+        flex: 0 1 auto;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
-      .muted {
+      &--supplemental {
+        align-items: center;
+        display: flex;
+      }
+
+      &--has-status-bar {
         color: @page-header-breadcrumbs-muted-color;
+        display: flex;
+        flex: 1 1 auto;
         font-weight: @page-header-breadcrumbs-muted-font-weight;
-      }
+        min-width: 0;
 
-      &.inverse {
-        color: @page-header-breadcrumbs-inverse-color;
-
-        .emphasis {
-          color: @page-header-breadcrumbs-inverse-emphasis-color;
+        .tooltip-wrapper {
+          align-items: center;
+          display: flex;
+          flex: 0 1 @page-header-breadcrumb-status-bar-width;
+          padding: @base-spacing-unit * 1/4 0;
+          width: @page-header-breadcrumb-status-bar-width;
         }
 
-        .muted {
-          color: @page-header-breadcrumbs-inverse-muted-color;
+        .status-bar {
+          flex: 1 1 auto;
+          height: @page-header-breadcrumb-status-bar-height;
+          vertical-align: middle;
+          width: auto;
         }
-      }
-
-      &-content-secondary {
-        margin-left: @page-header-breadcrumbs-margin-right;
       }
     }
 
-    &__breadcrumb-status {
-      display: flex;
-      flex: 1 1 auto;
-      min-width: 0;
+    .emphasis {
+      color: @page-header-breadcrumbs-emphasis-color;
+      font-weight: @page-header-breadcrumbs-emphasis-font-weight;
+    }
 
-      &__copy {
-        flex: 0 1 auto;
+    &.inverse {
+      color: @page-header-breadcrumbs-inverse-color;
+
+      .emphasis {
+        color: @page-header-breadcrumbs-inverse-emphasis-color;
       }
 
-      .tooltip-wrapper {
-        align-items: center;
-        display: flex;
-        flex: 0 1 @page-header-breadcrumb-status-bar-width;
-        margin-left: @page-header-breadcrumb-status-bar-margin-left;
-        min-width: @page-header-breadcrumb-status-bar-min-width;
-      }
-
-      .status-bar {
-        flex: 1 1 auto;
-        height: @page-header-breadcrumb-status-bar-height;
-        vertical-align: middle;
-        width: auto;
+      .muted {
+        color: @page-header-breadcrumbs-inverse-muted-color;
       }
     }
   }
@@ -152,31 +163,11 @@
 
     & when (@page-header-enabled) and (@page-header-screen-small-enabled) {
 
-      .page-header {
+      .breadcrumb {
+        margin-right: @page-header-breadcrumbs-margin-right-screen-small;
 
-        &__breadcrumb-status {
-
-          .tooltip-wrapper {
-            margin-left: @page-header-breadcrumb-status-bar-margin-left-screen-small;
-          }
-        }
-
-        &-breadcrumb {
-          margin-right: @page-header-breadcrumbs-margin-right-screen-small;
-
-          &-content-secondary {
-            margin-left: @page-header-breadcrumbs-margin-right-screen-small;
-          }
-
-          &-item {
-
-            &-icon {
-
-              &-container {
-                padding-left: @page-header-breadcrumb-item-icon-container-padding-left-screen-small;
-              }
-            }
-          }
+        &__content {
+          margin-right: @page-header-breadcrumb-content-supplemental-margin-horizontal-screen-small;
         }
       }
     }
@@ -189,39 +180,41 @@
 
     & when (@page-header-enabled) and (@page-header-screen-medium-enabled) {
 
-      .page-header {
+      .breadcrumbs {
 
-        &__breadcrumb-status {
+        &--is-truncated {
 
-          .tooltip-wrapper {
-            margin-left: @page-header-breadcrumb-status-bar-margin-left-screen-medium;
-          }
-        }
+          .breadcrumb {
 
-        &-breadcrumb {
-          display: block;
-          margin-right: @page-header-breadcrumbs-margin-right-screen-medium;
+            &:first-child {
 
-          &:first-child {
+              & + .breadcrumb {
 
-            & + .page-header-breadcrumb-caret {
-              display: none;
-            }
-          }
-
-          &-content-secondary {
-            margin-left: @page-header-breadcrumbs-margin-right-screen-medium;
-          }
-
-          &-item {
-
-            &-icon {
-
-              &-container {
-                padding-left: @page-header-breadcrumb-item-icon-container-padding-left-screen-medium;
+                &--is-caret {
+                  display: flex;
+                }
               }
             }
           }
+        }
+      }
+
+      .breadcrumb {
+        display: flex;
+        margin-right: @page-header-breadcrumbs-margin-right-screen-medium;
+
+        &:first-child {
+
+          & + .breadcrumb {
+
+            &--is-caret {
+              display: none;
+            }
+          }
+        }
+
+        &__content {
+          margin-right: @page-header-breadcrumb-content-supplemental-margin-horizontal-screen-medium;
         }
       }
     }
@@ -234,31 +227,11 @@
 
     & when (@page-header-enabled) and (@page-header-screen-large-enabled) {
 
-      .page-header {
+      .breadcrumb {
+        margin-right: @page-header-breadcrumbs-margin-right-screen-large;
 
-        &__breadcrumb-status {
-
-          .tooltip-wrapper {
-            margin-left: @page-header-breadcrumb-status-bar-margin-left-screen-large;
-          }
-        }
-
-        &-breadcrumb {
-          margin-right: @page-header-breadcrumbs-margin-right-screen-large;
-
-          &-content-secondary {
-            margin-left: @page-header-breadcrumbs-margin-right-screen-large;
-          }
-
-          &-item {
-
-            &-icon {
-
-              &-container {
-                padding-left: @page-header-breadcrumb-item-icon-container-padding-left-screen-large;
-              }
-            }
-          }
+        &__content {
+          margin-right: @page-header-breadcrumb-content-supplemental-margin-horizontal-screen-large;
         }
       }
     }
@@ -271,31 +244,11 @@
 
     & when (@page-header-enabled) and (@page-header-screen-jumbo-enabled) {
 
-      .page-header {
+      .breadcrumb {
+        margin-right: @page-header-breadcrumbs-margin-right-screen-jumbo;
 
-        &__breadcrumb-status {
-
-          .tooltip-wrapper {
-            margin-left: @page-header-breadcrumb-status-bar-margin-left-screen-jumbo;
-          }
-        }
-
-        &-breadcrumb {
-          margin-right: @page-header-breadcrumbs-margin-right-screen-jumbo;
-
-          &-content-secondary {
-            margin-left: @page-header-breadcrumbs-margin-right-screen-jumbo;
-          }
-
-          &-item {
-
-            &-icon {
-
-              &-container {
-                padding-left: @page-header-breadcrumb-item-icon-container-padding-left-screen-jumbo;
-              }
-            }
-          }
+        &__content {
+          margin-right: @page-header-breadcrumb-content-supplemental-margin-horizontal-screen-jumbo;
         }
       }
     }

--- a/src/styles/components/page-header/breadcrumbs/variables.less
+++ b/src/styles/components/page-header/breadcrumbs/variables.less
@@ -1,0 +1,50 @@
+@page-header-breadcrumbs-color: color-lighten(@neutral, 0);
+@page-header-breadcrumbs-font-weight: 400;
+
+@page-header-breadcrumbs-emphasis-color: color-lighten(@neutral, -20);
+@page-header-breadcrumbs-emphasis-font-weight: 800;
+
+@page-header-breadcrumbs-muted-color: color-lighten(@neutral, 60);
+@page-header-breadcrumbs-muted-font-weight: 300;
+
+@page-header-breadcrumbs-inverse-color: color-lighten(@neutral, 100);
+
+@page-header-breadcrumbs-inverse-emphasis-color: color-lighten(@neutral, 100);
+
+@page-header-breadcrumbs-inverse-muted-color: color-lighten(@neutral, 40);
+
+@page-header-breadcrumbs-font-size: 1.45rem;
+
+@page-header-breadcrumbs-line-height: @page-header-breadcrumbs-font-size * 1.1;
+
+@page-header-breadcrumbs-margin-top: 1.7rem;
+@page-header-breadcrumbs-margin-top-screen-medium: 1.1 * 1.7rem;
+@page-header-breadcrumbs-margin-top-screen-large: 1.2 * 1.7rem;
+
+@page-header-breadcrumbs-margin-bottom: 1.3rem;
+@page-header-breadcrumbs-margin-bottom-screen-medium: 1.1 * 1.3rem;
+@page-header-breadcrumbs-margin-bottom-screen-large: 1.2 * 1.3rem;
+
+@page-header-breadcrumbs-short-margin-top-scale: 0.5;
+@page-header-breadcrumbs-short-margin-bottom-scale: 0.5;
+
+@page-header-breadcrumbs-tall-margin-top-scale: 2;
+@page-header-breadcrumbs-tall-margin-bottom-scale: 2;
+
+@page-header-breadcrumbs-link-color: color-lighten(@neutral, 0);
+
+@page-header-breadcrumb-item-icon-container-padding-left: @icon-small-width + @base-spacing-unit * 1/4;
+@page-header-breadcrumb-item-icon-container-padding-left-screen-small: @icon-small-width + @base-spacing-unit-screen-small * 1/4;
+@page-header-breadcrumb-item-icon-container-padding-left-screen-medium: @icon-small-width + @base-spacing-unit-screen-medium * 1/4;
+@page-header-breadcrumb-item-icon-container-padding-left-screen-large: @icon-small-width + @base-spacing-unit-screen-large * 1/4;
+@page-header-breadcrumb-item-icon-container-padding-left-screen-jumbo: @icon-small-width + @base-spacing-unit-screen-jumbo * 1/4;
+
+@page-header-breadcrumb-status-bar-height: 4px;
+@page-header-breadcrumb-status-bar-width: 60px;
+@page-header-breadcrumb-status-bar-min-width: 30px;
+
+@page-header-breadcrumb-status-bar-margin-left: @base-spacing-unit * 1/2;
+@page-header-breadcrumb-status-bar-margin-left-screen-small: @base-spacing-unit-screen-small * 1/2;
+@page-header-breadcrumb-status-bar-margin-left-screen-medium: @base-spacing-unit-screen-medium * 1/2;
+@page-header-breadcrumb-status-bar-margin-left-screen-large: @base-spacing-unit-screen-large * 1/2;
+@page-header-breadcrumb-status-bar-margin-left-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/2;

--- a/src/styles/components/page-header/breadcrumbs/variables.less
+++ b/src/styles/components/page-header/breadcrumbs/variables.less
@@ -33,18 +33,12 @@
 
 @page-header-breadcrumbs-link-color: color-lighten(@neutral, 0);
 
-@page-header-breadcrumb-item-icon-container-padding-left: @icon-small-width + @base-spacing-unit * 1/4;
-@page-header-breadcrumb-item-icon-container-padding-left-screen-small: @icon-small-width + @base-spacing-unit-screen-small * 1/4;
-@page-header-breadcrumb-item-icon-container-padding-left-screen-medium: @icon-small-width + @base-spacing-unit-screen-medium * 1/4;
-@page-header-breadcrumb-item-icon-container-padding-left-screen-large: @icon-small-width + @base-spacing-unit-screen-large * 1/4;
-@page-header-breadcrumb-item-icon-container-padding-left-screen-jumbo: @icon-small-width + @base-spacing-unit-screen-jumbo * 1/4;
-
 @page-header-breadcrumb-status-bar-height: 4px;
 @page-header-breadcrumb-status-bar-width: 60px;
 @page-header-breadcrumb-status-bar-min-width: 30px;
 
-@page-header-breadcrumb-status-bar-margin-left: @base-spacing-unit * 1/2;
-@page-header-breadcrumb-status-bar-margin-left-screen-small: @base-spacing-unit-screen-small * 1/2;
-@page-header-breadcrumb-status-bar-margin-left-screen-medium: @base-spacing-unit-screen-medium * 1/2;
-@page-header-breadcrumb-status-bar-margin-left-screen-large: @base-spacing-unit-screen-large * 1/2;
-@page-header-breadcrumb-status-bar-margin-left-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/2;
+@page-header-breadcrumb-content-supplemental-margin-horizontal: @base-spacing-unit * 1/4;
+@page-header-breadcrumb-content-supplemental-margin-horizontal-screen-small: @base-spacing-unit-screen-small * 1/4;
+@page-header-breadcrumb-content-supplemental-margin-horizontal-screen-medium: @base-spacing-unit-screen-medium * 1/4;
+@page-header-breadcrumb-content-supplemental-margin-horizontal-screen-large: @base-spacing-unit-screen-large * 1/4;
+@page-header-breadcrumb-content-supplemental-margin-horizontal-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/4;

--- a/src/styles/components/page-header/styles.less
+++ b/src/styles/components/page-header/styles.less
@@ -76,24 +76,34 @@
     }
 
     &-breadcrumb {
-      flex: 0 1 auto;
+      // Increase the shrink factor for all breadcrumbs (except the last one).
+      // The last breadcrumb should shrink only when earlier breadcrumbs have
+      // already shrunk.
+      flex: 0 5 auto;
       line-height: normal;
       margin: 0 @page-header-breadcrumbs-margin-right 0 0;
-      min-width: 0;
+      min-width: 1.2rem;
       overflow: hidden;
       padding: 0;
       text-overflow: ellipsis;
       white-space: nowrap;
 
       &:last-child {
-        flex: 0 0 auto;
+        flex: 1 1 auto;
         margin-right: 0;
-        min-width: auto;
-        overflow: visible;
+        min-width: 0;
       }
 
       &:before {
         display: none;
+      }
+
+      &--force-ellipsis {
+        width: 1.2rem;
+      }
+
+      &--has-status-bar {
+        display: flex;
       }
 
       &-icon {
@@ -122,6 +132,10 @@
         }
       }
 
+      .text-overflow {
+        display: block;
+      }
+
       /* Styling Variants */
 
       .emphasis {
@@ -148,6 +162,31 @@
 
       &-content-secondary {
         margin-left: @page-header-breadcrumbs-margin-right;
+      }
+    }
+
+    &__breadcrumb-status {
+      display: flex;
+      flex: 1 1 auto;
+      min-width: 0;
+
+      &__copy {
+        flex: 0 1 auto;
+      }
+
+      .tooltip-wrapper {
+        align-items: center;
+        display: flex;
+        flex: 0 1 @page-header-breadcrumb-status-bar-width;
+        margin-left: @page-header-breadcrumb-status-bar-margin-left;
+        min-width: @page-header-breadcrumb-status-bar-min-width;
+      }
+
+      .status-bar {
+        flex: 1 1 auto;
+        height: @page-header-breadcrumb-status-bar-height;
+        vertical-align: middle;
+        width: auto;
       }
     }
 
@@ -181,6 +220,13 @@
     & when (@page-header-enabled) and (@page-header-screen-small-enabled) {
 
       .page-header {
+
+        &__breadcrumb-status {
+
+          .tooltip-wrapper {
+            margin-left: @page-header-breadcrumb-status-bar-margin-left-screen-small;
+          }
+        }
 
         &-content-section {
 
@@ -234,6 +280,13 @@
     & when (@page-header-enabled) and (@page-header-screen-medium-enabled) {
 
       .page-header {
+
+        &__breadcrumb-status {
+
+          .tooltip-wrapper {
+            margin-left: @page-header-breadcrumb-status-bar-margin-left-screen-medium;
+          }
+        }
 
         &-content-section {
 
@@ -296,6 +349,13 @@
 
       .page-header {
 
+        &__breadcrumb-status {
+
+          .tooltip-wrapper {
+            margin-left: @page-header-breadcrumb-status-bar-margin-left-screen-large;
+          }
+        }
+
         &-content-section {
 
           &-primary {
@@ -349,6 +409,13 @@
     & when (@page-header-enabled) and (@page-header-screen-jumbo-enabled) {
 
       .page-header {
+
+        &__breadcrumb-status {
+
+          .tooltip-wrapper {
+            margin-left: @page-header-breadcrumb-status-bar-margin-left-screen-jumbo;
+          }
+        }
 
         &-content-section {
 

--- a/src/styles/components/page-header/styles.less
+++ b/src/styles/components/page-header/styles.less
@@ -58,138 +58,6 @@
       }
     }
 
-    &-breadcrumbs {
-      align-items: center;
-      color: @page-header-breadcrumbs-color;
-      display: flex;
-      flex: 1 1 auto;
-      font-size: @page-header-breadcrumbs-font-size;
-      font-weight: @page-header-breadcrumbs-font-weight;
-      list-style: none;
-      margin-bottom: 0;
-      min-width: 0;
-
-      a {
-        color: @page-header-breadcrumbs-link-color;
-        text-decoration: none;
-      }
-    }
-
-    &-breadcrumb {
-      // Increase the shrink factor for all breadcrumbs (except the last one).
-      // The last breadcrumb should shrink only when earlier breadcrumbs have
-      // already shrunk.
-      flex: 0 5 auto;
-      line-height: normal;
-      margin: 0 @page-header-breadcrumbs-margin-right 0 0;
-      min-width: 1.2rem;
-      overflow: hidden;
-      padding: 0;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-
-      &:last-child {
-        flex: 1 1 auto;
-        margin-right: 0;
-        min-width: 0;
-      }
-
-      &:before {
-        display: none;
-      }
-
-      &--force-ellipsis {
-        width: 1.2rem;
-      }
-
-      &--has-status-bar {
-        display: flex;
-      }
-
-      &-icon {
-        flex: 0 0 auto;
-        margin-left: 0;
-        margin-top: 0;
-      }
-
-      &-caret {
-        flex: 0 0 auto;
-        min-width: auto;
-      }
-
-      &-item {
-
-        &-icon {
-          left: 0;
-          position: absolute;
-          top: 50%;
-          transform: translateY(-50%);
-
-          &-container {
-            padding-left: @page-header-breadcrumb-item-icon-container-padding-left;
-            position: relative;
-          }
-        }
-      }
-
-      .text-overflow {
-        display: block;
-      }
-
-      /* Styling Variants */
-
-      .emphasis {
-        color: @page-header-breadcrumbs-emphasis-color;
-        font-weight: @page-header-breadcrumbs-emphasis-font-weight;
-      }
-
-      .muted {
-        color: @page-header-breadcrumbs-muted-color;
-        font-weight: @page-header-breadcrumbs-muted-font-weight;
-      }
-
-      &.inverse {
-        color: @page-header-breadcrumbs-inverse-color;
-
-        .emphasis {
-          color: @page-header-breadcrumbs-inverse-emphasis-color;
-        }
-
-        .muted {
-          color: @page-header-breadcrumbs-inverse-muted-color;
-        }
-      }
-
-      &-content-secondary {
-        margin-left: @page-header-breadcrumbs-margin-right;
-      }
-    }
-
-    &__breadcrumb-status {
-      display: flex;
-      flex: 1 1 auto;
-      min-width: 0;
-
-      &__copy {
-        flex: 0 1 auto;
-      }
-
-      .tooltip-wrapper {
-        align-items: center;
-        display: flex;
-        flex: 0 1 @page-header-breadcrumb-status-bar-width;
-        margin-left: @page-header-breadcrumb-status-bar-margin-left;
-        min-width: @page-header-breadcrumb-status-bar-min-width;
-      }
-
-      .status-bar {
-        flex: 1 1 auto;
-        height: @page-header-breadcrumb-status-bar-height;
-        vertical-align: middle;
-        width: auto;
-      }
-    }
-
     &-navigation {
       align-items: flex-start;
       display: flex;
@@ -221,13 +89,6 @@
 
       .page-header {
 
-        &__breadcrumb-status {
-
-          .tooltip-wrapper {
-            margin-left: @page-header-breadcrumb-status-bar-margin-left-screen-small;
-          }
-        }
-
         &-content-section {
 
           &-primary {
@@ -238,24 +99,6 @@
         &-sidebar-toggle {
           left: @page-header-sidebar-toggle-left-screen-small;
           padding: @page-header-sidebar-toggle-padding-screen-small;
-        }
-
-        &-breadcrumb {
-          margin-right: @page-header-breadcrumbs-margin-right-screen-small;
-
-          &-content-secondary {
-            margin-left: @page-header-breadcrumbs-margin-right-screen-small;
-          }
-
-          &-item {
-
-            &-icon {
-
-              &-container {
-                padding-left: @page-header-breadcrumb-item-icon-container-padding-left-screen-small;
-              }
-            }
-          }
         }
 
         &-navigation {
@@ -281,13 +124,6 @@
 
       .page-header {
 
-        &__breadcrumb-status {
-
-          .tooltip-wrapper {
-            margin-left: @page-header-breadcrumb-status-bar-margin-left-screen-medium;
-          }
-        }
-
         &-content-section {
 
           &-primary {
@@ -305,24 +141,6 @@
 
           .sidebar-docked & {
             display: none;
-          }
-        }
-
-        &-breadcrumb {
-          margin-right: @page-header-breadcrumbs-margin-right-screen-medium;
-
-          &-content-secondary {
-            margin-left: @page-header-breadcrumbs-margin-right-screen-medium;
-          }
-
-          &-item {
-
-            &-icon {
-
-              &-container {
-                padding-left: @page-header-breadcrumb-item-icon-container-padding-left-screen-medium;
-              }
-            }
           }
         }
 
@@ -349,13 +167,6 @@
 
       .page-header {
 
-        &__breadcrumb-status {
-
-          .tooltip-wrapper {
-            margin-left: @page-header-breadcrumb-status-bar-margin-left-screen-large;
-          }
-        }
-
         &-content-section {
 
           &-primary {
@@ -367,24 +178,6 @@
         &-sidebar-toggle {
           left: @page-header-sidebar-toggle-left-screen-large;
           padding: @page-header-sidebar-toggle-padding-screen-large;
-        }
-
-        &-breadcrumb {
-          margin-right: @page-header-breadcrumbs-margin-right-screen-large;
-
-          &-content-secondary {
-            margin-left: @page-header-breadcrumbs-margin-right-screen-large;
-          }
-
-          &-item {
-
-            &-icon {
-
-              &-container {
-                padding-left: @page-header-breadcrumb-item-icon-container-padding-left-screen-large;
-              }
-            }
-          }
         }
 
         &-navigation {
@@ -410,13 +203,6 @@
 
       .page-header {
 
-        &__breadcrumb-status {
-
-          .tooltip-wrapper {
-            margin-left: @page-header-breadcrumb-status-bar-margin-left-screen-jumbo;
-          }
-        }
-
         &-content-section {
 
           &-primary {
@@ -427,24 +213,6 @@
         &-sidebar-toggle {
           left: @page-header-sidebar-toggle-left-screen-jumbo;
           padding: @page-header-sidebar-toggle-padding-screen-jumbo;
-        }
-
-        &-breadcrumb {
-          margin-right: @page-header-breadcrumbs-margin-right-screen-jumbo;
-
-          &-content-secondary {
-            margin-left: @page-header-breadcrumbs-margin-right-screen-jumbo;
-          }
-
-          &-item {
-
-            &-icon {
-
-              &-container {
-                padding-left: @page-header-breadcrumb-item-icon-container-padding-left-screen-jumbo;
-              }
-            }
-          }
         }
 
         &-navigation {

--- a/src/styles/components/page-header/styles.less
+++ b/src/styles/components/page-header/styles.less
@@ -58,6 +58,104 @@
       }
     }
 
+    &-breadcrumbs {
+      align-items: center;
+      color: @page-header-breadcrumbs-color;
+      display: flex;
+      flex: 1 1 auto;
+      font-size: @page-header-breadcrumbs-font-size;
+      font-weight: @page-header-breadcrumbs-font-weight;
+      list-style: none;
+      margin-bottom: 0;
+      min-width: 0;
+
+      a {
+        color: @page-header-breadcrumbs-link-color;
+        text-decoration: none;
+
+        &:hover,
+        &:focus {
+          text-decoration: underline;
+        }
+      }
+    }
+
+    &-breadcrumb {
+      flex: 0 1 auto;
+      line-height: normal;
+      margin: 0 @page-header-breadcrumbs-margin-right 0 0;
+      min-width: 0;
+      overflow: hidden;
+      padding: 0;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+
+      &:last-child {
+        flex: 0 0 auto;
+        margin-right: 0;
+        min-width: auto;
+        overflow: visible;
+      }
+
+      &:before {
+        display: none;
+      }
+
+      &-icon {
+        flex: 0 0 auto;
+        margin-left: 0;
+        margin-top: 0;
+      }
+
+      &-caret {
+        flex: 0 0 auto;
+        min-width: auto;
+      }
+
+      &-item {
+
+        &-icon {
+          left: 0;
+          position: absolute;
+          top: 50%;
+          transform: translateY(-50%);
+
+          &-container {
+            padding-left: @page-header-breadcrumb-item-icon-container-padding-left;
+            position: relative;
+          }
+        }
+      }
+
+      /* Styling Variants */
+
+      .emphasis {
+        color: @page-header-breadcrumbs-emphasis-color;
+        font-weight: @page-header-breadcrumbs-emphasis-font-weight;
+      }
+
+      .muted {
+        color: @page-header-breadcrumbs-muted-color;
+        font-weight: @page-header-breadcrumbs-muted-font-weight;
+      }
+
+      &.inverse {
+        color: @page-header-breadcrumbs-inverse-color;
+
+        .emphasis {
+          color: @page-header-breadcrumbs-inverse-emphasis-color;
+        }
+
+        .muted {
+          color: @page-header-breadcrumbs-inverse-muted-color;
+        }
+      }
+
+      &-content-secondary {
+        margin-left: @page-header-breadcrumbs-margin-right;
+      }
+    }
+
     &-navigation {
       align-items: flex-start;
       display: flex;
@@ -99,6 +197,24 @@
         &-sidebar-toggle {
           left: @page-header-sidebar-toggle-left-screen-small;
           padding: @page-header-sidebar-toggle-padding-screen-small;
+        }
+
+        &-breadcrumb {
+          margin-right: @page-header-breadcrumbs-margin-right-screen-small;
+
+          &-content-secondary {
+            margin-left: @page-header-breadcrumbs-margin-right-screen-small;
+          }
+
+          &-item {
+
+            &-icon {
+
+              &-container {
+                padding-left: @page-header-breadcrumb-item-icon-container-padding-left-screen-small;
+              }
+            }
+          }
         }
 
         &-navigation {
@@ -144,6 +260,24 @@
           }
         }
 
+        &-breadcrumb {
+          margin-right: @page-header-breadcrumbs-margin-right-screen-medium;
+
+          &-content-secondary {
+            margin-left: @page-header-breadcrumbs-margin-right-screen-medium;
+          }
+
+          &-item {
+
+            &-icon {
+
+              &-container {
+                padding-left: @page-header-breadcrumb-item-icon-container-padding-left-screen-medium;
+              }
+            }
+          }
+        }
+
         &-navigation {
 
           & when not (@pod-margin-top-screen-medium = null) {
@@ -180,6 +314,24 @@
           padding: @page-header-sidebar-toggle-padding-screen-large;
         }
 
+        &-breadcrumb {
+          margin-right: @page-header-breadcrumbs-margin-right-screen-large;
+
+          &-content-secondary {
+            margin-left: @page-header-breadcrumbs-margin-right-screen-large;
+          }
+
+          &-item {
+
+            &-icon {
+
+              &-container {
+                padding-left: @page-header-breadcrumb-item-icon-container-padding-left-screen-large;
+              }
+            }
+          }
+        }
+
         &-navigation {
 
           & when not (@pod-margin-top-screen-large = null) {
@@ -213,6 +365,24 @@
         &-sidebar-toggle {
           left: @page-header-sidebar-toggle-left-screen-jumbo;
           padding: @page-header-sidebar-toggle-padding-screen-jumbo;
+        }
+
+        &-breadcrumb {
+          margin-right: @page-header-breadcrumbs-margin-right-screen-jumbo;
+
+          &-content-secondary {
+            margin-left: @page-header-breadcrumbs-margin-right-screen-jumbo;
+          }
+
+          &-item {
+
+            &-icon {
+
+              &-container {
+                padding-left: @page-header-breadcrumb-item-icon-container-padding-left-screen-jumbo;
+              }
+            }
+          }
         }
 
         &-navigation {

--- a/src/styles/components/page-header/variables.less
+++ b/src/styles/components/page-header/variables.less
@@ -127,13 +127,3 @@
 @page-header-breadcrumb-item-icon-container-padding-left-screen-medium: @icon-small-width + @base-spacing-unit-screen-medium * 1/4;
 @page-header-breadcrumb-item-icon-container-padding-left-screen-large: @icon-small-width + @base-spacing-unit-screen-large * 1/4;
 @page-header-breadcrumb-item-icon-container-padding-left-screen-jumbo: @icon-small-width + @base-spacing-unit-screen-jumbo * 1/4;
-
-@page-header-breadcrumb-status-bar-height: 4px;
-@page-header-breadcrumb-status-bar-width: 60px;
-@page-header-breadcrumb-status-bar-min-width: 30px;
-
-@page-header-breadcrumb-status-bar-margin-left: @base-spacing-unit * 1/2;
-@page-header-breadcrumb-status-bar-margin-left-screen-small: @base-spacing-unit-screen-small * 1/2;
-@page-header-breadcrumb-status-bar-margin-left-screen-medium: @base-spacing-unit-screen-medium * 1/2;
-@page-header-breadcrumb-status-bar-margin-left-screen-large: @base-spacing-unit-screen-large * 1/2;
-@page-header-breadcrumb-status-bar-margin-left-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/2;

--- a/src/styles/components/page-header/variables.less
+++ b/src/styles/components/page-header/variables.less
@@ -127,3 +127,13 @@
 @page-header-breadcrumb-item-icon-container-padding-left-screen-medium: @icon-small-width + @base-spacing-unit-screen-medium * 1/4;
 @page-header-breadcrumb-item-icon-container-padding-left-screen-large: @icon-small-width + @base-spacing-unit-screen-large * 1/4;
 @page-header-breadcrumb-item-icon-container-padding-left-screen-jumbo: @icon-small-width + @base-spacing-unit-screen-jumbo * 1/4;
+
+@page-header-breadcrumb-status-bar-height: 4px;
+@page-header-breadcrumb-status-bar-width: 60px;
+@page-header-breadcrumb-status-bar-min-width: 30px;
+
+@page-header-breadcrumb-status-bar-margin-left: @base-spacing-unit * 1/2;
+@page-header-breadcrumb-status-bar-margin-left-screen-small: @base-spacing-unit-screen-small * 1/2;
+@page-header-breadcrumb-status-bar-margin-left-screen-medium: @base-spacing-unit-screen-medium * 1/2;
+@page-header-breadcrumb-status-bar-margin-left-screen-large: @base-spacing-unit-screen-large * 1/2;
+@page-header-breadcrumb-status-bar-margin-left-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/2;

--- a/src/styles/components/status-bar/styles.less
+++ b/src/styles/components/status-bar/styles.less
@@ -100,7 +100,7 @@
       }
     }
 
-    &.status-bar-large {
+    &--large {
       height: @base-spacing-unit * 1/3;
       line-height: @base-spacing-unit * 1/3;
     }
@@ -113,7 +113,7 @@
 
     .status-bar {
 
-      &.status-bar-large {
+      &--large {
         width: @base-spacing-unit * 4;
       }
     }

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -363,6 +363,11 @@
 @import 'components/page-header/variables.less';
 @import 'components/page-header/styles.less';
 
+// Page Header: Breadcrumbs
+
+@import 'components/page-header/breadcrumbs/variables.less';
+@import 'components/page-header/breadcrumbs/styles.less';
+
 // Panel
 
 @import 'components/panel/variables.less';

--- a/src/styles/views/services/styles.less
+++ b/src/styles/views/services/styles.less
@@ -65,23 +65,6 @@
       align-items: center;
     }
   }
-
-  .service-page-header {
-
-    &-status {
-      display: inline-block;
-
-      .tooltip-wrapper {
-        margin-left: @services-page-header-status-margin-left;
-      }
-
-      .status-bar {
-        height: @services-page-header-status-height;
-        vertical-align: middle;
-        width: @services-page-header-status-width;
-      }
-    }
-  }
 }
 
 & when (@services-view-enabled) and (@layout-screen-small-enabled) {
@@ -92,16 +75,6 @@
 
       &-icon {
         margin-right: @base-spacing-unit-screen-small * 1/4;
-      }
-    }
-
-    .service-page-header {
-
-      &-status {
-
-        .tooltip-wrapper {
-          margin-left: @services-page-header-status-margin-left-screen-small;
-        }
       }
     }
   }
@@ -115,16 +88,6 @@
 
       &-icon {
         margin-right: @base-spacing-unit-screen-medium * 1/4;
-      }
-    }
-
-    .service-page-header {
-
-      &-status {
-
-        .tooltip-wrapper {
-          margin-left: @services-page-header-status-margin-left-screen-medium;
-        }
       }
     }
   }
@@ -144,16 +107,6 @@
         margin-right: @base-spacing-unit-screen-large * 1/4;
       }
     }
-
-    .service-page-header {
-
-      &-status {
-
-        .tooltip-wrapper {
-          margin-left: @services-page-header-status-margin-left-screen-large;
-        }
-      }
-    }
   }
 }
 
@@ -169,16 +122,6 @@
 
       &-icon {
         margin-right: @base-spacing-unit-screen-jumbo * 1/4;
-      }
-    }
-
-    .service-page-header {
-
-      &-status {
-
-        .tooltip-wrapper {
-          margin-left: @services-page-header-status-margin-left-screen-jumbo;
-        }
       }
     }
   }

--- a/src/styles/views/services/variables.less
+++ b/src/styles/views/services/variables.less
@@ -1,13 +1,4 @@
 @services-view-enabled: true;
 
-@services-page-header-status-height: 4px;
-@services-page-header-status-width: 60px;
-
-@services-page-header-status-margin-left: @base-spacing-unit * 1/2;
-@services-page-header-status-margin-left-screen-small: @base-spacing-unit-screen-small * 1/2;
-@services-page-header-status-margin-left-screen-medium: @base-spacing-unit-screen-medium * 1/2;
-@services-page-header-status-margin-left-screen-large: @base-spacing-unit-screen-large * 1/2;
-@services-page-header-status-margin-left-screen-jumbo: @base-spacing-unit-screen-jumbo * 1/2;
-
 @service-sidebar-width-screen-large: 200px;
 @service-sidebar-width-screen-jumbo: 225px;


### PR DESCRIPTION
This is a refactor of the `ServicesBreadcrumbs` components. It adds some new features:
* If the user is navigating through groups, only the last two groups will appear in the breadcrumb. All other breadcrumbs get "collapsed" into the ellipsis. Clicking the ellipsis navigates one level up.
* When there is not enough horizontal space to display the service health, it gets removed from the DOM.

I also introduced four new breadcrumb components:
* `Breadcrumb`: this wraps the rest of the Breadcrumb components
* `BreadcrumbCaret`: this will render a caret
* `BreadcrumbSupplementalContent`: this content will not shrink by default, and is meant for icons or other supplemental content
* `BreadcrumbTextContent`: this is the primary content; it will shrink and display an ellipsis when truncated

A follow-up PR will implement these new components in the rest of the app. Until then the breadcrumb styling will incorrect.

This styling is intentional for this PR:
![](https://cl.ly/3A33102L3D1o/Screen%20Shot%202017-02-17%20at%2010.03.33%20AM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?