### PR TITLE
DCOS-13415: Volume detail missing tab nav

### DIFF
--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -235,7 +235,7 @@ class ServiceBreadcrumbs extends React.Component {
 }
 
 ServiceBreadcrumbs.propTypes = {
-  extra: React.PropTypes.node,
+  extra: React.PropTypes.arrayOf(React.PropTypes.node),
   serviceID: React.PropTypes.string.isRequired,
   taskID: React.PropTypes.string,
   taskName: React.PropTypes.string

--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -157,13 +157,13 @@ class ServiceBreadcrumbs extends React.Component {
   }
 
   render() {
-    const {serviceID, taskID, taskName} = this.props;
+    const {serviceID, taskID, taskName, extra} = this.props;
     const trimmedServiceID = decodeURIComponent(serviceID).replace(/^\//, '');
     const ids = trimmedServiceID.split('/');
 
     let aggregateIDs = '';
 
-    const crumbs = [
+    let crumbs = [
       <Breadcrumb key={-1} title="Services">
         <BreadcrumbTextContent>
           <Link to="/services">Services</Link>
@@ -221,6 +221,10 @@ class ServiceBreadcrumbs extends React.Component {
       );
     }
 
+    if (Array.isArray(extra)) {
+      crumbs = crumbs.concat(extra);
+    }
+
     return (
       <PageHeaderBreadcrumbs
         iconID="services"
@@ -229,5 +233,12 @@ class ServiceBreadcrumbs extends React.Component {
     );
   }
 }
+
+ServiceBreadcrumbs.propTypes = {
+  extra: React.PropTypes.node,
+  serviceID: React.PropTypes.string.isRequired,
+  taskID: React.PropTypes.string,
+  taskName: React.PropTypes.string
+};
 
 module.exports = ServiceBreadcrumbs;

--- a/plugins/services/src/js/components/__tests__/ServiceBreadcrumbs-test.js
+++ b/plugins/services/src/js/components/__tests__/ServiceBreadcrumbs-test.js
@@ -1,0 +1,48 @@
+jest.dontMock('../ServiceBreadcrumbs');
+jest.dontMock('../../../../../../src/js/components/PageHeaderBreadcrumbs');
+jest.dontMock('../../structs/Service');
+/* eslint-disable no-unused-vars */
+const React = require('react');
+/* eslint-enable no-unused-vars */
+const TestUtils = require('react-addons-test-utils');
+const DCOSStore = require('foundation-ui').DCOSStore;
+const ServiceBreadcrumbs = require('../ServiceBreadcrumbs');
+const Service = require('../../structs/Service');
+
+const renderer = TestUtils.createRenderer();
+const service = new Service({
+  id: '/test'
+});
+
+describe('ServiceBreadcrumbs instance', function () {
+
+  beforeEach(function () {
+    DCOSStore.serviceTree = {
+      findItemById() {
+        return service;
+      }
+    };
+  });
+
+  describe('extra breadcrumbs', function () {
+    it('does not render extra crumbs when there is none', function () {
+      renderer.render(<ServiceBreadcrumbs serviceID="/test" />);
+      const result = renderer.getRenderOutput();
+      expect(result.props.breadcrumbs.length).toEqual(2);
+    });
+
+    it('renders extra crumbs', function () {
+      renderer.render(
+        <ServiceBreadcrumbs
+          serviceID="/test"
+          extra={[
+            <a>Dummy</a>
+          ]}
+        />
+      );
+      const result = renderer.getRenderOutput();
+      expect(result.props.breadcrumbs.length).toEqual(3);
+      expect(result.props.breadcrumbs[2].props.children).toEqual('Dummy');
+    });
+  });
+});

--- a/plugins/services/src/js/containers/volume-detail/VolumeDetail.js
+++ b/plugins/services/src/js/containers/volume-detail/VolumeDetail.js
@@ -1,6 +1,9 @@
 import classNames from 'classnames';
 import React from 'react';
+import {Link} from 'react-router';
 
+import Breadcrumb from '../../../../../../src/js/components/Breadcrumb';
+import BreadcrumbTextContent from '../../../../../../src/js/components/BreadcrumbTextContent';
 import ConfigurationMap from '../../../../../../src/js/components/ConfigurationMap';
 import ConfigurationMapLabel from '../../../../../../src/js/components/ConfigurationMapLabel';
 import ConfigurationMapRow from '../../../../../../src/js/components/ConfigurationMapRow';
@@ -27,13 +30,37 @@ class VolumeDetail extends React.Component {
   render() {
     const {service, volume} = this.props;
 
+    const serviceID = service.getId();
+    const encodedServiceId = encodeURIComponent(serviceID);
+    const volumeId = volume.getId();
+
+    const extraCrumbs = [
+      <Breadcrumb key={-1} title="Services">
+        <BreadcrumbTextContent>
+          <Link
+            to={`/services/overview/${encodedServiceId}/volumes/${volumeId}`}
+            key="volume">
+
+            {volumeId}
+          </Link>
+        </BreadcrumbTextContent>
+      </Breadcrumb>
+    ];
+
+    const breadcrumbs = (
+      <ServiceBreadcrumbs
+        serviceID={serviceID}
+        extra={extraCrumbs}
+      />
+    );
+
     return (
       <Page>
         <Page.Header
-          breadcrumbs={<ServiceBreadcrumbs serviceID={service.id} />} />
+          breadcrumbs={breadcrumbs} />
         <DetailViewHeader
           subTitle={this.renderSubHeader()}
-          title={volume.getId()} />
+          title={volumeId} />
         <ConfigurationMap>
           <ConfigurationMapSection>
             <ConfigurationMapRow>
@@ -65,7 +92,7 @@ class VolumeDetail extends React.Component {
                 Application
               </ConfigurationMapLabel>
               <ConfigurationMapValue>
-                {service.getId()}
+                {serviceID}
               </ConfigurationMapValue>
             </ConfigurationMapRow>
             <ConfigurationMapRow>


### PR DESCRIPTION
This PR adds two things:

1. a new param `extra` for the ServiceBreadcrumbs so that one can add some additional crumbs
2. a new breadcrumb on the VolumeDetail page with the Volume name to indicate that we're one level deeper and thus tab nav goes missing.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
