### PR TITLE
DCOS-13445: Rename Cluster to System Overview

### DIFF
--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -29,7 +29,7 @@ const defaultMenuItems = [
   '/nodes',
   '/networking',
   '/security',
-  '/cluster',
+  '/system-overview',
   '/components',
   '/settings',
   '/organization'

--- a/src/js/components/SidebarHeader.js
+++ b/src/js/components/SidebarHeader.js
@@ -106,11 +106,11 @@ class SidebarHeader extends mixin(StoreMixin) {
         onClick: this.handleItemSelect
       },
       {
-        html: 'Cluster Settings',
-        id: 'cluster-settings',
+        html: 'System Overview',
+        id: 'system-overview',
         onClick: () => {
           SidebarActions.close();
-          this.context.router.push('/cluster');
+          this.context.router.push('/system-overview');
         }
       },
       {

--- a/src/js/pages/SystemOverviewPage.js
+++ b/src/js/pages/SystemOverviewPage.js
@@ -2,16 +2,16 @@ import React from 'react';
 
 import Icon from '../components/Icon';
 
-class ClusterPage extends React.Component {
+class SystemOverviewPage extends React.Component {
   render() {
     return this.props.children;
   }
 }
 
-ClusterPage.routeConfig = {
-  label: 'Cluster',
+SystemOverviewPage.routeConfig = {
+  label: 'System Overview',
   icon: <Icon id="cluster-inverse" size="small" family="product" />,
-  matches: /^\/cluster/
+  matches: /^\/system-overview/
 };
 
-module.exports = ClusterPage;
+module.exports = SystemOverviewPage;

--- a/src/js/pages/system/OverviewDetailTab.js
+++ b/src/js/pages/system/OverviewDetailTab.js
@@ -29,11 +29,11 @@ const METHODS_TO_BIND = [
   'handleClusterConfigModalOpen'
 ];
 
-const ClusterDetailsBreadcrumbs = () => {
+const SystemOverviewBreadcrumbs = () => {
   const crumbs = [
     <Breadcrumb key={0} title="Cluster">
       <BreadcrumbTextContent>
-        <Link to="/cluster">Cluster</Link>
+        <Link to="/system-overview">System Overview</Link>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];
@@ -196,7 +196,7 @@ class OverviewDetailTab extends mixin(StoreMixin) {
     return (
       <Page>
         <Page.Header actions={this.getPageHeaderActions()}
-          breadcrumbs={<ClusterDetailsBreadcrumbs />} />
+          breadcrumbs={<SystemOverviewBreadcrumbs />} />
         <div className="container">
           <ConfigurationMap>
             <ConfigurationMapHeading className="flush-top">
@@ -219,7 +219,7 @@ class OverviewDetailTab extends mixin(StoreMixin) {
 
 OverviewDetailTab.routeConfig = {
   label: 'Overview',
-  matches: /^\/cluster\/details/
+  matches: /^\/system-overview\/details/
 };
 
 module.exports = OverviewDetailTab;

--- a/src/js/routes/index.js
+++ b/src/js/routes/index.js
@@ -1,7 +1,6 @@
 import {Route, Redirect} from 'react-router';
 import {Hooks} from 'PluginSDK';
 
-import cluster from './cluster';
 import components from './components';
 import dashboard from './dashboard';
 import Index from '../pages/Index';
@@ -14,6 +13,7 @@ import {RoutingService} from '../../../foundation-ui/routing';
 import services from '../../../plugins/services/src/js/routes/services';
 import settings from './settings';
 import styles from './styles'; // eslint-disable-line
+import systemOverview from './system-overview';
 import universe from './universe';
 
 // Modules that produce routes
@@ -32,7 +32,7 @@ function getApplicationRoutes() {
     jobs,
     nodes,
     universe,
-    cluster,
+    systemOverview,
     components,
     settings
     // Plugins routes will be appended to this array

--- a/src/js/routes/system-overview.js
+++ b/src/js/routes/system-overview.js
@@ -1,12 +1,12 @@
 import {Route, IndexRoute} from 'react-router';
 
-import ClusterPage from '../pages/ClusterPage';
+import SystemOverviewPage from '../pages/SystemOverviewPage';
 import OverviewDetailTab from '../pages/system/OverviewDetailTab';
 
-const clusterRoutes = {
+const systemOverviewRoutes = {
   type: Route,
-  path: 'cluster',
-  component: ClusterPage,
+  path: 'system-overview',
+  component: SystemOverviewPage,
   category: 'system',
   isInSidebar: true,
   children: [
@@ -17,4 +17,4 @@ const clusterRoutes = {
   ]
 };
 
-module.exports = clusterRoutes;
+module.exports = systemOverviewRoutes;


### PR DESCRIPTION
This PR renames `Cluster` to `System Overview` throughout the app.

Before: Imagine the word "Cluster"
After: Now imagine the words "System Overview" :trollface: 

![](https://cl.ly/1c1m0L071b1K/Screen%20Shot%202017-02-14%20at%201.20.27%20PM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
