### PR TITLE
DCOS-14733: Fix review screen for app definitions with args

### DIFF
--- a/plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js
@@ -210,9 +210,11 @@ class ServiceGeneralConfigSection extends ServiceConfigBaseSectionDisplay {
               return getDisplayValue(null);
             }
 
-            return value.map((arg, index) => (
+            const args = value.map((arg, index) => (
               <pre key={index} className="flush transparent wrap">{arg}</pre>
             ));
+
+            return <div>{args}</div>;
           }
         },
         {


### PR DESCRIPTION
This PR addresses the inability to create an app with arguments by wrapping the array of `<pre>` in `<div>` so that ServiceConfigDisplayUtil.getDisplayValue won't `JSON.stringify` it.

To test try to launch appDefinition and try without args.

```json
{
    "id": "inky", 
    "container": {
        "docker": {
            "image": "mesosphere/inky"
        },
        "type": "DOCKER",
        "volumes": []
    },
    "args": ["hello"],
    "cpus": 0.2,
    "mem": 32.0,
    "instances": 1
}
```