### PR TITLE
Clean up create service headings

### DIFF
--- a/plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js
@@ -196,7 +196,7 @@ class ContainerServiceFormAdvancedSection extends Component {
 
     return (
       <div>
-        <h3 className="short-top short-bottom">
+        <h3 className="short-bottom">
           Advanced Settings
         </h3>
         <p>Advanced settings related to the runtime you have selected above.</p>

--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -170,6 +170,16 @@ class EnvironmentFormSection extends Component {
         <h2 className="flush-top short-bottom">
           <FormGroupHeading>
             <FormGroupHeadingContent primary={true}>
+              Environment
+            </FormGroupHeadingContent>
+          </FormGroupHeading>
+        </h2>
+        <p>
+          Configure any environment values to be attached to each instance that is launched.
+        </p>
+        <h3 className="short-bottom">
+          <FormGroupHeading>
+            <FormGroupHeadingContent primary={true}>
               Environment Variables
             </FormGroupHeadingContent>
             <FormGroupHeadingContent>
@@ -183,7 +193,7 @@ class EnvironmentFormSection extends Component {
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>
-        </h2>
+        </h3>
         <p>
           Set up environment variables for each instance your service launches.
         </p>
@@ -198,7 +208,7 @@ class EnvironmentFormSection extends Component {
             </AddButton>
           </FormGroup>
         </FormRow>
-        <h2 className="short-bottom">
+        <h3 className="short-bottom">
           <FormGroupHeading>
             <FormGroupHeadingContent primary={true}>
               Labels
@@ -214,7 +224,7 @@ class EnvironmentFormSection extends Component {
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>
-        </h2>
+        </h3>
         <p>
           Attach metadata to expose additional information to other services.
         </p>

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -214,6 +214,7 @@ class GeneralServiceFormSection extends Component {
       this.props.errors,
       'constraints'
     );
+    let errorNode = null;
     const placementTooltipContent = (
       <span>
         {'Constraints have three parts: a field name, an operator, and an optional parameter. The field can be the hostname of the agent node or any attribute of the agent node. '}
@@ -224,6 +225,19 @@ class GeneralServiceFormSection extends Component {
         </a>.
       </span>
     );
+    const hasErrors = (
+      constraintsErrors != null && !Array.isArray(constraintsErrors)
+    );
+
+    if (hasErrors) {
+      errorNode = (
+        <FormGroup showError={hasErrors}>
+          <FieldError>
+            {constraintsErrors}
+          </FieldError>
+        </FormGroup>
+      );
+    }
 
     return (
       <div>
@@ -246,11 +260,7 @@ class GeneralServiceFormSection extends Component {
         </h3>
         <p>Constraints control where apps run to allow optimization for either fault tolerance or locality.</p>
         {this.getPlacementConstraintsFields(data.constraints)}
-        <FormGroup showError={constraintsErrors != null && !Array.isArray(constraintsErrors)}>
-          <FieldError>
-            {constraintsErrors}
-          </FieldError>
-        </FormGroup>
+        {errorNode}
         <FormRow>
           <FormGroup className="column-12">
             <AddButton onClick={this.props.onAddItem.bind(

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -188,9 +188,9 @@ class GeneralServiceFormSection extends Component {
 
     return (
       <div>
-        <h2 className="short-bottom short-top">
+        <h3 className="short-bottom">
           Containers
-        </h2>
+        </h3>
         {containerElements}
         <AddButton onClick={this.props.onAddItem.bind(
             this,

--- a/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
@@ -298,10 +298,10 @@ class MultiContainerHealthChecksFormSection extends Component {
       return (
         <div key={container.name}>
           <div className="form-row-element">
-            <h3 className="form-header short-bottom">
+            <h4 className="form-header short-bottom">
               <Icon id="container" size="mini" color="purple" />
               {` ${container.name}`}
-            </h3>
+            </h4>
           </div>
           {this.getHealthChecksBody(container, index)}
         </div>

--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -331,10 +331,10 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
 
       return (
         <div key={index}>
-          <h3 className="short-bottom">
+          <h4 className="short-bottom">
             <Icon id="container" size="mini" color="purple" />
             {` ${container.name}`}
-          </h3>
+          </h4>
           {this.getServiceContainerEndpoints(endpoints, index)}
           <div>
             <AddButton onClick={this.props.onAddItem.bind(

--- a/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
@@ -169,7 +169,7 @@ class MultiContainerVolumesFormSection extends Component {
         <p>
           Create a stateful service by configuring a persistent volume. Persistent volumes enable instances to be restarted without data loss.
         </p>
-        <h3 className="flush-top">
+        <h3 className="short-bottom">
           Ephemeral Volumes
         </h3>
         <p>


### PR DESCRIPTION
This PR cleans up the hierarchy and spacing of headings through the create service flow. Today there are a few examples where the headings are inconsistent, the spacing is off, or it is the wrong type of heading. 

Each tab should follow a H2 > H3 > H4 rule and related headings/objects should visually be grouped together.

Some before and after examples:

Before - Three H2 headings, inconsistent with other tabs
![image](https://cloud.githubusercontent.com/assets/15963/24019888/2615505c-0a57-11e7-916d-0593966c9bfc.png)

After - One H2 heading, three H3s
![image](https://cloud.githubusercontent.com/assets/15963/24019907/35de589e-0a57-11e7-871c-5a2f162f5e9d.png)

Before - Two H2 headings and some minor spacing issues
![image](https://cloud.githubusercontent.com/assets/15963/24019937/4eb074ec-0a57-11e7-8eb7-3c6b236e5be2.png)

After - One H2 heading, two H3s, spacing improved
![image](https://cloud.githubusercontent.com/assets/15963/24019961/6f6bf0da-0a57-11e7-837c-7acb94ff4c7b.png)

Before - One H2 heading, three H3s
![image](https://cloud.githubusercontent.com/assets/15963/24019971/79932b00-0a57-11e7-9481-62a20a28f3a2.png)

After - One H2 heading, one H3, two H4s
![image](https://cloud.githubusercontent.com/assets/15963/24019977/830fb02c-0a57-11e7-94a9-32e77aaa29af.png)

cc @ashenden @jfurrow for visual review.


