### PR TITLE
DCOS-14093: Fix text wrapping in package install notes.

### DIFF
--- a/src/js/components/modals/InstallPackageModal.js
+++ b/src/js/components/modals/InstallPackageModal.js
@@ -282,7 +282,7 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
     }
 
     return (
-      <p className="small flush-bottom">
+      <p className="small text-align-left flush-bottom">
         {notes}{this.getPreInstallNotesToggle(truncated, notes)}
       </p>
     );
@@ -353,7 +353,7 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
     return (
       <div>
         <div className="modal-body">
-          <div className="horizontal-center">
+          <div className="text-align-center">
             <div className="icon icon-jumbo icon-image-container icon-app-container">
               <Image
                 fallbackSrc={defaultServiceImage}


### PR DESCRIPTION
This PR applies `.text-align-center` instead of `.horizontal-center` for the contents of the `InstallPackageModal`. This fixes the text wrapping bug in IE11.

Before:
![](https://cl.ly/0f3425460R0k/Screen%20Shot%202017-03-01%20at%205.11.49%20PM.png)

After:
![](https://cl.ly/332v3S2L3G39/Screen%20Shot%202017-03-01%20at%205.04.37%20PM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?