### PR TITLE
[2 of 2] DCOS-12713: Adding contextual XHR errors to services, nodes, jobs

### DIFF
--- a/plugins/nodes/src/js/components/NodesGridView.js
+++ b/plugins/nodes/src/js/components/NodesGridView.js
@@ -5,7 +5,6 @@ import React from 'react';
 
 import Loader from '../../../../../src/js/components/Loader';
 import NodesGridDials from './NodesGridDials';
-import RequestErrorMsg from '../../../../../src/js/components/RequestErrorMsg';
 
 var MAX_SERVICES_TO_SHOW = 32;
 var OTHER_SERVICES_COLOR = 32;
@@ -17,7 +16,6 @@ var NodesGridView = React.createClass({
   mixins: [PureRender],
 
   propTypes: {
-    hasLoadingError: React.PropTypes.bool,
     hiddenServices: React.PropTypes.array,
     hosts: React.PropTypes.array.isRequired,
     receivedEmptyMesosState: React.PropTypes.bool,
@@ -31,7 +29,6 @@ var NodesGridView = React.createClass({
   },
 
   defaultProps: {
-    hasLoadingError: false,
     hiddenServices: [],
     receivedNodeHealthResponse: false,
     showServices: false
@@ -42,20 +39,9 @@ var NodesGridView = React.createClass({
   },
 
   getLoadingScreen() {
-    var {hasLoadingError} = this.props;
-    var errorMsg = null;
-    if (hasLoadingError) {
-      errorMsg = <RequestErrorMsg />;
-    }
-
-    var loadingClassSet = classNames({
-      hidden: hasLoadingError
-    });
-
     return (
       <div className="pod flush-left flush-right">
-        <Loader className={loadingClassSet} />
-        {errorMsg}
+        <Loader />
       </div>
     );
   },
@@ -146,12 +132,11 @@ var NodesGridView = React.createClass({
 
   render() {
     const {
-      hasLoadingError,
       receivedEmptyMesosState,
       receivedNodeHealthResponse
     } = this.props;
 
-    if (hasLoadingError || receivedEmptyMesosState || !receivedNodeHealthResponse) {
+    if (receivedEmptyMesosState || !receivedNodeHealthResponse) {
       return this.getLoadingScreen();
     } else {
       return this.getNodesGrid();

--- a/plugins/nodes/src/js/pages/__tests__/NodeDetailPage-test.js
+++ b/plugins/nodes/src/js/pages/__tests__/NodeDetailPage-test.js
@@ -3,7 +3,7 @@ jest.dontMock('../../../../../../src/js/mixins/InternalStorageMixin');
 jest.dontMock('../../../../../../src/js/mixins/TabsMixin');
 jest.dontMock('../../../../../../src/js/stores/MesosSummaryStore');
 jest.dontMock('../nodes/NodeDetailPage');
-jest.dontMock('../../../../../../src/js/components/RequestErrorMsg');
+jest.dontMock('../../../../../../src/js/components/ContextualXHRError');
 jest.dontMock('../../../../../../src/js/structs/CompositeState');
 jest.dontMock('../../../../../../src/js/components/Page');
 

--- a/plugins/services/src/js/components/MesosLogContainer.js
+++ b/plugins/services/src/js/components/MesosLogContainer.js
@@ -25,7 +25,7 @@ class MesosLogContainer extends mixin(StoreMixin) {
       fullLog: null,
       isFetchingPrevious: false,
       isLoading: true,
-      hasLoadingError: 0
+      mesosLogXHRError: null
     };
 
     this.store_listeners = [{
@@ -62,7 +62,7 @@ class MesosLogContainer extends mixin(StoreMixin) {
       fullLog: null,
       isFetchingPrevious: false,
       isLoading: true,
-      hasLoadingError: 0
+      mesosLogXHRError: null
     });
     if (props.filePath) {
       // Clean up data as well
@@ -90,7 +90,7 @@ class MesosLogContainer extends mixin(StoreMixin) {
     const {
       direction,
       fullLog,
-      hasLoadingError,
+      mesosLogXHRError,
       isFetchingPrevious,
       isLoading
     } = this.state;
@@ -110,8 +110,8 @@ class MesosLogContainer extends mixin(StoreMixin) {
       (task.slave_id !== nextProps.task.slave_id) ||
       // Check direction
       (direction !== nextState.direction) ||
-      // Check hasLoadingError
-      (hasLoadingError !== nextState.hasLoadingError) ||
+      // Check mesosLogXHRError
+      (mesosLogXHRError !== nextState.mesosLogXHRError) ||
       // Check isFetchingPrevious
       (isFetchingPrevious !== nextState.isFetchingPrevious) ||
       // Check isLoading
@@ -121,7 +121,7 @@ class MesosLogContainer extends mixin(StoreMixin) {
     );
   }
 
-  onMesosLogStoreError(path) {
+  onMesosLogStoreError(path, xhr) {
     // Check the filePath before we reload
     if (path !== this.props.filePath) {
       // This event is not for our filePath
@@ -129,7 +129,7 @@ class MesosLogContainer extends mixin(StoreMixin) {
     }
 
     this.setState({
-      hasLoadingError: this.state.hasLoadingError + 1,
+      mesosLogXHRError: xhr,
       isFetchingPrevious: false
     });
   }
@@ -147,7 +147,7 @@ class MesosLogContainer extends mixin(StoreMixin) {
 
     this.setState({
       direction,
-      hasLoadingError: 0,
+      mesosLogXHRError: null,
       isFetchingPrevious: false,
       isLoading: !filePath,
       fullLog
@@ -216,9 +216,9 @@ class MesosLogContainer extends mixin(StoreMixin) {
   }
 
   render() {
-    const {hasLoadingError, isLoading} = this.state;
+    const {mesosLogXHRError, isLoading} = this.state;
 
-    if (hasLoadingError >= 3) {
+    if (mesosLogXHRError) {
       return this.getErrorScreen();
     }
 

--- a/plugins/services/src/js/components/__tests__/MesosLogContainer-test.js
+++ b/plugins/services/src/js/components/__tests__/MesosLogContainer-test.js
@@ -154,19 +154,11 @@ describe('MesosLogContainer', function () {
   describe('#render', function () {
 
     it('should call getErrorScreen when error occurred', function () {
-      this.instance.state.hasLoadingError = 3;
+      this.instance.state.mesosLogXHRError = {status: 400};
       this.instance.getErrorScreen = jasmine.createSpy('getErrorScreen');
 
       this.instance.render();
       expect(this.instance.getErrorScreen).toHaveBeenCalled();
-    });
-
-    it('ignores getErrorScreen when error has not occurred', function () {
-      this.instance.state.hasLoadingError = 2;
-      this.instance.getErrorScreen = jasmine.createSpy('getErrorScreen');
-
-      this.instance.render();
-      expect(this.instance.getErrorScreen).not.toHaveBeenCalled();
     });
 
     it('shouldn\'t call getLoadingScreen when fullLog is empty', function () {

--- a/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
+++ b/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
@@ -22,7 +22,7 @@ const METHODS_TO_BIND = [
 
 // Number of lines (entries) we asses to be a page
 const PAGE_ENTRY_COUNT = 400;
-
+// Server send events doesn't bubble an appropriate event so we use this
 const EVENT_STREAM_ERROR = {status: 400, message: 'EventStream Error'};
 
 function getLogParameters(task, options) {

--- a/plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.js
+++ b/plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.js
@@ -86,15 +86,15 @@ describe('TaskDetail', function () {
   describe('#onTaskDirectoryStoreError', function () {
 
     it('should setState', function () {
-      this.instance.onTaskDirectoryStoreError();
+      this.instance.onTaskDirectoryStoreError({status: 400});
       expect(this.instance.setState).toHaveBeenCalled();
     });
 
-    it('should setState increment taskDirectoryErrorCount', function () {
-      this.instance.state = {taskDirectoryErrorCount: 1};
-      this.instance.onTaskDirectoryStoreError();
+    it('should setState taskDirectoryXHRError', function () {
+      this.instance.state = {taskDirectoryXHRError: null};
+      this.instance.onTaskDirectoryStoreError(null, {status: 400});
       expect(this.instance.setState)
-        .toHaveBeenCalledWith({taskDirectoryErrorCount: 2});
+        .toHaveBeenCalledWith({taskDirectoryXHRError: {status: 400}});
     });
 
   });
@@ -106,7 +106,7 @@ describe('TaskDetail', function () {
       expect(this.instance.setState).toHaveBeenCalled();
     });
 
-    it('should setState increment onTaskDirectoryStoreSuccess', function () {
+    it('should setState on onTaskDirectoryStoreSuccess', function () {
       const directory = new TaskDirectory({items: [{nlink: 1, path: '/stdout'}]});
       // Let directory return something
       TaskDirectoryStore.get = jasmine.createSpy('TaskDirectoryStore#get')
@@ -114,7 +114,7 @@ describe('TaskDetail', function () {
 
       this.instance.onTaskDirectoryStoreSuccess();
       expect(this.instance.setState)
-        .toHaveBeenCalledWith({directory, taskDirectoryErrorCount: 0});
+        .toHaveBeenCalledWith({directory, taskDirectoryXHRError: null});
     });
 
   });
@@ -137,7 +137,7 @@ describe('TaskDetail', function () {
     it('should call getErrorScreen when error occurred', function () {
       this.instance.state = {
         directory: new TaskDirectory({items: [{nlink: 1, path: '/stdout'}]}),
-        taskDirectoryErrorCount: 3
+        taskDirectoryXHRError: {status: 400}
       };
       this.instance.getSubView();
 

--- a/plugins/services/src/js/pages/task-details/__tests__/TaskFileViewer-test.js
+++ b/plugins/services/src/js/pages/task-details/__tests__/TaskFileViewer-test.js
@@ -1,6 +1,6 @@
 jest.dontMock('../../../../../../../src/js/components/Icon');
 jest.dontMock('../../../components/MesosLogContainer');
-jest.dontMock('../../../../../../../src/js/components/RequestErrorMsg');
+jest.dontMock('../../../../../../../src/js/components/ContextualXHRError');
 jest.dontMock('../TaskFileViewer');
 jest.dontMock('../../../../../../../src/js/components/FilterBar');
 

--- a/plugins/services/src/js/stores/MesosLogStore.js
+++ b/plugins/services/src/js/stores/MesosLogStore.js
@@ -60,7 +60,7 @@ class MesosLogStore extends BaseStore {
           this.processLogEntry(action.slaveID, action.path, action.data);
           break;
         case REQUEST_MESOS_LOG_ERROR:
-          this.processLogError(action.slaveID, action.path);
+          this.processLogError(action.slaveID, action.path, action.xhr);
           break;
         case REQUEST_PREVIOUS_MESOS_LOG_SUCCESS:
           this.processLogPrepend(action.slaveID, action.path, action.data);
@@ -207,7 +207,7 @@ class MesosLogStore extends BaseStore {
     this.emit(MESOS_LOG_CHANGE, path, PREPEND);
   }
 
-  processLogError(slaveID, path) {
+  processLogError(slaveID, path, xhr) {
     const logBuffer = this.getLogBuffer(path);
     if (!logBuffer) {
       return;
@@ -223,7 +223,7 @@ class MesosLogStore extends BaseStore {
       );
     }, Config.tailRefresh);
 
-    this.emit(MESOS_LOG_REQUEST_ERROR, path);
+    this.emit(MESOS_LOG_REQUEST_ERROR, path, xhr);
   }
 
   processLogPrependError(slaveID, path) {

--- a/plugins/services/src/js/stores/TaskDirectoryStore.js
+++ b/plugins/services/src/js/stores/TaskDirectoryStore.js
@@ -68,16 +68,16 @@ class TaskDirectoryStore extends GetSetBaseStore {
         return false;
       }
 
-      const {data, innerPath, task, type} = payload.action;
+      const {data, innerPath, task, type, xhr = null} = payload.action;
       switch (type) {
         case REQUEST_TASK_DIRECTORY_SUCCESS:
           this.processStateSuccess(data, innerPath, task.id);
           break;
         case REQUEST_TASK_DIRECTORY_ERROR:
-          this.emit(TASK_DIRECTORY_ERROR, task.id);
+          this.emit(TASK_DIRECTORY_ERROR, task.id, xhr);
           break;
         case REQUEST_NODE_STATE_ERROR:
-          this.emit(NODE_STATE_ERROR, task.id);
+          this.emit(NODE_STATE_ERROR, task.id, xhr);
           break;
         case REQUEST_NODE_STATE_SUCCESS:
           activeXHR = TaskDirectoryActions

--- a/src/js/components/ContextualXHRError.js
+++ b/src/js/components/ContextualXHRError.js
@@ -1,0 +1,25 @@
+import {MountService} from 'foundation-ui';
+import React from 'react';
+
+import RequestErrorMsg from './RequestErrorMsg';
+
+class ContextualXHRError extends React.Component {
+  render() {
+    return (
+      <MountService.Mount
+        limit={1}
+        type="ContextualXHRError"
+        xhr={this.props.xhr}>
+        <RequestErrorMsg />
+      </MountService.Mount>
+    );
+  }
+}
+
+ContextualXHRError.propTypes = {
+  xhr: React.PropTypes.shape({
+    status: React.PropTypes.number.isRequired
+  }).isRequired
+};
+
+module.exports = ContextualXHRError;

--- a/src/js/pages/jobs/JobDetailPage.js
+++ b/src/js/pages/jobs/JobDetailPage.js
@@ -9,6 +9,7 @@ import {routerShape} from 'react-router';
 
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
+import ContextualXHRError from '../../components/ContextualXHRError';
 import Icon from '../../components/Icon';
 import JobConfiguration from './JobConfiguration';
 import JobFormModal from '../../components/modals/JobFormModal';
@@ -17,7 +18,6 @@ import JobsBreadcrumbs from '../../components/breadcrumbs/JobsBreadcrumbs';
 import Loader from '../../components/Loader';
 import MetronomeStore from '../../stores/MetronomeStore';
 import Page from '../../components/Page';
-import RequestErrorMsg from '../../components/RequestErrorMsg';
 import StringUtil from '../../utils/StringUtil';
 import TabsMixin from '../../mixins/TabsMixin';
 import TimeAgo from '../../components/TimeAgo';
@@ -71,7 +71,7 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
       disabledDialog: null,
       jobActionDialog: null,
       errorMsg: null,
-      errorCount: 0,
+      jobDetailXHRError: null,
       isJobFormModalOpen: false,
       isLoading: true
     };
@@ -109,12 +109,12 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
     this.context.router.push('/jobs');
   }
 
-  onMetronomeStoreJobDetailError() {
-    this.setState({errorCount: this.state.errorCount + 1});
+  onMetronomeStoreJobDetailError(xhr) {
+    this.setState({jobDetailXHRError: xhr});
   }
 
   onMetronomeStoreJobDetailChange() {
-    this.setState({errorCount: 0, isLoading: false});
+    this.setState({jobDetailXHRError: null, isLoading: false});
   }
 
   handleEditButtonClick() {
@@ -210,7 +210,7 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
     return (
       <Page>
         <Page.Header breadcrumbs={<JobsBreadcrumbs/>} />
-        <RequestErrorMsg />
+        <ContextualXHRError xhr={this.state.jobDetailXHRError} />
       </Page>
     );
   }
@@ -391,7 +391,7 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
   }
 
   render() {
-    if (this.state.errorCount > 3) {
+    if (this.state.jobDetailXHRError) {
       return this.getErrorScreen();
     }
 

--- a/src/js/pages/jobs/JobTaskDetailPage.js
+++ b/src/js/pages/jobs/JobTaskDetailPage.js
@@ -1,5 +1,8 @@
+import mixin from 'reactjs-mixin';
 import React from 'react';
+import {StoreMixin} from 'mesosphere-shared-reactjs';
 
+import ContextualXHRError from '../../components/ContextualXHRError';
 import TaskDetail from '../../../../plugins/services/src/js/pages/task-details/TaskDetail';
 import MesosStateStore from '../../stores/MesosStateStore';
 import JobsBreadcrumbs from '../../components/breadcrumbs/JobsBreadcrumbs';
@@ -10,10 +13,51 @@ const dontScrollRoutes = [
   /\/logs.*$/
 ];
 
-class JobTaskDetailPage extends React.Component {
+const METHODS_TO_BIND = [
+  'onStateStoreSuccess',
+  'onStateStoreError'
+];
+
+class JobTaskDetailPage extends mixin(StoreMixin) {
+  constructor() {
+    super(...arguments);
+
+    this.state = {
+      lastUpdate: 0,
+      mesosXHRError: null
+    };
+
+    this.store_listeners = [
+      {name: 'state', events: ['success', 'error'], suppressUpdate: true}
+    ];
+
+    METHODS_TO_BIND.forEach((method) => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  onStateStoreSuccess() {
+    // Throttle updates
+    if (Date.now() - this.state.lastUpdate > 1000
+      || this.state.mesosXHRError) {
+
+      this.setState({
+        lastUpdate: Date.now(),
+        mesosXHRError: null
+      });
+    }
+  }
+
+  onStateStoreError(xhr) {
+    this.setState({
+      mesosXHRError: xhr
+    });
+  }
+
   render() {
     const {location, params, routes} = this.props;
     const {id, taskID} = params;
+    const {mesosXHRError} = this.state;
 
     const routePrefix = `/jobs/${encodeURIComponent(id)}/tasks/${encodeURIComponent(taskID)}`;
     const tabs = [
@@ -21,6 +65,10 @@ class JobTaskDetailPage extends React.Component {
       {label: 'Files', routePath: routePrefix + '/files'},
       {label: 'Logs', routePath: routePrefix + '/logs'}
     ];
+
+    if (mesosXHRError) {
+      return <ContextualXHRError xhr={mesosXHRError} />;
+    }
 
     const task = MesosStateStore.getTaskFromTaskID(taskID);
 

--- a/src/js/stores/MetronomeStore.js
+++ b/src/js/stores/MetronomeStore.js
@@ -136,7 +136,7 @@ class MetronomeStore extends EventEmitter {
         case REQUEST_METRONOME_JOB_DETAIL_ONGOING:
           break;
         case REQUEST_METRONOME_JOB_DETAIL_ERROR:
-          this.emit(METRONOME_JOB_DETAIL_ERROR);
+          this.emit(METRONOME_JOB_DETAIL_ERROR, action.xhr);
           break;
         case REQUEST_METRONOME_JOB_UPDATE_SUCCESS:
           this.emit(METRONOME_JOB_UPDATE_SUCCESS);

--- a/src/js/stores/SystemLogStore.js
+++ b/src/js/stores/SystemLogStore.js
@@ -52,7 +52,7 @@ class SystemLogStore extends BaseStore {
         return false;
       }
 
-      const {data, firstEntry, subscriptionID, type} = payload.action;
+      const {data, firstEntry, subscriptionID, type, xhr = null} = payload.action;
 
       switch (type) {
         case REQUEST_SYSTEM_LOG_SUCCESS:
@@ -71,7 +71,7 @@ class SystemLogStore extends BaseStore {
           this.emit(SYSTEM_LOG_STREAM_TYPES_SUCCESS, data);
           break;
         case REQUEST_SYSTEM_LOG_STREAM_TYPES_ERROR:
-          this.emit(SYSTEM_LOG_STREAM_TYPES_ERROR, data);
+          this.emit(SYSTEM_LOG_STREAM_TYPES_ERROR, data, xhr);
           break;
       }
 


### PR DESCRIPTION
~~**Note**: Includes bits from https://github.com/dcos/dcos-ui/pull/1917~~ (merged and rebased)

This PR pushes the XHR object to a new component `ContextualXHRError` when an API read fails.

The `ContextualXHRError` component defaults to showing `RequestErrorMsg` but can be replaced via the `MountService` for more complex error message handling based on the XHR object.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
