### PR TITLE
DCOS-14010: Add container to pick logging component and API

### DIFF
--- a/plugins/nodes/src/js/routes/nodes.js
+++ b/plugins/nodes/src/js/routes/nodes.js
@@ -18,7 +18,7 @@ import TaskDetailsTab from '../../../../services/src/js/pages/task-details/TaskD
 import TaskFileBrowser from '../../../../services/src/js/pages/task-details/TaskFileBrowser';
 import TaskFilesTab from '../../../../services/src/js/pages/task-details/TaskFilesTab';
 import TaskFileViewer from '../../../../services/src/js/pages/task-details/TaskFileViewer';
-import TaskLogsTab from '../../../../services/src/js/pages/task-details/TaskLogsTab';
+import TaskLogsAPIContainer from '../../../../services/src/js/pages/task-details/TaskLogsAPIContainer';
 import TaskVolumeContainer from '../../../../services/src/js/containers/volume-detail/TaskVolumeContainer';
 import UnitsHealthDetailBreadcrumb from '../../../../../src/js/pages/system/breadcrumbs/UnitsHealthDetailBreadcrumb';
 import NodesUnitsHealthDetailPage from '../pages/nodes/NodesUnitsHealthDetailPage';
@@ -205,10 +205,10 @@ const nodesRoutes = {
           ]
         },
         {
-          component: TaskLogsTab,
+          component: TaskLogsAPIContainer,
           hideHeaderNavigation: true,
           isTab: true,
-          path: 'logs(/:fileName)',
+          path: 'logs(/:filePath)',
           title: 'Logs',
           type: Route,
           buildBreadCrumb() {

--- a/plugins/nodes/src/js/routes/nodes.js
+++ b/plugins/nodes/src/js/routes/nodes.js
@@ -18,7 +18,7 @@ import TaskDetailsTab from '../../../../services/src/js/pages/task-details/TaskD
 import TaskFileBrowser from '../../../../services/src/js/pages/task-details/TaskFileBrowser';
 import TaskFilesTab from '../../../../services/src/js/pages/task-details/TaskFilesTab';
 import TaskFileViewer from '../../../../services/src/js/pages/task-details/TaskFileViewer';
-import TaskLogsAPIContainer from '../../../../services/src/js/pages/task-details/TaskLogsAPIContainer';
+import TaskLogsContainer from '../../../../services/src/js/pages/task-details/TaskLogsContainer';
 import TaskVolumeContainer from '../../../../services/src/js/containers/volume-detail/TaskVolumeContainer';
 import UnitsHealthDetailBreadcrumb from '../../../../../src/js/pages/system/breadcrumbs/UnitsHealthDetailBreadcrumb';
 import NodesUnitsHealthDetailPage from '../pages/nodes/NodesUnitsHealthDetailPage';
@@ -205,7 +205,7 @@ const nodesRoutes = {
           ]
         },
         {
-          component: TaskLogsAPIContainer,
+          component: TaskLogsContainer,
           hideHeaderNavigation: true,
           isTab: true,
           path: 'logs(/:filePath)',

--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -28,8 +28,17 @@ const METHODS_TO_BIND = [
 // TODO remove
 const HIDE_BREADCRUMBS = [
   '/jobs/:id/tasks/:taskID/details',
+  '/jobs/:id/tasks/:taskID/logs(/:filePath)',
+  '/jobs/:id/tasks/:taskID/files/view(/:filePath(/:innerPath))',
+
   '/networking/networks/:overlayName/tasks/:taskID/details',
+  '/networking/networks/:overlayName/tasks/:taskID/logs(/:filePath)',
+  '/networking/networks/:overlayName/tasks/:taskID/files/view(/:filePath(/:innerPath))',
+
   '/nodes/:nodeID/tasks/:taskID/details',
+  '/nodes/:nodeID/tasks/:taskID/logs(/:filePath)',
+  '/nodes/:nodeID/tasks/:taskID/files/view(/:filePath(/:innerPath))',
+
   '/services/overview/:id/tasks/:taskID/details',
   '/services/overview/:id/tasks/:taskID/logs(/:filePath)',
   '/services/overview/:id/tasks/:taskID/files/view(/:filePath(/:innerPath))'

--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -31,7 +31,7 @@ const HIDE_BREADCRUMBS = [
   '/networking/networks/:overlayName/tasks/:taskID/details',
   '/nodes/:nodeID/tasks/:taskID/details',
   '/services/overview/:id/tasks/:taskID/details',
-  '/services/overview/:id/tasks/:taskID/logs(/:fileName)',
+  '/services/overview/:id/tasks/:taskID/logs(/:filePath)',
   '/services/overview/:id/tasks/:taskID/files/view(/:filePath(/:innerPath))'
 ];
 

--- a/plugins/services/src/js/pages/task-details/TaskFileViewer.js
+++ b/plugins/services/src/js/pages/task-details/TaskFileViewer.js
@@ -52,14 +52,18 @@ class TaskFileViewer extends React.Component {
   }
 
   getLogFiles() {
-    const {directory} = this.props;
+    const {directory, limitLogFiles} = this.props;
     const logViews = [];
     if (!directory) {
       return logViews;
     }
 
     directory.getItems().forEach((item) => {
-      if (!item.isLogFile()) {
+      const excludeFile = (
+        limitLogFiles.length > 0 &&
+        !limitLogFiles.includes(item.getName())
+      );
+      if (!item.isLogFile() || excludeFile) {
         return;
       }
 
@@ -202,11 +206,13 @@ TaskFileViewer.contextTypes = {
 };
 
 TaskFileViewer.defaultProps = {
+  limitLogFiles: [],
   task: {}
 };
 
 TaskFileViewer.propTypes = {
   directory: React.PropTypes.object,
+  limitLogFiles: React.PropTypes.arrayOf(React.PropTypes.string),
   selectedLogFile: React.PropTypes.object,
   task: React.PropTypes.object
 };

--- a/plugins/services/src/js/pages/task-details/TaskLogsAPIContainer.js
+++ b/plugins/services/src/js/pages/task-details/TaskLogsAPIContainer.js
@@ -61,7 +61,7 @@ class TaskLogsAPIContainer extends mixin(StoreMixin) {
       return <TaskSystemLogsContainer {...props} />;
     }
 
-    return <TaskFileViewer {...props} />;
+    return <TaskFileViewer limitLogFiles={['stdout', 'stderr']} {...props} />;
   }
 }
 

--- a/plugins/services/src/js/pages/task-details/TaskLogsAPIContainer.js
+++ b/plugins/services/src/js/pages/task-details/TaskLogsAPIContainer.js
@@ -1,0 +1,68 @@
+import mixin from 'reactjs-mixin';
+import React from 'react';
+import {StoreMixin} from 'mesosphere-shared-reactjs';
+
+import ConfigStore from '../../../../../../src/js/stores/ConfigStore';
+import Loader from '../../../../../../src/js/components/Loader';
+import {SYSTEM_LOGS} from '../../../../../../src/js/constants/MesosLoggingStrategy';
+import TaskSystemLogsContainer from './TaskSystemLogsContainer';
+import TaskFileViewer from './TaskFileViewer';
+import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
+
+class TaskLogsAPIContainer extends mixin(StoreMixin) {
+  constructor() {
+    super(...arguments);
+    this.state = {
+      isLoading: true
+    };
+
+    this.store_listeners = [{
+      name: 'config',
+      events: ['success', 'error'],
+      listenAlways: false
+    }];
+  }
+
+  componentWillMount() {
+    // We already have a configuration, so stop loading. No need to fetch
+    if (this.state.isLoading && ConfigStore.get('config') != null) {
+      this.setState({isLoading: false});
+    }
+  }
+
+  componentDidMount() {
+    // We did not already receive the configuration
+    if (this.state.isLoading && ConfigStore.get('config') == null) {
+      ConfigStore.fetch();
+    }
+  }
+
+  onConfigStoreSuccess() {
+    this.setState({isLoading: false});
+  }
+
+  onConfigStoreError() {
+    this.setState({isLoading: false});
+  }
+
+  render() {
+    if (this.state.isLoading) {
+      return <Loader />;
+    }
+
+    const {props} = this;
+    const config = ConfigStore.get('config');
+    const useSystemLogsAPI = findNestedPropertyInObject(
+      config,
+      'uiConfiguration.plugins.mesos.logging-strategy'
+    ) === SYSTEM_LOGS;
+
+    if (useSystemLogsAPI) {
+      return <TaskSystemLogsContainer {...props} />;
+    }
+
+    return <TaskFileViewer {...props} />;
+  }
+}
+
+module.exports = TaskLogsAPIContainer;

--- a/plugins/services/src/js/pages/task-details/TaskLogsContainer.js
+++ b/plugins/services/src/js/pages/task-details/TaskLogsContainer.js
@@ -9,7 +9,7 @@ import TaskSystemLogsContainer from './TaskSystemLogsContainer';
 import TaskFileViewer from './TaskFileViewer';
 import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
 
-class TaskLogsAPIContainer extends mixin(StoreMixin) {
+class TaskLogsContainer extends mixin(StoreMixin) {
   constructor() {
     super(...arguments);
     this.state = {
@@ -52,12 +52,12 @@ class TaskLogsAPIContainer extends mixin(StoreMixin) {
 
     const {props} = this;
     const config = ConfigStore.get('config');
-    const useSystemLogsAPI = findNestedPropertyInObject(
+    const loggingStrategy = findNestedPropertyInObject(
       config,
       'uiConfiguration.plugins.mesos.logging-strategy'
-    ) === SYSTEM_LOGS;
+    );
 
-    if (useSystemLogsAPI) {
+    if (loggingStrategy === SYSTEM_LOGS) {
       return <TaskSystemLogsContainer {...props} />;
     }
 
@@ -65,4 +65,4 @@ class TaskLogsAPIContainer extends mixin(StoreMixin) {
   }
 }
 
-module.exports = TaskLogsAPIContainer;
+module.exports = TaskLogsContainer;

--- a/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
+++ b/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
@@ -37,7 +37,7 @@ function getLogParameters(task, options) {
   }, options);
 }
 
-class TaskLogsTab extends mixin(StoreMixin) {
+class TaskSystemLogsContainer extends mixin(StoreMixin) {
   constructor() {
     super(...arguments);
 
@@ -353,10 +353,10 @@ class TaskLogsTab extends mixin(StoreMixin) {
   }
 }
 
-TaskLogsTab.propTypes = {
+TaskSystemLogsContainer.propTypes = {
   task: React.PropTypes.shape({
     slave_id: React.PropTypes.string
   })
 };
 
-module.exports = TaskLogsTab;
+module.exports = TaskSystemLogsContainer;

--- a/plugins/services/src/js/pages/task-details/__tests__/TaskFileViewer-test.js
+++ b/plugins/services/src/js/pages/task-details/__tests__/TaskFileViewer-test.js
@@ -93,6 +93,46 @@ describe('TaskFileViewer', function () {
         .toHaveBeenCalledWith('foo', '/stderr');
     });
 
+    it('limits files to stdout and stderr when provided', function () {
+      this.instance = ReactDOM.render(
+        <TaskFileViewer
+          directory={new TaskDirectory({items: [
+            {nlink: 1, path: '/foo'},
+            {nlink: 1, path: '/stdout'},
+            {nlink: 1, path: '/stderr'}
+          ]})}
+          params={{}}
+          limitLogFiles={['stdout', 'stderr']}
+          task={{slave_id: 'foo'}} />,
+        this.container
+      );
+
+      expect(this.instance.getLogFiles()).toEqual([
+        new DirectoryItem({nlink: 1, path: '/stdout'}),
+        new DirectoryItem({nlink: 1, path: '/stderr'})
+      ]);
+    });
+
+    it('includes all files when limit is not provided', function () {
+      this.instance = ReactDOM.render(
+        <TaskFileViewer
+          directory={new TaskDirectory({items: [
+            {nlink: 1, path: '/foo'},
+            {nlink: 1, path: '/stdout'},
+            {nlink: 1, path: '/stderr'}
+          ]})}
+          params={{}}
+          task={{slave_id: 'foo'}} />,
+        this.container
+      );
+
+      expect(this.instance.getLogFiles()).toEqual([
+        new DirectoryItem({nlink: 1, path: '/foo'}),
+        new DirectoryItem({nlink: 1, path: '/stdout'}),
+        new DirectoryItem({nlink: 1, path: '/stderr'})
+      ]);
+    });
+
   });
 
 });

--- a/plugins/services/src/js/routes/services.js
+++ b/plugins/services/src/js/routes/services.js
@@ -14,7 +14,7 @@ import TaskDetailsTab from '../pages/task-details/TaskDetailsTab';
 import TaskFileBrowser from '../pages/task-details/TaskFileBrowser';
 import TaskFilesTab from '../pages/task-details/TaskFilesTab';
 import TaskFileViewer from '../pages/task-details/TaskFileViewer';
-import TaskLogsAPIContainer from '../pages/task-details/TaskLogsAPIContainer';
+import TaskLogsContainer from '../pages/task-details/TaskLogsContainer';
 import TaskVolumeContainer from '../containers/volume-detail/TaskVolumeContainer';
 import VolumeTable from '../components/VolumeTable';
 
@@ -207,7 +207,7 @@ const serviceRoutes = [
                         ]
                       },
                       {
-                        component: TaskLogsAPIContainer,
+                        component: TaskLogsContainer,
                         hideHeaderNavigation: true,
                         isTab: true,
                         path: 'logs(/:filePath)',

--- a/plugins/services/src/js/routes/services.js
+++ b/plugins/services/src/js/routes/services.js
@@ -14,7 +14,7 @@ import TaskDetailsTab from '../pages/task-details/TaskDetailsTab';
 import TaskFileBrowser from '../pages/task-details/TaskFileBrowser';
 import TaskFilesTab from '../pages/task-details/TaskFilesTab';
 import TaskFileViewer from '../pages/task-details/TaskFileViewer';
-import TaskLogsTab from '../pages/task-details/TaskLogsTab';
+import TaskLogsAPIContainer from '../pages/task-details/TaskLogsAPIContainer';
 import TaskVolumeContainer from '../containers/volume-detail/TaskVolumeContainer';
 import VolumeTable from '../components/VolumeTable';
 
@@ -207,10 +207,10 @@ const serviceRoutes = [
                         ]
                       },
                       {
-                        component: TaskLogsTab,
+                        component: TaskLogsAPIContainer,
                         hideHeaderNavigation: true,
                         isTab: true,
-                        path: 'logs(/:fileName)',
+                        path: 'logs(/:filePath)',
                         title: 'Logs',
                         type: Route,
                         buildBreadCrumb() {

--- a/src/js/config/Config.template.js
+++ b/src/js/config/Config.template.js
@@ -11,6 +11,9 @@ var ConfigDev = {
         banner: {
           enabled: false
         },
+        mesos: {
+          'logging-strategy': 'logrotate'
+        },
         oauth: {
           enabled: true,
           authHost: 'https://dcos.auth0.com'

--- a/src/js/constants/MesosLoggingStrategy.js
+++ b/src/js/constants/MesosLoggingStrategy.js
@@ -1,0 +1,7 @@
+const MesosLoggingStrategy = {
+  SYSTEM_LOGS: 'journald',
+  MESOS_LOGS: 'logrotate',
+  SYSTEM_AND_MESOS_LOGS: 'journald+logrotate'
+};
+
+module.exports = MesosLoggingStrategy;

--- a/src/js/routes/factories/network.js
+++ b/src/js/routes/factories/network.js
@@ -9,7 +9,7 @@ import TaskDetailsTab from '../../../../plugins/services/src/js/pages/task-detai
 import TaskFileBrowser from '../../../../plugins/services/src/js/pages/task-details/TaskFileBrowser';
 import TaskFilesTab from '../../../../plugins/services/src/js/pages/task-details/TaskFilesTab';
 import TaskFileViewer from '../../../../plugins/services/src/js/pages/task-details/TaskFileViewer';
-import TaskLogsAPIContainer from '../../../../plugins/services/src/js/pages/task-details/TaskLogsAPIContainer';
+import TaskLogsContainer from '../../../../plugins/services/src/js/pages/task-details/TaskLogsContainer';
 import VirtualNetworkDetail from '../../pages/network/virtual-network-detail/VirtualNetworkDetail';
 import VirtualNetworkDetailsTab from '../../pages/network/virtual-network-detail/VirtualNetworkDetailsTab';
 import VirtualNetworksTab from '../../pages/network/VirtualNetworksTab';
@@ -153,7 +153,7 @@ const RouteFactory = {
             ]
           },
           {
-            component: TaskLogsAPIContainer,
+            component: TaskLogsContainer,
             hideHeaderNavigation: true,
             isTab: true,
             path: 'logs(/:filePath)',

--- a/src/js/routes/factories/network.js
+++ b/src/js/routes/factories/network.js
@@ -9,7 +9,7 @@ import TaskDetailsTab from '../../../../plugins/services/src/js/pages/task-detai
 import TaskFileBrowser from '../../../../plugins/services/src/js/pages/task-details/TaskFileBrowser';
 import TaskFilesTab from '../../../../plugins/services/src/js/pages/task-details/TaskFilesTab';
 import TaskFileViewer from '../../../../plugins/services/src/js/pages/task-details/TaskFileViewer';
-import TaskLogsTab from '../../../../plugins/services/src/js/pages/task-details/TaskLogsTab';
+import TaskLogsAPIContainer from '../../../../plugins/services/src/js/pages/task-details/TaskLogsAPIContainer';
 import VirtualNetworkDetail from '../../pages/network/virtual-network-detail/VirtualNetworkDetail';
 import VirtualNetworkDetailsTab from '../../pages/network/virtual-network-detail/VirtualNetworkDetailsTab';
 import VirtualNetworksTab from '../../pages/network/VirtualNetworksTab';
@@ -153,10 +153,10 @@ const RouteFactory = {
             ]
           },
           {
-            component: TaskLogsTab,
+            component: TaskLogsAPIContainer,
             hideHeaderNavigation: true,
             isTab: true,
-            path: 'logs(/:fileName)',
+            path: 'logs(/:filePath)',
             title: 'Logs',
             type: Route,
             buildBreadCrumb() {

--- a/src/js/routes/jobs.js
+++ b/src/js/routes/jobs.js
@@ -12,7 +12,7 @@ import TaskDetailsTab from '../../../plugins/services/src/js/pages/task-details/
 import TaskFileBrowser from '../../../plugins/services/src/js/pages/task-details/TaskFileBrowser';
 import TaskFilesTab from '../../../plugins/services/src/js/pages/task-details/TaskFilesTab';
 import TaskFileViewer from '../../../plugins/services/src/js/pages/task-details/TaskFileViewer';
-import TaskLogsAPIContainer from '../../../plugins/services/src/js/pages/task-details/TaskLogsAPIContainer';
+import TaskLogsContainer from '../../../plugins/services/src/js/pages/task-details/TaskLogsContainer';
 
 function buildJobCrumbs({id}) {
   const ids = id.split('.');
@@ -142,7 +142,7 @@ const jobsRoutes = {
                   ]
                 },
                 {
-                  component: TaskLogsAPIContainer,
+                  component: TaskLogsContainer,
                   hideHeaderNavigation: true,
                   isTab: true,
                   path: 'logs(/:filePath)',

--- a/src/js/routes/jobs.js
+++ b/src/js/routes/jobs.js
@@ -12,7 +12,7 @@ import TaskDetailsTab from '../../../plugins/services/src/js/pages/task-details/
 import TaskFileBrowser from '../../../plugins/services/src/js/pages/task-details/TaskFileBrowser';
 import TaskFilesTab from '../../../plugins/services/src/js/pages/task-details/TaskFilesTab';
 import TaskFileViewer from '../../../plugins/services/src/js/pages/task-details/TaskFileViewer';
-import TaskLogsTab from '../../../plugins/services/src/js/pages/task-details/TaskLogsTab';
+import TaskLogsAPIContainer from '../../../plugins/services/src/js/pages/task-details/TaskLogsAPIContainer';
 
 function buildJobCrumbs({id}) {
   const ids = id.split('.');
@@ -142,10 +142,10 @@ const jobsRoutes = {
                   ]
                 },
                 {
-                  component: TaskLogsTab,
+                  component: TaskLogsAPIContainer,
                   hideHeaderNavigation: true,
                   isTab: true,
-                  path: 'logs(/:fileName)',
+                  path: 'logs(/:filePath)',
                   title: 'Logs',
                   type: Route,
                   buildBreadCrumb() {


### PR DESCRIPTION
---
Note: DCOS-14078 will take care of the breadcrumb bug. It is not handled in this PR!
~Dependent on this PR: https://github.com/dcos/dcos-ui/pull/1907~ (merged)

---

This PR adds functionality to choose one of the existing logging APIs. To use Mesos API set this variable in your `Config.dev.js`:
```js
mesos: {
  'logging-strategy': 'logrotate'
}
```
To use journald API set this variable in your `Config.dev.js`:
```js
mesos: {
  'logging-strategy': 'journald'
}
```

It will limit the files to view to be only `stdout` and `stderr`, when using Mesos API. Other files will still be available to view using the file viewer under the files tab.

Using Mesos API:
![Mesos API](https://cl.ly/2F3N1X3x2Q0S/Screen%20Recording%202017-02-27%20at%2018.08.gif)
Using `journald` API
![journald API](https://cl.ly/373o2z2V0a2x/Screen%20Recording%202017-02-27%20at%2018.11.gif)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] ~~If this is a regression, did you write a test to catch this in the future?~~ (Not applicable)

~~For reviewers: View diff between PRs [here](https://github.com/dcos/dcos-ui/compare/mlunoe/bug-fix/logs-unsubscribing-on-file-load…mlunoe/feature/DCOS-14010-add-container-to-pick-logging-component-and-api?expand=1)~~ Merged!
