### PR TITLE
DCOS-14089: Use height instead of min-height for .modal-body

### DIFF
--- a/src/styles/components/modal/full-screen/styles.less
+++ b/src/styles/components/modal/full-screen/styles.less
@@ -28,7 +28,7 @@
     .modal-body {
       display: flex;
       flex: 1 0 auto;
-      min-height: 100%;
+      height: 100%;
       overflow: hidden;
     }
 


### PR DESCRIPTION
This PR changes the `min-height` property on the full screen's `.modal-body` to `height` to make the flexbox children vertically centered in IE11.

Before:
![](https://cl.ly/3L343x1e0I3C/Screen%20Shot%202017-03-01%20at%203.08.24%20PM.png)

After:
![](https://cl.ly/1d1g0O3K1O13/Screen%20Shot%202017-03-01%20at%203.07.28%20PM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?