### PR TITLE
DCOS-14431: Fix memory leak where events would not be closed properly

### DIFF
--- a/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
+++ b/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
@@ -5,7 +5,7 @@ import mixin from 'reactjs-mixin';
 import React from 'react';
 import {StoreMixin} from 'mesosphere-shared-reactjs';
 
-import {APPEND} from '../../../../../../src/js/constants/SystemLogTypes';
+import {APPEND, PREPEND} from '../../../../../../src/js/constants/SystemLogTypes';
 import LogView from '../../components/LogView';
 import Loader from '../../../../../../src/js/components/Loader';
 import MesosStateUtil from '../../../../../../src/js/utils/MesosStateUtil';
@@ -110,16 +110,22 @@ class TaskSystemLogsContainer extends mixin(StoreMixin) {
     );
   }
 
-  onSystemLogStoreError(subscriptionID) {
+  onSystemLogStoreError(subscriptionID, direction) {
     if (subscriptionID !== this.state.subscriptionID) {
       return;
     }
 
-    this.setState({
+    const newState = {
       hasError: true,
-      isFetchingPrevious: false,
       isLoading: false
-    });
+    };
+
+    // Only set isFetchingPrevious when we receive prepending log event
+    if (this.state.isFetchingPrevious && direction === PREPEND) {
+      newState.isFetchingPrevious = false;
+    }
+
+    this.setState(newState);
   }
 
   onSystemLogStoreSuccess(subscriptionID, direction) {
@@ -133,13 +139,19 @@ class TaskSystemLogsContainer extends mixin(StoreMixin) {
       this.handleFetchPreviousLog();
     }
 
-    this.setState({
+    const newState = {
       hasError: false,
       direction,
-      isFetchingPrevious: false,
       isLoading: false,
       fullLog: SystemLogStore.getFullLog(subscriptionID)
-    });
+    };
+
+    // Only set isFetchingPrevious when we receive prepending log event
+    if (this.state.isFetchingPrevious && direction === PREPEND) {
+      newState.isFetchingPrevious = false;
+    }
+
+    this.setState(newState);
   }
 
   onSystemLogStoreStreamError() {
@@ -179,6 +191,8 @@ class TaskSystemLogsContainer extends mixin(StoreMixin) {
       return;
     }
 
+    this.setState({isFetchingPrevious: true});
+
     const {task} = this.props;
     const {subscriptionID} = this.state;
 
@@ -189,8 +203,8 @@ class TaskSystemLogsContainer extends mixin(StoreMixin) {
       limit: PAGE_ENTRY_COUNT,
       subscriptionID
     });
+
     SystemLogStore.fetchRange(task.slave_id, params);
-    this.setState({isFetchingPrevious: true});
   }
 
   handleViewChange(selectedStream) {

--- a/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
+++ b/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
@@ -189,7 +189,7 @@ class TaskSystemLogsContainer extends mixin(StoreMixin) {
       limit: PAGE_ENTRY_COUNT,
       subscriptionID
     });
-    SystemLogStore.fetchLogRange(task.slave_id, params);
+    SystemLogStore.fetchRange(task.slave_id, params);
     this.setState({isFetchingPrevious: true});
   }
 

--- a/src/js/events/SystemLogActions.js
+++ b/src/js/events/SystemLogActions.js
@@ -83,7 +83,7 @@ const SystemLogActions = {
     this.stopTail(subscriptionID);
 
     const url = SystemLogUtil.getUrl(nodeID, options);
-    subscriptionID = subscriptionID || Symbol(url + Date.now());
+    subscriptionID = subscriptionID || Symbol.for(url);
 
     function messageListener({data, origin} = {}) {
       if (origin !== global.location.origin) {
@@ -160,7 +160,7 @@ const SystemLogActions = {
       Object.assign(options, {read_reverse: true}),
       false
     );
-    subscriptionID = subscriptionID || Symbol(url + Date.now());
+    subscriptionID = subscriptionID || Symbol.for(url);
 
     const items = [];
 

--- a/src/js/events/SystemLogActions.js
+++ b/src/js/events/SystemLogActions.js
@@ -39,7 +39,7 @@ const SystemLogActions = {
    * @param {String} [options.read_reverse] will read events in reverse order if set to true
    * @return {Symbol} subscriptionID to unsubscribe or resubscribe with
    */
-  subscribe(nodeID, options = {}) {
+  startTail(nodeID, options = {}) {
     let {subscriptionID, cursor, skip_prev} = options;
 
     // Unsubscribe if any open connection exists with the same ID

--- a/src/js/events/SystemLogActions.js
+++ b/src/js/events/SystemLogActions.js
@@ -43,7 +43,7 @@ const SystemLogActions = {
     let {subscriptionID, cursor, skip_prev} = options;
 
     // Unsubscribe if any open connection exists with the same ID
-    this.unsubscribe(subscriptionID);
+    this.stopTail(subscriptionID);
 
     const url = SystemLogUtil.getUrl(nodeID, options);
     subscriptionID = subscriptionID || Symbol(url + Date.now());
@@ -101,7 +101,7 @@ const SystemLogActions = {
    * Unsubscribes from the event stream from the given subscriptionID
    * @param {String} subscriptionID ID returned from subscribe function
    */
-  unsubscribe(subscriptionID) {
+  stopTail(subscriptionID) {
     if (sources[subscriptionID]) {
       // Clean up event listeners
       const {errorListener, messageListener, source} = sources[subscriptionID];

--- a/src/js/events/SystemLogActions.js
+++ b/src/js/events/SystemLogActions.js
@@ -161,11 +161,9 @@ const SystemLogActions = {
       false
     );
     subscriptionID = subscriptionID || Symbol(url + Date.now());
-    const source = new EventSource(url, {
-      withCredentials: Boolean(CookieUtils.getUserMetadata())
-    });
 
     const items = [];
+
     function messageListener({data, origin} = {}) {
       if (origin !== global.location.origin) {
         // Ignore events that are not from this origin
@@ -205,16 +203,11 @@ const SystemLogActions = {
           subscriptionID
         });
       }
-      // Clean up event listeners
-      source.removeEventListener('message', messageListener);
-      source.removeEventListener('error', errorListener);
-      // Close connection,
-      // no need to delete source as the reference is not stored
-      source.close();
+
+      unsubscribe(subscriptionID);
     }
 
-    source.addEventListener('message', messageListener, false);
-    source.addEventListener('error', errorListener, false);
+    subscribe(url, subscriptionID, messageListener, errorListener);
   },
 
   fetchStreamTypes(nodeID) {

--- a/src/js/events/SystemLogActions.js
+++ b/src/js/events/SystemLogActions.js
@@ -151,7 +151,7 @@ const SystemLogActions = {
    * @param {String} [options.executorID] ID for executor to retrieve logs from
    * @param {String} [options.containerID] ID for container to retrieve logs from
    */
-  fetchLogRange(nodeID, options = {}) {
+  fetchRange(nodeID, options = {}) {
     let {limit, subscriptionID} = options;
     const url = SystemLogUtil.getUrl(
       nodeID,

--- a/src/js/events/__tests__/SystemLogActions-test.js
+++ b/src/js/events/__tests__/SystemLogActions-test.js
@@ -36,15 +36,15 @@ describe('SystemLogActions', function () {
     this.eventSource.close();
   });
 
-  describe('#subscribe', function () {
+  describe('#startTail', function () {
 
     beforeEach(function () {
-      SystemLogActions.subscribe('foo', {cursor: 'bar', subscriptionID: 'subscriptionID'});
+      SystemLogActions.startTail('foo', {cursor: 'bar', subscriptionID: 'subscriptionID'});
     });
 
     it('calls #addEventListener from the global.EventSource', function () {
       this.eventSource.addEventListener = jasmine.createSpy('addEventListener').and.callThrough();
-      SystemLogActions.subscribe('foo', {cursor: 'bar'});
+      SystemLogActions.startTail('foo', {cursor: 'bar'});
       expect(this.eventSource.addEventListener).toHaveBeenCalled();
     });
 
@@ -63,7 +63,7 @@ describe('SystemLogActions', function () {
         return cookieObj;
       };
 
-      SystemLogActions.subscribe('foo', {cursor: 'bar'});
+      SystemLogActions.startTail('foo', {cursor: 'bar'});
       const mostRecent = global.EventSource.calls.mostRecent();
       expect(mostRecent.args[1]).toEqual({withCredentials: false});
     });
@@ -127,7 +127,7 @@ describe('SystemLogActions', function () {
   describe('#unsubscribe', function () {
 
     beforeEach(function () {
-      SystemLogActions.subscribe('foo', {cursor: 'bar', subscriptionID: 'subscriptionID'});
+      SystemLogActions.startTail('foo', {cursor: 'bar', subscriptionID: 'subscriptionID'});
     });
 
     it('calls #close on the EventSource', function () {

--- a/src/js/events/__tests__/SystemLogActions-test.js
+++ b/src/js/events/__tests__/SystemLogActions-test.js
@@ -124,7 +124,7 @@ describe('SystemLogActions', function () {
 
   });
 
-  describe('#unsubscribe', function () {
+  describe('#stopTail', function () {
 
     beforeEach(function () {
       SystemLogActions.startTail('foo', {cursor: 'bar', subscriptionID: 'subscriptionID'});
@@ -132,14 +132,14 @@ describe('SystemLogActions', function () {
 
     it('calls #close on the EventSource', function () {
       this.eventSource.close = jasmine.createSpy('close');
-      SystemLogActions.unsubscribe('subscriptionID');
+      SystemLogActions.stopTail('subscriptionID');
       expect(this.eventSource.close).toHaveBeenCalled();
     });
 
     it('unsubscribes event listeners on message', function () {
       this.messageSpy = jasmine.createSpy('message');
       this.eventSource.addEventListener('message', this.messageSpy);
-      SystemLogActions.unsubscribe('subscriptionID');
+      SystemLogActions.stopTail('subscriptionID');
 
       const event = {
         data: '{}',

--- a/src/js/events/__tests__/SystemLogActions-test.js
+++ b/src/js/events/__tests__/SystemLogActions-test.js
@@ -153,10 +153,10 @@ describe('SystemLogActions', function () {
 
   });
 
-  describe('#fetchLogRange', function () {
+  describe('#fetchRange', function () {
 
     beforeEach(function () {
-      SystemLogActions.fetchLogRange(
+      SystemLogActions.fetchRange(
         'foo',
         {cursor: 'bar', limit: 3, subscriptionID: 'subscriptionID'}
       );
@@ -165,7 +165,7 @@ describe('SystemLogActions', function () {
     it('calls #addEventListener from the EventSource', function () {
       this.eventSource.addEventListener = jasmine.createSpy('addEventListener')
         .and.callThrough();
-      SystemLogActions.fetchLogRange('foo', {cursor: 'bar'});
+      SystemLogActions.fetchRange('foo', {cursor: 'bar'});
       expect(this.eventSource.addEventListener).toHaveBeenCalled();
     });
 
@@ -184,7 +184,7 @@ describe('SystemLogActions', function () {
         return cookieObj;
       };
 
-      SystemLogActions.fetchLogRange('foo', {cursor: 'bar'});
+      SystemLogActions.fetchRange('foo', {cursor: 'bar'});
       const mostRecent = global.EventSource.calls.mostRecent();
       expect(mostRecent.args[1]).toEqual({withCredentials: false});
     });

--- a/src/js/stores/SystemLogStore.js
+++ b/src/js/stores/SystemLogStore.js
@@ -172,7 +172,7 @@ class SystemLogStore extends BaseStore {
       delete this.logs[subscriptionID];
     }
 
-    SystemLogActions.unsubscribe(subscriptionID);
+    SystemLogActions.stopTail(subscriptionID);
   }
 
   fetchLogRange(nodeID, options) {

--- a/src/js/stores/SystemLogStore.js
+++ b/src/js/stores/SystemLogStore.js
@@ -175,7 +175,7 @@ class SystemLogStore extends BaseStore {
     SystemLogActions.stopTail(subscriptionID);
   }
 
-  fetchLogRange(nodeID, options) {
+  fetchRange(nodeID, options) {
     const {subscriptionID} = options;
     const cursor = findNestedPropertyInObject(
       this.logs[subscriptionID],
@@ -185,7 +185,7 @@ class SystemLogStore extends BaseStore {
       return false;
     }
 
-    SystemLogActions.fetchLogRange(
+    SystemLogActions.fetchRange(
       nodeID,
       Object.assign({cursor}, options)
     );

--- a/src/js/stores/SystemLogStore.js
+++ b/src/js/stores/SystemLogStore.js
@@ -149,7 +149,7 @@ class SystemLogStore extends BaseStore {
     }
 
     // Will return unchanged subscriptionID if provided in the options
-    subscriptionID = SystemLogActions.subscribe(nodeID, options);
+    subscriptionID = SystemLogActions.startTail(nodeID, options);
 
     // Start a timer to notify view if we have received nothing
     // within reasonable time

--- a/src/js/stores/SystemLogStore.js
+++ b/src/js/stores/SystemLogStore.js
@@ -212,7 +212,7 @@ class SystemLogStore extends BaseStore {
     if (!this.logs[subscriptionID]) {
       this.logs[subscriptionID] = {entries: [], totalSize: 0};
     }
-    this.emit(SYSTEM_LOG_REQUEST_ERROR, subscriptionID, data);
+    this.emit(SYSTEM_LOG_REQUEST_ERROR, subscriptionID, APPEND, data);
   }
 
   processLogPrepend(subscriptionID, firstEntry, entries = []) {
@@ -235,7 +235,7 @@ class SystemLogStore extends BaseStore {
     if (!this.logs[subscriptionID]) {
       this.logs[subscriptionID] = {entries: [], totalSize: 0};
     }
-    this.emit(SYSTEM_LOG_REQUEST_ERROR, subscriptionID, data);
+    this.emit(SYSTEM_LOG_REQUEST_ERROR, subscriptionID, PREPEND, data);
   }
 
   get storeID() {

--- a/src/js/stores/__tests__/SystemLogStore-test.js
+++ b/src/js/stores/__tests__/SystemLogStore-test.js
@@ -316,6 +316,7 @@ describe('SystemLogStore', function () {
 
       expect(changeHandler).toHaveBeenCalledWith(
         'subscriptionID',
+        SystemLogTypes.APPEND,
         {error: 'foo'}
       );
     });
@@ -353,6 +354,7 @@ describe('SystemLogStore', function () {
 
       expect(changeHandler).toHaveBeenCalledWith(
         'subscriptionID',
+        SystemLogTypes.APPEND,
         {error: 'foo'}
       );
     });


### PR DESCRIPTION
Refactor the `SystemLogActions` to improve the log view performance. 

* Introduce a general (un)subscribe functions
* Change the default subscription ID not to change if the URL is the same
* Unify the (un)subscribe handling to make sure event listeners are properly removed

Closes DCOS-14431

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
