### PR TITLE
DCOS_OSS-733: Corrupted log files

### DIFF
--- a/plugins/services/src/js/components/LogView.js
+++ b/plugins/services/src/js/components/LogView.js
@@ -199,7 +199,6 @@ class LogView extends React.Component {
 
     if (isAtBottom !== this.state.isAtBottom) {
       this.setState({isAtBottom});
-      this.props.onAtBottomChange(isAtBottom);
     }
 
   }
@@ -313,7 +312,6 @@ LogView.defaultProps = {
   hasLoadedTop: false,
   highlightText: '',
   fetchPreviousLogs() {},
-  onAtBottomChange() {},
   onCountChange() {}
 };
 
@@ -321,7 +319,6 @@ LogView.propTypes = {
   hasLoadedTop: React.PropTypes.bool,
   highlightText: React.PropTypes.string,
   fetchPreviousLogs: React.PropTypes.func,
-  onAtBottomChange: React.PropTypes.func,
   onCountChange: React.PropTypes.func,
   logName: React.PropTypes.string,
   watching: React.PropTypes.number

--- a/plugins/services/src/js/components/MesosLogContainer.js
+++ b/plugins/services/src/js/components/MesosLogContainer.js
@@ -10,7 +10,6 @@ import TaskDirectoryStore from '../stores/TaskDirectoryStore';
 import {APPEND} from '../../../../../src/js/constants/SystemLogTypes';
 
 const METHODS_TO_BIND = [
-  'handleAtBottomChange',
   'handleGoToWorkingDirectory',
   'handleFetchPreviousLog',
   'onMesosLogStoreError',
@@ -159,16 +158,6 @@ class MesosLogContainer extends mixin(StoreMixin) {
     TaskDirectoryStore.setPath(this.props.task, '');
   }
 
-  handleAtBottomChange(isAtBottom) {
-    const {task, filePath} = this.props;
-    if (isAtBottom) {
-      // Do not request anymore backwards, but continue stream where we left off
-      MesosLogStore.startTailing(task.slave_id, filePath);
-    } else {
-      MesosLogStore.stopTailing(filePath);
-    }
-  }
-
   handleFetchPreviousLog(props = this.props) {
     const {isFetchingPrevious} = this.state;
     const {task, filePath} = props;
@@ -207,7 +196,6 @@ class MesosLogContainer extends mixin(StoreMixin) {
         hasLoadedTop={MesosLogStore.hasLoadedTop(filePath)}
         highlightText={highlightText}
         logName={logName}
-        onAtBottomChange={this.handleAtBottomChange}
         onCountChange={onCountChange}
         watching={watching} />
     );

--- a/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
+++ b/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
@@ -16,7 +16,6 @@ import SystemLogStore from '../../../../../../src/js/stores/SystemLogStore';
 import SystemLogUtil from '../../../../../../src/js/utils/SystemLogUtil';
 
 const METHODS_TO_BIND = [
-  'handleAtBottomChange',
   'handleFetchPreviousLog',
   'handleItemSelection'
 ];
@@ -194,22 +193,6 @@ class TaskSystemLogsContainer extends mixin(StoreMixin) {
     this.setState({isFetchingPrevious: true});
   }
 
-  handleAtBottomChange(isAtBottom) {
-    const {task} = this.props;
-    const {subscriptionID} = this.state;
-    if (isAtBottom) {
-      // Do not request anymore backwards, but continue stream where we left off
-      const params = getLogParameters(task, {
-        filter: {STREAM: this.state.selectedStream},
-        limit: 0,
-        subscriptionID
-      });
-      SystemLogStore.startTailing(this.props.task.slave_id, params);
-    } else {
-      SystemLogStore.stopTailing(this.state.subscriptionID);
-    }
-  }
-
   handleViewChange(selectedStream) {
     const {task} = this.props;
     // Limit 0 means continuous stream
@@ -344,7 +327,6 @@ class TaskSystemLogsContainer extends mixin(StoreMixin) {
         hasLoadedTop={SystemLogStore.hasLoadedTop(subscriptionID)}
         highlightText={highlightText}
         logName={selectedStream}
-        onAtBottomChange={this.handleAtBottomChange}
         onCountChange={onCountChange}
         watching={watching} />
     );

--- a/plugins/services/src/js/stores/MesosLogStore.js
+++ b/plugins/services/src/js/stores/MesosLogStore.js
@@ -100,15 +100,17 @@ class MesosLogStore extends BaseStore {
     }
 
     let startOffset = logBuffer.getStart() - MAX_FILE_SIZE;
+    let length = MAX_FILE_SIZE;
     if (startOffset < 0) {
       startOffset = 0;
+      length = logBuffer.getStart();
     }
 
     MesosLogActions.fetchPreviousLog(
       slaveID,
       path,
       startOffset,
-      MAX_FILE_SIZE
+      length
     );
   }
 

--- a/plugins/services/src/js/stores/__tests__/MesosLogStore-test.js
+++ b/plugins/services/src/js/stores/__tests__/MesosLogStore-test.js
@@ -89,7 +89,7 @@ describe('MesosLogStore', function () {
       expect(MesosLogActions.fetchPreviousLog).not.toHaveBeenCalled();
     });
 
-    it('calls #fetchPreviousLog with the correct args', function () {
+    it('adjusts length when reaching the top', function () {
       var MockMesosLogStore = {
         getLogBuffer(key) {
           if (key === 'exists') {
@@ -106,7 +106,28 @@ describe('MesosLogStore', function () {
       );
 
       expect(MesosLogActions.fetchPreviousLog).toHaveBeenCalledWith(
-        'slaveID', 'exists', 0, 50000
+        'slaveID', 'exists', 0, 100
+      );
+    });
+
+    it('requests full page when below top', function () {
+      var MockMesosLogStore = {
+        getLogBuffer(key) {
+          if (key === 'exists') {
+            return {
+              hasLoadedTop() { return false; },
+              getStart() { return 50100; }
+            };
+          }
+        }
+      };
+
+      MesosLogStore.getPreviousLogs.call(
+        MockMesosLogStore, 'slaveID', 'exists'
+      );
+
+      expect(MesosLogActions.fetchPreviousLog).toHaveBeenCalledWith(
+        'slaveID', 'exists', 100, 50000
       );
     });
 


### PR DESCRIPTION
This PR fixes issues that will corrupt the logs.

To test this out create a task that echos something every 1s, page upwards through the file. If you pause paging upwards and then continue you will see one issue that will corrupt the log files, since the offset would not be updated in the mesos logs.

The second issue emerges at the top. Whenever you have paged all the way to the top you will see corrupt log files since we would not properly update the requested page length at the top.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [x] If this is a regression, did you write a test to catch this in the future?
