### PR TITLE
DCOS-13152: Add service validators hooks

### DIFF
--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -19,7 +19,9 @@ class EnvironmentFormSection extends Component {
   getEnvironmentLines(data) {
     const errors = this.props.errors.env || {};
 
-    return data.map((env, key) => {
+    return data.filter(function (item) {
+      return item.value == null || typeof item.value === 'string';
+    }).map((env, key) => {
       let keyLabel = null;
       let valueLabel = null;
       if (key === 0) {

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -388,20 +388,28 @@ class NewCreateServiceModal extends Component {
     const {serviceFormErrors, serviceSpec} = this.state;
     let validationErrors = [];
 
+    const appValidators = APP_VALIDATORS.concat(
+      Hooks.applyFilter('appValidators', [])
+    );
+
+    const podValidators = POD_VALIDATORS.concat(
+      Hooks.applyFilter('podValidators', [])
+    );
+
     // Validate Application or Pod according to the contents
     // of the serviceSpec property.
 
     if (serviceSpec instanceof ApplicationSpec) {
       validationErrors = DataValidatorUtil.validate(
         getServiceJSON(serviceSpec),
-        APP_VALIDATORS
+        appValidators
       );
     }
 
     if (serviceSpec instanceof PodSpec) {
       validationErrors = DataValidatorUtil.validate(
         getServiceJSON(serviceSpec),
-        POD_VALIDATORS
+        podValidators
       );
     }
 

--- a/plugins/services/src/js/constants/ServiceErrorPathMapping.js
+++ b/plugins/services/src/js/constants/ServiceErrorPathMapping.js
@@ -10,6 +10,10 @@ const ServiceErrorPathMapping = [
   {
     match: /^cpus$/,
     name: 'The number of CPUs'
+  },
+  {
+    match: /^env\.\*$/,
+    name: 'An environment variable'
   }
 ];
 

--- a/plugins/services/src/js/reducers/serviceForm/EnvironmentVariables.js
+++ b/plugins/services/src/js/reducers/serviceForm/EnvironmentVariables.js
@@ -67,9 +67,7 @@ module.exports = {
       return [];
     }
 
-    return Object.keys(state.env).filter((key) => {
-      return !(typeof state.env[key] !== 'string');
-    }).reduce(function (memo, key, index) {
+    return Object.keys(state.env).reduce(function (memo, key, index) {
       /**
        * For the environment variables which are a key => value based object
        * we want to create a new item and fill it with the key and the

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/EnvironmentVariables-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/EnvironmentVariables-test.js
@@ -15,6 +15,7 @@ describe('Environment Variables', function () {
       expect(batch.reduce(EnvironmentVariables.JSONReducer.bind({}), {}))
         .toEqual({key: 'value'});
     });
+
     it('should keep the last value if they have the same key', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['env'], 0, ADD_ITEM));
@@ -27,6 +28,7 @@ describe('Environment Variables', function () {
       expect(batch.reduce(EnvironmentVariables.JSONReducer.bind({}), {}))
         .toEqual({key: 'value2'});
     });
+
     it('should keep remove the first item', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['env'], 0, ADD_ITEM));
@@ -42,6 +44,7 @@ describe('Environment Variables', function () {
     });
 
   });
+
   describe('#FormReducer', function () {
     it('should return a array containing key value objects', function () {
       let batch = new Batch();
@@ -52,6 +55,7 @@ describe('Environment Variables', function () {
       expect(batch.reduce(EnvironmentVariables.FormReducer.bind({}), []))
         .toEqual([{key: 'key', value: 'value'}]);
     });
+
     it('should multiple items if they have the same key', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['env'], 0, ADD_ITEM));
@@ -67,6 +71,7 @@ describe('Environment Variables', function () {
           {key: 'key', value: 'value2'}
         ]);
     });
+
     it('should keep remove the first item', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['env'], 0, ADD_ITEM));
@@ -81,15 +86,25 @@ describe('Environment Variables', function () {
         .toEqual([{key: 'second', value: 'value'}]);
     });
   });
+
   describe('#JSONParser', function () {
     it('should return an empty array', function () {
       expect(EnvironmentVariables.JSONParser({})).toEqual([]);
     });
+
     it('should return an array of transactions', function () {
       expect(EnvironmentVariables.JSONParser({env: {key: 'value'}})).toEqual([
         {type: ADD_ITEM, value: 0, path: ['env']},
         {type: SET, value: 'key', path: ['env', 0, 'key']},
         {type: SET, value: 'value', path: ['env', 0, 'value']}
+      ]);
+    });
+
+    it('should keep complex values', function () {
+      expect(EnvironmentVariables.JSONParser({env: {foo: {secret: 'value'}}})).toEqual([
+        {type: ADD_ITEM, value: 0, path: ['env']},
+        {type: SET, value: 'foo', path: ['env', 0, 'key']},
+        {type: SET, value: {secret: 'value'}, path: ['env', 0, 'value']}
       ]);
     });
   });

--- a/src/js/constants/DefaultErrorMessages.js
+++ b/src/js/constants/DefaultErrorMessages.js
@@ -168,6 +168,19 @@ const DefaultErrorMessages = [
     path: /.*/,
     type: 'ALREADY_EXISTS',
     message: 'Already Exists'
+  },
+
+  //
+  // [C] Custom Error Messages
+  //
+
+  /**
+   * Value of a certain shape
+   */
+  {
+    path: /.*/,
+    type: 'VALUE_SHAPE',
+    message: 'Must be a certain shape: {{shape}}'
   }
 
 ];


### PR DESCRIPTION
Two things:
- JSON parser has been adjusted to let all the values in the batch so that we don't delete something we don't support in the form
- Form validators moved from the module level inside `getFormErrors` method so that we could apply hooks and extend validators

<!--- Thank you for your contribution! Please provide enough information for others to best review your code. -->

<!-- Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it. -->

<!-- Description of motivation for making this change, what does it solve and steps needed to see change. -->

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
