### PR TITLE
[System Tests]: Adding development environment dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+FROM mesosphere/dcos-system-test-driver:latest
+
+# Specify the component versions to use
+ENV CYPRESS_VERSION="0.19.1" \
+    NODE_VERSION="4.4.7" \
+    NPM_VERSION="3.9"
+
+# Expose the 4200 port
+EXPOSE 4200
+
+# Copy required files in order to be able to do npm install
+WORKDIR /dcos-ui
+COPY package.json npm-shrinkwrap.json scripts /dcos-ui/
+
+# Copy the entrypoint script that takes care of executing run-time init tasks,
+# such as creating the scaffold in the user's repository
+COPY scripts/docker-entrypoint /usr/local/bin/dcos-ui-docker-entrypoint
+
+# Install required components & prepare environment
+RUN set -x \
+
+  # Install node 4.4.7 & npm 3.9
+  && curl -o- https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz | tar -C /usr/local --strip-components=1 -zx \
+  && npm install -g npm@${NPM_VERSION} \
+
+  # Install cypress dependencies
+  && apt-get update \
+  && apt-get install -y xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+
+  # Install npm dependencies
+  && cd /dcos-ui \
+  && npm install \
+  && npm install -g cypress-cli http-server compression-webpack-plugin \
+
+  # Install cypress
+  && cypress install --cypress-version ${CYPRESS_VERSION} \
+
+  # Move node_modules out of the directory to make it clean for mounting
+  # this will be brought back in by the entry point
+  && mv node_modules /var/lib/ \
+
+  # Calculate the checksum of package.json in order to detect changes that
+  # will trigger a new npm install
+  && sha512sum package.json > /var/lib/package.json.sha512 \
+
+  # Ensure entrypoint is executable
+  && chmod +x /usr/local/bin/dcos-ui-docker-entrypoint \
+
+  # Make sure bash is the default shell
+  && rm /bin/sh \
+  && ln -sf /bin/bash /bin/sh
+
+# Define entrypoint
+ENTRYPOINT [ "/bin/bash", "/usr/local/bin/dcos-ui-docker-entrypoint" ]
+
+# Export the working directory
+VOLUME /dcos-ui

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN set -x \
   # Install npm dependencies
   && cd /dcos-ui \
   && npm install \
-  && npm install -g cypress-cli http-server compression-webpack-plugin \
+  && npm install -g cypress-cli git://github.com/johntron/http-server.git#proxy-secure-flag \
 
   # Install cypress
   && cypress install --cypress-version ${CYPRESS_VERSION} \

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -50,9 +50,9 @@
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
     },
     "amdefine": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "from": "amdefine@>=0.0.4",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
     },
     "ansi-escapes": {
       "version": "1.4.0",
@@ -170,9 +170,9 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.6.0.tgz"
     },
     "assert": {
-      "version": "1.3.0",
+      "version": "1.4.1",
       "from": "assert@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz"
     },
     "assert-plus": {
       "version": "0.2.0",
@@ -394,14 +394,14 @@
       }
     },
     "babel-loader": {
-      "version": "6.2.4",
-      "from": "babel-loader@6.2.4",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.4.tgz",
+      "version": "6.2.8",
+      "from": "babel-loader@6.2.8",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.8.tgz",
       "dependencies": {
         "object-assign": {
-          "version": "4.1.0",
+          "version": "4.1.1",
           "from": "object-assign@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
         }
       }
     },
@@ -1022,6 +1022,11 @@
       "from": "builtin-modules@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
     },
+    "builtin-status-codes": {
+      "version": "3.0.0",
+      "from": "builtin-status-codes@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz"
+    },
     "bytes": {
       "version": "2.1.0",
       "from": "bytes@2.1.0",
@@ -1315,6 +1320,11 @@
       "version": "2.9.0",
       "from": "commander@>=2.9.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "from": "commondir@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
     },
     "compressible": {
       "version": "2.0.8",
@@ -2590,9 +2600,9 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz"
     },
     "events": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "from": "events@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz"
     },
     "eventsource": {
       "version": "0.1.6",
@@ -2901,6 +2911,11 @@
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
         }
       }
+    },
+    "find-cache-dir": {
+      "version": "0.1.1",
+      "from": "find-cache-dir@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz"
     },
     "find-index": {
       "version": "0.1.1",
@@ -3592,9 +3607,9 @@
       "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.0.2.tgz"
     },
     "ieee754": {
-      "version": "1.1.6",
+      "version": "1.1.8",
       "from": "ieee754@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
     },
     "ignore": {
       "version": "3.1.5",
@@ -5812,6 +5827,11 @@
           "version": "0.11.3",
           "from": "process@>=0.11.0 <0.12.0",
           "resolved": "https://registry.npmjs.org/process/-/process-0.11.3.tgz"
+        },
+        "timers-browserify": {
+          "version": "1.4.2",
+          "from": "timers-browserify@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
         }
       }
     },
@@ -6046,9 +6066,9 @@
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz"
     },
     "pako": {
-      "version": "0.2.8",
+      "version": "0.2.9",
       "from": "pako@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
     },
     "param-case": {
       "version": "1.1.2",
@@ -7263,6 +7283,11 @@
       "from": "set-immediate-shim@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "from": "setimmediate@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+    },
     "sha.js": {
       "version": "2.4.5",
       "from": "sha.js@>=2.3.6 <3.0.0",
@@ -7553,6 +7578,11 @@
       "version": "1.0.1",
       "from": "stream-exhaust@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.1.tgz"
+    },
+    "stream-http": {
+      "version": "2.6.3",
+      "from": "stream-http@>=2.3.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.6.3.tgz"
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -7904,16 +7934,9 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
     },
     "timers-browserify": {
-      "version": "1.4.2",
-      "from": "timers-browserify@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
-      "dependencies": {
-        "process": {
-          "version": "0.11.3",
-          "from": "process@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.3.tgz"
-        }
-      }
+      "version": "2.0.2",
+      "from": "timers-browserify@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz"
     },
     "tiny-emitter": {
       "version": "1.0.2",
@@ -7968,6 +7991,11 @@
       "version": "0.1.1",
       "from": "to-absolute-glob@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz"
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "from": "to-arraybuffer@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
     },
     "to-fast-properties": {
       "version": "1.0.2",
@@ -8409,34 +8437,24 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
     },
     "webpack": {
-      "version": "1.13.0",
-      "from": "webpack@1.13.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.13.0.tgz",
+      "version": "1.14.0",
+      "from": "webpack@1.14.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.14.0.tgz",
       "dependencies": {
-        "base64-js": {
-          "version": "0.0.8",
-          "from": "base64-js@0.0.8",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+        "browserify-aes": {
+          "version": "0.4.0",
+          "from": "browserify-aes@0.4.0",
+          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz"
         },
         "buffer": {
-          "version": "3.6.0",
-          "from": "buffer@>=3.0.3 <4.0.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz"
-        },
-        "constants-browserify": {
-          "version": "0.0.1",
-          "from": "constants-browserify@0.0.1",
-          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+          "version": "4.9.1",
+          "from": "buffer@>=4.9.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz"
         },
         "crypto-browserify": {
-          "version": "3.2.8",
-          "from": "crypto-browserify@>=3.2.6 <3.3.0",
-          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz"
-        },
-        "https-browserify": {
-          "version": "0.0.0",
-          "from": "https-browserify@0.0.0",
-          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+          "version": "3.3.0",
+          "from": "crypto-browserify@3.3.0",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz"
         },
         "interpret": {
           "version": "0.6.6",
@@ -8444,31 +8462,14 @@
           "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
         },
         "node-libs-browser": {
-          "version": "0.5.3",
-          "from": "node-libs-browser@>=0.4.0 <=0.6.0",
-          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz"
-        },
-        "os-browserify": {
-          "version": "0.1.2",
-          "from": "os-browserify@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+          "version": "0.7.0",
+          "from": "node-libs-browser@>=0.7.0 <0.8.0",
+          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz"
         },
         "process": {
-          "version": "0.11.3",
+          "version": "0.11.9",
           "from": "process@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.3.tgz"
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "from": "readable-stream@>=1.1.13 <2.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
-              "from": "isarray@0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-            }
-          }
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz"
         },
         "ripemd160": {
           "version": "0.2.0",
@@ -8480,30 +8481,35 @@
           "from": "sha.js@2.2.6",
           "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
         },
-        "stream-browserify": {
-          "version": "1.0.0",
-          "from": "stream-browserify@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
+        "source-map": {
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         },
-        "url": {
-          "version": "0.10.3",
-          "from": "url@>=0.10.1 <0.11.0",
-          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+        "uglify-js": {
+          "version": "2.7.5",
+          "from": "uglify-js@>=2.7.3 <2.8.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
           "dependencies": {
-            "punycode": {
-              "version": "1.3.2",
-              "from": "punycode@1.3.2",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             }
           }
         }
       }
     },
     "webpack-core": {
-      "version": "0.6.8",
-      "from": "webpack-core@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
+      "version": "0.6.9",
+      "from": "webpack-core@>=0.6.9 <0.7.0",
+      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
       "dependencies": {
+        "source-list-map": {
+          "version": "0.1.8",
+          "from": "source-list-map@>=0.1.7 <0.2.0",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
+        },
         "source-map": {
           "version": "0.4.4",
           "from": "source-map@>=0.4.1 <0.5.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "babel": "6.5.2",
     "babel-cli": "6.9.0",
     "babel-core": "6.9.1",
-    "babel-loader": "6.2.4",
+    "babel-loader": "6.2.8",
     "babel-plugin-transform-runtime": "6.9.0",
     "babel-preset-es2015": "6.9.0",
     "babel-preset-jest": "16.0.0",
@@ -118,7 +118,7 @@
     "svg-sprite": "1.3.1",
     "transform-loader": "0.2.3",
     "vinyl": "1.1.1",
-    "webpack": "1.13.0",
+    "webpack": "1.14.0",
     "webpack-dev-server": "1.14.1",
     "webpack-notifier": "1.3.0"
   },

--- a/scripts/docker-entrypoint
+++ b/scripts/docker-entrypoint
@@ -1,0 +1,54 @@
+#!/bin/bash
+# This script is executed in the development docker image when the user
+# runs any command within it. It's purpose is to check the if scaffolding
+# is needed and apply it.
+
+# The docker file has a cached version of the dependencies in a node_modules
+# folder in /var/lib. In oder to speed things up don't copy, just sym-link to
+# the user's mountpoint
+if [[ -a node_modules ]]; then
+  mv node_modules _node_modules
+fi
+ln -s /var/lib/node_modules
+
+# If the package.json has changed re-run npm install
+if ! sha512sum -c /var/lib/package.json.sha512 2>/dev/null >/dev/null; then
+  npm install
+  sha512sum package.json > /var/lib/package.json.sha512
+fi
+
+#
+# Define externalplugins if we have mounted such directory
+#
+if [[ -d /dcos-ui-plugins ]]; then
+  npm config set externalplugins ../dcos-ui-plugins
+fi
+
+#
+# Run preinstall if pre-install dependencies are missing. These are:
+#
+# - Marathon RAM Files
+#
+if [[ ! -d src/resources/raml/marathon ]]; then
+  ./scripts/pre-install
+fi
+
+#
+# Run scaffold if some files are missing:
+#
+# - src/js/config/Config.dev.js
+# - webpack/proxy.dev.js
+#
+if [[ ! -f ./src/js/config/Config.dev.js || ! -f ./webpack/proxy.dev.js ]]; then
+  npm run scaffold
+fi
+
+# Pass through everything else
+$*
+
+# Recover user's version of node_modules at exit
+rm node_modules
+if [[ -a _node_modules ]]; then
+  mv _node_modules node_modules
+fi
+

--- a/webpack/webpack.dev.babel.js
+++ b/webpack/webpack.dev.babel.js
@@ -99,7 +99,7 @@ module.exports = Object.assign({}, webpackConfig, {
         // Exclude all node_modules except dcos-dygraphs
         exclude: /(?=\/node_modules\/)(?!\/node_modules\/dcos-dygraphs\/)/,
         loader: reactHotLoader + 'babel?' + JSON.stringify({
-          cacheDirectory: true,
+          cacheDirectory: '/tmp',
           // Map through resolve to fix preset loading problem
           presets: [
             'babel-preset-es2015',

--- a/webpack/webpack.production.babel.js
+++ b/webpack/webpack.production.babel.js
@@ -85,7 +85,7 @@ module.exports = Object.assign({}, webpackConfig, {
         // Exclude all node_modules except dcos-dygraphs
         exclude: /(?=\/node_modules\/)(?!\/node_modules\/dcos-dygraphs\/)/,
         loader: 'babel?' + JSON.stringify({
-          cacheDirectory: true,
+          cacheDirectory: '/tmp',
           // Map through resolve to fix preset loading problem
           presets: [
             'babel-preset-es2015',


### PR DESCRIPTION
This PR introduces a `Dockerfile` that is used to build the [dcos-ui docker image](https://hub.docker.com/r/mesosphere/dcos-ui/) for use in development and build environments.

**NOTE:** Due to some bugs on the previous versions of `webpack` and `babel-loader` I also had to update the respective versions to the next available one.

This container **does not contain the dcos-ui sources**. It contains only the tooling required by the developer, the build system or the system integration tests.

In detail the docker image contains:
* Node 4.4.7 & npm 3.9
* The current branch's dependencies pre-installed
* Automatic initialisation script that runs `npm run scaffold` if requested to run on a clean repo

### How to use

You must mount the `dcos-ui` repository manually under the `/dcos-ui` volume. For example:

```
docker run -it --rm \
  -v `pwd`:/dcos-ui \
  -p 4200:4200 \
  mesosphere/dcos-ui:latest \
  npm start
```

_If you are developing your own plugins you can mount their directory in the `/dcos-ui-plugins` volume. The container will automatically set-up the environment to include them_ 

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?