### PR TITLE
[System Tests]: DCOS-12808: Add SI tests for pod with virtual network

### DIFF
--- a/system-tests/services/test-pods.js
+++ b/system-tests/services/test-pods.js
@@ -757,5 +757,181 @@ describe("Services", function() {
         .getTableRowThatContains(serviceName)
         .should("exist");
     });
+
+    it("Create a pod with virtual network", function() {
+      const serviceName = "pod-with-virtual-network";
+      const command = "python3 -m http.server 8080";
+      const containerImage = "python:3";
+
+      cy.contains("Multi-container (Pod)").click();
+
+      cy
+        .root()
+        .getFormGroupInputFor("Service ID *")
+        .type(`{selectall}{rightarrow}${serviceName}`);
+
+      cy.get(".menu-tabbed-item").contains("container-1").click();
+
+      // TODO: Due to a bug in cypress you cannot type values with dots
+      // cy
+      //   .root()
+      //   .getFormGroupInputFor('CPUs *')
+      //   .type('{selectall}0.5');
+
+      cy.root().getFormGroupInputFor("Memory (MiB) *").type("{selectall}32");
+
+      cy.root().getFormGroupInputFor("Container Image").type(containerImage);
+
+      cy.root().getFormGroupInputFor("Command").type(command);
+
+      cy.get(".menu-tabbed-item").contains("Networking").click();
+
+      cy
+        .root()
+        .getFormGroupInputFor("Network Type")
+        .select("Virtual Network: dcos");
+
+      cy.get(".button").contains("Add Service Endpoint").click();
+
+      cy.root().getFormGroupInputFor("Container Port").type("8080");
+
+      cy.root().getFormGroupInputFor("Service Endpoint Name").type("http");
+
+      cy.get("label").contains("JSON Editor").click();
+
+      cy.get("#brace-editor").contents().asJson().should("deep.equal", [
+        {
+          id: `/${Cypress.env("TEST_UUID")}/${serviceName}`,
+          containers: [
+            {
+              name: "container-1",
+              resources: {
+                cpus: 0.1,
+                mem: 32
+              },
+              endpoints: [
+                {
+                  name: "http",
+                  containerPort: 8080,
+                  hostPort: 0,
+                  protocol: ["tcp"]
+                }
+              ],
+              image: {
+                id: "python:3",
+                kind: "DOCKER"
+              },
+              exec: {
+                command: {
+                  shell: "python3 -m http.server 8080"
+                }
+              }
+            }
+          ],
+          scaling: {
+            kind: "fixed",
+            instances: 1
+          },
+          networks: [
+            {
+              name: "dcos",
+              mode: "container"
+            }
+          ]
+        }
+      ]);
+
+      cy.get("button").contains("Review & Run").click();
+
+      cy
+        .root()
+        .configurationSection("General")
+        .configurationMapValue("Service ID")
+        .contains(`/${Cypress.env("TEST_UUID")}/${serviceName}`);
+
+      cy
+        .root()
+        .configurationSection("General")
+        .configurationMapValue("CPU")
+        .contains("0.1 (0.1 container-1)");
+
+      cy
+        .root()
+        .configurationSection("General")
+        .configurationMapValue("Memory")
+        .contains("32 MiB (32 MiB container-1)");
+
+      cy
+        .root()
+        .configurationSection("General")
+        .configurationMapValue("Disk")
+        .contains("Not Supported");
+
+      cy
+        .root()
+        .configurationSection("General")
+        .configurationMapValue("GPU")
+        .contains("Not Supported");
+
+      cy
+        .root()
+        .configurationSection("Containers")
+        .configurationMapValue("Container Image")
+        .contains("python:3");
+
+      cy
+        .root()
+        .configurationSection("Containers")
+        .configurationMapValue("Force Pull On Launch")
+        .contains("Not Configured");
+
+      cy
+        .root()
+        .configurationSection("Containers")
+        .configurationMapValue("CPUs")
+        .contains("0.1");
+
+      cy
+        .root()
+        .configurationSection("Containers")
+        .configurationMapValue("Memory")
+        .contains("32 MiB");
+
+      cy
+        .root()
+        .configurationSection("Containers")
+        .configurationMapValue("Command")
+        .contains(command);
+
+      cy
+        .root()
+        .configurationSection("Network")
+        .configurationMapValue("Network Type")
+        .contains("Container");
+
+      cy
+        .root()
+        .configurationSection("Service Endpoints")
+        .then(function($serviceEndpointsSection) {
+          const $tableRow = $serviceEndpointsSection.find("tr:visible");
+          const $tableCells = $tableRow.find("td");
+          const cellValues = ["http", "tcp", "8080", "container-1", "Edit"];
+
+          expect($tableCells.length).to.equal(5);
+
+          $tableCells.each(function(index) {
+            expect(this.textContent.trim()).to.equal(cellValues[index]);
+          });
+        });
+
+      cy.get("button").contains("Run Service").click();
+
+      cy.get(".page-body-content table").contains(serviceName).should("exist");
+
+      cy
+        .get(".page-body-content table")
+        .getTableRowThatContains(serviceName)
+        .should("exist");
+    });
   });
 });


### PR DESCRIPTION
This PR introduces the automated tests for [Create a pod with a virtual network](https://wiki.mesosphere.com/pages/viewpage.action?pageId=101253133)

**The following test is expected to fail**, because some volume labels have changed (`MiB` to `GiB`, or vice versa, I can't remember) and they have not yet been released in the DCOS release branches:
```
✘ Services Applications Create an app with external volume
```

To run this test, use:
<pre>
docker pull mesosphere/dcos-ui && docker run -it --rm --ipc=host \
  -e CLUSTER_URL=$CLUSTER_URL  \
  -v `pwd`:/dcos-ui \
  mesosphere/dcos-ui dcos-system-test-driver \
  ./system-tests/driver-config/cluster.sh
</pre>