### PR TITLE
DCOS-13107: Hide empty endpoints table on the review screen

### DIFF
--- a/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {Table} from 'reactjs-components';
 
 import ConfigurationMapEditAction from '../components/ConfigurationMapEditAction';
+import ConfigurationMapHeading from '../../../../../src/js/components/ConfigurationMapHeading';
 import Networking from '../../../../../src/js/constants/Networking';
 import {
   getColumnClassNameFn,
@@ -11,6 +12,7 @@ import {
 import ServiceConfigUtil from '../utils/ServiceConfigUtil';
 import ServiceConfigBaseSectionDisplay from './ServiceConfigBaseSectionDisplay';
 import {findNestedPropertyInObject} from '../../../../../src/js/utils/Util';
+import ValidatorUtil from '../../../../../src/js/utils/ValidatorUtil';
 
 function getNetworkType(networkType, appDefinition) {
   networkType = networkType || Networking.type.HOST;
@@ -60,10 +62,6 @@ class ServiceNetworkingConfigSection extends ServiceConfigBaseSectionDisplay {
         {
           key: 'ipAddress.networkName',
           label: 'Network Name'
-        },
-        {
-          heading: 'Service Endpoints',
-          headingLevel: 2
         },
         {
           key: 'portDefinitions',
@@ -181,13 +179,23 @@ class ServiceNetworkingConfigSection extends ServiceConfigBaseSectionDisplay {
               });
             }
 
-            return (
+            if (ValidatorUtil.isEmpty(portDefinitions)) {
+              return;
+            }
+
+            return [
+              <ConfigurationMapHeading
+                key="service-endpoints-heading"
+                level={2}>
+
+                Service Endpoints
+              </ConfigurationMapHeading>,
               <Table
                 key="service-endpoints"
                 className="table table-simple table-align-top table-break-word table-fixed-layout flush-bottom"
                 columns={columns}
                 data={portDefinitions} />
-            );
+            ];
           }
         }
       ]


### PR DESCRIPTION
This PR hides **Service Endpoints** section on the review screen when no endpoints have been specified. 

Sorry @wavesoft I decided to address the issue without doing the complete refactoring of the section. So it makes it faster through the review process. I'd say we separate refactoring and the fix so that we could continue @jfurrow 💪  effort on refactoring after 1.9

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
