### PR TITLE
DCOS-14090: Allow menu tabbed content to shrink in IE11

### DIFF
--- a/src/styles/components/menu-tabbed/styles.less
+++ b/src/styles/components/menu-tabbed/styles.less
@@ -6,7 +6,7 @@
 
     .menu-tabbed-view-container {
       flex: 1 1 auto;
-      min-width: 0;
+      min-width: 1px;
     }
   }
 


### PR DESCRIPTION
This PR fixes a bug in IE11 where flex children don't shrink as they should. It's present anywhere we use `.menu-tabbed`, but most notably in the service create form:

Before:
![](https://cl.ly/1R2j3e0K2h0q/Screen%20Shot%202017-02-28%20at%204.53.44%20PM.png)

After:
![](https://cl.ly/1y3x0q0c461R/Screen%20Shot%202017-02-28%20at%204.50.04%20PM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
