### PR TITLE
Add tooltip to logs icon

### DIFF
--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -268,11 +268,14 @@ class TaskTable extends React.Component {
     return (
       <div className="flex-box flex-box-align-vertical-center
         table-cell-flex-box flex-align-items-center flex-direction-top-to-bottom">
-        <Link
-          to={linkTo}
-          title={title}>
-          <Icon color="grey" id="page-document" size="mini" />
-        </Link>
+        <Tooltip content="View logs"
+          wrapperClassName="tooltip-wrapper text-align-center description">
+          <Link
+            to={linkTo}
+            title={title}>
+            <Icon color="grey" id="page-document" size="mini" />
+          </Link>
+        </Tooltip>
       </div>
     );
   }

--- a/src/styles/components/icons/styles.less
+++ b/src/styles/components/icons/styles.less
@@ -81,6 +81,13 @@
     &.icon-grey {
       color: color-lighten(@neutral, 30%);
 
+      a & {
+
+        &:hover {
+          color: color-lighten(@neutral, 20%);
+        }
+      }
+
       &.inverse {
         color: color-lighten(@neutral, 70%);
       }


### PR DESCRIPTION
This PR adds a tooltip to the ambiguous logs icon in the tasks table. We've heard lots of feedback from users that they don't know what this icon means. Adding a tooltip helps add a lot of clarity.

![](https://d3vv6lp55qjaqc.cloudfront.net/items/1D2h0L0Q2v402z0P1119/Screen%20Recording%202017-03-16%20at%2009.03%20PM.gif?X-CloudApp-Visitor-Id=2089277&v=26bbec08) 