### PR TITLE
Update reactjs-components to 0.16.0-beta.13

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6816,9 +6816,9 @@
       "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz"
     },
     "reactjs-components": {
-      "version": "0.16.0-beta.9",
-      "from": "reactjs-components@0.16.0-beta.9",
-      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.16.0-beta.9.tgz"
+      "version": "0.16.0-beta.13",
+      "from": "reactjs-components@0.16.0-beta.13",
+      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.16.0-beta.13.tgz"
     },
     "reactjs-mixin": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-gemini-scrollbar": "2.1.0",
     "react-redux": "4.4.0",
     "react-router": "2.8.1",
-    "reactjs-components": "0.16.0-beta.9",
+    "reactjs-components": "0.16.0-beta.13",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
     "tv4": "1.2.7"

--- a/src/js/pages/universe/__tests__/PackagesTab-test.js
+++ b/src/js/pages/universe/__tests__/PackagesTab-test.js
@@ -65,38 +65,6 @@ describe('PackagesTab', function () {
 
   });
 
-  describe('#handleInstallModalOpen', function () {
-
-    beforeEach(function () {
-      this.instance.handleInstallModalOpen =
-        jasmine.createSpy('handleInstallModalOpen');
-      this.instance.context = {
-        router: {
-          push: jasmine.createSpy()
-        }
-      };
-      jest.runAllTimers();
-    });
-
-    it('should call handler when panel button is clicked', function () {
-      var panelButton = ReactDOM.findDOMNode(this.instance)
-        .querySelector('.panel .button');
-      TestUtils.Simulate.click(panelButton);
-      expect(
-        this.instance.handleInstallModalOpen.calls.mostRecent().args[0].get('name')
-      ).toEqual('arangodb');
-    });
-
-    it('shouldn\'t call handler when panel is clicked', function () {
-      var panel = ReactDOM.findDOMNode(this.instance)
-        .querySelector('.panel.clickable');
-      TestUtils.Simulate.click(panel);
-
-      expect(this.instance.handleInstallModalOpen).not.toHaveBeenCalled();
-    });
-
-  });
-
   describe('#getSelectedPackages', function () {
 
     beforeEach(function () {

--- a/tests/pages/universe/packages/PackagesTab-cy.js
+++ b/tests/pages/universe/packages/PackagesTab-cy.js
@@ -114,4 +114,28 @@ describe('Packages Tab', function () {
     });
   });
 
+  context('package panels', function () {
+    beforeEach(function () {
+      cy.visitUrl({url: '/universe', logIn: true});
+      cy.get('.panel').as('panels');
+    });
+
+    it('should open the modal when the panel button is clicked', function () {
+      cy.get('.panel .button').click();
+
+      cy.get('.modal').should(function ($modal) {
+        expect($modal.length).to.equal(1);
+      });
+    });
+
+    it('shouldn\'t open the modal when the panel is clicked', function () {
+      cy.get('.panel').click();
+
+      cy.get('.modal').should(function ($modal) {
+        expect($modal.length).to.equal(0);
+      });
+    });
+
+  });
+
 });


### PR DESCRIPTION
This PR updates `reactjs-components` to `0.16.0-beta.13` which includes the following changes:
1. [Specify c++ version for Travis build](https://github.com/mesosphere/reactjs-components/pull/389)
2. [Update stylelint deps](https://github.com/mesosphere/reactjs-components/pull/388)
3. [Make virtual list bind its onScroll function correctly](https://github.com/mesosphere/reactjs-components/pull/391)
4. [Fix modal height calculations in IE11](https://github.com/mesosphere/reactjs-components/pull/393)
5. [Explicitly set dropdown positioning properties to auto](https://github.com/mesosphere/reactjs-components/pull/394)
6. [Push commit and tags in release script](https://github.com/mesosphere/reactjs-components/pull/395)
7. [Properly remove event listener](https://github.com/mesosphere/reactjs-components/pull/396)

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?