### PR TITLE
DCOS_OSS-702: Remove API errors on CreateServiceJsonOnly when changed

### DIFF
--- a/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
+++ b/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
@@ -92,7 +92,7 @@ class CreateServiceJsonOnly extends React.Component {
 
   render() {
     const {appConfig} = this.state;
-    const {errors} = this.props;
+    const {errors, onPropertyChange} = this.props;
 
     return (
       <div className="create-service-modal-json-only container container-wide">
@@ -108,6 +108,7 @@ class CreateServiceJsonOnly extends React.Component {
             errors={errors}
             onChange={this.handleJSONChange}
             onErrorStateChange={this.handleJSONErrorStateChange}
+            onPropertyChange={onPropertyChange}
             showGutter={true}
             showPrintMargin={false}
             theme="monokai"
@@ -120,13 +121,15 @@ class CreateServiceJsonOnly extends React.Component {
 
 CreateServiceJsonOnly.defaultProps = {
   onChange() {},
-  onErrorsChange() {}
+  onErrorsChange() {},
+  onPropertyChange() {}
 };
 
 CreateServiceJsonOnly.propTypes = {
   errors: PropTypes.array.isRequired,
   onChange: PropTypes.func,
   onErrorsChange: PropTypes.func,
+  onPropertyChange: PropTypes.func,
   service: PropTypes.object
 };
 

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -69,6 +69,7 @@ const METHODS_TO_BIND = [
   'handleRouterWillLeave',
   'handleServiceChange',
   'handleServiceErrorsChange',
+  'handleServicePropertyChange',
   'handleServiceReview',
   'handleServiceRun',
   'handleServiceSelection',
@@ -362,6 +363,25 @@ class NewCreateServiceModal extends Component {
     this.setState({serviceFormErrors: errors});
   }
 
+  handleServicePropertyChange(path) {
+    const refPath = path.join('.');
+    let {apiErrors} = this.state;
+
+    apiErrors = apiErrors.filter((error) => {
+      const errorPath = error.path.join('.');
+
+      // Remove all root errors on a simple update
+      if (errorPath === '') {
+        return false;
+      }
+
+      // Otherwise remove errors on the given path
+      return errorPath !== refPath;
+    });
+
+    this.setState({apiErrors});
+  }
+
   handleServiceSelection(event) {
     const {route, type} = event;
     const {params} = this.props;
@@ -642,6 +662,7 @@ class NewCreateServiceModal extends Component {
           errors={this.getAllErrors()}
           onChange={this.handleServiceChange}
           onErrorsChange={this.handleServiceErrorsChange}
+          onPropertyChange={this.handleServicePropertyChange}
           ref={(ref) => {
             return this.createComponent = ref;
           }}


### PR DESCRIPTION
This PR ensures that the API errors are removed when the user uses the `CreateServiceJsonOnly` form and there are marathon errors after review.

Without this PR the API errors would always persist, giving the feeling that the JSON is never correct.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
