### PR TITLE
DCOS-13909: A couple of error fixes

### DIFF
--- a/plugins/services/src/js/constants/ServiceErrorMessages.js
+++ b/plugins/services/src/js/constants/ServiceErrorMessages.js
@@ -22,6 +22,12 @@ const ServiceErrorMessages = [
     type: 'SERVICE_DEPLOYING',
     message: 'The service is currently locked by one or more deployments. ' +
       'Press again to force this operation.'
+  },
+  {
+    path: /^container\.docker\.portMappings\.[0-9]+\.name$|^portDefinitions\.[0-9]+\.name$/,
+    type: 'STRING_PATTERN',
+    message: 'May only contain digits (0-9), dashes (-) and ' +
+      'lowercase letters (a-z) e.g. web-server'
   }
 ].concat(DefaultErrorMessages);
 

--- a/plugins/services/src/js/constants/ServiceErrorMessages.js
+++ b/plugins/services/src/js/constants/ServiceErrorMessages.js
@@ -24,7 +24,13 @@ const ServiceErrorMessages = [
       'Press again to force this operation.'
   },
   {
-    path: /^container\.docker\.portMappings\.[0-9]+\.name$|^portDefinitions\.[0-9]+\.name$/,
+    path: /^container\.docker\.portMappings\.[0-9]+\.name$/,
+    type: 'STRING_PATTERN',
+    message: 'May only contain digits (0-9), dashes (-) and ' +
+      'lowercase letters (a-z) e.g. web-server'
+  },
+  {
+    path: /^portDefinitions\.[0-9]+\.name$/,
     type: 'STRING_PATTERN',
     message: 'May only contain digits (0-9), dashes (-) and ' +
       'lowercase letters (a-z) e.g. web-server'

--- a/plugins/services/src/js/constants/ServiceErrorPathMapping.js
+++ b/plugins/services/src/js/constants/ServiceErrorPathMapping.js
@@ -1,19 +1,95 @@
 const ServiceErrorPathMapping = [
   {
     match: /^id$/,
-    name: 'The service ID'
+    name: 'Service ID'
   },
   {
     match: /^instances$/,
-    name: 'The number of instances'
+    name: 'Instances'
   },
   {
     match: /^cpus$/,
-    name: 'The number of CPUs'
+    name: 'CPUs'
+  },
+  {
+    match: /^mem$/,
+    name: 'Memory'
   },
   {
     match: /^env\.\*$/,
-    name: 'An environment variable'
+    name: 'Environment variables'
+  },
+
+  //
+  // Volumes
+  //
+  {
+    match: /^container\.volumes\.[0-9]+\.containerPath$/,
+    name: 'Volume container path'
+  },
+  {
+    match: /^container\.volumes\.[0-9]+\..*size$/,
+    name: 'Volume size'
+  },
+  {
+    match: /^container\.volumes\.[0-9]+\.hostPath$/,
+    name: 'Volume host path'
+  },
+  {
+    match: /^container\.volumes\.[0-9]+\.mode$/,
+    name: 'Volume mode'
+  },
+
+  //
+  // Networking (Host)
+  //
+  {
+    match: /^portDefinitions\.[0-9]+\.name$/,
+    name: 'Service endpoint names'
+  },
+  {
+    match: /^portDefinitions\.[0-9]+\.port$/,
+    name: 'Service endpoint host ports'
+  },
+  {
+    match: /^portDefinitions\.[0-9]+\.labels\.VIP_/,
+    name: 'Service endpoint host ports'
+  },
+
+  //
+  // Networking (Bridge)
+  //
+  {
+    match: /^container\.docker\.portMappings\.[0-9]+\.name/,
+    name: 'Service endpoint names'
+  },
+  {
+    match: /^container\.docker\.portMappings\.[0-9]+\.containerPort/,
+    name: 'Service endpoint container ports'
+  },
+  {
+    match: /^container\.docker\.portMappings\.[0-9]+\.hostPort/,
+    name: 'Service endpoint host ports'
+  },
+
+  //
+  // Health checks
+  //
+  {
+    match: /^healthChecks\.[0-9]+\.gracePeriodSeconds/,
+    name: 'Health check grace periods'
+  },
+  {
+    match: /^healthChecks\.[0-9]+\.intervalSeconds/,
+    name: 'Health check intervals'
+  },
+  {
+    match: /^healthChecks\.[0-9]+\.timeoutSeconds/,
+    name: 'Health check timeouts'
+  },
+  {
+    match: /^healthChecks\.[0-9]+\.maxConsecutiveFailures/,
+    name: 'Health check max failures'
   }
 ];
 

--- a/plugins/services/src/js/validators/VipLabelsValidators.js
+++ b/plugins/services/src/js/validators/VipLabelsValidators.js
@@ -31,7 +31,7 @@ function checkServiceEndpoints(ports, pathPrefix) {
           if (!NetworkValidatorUtil.isValidPort(vipPort)) {
             return errorsMemo.concat({
               path: pathPrefix.concat([index, 'labels', label]),
-              message: 'Port should be an integrer less than or equal to 65535'
+              message: 'Port should be an integer less than or equal to 65535'
             });
           }
 

--- a/plugins/services/src/js/validators/__tests__/VipLabelsValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/VipLabelsValidators-test.js
@@ -72,7 +72,7 @@ describe('VipLabelsValidators', function () {
           };
           expect(VipLabelsValidators.mustContainPort(spec)).toEqual([
             {
-              message: 'Port should be an integrer less than or equal to 65535',
+              message: 'Port should be an integer less than or equal to 65535',
               path: [
                 'container',
                 'docker',

--- a/src/js/components/ErrorsAlert.js
+++ b/src/js/components/ErrorsAlert.js
@@ -17,9 +17,19 @@ const ErrorsAlert = function (props) {
     return <noscript />;
   }
 
-  const errorItems = showErrors.map((error, index) => {
+  // De-duplicate error messages that have exactly the same translated output
+  const errorMessages = showErrors.reduce(function (messages, error) {
     const message = getUnanchoredErrorMessage(error, pathMapping);
+    if (messages.indexOf(message) !== -1) {
+      return messages;
+    }
 
+    messages.push(message);
+
+    return messages;
+  }, []);
+
+  const errorItems = errorMessages.map((message, index) => {
     return (
       <li key={index} className="short">
         {message}


### PR DESCRIPTION
This PR comes after a testing session with @leemunroe . It fixes the following:

* Adding name aliases in all property paths. (For example "cmd: Missing" -> "Command missing").
* Adding a more user-friendly error message for the `STRING_PATTERN` error on port endpoint name.
* Removing duplicate messages from the `ErrorsAlert.js` component that displays the unanchored messages.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
