### PR TITLE
DCOS-14157: Properly pass the JobRunHistoryTable sort properties

### DIFF
--- a/src/js/pages/jobs/JobRunHistoryTable.js
+++ b/src/js/pages/jobs/JobRunHistoryTable.js
@@ -386,7 +386,8 @@ class JobRunHistoryTable extends React.Component {
           checkedItemsMap={this.state.checkedItems}
           disabledItemsMap={disabledItems}
           onCheckboxChange={this.handleItemCheck}
-          sortBy={{prop: 'startedAt', order: 'desc'}}
+          sortOrder="desc"
+          sortProp="startedAt"
           tableComponent={CheckboxTable} />
         {this.getStopRunModal(checkedItems, hasCheckedTasks)}
       </div>


### PR DESCRIPTION
This PR fixes the way we were passing the `sortBy` props to the `CheckboxTable`.

I can add integration tests when #1654 is fixed up :)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?