### PR TITLE
DCOS-13032: Aggregate child tasks resources

### DIFF
--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -15,6 +15,7 @@ import ServiceModals from '../../components/modals/ServiceModals';
 import ServiceTree from '../../structs/ServiceTree';
 import ServiceTreeView from './ServiceTreeView';
 
+import MesosStateStore from '../../../../../../src/js/stores/MesosStateStore';
 import AppDispatcher from '../../../../../../src/js/events/AppDispatcher';
 import ContainerUtil from '../../../../../../src/js/utils/ContainerUtil';
 import Icon from '../../../../../../src/js/components/Icon';
@@ -34,7 +35,8 @@ import ServiceAttributeIsUniverseFilter from '../../filters/ServiceAttributeIsUn
 import ServiceAttributeHasVolumesFilter from '../../filters/ServiceAttributeHasVolumesFilter';
 
 import {
-  DCOS_CHANGE
+  DCOS_CHANGE,
+  MESOS_STATE_CHANGE
 } from '../../../../../../src/js/constants/EventTypes';
 
 import {
@@ -150,6 +152,10 @@ class ServicesContainer extends React.Component {
 
   componentDidMount() {
     DCOSStore.addChangeListener(DCOS_CHANGE, this.onStoreChange);
+
+    // Don't block the whole screen if Mesos state is not there
+    // Mesos state is needed to aggregate frameworks resources correctly
+    MesosStateStore.addChangeListener(MESOS_STATE_CHANGE, function () {});
 
     // Listen for server actions so we can update state immediately
     // on the completion of an API request.

--- a/plugins/services/src/js/structs/__tests__/Framework-test.js
+++ b/plugins/services/src/js/structs/__tests__/Framework-test.js
@@ -1,4 +1,13 @@
+jest.dontMock('../../../../../../src/js/stores/MesosStateStore');
+
+const JestUtil = require('../../../../../../src/js/utils/JestUtil');
+
+JestUtil.unMockStores(['MesosStateStore']);
+
+const MesosStateStore = require('../../../../../../src/js/stores/MesosStateStore');
+
 const Framework = require('../Framework');
+const Task = require('../Task');
 
 describe('Framework', function () {
 
@@ -142,7 +151,42 @@ describe('Framework', function () {
         TASK_RUNNING: 1
       });
 
-      expect(service.getInstancesCount()).toEqual(2);
+      expect(service.getInstancesCount()).toEqual(1);
+    });
+
+  });
+
+  describe('#getResources', function () {
+
+    it('aggregates child task resources properly', function () {
+      MesosStateStore.getTasksByService = function () {
+        return [
+          new Task({
+            id: '/fake_1',
+            isStartedByMarathon: true,
+            state: 'TASK_RUNNING',
+            resources: {cpus: 0.2, mem: 300, gpus: 0, disk: 0}
+          }),
+          new Task({
+            id: '/fake_2',
+            state: 'TASK_RUNNING',
+            resources: {cpus: 0.8, mem: 700, gpus: 0, disk: 0}
+          })
+        ];
+      };
+
+      const service = new Framework({
+        instances: 1,
+        cpus: 1,
+        mem: 1000
+      });
+
+      expect(service.getResources()).toEqual({
+        cpus: 1.8,
+        mem: 1700,
+        gpus: 0,
+        disk: 0
+      });
     });
 
   });


### PR DESCRIPTION
With this PR we stop counting a framework's child tasks as its instances and properly aggregate their resources instead.

Note! It works only one level deep, so if you run MoM and then Kafka on that MoM and then something on that Kafka - only Kafka's resource will be aggregated.

Testing

Easy mode: start confluent-kafka, wait until broker task starts, verify
Harder: start MoM, start a bunch of tasks on MoM, verify

<!--- Thank you for your contribution! Please provide enough information for others to best review your code. -->

<!-- Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it. -->

<!-- Description of motivation for making this change, what does it solve and steps needed to see change. -->

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
