### PR TITLE
Fix active navigation item default

### DIFF
--- a/src/js/components/PageHeaderNavigationDropdown.js
+++ b/src/js/components/PageHeaderNavigationDropdown.js
@@ -15,7 +15,7 @@ class PageHeaderNavigationDropdown extends React.Component {
     }
 
     if (items.length > 0) {
-      return activeTab[0].id;
+      return items[0].id;
     }
   }
 


### PR DESCRIPTION
This PR fixes a bug in the `PageHeaderNavigationDropdown` component when it can't find an active tab.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
