### PR TITLE
DCOS-14091: Apply flex workaround for service create modal in IE11

### DIFF
--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -525,8 +525,7 @@ class NewCreateServiceModalForm extends Component {
 
     return (
       <div className="flex flex-item-grow-1">
-        <div
-          className="flex flex-item-grow-1 modal-body-offset gm-scrollbar-container-flex">
+        <div className="create-service-modal-form__scrollbar-container modal-body-offset gm-scrollbar-container-flex">
           <FluidGeminiScrollbar>
             <div className="modal-body-padding-surrogate create-service-modal-form-container">
               <form

--- a/src/styles/views/create-service-modal/styles.less
+++ b/src/styles/views/create-service-modal/styles.less
@@ -23,9 +23,24 @@
 
       &-container {
         display: flex;
-        flex: 1 1 auto;
+        flex: 1 0 auto;
         flex-direction: row;
-        min-height: 100%;
+      }
+
+      &__scrollbar-container {
+        display: flex;
+        flex: 1 0 auto;
+
+        // We need these specific flex properties to fix an IE11 bug.
+        // https://github.com/philipwalton/flexbugs#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items
+        & > .gm-scrollbar-container,
+        & > .gm-prevented {
+
+          & > .gm-scroll-view {
+            display: flex;
+            flex-direction: column;
+          }
+        }
       }
 
       .menu-tabbed-container {


### PR DESCRIPTION
This PR implements a `flex` workaround to force the service form to fill its parent in IE11.

The workaround is described here: https://github.com/philipwalton/flexbugs#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items

Before:
![](https://d3vv6lp55qjaqc.cloudfront.net/items/1Y1u0c3W1i3q2M1U1q0u/%5B12dc5dca27bbc3fe835d7e5a34c02a8e%5D_Screen%2520Shot%25202017-03-01%2520at%252011.48.12%2520AM.png)

After:
![](https://cl.ly/0S0Q0y18061A/Screen%20Shot%202017-03-01%20at%2011.46.43%20AM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
