### PR TITLE
[System Tests]: DCOS-12805: Add SI tests for creating a simple pod

### DIFF
--- a/system-tests/services/test-pods.js
+++ b/system-tests/services/test-pods.js
@@ -13,6 +13,199 @@ describe('Services', function () {
         .visitUrl(`services/overview/%2F${Cypress.env('TEST_UUID')}/create`);
     });
 
+    it('Create a simple pod', function () {
+      const serviceName = 'pod-with-inline-shell-script';
+      const command = 'while true ; do echo \'test\' ; sleep 100 ;';
+
+      cy
+        .contains('Multi-container (Pod)')
+        .click();
+
+      cy
+        .root()
+        .getFormGroupInputFor('Service ID *')
+        .type(`{selectall}{rightarrow}${serviceName}`);
+
+      cy
+        .get('.menu-tabbed-item')
+        .contains('container-1')
+        .click();
+
+      // TODO: Due to a bug in cypress you cannot type values with dots
+      // cy
+      //   .root()
+      //   .getFormGroupInputFor('CPUs *')
+      //   .type('{selectall}0.1');
+
+      cy
+        .root()
+        .getFormGroupInputFor('Memory (MiB) *')
+        .type('{selectall}10');
+
+      cy
+        .root()
+        .getFormGroupInputFor('Memory (MiB) *')
+        .type('{selectall}10');
+
+      cy
+        .root()
+        .getFormGroupInputFor('Command')
+        .type(command);
+
+      cy
+        .get('label')
+        .contains('JSON Editor')
+        .click();
+
+      cy
+        .get('#brace-editor')
+        .contents()
+        .asJson()
+        .should('deep.equal', [{
+          'id': `/${Cypress.env('TEST_UUID')}/${serviceName}`,
+          'containers': [
+            {
+              'name': 'container-1',
+              'resources': {
+                'cpus': 0.1,
+                'mem': 10
+              },
+              'exec': {
+                'command': {
+                  'shell': command
+                }
+              }
+            }
+          ],
+          'scaling': {
+            'kind': 'fixed',
+            'instances': 1
+          },
+          'networks': [
+            {
+              'mode': 'host'
+            }
+          ]
+        }]);
+
+      cy
+        .get('#brace-editor')
+        .contents()
+        .asJson()
+        .should('deep.equal', [{
+          'id': `/${Cypress.env('TEST_UUID')}/${serviceName}`,
+          'containers': [
+            {
+              'name': 'container-1',
+              'resources': {
+                'cpus': 0.1,
+                'mem': 10
+              },
+              'exec': {
+                'command': {
+                  'shell': command
+                }
+              }
+            }
+          ],
+          'scaling': {
+            'kind': 'fixed',
+            'instances': 1
+          },
+          'networks': [
+            {
+              'mode': 'host'
+            }
+          ]
+        }]);
+
+      cy
+        .get('button')
+        .contains('Review & Run')
+        .click();
+
+      cy
+        .root()
+        .configurationSection('General')
+        .configurationMapValue('Service ID')
+        .contains(`/${Cypress.env('TEST_UUID')}/${serviceName}`);
+
+      cy
+        .root()
+        .configurationSection('General')
+        .configurationMapValue('CPU')
+        .contains('0.1 (0.1 container-1)');
+
+      cy
+        .root()
+        .configurationSection('General')
+        .configurationMapValue('Memory')
+        .contains('10 MiB (10 MiB container-1)');
+
+      cy
+        .root()
+        .configurationSection('General')
+        .configurationMapValue('Disk')
+        .contains('Not Supported');
+
+      cy
+        .root()
+        .configurationSection('General')
+        .configurationMapValue('GPU')
+        .contains('Not Supported');
+
+      cy
+        .root()
+        .configurationSection('Containers')
+        .configurationMapValue('CPUs')
+        .contains('0.1');
+
+      cy
+        .root()
+        .configurationSection('Containers')
+        .configurationMapValue('Container Image')
+        .contains('Not Configured');
+
+      cy
+        .root()
+        .configurationSection('Containers')
+        .configurationMapValue('Force Pull On Launch')
+        .contains('Not Configured');
+
+      cy
+        .root()
+        .configurationSection('Containers')
+        .configurationMapValue('CPUs')
+        .contains('0.1');
+
+      cy
+        .root()
+        .configurationSection('Containers')
+        .configurationMapValue('Memory')
+        .contains('10 MiB');
+
+      cy
+        .root()
+        .configurationSection('Containers')
+        .configurationMapValue('Command')
+        .contains(command);
+
+      cy
+        .get('button')
+        .contains('Run Service')
+        .click();
+
+      cy
+        .get('.page-body-content table')
+        .contains(serviceName)
+        .should('exist');
+
+      cy
+        .get('.page-body-content table')
+        .getTableRowThatContains(serviceName)
+        .should('exist');
+    });
+
     it('Create a pod with multiple containers', function () {
       const serviceName = 'pod-with-multiple-containers';
       const cmdline = 'while true; do echo \'test\' ; sleep 100 ; done';

--- a/system-tests/services/tests.yml
+++ b/system-tests/services/tests.yml
@@ -23,15 +23,3 @@
       setup: ./services/_scripts/setup
       run: cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec services/test-environment.js --spec services/test-pods.js
       teardown: ./services/_scripts/teardown
-  - name: services.pods
-    title: Pods
-    cluster:
-      features: []
-    results:
-      junit: "cypress/results.xml"
-      assets:
-        - cypress
-    scripts:
-      setup: ./services/_scripts/setup
-      run: cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec services/test-pods.js
-      teardown: ./services/_scripts/teardown

--- a/system-tests/services/tests.yml
+++ b/system-tests/services/tests.yml
@@ -23,3 +23,15 @@
       setup: ./services/_scripts/setup
       run: cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec services/test-environment.js --spec services/test-pods.js
       teardown: ./services/_scripts/teardown
+  - name: services.pods
+    title: Pods
+    cluster:
+      features: []
+    results:
+      junit: "cypress/results.xml"
+      assets:
+        - cypress
+    scripts:
+      setup: ./services/_scripts/setup
+      run: cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec services/test-pods.js
+      teardown: ./services/_scripts/teardown


### PR DESCRIPTION
This PR introduces the automated tests for [Create a simple pod](https://wiki.mesosphere.com/pages/viewpage.action?pageId=99615053)

To run this test, use:

<pre>
docker run -it --rm --ipc=host \
  -e CLUSTER_URL=$CLUSTER_URL  \
  -v `pwd`:/dcos-ui \
  mesosphere/dcos-ui dcos-system-test-driver \
  ./system-tests/driver-config/cluster.sh
</pre>