### PR TITLE
DCOS-14255: Clean up advanced package install review

### DIFF
--- a/src/js/components/ReviewConfig.js
+++ b/src/js/components/ReviewConfig.js
@@ -1,7 +1,7 @@
-import classNames from 'classnames';
 import GeminiScrollbar from 'react-gemini-scrollbar';
 import React from 'react';
 
+import ConfigurationMap from './ConfigurationMap';
 import defaultServiceImage from '../../../plugins/services/src/img/icon-service-default-small@2x.png';
 import HashMapDisplay from './HashMapDisplay';
 import Icon from './Icon';
@@ -71,54 +71,12 @@ class ReviewConfig extends React.Component {
     );
   }
 
-  getFieldTitle(title, index) {
-    const classes = classNames({'flush-top': index === 0});
-
-    return <h3 className={classes} key={`${title}-header`}>{title}</h3>;
-  }
-
-  getFieldSubheader(title) {
-    return (<h5 key={`${title}-subheader`}>{title}</h5>);
-  }
-
   getDefinitionReview() {
-    var elementsToRender = [];
-    const {configuration} = this.props;
-    const fields = Object.keys(configuration);
-
-    fields.forEach((field, i) => {
-      var fieldObj = configuration[field];
-      elementsToRender.push(this.getFieldTitle(field, i));
-
-      Object.keys(fieldObj).forEach((fieldKey) => {
-        let fieldValue = fieldObj[fieldKey];
-        const uniqueKey = `${i}${fieldKey}`;
-
-        if (typeof fieldValue === 'object' && !Array.isArray(fieldValue)
-          && fieldValue !== null) {
-          elementsToRender.push(
-            this.getFieldSubheader(fieldKey),
-            this.renderHashMapDisplay(fieldValue, uniqueKey)
-          );
-
-          return;
-        }
-
-        if (Array.isArray(fieldValue)) {
-          fieldValue = fieldValue.join(' ');
-        }
-
-        elementsToRender.push(
-          this.renderHashMapDisplay({[fieldKey]: fieldValue}, uniqueKey)
-        );
-      });
-    });
-
-    return elementsToRender;
-  }
-
-  renderHashMapDisplay(hash, key) {
-    return <HashMapDisplay hash={hash} key={key} />;
+    return (
+      <ConfigurationMap>
+        <HashMapDisplay hash={this.props.configuration} />
+      </ConfigurationMap>
+    );
   }
 
   render() {

--- a/src/js/components/__tests__/ReviewConfig-test.js
+++ b/src/js/components/__tests__/ReviewConfig-test.js
@@ -1,3 +1,9 @@
+jest.dontMock('../ConfigurationMap');
+jest.dontMock('../ConfigurationMapRow');
+jest.dontMock('../ConfigurationMapHeading');
+jest.dontMock('../ConfigurationMapLabel');
+jest.dontMock('../ConfigurationMapValue');
+jest.dontMock('../HashMapDisplay');
 jest.dontMock('../ReviewConfig');
 
 /* eslint-disable no-unused-vars */
@@ -5,6 +11,7 @@ const React = require('react');
 /* eslint-enable no-unused-vars */
 const ReactDOM = require('react-dom');
 
+const ConfigurationMap = require('../ConfigurationMap');
 const ReviewConfig = require('../ReviewConfig');
 
 describe('ReviewConfig', function () {
@@ -17,40 +24,23 @@ describe('ReviewConfig', function () {
   });
 
   describe('#getDefinitionReview', function () {
-    it('renders a subheader for a nested document', function () {
-      var normalDocument = {
-        'application': {
-          'normal': 'value',
-          'normal2': 'value2',
-          'normal3': 'value3'
+    it('renders a configuration map', function () {
+      var configuration = {
+        'foo': {
+          'bar': 'baz',
+          'qux': 'quux',
+          'corgly': 'grault'
         }
       };
 
       var instance = ReactDOM.render(
-        <ReviewConfig configuration={normalDocument} />,
+        <ReviewConfig configuration={configuration} />,
         this.container
       );
 
       var result = instance.getDefinitionReview();
-      expect(result.length).toEqual(4);
-    });
 
-    it('renders a subheader for a nested document', function () {
-      var nestedDocument = {
-        'application': {
-          'nested': {
-            'name': 'trueValue'
-          }
-        }
-      };
-
-      var instance = ReactDOM.render(
-        <ReviewConfig configuration={nestedDocument} />,
-        this.container
-      );
-
-      var result = instance.getDefinitionReview();
-      expect(result.length).toEqual(3);
+      expect(result.type instanceof ConfigurationMap.constructor).toBeTruthy();
     });
   });
 });

--- a/src/js/components/__tests__/ReviewConfig-test.js
+++ b/src/js/components/__tests__/ReviewConfig-test.js
@@ -1,9 +1,4 @@
 jest.dontMock('../ConfigurationMap');
-jest.dontMock('../ConfigurationMapRow');
-jest.dontMock('../ConfigurationMapHeading');
-jest.dontMock('../ConfigurationMapLabel');
-jest.dontMock('../ConfigurationMapValue');
-jest.dontMock('../HashMapDisplay');
 jest.dontMock('../ReviewConfig');
 
 /* eslint-disable no-unused-vars */

--- a/src/js/components/modals/InstallPackageModal.js
+++ b/src/js/components/modals/InstallPackageModal.js
@@ -423,7 +423,7 @@ class InstallPackageModal extends mixin(InternalStorageMixin, TabsMixin, StoreMi
     }
 
     return (
-      <div className="flex flex-direction-top-to-bottom flex-item-grow-1 flex-item-shrink-1">
+      <div className="modal--install-package__review__wrapper">
         <ReviewConfig
           packageIcon={cosmosPackage.getIcons()['icon-small']}
           packageName={name}

--- a/src/styles/components/modal/install-package/styles.less
+++ b/src/styles/components/modal/install-package/styles.less
@@ -66,6 +66,32 @@
       .modal-footer {
         flex: 0 0 auto;
       }
+
+      .review-config {
+
+        .configuration-map {
+
+          &-section {
+
+            &:last-child {
+              margin-bottom: 0;
+            }
+          }
+        }
+      }
+    }
+
+    &--install-package {
+
+      &__review {
+
+        &__wrapper {
+          display: flex;
+          flex: 1 1 auto;
+          flex-direction: column;
+          min-height: 1px;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This PR fixes a bug where the advanced package install modal's review stage wasn't rendering properly in Firefox. The modal's body wasn't shrinking to allow for the modal footer to be visible.

I also reduced the complexity of the displayed configuration by simply passing it to `HashMapDisplay` which improves the consistency of this view.

Before:
![](https://cl.ly/2b3i0K2K0c2b/Screen%20Shot%202017-03-02%20at%2011.18.51%20AM.png)

After:
![](https://cl.ly/2Q0P3s1I1y2t/Screen%20Shot%202017-03-02%20at%2011.20.09%20AM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?