### PR TITLE
DCOS-14171: Clean up usage and styling of DeleteRowButton

### DIFF
--- a/plugins/services/src/js/components/forms/ArtifactsSection.js
+++ b/plugins/services/src/js/components/forms/ArtifactsSection.js
@@ -62,7 +62,7 @@ class ArtifactsSection extends Component {
       return (
         <FormRow key={`${path}.${index}`}>
           <FormGroup
-            className="column-10"
+            className="column-12"
             showError={Boolean(error)}>
             {label}
             <FieldInput
@@ -71,7 +71,7 @@ class ArtifactsSection extends Component {
               value={item.uri}/>
             <FieldError>{error}</FieldError>
           </FormGroup>
-          <FormGroup className="flex flex-item-align-end column-2 flush-left">
+          <FormGroup isDeleteButton={true} applyLabelOffset={index === 0}>
             <DeleteRowButton
               onClick={this.props.onRemoveItem.bind(
                 this,

--- a/plugins/services/src/js/components/forms/ArtifactsSection.js
+++ b/plugins/services/src/js/components/forms/ArtifactsSection.js
@@ -71,7 +71,7 @@ class ArtifactsSection extends Component {
               value={item.uri}/>
             <FieldError>{error}</FieldError>
           </FormGroup>
-          <FormGroup isDeleteButton={true} applyLabelOffset={index === 0}>
+          <FormGroup hasNarrowMargins={true} applyLabelOffset={index === 0}>
             <DeleteRowButton
               onClick={this.props.onRemoveItem.bind(
                 this,

--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -70,7 +70,7 @@ class EnvironmentFormSection extends Component {
               value={env.value}/>
             <FieldError>{errors[env.key]}</FieldError>
           </FormGroup>
-          <FormGroup className="flex flex-item-align-end column-auto flush-left">
+          <FormGroup isDeleteButton={true}>
             <DeleteRowButton
               onClick={this.props.onRemoveItem.bind(
                 this, {value: key, path: 'env'}
@@ -130,7 +130,7 @@ class EnvironmentFormSection extends Component {
               value={label.value}/>
             <FieldError>{errors[label.key]}</FieldError>
           </FormGroup>
-          <FormGroup className="flex flex-item-align-end column-auto flush-left">
+          <FormGroup isDeleteButton={true}>
             <DeleteRowButton
               onClick={this.props.onRemoveItem.bind(
                 this, {value: key, path: 'labels'}

--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -70,7 +70,7 @@ class EnvironmentFormSection extends Component {
               value={env.value}/>
             <FieldError>{errors[env.key]}</FieldError>
           </FormGroup>
-          <FormGroup isDeleteButton={true}>
+          <FormGroup hasNarrowMargins={true}>
             <DeleteRowButton
               onClick={this.props.onRemoveItem.bind(
                 this, {value: key, path: 'env'}
@@ -130,7 +130,7 @@ class EnvironmentFormSection extends Component {
               value={label.value}/>
             <FieldError>{errors[label.key]}</FieldError>
           </FormGroup>
-          <FormGroup isDeleteButton={true}>
+          <FormGroup hasNarrowMargins={true}>
             <DeleteRowButton
               onClick={this.props.onRemoveItem.bind(
                 this, {value: key, path: 'labels'}

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -373,7 +373,7 @@ class GeneralServiceFormSection extends Component {
             </FieldError>
           </FormGroup>
 
-          <FormGroup applyLabelOffset={index === 0} isDeleteButton={true}>
+          <FormGroup applyLabelOffset={index === 0} hasNarrowMargins={true}>
             <DeleteRowButton
               onClick={this.props.onRemoveItem.bind(
                 this,

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -1,4 +1,3 @@
-import classNames from 'classnames';
 import React, {Component} from 'react';
 import {Confirm, Tooltip} from 'reactjs-components';
 
@@ -300,10 +299,6 @@ class GeneralServiceFormSection extends Component {
         'column-4': !hideValueColumn,
         'column-6': hideValueColumn
       };
-      const deleteRowButtonClassNames = classNames(
-        'column-2 flush-left',
-        {'form-group-without-top-label': index === 0}
-      );
 
       if (index === 0) {
         fieldLabel = placementConstraintLabel(
@@ -378,7 +373,7 @@ class GeneralServiceFormSection extends Component {
             </FieldError>
           </FormGroup>
 
-          <FormGroup className={deleteRowButtonClassNames}>
+          <FormGroup applyLabelOffset={index === 0} isDeleteButton={true}>
             <DeleteRowButton
               onClick={this.props.onRemoveItem.bind(
                 this,

--- a/src/js/components/form/DeleteRowButton.js
+++ b/src/js/components/form/DeleteRowButton.js
@@ -6,11 +6,11 @@ import Icon from '../Icon';
 const DeleteRowButton = ({onClick}) => {
   return (
     <Tooltip content="Delete"
-      interactive={true}
+      interactive={false}
       maxWidth={300}
       scrollContainer=".gm-scroll-view"
       wrapText={true}>
-      <a className="button button-link"
+      <a className="button button-link button-narrow"
         onClick={onClick}>
         <Icon id="close" family="tiny" size="tiny" />
       </a>

--- a/src/js/components/form/FormGroup.js
+++ b/src/js/components/form/FormGroup.js
@@ -63,7 +63,11 @@ FormGroup.propTypes = {
   className: classPropType,
   // Class to be toggled, can be overridden by className
   errorClassName: React.PropTypes.string,
+  // When true, will add padding to the top of the form group to vertically
+  // align it with its siblings that have labels.
   applyLabelOffset: React.PropTypes.bool,
+  // When true, the component will apply specific styles for use with the delete
+  // row button
   isDeleteButton: React.PropTypes.bool
 };
 

--- a/src/js/components/form/FormGroup.js
+++ b/src/js/components/form/FormGroup.js
@@ -5,7 +5,14 @@ import FieldError from './FieldError';
 import {omit} from '../../utils/Util';
 
 const FormGroup = (props) => {
-  const {children, className, errorClassName, showError} = props;
+  const {
+    children,
+    className,
+    errorClassName,
+    isDeleteButton,
+    applyLabelOffset,
+    showError
+  } = props;
 
   const clonedChildren = React.Children.map(children, (child) => {
     if (child != null && !showError && child.type === FieldError) {
@@ -16,7 +23,12 @@ const FormGroup = (props) => {
   });
 
   const classes = classNames(
-    {[errorClassName]: showError},
+    {
+      [errorClassName]: showError,
+      'form-group-without-top-label': applyLabelOffset,
+      // 'flex-item-align-end': applyLabelOffset && isDeleteButton,
+      'column-auto flush-left flush-right': isDeleteButton
+    },
     'form-group',
     className
   );
@@ -31,7 +43,9 @@ const FormGroup = (props) => {
 };
 
 FormGroup.defaultProps = {
-  errorClassName: 'form-group-danger'
+  errorClassName: 'form-group-danger',
+  applyLabelOffset: false,
+  isDeleteButton: false
 };
 
 const classPropType = React.PropTypes.oneOfType([
@@ -48,7 +62,9 @@ FormGroup.propTypes = {
   // Classes
   className: classPropType,
   // Class to be toggled, can be overridden by className
-  errorClassName: React.PropTypes.string
+  errorClassName: React.PropTypes.string,
+  applyLabelOffset: React.PropTypes.bool,
+  isDeleteButton: React.PropTypes.bool
 };
 
 module.exports = FormGroup;

--- a/src/js/components/form/FormGroup.js
+++ b/src/js/components/form/FormGroup.js
@@ -9,7 +9,7 @@ const FormGroup = (props) => {
     children,
     className,
     errorClassName,
-    isDeleteButton,
+    hasNarrowMargins,
     applyLabelOffset,
     showError
   } = props;
@@ -26,8 +26,8 @@ const FormGroup = (props) => {
     {
       [errorClassName]: showError,
       'form-group-without-top-label': applyLabelOffset,
-      // 'flex-item-align-end': applyLabelOffset && isDeleteButton,
-      'column-auto flush-left flush-right': isDeleteButton
+      // 'flex-item-align-end': applyLabelOffset && hasNarrowMargins,
+      'column-auto flush-left flush-right': hasNarrowMargins
     },
     'form-group',
     className
@@ -45,7 +45,7 @@ const FormGroup = (props) => {
 FormGroup.defaultProps = {
   errorClassName: 'form-group-danger',
   applyLabelOffset: false,
-  isDeleteButton: false
+  hasNarrowMargins: false
 };
 
 const classPropType = React.PropTypes.oneOfType([
@@ -68,7 +68,7 @@ FormGroup.propTypes = {
   applyLabelOffset: React.PropTypes.bool,
   // When true, the component will apply specific styles for use with the delete
   // row button
-  isDeleteButton: React.PropTypes.bool
+  hasNarrowMargins: React.PropTypes.bool
 };
 
 module.exports = FormGroup;

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -401,6 +401,30 @@ describe('Service Form Modal', function () {
           .contains('Add Placement Constraint');
       });
 
+      it.only('Should vertically align the placement constraint delete row button', function () {
+        // We'll consider the two elements to be centered with one another if
+        // their midpoints are within 5 pixels of one another.
+        const alignmentThreshold = 5;
+
+        cy.get('.menu-tabbed-view .button.button-primary-link')
+          .contains('Add Placement Constraint').click();
+
+        cy.get('.menu-tabbed-view input[name="constraints.0.fieldName"').should(function ($inputElement) {
+          const $wrappingLabel = $inputElement.closest('.form-group');
+          const $deleteButtonFormGroup = $wrappingLabel.siblings('.form-group-without-top-label');
+
+          const inputClientRect = $inputElement.get(0).getBoundingClientRect();
+          const inputMidpoint = inputClientRect.top + (inputClientRect.height / 2);
+
+          const deleteButtonClientRect = $deleteButtonFormGroup.find('.button').get(0).getBoundingClientRect();
+          const deleteButtonMidpoint = deleteButtonClientRect.top + (deleteButtonClientRect.height / 2);
+
+          const midpointDifference = Math.abs(inputMidpoint - deleteButtonMidpoint);
+
+          expect(midpointDifference <= alignmentThreshold).to.equal(true);
+        });
+      });
+
       it('Should have a "Advanced Settings" section', function () {
         cy.get('.menu-tabbed-view')
           .contains('Advanced Settings');

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -401,7 +401,7 @@ describe('Service Form Modal', function () {
           .contains('Add Placement Constraint');
       });
 
-      it.only('Should vertically align the placement constraint delete row button', function () {
+      it('Should vertically align the placement constraint delete row button', function () {
         // We'll consider the two elements to be centered with one another if
         // their midpoints are within 5 pixels of one another.
         const alignmentThreshold = 5;


### PR DESCRIPTION
This PR cleans up the styling of the `DeleteRowButton` component. It removes all horizontal padding on the delete row button, uses `column-auto` instead of `column-2`, and increases the column width of all sibling `FormGroups` to ensure that the delete button takes up only as much space as is necessary. I also moved all classes to the `FormGroup` element so that we don't have to remember which classes to use in the future.

This adds two new props to the `FormGroup` component:
`isDeleteButton` — when true will apply the correct `column` and `flush` classes
`applyLabelOffset` — when true will apply the correct class, adds padding to the top of the form group so that it aligns vertically with its siblings who have labels

Before (note the real estate used by the button's column and its alignment with other delete buttons):
![](https://cl.ly/2b062z442x3J/Screen%20Shot%202017-03-17%20at%201.42.06%20PM.png)

After:
![](https://cl.ly/1N0R0f0z0L1u/Screen%20Shot%202017-03-17%20at%201.42.40%20PM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [x] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
