### PR TITLE
DCOS-13960: Remove modal body content's bottom margins

### DIFF
--- a/src/styles/components/modal/styles.less
+++ b/src/styles/components/modal/styles.less
@@ -12,6 +12,33 @@
     flex: 1 1 auto;
   }
 
+  .modal-body {
+
+    & > p {
+
+      // Remove bottom margins on the last paragraph tag when they are a direct
+      // descendent of .modal-body.
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    & > div {
+
+      &:last-child {
+
+        & > p {
+
+          // In some cases we wrap paragraph tags in divs, so we select the
+          // last descending div, and then its last descending paragraph tag.
+          &:last-child {
+            margin-bottom: 0;
+          }
+        }
+      }
+    }
+  }
+
   .modal-close {
     appearance: none;
     background: transparent;


### PR DESCRIPTION
This PR removes the `margin-bottom` from the last paragraph tags inside `modal-body`. I think it should be safe as it only targets `.modal-body > p:last-child` and `.modal-body > div:last-child > p:last-child`.

Before:
![](https://cl.ly/3n271H0i0303/Screen%20Shot%202017-02-23%20at%2010.38.14%20AM.png)
![](https://cl.ly/1Z0e1X2u130E/Screen%20Shot%202017-02-23%20at%2010.38.04%20AM.png)

After:
![](https://cl.ly/1f00220I2d1O/Screen%20Shot%202017-02-23%20at%2010.33.53%20AM.png)
![](https://cl.ly/243G1P0g3U3g/Screen%20Shot%202017-02-23%20at%2010.34.07%20AM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?