### PR TITLE
DCOS-14088: Fix sidebar styling in IE11

### DIFF
--- a/src/styles/components/user-account-dropdown/styles.less
+++ b/src/styles/components/user-account-dropdown/styles.less
@@ -37,6 +37,7 @@
       flex: 1 1 auto;
       flex-direction: column;
       min-width: 0;
+      overflow: hidden;
       text-align: left;
 
       &-primary {

--- a/src/styles/layout/sidebar/styles.less
+++ b/src/styles/layout/sidebar/styles.less
@@ -3,9 +3,9 @@
 
   // Sidebar Wrapper
   .sidebar-wrapper {
-    flex: 1 1 100%;
-    max-width: 0;
-    transition: max-width 0.25s;
+    flex: 0 0 auto;
+    transition: width 0.25s;
+    width: 0;
   }
 
   // Sidebar
@@ -368,7 +368,7 @@
       .sidebar-wrapper {
 
         .sidebar-docked & {
-          max-width: @sidebar-width-screen-medium;
+          width: @sidebar-width-screen-medium;
         }
       }
 
@@ -468,7 +468,7 @@
       .sidebar-wrapper {
 
         .sidebar-docked & {
-          max-width: @sidebar-width-screen-large;
+          width: @sidebar-width-screen-large;
         }
       }
 
@@ -553,7 +553,7 @@
       .sidebar-wrapper {
 
         .sidebar-docked & {
-          max-width: @sidebar-width-screen-jumbo;
+          width: @sidebar-width-screen-jumbo;
         }
       }
 

--- a/tests/components/Sidebar-cy.js
+++ b/tests/components/Sidebar-cy.js
@@ -1,0 +1,53 @@
+describe('Sidebar', function () {
+
+  beforeEach(function () {
+    cy.configureCluster({
+      mesos: '1-task-healthy',
+      componentHealth: false
+    })
+    .visitUrl({url: '/dashboard', identify: true, fakeAnalytics: true});
+  });
+
+  context('Sidebar Wrapper', function () {
+
+    it('is exactly the same width as the sidebar', function () {
+      cy.get('.sidebar').then(function ($sidebar) {
+        const sidebarWidth = $sidebar.get(0).getBoundingClientRect().width;
+
+        cy.get('.sidebar-wrapper').then(function ($sidebarWrapper) {
+          expect($sidebarWrapper.get(0).getBoundingClientRect().width)
+            .to.equal(sidebarWidth);
+        });
+      });
+    });
+
+  });
+
+  context('User Account Dropdown Button', function () {
+
+    it('is exactly the same width as the sidebar', function () {
+      cy.get('.sidebar').then(function ($sidebar) {
+        const sidebarWidth = $sidebar.get(0).getBoundingClientRect().width;
+
+        cy.get('.user-account-dropdown-button').then(function ($button) {
+          expect($button.get(0).getBoundingClientRect().width)
+            .to.equal(sidebarWidth);
+        });
+      });
+    });
+
+    it('does not have any children wider than itself', function () {
+      cy.get('.user-account-dropdown-button').then(function ($button) {
+        const buttonWidth = $button.get(0).getBoundingClientRect().width;
+
+        cy.get('.user-account-dropdown-button *').then(function ($children) {
+          $children.each(function (index, child) {
+            expect(child.getBoundingClientRect().width)
+              .to.be.lessThan(buttonWidth);
+          });
+        });
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
This PR changes the sidebar's `max-width` property to `width` to avoid any inconsistent behavior with the its width. Fixes a bug in IE11 where the sidebar container element wasn't as wide as the actual sidebar.

This also fixes a bug where the user account dropdown menu was overflowing its container.

Before:
![](https://cl.ly/3j2q2Y2l3X1T/Screen%20Shot%202017-02-22%20at%203.50.27%20PM.png)

After:
![](https://cl.ly/0h2N3C403w3E/Screen%20Shot%202017-02-22%20at%203.47.58%20PM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?