### PR TITLE
Remove unnecessary withCredentials from EventSource

### DIFF
--- a/src/js/events/SystemLogActions.js
+++ b/src/js/events/SystemLogActions.js
@@ -9,7 +9,6 @@ import {
   REQUEST_SYSTEM_LOG_STREAM_TYPES_SUCCESS
 } from '../constants/ActionTypes';
 import AppDispatcher from './AppDispatcher';
-import CookieUtils from '../utils/CookieUtils';
 import Config from '../config/Config';
 import {accumulatedThrottle, getUrl} from '../utils/SystemLogUtil';
 
@@ -27,9 +26,7 @@ function subscribe(url, onMessage, onError) {
   // Unsubscribe if any open connection exists with the same ID
   unsubscribe(url);
 
-  const source = new EventSource(url, {
-    withCredentials: Boolean(CookieUtils.getUserMetadata())
-  });
+  const source = new EventSource(url);
 
   source.addEventListener('message', onMessage, false);
   source.addEventListener('error', onError, false);

--- a/src/js/events/__tests__/SystemLogActions-test.js
+++ b/src/js/events/__tests__/SystemLogActions-test.js
@@ -2,9 +2,7 @@ jest.dontMock('../SystemLogActions');
 jest.dontMock('../../events/AppDispatcher');
 jest.dontMock('../../constants/ActionTypes');
 jest.dontMock('../../utils/SystemLogUtil');
-jest.dontMock('../../utils/CookieUtils');
 
-const cookie = require('cookie');
 const RequestUtil = require('mesosphere-shared-reactjs').RequestUtil;
 
 const ActionTypes = require('../../constants/ActionTypes');
@@ -12,27 +10,15 @@ const AppDispatcher = require('../../events/AppDispatcher');
 const Config = require('../../config/Config');
 const SystemLogActions = require('../SystemLogActions');
 
-const USER_COOKIE_KEY = 'dcos-acs-info-cookie';
-
 describe('SystemLogActions', function () {
 
   beforeEach(function () {
-    // Mock cookie
-    this.cookieParse = cookie.parse;
-    cookie.parse = function () {
-      var cookieObj = {};
-      cookieObj[USER_COOKIE_KEY] = 'aRandomCode';
-
-      return cookieObj;
-    };
-
     // Mock EventSource
     this.eventSource = new global.EventSource();
     spyOn(global, 'EventSource').and.returnValue(this.eventSource);
   });
 
   afterEach(function () {
-    cookie.parse = this.cookieParse;
     this.eventSource.close();
   });
 
@@ -52,20 +38,6 @@ describe('SystemLogActions', function () {
       const mostRecent = global.EventSource.calls.mostRecent();
       expect(mostRecent.args[0])
         .toEqual('/system/v1/agent/foo/logs/v1/stream/?cursor=bar');
-      expect(mostRecent.args[1]).toEqual({withCredentials: true});
-    });
-
-    it('sends without credentials when not available', function () {
-      cookie.parse = function () {
-        var cookieObj = {};
-        cookieObj[USER_COOKIE_KEY] = null;
-
-        return cookieObj;
-      };
-
-      SystemLogActions.startTail('foo', {cursor: 'bar'});
-      const mostRecent = global.EventSource.calls.mostRecent();
-      expect(mostRecent.args[1]).toEqual({withCredentials: false});
     });
 
     it('dispatches the correct action when successful', function () {
@@ -173,20 +145,6 @@ describe('SystemLogActions', function () {
       const mostRecent = global.EventSource.calls.mostRecent();
       expect(mostRecent.args[0])
         .toEqual('/system/v1/agent/foo/logs/v1/range/?cursor=bar&limit=3&read_reverse=true');
-      expect(mostRecent.args[1]).toEqual({withCredentials: true});
-    });
-
-    it('sends without credentials when not available', function () {
-      cookie.parse = function () {
-        var cookieObj = {};
-        cookieObj[USER_COOKIE_KEY] = null;
-
-        return cookieObj;
-      };
-
-      SystemLogActions.fetchRange('foo', {cursor: 'bar'});
-      const mostRecent = global.EventSource.calls.mostRecent();
-      expect(mostRecent.args[1]).toEqual({withCredentials: false});
     });
 
     it('dispatches the correct action when closing connection', function () {


### PR DESCRIPTION
Remove unnecessary withCredentials from EventSource. This should only be used for CORS, not for authentication.

I removed functionality, adjusted some tests and removed tests that explicitly was testing for this.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
