### PR TITLE
DCOS-13474: Fix invisible service form in Safari

### DIFF
--- a/src/styles/components/modal/full-screen/styles.less
+++ b/src/styles/components/modal/full-screen/styles.less
@@ -34,6 +34,11 @@
 
     .modal-body-offset {
       margin: -@modal-full-screen-body-padding-vertical -@modal-full-screen-body-padding-horizontal;
+
+      & > .gm-scrollbar-container {
+        flex: 1 1 auto;
+        height: auto;
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes the missing service form in Safari. 

To reproduce this, you'll need to make sure that the native macOS scrollbars are visible. You can force this by setting your "Show scroll bar" settings to "Always":
![](https://cl.ly/2O3d3X2r261I/Screen%20Shot%202017-02-22%20at%201.54.08%20PM.png)

Before:
![](https://cl.ly/3U2f1L192T30/Screen%20Shot%202017-02-22%20at%201.56.39%20PM.png)

After:
![](https://cl.ly/3w34211j3B1x/Screen%20Shot%202017-02-22%20at%201.59.38%20PM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
