### PR TITLE
Fix vertical menu tab width anomalies

### DIFF
--- a/src/styles/components/menu-tabbed/styles.less
+++ b/src/styles/components/menu-tabbed/styles.less
@@ -63,6 +63,7 @@
     }
 
     .menu-tabbed-item-label {
+      max-width: none;
       overflow: hidden;
       padding-bottom: @menu-tabbed-vertical-item-link-padding-bottom;
       padding-top: @menu-tabbed-vertical-item-link-padding-top;


### PR DESCRIPTION
This PR fixes the container tab's width in the "Run a Service" modal.

Before:
![](https://cl.ly/342d2o3r382v/Screen%20Shot%202017-03-13%20at%202.53.28%20PM.png)

After:
![](https://cl.ly/1N3n383w1r3Z/Screen%20Shot%202017-03-13%20at%202.50.45%20PM.png)

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
