### PR TITLE
Refactoring CosmosErrorMessages to be more flexible

### DIFF
--- a/src/js/components/Alert.js
+++ b/src/js/components/Alert.js
@@ -3,9 +3,10 @@ import React from 'react';
 
 import Icon from './Icon';
 
-const Alert = ({children, showIcon, type}) => {
+const Alert = ({children, flushBottom, showIcon, type}) => {
   const classes = classNames('alert', {
-    [`alert-${type}`]: type != null
+    [`alert-${type}`]: type != null,
+    'flush-bottom': flushBottom === true
   });
   let icon = null;
 
@@ -31,12 +32,14 @@ const Alert = ({children, showIcon, type}) => {
 };
 
 Alert.defaultProps = {
+  flushBottom: false,
   showIcon: true,
   type: 'danger'
 };
 
 Alert.propTypes = {
   children: React.PropTypes.node.isRequired,
+  flushBottom: React.PropTypes.bool,
   showIcon: React.PropTypes.bool,
   type: React.PropTypes.oneOf(['danger', 'success'])
 };

--- a/src/js/components/CosmosErrorHeader.js
+++ b/src/js/components/CosmosErrorHeader.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const CosmosErrorHeader = function (props) {
+
+  return (
+    <h3 className="text-align-center flush-top">
+      {props.children}
+    </h3>
+  );
+};
+
+CosmosErrorHeader.propTypes = {
+  children: React.PropTypes.node
+};
+
+module.exports = CosmosErrorHeader;
+

--- a/src/js/components/CosmosErrorMessage.js
+++ b/src/js/components/CosmosErrorMessage.js
@@ -1,6 +1,7 @@
 import React from 'react';
+
+import Alert from './Alert';
 import ErrorPaths from '../../../plugins/services/src/js/constants/ErrorPaths';
-import CollapsibleErrorMessage from './CollapsibleErrorMessage';
 
 const REPOSITORY_ERRORS = [
   'EmptyPackageImport',
@@ -14,19 +15,6 @@ const REPOSITORY_ERRORS = [
 ];
 
 class CosmosErrorMessage extends React.Component {
-  getHeader() {
-    const {header, headerClass} = this.props;
-    if (!header) {
-      return null;
-    }
-
-    return (
-      <span className={headerClass}>
-        {header}
-      </span>
-    );
-  }
-
   getMessage() {
     const {error} = this.props;
     if (!error) {
@@ -97,48 +85,40 @@ class CosmosErrorMessage extends React.Component {
   appendRepositoryLink(message) {
     return (
       <span>
-        {`${message} You can go to the `}
-        <a href="/#/system/overview/repositories/">Repositories Settings</a>
+        <strong>{`${message}. `}</strong><br />
+        {'You can go to the '}
+        <a href="/#/settings/repositories/">Repositories Settings</a>
         {' page to change installed repositories.'}
       </span>
     );
   }
 
   render() {
-    const {className, onResized, wrapperClass} = this.props;
-
     return (
-      <div className={wrapperClass}>
-        {this.getHeader()}
-        <CollapsibleErrorMessage
-          className={className}
-          onToggle={onResized}
-          message={this.getMessage()}
-          details={this.getDetails()} />
-      </div>
+      <Alert flushBottom={this.props.flushBottom}>
+        {this.getMessage()}
+        <div className="pod pod-narrower-left pod-shorter-top flush-bottom">
+          <ul className="short flush-bottom">
+            {this.getDetails()}
+          </ul>
+        </div>
+      </Alert>
     );
   }
 };
 
 CosmosErrorMessage.defaultProps = {
-  className: 'text-overflow-break-word column-small-8 column-small-offset-2 column-medium-6 column-medium-offset-3',
   error: {message: 'Please try again.'},
-  header: 'An Error Occurred',
-  headerClass: 'h3 text-align-center flush-top',
-  wrapperClass: 'row'
+  flushBottom: false
 };
 
 CosmosErrorMessage.propTypes = {
-  className: React.PropTypes.string,
   error: React.PropTypes.shape({
     message: React.PropTypes.node,
     type: React.PropTypes.string,
     data: React.PropTypes.object
   }),
-  header: React.PropTypes.string,
-  headerClass: React.PropTypes.string,
-  wrapperClass: React.PropTypes.string,
-  onResized: React.PropTypes.func
+  flushBottom: React.PropTypes.bool
 };
 
 module.exports = CosmosErrorMessage;

--- a/src/js/components/modals/InstallPackageModal.js
+++ b/src/js/components/modals/InstallPackageModal.js
@@ -4,6 +4,7 @@ import mixin from 'reactjs-mixin';
 import React from 'react';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
+import CosmosErrorHeader from '../CosmosErrorHeader';
 import CosmosErrorMessage from '../CosmosErrorMessage';
 import CosmosPackagesStore from '../../stores/CosmosPackagesStore';
 import defaultServiceImage from '../../../../plugins/services/src/img/icon-service-default-large@2x.png';
@@ -26,8 +27,6 @@ const METHODS_TO_BIND = [
   'handleInstallPackage',
   'handleAdvancedFormChange',
   'handleModalClose',
-  'handleModalRef',
-  'handleModalUpdateRequest',
   'handlePreinstallNotesToggle'
 ];
 
@@ -69,8 +68,6 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
     METHODS_TO_BIND.forEach((method) => {
       this[method] = this[method].bind(this);
     });
-
-    this.modalRef = undefined;
   }
 
   componentDidMount() {
@@ -200,16 +197,6 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
     this.setState({truncatedPreInstallNotes});
   }
 
-  handleModalRef(modal) {
-    this.modalRef = modal;
-  }
-
-  handleModalUpdateRequest() {
-    if (this.modalRef) {
-      this.modalRef.forceUpdate();
-    }
-  }
-
   getAdvancedSubmit(triggerSubmit) {
     this.triggerAdvancedSubmit = triggerSubmit;
   }
@@ -252,11 +239,10 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
     return (
       <div>
         <div className="modal-body">
-          <CosmosErrorMessage
-            onResized={this.handleModalUpdateRequest}
-            className="text-error-state text-overflow-break-word"
-            error={installError}
-            wrapperClass="" />
+          <CosmosErrorHeader>
+            An Error Occurred
+          </CosmosErrorHeader>
+          <CosmosErrorMessage error={installError} />
         </div>
         <div className="modal-footer">
           <div className="button-collection button-collection-stacked">
@@ -618,7 +604,6 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
 
     return (
       <Modal
-        ref={this.handleModalRef}
         backdropClass={backdropClasses}
         closeByBackdropClick={!isAdvanced}
         modalClass={modalClasses}

--- a/src/js/components/modals/UninstallPackageModal.js
+++ b/src/js/components/modals/UninstallPackageModal.js
@@ -97,7 +97,7 @@ class UninstallPackageModal extends mixin(StoreMixin) {
     return (
       <CosmosErrorMessage
         error={packageUninstallError}
-        flushBottom={false} />
+        flushBottom={true} />
     );
   }
 

--- a/src/js/components/modals/UninstallPackageModal.js
+++ b/src/js/components/modals/UninstallPackageModal.js
@@ -96,9 +96,8 @@ class UninstallPackageModal extends mixin(StoreMixin) {
 
     return (
       <CosmosErrorMessage
-        className="text-error-state text-overflow-break-word"
         error={packageUninstallError}
-        header="" />
+        flushBottom={false} />
     );
   }
 
@@ -144,10 +143,10 @@ class UninstallPackageModal extends mixin(StoreMixin) {
     return (
       <div className="text-align-center">
         <h3 className="flush-top">Are you sure?</h3>
+        {errorMessage}
         <p className={paragraphTagClasses}>
           {`${cosmosPackage.getAppIdName()} will be uninstalled from ${Config.productName}. All tasks belonging to this package will be killed.`}
         </p>
-        {errorMessage}
       </div>
     );
   }

--- a/src/js/components/modals/__tests__/InstallPackageModal-test.js
+++ b/src/js/components/modals/__tests__/InstallPackageModal-test.js
@@ -1,4 +1,6 @@
 jest.dontMock('../InstallPackageModal');
+jest.dontMock('../../Alert');
+jest.dontMock('../../CosmosErrorHeader');
 jest.dontMock('../../CosmosErrorMessage');
 jest.dontMock('../../Loader');
 jest.dontMock('../../ReviewConfig');
@@ -109,7 +111,7 @@ describe('InstallPackageModal', function () {
         this.container
       ));
 
-      var result = node.querySelector('.h3.text-align-center.flush-top');
+      var result = node.querySelector('h3.text-align-center.flush-top');
       expect(result.textContent).toEqual('An Error Occurred');
     });
 

--- a/src/js/pages/universe/PackagesTab.js
+++ b/src/js/pages/universe/PackagesTab.js
@@ -117,7 +117,7 @@ class PackagesTab extends mixin(StoreMixin) {
 
     return (
       <AlertPanel title="An Error Occurred">
-        <CosmosErrorMessage error={errorMessage} />
+        <CosmosErrorMessage error={errorMessage} flushBottom={true} />
       </AlertPanel>
     );
   }

--- a/src/js/pages/universe/PackagesTab.js
+++ b/src/js/pages/universe/PackagesTab.js
@@ -7,6 +7,7 @@ import React from 'react';
 /* eslint-enable no-unused-vars */
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
+import AlertPanel from '../../components/AlertPanel';
 import Breadcrumb from '../../components/Breadcrumb';
 import BreadcrumbTextContent from '../../components/BreadcrumbTextContent';
 import CosmosErrorMessage from '../../components/CosmosErrorMessage';
@@ -115,9 +116,9 @@ class PackagesTab extends mixin(StoreMixin) {
     const {errorMessage} = this.state;
 
     return (
-      <CosmosErrorMessage
-        error={errorMessage}
-        headerClass="h3 text-align-center flush-top" />
+      <AlertPanel title="An Error Occurred">
+        <CosmosErrorMessage error={errorMessage} />
+      </AlertPanel>
     );
   }
 

--- a/src/styles/components/alert/styles.less
+++ b/src/styles/components/alert/styles.less
@@ -6,6 +6,7 @@
     display: flex;
     margin-bottom: @alert-margin-bottom;
     padding: @alert-padding-vertical @alert-padding-horizontal;
+    text-align: left;
 
     &-icon {
       fill: currentColor;

--- a/src/styles/components/alert/styles.less
+++ b/src/styles/components/alert/styles.less
@@ -16,6 +16,7 @@
 
     &-content {
       flex: 1 1 auto;
+      word-break: break-word;
     }
 
     &-danger {

--- a/tests/pages/universe/packages/PackagesTab-cy.js
+++ b/tests/pages/universe/packages/PackagesTab-cy.js
@@ -13,12 +13,12 @@ describe('Packages Tab', function () {
         method: 'POST',
         url: /package\/search/,
         status: 400,
-        response: {type: 'RepositoryUriSyntax', name: 'Invalid', message: 'The url for Invalid does not have correct syntax.'}
+        response: {type: 'RepositoryUriSyntax', name: 'Invalid', message: 'The url for Invalid does not have correct syntax'}
       })
       .visitUrl({url: '/universe/packages', logIn: true});
 
     cy
-      .get('.page-body-content .text-overflow-break-word')
+      .get('.page-body-content .alert-content')
       .should('contain', 'The url for Invalid does not have correct syntax. You can go to the Repositories Settings page to change installed repositories.');
   });
 
@@ -28,12 +28,12 @@ describe('Packages Tab', function () {
         method: 'POST',
         url: /package\/search/,
         status: 400,
-        response: {type: 'IndexNotFound', name: 'Invalid', message: 'The index file is missing in Invalid.'}
+        response: {type: 'IndexNotFound', name: 'Invalid', message: 'The index file is missing in Invalid'}
       })
       .visitUrl({url: '/universe', logIn: true});
 
     cy
-      .get('.page-body-content .text-overflow-break-word')
+      .get('.page-body-content .alert-content')
       .should('contain', 'The index file is missing in Invalid. You can go to the Repositories Settings page to change installed repositories.');
   });
 
@@ -43,12 +43,12 @@ describe('Packages Tab', function () {
         method: 'POST',
         url: /package\/search/,
         status: 400,
-        response: {type: 'PackageFileMissing', name: 'Invalid', message: 'The package file is missing in Invalid.'}
+        response: {type: 'PackageFileMissing', name: 'Invalid', message: 'The package file is missing in Invalid'}
       })
       .visitUrl({url: '/universe', logIn: true});
 
     cy
-      .get('.page-body-content .text-overflow-break-word')
+      .get('.page-body-content .alert-content')
       .should('contain', 'The package file is missing in Invalid. You can go to the Repositories Settings page to change installed repositories.');
   });
 
@@ -58,12 +58,12 @@ describe('Packages Tab', function () {
         method: 'POST',
         url: /package\/search/,
         status: 400,
-        response: {type: 'PackageFileMissing', message: 'The package file is missing in a repository.'}
+        response: {type: 'PackageFileMissing', message: 'The package file is missing in a repository'}
       })
       .visitUrl({url: '/universe', logIn: true});
 
     cy
-      .get('.page-body-content .text-overflow-break-word')
+      .get('.page-body-content .alert-content')
       .should('contain', 'The package file is missing in a repository. You can go to the Repositories Settings page to change installed repositories.');
   });
 
@@ -78,7 +78,7 @@ describe('Packages Tab', function () {
       .visitUrl({url: '/universe', logIn: true});
 
     cy
-      .get('.page-body-content .h3.text-align-center')
+      .get('.panel-content h3')
       .should('contain', 'An Error Occurred');
   });
 


### PR DESCRIPTION
… and not use `CollapsibleErrorMessage` component.

This PR updates the cosmos error message handling, so all details are displayed without having to click "view details". It uses `Alert` component rather than the `CollapsibleErrorMessage` component.

PackageTab page:
![](https://cl.ly/2L3v1a0O3M3U/Image%202017-03-01%20at%2011.11.07.png)
Install:
![](https://cl.ly/1U0J212u1S1c/Image%202017-03-01%20at%2011.20.35.png)
Uninstall:
![](https://cl.ly/1M0w2E3N1B0M/Image%202017-03-01%20at%2011.46.35.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] ~~If this is a regression, did you write a test to catch this in the future?~~ Not applicable
