### PR TITLE
Don't allow flex shrinking on page header

### DIFF
--- a/src/styles/components/page-header/styles.less
+++ b/src/styles/components/page-header/styles.less
@@ -4,7 +4,7 @@
 
   .page-header {
     .clearfix();
-    flex: 0 1 auto;
+    flex: 0 0 auto;
     position: relative;
 
     &:before {


### PR DESCRIPTION
This PR fixes a weird bug in IE11 where the `.page-header` element would grow a little bit when the `.page-body-content` content changed. I think it's due to the overflowing children of `.page-body-content`; the bug seems to occur when the content was overflowing, then isn't (due to its content changing to a loading indicator), and then back to overflowing (due to the content being loaded).

Reproduction steps (in IE11 only):
1. Navigate to the service detail page
2. Select a task to view the task detail page
3. Navigate between the tabs

Before:
![](https://cl.ly/3p0M3Z053B3o/Screen%20Recording%202017-03-10%20at%2001.45%20PM.gif)

After:
![](https://cl.ly/0j2v1o1c0W07/Screen%20Recording%202017-03-10%20at%2001.40%20PM.gif)

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?