### PR TITLE
DCOS-14022: Adding validate-build script to ensure minification

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2542,11 +2542,6 @@
       "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
     },
-    "esprima-walk": {
-      "version": "0.1.0",
-      "from": "esprima-walk@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/esprima-walk/-/esprima-walk-0.1.0.tgz"
-    },
     "esrecurse": {
       "version": "4.1.0",
       "from": "esrecurse@>=4.1.0 <5.0.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2532,10 +2532,20 @@
         }
       }
     },
+    "esprima": {
+      "version": "3.1.3",
+      "from": "esprima@>=3.1.3 <4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+    },
     "esprima-fb": {
       "version": "13001.1001.0-dev-harmony-fb",
       "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
       "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
+    },
+    "esprima-walk": {
+      "version": "0.1.0",
+      "from": "esprima-walk@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/esprima-walk/-/esprima-walk-0.1.0.tgz"
     },
     "esrecurse": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -78,11 +78,13 @@
     "eslint": "3.14.1",
     "eslint-config-airbnb": "10.0.1",
     "eslint-plugin-compat": "1.0.1",
+    "eslint-plugin-destructuring": "2.1.0",
     "eslint-plugin-import": "1.13.0",
     "eslint-plugin-jsx-a11y": "2.1.0",
     "eslint-plugin-jsx-max-len": "1.0.0",
     "eslint-plugin-react": "6.9.0",
-    "eslint-plugin-destructuring": "2.1.0",
+    "esprima": "3.1.3",
+    "esprima-walk": "0.1.0",
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.8.5",
     "glob": "7.0.5",
@@ -128,7 +130,7 @@
     "prebuild-assets": "./node_modules/.bin/gulp checkDependencies && npm install compression-webpack-plugin@latest",
     "build-assets": "npm run clean && NODE_ENV=production webpack --config ./webpack/webpack.production.babel.js",
     "postbuild-assets": "rm -rf node_modules/compression-webpack-plugin",
-    "build": "npm run lint && npm test && npm run build-assets",
+    "build": "npm run lint && npm test && npm run build-assets && npm run validate-build",
     "build-with-external-plugins": "npm run lint && npm run lint-plugins && npm test && npm run build-assets",
     "lint": "npm run stylelint && npm run eslint",
     "eslint": "bash -c 'opts=$@ ; set -f; if [[ $# -lt 1 ]]; then opts=\"{src/js,plugins,foundation-ui}/**/*.js\"; fi ; eslint --quiet ${opts}' 0",
@@ -140,7 +142,8 @@
     "scaffold": "./node_modules/.bin/gulp ensureConfig && ./node_modules/.bin/gulp ensureDevProxy",
     "start": "npm run check-env && NODE_ENV=development webpack-dev-server --config ./webpack/webpack.dev.babel.js --hot --progress --colors --content-base ./build --host 0.0.0.0 --port $npm_package_config_port",
     "test": "node jest/gen-config.js && NODE_PATH=node_modules jest --config=jest/config.json --no-cache",
-    "testing": "NODE_ENV=testing webpack-dev-server --config ./webpack/webpack.dev.babel.js --progress --colors --content-base ./build --port $npm_package_config_port"
+    "testing": "NODE_ENV=testing webpack-dev-server --config ./webpack/webpack.dev.babel.js --progress --colors --content-base ./build --port $npm_package_config_port",
+    "validate-build": "node scripts/validate-build.js dist/*.js"
   },
   "jest-webpack-alias": {
     "configFile": "./webpack/webpack.test.js"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "eslint-plugin-jsx-max-len": "1.0.0",
     "eslint-plugin-react": "6.9.0",
     "esprima": "3.1.3",
-    "esprima-walk": "0.1.0",
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.8.5",
     "glob": "7.0.5",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "babel-preset-react-hmre": "1.1.1",
     "babel-register": "6.9.0",
     "babel-runtime": "6.9.2",
+    "colors": "1.1.2",
     "css-loader": "0.23.1",
     "eslint": "3.14.1",
     "eslint-config-airbnb": "10.0.1",
@@ -143,7 +144,7 @@
     "start": "npm run check-env && NODE_ENV=development webpack-dev-server --config ./webpack/webpack.dev.babel.js --hot --progress --colors --content-base ./build --host 0.0.0.0 --port $npm_package_config_port",
     "test": "node jest/gen-config.js && NODE_PATH=node_modules jest --config=jest/config.json --no-cache",
     "testing": "NODE_ENV=testing webpack-dev-server --config ./webpack/webpack.dev.babel.js --progress --colors --content-base ./build --port $npm_package_config_port",
-    "validate-build": "node scripts/validate-build.js dist/*.js"
+    "validate-build": "scripts/validate-build dist/*.js"
   },
   "jest-webpack-alias": {
     "configFile": "./webpack/webpack.test.js"

--- a/scripts/validate-build
+++ b/scripts/validate-build
@@ -2,10 +2,10 @@
 // eslint-disable-next-line strict
 'use strict';
 
-const fs = require('fs');
-const esprima = require('esprima');
-const walk = require('esprima-walk');
 const colors = require('colors');
+const esprima = require('esprima');
+const fs = require('fs');
+const walk = require('esprima-walk');
 
 /**
  * Load the Abstract Syntax Tree from the javascript file given
@@ -97,7 +97,7 @@ process.exit(
   process.argv.slice(2).reduce(function (code, file) {
     const isOk = isMinified(file);
     if (isOk) {
-      console.error(
+      console.log(
         colors.green('PASS') + ': ' + colors.bold(file) + ' is minified'
       );
     } else {

--- a/scripts/validate-build
+++ b/scripts/validate-build
@@ -5,7 +5,6 @@
 const colors = require('colors');
 const esprima = require('esprima');
 const fs = require('fs');
-const walk = require('esprima-walk');
 
 /**
  * Load the Abstract Syntax Tree from the javascript file given
@@ -25,24 +24,6 @@ function loadAST(file) {
 
     return false;
   }
-}
-
-/**
- * Collect all comments from the AST
- *
- * @param {ASTTree} ast - The AST tree
- * @returns {Array<ASTNode>} Returns the comment AST nodes
- */
-function loadComments(ast) {
-  let comments = [];
-
-  walk(ast, function (node) {
-    if (node && node.comments) {
-      comments = comments.concat(node.comments);
-    }
-  });
-
-  return comments;
 }
 
 /**
@@ -81,7 +62,7 @@ function isMinified(file) {
     return false;
   }
 
-  const comments = loadComments(ast);
+  const comments = ast.comments;
   if (comments.length === 0) {
     return true;
   }

--- a/scripts/validate-build.js
+++ b/scripts/validate-build.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// eslint-disable-next-line strict
+'use strict';
+
+const fs = require('fs');
+const esprima = require('esprima');
+const walk = require('esprima-walk');
+const colors = require('colors');
+
+/**
+ * Load the Abstract Syntax Tree from the javascript file given
+ *
+ * @param {String} file - The path to the javascript filename
+ * @returns {ASTTree} Returns the AST tree
+ */
+function loadAST(file) {
+  try {
+    return esprima.parse(
+      String(fs.readFileSync(file)),
+      { comment: true }
+    );
+
+  } catch (e) {
+    console.error('Unable to parse source:', e);
+
+    return false;
+  }
+}
+
+/**
+ * Collect all comments from the AST
+ *
+ * @param {ASTTree} ast - The AST tree
+ * @returns {Array<ASTNode>} Returns the comment AST nodes
+ */
+function loadComments(ast) {
+  let comments = [];
+
+  walk(ast, function (node) {
+    if (node && node.comments) {
+      comments = comments.concat(node.comments);
+    }
+  });
+
+  return comments;
+}
+
+/**
+ * Checks if the given comment is accepted
+ *
+ * @param {String} commentAst - The comment contents
+ * @returns {Boolean} Returns `true` if the comment is accepted
+ */
+function isCommentAccepted(commentAst) {
+  const value = commentAst.value;
+
+  // Source map comments are accepted
+  if (/^[@#]\s*sourceMappingURL=/.test(value)) {
+    return true;
+  }
+
+  // Comments that are supposed to be perserved are accepted
+  if (/^\*?!/.test(value) || /@(perserve|license)/.test(value)) {
+    return true;
+  }
+
+  // Otherwise the comment is not accepted
+  return false;
+}
+
+/**
+ * Checks if the specified file is minified by processing the comment
+ * nodes in the AST.
+ *
+ * @param {String} file - The path to the filename to check
+ * @returns {Boolean} Returns `true` if the file is minified
+ */
+function isMinified(file) {
+  const ast = loadAST(file);
+  if (!ast) {
+    return false;
+  }
+
+  const comments = loadComments(ast);
+  if (comments.length === 0) {
+    return true;
+  }
+
+  return comments.every(isCommentAccepted);
+}
+
+/**
+ * Iterate over the command-line arguments (them being file names) and check
+ * if the files given are minified.
+ */
+process.exit(
+  process.argv.slice(2).reduce(function (code, file) {
+    const isOk = isMinified(file);
+    if (isOk) {
+      console.error(
+        colors.green('PASS') + ': ' + colors.bold(file) + ' is minified'
+      );
+    } else {
+      console.error(
+        colors.red('FAIL') + ': ' + colors.bold(file) + ' does not look minified'
+      );
+
+      return 1;
+    }
+
+    return code;
+  }, 0)
+);


### PR DESCRIPTION
This PR introduces the `scripts/validate-build.js` script and the `validate-build` command in `package.json` that checks if the files in `dist/*.js` are minified.

In order to efficiently and correctly process the javscript AST the script uses the `esprima` ecmascript parser and ensures that every comment found in the source is a legit one. Such comments are:

* Source maps
* Comments kept by default by the [UglifyJSPlugin](https://webpack.github.io/docs/list-of-plugins.html#uglifyjsplugin)