### PR TITLE
DCOS-14141: Styling fixes for IE11

### DIFF
--- a/src/js/components/modals/FullScreenModal.js
+++ b/src/js/components/modals/FullScreenModal.js
@@ -20,6 +20,7 @@ class FullScreenModal extends React.Component {
     return (
       <Modal
         geminiClass={geminiClasses}
+        isFullScreen={true}
         modalClass="modal modal-full-screen"
         modalHeight={modalHeight}
         showHeader={true}

--- a/src/styles/components/modal/install-package/styles.less
+++ b/src/styles/components/modal/install-package/styles.less
@@ -28,7 +28,8 @@
         display: flex;
         flex: 1 1 auto;
         flex-direction: column;
-        min-height: 0;
+        // IE11 requires a minimum height of at least one pixel.
+        min-height: 1px;
         position: relative;
 
         .tab-form-wrapper {
@@ -45,13 +46,15 @@
           display: flex;
           flex: 1 1 auto;
           height: auto;
-          min-height: 0;
+          // IE11 requires a minimum height of at least one pixel.
+          min-height: 1px;
         }
 
         .multiple-form-left-column,
         .multiple-form-right-column {
           height: auto;
-          min-height: 0;
+          // IE11 requires a minimum height of at least one pixel.
+          min-height: 1px;
         }
 
         .multiple-form-left-column {
@@ -68,6 +71,7 @@
       }
 
       .review-config {
+        flex: 1 1 auto;
 
         .configuration-map {
 


### PR DESCRIPTION
This PR fixes the modal height calculation in IE11, which caused some modals to be unusable in short viewports.

_Note_: A release of `reactjs-components` is necessary for this to take place. Please see the corresponding PR here: https://github.com/mesosphere/reactjs-components/pull/393

Before:
![](https://cl.ly/0D2w1F0q1z2A/Screen%20Recording%202017-02-28%20at%2002.53%20PM.gif)

After:
![](https://cl.ly/0H1W0C2b2h1V/Screen%20Recording%202017-02-28%20at%2002.45%20PM.gif)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?