### PR TITLE
DCOS-14277: Fix pod container status string

### DIFF
--- a/plugins/services/src/js/constants/PodContainerStatus.js
+++ b/plugins/services/src/js/constants/PodContainerStatus.js
@@ -68,7 +68,7 @@ const POD_CONTAINER_STATUS = {
   FINISHED: {
     dotClassName: 'dot inactive danger',
     textClassName: '',
-    displayName: 'Killed',
+    displayName: 'Completed',
     healthStatus: 'NA'
   },
   LOST: {

--- a/plugins/services/src/js/constants/PodInstanceStatus.js
+++ b/plugins/services/src/js/constants/PodInstanceStatus.js
@@ -29,6 +29,12 @@ const POD_INSTANCE_STATUS = {
     displayName: 'Killed',
     healthStatus: 'NA'
   },
+  FINISHED: {
+    dotClassName: 'dot inactive danger',
+    textClassName: '',
+    displayName: 'Completed',
+    healthStatus: 'NA'
+  },
   NA: {
     dotClassName: 'dot inactive unknown',
     textClassName: '',

--- a/plugins/services/src/js/structs/PodInstance.js
+++ b/plugins/services/src/js/structs/PodInstance.js
@@ -1,5 +1,6 @@
 import Item from '../../../../../src/js/structs/Item';
 import PodContainer from './PodContainer';
+import PodContainerStatus from '../constants/PodContainerStatus';
 import PodInstanceStatus from '../constants/PodInstanceStatus';
 import PodInstanceState from '../constants/PodInstanceState';
 import StringUtil from '../../../../../src/js/utils/StringUtil';
@@ -53,6 +54,19 @@ module.exports = class PodInstance extends Item {
         return PodInstanceStatus.UNHEALTHY;
 
       case PodInstanceState.TERMINAL:
+
+        // If all containers are in completed state, mark us as completed
+        const containers = this.getContainers();
+        const isFinished = (containers.length > 0) && containers.every(
+          function (container) {
+            return container.getContainerStatus() === PodContainerStatus.FINISHED;
+          }
+        );
+
+        if (isFinished) {
+          return PodInstanceStatus.FINISHED;
+        }
+
         return PodInstanceStatus.KILLED;
 
       default:

--- a/plugins/services/src/js/structs/__tests__/PodInstance-test.js
+++ b/plugins/services/src/js/structs/__tests__/PodInstance-test.js
@@ -63,6 +63,26 @@ describe('PodInstance', function () {
 
   });
 
+  describe('#getStatus', function () {
+
+    it('should return FINISHED when all containers are FINISHED', function () {
+      const podInstance = new PodInstance({
+        status: 'terminal',
+        containers: [
+          {
+            status: 'TASK_FINISHED'
+          }
+        ]
+      });
+
+      // when we are in TERMINAL state, but all containers are FINISHED, then
+      // we should be considered FINISHED too.
+      expect(podInstance.getInstanceStatus())
+        .toEqual(PodInstanceStatus.FINISHED);
+    });
+
+  });
+
   describe('#getInstanceStatus', function () {
 
     it('should correctly detect container in PENDING state', function () {


### PR DESCRIPTION
This PR fixes a typo in the `PodContainerStatus.js` and introduces the new `PodInstanceStatus.js` state `FINISHED` that will be used when the pod is in `terminal` state, yet all of it's containers are in `FINISHED` state.

Before:

![image](https://cloud.githubusercontent.com/assets/883486/23745560/eedaf5fe-04b8-11e7-8676-78d2cde05c61.png)

After:

![image](https://cloud.githubusercontent.com/assets/883486/23745511/c7162494-04b8-11e7-8a03-74de85072456.png)


**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
