### PR TITLE
DCOS-13072: Proper access denied when user has no permissions in services

### DIFF
--- a/plugins/services/src/js/pages/ServicesPage.js
+++ b/plugins/services/src/js/pages/ServicesPage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {routerShape} from 'react-router';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
+import {Hooks} from 'PluginSDK';
 
 import Icon from '../../../../../src/js/components/Icon';
 import RouterUtil from '../../../../../src/js/utils/RouterUtil';
@@ -38,6 +39,15 @@ var ServicesPage = React.createClass({
       '/services/overview': 'Services',
       '/services/deployments': 'Deployments'
     };
+
+    if (!Hooks.applyFilter('hasCapability', false, 'mesosAPI') ||
+        !Hooks.applyFilter('hasCapability', false, 'marathonAPI')) {
+
+      this.context.router.replace('/access-denied');
+
+      return;
+    }
+
     this.updateCurrentTab();
   },
 


### PR DESCRIPTION
This commit ensures that the user has `mesosAPI` and `marathonAPI` permissions in order to grant access to the `/services` page. If not, it redirects to the `/access-denied` page. 

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
