### PR TITLE
Change LogView container offset

### DIFF
--- a/plugins/services/src/js/components/LogView.js
+++ b/plugins/services/src/js/components/LogView.js
@@ -34,12 +34,15 @@ class LogView extends React.Component {
     // as possible. This has impact on both checkIfCloseToTop and
     // checkIfAwayFromBottom. Trailing edge will call them too late, i.e. when
     // the data is out of data and possibly scrolled passed the trigger range.
+    // We also want it at the trailing end because if a user scrolls too fast
+    // there's a chance that the callback will get fired but not where the
+    // scrolling position has ended.
     // We need them to be called as soon as we hit the range wherein these will
     // trigger handlers.
     this.handleLogContainerScroll = Util.throttle(
       this.handleLogContainerScroll,
       50,
-      {leading: true, trailing: false}
+      {leading: true, trailing: true}
     );
 
     this.handleWindowResize = Util.throttle(

--- a/plugins/services/src/js/components/LogView.js
+++ b/plugins/services/src/js/components/LogView.js
@@ -8,7 +8,7 @@ import Highlight from './Highlight';
 import Loader from '../../../../../src/js/components/Loader';
 import Util from '../../../../../src/js/utils/Util';
 
-const CONTAINER_OFFSET_HEIGHT = 200;
+const CONTAINER_OFFSET_HEIGHT = 25;
 
 const METHODS_TO_BIND = [
   'handleGoToBottom',


### PR DESCRIPTION
When I was testing out the log viewer I noticed that if I scrolled up a  little and a new log line would come through, the autoscroll would kick in, thinking that I was at the bottom, but I scrolled up just a bit. This confused me and frustrated me, so I've lowered this buffer that we have to something really small.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
