### PR TITLE
[System Tests]: DCOS-12811: Add SI tests for pod with ephemeral volume

### DIFF
--- a/system-tests/services/test-pods.js
+++ b/system-tests/services/test-pods.js
@@ -933,5 +933,166 @@ describe("Services", function() {
         .getTableRowThatContains(serviceName)
         .should("exist");
     });
+
+    it("Create a pod with ephemeral volume", function() {
+      const serviceName = "pod-with-ephemeral-volume";
+      const command = "`while true ; do echo 'test' ; sleep 100 ; done";
+
+      cy.contains("Multi-container (Pod)").click();
+
+      cy
+        .root()
+        .getFormGroupInputFor("Service ID *")
+        .type(`{selectall}{rightarrow}${serviceName}`);
+
+      cy.get(".menu-tabbed-item").contains("container-1").click();
+
+      // TODO: Due to a bug in cypress you cannot type values with dots
+      // cy
+      //   .root()
+      //   .getFormGroupInputFor('CPUs *')
+      //   .type('{selectall}0.1');
+
+      cy.root().getFormGroupInputFor("Memory (MiB) *").type("{selectall}10");
+
+      cy.root().getFormGroupInputFor("Command").type(command);
+
+      cy.get(".menu-tabbed-item").contains("Volumes").click();
+
+      cy.get(".button").contains("Add Ephemeral Volume").click();
+
+      cy.root().getFormGroupInputFor("Name").type("test");
+
+      cy.root().getFormGroupInputFor("Container Path").type("test");
+
+      cy.get("#brace-editor").contents().asJson().should("deep.equal", [
+        {
+          id: `/${Cypress.env("TEST_UUID")}/${serviceName}`,
+          containers: [
+            {
+              name: "container-1",
+              resources: {
+                cpus: 0.1,
+                mem: 10
+              },
+              exec: {
+                command: {
+                  shell: command
+                }
+              },
+              volumeMounts: [
+                {
+                  name: "test",
+                  mountPath: "test"
+                }
+              ]
+            }
+          ],
+          scaling: {
+            kind: "fixed",
+            instances: 1
+          },
+          networks: [
+            {
+              mode: "host"
+            }
+          ],
+          volumes: [
+            {
+              name: "test"
+            }
+          ]
+        }
+      ]);
+
+      cy.get("button").contains("Review & Run").click();
+
+      cy
+        .root()
+        .configurationSection("General")
+        .configurationMapValue("Service ID")
+        .contains(`/${Cypress.env("TEST_UUID")}/${serviceName}`);
+
+      cy
+        .root()
+        .configurationSection("General")
+        .configurationMapValue("Instances")
+        .contains("1");
+
+      cy
+        .root()
+        .configurationSection("General")
+        .configurationMapValue("CPU")
+        .contains("0.1 (0.1 container-1)");
+
+      cy
+        .root()
+        .configurationSection("General")
+        .configurationMapValue("Memory")
+        .contains("10 MiB (10 MiB container-1)");
+
+      cy
+        .root()
+        .configurationSection("General")
+        .configurationMapValue("Disk")
+        .contains("Not Supported");
+
+      cy
+        .root()
+        .configurationSection("General")
+        .configurationMapValue("GPU")
+        .contains("Not Supported");
+
+      cy
+        .root()
+        .configurationSection("Containers")
+        .configurationMapValue("Container Image")
+        .contains("Not Configured");
+
+      cy
+        .root()
+        .configurationSection("Containers")
+        .configurationMapValue("Force Pull On Launch")
+        .contains("Not Configured");
+
+      cy
+        .root()
+        .configurationSection("Containers")
+        .configurationMapValue("CPUs")
+        .contains("0.1");
+
+      cy
+        .root()
+        .configurationSection("Containers")
+        .configurationMapValue("Memory")
+        .contains("10 MiB");
+
+      cy
+        .root()
+        .configurationSection("Containers")
+        .configurationMapValue("Command")
+        .contains(command);
+
+      cy.root().configurationSection("Storage").then(function($storageSection) {
+        const $tableRow = $storageSection.find("tbody tr:visible");
+        const $tableCells = $tableRow.find("td");
+        const cellValues = ["test", "FALSE", "test", "container-1", "Edit"];
+
+        expect($tableCells.length).to.equal(5);
+
+        $tableCells.each(function(index) {
+          expect(this.textContent.trim()).to.equal(cellValues[index]);
+        });
+      });
+
+      cy.get("button").contains("Run Service").click();
+
+      cy.get(".page-body-content table").contains(serviceName).should("exist");
+
+      cy
+        .get(".page-body-content table")
+        .getTableRowThatContains(serviceName)
+        .should("exist");
+    });
   });
 });


### PR DESCRIPTION
This PR introduces the automated tests for [Create a pod with a virtual network](https://wiki.mesosphere.com/pages/viewpage.action?pageId=101253133)

**The following test is expected to fail**, because some volume labels have changed (`MiB` to `GiB`, or vice versa, I can't remember) and they have not yet been released in the DCOS release branches:
```
✘ Services Applications Create an app with external volume
```

To run this test use:
<pre>
docker pull mesosphere/dcos-ui && docker run -it --rm --ipc=host \
  -e CLUSTER_URL=$CLUSTER_URL  \
  -v `pwd`:/dcos-ui \
  mesosphere/dcos-ui dcos-system-test-driver \
  ./system-tests/driver-config/cluster.sh
</pre>