### PR TITLE
DCOS_OSS-653: Handle {message: null} marathon response

### DIFF
--- a/plugins/services/src/js/utils/MarathonErrorUtil.js
+++ b/plugins/services/src/js/utils/MarathonErrorUtil.js
@@ -52,6 +52,19 @@ const MarathonErrorUtil = {
     // Both `details` and `errors` can be missing
     if (ValidatorUtil.isEmpty(error.details) &&
       ValidatorUtil.isEmpty(error.message)) {
+
+      // `null` is a special case
+      if (error.message === null) {
+        return [
+          {
+            path: [],
+            message: 'An unknown error occurred (Marathon did not provide any description)',
+            type: ServiceErrorTypes.GENERIC,
+            variables: {}
+          }
+        ];
+      }
+
       return [];
     }
 

--- a/plugins/services/src/js/utils/__tests__/MarathonErrorUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/MarathonErrorUtil-test.js
@@ -51,6 +51,21 @@ describe('MarathonErrorUtil', function () {
       ]);
     });
 
+    it('should properly handle object errors with null message', function () {
+      const marathonError = {
+        message: null
+      };
+
+      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([
+        {
+          path: [],
+          message: 'An unknown error occurred (Marathon did not provide any description)',
+          type: ServiceErrorTypes.GENERIC,
+          variables: {}
+        }
+      ]);
+    });
+
     it('should properly handle object errors with array details', function () {
       const marathonError = {
         message: 'Some error',

--- a/plugins/services/src/js/utils/__tests__/MarathonErrorUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/MarathonErrorUtil-test.js
@@ -148,13 +148,6 @@ describe('MarathonErrorUtil', function () {
       ]);
     });
 
-    it('should handle a message value of null as empty', function () {
-      // TODO (JIRA DCOS_OSS-653): We should include these with a generic error
-      const marathonError = {message: null};
-
-      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([]);
-    });
-
     it('should handle a message value of empty object as empty', function () {
       // TODO (JIRA DCOS_OSS-653): We should include these with a generic error
       const marathonError = {message: {}};


### PR DESCRIPTION
This PR ensures that the `MarathonErrorUtil` utility properly parses `{message: null}` marathon error responses.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [x] If this is a regression, did you write a test to catch this in the future?