### PR TITLE
DCOS-13710 [preparation]: Fix the code that prettier can't process 

### DIFF
--- a/plugins/services/src/js/components/LogView.js
+++ b/plugins/services/src/js/components/LogView.js
@@ -64,23 +64,25 @@ class LogView extends React.Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    const {hasLoadedTop, highlightText, logName, watching} = this.props;
-    const {fullLog, isAtBottom} = this.state;
+    const curState = this.state;
+    const curProps = this.props;
+    const propsToCheck = [
+      'hasLoadedTop',
+      'highlightText',
+      'logName',
+      'watching'
+    ];
 
-    return (
-      // Check hasLoadedTop
-      (hasLoadedTop !== nextProps.hasLoadedTop) ||
-      // Check highlightText
-      (highlightText !== nextProps.highlightText) ||
-      // Check logName
-      (logName !== nextProps.logName) ||
-      // Check watching
-      (watching !== nextProps.watching) ||
-      // Check isAtBottom
-      (isAtBottom !== nextState.isAtBottom) ||
-      // Check fullLog at the end, as this could be a long string
-      (fullLog !== nextState.fullLog)
-    );
+    const stateToCheck = [
+      'isAtBottom',
+      'fullLog' // Check fullLog at the end, as this could be a long string
+    ];
+
+    return propsToCheck.some(function (key) {
+      return curProps[key] !== nextProps[key];
+    }) || stateToCheck.some(function (key) {
+      return curState[key] !== nextState[key];
+    });
   }
 
   componentDidUpdate(prevProps) {

--- a/plugins/services/src/js/components/MesosLogContainer.js
+++ b/plugins/services/src/js/components/MesosLogContainer.js
@@ -79,46 +79,35 @@ class MesosLogContainer extends mixin(StoreMixin) {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    const {
-      filePath,
-      highlightText,
-      logName,
-      onCountChange,
-      task,
-      watching
-    } = this.props;
-    const {
-      direction,
-      fullLog,
-      hasLoadingError,
-      isFetchingPrevious,
-      isLoading
-    } = this.state;
+    const curProps = this.props;
+    const curState = this.state;
 
-    return (
-      // Check filePath
-      (filePath !== nextProps.filePath) ||
-      // Check logName
-      (logName !== nextProps.logName) ||
-      // Check highlightText
-      (highlightText !== nextProps.highlightText) ||
-      // Check watching
-      (watching !== nextProps.watching) ||
-      // Check watching
-      (onCountChange !== nextProps.onCountChange) ||
-      // Check task (slave_id is the only property being used)
-      (task.slave_id !== nextProps.task.slave_id) ||
-      // Check direction
-      (direction !== nextState.direction) ||
-      // Check hasLoadingError
-      (hasLoadingError !== nextState.hasLoadingError) ||
-      // Check isFetchingPrevious
-      (isFetchingPrevious !== nextState.isFetchingPrevious) ||
-      // Check isLoading
-      (isLoading !== nextState.isLoading) ||
-      // Check fullLog at the end, as this could be a long string
-      (fullLog !== nextState.fullLog)
-    );
+    const propsToCheck = [
+      'filePath',
+      'logName',
+      'highlightText',
+      'watching',
+      'onCountChange'
+    ];
+
+    const stateToCheck = [
+      'direction',
+      'hasLoadingError',
+      'isFetchingPrevious',
+      'isLoading',
+      'fullLog' // Check fullLog at the end, as this could be a long string
+    ];
+
+    // Check task (slave_id is the only property being used)
+    if (curProps.task.slave_id !== nextProps.task.slave_id) {
+      return true;
+    }
+
+    return propsToCheck.some(function (key) {
+      return curProps[key] !== nextProps[key];
+    }) || stateToCheck.some(function (key) {
+      return curState[key] !== nextState[key];
+    });
   }
 
   onMesosLogStoreError(path) {

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -159,12 +159,17 @@ class NewCreateServiceModalForm extends Component {
       return true;
     }
 
+    const isBaseConfigChanged = this.state.baseConfig !== nextState.baseConfig;
+    const isBatchChanged = this.state.batch !== nextState.batch;
+    const isEditingFieldPathChanged = this.state.editingFieldPath !== nextState.editingFieldPath;
+    const isActiveTabChanged = this.props.activeTab !== nextProps.activeTab;
+
     // Otherwise update if the state has changed
-    return (this.state.baseConfig !== nextState.baseConfig) ||
-      (this.state.batch !== nextState.batch) ||
-      (this.state.editingFieldPath !== nextState.editingFieldPath) ||
-      (this.props.activeTab !== nextProps.activeTab) ||
-      (!deepEqual(this.props.errors, nextProps.errors));
+    return isBaseConfigChanged ||
+      isBatchChanged ||
+      isEditingFieldPathChanged ||
+      isActiveTabChanged ||
+      !deepEqual(this.props.errors, nextProps.errors);
   }
 
   getNewStateForJSON(baseConfig = {}, isPod = this.state.isPod) {

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -159,16 +159,16 @@ class NewCreateServiceModalForm extends Component {
       return true;
     }
 
-    const isBaseConfigChanged = this.state.baseConfig !== nextState.baseConfig;
-    const isBatchChanged = this.state.batch !== nextState.batch;
-    const isEditingFieldPathChanged = this.state.editingFieldPath !== nextState.editingFieldPath;
-    const isActiveTabChanged = this.props.activeTab !== nextProps.activeTab;
+    const didBaseConfigChange = this.state.baseConfig !== nextState.baseConfig;
+    const didBatchChange = this.state.batch !== nextState.batch;
+    const didEditingFieldPathChange = this.state.editingFieldPath !== nextState.editingFieldPath;
+    const didActiveTabChange = this.props.activeTab !== nextProps.activeTab;
 
     // Otherwise update if the state has changed
-    return isBaseConfigChanged ||
-      isBatchChanged ||
-      isEditingFieldPathChanged ||
-      isActiveTabChanged ||
+    return didBaseConfigChange ||
+      didBatchChange ||
+      didEditingFieldPathChange ||
+      didActiveTabChange ||
       !deepEqual(this.props.errors, nextProps.errors);
   }
 

--- a/plugins/services/src/js/pages/task-details/TaskFileViewer.js
+++ b/plugins/services/src/js/pages/task-details/TaskFileViewer.js
@@ -19,22 +19,28 @@ class TaskFileViewer extends React.Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    const {props, state} = this;
-    const directory = props.directory;
-    const nextDirectory = nextProps.directory;
-    const task = state.task;
-    const nextTask = nextState.task;
+    const curProps = this.props;
+    const curState = this.state;
 
-    return (
-      // Check task
-      (props.task !== nextProps.task) ||
-      (task && nextTask && task.slave_id !== nextTask.slave_id) ||
-      // Check current view
-      (state.currentFile !== nextState.currentFile) ||
-      // Check directory
-      (directory !== nextDirectory) || (directory && nextDirectory &&
-        directory.getItems().length !== nextDirectory.getItems().length)
-    );
+    const task = curState.task;
+    const nextTask = nextState.task;
+    const isSlaveIdChanged = task && nextTask &&
+      task.slave_id !== nextTask.slave_id;
+
+    const isTaskChanged = curProps.task !== nextProps.task ||
+      isSlaveIdChanged;
+
+    const directory = curProps.directory;
+    const nextDirectory = nextProps.directory;
+    const isDirectoryItemsChanged = directory && nextDirectory &&
+      directory.getItems().length !== nextDirectory.getItems().length;
+
+    const isDirectoryChanged = directory !== nextDirectory ||
+      isDirectoryItemsChanged;
+
+    const isCurrentFileChanged = curState.currentFile !== nextState.currentFile;
+
+    return isTaskChanged || isCurrentFileChanged || isDirectoryChanged;
   }
 
   handleViewChange(currentFile) {

--- a/plugins/services/src/js/pages/task-details/TaskFileViewer.js
+++ b/plugins/services/src/js/pages/task-details/TaskFileViewer.js
@@ -24,23 +24,23 @@ class TaskFileViewer extends React.Component {
 
     const task = curState.task;
     const nextTask = nextState.task;
-    const isSlaveIdChanged = task && nextTask &&
+    const didSlaveIdChange = task && nextTask &&
       task.slave_id !== nextTask.slave_id;
 
-    const isTaskChanged = curProps.task !== nextProps.task ||
-      isSlaveIdChanged;
+    const didTaskChange = curProps.task !== nextProps.task ||
+      didSlaveIdChange;
 
     const directory = curProps.directory;
     const nextDirectory = nextProps.directory;
-    const isDirectoryItemsChanged = directory && nextDirectory &&
+    const didDirectoryItemsChange = directory && nextDirectory &&
       directory.getItems().length !== nextDirectory.getItems().length;
 
-    const isDirectoryChanged = directory !== nextDirectory ||
-      isDirectoryItemsChanged;
+    const didDirectoryChange = directory !== nextDirectory ||
+      didDirectoryItemsChange;
 
-    const isCurrentFileChanged = curState.currentFile !== nextState.currentFile;
+    const didCurrentFileChange = curState.currentFile !== nextState.currentFile;
 
-    return isTaskChanged || isCurrentFileChanged || isDirectoryChanged;
+    return didTaskChange || didCurrentFileChange || didDirectoryChange;
   }
 
   handleViewChange(currentFile) {

--- a/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
+++ b/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
@@ -78,36 +78,29 @@ class TaskSystemLogsContainer extends mixin(StoreMixin) {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
+    const curState = this.state;
     const {highlightText, task = {}, watching} = this.props;
-    const {
-      direction,
-      fullLog,
-      hasError,
-      streams,
-      isFetchingPrevious,
-      isLoading
-    } = this.state;
+    const stateToCheck = [
+      'direction',
+      'fullLog',
+      'hasError',
+      'isFetchingPrevious',
+      'isLoading'
+    ];
 
-    return Boolean(
-      // Check highlightText
-      (highlightText !== nextProps.highlightText) ||
-      // Check watching
-      (watching !== nextProps.watching) ||
-      // Check task
-      (nextProps.task && task.slave_id !== nextProps.task.slave_id) ||
-      // Check direction
-      (direction !== nextState.direction) ||
-      // Check fullLog
-      (fullLog !== nextState.fullLog) ||
-      // Check hasError
-      (hasError !== nextState.hasError) ||
-      // Check streams
-      (!deepEqual(streams, nextState.streams)) ||
-      // Check isFetchingPrevious
-      (isFetchingPrevious !== nextState.isFetchingPrevious) ||
-      // Check isLoading
-      (isLoading !== nextState.isLoading)
-    );
+    const isHighlightTextChanged = highlightText !== nextProps.highlightText;
+    const isWatchingChanged = watching !== nextProps.watching;
+
+    const isSlaveIdChanged = nextProps.task &&
+      task.slave_id !== nextProps.task.slave_id;
+
+    return isHighlightTextChanged ||
+      isWatchingChanged ||
+      isSlaveIdChanged ||
+      stateToCheck.some(function (key) {
+        return curState[key] !== nextState[key];
+      }) ||
+      !deepEqual(curState.streams, nextState.streams);
   }
 
   onSystemLogStoreError(subscriptionID, direction) {

--- a/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
+++ b/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
@@ -88,15 +88,15 @@ class TaskSystemLogsContainer extends mixin(StoreMixin) {
       'isLoading'
     ];
 
-    const isHighlightTextChanged = highlightText !== nextProps.highlightText;
-    const isWatchingChanged = watching !== nextProps.watching;
+    const didHighlightTextChange = highlightText !== nextProps.highlightText;
+    const didWatchingChange = watching !== nextProps.watching;
 
-    const isSlaveIdChanged = nextProps.task &&
+    const didSlaveIdChange = nextProps.task &&
       task.slave_id !== nextProps.task.slave_id;
 
-    return isHighlightTextChanged ||
-      isWatchingChanged ||
-      isSlaveIdChanged ||
+    return didHighlightTextChange ||
+      didWatchingChange ||
+      didSlaveIdChange ||
       stateToCheck.some(function (key) {
         return curState[key] !== nextState[key];
       }) ||


### PR DESCRIPTION
Currently prettier can't prettify pieces of code where return statements have comments in it.
```javascript
return (
  // Comment
  someLogic !== here
);
```

So I decided to fix those as a separate PR so that these changes could be tested separately.