### PR TITLE
DCOS-13386: Add Resume option for suspended services

### DIFF
--- a/plugins/services/src/js/components/modals/ServiceModals.js
+++ b/plugins/services/src/js/components/modals/ServiceModals.js
@@ -7,6 +7,7 @@ import ServiceActionItem from '../../constants/ServiceActionItem';
 import ServiceDestroyModal from './ServiceDestroyModal';
 import ServiceGroupFormModal from './ServiceGroupFormModal';
 import ServiceRestartModal from './ServiceRestartModal';
+import ServiceResumeModal from './ServiceResumeModal';
 import ServiceScaleFormModal from './ServiceScaleFormModal';
 import ServiceSpecUtil from '../../utils/ServiceSpecUtil';
 import ServiceSuspendModal from './ServiceSuspendModal';
@@ -96,6 +97,36 @@ class ServiceModals extends React.Component {
     );
   }
 
+  getResumeModal() {
+    const {
+      actions,
+      actionErrors,
+      onClose,
+      modalProps,
+      pendingActions
+    } = this.props;
+
+    const key = ActionKeys.SERVICE_EDIT;
+    const {service} = modalProps;
+
+    const resumeService = (instances, force) => actions.editService(
+      service,
+      ServiceSpecUtil.setServiceInstances(
+        service.getSpec(),
+        parseInt(instances, 10)
+      ), force);
+
+    return (
+      <ServiceResumeModal
+        resumeService={resumeService}
+        isPending={!!pendingActions[key]}
+        errors={actionErrors[key]}
+        open={modalProps.id === ServiceActionItem.RESUME}
+        onClose={() => onClose(key)}
+        service={service} />
+    );
+  }
+
   getScaleModal() {
     const {
       actionErrors,
@@ -177,6 +208,7 @@ class ServiceModals extends React.Component {
         {this.getGroupModal()}
         {this.getDestroyModal()}
         {this.getRestartModal()}
+        {this.getResumeModal()}
         {this.getScaleModal()}
         {this.getSuspendModal()}
       </div>

--- a/plugins/services/src/js/components/modals/ServiceResumeModal.js
+++ b/plugins/services/src/js/components/modals/ServiceResumeModal.js
@@ -72,10 +72,11 @@ class ServiceResumeModal extends React.Component {
   }
 
   handleConfirmation() {
-    this.props.resumeService(
-      this.state.instancesFieldValue || 0,
-      this.shouldForceUpdate()
-    );
+    const instances = this.state.instancesFieldValue == null
+      ? 1
+      : this.state.instancesFieldValue;
+
+    this.props.resumeService(instances, this.shouldForceUpdate());
   }
 
   handleInstancesFieldChange(event) {

--- a/plugins/services/src/js/components/modals/ServiceResumeModal.js
+++ b/plugins/services/src/js/components/modals/ServiceResumeModal.js
@@ -1,0 +1,179 @@
+import {Confirm} from 'reactjs-components';
+import React, {PropTypes} from 'react';
+import PureRender from 'react-addons-pure-render-mixin';
+
+import AppLockedMessage from './AppLockedMessage';
+import FieldInput from '../../../../../../src/js/components/form/FieldInput';
+import FormGroup from '../../../../../../src/js/components/form/FormGroup';
+import FormRow from '../../../../../../src/js/components/form/FormRow';
+import ModalHeading from '../../../../../../src/js/components/modals/ModalHeading';
+import Service from '../../structs/Service';
+import ServiceTree from '../../structs/ServiceTree';
+
+const METHODS_TO_BIND = [
+  'handleConfirmation',
+  'handleInstancesFieldChange'
+];
+
+class ServiceResumeModal extends React.Component {
+  constructor() {
+    super(...arguments);
+
+    this.state = {
+      instancesFieldValue: null,
+      errorMsg: null
+    };
+
+    this.shouldComponentUpdate = PureRender.shouldComponentUpdate.bind(this);
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  componentWillUpdate(nextProps) {
+    const requestCompleted = this.props.isPending
+      && !nextProps.isPending;
+    const shouldClose = requestCompleted && !nextProps.errors;
+
+    if (shouldClose) {
+      this.props.onClose();
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const {errors} = nextProps;
+    if (!errors) {
+      this.setState({errorMsg: null});
+
+      return;
+    }
+
+    if (typeof errors === 'string') {
+      this.setState({errorMsg: errors});
+
+      return;
+    }
+
+    let {message: errorMsg = '', details} = errors;
+    const hasDetails = details && details.length !== 0;
+
+    if (hasDetails) {
+      errorMsg = details.reduce(function (memo, error) {
+        return `${memo} ${error.errors.join(' ')}`;
+      }, '');
+    }
+
+    if (!errorMsg || !errorMsg.length) {
+      errorMsg = null;
+    }
+
+    this.setState({errorMsg});
+  }
+
+  handleConfirmation() {
+    this.props.resumeService(
+      this.state.instancesFieldValue || 0,
+      this.shouldForceUpdate()
+    );
+  }
+
+  handleInstancesFieldChange(event) {
+    this.setState({
+      instancesFieldValue: event.target.value
+    });
+  }
+
+  getErrorMessage() {
+    const {errorMsg = null} = this.state;
+
+    if (!errorMsg) {
+      return null;
+    }
+
+    if (this.shouldForceUpdate()) {
+      return (
+        <AppLockedMessage service={this.props.service} />
+      );
+    }
+
+    return (
+      <h4 className="text-align-center text-danger flush-top">{errorMsg}</h4>
+    );
+  }
+
+  getModalContent() {
+    const {props: {service}} = this;
+
+    if (service.getLabels().MARATHON_SINGLE_INSTANCE_APP) {
+      return (
+        <p>
+          This service is currently suspended. Do you want to resume this service?
+        </p>
+      );
+    }
+
+    return (
+      <div>
+        <p>This service is currently suspended. Do you want to resume this service? You can change the number of instances to resume by using the field below.</p>
+        <FormRow>
+          <FormGroup
+            className="column-12 column-small-6 column-small-offset-3 flush-bottom">
+            <FieldInput
+              name="instances"
+              onChange={this.handleInstancesFieldChange}
+              type="number"
+              value="1" />
+          </FormGroup>
+        </FormRow>
+      </div>
+    );
+  }
+
+  shouldForceUpdate() {
+    return this.state.errorMsg && /force=true/.test(this.state.errorMsg);
+  }
+
+  render() {
+    const {isPending, onClose, open} = this.props;
+
+    const heading = (
+      <ModalHeading>
+        Resume Service
+      </ModalHeading>
+    );
+
+    return (
+      <Confirm
+        disabled={isPending}
+        header={heading}
+        open={open}
+        onClose={onClose}
+        leftButtonCallback={onClose}
+        rightButtonText="Resume Service"
+        rightButtonClassName="button button-primary"
+        rightButtonCallback={this.handleConfirmation}
+        showHeader={true}>
+        {this.getModalContent()}
+        {this.getErrorMessage()}
+      </Confirm>
+    );
+  }
+}
+
+ServiceResumeModal.propTypes = {
+  errors: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.string
+  ]),
+  isPending: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  open: PropTypes.bool.isRequired,
+  resumeService: PropTypes.func.isRequired,
+  service: PropTypes.oneOfType([
+    PropTypes.instanceOf(ServiceTree),
+    PropTypes.instanceOf(Service)
+  ]).isRequired
+};
+
+module.exports = ServiceResumeModal;

--- a/plugins/services/src/js/constants/ServiceActionItem.js
+++ b/plugins/services/src/js/constants/ServiceActionItem.js
@@ -4,6 +4,7 @@ const ServiceActionItem = {
   EDIT: 'edit',
   DESTROY: 'destroy',
   RESTART: 'restart',
+  RESUME: 'resume',
   SCALE: 'scale',
   SUSPEND: 'suspend',
   MORE: 'more',

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -154,6 +154,13 @@ class ServiceDetail extends mixin(TabsMixin) {
       });
     }
 
+    if (instanceCount === 0) {
+      actions.push({
+        label: 'Resume',
+        onItemSelect: modalHandlers.resumeService
+      });
+    }
+
     actions.push({
       className: 'text-danger',
       label: 'Destroy',

--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -390,6 +390,7 @@ class ServicesContainer extends React.Component {
       deleteService: (props) => set(ServiceActionItem.DESTROY, props),
       editService: (props) => set(ServiceActionItem.EDIT, props),
       restartService: (props) => set(ServiceActionItem.RESTART, props),
+      resumeService: (props) => set(ServiceActionItem.RESUME, props),
       scaleService: (props) => set(ServiceActionItem.SCALE, props),
       suspendService: (props) => set(ServiceActionItem.SUSPEND, props)
     };
@@ -540,6 +541,7 @@ ServicesContainer.childContextTypes = {
     deleteService: PropTypes.func,
     editService: PropTypes.func,
     restartService: PropTypes.func,
+    resumeService: PropTypes.func,
     scaleService: PropTypes.func,
     suspendService: PropTypes.func
   })

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -79,6 +79,9 @@ class ServicesTable extends React.Component {
       case ServiceActionItem.RESTART:
         modalHandlers.restartService({service});
         break;
+      case ServiceActionItem.RESUME:
+        modalHandlers.resumeService({service});
+        break;
       case ServiceActionItem.SUSPEND:
         modalHandlers.suspendService({service});
         break;
@@ -192,6 +195,13 @@ class ServicesTable extends React.Component {
         }),
         id: ServiceActionItem.SUSPEND,
         html: 'Suspend'
+      },
+      {
+        className: classNames({
+          hidden: isGroup || instancesCount > 0
+        }),
+        id: ServiceActionItem.RESUME,
+        html: 'Resume'
       },
       {
         id: ServiceActionItem.DESTROY,
@@ -365,6 +375,7 @@ ServicesTable.contextTypes = {
   modalHandlers: PropTypes.shape({
     scaleService: PropTypes.func,
     restartService: PropTypes.func,
+    resumeService: PropTypes.func,
     suspendService: PropTypes.func,
     deleteService: PropTypes.func
   }).isRequired

--- a/tests/_fixtures/marathon-1-task/app-suspended-single-instance.json
+++ b/tests/_fixtures/marathon-1-task/app-suspended-single-instance.json
@@ -6,21 +6,21 @@
       "args": null,
       "user": null,
       "env": {
-        
+
       },
-      "instances": 1,
+      "instances": 0,
       "cpus": 0.1,
       "mem": 16,
       "disk": 0,
       "executor": "",
       "constraints": [
-        
+
       ],
       "uris": [
-        
+
       ],
       "storeUrls": [
-        
+
       ],
       "ports": [
         10000
@@ -31,10 +31,10 @@
       "maxLaunchDelaySeconds": 3600,
       "container": null,
       "healthChecks": [
-        
+
       ],
       "dependencies": [
-        
+
       ],
       "upgradeStrategy": {
         "minimumHealthCapacity": 1,
@@ -50,12 +50,8 @@
       "tasksHealthy": 0,
       "tasksUnhealthy": 0,
       "deployments": [
-        
+
       ]
     }
-  ],
-  "groups": [
-    
-  ],
-  "id": "/"
+  ]
 }

--- a/tests/_fixtures/marathon-1-task/app-suspended.json
+++ b/tests/_fixtures/marathon-1-task/app-suspended.json
@@ -6,21 +6,21 @@
       "args": null,
       "user": null,
       "env": {
-        
+
       },
-      "instances": 1,
+      "instances": 0,
       "cpus": 0.1,
       "mem": 16,
       "disk": 0,
       "executor": "",
       "constraints": [
-        
+
       ],
       "uris": [
-        
+
       ],
       "storeUrls": [
-        
+
       ],
       "ports": [
         10000
@@ -31,17 +31,17 @@
       "maxLaunchDelaySeconds": 3600,
       "container": null,
       "healthChecks": [
-        
+
       ],
       "dependencies": [
-        
+
       ],
       "upgradeStrategy": {
         "minimumHealthCapacity": 1,
         "maximumOverCapacity": 1
       },
       "labels": {
-        "MARATHON_SINGLE_INSTANCE_APP": true
+
       },
       "acceptedResourceRoles": null,
       "version": "2015-08-28T01:26:14.620Z",
@@ -50,12 +50,8 @@
       "tasksHealthy": 0,
       "tasksUnhealthy": 0,
       "deployments": [
-        
+
       ]
     }
-  ],
-  "groups": [
-    
-  ],
-  "id": "/"
+  ]
 }

--- a/tests/_fixtures/marathon-1-task/groups-suspended-single-instance.json
+++ b/tests/_fixtures/marathon-1-task/groups-suspended-single-instance.json
@@ -8,7 +8,7 @@
       "env": {
         
       },
-      "instances": 1,
+      "instances": 0,
       "cpus": 0.1,
       "mem": 16,
       "disk": 0,

--- a/tests/_fixtures/marathon-1-task/groups-suspended.json
+++ b/tests/_fixtures/marathon-1-task/groups-suspended.json
@@ -8,7 +8,7 @@
       "env": {
         
       },
-      "instances": 1,
+      "instances": 0,
       "cpus": 0.1,
       "mem": 16,
       "disk": 0,
@@ -41,7 +41,7 @@
         "maximumOverCapacity": 1
       },
       "labels": {
-        "MARATHON_SINGLE_INSTANCE_APP": true
+        
       },
       "acceptedResourceRoles": null,
       "version": "2015-08-28T01:26:14.620Z",

--- a/tests/_fixtures/marathon-1-task/groups.json
+++ b/tests/_fixtures/marathon-1-task/groups.json
@@ -6,7 +6,7 @@
       "args": null,
       "user": null,
       "env": {
-        
+
       },
       "instances": 1,
       "cpus": 0.1,
@@ -14,13 +14,13 @@
       "disk": 0,
       "executor": "",
       "constraints": [
-        
+
       ],
       "uris": [
-        
+
       ],
       "storeUrls": [
-        
+
       ],
       "ports": [
         10000
@@ -31,17 +31,17 @@
       "maxLaunchDelaySeconds": 3600,
       "container": null,
       "healthChecks": [
-        
+
       ],
       "dependencies": [
-        
+
       ],
       "upgradeStrategy": {
         "minimumHealthCapacity": 1,
         "maximumOverCapacity": 1
       },
       "labels": {
-        "MARATHON_SINGLE_INSTANCE_APP": true
+        "MARATHON_SINGLE_INSTANCE_APP": "true"
       },
       "acceptedResourceRoles": null,
       "version": "2015-08-28T01:26:14.620Z",
@@ -50,12 +50,12 @@
       "tasksHealthy": 0,
       "tasksUnhealthy": 0,
       "deployments": [
-        
+
       ]
     }
   ],
   "groups": [
-    
+
   ],
   "id": "/"
 }

--- a/tests/_support/index.js
+++ b/tests/_support/index.js
@@ -35,9 +35,9 @@ Cypress.addParentCommand('configureCluster', function (configuration) {
       .route(/service\/marathon\/v2\/apps/, 'fx:marathon-1-task/app')
       .route(/service\/marathon\/v2\/apps\/\/sleep\/versions/,
         'fx:marathon-1-task/versions')
-      .route(/service\/marathon\/v2\/apps\/\/sleep\/versions\/2015\-08\-28T01:26:14\.620Z/,
+      .route(/service\/marathon\/v2\/apps\/\/sleep\/versions\/2015-08-28T01:26:14\.620Z/,
         'fx:marathon-1-task/app-version-1')
-      .route(/service\/marathon\/v2\/apps\/\/sleep\/versions\/2015\-02\-28T05:12:12\.221Z/,
+      .route(/service\/marathon\/v2\/apps\/\/sleep\/versions\/2015-02-28T05:12:12\.221Z/,
         'fx:marathon-1-task/app-version-2')
       .route(/service\/marathon\/v2\/groups/, 'fx:marathon-1-task/groups')
       .route(/service\/marathon\/v2\/deployments/, 'fx:marathon-1-task/deployments')
@@ -49,6 +49,7 @@ Cypress.addParentCommand('configureCluster', function (configuration) {
       .route(/state/, 'fx:marathon-1-task/state')
       .route(/overlay-master\/state/, 'fx:mesos/overlay-master');
   }
+
   if (configuration.mesos === '1-empty-group') {
     cy
       .route(/marathon\/v2\/groups/, 'fx:marathon-1-group/groups');
@@ -106,6 +107,28 @@ Cypress.addParentCommand('configureCluster', function (configuration) {
     cy
       .route(/marathon\/v2\/deployments/, 'fx:deployments/one-deployment')
       .route(/service\/marathon\/v2\/groups/, 'fx:marathon-1-group/kafka');
+  }
+
+  if (configuration.mesos === '1-service-suspended') {
+    cy
+      .route(/service\/marathon\/v2\/apps/, 'fx:marathon-1-task/app-suspended')
+      .route(/service\/marathon\/v2\/groups/, 'fx:marathon-1-task/groups-suspended')
+      .route(/service\/marathon\/v2\/deployments/, 'fx:marathon-1-task/deployments')
+      .route(/history\/minute/, 'fx:marathon-1-task/history-minute')
+      .route(/history\/last/, 'fx:marathon-1-task/summary')
+      .route(/state-summary/, 'fx:marathon-1-task/summary')
+      .route(/state/, 'fx:marathon-1-task/state');
+  }
+
+  if (configuration.mesos === '1-service-suspended-single-instance') {
+    cy
+      .route(/service\/marathon\/v2\/apps/, 'fx:marathon-1-task/app-suspended-single-instance')
+      .route(/service\/marathon\/v2\/groups/, 'fx:marathon-1-task/groups-suspended-single-instance')
+      .route(/service\/marathon\/v2\/deployments/, 'fx:marathon-1-task/deployments')
+      .route(/history\/minute/, 'fx:marathon-1-task/history-minute')
+      .route(/history\/last/, 'fx:marathon-1-task/summary')
+      .route(/state-summary/, 'fx:marathon-1-task/summary')
+      .route(/state/, 'fx:marathon-1-task/state');
   }
 
   if (configuration.networkVIPSummaries) {

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -30,7 +30,7 @@ describe('Service Actions', function () {
       cy
         .route({
           method: 'PUT',
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: []
         });
       cy.get('.modal .modal-header .button')
@@ -160,7 +160,7 @@ describe('Service Actions', function () {
       cy
         .route({
           method: 'PUT',
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: []
         });
       cy.get('.modal-footer .button-collection .button-primary')
@@ -172,7 +172,7 @@ describe('Service Actions', function () {
       cy
         .route({
           method: 'PUT',
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: []
         });
       cy.get('.modal-footer .button-collection .button-primary').click();
@@ -184,7 +184,7 @@ describe('Service Actions', function () {
         .route({
           method: 'PUT',
           status: 409,
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: {
             message: 'App is locked by one or more deployments.'
           }
@@ -199,7 +199,7 @@ describe('Service Actions', function () {
         .route({
           method: 'PUT',
           status: 403,
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: {
             message: 'Not Authorized to perform this action!'
           }
@@ -213,7 +213,7 @@ describe('Service Actions', function () {
       cy
         .route({
           method: 'PUT',
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: [],
           delay: SERVER_RESPONSE_DELAY
         });
@@ -244,7 +244,7 @@ describe('Service Actions', function () {
       cy
         .route({
           method: 'PUT',
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: []
         });
       cy.get('.confirm-modal .button-collection .button-primary')
@@ -256,7 +256,7 @@ describe('Service Actions', function () {
       cy
         .route({
           method: 'PUT',
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: []
         });
       cy.get('.confirm-modal .button-collection .button-primary').click();
@@ -268,7 +268,7 @@ describe('Service Actions', function () {
         .route({
           method: 'PUT',
           status: 409,
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: {
             message: 'App is locked by one or more deployments.'
           }
@@ -283,7 +283,7 @@ describe('Service Actions', function () {
         .route({
           method: 'PUT',
           status: 403,
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: {
             message: 'Not Authorized to perform this action!'
           }
@@ -297,7 +297,7 @@ describe('Service Actions', function () {
       cy
         .route({
           method: 'PUT',
-          url: /marathon\/v2\/apps\/\/cassandra\-healthy/,
+          url: /marathon\/v2\/apps\/\/cassandra-healthy/,
           response: [],
           delay: SERVER_RESPONSE_DELAY
         });
@@ -311,6 +311,176 @@ describe('Service Actions', function () {
       cy.get('.confirm-modal .button-collection .button').contains('Cancel')
         .click();
       cy.get('.confirm-modal').should('to.have.length', 0);
+    });
+  });
+
+  context('Resume Action', function () {
+    function openDropdown() {
+      cy.get('.service-table-column-name')
+        .contains('sleep')
+        .get('.dropdown-toggle')
+        .click({force: true});
+    }
+
+    function clickResume() {
+      cy.get('.dropdown-menu-items')
+        .get('li')
+        .contains('Resume')
+        .click();
+    }
+
+    beforeEach(function () {
+      cy.configureCluster({
+        mesos: '1-service-suspended',
+        nodeHealth: true
+      });
+
+      cy.visitUrl({url: '/services/overview'});
+    });
+
+    it('hides the suspend option in the service action dropdown', function () {
+      openDropdown();
+
+      cy.get('.dropdown-menu-items')
+        .get('li')
+        .contains('Suspend')
+        .should('have.class', 'hidden');
+    });
+
+    it('shows the resume option in the service action dropdown', function () {
+      openDropdown();
+
+      cy.get('.dropdown-menu-items')
+        .get('li')
+        .contains('Resume')
+        .should('not.have.class', 'hidden');
+    });
+
+    it('opens the resume dialog', function () {
+      openDropdown();
+      clickResume();
+
+      cy.get('.modal-header')
+        .contains('Resume Service')
+        .should('have.length', 1);
+    });
+
+    it('opens the resume dialog with the instances textbox if the single app instance label does not exist', function () {
+      openDropdown();
+      clickResume();
+
+      cy.get('input[name="instances"]')
+        .should('have.length', 1);
+    });
+
+    it('opens the resume dialog without the instances textbox if the single app instance label exists', function () {
+      cy.configureCluster({
+        mesos: '1-service-suspended-single-instance',
+        nodeHealth: true
+      });
+
+      cy.visitUrl({url: '/services/overview'});
+
+      openDropdown();
+      clickResume();
+
+      cy.get('input[name="instances"]')
+        .should('have.length', 0);
+    });
+
+    it('disables button during API request', function () {
+      cy.route({
+        method: 'PUT',
+        url: /marathon\/v2\/apps\/\/sleep/,
+        response: []
+      });
+
+      openDropdown();
+      clickResume();
+
+      cy.get('.modal-footer .button-collection .button-primary')
+        .click()
+        .should('have.class', 'disabled');
+    });
+
+    it('closes dialog on successful API request', function () {
+      cy
+        .route({
+          method: 'PUT',
+          url: /marathon\/v2\/apps\/\/sleep/,
+          response: []
+        });
+
+      openDropdown();
+      clickResume();
+
+      cy.get('.modal-footer .button-collection .button-primary').click();
+      cy.get('.modal-body').should('to.have.length', 0);
+    });
+
+    it('shows error message on conflict', function () {
+      cy
+        .route({
+          method: 'PUT',
+          status: 409,
+          url: /marathon\/v2\/apps\/\/sleep/,
+          response: {
+            message: 'App is locked by one or more deployments.'
+          }
+        });
+
+      openDropdown();
+      clickResume();
+
+      cy.get('.modal-footer .button-collection .button-primary').click();
+      cy.get('.modal-body .text-danger')
+        .should('to.have.text', 'App is locked by one or more deployments.');
+    });
+
+    it('shows error message on not authorized', function () {
+      cy
+        .route({
+          method: 'PUT',
+          status: 403,
+          url: /marathon\/v2\/apps\/\/sleep/,
+          response: {
+            message: 'Not Authorized to perform this action!'
+          }
+        });
+
+      openDropdown();
+      clickResume();
+
+      cy.get('.modal-footer .button-collection .button-primary').click();
+      cy.get('.modal-body .text-danger')
+        .should('to.have.text', 'Not Authorized to perform this action!');
+    });
+
+    it('reenables button after faulty request', function () {
+      cy
+        .route({
+          method: 'PUT',
+          url: /marathon\/v2\/apps\/\/sleep/,
+          response: [],
+          delay: SERVER_RESPONSE_DELAY
+        });
+
+      openDropdown();
+      clickResume();
+
+      cy.get('.modal-footer .button-collection .button-primary')
+        .as('primaryButton').click();
+      cy.get('@primaryButton').should('have.class', 'disabled');
+      cy.get('@primaryButton').should('not.have.class', 'disabled');
+    });
+
+    it('closes dialog on secondary button click', function () {
+      openDropdown();
+      clickResume();
+
+      cy.get('.modal-footer .button-collection .button').contains('Cancel')
+        .click();
+      cy.get('.modal-body').should('to.have.length', 0);
     });
   });
 


### PR DESCRIPTION
This PR adds a "Resume" option for suspended services (meaning their instance count is 0).

When the modal appears, the user can choose how many instances they'd like to resume to. If the app label `MARATHON_SINGLE_INSTANCE_APP` is present, we do not present the instance count textbox, and instead scale the service back to a single instance.

![](https://cl.ly/2V0Y450x1r25/Screen%20Recording%202017-02-15%20at%2005.01%20PM.gif)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [x] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?