### PR TITLE
Move icon to top of alert

### DIFF
--- a/src/js/components/Alert.js
+++ b/src/js/components/Alert.js
@@ -17,7 +17,9 @@ const Alert = ({children, flushBottom, showIcon, type}) => {
     };
 
     icon = (
-      <Icon className="alert-icon" id={ids[type]} size="mini" />
+      <div className="alert-icon">
+        <Icon id={ids[type]} size="mini" />
+      </div>
     );
   }
 

--- a/src/styles/components/alert/styles.less
+++ b/src/styles/components/alert/styles.less
@@ -1,7 +1,7 @@
 & when (@alert-enabled) {
 
   .alert {
-    align-items: center;
+    align-items: flex-start;
     border-radius: @alert-border-radius;
     display: flex;
     margin-bottom: @alert-margin-bottom;


### PR DESCRIPTION
Moves the icon that is part of the alert to the top of the alert so it is not floating arbitrarily in the middle.

Before
![image](https://cloud.githubusercontent.com/assets/15963/24312915/04ce781e-1098-11e7-9e0e-d010bcaac914.png)

After
![image](https://cloud.githubusercontent.com/assets/15963/24312898/f1af5050-1097-11e7-8500-b7fd3f2bb9fe.png)

