### PR TITLE
IE11: Fix bug where log viewer doesn't scroll

### DIFF
--- a/src/styles/layout/page-body/styles.less
+++ b/src/styles/layout/page-body/styles.less
@@ -7,7 +7,7 @@
 
     &,
     .flex-item-shrink-1 {
-      min-height: 0;
+      min-height: 1px;
     }
   }
 }


### PR DESCRIPTION
This PR uses `min-height: 1px` instead of `min-height: 0` on a flex child that should shrink. This fixes a flexbox quirk in IE11.

Before (the content expands indefinitely, and scrolling is not possible):
![](https://cl.ly/1C1L2L3S0X16/Screen%20Shot%202017-03-10%20at%2010.59.34%20AM.png)

After:
![](https://cl.ly/243z2d2Z0E2G/Screen%20Shot%202017-03-10%20at%2010.58.09%20AM.png)

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?