### PR TITLE
DCOS-14449: Remove outdated volume marathon app validation

### DIFF
--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -88,7 +88,6 @@ const APP_VALIDATORS = [
   MarathonAppValidators.complyWithIpAddressRules,
   MarathonAppValidators.mustContainImageOnDocker,
   MarathonAppValidators.validateConstraints,
-  MarathonAppValidators.containerVolmesPath,
   MarathonAppValidators.mustNotContainUris,
   VipLabelsValidators.mustContainPort
 ];

--- a/plugins/services/src/js/reducers/serviceForm/Container.js
+++ b/plugins/services/src/js/reducers/serviceForm/Container.js
@@ -1,6 +1,9 @@
 import {combineReducers} from '../../../../../../src/js/utils/ReducerUtil';
 import {findNestedPropertyInObject} from '../../../../../../src/js/utils/Util';
-import {JSONReducer as volumes} from './Volumes';
+import {
+  FormReducer as volumesFormReducer,
+  JSONReducer as volumesJSONReducer
+} from './Volumes';
 import {SET, ADD_ITEM, REMOVE_ITEM} from '../../../../../../src/js/constants/TransactionTypes';
 import {simpleParser, combineParsers} from '../../../../../../src/js/utils/ParserUtil';
 import ContainerConstants from '../../constants/ContainerConstants';
@@ -85,7 +88,7 @@ const containerJSONReducer = combineReducers({
       return Object.assign({}, this.internalState);
     }
   },
-  volumes
+  volumes: volumesJSONReducer
 });
 
 const containerReducer = combineReducers({
@@ -125,7 +128,7 @@ const containerReducer = combineReducers({
       return newState;
     }
   },
-  volumes
+  volumes: volumesFormReducer
 });
 
 module.exports = {

--- a/plugins/services/src/js/reducers/serviceForm/ExternalVolumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/ExternalVolumes.js
@@ -3,6 +3,7 @@ import {
   REMOVE_ITEM,
   SET
 } from '../../../../../../src/js/constants/TransactionTypes';
+import {parseIntValue} from '../../../../../../src/js/utils/ReducerUtil';
 import Transaction from '../../../../../../src/js/structs/Transaction';
 
 module.exports = {
@@ -116,22 +117,23 @@ module.exports = {
 
       const index = path[1];
       if (type === SET && `externalVolumes.${index}.provider` === joinedPath) {
-        state[index].provider = value;
+        state[index].provider = String(value);
       }
       if (type === SET && `externalVolumes.${index}.options` === joinedPath) {
+        // Options is of type object, so we are not processing it
         state[index].options = value;
       }
       if (type === SET && `externalVolumes.${index}.name` === joinedPath) {
-        state[index].name = value;
+        state[index].name = String(value);
       }
       if (type === SET && `externalVolumes.${index}.containerPath` === joinedPath) {
-        state[index].containerPath = value;
+        state[index].containerPath = String(value);
       }
       if (type === SET && `externalVolumes.${index}.size` === joinedPath) {
-        state[index].size = value;
+        state[index].size = parseIntValue(value);
       }
       if (type === SET && `externalVolumes.${index}.mode` === joinedPath) {
-        state[index].mode = value;
+        state[index].mode = String(value);
       }
     }
 

--- a/plugins/services/src/js/reducers/serviceForm/LocalVolumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/LocalVolumes.js
@@ -3,6 +3,7 @@ import {
   REMOVE_ITEM,
   SET
 } from '../../../../../../src/js/constants/TransactionTypes';
+import {parseIntValue} from '../../../../../../src/js/utils/ReducerUtil';
 import Transaction from '../../../../../../src/js/structs/Transaction';
 
 module.exports = {
@@ -101,19 +102,19 @@ module.exports = {
 
       const index = joinedPath.match(/\d+/)[0];
       if (type === SET && `localVolumes.${index}.type` === joinedPath) {
-        state[index].type = value;
+        state[index].type = String(value);
       }
       if (type === SET && `localVolumes.${index}.size` === joinedPath) {
-        state[index].size = value;
+        state[index].size = parseIntValue(value);
       }
       if (type === SET && `localVolumes.${index}.mode` === joinedPath) {
-        state[index].mode = value;
+        state[index].mode = String(value);
       }
       if (type === SET && `localVolumes.${index}.containerPath` === joinedPath) {
-        state[index].containerPath = value;
+        state[index].containerPath = String(value);
       }
       if (type === SET && `localVolumes.${index}.hostPath` === joinedPath) {
-        state[index].hostPath = value;
+        state[index].hostPath = String(value);
       }
     }
 

--- a/plugins/services/src/js/reducers/serviceForm/MultiContainerVolumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/MultiContainerVolumes.js
@@ -136,10 +136,10 @@ module.exports = {
     }
 
     if (name === 'name') {
-      newState[index].name = value;
+      newState[index].name = String(value);
     }
     if (name === 'mountPath') {
-      newState[index].mountPath[secondIndex] = value;
+      newState[index].mountPath[secondIndex] = String(value);
     }
 
     return newState;

--- a/plugins/services/src/js/reducers/serviceForm/Volumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/Volumes.js
@@ -25,150 +25,152 @@ const filterHostVolumes = function (volume) {
   return volume.type !== 'HOST' || this.docker;
 };
 
-module.exports = {
-  JSONReducer(state, {type, path, value}) {
-    if (path == null) {
-      return state;
-    }
+// NB: This is being used as FormReducer and JSONReducer
+function reduceVolumes(state, {type, path, value}) {
+  if (path == null) {
+    return state;
+  }
 
-    // `this` is a context which is given to every reducer so it could
-    // cache information.
-    // In this case we are caching an two array's one for the localVolumes
-    // and one for externalVolumes we need this so that there index is
-    // fitting with the ones in ExternalVolumes. we combine them before
-    // returning.
-    if (this.externalVolumes == null) {
-      this.externalVolumes = [];
-    }
+  // `this` is a context which is given to every reducer so it could
+  // cache information.
+  // In this case we are caching an two array's one for the localVolumes
+  // and one for externalVolumes we need this so that there index is
+  // fitting with the ones in ExternalVolumes. we combine them before
+  // returning.
+  if (this.externalVolumes == null) {
+    this.externalVolumes = [];
+  }
 
-    if (this.localVolumes == null) {
-      this.localVolumes = [];
-    }
+  if (this.localVolumes == null) {
+    this.localVolumes = [];
+  }
 
-    if (this.docker == null) {
-      this.docker = false;
-    }
+  if (this.docker == null) {
+    this.docker = false;
+  }
 
-    const joinedPath = path.join('.');
+  const joinedPath = path.join('.');
 
-    // Make sure to parse as integer when possible
-    value = parseIntValue(value);
+  if (joinedPath === 'container.docker.image') {
+    this.docker = value !== '';
+  }
 
-    if (joinedPath === 'container.docker.image') {
-      this.docker = value !== '';
-    }
+  if (joinedPath === 'container.type') {
+    this.docker = value !== 'NONE';
+  }
 
-    if (joinedPath === 'container.type') {
-      this.docker = value !== 'NONE';
-    }
-
-    if (path[0] === 'externalVolumes') {
-      if (joinedPath === 'externalVolumes') {
-        switch (type) {
-          case ADD_ITEM:
-            this.externalVolumes.push({
-              containerPath: null,
-              external: {
-                name: null,
-                provider: 'dvdi',
-                options: {'dvdi/driver': 'rexray'}
-              },
-              mode: 'RW'
-            });
-            break;
-          case REMOVE_ITEM:
-            this.externalVolumes =
-              this.externalVolumes.filter((item, index) => {
-                return index !== value;
-              });
-            break;
-        }
-
-        /**
-         * localVolumes and externalVolumes share the same reducer and
-         * the section in the form but representing quite different things.
-         *
-         * Reducer should use the same format therefore we need to pick either
-         * localVolumes format or externalVolumes format.
-         * We picked externalVolumes format. External Volumes are just external volumes.
-         *
-         * The following code converts localVolumes by filtering HOST volumes and
-         * mapping them to the common structure
-         */
-        return [].concat(
-          this.localVolumes
-            .filter(filterHostVolumes.bind(this))
-            .map(mapLocalVolumes),
-          this.externalVolumes);
-      }
-
-      const index = path[1];
-      if (type === SET && `externalVolumes.${index}.provider` === joinedPath) {
-        this.externalVolumes[index].external.provider = value;
-      }
-      if (type === SET && `externalVolumes.${index}.options` === joinedPath) {
-        this.externalVolumes[index].external.options = value;
-      }
-      if (type === SET && `externalVolumes.${index}.name` === joinedPath) {
-        this.externalVolumes[index].external.name = value;
-      }
-      if (type === SET && `externalVolumes.${index}.containerPath` === joinedPath) {
-        this.externalVolumes[index].containerPath = value;
-      }
-      if (type === SET && `externalVolumes.${index}.size` === joinedPath) {
-        this.externalVolumes[index].external.size = parseIntValue(value);
-      }
-      if (type === SET && `externalVolumes.${index}.mode` === joinedPath) {
-        this.externalVolumes[index].mode = value;
-      }
-    }
-
-    if (joinedPath.search('localVolumes') !== -1) {
-      if (joinedPath === 'localVolumes') {
-        switch (type) {
-          case ADD_ITEM:
-            this.localVolumes.push({
-              containerPath: null,
-              persistent: {size: null},
-              mode: 'RW'
-            });
-            break;
-          case REMOVE_ITEM:
-            this.localVolumes = this.localVolumes.filter((item, index) => {
+  if (path[0] === 'externalVolumes') {
+    if (joinedPath === 'externalVolumes') {
+      switch (type) {
+        case ADD_ITEM:
+          this.externalVolumes.push({
+            containerPath: null,
+            external: {
+              name: null,
+              provider: 'dvdi',
+              options: {'dvdi/driver': 'rexray'}
+            },
+            mode: 'RW'
+          });
+          break;
+        case REMOVE_ITEM:
+          this.externalVolumes =
+            this.externalVolumes.filter((item, index) => {
               return index !== value;
             });
-            break;
-        }
-
-        return [].concat(
-          this.localVolumes
-            .filter(filterHostVolumes.bind(this))
-            .map(mapLocalVolumes),
-          this.externalVolumes);
+          break;
       }
 
-      const index = path[1];
-      if (type === SET && `localVolumes.${index}.size` === joinedPath) {
-        this.localVolumes[index].persistent.size = value;
-      }
-      if (type === SET && `localVolumes.${index}.type` === joinedPath) {
-        this.localVolumes[index].type = value;
-      }
-      if (type === SET && `localVolumes.${index}.mode` === joinedPath) {
-        this.localVolumes[index].mode = value;
-      }
-      if (type === SET && `localVolumes.${index}.hostPath` === joinedPath) {
-        this.localVolumes[index].hostPath = value;
-      }
-      if (type === SET && `localVolumes.${index}.containerPath` === joinedPath) {
-        this.localVolumes[index].containerPath = value;
-      }
+      /**
+       * localVolumes and externalVolumes share the same reducer and
+       * the section in the form but representing quite different things.
+       *
+       * Reducer should use the same format therefore we need to pick either
+       * localVolumes format or externalVolumes format.
+       * We picked externalVolumes format. External Volumes are just external volumes.
+       *
+       * The following code converts localVolumes by filtering HOST volumes and
+       * mapping them to the common structure
+       */
+      return [].concat(
+        this.localVolumes
+          .filter(filterHostVolumes.bind(this))
+          .map(mapLocalVolumes),
+        this.externalVolumes);
     }
 
-    return [].concat(
-      this.localVolumes
-        .filter(filterHostVolumes.bind(this))
-        .map(mapLocalVolumes),
-      this.externalVolumes);
+    const index = path[1];
+    if (type === SET && `externalVolumes.${index}.provider` === joinedPath) {
+      this.externalVolumes[index].external.provider = String(value);
+    }
+    if (type === SET && `externalVolumes.${index}.options` === joinedPath) {
+      // Options is of type object, so we are not processing it
+      this.externalVolumes[index].external.options = value;
+    }
+    if (type === SET && `externalVolumes.${index}.name` === joinedPath) {
+      this.externalVolumes[index].external.name = String(value);
+    }
+    if (type === SET && `externalVolumes.${index}.containerPath` === joinedPath) {
+      this.externalVolumes[index].containerPath = String(value);
+    }
+    if (type === SET && `externalVolumes.${index}.size` === joinedPath) {
+      this.externalVolumes[index].external.size = parseIntValue(value);
+    }
+    if (type === SET && `externalVolumes.${index}.mode` === joinedPath) {
+      this.externalVolumes[index].mode = String(value);
+    }
   }
+
+  if (joinedPath.search('localVolumes') !== -1) {
+    if (joinedPath === 'localVolumes') {
+      switch (type) {
+        case ADD_ITEM:
+          this.localVolumes.push({
+            containerPath: null,
+            persistent: {size: null},
+            mode: 'RW'
+          });
+          break;
+        case REMOVE_ITEM:
+          this.localVolumes = this.localVolumes.filter((item, index) => {
+            return index !== value;
+          });
+          break;
+      }
+
+      return [].concat(
+        this.localVolumes
+          .filter(filterHostVolumes.bind(this))
+          .map(mapLocalVolumes),
+        this.externalVolumes);
+    }
+
+    const index = path[1];
+    if (type === SET && `localVolumes.${index}.size` === joinedPath) {
+      this.localVolumes[index].persistent.size = parseIntValue(value);
+    }
+    if (type === SET && `localVolumes.${index}.type` === joinedPath) {
+      this.localVolumes[index].type = String(value);
+    }
+    if (type === SET && `localVolumes.${index}.mode` === joinedPath) {
+      this.localVolumes[index].mode = String(value);
+    }
+    if (type === SET && `localVolumes.${index}.hostPath` === joinedPath) {
+      this.localVolumes[index].hostPath = String(value);
+    }
+    if (type === SET && `localVolumes.${index}.containerPath` === joinedPath) {
+      this.localVolumes[index].containerPath = String(value);
+    }
+  }
+
+  return [].concat(
+    this.localVolumes
+      .filter(filterHostVolumes.bind(this))
+      .map(mapLocalVolumes),
+    this.externalVolumes);
+}
+
+module.exports = {
+  JSONReducer: reduceVolumes,
+  FormReducer: reduceVolumes
 };

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/ExternalVolumes-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/ExternalVolumes-test.js
@@ -33,6 +33,23 @@ describe('Labels', function () {
       }]);
     });
 
+    it('should parse wrong typed values correctly', function () {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(['externalVolumes'], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(['externalVolumes', 0, 'name'], 123));
+      batch = batch.add(new Transaction(['externalVolumes', 0, 'provider'], 123));
+      batch = batch.add(new Transaction(['externalVolumes', 0, 'containerPath'], 123));
+      batch = batch.add(new Transaction(['externalVolumes', 0, 'size'], '1024'));
+      batch = batch.add(new Transaction(['externalVolumes', 0, 'mode'], 123));
+      expect(batch.reduce(ExternalVolumes.FormReducer, [])).toEqual([{
+        containerPath: '123', name: '123', provider: '123', size: 1024,
+        options: {
+          'dvdi/driver': 'rexray'
+        },
+        mode: '123'
+      }]);
+    });
+
     it('should contain two full external Volumes items', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['externalVolumes'], 0, ADD_ITEM));

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/LocalVolumes-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/LocalVolumes-test.js
@@ -22,6 +22,23 @@ describe('LocalVolumes', function () {
       expect(batch.reduce(LocalVolumes.FormReducer, [])).toEqual([{size: 1024, containerPath: '/dev/null', mode: 'RW', type: 'PERSISTENT'}]);
     });
 
+    it('should parse wrong typed values correctly', function () {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(['localVolumes'], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(['localVolumes', 0, 'type'], 123));
+      batch = batch.add(new Transaction(['localVolumes', 0, 'hostPath'], 123));
+      batch = batch.add(new Transaction(['localVolumes', 0, 'containerPath'], 123));
+      batch = batch.add(new Transaction(['localVolumes', 0, 'size'], '1024'));
+      batch = batch.add(new Transaction(['localVolumes', 0, 'mode'], 123));
+      expect(batch.reduce(LocalVolumes.FormReducer, [])).toEqual([{
+        size: 1024,
+        hostPath: '123',
+        containerPath: '123',
+        mode: '123',
+        type: '123'
+      }]);
+    });
+
     it('should contain two full local Volumes items', function () {
       const batch = new Batch()
         .add(new Transaction(['localVolumes'], 0, ADD_ITEM))

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Volumes-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Volumes-test.js
@@ -29,6 +29,45 @@ describe('Volumes', function () {
       ]);
     });
 
+    it('should parse wrong values in local volume', function () {
+      let batch = new Batch();
+
+      batch = batch.add(new Transaction(['localVolumes'], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(['localVolumes', 0, 'size'], '123', SET));
+      batch = batch.add(new Transaction(['localVolumes', 0, 'type'], 'PERSISTENT', SET));
+      batch = batch.add(new Transaction(['localVolumes', 0, 'mode'], 123, SET));
+      batch = batch.add(new Transaction(['localVolumes', 0, 'containerPath'], 123, SET));
+
+      expect(batch.reduce(Volumes.JSONReducer.bind({}), [])).toEqual([
+        {
+          containerPath: '123',
+          persistent: {
+            size: 123
+          },
+          mode: '123'
+        }
+      ]);
+    });
+
+    it('should parse wrong values in local volume', function () {
+      let batch = new Batch();
+
+      batch = batch.add(new Transaction(['localVolumes'], 0, ADD_ITEM));
+      // Ignores wrong type
+      batch = batch.add(new Transaction(['localVolumes', 0, 'type'], 123, SET));
+      batch = batch.add(new Transaction(['localVolumes', 0, 'mode'], 123, SET));
+      batch = batch.add(new Transaction(['localVolumes', 0, 'hostPath'], 123, SET));
+      batch = batch.add(new Transaction(['localVolumes', 0, 'containerPath'], 123, SET));
+
+      expect(batch.reduce(Volumes.JSONReducer.bind({}), [])).toEqual([
+        {
+          hostPath: '123',
+          containerPath: '123',
+          mode: '123'
+        }
+      ]);
+    });
+
     it('should return an external volume', function () {
       let batch = new Batch();
 
@@ -46,6 +85,32 @@ describe('Volumes', function () {
           },
           mode: 'RW'
 
+        }
+      ]);
+    });
+
+    it('should parse wrong values in external volume', function () {
+      let batch = new Batch();
+
+      batch = batch.add(new Transaction(['externalVolumes'], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(['externalVolumes', 0, 'provider'], 123, SET));
+      batch = batch.add(new Transaction(['externalVolumes', 0, 'name'], 123, SET));
+      batch = batch.add(new Transaction(['externalVolumes', 0, 'containerPath'], 123, SET));
+      batch = batch.add(new Transaction(['externalVolumes', 0, 'size'], '123', SET));
+      batch = batch.add(new Transaction(['externalVolumes', 0, 'mode'], 123, SET));
+
+      expect(batch.reduce(Volumes.JSONReducer.bind({}), [])).toEqual([
+        {
+          containerPath: '123',
+          external: {
+            name: '123',
+            provider: '123',
+            size: 123,
+            options: {
+              'dvdi/driver': 'rexray'
+            }
+          },
+          mode: '123'
         }
       ]);
     });
@@ -245,4 +310,5 @@ describe('Volumes', function () {
       ]);
     });
   });
+  // FormReducer is equal to JSONReducer
 });

--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -166,34 +166,6 @@ const MarathonAppValidators = {
     return [];
   },
 
-  /*
-   * This validator ensures that `container.volumes.X.containerPath` does
-   * not contain the character '/', according to marathon `^[^/]*$ rule
-   *
-   * @param {Object} app - The data to validate
-   * @returns {Array} Returns an array with validation errors
-   */
-  containerVolmesPath(app) {
-    const volumes = findNestedPropertyInObject(app, 'container.volumes');
-    if (ValidatorUtil.isEmpty(volumes)) {
-      return [];
-    }
-
-    return volumes.reduce(function (memo, volume, index) {
-      const containerPath = volume.containerPath || '';
-
-      // Local or external volumes require the same check
-      if (containerPath.indexOf('/') !== -1) {
-        memo.push({
-          path: ['container', 'volumes', index, 'containerPath'],
-          message: 'Should not contain "/"'
-        });
-      }
-
-      return memo;
-    }, []);
-  },
-
   /**
    * @param {Object} app - The data to validate
    * @returns {Array} Returns an array with validation errors


### PR DESCRIPTION
This PR reverts the introduction of an appValidator introduced here: https://github.com/dcos/dcos-ui/pull/1814

The validator is now out of date and the latest requirement is that it should just be a string: https://github.com/mesosphere/marathon/blob/master/docs/docs/rest-api/public/api/v2/types/volumes.raml#L80

There was also a bug with parsing, where it would always try to parse an integer if passed to any of the volume fields. Here is where it was introduced:
https://github.com/dcos/dcos-ui/pull/1605/files#diff-7df350c7661c694dcce5e1552dcde9feR53

Before (checks if it contains `/` which is ok now):
![Before](https://cl.ly/3s3G0z410i3B/Screen%20Shot%202017-03-13%20at%2012.47.57.png)

After (only validates for string):
![After](https://cl.ly/260t1D3y1r35/Image%202017-03-13%20at%2012.41.54.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] ~~If this is a regression, did you write a test to catch this in the future?~~ Not applicable