### PR TITLE
[System Tests]: DCOS-12807: Adding the 'Create a simple app' test

### DIFF
--- a/system-tests/services/test-apps.js
+++ b/system-tests/services/test-apps.js
@@ -1,0 +1,128 @@
+require('../_support/utils/ServicesUtil');
+
+describe('Services', function () {
+
+  /**
+   * Test the applications
+   */
+  describe('Applications', function () {
+
+    beforeEach(function () {
+      cy
+        .visitUrl(`services/overview/%2F${Cypress.env('TEST_UUID')}/create`);
+    });
+
+    function selectMesosRuntime() {
+      cy
+        .contains('More Settings')
+        .click();
+      cy
+        .contains('Mesos Runtime')
+        .click();
+    }
+
+    it('Create a simple app', function () {
+      const serviceName = 'app-with-inline-shell-script';
+      const cmdline = 'while true; do echo \'test\' ; sleep 100 ; done';
+
+      // Select 'Single Container'
+      cy
+        .contains('Single Container')
+        .click();
+
+      // Fill-in the input elements
+      cy
+        .root()
+        .getFormGroupInputFor('Service ID *')
+        .type(`{selectall}{rightarrow}${serviceName}`);
+      //
+      // TODO: Due to a bug in cypress you cannot type values with dots
+      // cy
+      //   .get('input[name=cpus]')
+      //   .type('{selectall}0.5');
+      //
+      cy
+        .root()
+        .getFormGroupInputFor('Memory (MiB) *')
+        .type('{selectall}10');
+      cy
+        .root()
+        .getFormGroupInputFor('Command')
+        .type(cmdline);
+
+      // Select mesos runtime
+      selectMesosRuntime();
+
+      // Check JSON view
+      cy
+        .contains('JSON Editor')
+        .click();
+
+      // Check contents of the JSON editor
+      cy
+        .get('#brace-editor')
+        .contents()
+        .asJson()
+        .should('deep.equal', [{
+          'id': `/${Cypress.env('TEST_UUID')}/${serviceName}`,
+          'cmd': cmdline,
+          'cpus': 0.1,
+          'mem': 10,
+          'instances': 1
+        }]);
+
+      // Click Review and Run
+      cy
+        .contains('Review & Run')
+        .click();
+
+      // Verify the review screen
+      cy
+        .root()
+        .configurationSection('General')
+        .configurationMapValue('Service ID')
+        .contains(`/${Cypress.env('TEST_UUID')}/${serviceName}`);
+      cy
+        .root()
+        .configurationSection('General')
+        .configurationMapValue('Container Runtime')
+        .contains('Mesos Runtime');
+      cy
+        .root()
+        .configurationSection('General')
+        .configurationMapValue('CPU')
+        .contains('0.1');
+      cy
+        .root()
+        .configurationSection('General')
+        .configurationMapValue('Memory')
+        .contains('10 MiB');
+      cy
+        .root()
+        .configurationSection('General')
+        .configurationMapValue('Disk')
+        .contains('Not Configured');
+
+      // Run service
+      cy
+        .get('button.button-primary')
+        .contains('Run Service')
+        .click();
+
+      // Wait for the table and the service to appear
+      cy
+        .get('.page-body-content table')
+        .contains(serviceName)
+        .should('exist');
+
+      // Wait for the table and the service to appear
+      cy
+        .get('.page-body-content table')
+        .getTableRowThatContains(serviceName)
+        .should('exist');
+
+    });
+
+  });
+
+});

--- a/system-tests/services/tests.yml
+++ b/system-tests/services/tests.yml
@@ -8,5 +8,5 @@
         - cypress
     scripts:
       setup: ./services/_scripts/setup
-      run: cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec services/test-environment.js
+      run: cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec services/test-environment.js --spec services/test-apps.js
       teardown: ./services/_scripts/teardown


### PR DESCRIPTION
---
⚠️  ~~Depends on #2029~~ (Merged)

---

This PR introduces the automated tests for _Create a simple app_

To run this test, use:

<pre>
docker run -it --rm \
  -v `pwd`:/dcos-ui \
  mesosphere/dcos-ui \
  dcos-system-test-driver ./.systemtest-dev.sh <strong>$CLUSTER_URL</strong>
</pre>