### PR TITLE
DCOS-14053: Remove container field from JSON when switching to Mesos

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/Container.js
+++ b/plugins/services/src/js/reducers/serviceForm/Container.js
@@ -155,7 +155,7 @@ module.exports = {
     }
 
     if (ValidatorUtil.isEmpty(newState.type)) {
-      delete newState.type;
+      newState.type = null;
     }
 
     if (ValidatorUtil.isEmpty(newState)) {

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -22,6 +22,7 @@ describe('Container', function () {
             network: null,
             portMappings: null
           },
+          type: null,
           volumes: []
         });
     });
@@ -241,6 +242,7 @@ describe('Container', function () {
           network: null,
           portMappings: null
         },
+        type: null,
         volumes: []
       });
     });
@@ -363,6 +365,7 @@ describe('Container', function () {
           network: null,
           portMappings: null
         },
+        type: null,
         volumes: []
       });
     });
@@ -549,6 +552,7 @@ describe('Container', function () {
                 network: null,
                 portMappings: null
               },
+              type: null,
               volumes: []
             });
         });
@@ -1162,6 +1166,7 @@ describe('Container', function () {
               network: null,
               portMappings: null
             },
+            type: null,
             volumes: []
           });
       });
@@ -1286,6 +1291,7 @@ describe('Container', function () {
                 network: null,
                 portMappings: null
               },
+              type: null,
               volumes: []
             });
         }

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -133,6 +133,14 @@ describe('Service Form Modal', function () {
           .should('to.have.value', '1');
       });
 
+      it('uses Docker by default', function () {
+        openServiceModal();
+        openServiceJSON();
+        cy.get('.ace_content').should(function (nodeList) {
+          expect(nodeList[0].textContent).to.contain('"type": "DOCKER"');
+        });
+      });
+
       it('contains the right JSON in the JSON editor', function () {
         openServiceModal();
         openServiceJSON();
@@ -420,6 +428,18 @@ describe('Service Form Modal', function () {
       it('Should have a "Add Artifact" link', function () {
         cy.get('.menu-tabbed-view .button.button-primary-link')
           .contains('Add Artifact');
+      });
+
+      context('Switching runtime', function () {
+        it('switches from Docker to Mesos correctly', function () {
+          cy.get('label')
+            .contains('Mesos Runtime')
+            .click();
+
+          cy.get('.ace_content').should(function (nodeList) {
+            expect(nodeList[0].textContent).not.to.contain('"container": {');
+          });
+        });
       });
 
     });


### PR DESCRIPTION
This PR fixes the container reducer so that when we switch from the Docker engine to Mesos runtime `container` section goes away from the JSON

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [x] Did you add new integration tests?
- [x] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
