### PR TITLE
DCOS-13950: Fix sorting by health

### DIFF
--- a/plugins/services/src/js/constants/HealthSorting.js
+++ b/plugins/services/src/js/constants/HealthSorting.js
@@ -1,9 +1,15 @@
+/**
+ * Order health types by it's label and number value
+ * This will depend on the sorting method/function
+ * suggested use is ascending 0 meaning ((top of the list)) more important
+ * visibility and 3 meaning least important (bottom of the order)
+ */
 var HealthSorting = {
   UNHEALTHY: 0,
-  HEALTHY: 1,
+  HEALTHY: 3,
   IDLE: 2,
-  WARN: 2,
-  NA: 3
+  NA: 1,
+  WARN: 2
 };
 
 module.exports = HealthSorting;

--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -70,6 +70,7 @@ class TaskTable extends React.Component {
     var className = this.getClassName;
     var heading = ResourceTableUtil.renderHeading(TaskTableHeaderLabels);
     const sortFunction = TaskTableUtil.getSortFunction('id');
+    const getHealthSorting = TaskTableUtil.getHealthSorting;
 
     return [
       {
@@ -119,7 +120,7 @@ class TaskTable extends React.Component {
         prop: 'health',
         render: this.renderHealth,
         sortable: true,
-        sortFunction
+        sortFunction: getHealthSorting
       },
       {
         cacheCell: false,

--- a/plugins/services/src/js/structs/ServiceTree.js
+++ b/plugins/services/src/js/structs/ServiceTree.js
@@ -1,5 +1,5 @@
 import Framework from './Framework';
-import HealthSorting from '../constants/HealthSorting';
+import HealthTypes from '../constants/HealthTypes';
 import HealthStatus from '../constants/HealthStatus';
 import List from '../../../../../src/js/structs/List';
 import Pod from './Pod';
@@ -70,7 +70,7 @@ module.exports = class ServiceTree extends Tree {
     return this.reduceItems(function (aggregatedHealth, item) {
       if (item instanceof Service) {
         const health = item.getHealth();
-        if (HealthSorting[aggregatedHealth.key] > HealthSorting[health.key]) {
+        if (HealthTypes[aggregatedHealth.key] > HealthTypes[health.key]) {
           aggregatedHealth = health;
         }
       }

--- a/plugins/services/src/js/utils/__tests__/TaskTableUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/TaskTableUtil-test.js
@@ -1,17 +1,12 @@
 jest.dontMock('../../constants/HealthSorting');
 jest.dontMock('../TaskTableUtil');
 
-const MarathonStore = require('../../stores/MarathonStore');
 const Service = require('../../structs/Service');
 const TaskTableUtil = require('../TaskTableUtil');
+const HealthSorting = require('../../constants/HealthSorting');
 
 describe('TaskTableUtil', function () {
   beforeEach(function () {
-    this.getServiceHealth = MarathonStore.getServiceHealth;
-    MarathonStore.getServiceHealth = function (prop) {
-      return this[prop].get('health');
-    }.bind(this);
-
     this.foo = {
       name: 'foo',
       statuses: [{timestamp: 1}, {timestamp: 2}],
@@ -35,7 +30,6 @@ describe('TaskTableUtil', function () {
       name: 'fooStruct',
       statuses: [{timestamp: 1}, {timestamp: 2}],
       updated: 0,
-      health: {key: 'UNHEALTHY'},
       used_resources: {
         cpus: 100,
         mem: [{value: 2}, {value: 3}]
@@ -45,91 +39,107 @@ describe('TaskTableUtil', function () {
       name: 'barStruct',
       statuses: [{timestamp: 4}],
       updated: 1,
-      health: {key: 'HEALTHY'},
       used_resources: {
         cpus: 5,
         mem: [{value: 0}, {value: 1}]
       }
     });
 
-    this.sortFunction = TaskTableUtil.getSortFunction('name');
+    this.tasks = [{
+      'id': 'task-healthy.111',
+      'name': 'task-healthy',
+      'state': 'TASK_RUNNING',
+      'health': 'Healthy'
+    },
+    {
+      'id': 'task-unhealthy.222',
+      'name': 'task-unhealthy',
+      'state': 'TASK_STAGING',
+      'health': 'Unhealthy'
+    }];
+
+    this.getComparator = TaskTableUtil.getSortFunction('name');
   });
 
-  afterEach(function () {
-    MarathonStore.getServiceHealth = this.getServiceHealth;
+  describe('#getHealthValueByName', function () {
+    it('should get default health (NA) value when param is not number', function () {
+      expect(TaskTableUtil.getHealthValueByName('invalid')).toEqual(HealthSorting.NA);
+    });
+
+    it('should get health value by type/name', function () {
+      expect(TaskTableUtil.getHealthValueByName('Healthy')).toEqual(HealthSorting.HEALTHY);
+    });
+  });
+
+  describe('#sortHealthValues', function () {
+    it('should order health status by most important visible', function () {
+      const expectedOrder = [{
+        'id': 'task-unhealthy.222',
+        'name': 'task-unhealthy',
+        'state': 'TASK_STAGING',
+        'health': 'Unhealthy'
+      },
+      {
+        'id': 'task-healthy.111',
+        'name': 'task-healthy',
+        'state': 'TASK_RUNNING',
+        'health': 'Healthy'
+      }];
+      const sortingResult = this.tasks.sort(TaskTableUtil.sortHealthValues);
+
+      expect(sortingResult).toEqual(expectedOrder);
+    });
   });
 
   describe('#getSortFunction for regular items', function () {
     it('should return a function', function () {
-      expect(typeof this.sortFunction).toEqual('function');
+      expect(typeof this.getComparator).toEqual('function');
     });
 
-    it('should compare the most recent timestamps when prop is updated',
-      function () {
-        var sortFunction = this.sortFunction('updated');
-        expect(sortFunction(this.foo, this.bar)).toEqual(-1);
-      }
-    );
+    it('should compare the most recent timestamps when prop is updated', function () {
+      var compareFunction = this.getComparator('updated');
+      expect(compareFunction(this.foo, this.bar)).toEqual(-1);
+    });
 
     it('should compare tieBreaker values', function () {
-      var sortFunction = this.sortFunction('name');
+      var compareFunction = this.getComparator('name');
 
       // 'foo' > 'bar' will equal true and compareValues returns 1
-      expect(sortFunction(this.foo, this.bar)).toEqual(1);
+      expect(compareFunction(this.foo, this.bar)).toEqual(1);
     });
 
     it('should compare resource values', function () {
-      var sortFunction = this.sortFunction('cpus');
-      expect(sortFunction(this.foo, this.bar)).toEqual(1);
+      var compareFunction = this.getComparator('cpus');
+      expect(compareFunction(this.foo, this.bar)).toEqual(1);
     });
 
     it('should compare last resource values', function () {
-      var sortFunction = this.sortFunction('mem');
-      expect(sortFunction(this.foo, this.bar)).toEqual(1);
+      var compareFunction = this.getComparator('mem');
+      expect(compareFunction(this.foo, this.bar)).toEqual(1);
     });
   });
 
   describe('#getSortFunction for structs', function () {
-
-    it('should compare the most recent timestamps when prop is updated',
-      function () {
-        var sortFunction = this.sortFunction('updated');
-        expect(sortFunction(this.fooStruct, this.barStruct)).toEqual(-1);
-      }
-    );
+    it('should compare the most recent timestamps when prop is updated', function () {
+      var compareFunction = this.getComparator('updated');
+      expect(compareFunction(this.fooStruct, this.barStruct)).toEqual(-1);
+    });
 
     it('should compare tieBreaker values', function () {
-      var sortFunction = this.sortFunction('name');
+      var compareFunction = this.getComparator('name');
 
       // 'foo' > 'bar' will equal true and compareValues returns 1
-      expect(sortFunction(this.fooStruct, this.barStruct)).toEqual(1);
-    });
-
-    it('should compare the health correctly', function () {
-      var sortFunction = this.sortFunction('health');
-      expect(sortFunction(this.fooStruct, this.barStruct)).toEqual(-1);
-    });
-
-    it('should use the tieBreaker if health is the same', function () {
-      var prevHealth = this.barStruct.get('health').key;
-      this.barStruct.get('health').key = this.fooStruct.get('health').key;
-      var sortFunction = this.sortFunction('health');
-
-      // Will compare with names now: 'foo' > 'bar' which will return 1
-      expect(sortFunction(this.fooStruct, this.barStruct)).toEqual(1);
-
-      // Set it back to original health
-      this.barStruct.get('health').key = prevHealth;
+      expect(compareFunction(this.fooStruct, this.barStruct)).toEqual(1);
     });
 
     it('should compare resource values', function () {
-      var sortFunction = this.sortFunction('cpus');
-      expect(sortFunction(this.fooStruct, this.barStruct)).toEqual(1);
+      var compareFunction = this.getComparator('cpus');
+      expect(compareFunction(this.fooStruct, this.barStruct)).toEqual(1);
     });
 
     it('should compare last resource values', function () {
-      var sortFunction = this.sortFunction('mem');
-      expect(sortFunction(this.fooStruct, this.barStruct)).toEqual(1);
+      var compareFunction = this.getComparator('mem');
+      expect(compareFunction(this.fooStruct, this.barStruct)).toEqual(1);
     });
   });
 });

--- a/src/js/utils/TableUtil.js
+++ b/src/js/utils/TableUtil.js
@@ -1,13 +1,7 @@
-function toLowerCaseIfString(item) {
-  if (typeof item === 'string') {
-    return item.toLowerCase();
-  }
-
-  return item;
-}
+import Util from './Util';
 
 var TableUtil = {
-  /**
+    /**
    * WARNING: When removing/modifying this function be aware of comments/sizes
    * in variables-layout.less
    * Returns an integer of what the expected height of a
@@ -36,10 +30,10 @@ var TableUtil = {
   },
 
   compareValues(a, b, aTieBreaker, bTieBreaker) {
-    a = toLowerCaseIfString(a);
-    b = toLowerCaseIfString(b);
-    aTieBreaker = toLowerCaseIfString(aTieBreaker);
-    bTieBreaker = toLowerCaseIfString(bTieBreaker);
+    a = Util.toLowerCaseIfString(a);
+    b = Util.toLowerCaseIfString(b);
+    aTieBreaker = Util.toLowerCaseIfString(aTieBreaker);
+    bTieBreaker = Util.toLowerCaseIfString(bTieBreaker);
     if (a === b || a == null || b == null) {
       a = aTieBreaker;
       b = bTieBreaker;

--- a/src/js/utils/Util.js
+++ b/src/js/utils/Util.js
@@ -244,7 +244,40 @@ const Util = {
     return queryString
       ? `?${queryString}`
       : '';
+  },
+
+  /**
+   * Transform param to lower case
+   * if param is string otherwise
+   * return unchanged param
+   *
+   * @param {String} item
+   * @returns {String} item param lowercased
+   */
+  toLowerCaseIfString(item) {
+    if (typeof item === 'string') {
+      return item.toLowerCase();
+    }
+
+    return item;
+  },
+
+  /**
+   * Transform param to upper case
+   * if param is string otherwise
+   * return unchanged param
+   *
+   * @param {String} item
+   * @returns {String} item param lowercased
+   */
+  toUpperCaseIfString(item) {
+    if (typeof item === 'string') {
+      return item.toUpperCase();
+    }
+
+    return item;
   }
+
 };
 
 module.exports = Util;

--- a/src/js/utils/__tests__/Util-test.js
+++ b/src/js/utils/__tests__/Util-test.js
@@ -420,4 +420,28 @@ describe('Util', function () {
     });
   });
 
+  describe('#toLowerCaseIfString', function () {
+    it('should lower case string', function () {
+      expect(Util.toLowerCaseIfString('Name')).toEqual('name');
+    });
+
+    it('should return original param', function () {
+      const value = 10;
+
+      expect(Util.toLowerCaseIfString(value)).toEqual(value);
+    });
+  });
+
+  describe('#toUpperCaseIfString', function () {
+    it('should upper case string', function () {
+      expect(Util.toUpperCaseIfString('Name')).toEqual('NAME');
+    });
+
+    it('should return original param', function () {
+      const value = 10;
+
+      expect(Util.toUpperCaseIfString(value)).toEqual(value);
+    });
+  });
+
 });


### PR DESCRIPTION
This PR fixes the issue when sorting by health in service table, adds minor refactoring (naming, code structure), unit test improvement based on code changes.

After talking to @mlunoe we decided that code fix was needed for the sorting to work properly as well.

As a effort to move from this [reusable sorting](https://github.com/dcos/dcos-ui/blob/2e63bbbc94875485c6dadfa9298649b42a6f213f/plugins/services/src/js/utils/TaskTableUtil.js#L19) because of reasons, code complexity, hard to follow code flow and hard to create more precise unit tests. 

That being said code refactoring was added, removing the sorting work from the `reusable sorting` function health and created a new method targeting specifically health sorting.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
