### PR TITLE
DCOS-14307: Fix Discard dialogue behavior

### DIFF
--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -244,6 +244,7 @@ class NewCreateServiceModal extends Component {
     if (serviceFormActive) {
       this.setState({
         isConfirmOpen: false,
+        hasChangesApplied: false,
         servicePickerActive: true,
         serviceFormActive: false
       });
@@ -255,6 +256,7 @@ class NewCreateServiceModal extends Component {
     if (serviceJsonActive) {
       this.setState({
         isConfirmOpen: false,
+        hasChangesApplied: false,
         servicePickerActive: true,
         serviceJsonActive: false
       });


### PR DESCRIPTION
This PR addresses the issue when discarding changes would have just closed the form which cause a glitch with Universe install button.

The issue is addressed by resetting the flag `hasChangesApplied` every time we discard changes.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
