### PR TITLE
Check for the proper key containing environment variables

### DIFF
--- a/plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.js
@@ -24,16 +24,16 @@ const columns = [
 ];
 
 const PodEnvironmentVariablesConfigSection = ({appConfig, onEditClick}) => {
-  const {environment = {}, containers = []} = appConfig;
+  const {env = {}, containers = []} = appConfig;
 
-  if (!environment || !containers) {
+  if (!env || !containers) {
     return <noscript />;
   }
 
-  let combinedEnv = Object.keys(environment).reduce((memo, key) => {
+  let combinedEnv = Object.keys(env).reduce((memo, key) => {
     memo.push({
       key: <code>{key}</code>,
-      value: environment[key],
+      value: env[key],
       container: getSharedIconWithLabel()
     });
 
@@ -41,12 +41,12 @@ const PodEnvironmentVariablesConfigSection = ({appConfig, onEditClick}) => {
   }, []);
 
   combinedEnv = containers.reduce((memo, container) => {
-    const {environment = {}} = container;
+    const {env = {}} = container;
 
-    return Object.keys(environment).reduce((cvMemo, key) => {
+    return Object.keys(env).reduce((cvMemo, key) => {
       cvMemo.push({
         key: <code>{key}</code>,
-        value: environment[key],
+        value: env[key],
         container: getContainerNameWithIcon(container)
       });
 


### PR DESCRIPTION
This PR fixes a bug where environment variables weren't displayed on the pod's configuration screen. We were looking for the `environment` key but the environment variables are defined on the `env` key.

I didn't add a test in this PR because I'm currently writing SI tests for this in a subsequent PR.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
