### PR TITLE
DCOS-397: Adjust serivce task handling

### DIFF
--- a/plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.js
+++ b/plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.js
@@ -1,6 +1,7 @@
 import {DCOSStore} from 'foundation-ui';
 import React from 'react';
 
+import MesosStateStore from '../../../../../../src/js/stores/MesosStateStore';
 import ServiceItemNotFound from '../../components/ServiceItemNotFound';
 import VolumeDetail from './VolumeDetail';
 import Loader from '../../../../../../src/js/components/Loader';
@@ -47,8 +48,8 @@ class TaskVolumeContainer extends React.Component {
 
   render() {
     const {taskID, volumeID} = this.props.params;
-    const taskId = decodeURIComponent(taskID);
-    const service = DCOSStore.serviceTree.getServiceFromTaskID(taskId);
+    const task = MesosStateStore.getTaskFromTaskID(taskID);
+    const service = DCOSStore.serviceTree.findItemById(task.getServiceId());
     const volumeId = decodeURIComponent(volumeID);
 
     if (this.state.isLoading) {

--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -180,16 +180,6 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
     return <Loader />;
   }
 
-  getService() {
-    let {params, service = null} = this.props;
-    // Get the service from the taskID if it wasn't explicitly passed.
-    if (!!params.taskID && service === null) {
-      service = DCOSStore.serviceTree.getServiceFromTaskID(params.taskID);
-    }
-
-    return service;
-  }
-
   hasVolumes(service) {
     return !!service && service.getVolumes().getItems().length > 0;
   }
@@ -221,7 +211,7 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
       return null;
     }
 
-    const service = this.getService();
+    const service = DCOSStore.serviceTree.findItemById(task.getServiceId());
     const taskIcon = (
       <img src={task.getImages()['icon-large']} />
     );
@@ -317,6 +307,7 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
 
   getSubView() {
     const task = MesosStateStore.getTaskFromTaskID(this.props.params.taskID);
+    const service = DCOSStore.serviceTree.findItemById(task.getServiceId());
     const {directory, selectedLogFile} = this.state;
     if (this.hasLoadingError()) {
       return this.getErrorScreen();
@@ -333,7 +324,7 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
           selectedLogFile,
           task,
           onOpenLogClick: this.handleOpenLogClick,
-          service: this.getService()
+          service
         })}
       </div>
     );

--- a/plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.js
+++ b/plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.js
@@ -1,3 +1,5 @@
+jest.dontMock('foundation-ui');
+jest.dontMock('foundation-ui/stores/DCOSStore');
 jest.dontMock('../TaskFilesTab');
 jest.dontMock('../TaskDetail');
 jest.dontMock('../../../stores/MarathonStore');

--- a/plugins/services/src/js/structs/Task.js
+++ b/plugins/services/src/js/structs/Task.js
@@ -3,7 +3,7 @@ import ServiceImages from '../constants/ServiceImages';
 
 module.exports = class Task extends Item {
   getId() {
-    return this.get('id');
+    return this.get('id') || '';
   }
 
   getImages() {

--- a/plugins/services/src/js/structs/Task.js
+++ b/plugins/services/src/js/structs/Task.js
@@ -6,12 +6,11 @@ module.exports = class Task extends Item {
     return this.get('id');
   }
 
-  getName() {
-    return this.get('name');
-  }
-
   getImages() {
     return ServiceImages.NA_IMAGES;
   }
 
+  getName() {
+    return this.get('name');
+  }
 };

--- a/plugins/services/src/js/structs/Task.js
+++ b/plugins/services/src/js/structs/Task.js
@@ -13,4 +13,22 @@ module.exports = class Task extends Item {
   getName() {
     return this.get('name');
   }
+
+  /**
+   * Get corresponding service id
+   *
+   * @return {string} service id
+   */
+  getServiceId() {
+    // Parse the task id (e.g. foo_bar.abc-123) to get the corresponding
+    // service id parts (foo, bar)
+    const parts = this.getId().match(/([^_]+)(?=[_.])/g);
+
+    // Join service id parts and prepend with a slash to form a valid id
+    if (parts) {
+      return `/${parts.join('/')}`;
+    }
+
+    return '';
+  }
 };

--- a/plugins/services/src/js/structs/__tests__/Task-test.js
+++ b/plugins/services/src/js/structs/__tests__/Task-test.js
@@ -13,6 +13,12 @@ describe('Task', function () {
       expect(task.getId()).toEqual('test.a1f67e90-1c86-11e6-ae46-0ed0cffa3d76');
     });
 
+    it('returns empty string if id is undefined', function () {
+      const task = new Task({});
+
+      expect(task.getId()).toEqual('');
+    });
+
   });
 
   describe('#getImages', function () {

--- a/plugins/services/src/js/structs/__tests__/Task-test.js
+++ b/plugins/services/src/js/structs/__tests__/Task-test.js
@@ -15,6 +15,16 @@ describe('Task', function () {
 
   });
 
+  describe('#getImages', function () {
+
+    it('defaults to NA images', function () {
+      const task = new Task({});
+
+      expect(task.getImages()).toEqual(ServiceImages.NA_IMAGES);
+    });
+
+  });
+
   describe('#geName', function () {
 
     it('returns correct name', function () {
@@ -24,16 +34,6 @@ describe('Task', function () {
       });
 
       expect(task.getName()).toEqual('foo.bar.baz');
-    });
-
-  });
-
-  describe('#getImages', function () {
-
-    it('defaults to NA images', function () {
-      const task = new Task({});
-
-      expect(task.getImages()).toEqual(ServiceImages.NA_IMAGES);
     });
 
   });

--- a/plugins/services/src/js/structs/__tests__/Task-test.js
+++ b/plugins/services/src/js/structs/__tests__/Task-test.js
@@ -44,4 +44,30 @@ describe('Task', function () {
 
   });
 
+  describe('#getServiceId', function () {
+
+    it('returns correct service id for a service in root', function () {
+      const task = new Task({
+        id: 'test.a1f67e90-1c86-11e6-ae46-0ed0cffa3d76'
+      });
+
+      expect(task.getServiceId()).toEqual('/test');
+    });
+
+    it('returns correct service id for a service in a group', function () {
+      const task = new Task({
+        id: 'group_test.a1f67e90-1c86-11e6-ae46-0ed0cffa3d76'
+      });
+
+      expect(task.getServiceId()).toEqual('/group/test');
+    });
+
+    it('returns empty string if id is undefined', function () {
+      const task = new Task({});
+
+      expect(task.getServiceId()).toEqual('');
+    });
+
+  });
+
 });


### PR DESCRIPTION
Add a service id getter to the Task struct, which returns the corresponding service id. Refactor `TaskDetail` and `TaskVolumeContainer` to sue the new getter in combination with the
`ServiceTree.findItemById()` method instead of the old `ServiceTree.getServiceFromTaskID()` to retrieve the corresponding service. The change address issues with wrong task health reports and potentially wrong volume mappings which were caused be inexact matches.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
