### PR TITLE
Restyle table row actions dropdown

### DIFF
--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import {Dropdown, Table} from 'reactjs-components';
+import {Dropdown, Table, Tooltip} from 'reactjs-components';
 import {Link} from 'react-router';
 import React, {PropTypes} from 'react';
 import {ResourceTableUtil} from 'foundation-ui';
@@ -28,14 +28,16 @@ const columnClasses = {
   status: 'service-table-column-status',
   cpus: 'service-table-column-cpus',
   mem: 'service-table-column-mem',
-  disk: 'service-table-column-disk'
+  disk: 'service-table-column-disk',
+  actions: 'service-table-column-actions'
 };
 
 const METHODS_TO_BIND = [
   'onActionsItemSelection',
   'renderHeadline',
   'renderStats',
-  'renderStatus'
+  'renderStatus',
+  'renderServiceActions'
 ];
 
 class ServicesTable extends React.Component {
@@ -148,12 +150,11 @@ class ServicesTable extends React.Component {
           {this.getServiceLink(service)}
           {this.getOpenInNewWindowLink(service)}
         </span>
-        {this.renderServiceActions(service)}
       </div>
     );
   }
 
-  renderServiceActions(service) {
+  renderServiceActions(prop, service) {
     const isGroup = service instanceof ServiceTree;
     const isPod = service instanceof Pod;
     const isSingleInstanceApp = service.getLabels().MARATHON_SINGLE_INSTANCE_APP;
@@ -170,7 +171,6 @@ class ServicesTable extends React.Component {
         html: '',
         selectedHtml: (
           <Icon className="icon-alert"
-            color="neutral"
             id="ellipsis-vertical"
             size="mini" />
         )
@@ -210,21 +210,24 @@ class ServicesTable extends React.Component {
     ];
 
     return (
-      <Dropdown
-        key="actions-dropdown"
-        anchorRight={true}
-        buttonClassName="button button-mini button-link"
-        dropdownMenuClassName="dropdown-menu"
-        dropdownMenuListClassName="dropdown-menu-list"
-        dropdownMenuListItemClassName="clickable"
-        wrapperClassName="dropdown flush-bottom table-cell-icon"
-        items={dropdownItems}
-        persistentID={ServiceActionItem.MORE}
-        onItemSelection={this.onActionsItemSelection.bind(this, service)}
-        scrollContainer=".gm-scroll-view"
-        scrollContainerParentSelector=".gm-prevented"
-        transition={true}
-        transitionName="dropdown-menu" />
+      <Tooltip interactive={true} content={'More actions'}>
+        <Dropdown
+          key="actions-dropdown"
+          anchorRight={true}
+          buttonClassName="button button-mini button-link"
+          dropdownMenuClassName="dropdown-menu"
+          dropdownMenuListClassName="dropdown-menu-list"
+          dropdownMenuListItemClassName="clickable"
+          wrapperClassName="dropdown flush-bottom table-cell-icon"
+          items={dropdownItems}
+          persistentID={ServiceActionItem.MORE}
+          onItemSelection={this.onActionsItemSelection.bind(this, service)}
+          scrollContainer=".gm-scroll-view"
+          scrollContainerParentSelector=".gm-prevented"
+          title="More actions"
+          transition={true}
+          transitionName="dropdown-menu" />
+      </Tooltip>
     );
   }
 
@@ -340,6 +343,16 @@ class ServicesTable extends React.Component {
         sortable: true,
         sortFunction: ServiceTableUtil.propCompareFunctionFactory,
         heading
+      },
+      {
+        className: this.getCellClasses,
+        headerClassName: this.getCellClasses,
+        prop: 'actions',
+        render: this.renderServiceActions,
+        sortable: false,
+        heading() {
+          return null;
+        }
       }
     ];
   }
@@ -352,6 +365,7 @@ class ServicesTable extends React.Component {
         <col className={columnClasses.cpus} />
         <col className={columnClasses.mem} />
         <col className={columnClasses.disk} />
+        <col className={columnClasses.actions} />
       </colgroup>
     );
   }

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -210,9 +210,8 @@ class ServicesTable extends React.Component {
     ];
 
     return (
-      <Tooltip interactive={true} content={'More actions'}>
+      <Tooltip content={'More actions'}>
         <Dropdown
-          key="actions-dropdown"
           anchorRight={true}
           buttonClassName="button button-mini button-link"
           dropdownMenuClassName="dropdown-menu"

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -170,8 +170,7 @@ class ServicesTable extends React.Component {
         id: ServiceActionItem.MORE,
         html: '',
         selectedHtml: (
-          <Icon className="icon-alert"
-            id="ellipsis-vertical"
+          <Icon id="ellipsis-vertical"
             size="mini" />
         )
       },

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -171,7 +171,7 @@ class ServicesTable extends React.Component {
         selectedHtml: (
           <Icon className="icon-alert"
             color="neutral"
-            id="gear"
+            id="ellipsis-vertical"
             size="mini" />
         )
       },
@@ -213,7 +213,7 @@ class ServicesTable extends React.Component {
       <Dropdown
         key="actions-dropdown"
         anchorRight={true}
-        buttonClassName="button button-mini dropdown-toggle button-link"
+        buttonClassName="button button-mini button-link"
         dropdownMenuClassName="dropdown-menu"
         dropdownMenuListClassName="dropdown-menu-list"
         dropdownMenuListItemClassName="clickable"

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -213,7 +213,7 @@ class ServicesTable extends React.Component {
       <Dropdown
         key="actions-dropdown"
         anchorRight={true}
-        buttonClassName="button button-mini dropdown-toggle button-link table-display-on-row-hover"
+        buttonClassName="button button-mini dropdown-toggle button-link"
         dropdownMenuClassName="dropdown-menu"
         dropdownMenuListClassName="dropdown-menu-list"
         dropdownMenuListItemClassName="clickable"

--- a/src/styles/components/service-table/styles.less
+++ b/src/styles/components/service-table/styles.less
@@ -32,6 +32,10 @@
       &-cpus {
         width: 65px;
       }
+
+      &-actions {
+        width: 40px;
+      }
     }
 
     // We don't want the status bar to increase the height of the table row

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -382,8 +382,7 @@ describe('Service Actions', function () {
       configureClusterWithSuspendedServiceAndVisitServices();
       openDropdown();
 
-      cy.get('.dropdown-menu-items')
-        .get('li')
+      cy.get('.dropdown-menu-items li')
         .contains('Suspend')
         .should('have.class', 'hidden');
     });
@@ -392,8 +391,7 @@ describe('Service Actions', function () {
       configureClusterWithSuspendedServiceAndVisitServices();
       openDropdown();
 
-      cy.get('.dropdown-menu-items')
-        .get('li')
+      cy.get('.dropdown-menu-items li')
         .contains('Resume')
         .should('not.have.class', 'hidden');
     });

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -364,8 +364,7 @@ describe('Service Actions', function () {
     }
 
     function clickResume() {
-      cy.get('.dropdown-menu-items')
-        .get('li')
+      cy.get('.dropdown-menu-items li')
         .contains('Resume')
         .click();
     }

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -359,9 +359,7 @@ describe('Service Actions', function () {
 
   context('Resume Action', function () {
     function openDropdown() {
-      cy.get('.service-table-column-name')
-        .contains('sleep')
-        .get('.dropdown-toggle')
+      cy.get('.service-table-column-actions .dropdown .button')
         .click({force: true});
     }
 


### PR DESCRIPTION
This PR restyles the actions dropdown for service collection rows and moves it to the right. 

Why? We want a consistent style and location for row actions throughout DC/OS. Using the ellipsis and positioning it to the right will keep us consistent and also keeps us open to adding more actions here. A tooltip has also been added for extra clarity.

Before
![image](https://d3vv6lp55qjaqc.cloudfront.net/items/253C020q3n001M1Y041G/Screen%20Recording%202017-03-16%20at%2005.17%20PM.gif?X-CloudApp-Visitor-Id=2089277&v=93298554)

After
![image](https://d3vv6lp55qjaqc.cloudfront.net/items/0L1n3F0B303L1B3W1R0L/Screen%20Recording%202017-03-16%20at%2005.18%20PM.gif?X-CloudApp-Visitor-Id=2089277&v=caa943af)

