### PR TITLE
DCOS-14010: Fix tab not being highlighted for log tab sub routes

### DIFF
--- a/plugins/nodes/src/js/routes/nodes.js
+++ b/plugins/nodes/src/js/routes/nodes.js
@@ -208,7 +208,7 @@ const nodesRoutes = {
           component: TaskLogsContainer,
           hideHeaderNavigation: true,
           isTab: true,
-          path: 'logs(/:filePath)',
+          path: 'logs',
           title: 'Logs',
           type: Route,
           buildBreadCrumb() {
@@ -216,7 +216,13 @@ const nodesRoutes = {
               parentCrumb: '/nodes/:nodeID/tasks/:taskID',
               getCrumbs() { return []; }
             };
-          }
+          },
+          children: [
+            {
+              path: ':filePath',
+              type: Route
+            }
+          ]
         },
         {
           component: VolumeTable,

--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -28,19 +28,23 @@ const METHODS_TO_BIND = [
 // TODO remove
 const HIDE_BREADCRUMBS = [
   '/jobs/:id/tasks/:taskID/details',
-  '/jobs/:id/tasks/:taskID/logs(/:filePath)',
+  '/jobs/:id/tasks/:taskID/logs',
+  '/jobs/:id/tasks/:taskID/logs/:filePath',
   '/jobs/:id/tasks/:taskID/files/view(/:filePath(/:innerPath))',
 
   '/networking/networks/:overlayName/tasks/:taskID/details',
-  '/networking/networks/:overlayName/tasks/:taskID/logs(/:filePath)',
+  '/networking/networks/:overlayName/tasks/:taskID/logs',
+  '/networking/networks/:overlayName/tasks/:taskID/logs/:filePath',
   '/networking/networks/:overlayName/tasks/:taskID/files/view(/:filePath(/:innerPath))',
 
   '/nodes/:nodeID/tasks/:taskID/details',
-  '/nodes/:nodeID/tasks/:taskID/logs(/:filePath)',
+  '/nodes/:nodeID/tasks/:taskID/logs',
+  '/nodes/:nodeID/tasks/:taskID/logs/:filePath',
   '/nodes/:nodeID/tasks/:taskID/files/view(/:filePath(/:innerPath))',
 
   '/services/overview/:id/tasks/:taskID/details',
-  '/services/overview/:id/tasks/:taskID/logs(/:filePath)',
+  '/services/overview/:id/tasks/:taskID/logs',
+  '/services/overview/:id/tasks/:taskID/logs/:filePath',
   '/services/overview/:id/tasks/:taskID/files/view(/:filePath(/:innerPath))'
 ];
 

--- a/plugins/services/src/js/pages/task-details/TaskFileViewer.js
+++ b/plugins/services/src/js/pages/task-details/TaskFileViewer.js
@@ -44,7 +44,14 @@ class TaskFileViewer extends React.Component {
       return;
     }
 
-    const routePath = RouterUtil.reconstructPathFromRoutes(routes);
+    let routePath = RouterUtil.reconstructPathFromRoutes(routes);
+    const hasFilePathParam = routePath.endsWith(':filePath');
+    if (!hasFilePathParam && routePath.endsWith('/')) {
+      routePath += ':filePath';
+    }
+    if (!hasFilePathParam && !routePath.endsWith('/')) {
+      routePath += '/:filePath';
+    }
     this.context.router.push(formatPattern(
       routePath,
       Object.assign({}, params, {filePath: encodeURIComponent(path)})

--- a/plugins/services/src/js/pages/task-details/TaskFileViewer.js
+++ b/plugins/services/src/js/pages/task-details/TaskFileViewer.js
@@ -65,11 +65,14 @@ class TaskFileViewer extends React.Component {
       return logViews;
     }
 
+    const limitLogFilesIsNotEmpty = limitLogFiles.length > 0;
+
     directory.getItems().forEach((item) => {
       const excludeFile = (
-        limitLogFiles.length > 0 &&
+        limitLogFilesIsNotEmpty &&
         !limitLogFiles.includes(item.getName())
       );
+
       if (!item.isLogFile() || excludeFile) {
         return;
       }

--- a/plugins/services/src/js/pages/task-details/TaskLogsContainer.js
+++ b/plugins/services/src/js/pages/task-details/TaskLogsContainer.js
@@ -2,12 +2,12 @@ import mixin from 'reactjs-mixin';
 import React from 'react';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
+import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
+import {SYSTEM_LOGS} from '../../../../../../src/js/constants/MesosLoggingStrategy';
 import ConfigStore from '../../../../../../src/js/stores/ConfigStore';
 import Loader from '../../../../../../src/js/components/Loader';
-import {SYSTEM_LOGS} from '../../../../../../src/js/constants/MesosLoggingStrategy';
-import TaskSystemLogsContainer from './TaskSystemLogsContainer';
 import TaskFileViewer from './TaskFileViewer';
-import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
+import TaskSystemLogsContainer from './TaskSystemLogsContainer';
 
 class TaskLogsContainer extends mixin(StoreMixin) {
   constructor() {

--- a/plugins/services/src/js/routes/services.js
+++ b/plugins/services/src/js/routes/services.js
@@ -210,7 +210,7 @@ const serviceRoutes = [
                         component: TaskLogsContainer,
                         hideHeaderNavigation: true,
                         isTab: true,
-                        path: 'logs(/:filePath)',
+                        path: 'logs',
                         title: 'Logs',
                         type: Route,
                         buildBreadCrumb() {
@@ -218,7 +218,13 @@ const serviceRoutes = [
                             parentCrumb: '/services/overview/:id/tasks/:taskID',
                             getCrumbs() { return []; }
                           };
-                        }
+                        },
+                        children: [
+                          {
+                            path: ':filePath',
+                            type: Route
+                          }
+                        ]
                       },
                       {
                         component: VolumeTable,

--- a/src/js/routes/factories/network.js
+++ b/src/js/routes/factories/network.js
@@ -156,7 +156,7 @@ const RouteFactory = {
             component: TaskLogsContainer,
             hideHeaderNavigation: true,
             isTab: true,
-            path: 'logs(/:filePath)',
+            path: 'logs',
             title: 'Logs',
             type: Route,
             buildBreadCrumb() {
@@ -164,7 +164,13 @@ const RouteFactory = {
                 parentCrumb: '/networking/networks/:overlayName/tasks/:taskID',
                 getCrumbs() { return []; }
               };
-            }
+            },
+            children: [
+              {
+                path: ':filePath',
+                type: Route
+              }
+            ]
           }
         ]
       }

--- a/src/js/routes/jobs.js
+++ b/src/js/routes/jobs.js
@@ -145,7 +145,7 @@ const jobsRoutes = {
                   component: TaskLogsContainer,
                   hideHeaderNavigation: true,
                   isTab: true,
-                  path: 'logs(/:filePath)',
+                  path: 'logs',
                   title: 'Logs',
                   type: Route,
                   buildBreadCrumb() {
@@ -153,7 +153,13 @@ const jobsRoutes = {
                       parentCrumb: '/jobs/:id/tasks/:taskID',
                       getCrumbs() { return []; }
                     };
-                  }
+                  },
+                  children: [
+                    {
+                      path: ':filePath',
+                      type: Route
+                    }
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
---
~~⚠️ Depends on this PR: https://github.com/dcos/dcos-ui/pull/1954~~ (merged)

---

This PR fixes the log tab not being highlighted for sub-routes

Please set this in your config dev:
```js
mesos: {
  'logging-strategy': 'logrotate'
},
```

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

For reviewers: View diff between PRs [here](https://github.com/dcos/dcos-ui/compare/mlunoe/feature/DCOS-14010-add-container-to-pick-logging-component-and-api...mlunoe/bug-fix/DCOS-14010-fix-tab-not-being-highlighted-for-log-tab-sub-routes?expand=1)