### PR TITLE
DCOS-13770: Pass patchUpdate=false to Marathon on edit action

### DIFF
--- a/plugins/services/src/js/events/MarathonActions.js
+++ b/plugins/services/src/js/events/MarathonActions.js
@@ -211,19 +211,21 @@ var MarathonActions = {
     }
 
     let url = buildURI(`/apps/${service.getId()}`);
+    const params = {
+      force,
+      patchUpdate: false // Switching Marathon edit endpoint into proper PUT
+    };
 
     if (service instanceof Pod) {
       url = buildURI(`/pods/${service.getId()}`);
     }
 
-    if (force === true) {
-      url += '?force=true';
-    }
+    url = url + Util.objectToGetParams(params);
 
     RequestUtil.json({
       url,
       method: 'PUT',
-      data:spec,
+      data: spec,
       success() {
         AppDispatcher.handleServerAction({
           type: REQUEST_MARATHON_SERVICE_EDIT_SUCCESS

--- a/plugins/services/src/js/events/__tests__/MarathonActions-test.js
+++ b/plugins/services/src/js/events/__tests__/MarathonActions-test.js
@@ -413,7 +413,7 @@ describe('MarathonActions', function () {
 
       it('sends data to the correct URL', function () {
         expect(this.configuration.url)
-            .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//test`);
+            .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//test?patchUpdate=false`);
       });
 
       it('sends data to the' +
@@ -423,7 +423,7 @@ describe('MarathonActions', function () {
             this.configuration = RequestUtil.json.calls.mostRecent().args[0];
 
             expect(this.configuration.url)
-                .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//test?force=true`);
+                .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//test?force=true&patchUpdate=false`);
           });
 
       it('uses PUT for the request method', function () {
@@ -473,7 +473,7 @@ describe('MarathonActions', function () {
 
       it('sends data to the correct URL', function () {
         expect(this.configuration.url)
-            .toEqual(`${Config.rootUrl}/service/marathon/v2/pods//test`);
+            .toEqual(`${Config.rootUrl}/service/marathon/v2/pods//test?patchUpdate=false`);
       });
 
       it('sends data to the correct URL with the force=true parameter',
@@ -482,7 +482,7 @@ describe('MarathonActions', function () {
             this.configuration = RequestUtil.json.calls.mostRecent().args[0];
 
             expect(this.configuration.url)
-                .toEqual(`${Config.rootUrl}/service/marathon/v2/pods//test?force=true`);
+                .toEqual(`${Config.rootUrl}/service/marathon/v2/pods//test?force=true&patchUpdate=false`);
           });
 
       it('uses PUT for the request method', function () {

--- a/src/js/utils/Util.js
+++ b/src/js/utils/Util.js
@@ -197,6 +197,18 @@ const Util = {
 
       return memo;
     }, {});
+  },
+
+  objectToGetParams(obj) {
+    const queryString = Object.keys(obj).filter(function (param) {
+      return obj[param] != null;
+    }).map(function (param) {
+      return `${encodeURIComponent(param)}=${encodeURIComponent(obj[param])}`;
+    }).join('&');
+
+    return queryString
+      ? `?${queryString}`
+      : '';
   }
 };
 

--- a/src/js/utils/__tests__/Util-test.js
+++ b/src/js/utils/__tests__/Util-test.js
@@ -400,4 +400,24 @@ describe('Util', function () {
 
   });
 
+  describe('#objectToGetParams', function () {
+    it('returns empty string when no params has been provided', function () {
+      expect(Util.objectToGetParams({})).toEqual('');
+    });
+
+    it('returns filters out null value params', function () {
+      expect(Util.objectToGetParams({force: null, use: undefined})).toEqual('');
+    });
+
+    it('returns correct query string', function () {
+      expect(Util.objectToGetParams({name: 'DCOS', patchUpdate: true}))
+        .toEqual('?name=DCOS&patchUpdate=true');
+    });
+
+    it('escapes both param and its value', function () {
+      expect(Util.objectToGetParams({'es%cape': '/some/param'}))
+        .toEqual('?es%25cape=%2Fsome%2Fparam');
+    });
+  });
+
 });


### PR DESCRIPTION
This PR adds `patchUpdate=false` to all service edit requests the UI sends to Marathon. So that Marathon doesn't do `patch` but proper `put` update. That hopefully will fix ~it doesn't~ some related issues

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
