### PR TITLE
[System Tests]: Modified Dockerfile for Jenkins use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,14 @@ FROM mesosphere/dcos-system-test-driver:latest
 # Specify the component versions to use
 ENV CYPRESS_VERSION="0.19.1" \
     NODE_VERSION="4.4.7" \
-    NPM_VERSION="3.9"
+    NPM_VERSION="3.9" \
+    JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
 
 # Expose the 4200 port
 EXPOSE 4200
 
 # Copy required files in order to be able to do npm install
 WORKDIR /dcos-ui
-COPY package.json npm-shrinkwrap.json scripts /dcos-ui/
 
 # Copy the entrypoint script that takes care of executing run-time init tasks,
 # such as creating the scaffold in the user's repository
@@ -23,27 +23,23 @@ RUN set -x \
   && curl -o- https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz | tar -C /usr/local --strip-components=1 -zx \
   && npm install -g npm@${NPM_VERSION} \
 
-  # Install cypress dependencies
+  # Install cypress dependencies & JRE (required by Jenkins)
+  && echo 'deb http://ftp.debian.org/debian jessie-backports main' >> /etc/apt/sources.list \
   && apt-get update \
   && apt-get install -y xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 \
+  && apt-get install -t jessie-backports -y openjdk-8-jre-headless ca-certificates-java \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
 
+  # Post-install java certificates
+  /var/lib/dpkg/info/ca-certificates-java.postinst configure \
+
   # Install npm dependencies
   && cd /dcos-ui \
-  && npm install \
   && npm install -g cypress-cli git://github.com/johntron/http-server.git#proxy-secure-flag \
 
   # Install cypress
   && cypress install --cypress-version ${CYPRESS_VERSION} \
-
-  # Move node_modules out of the directory to make it clean for mounting
-  # this will be brought back in by the entry point
-  && mv node_modules /var/lib/ \
-
-  # Calculate the checksum of package.json in order to detect changes that
-  # will trigger a new npm install
-  && sha512sum package.json > /var/lib/package.json.sha512 \
 
   # Ensure entrypoint is executable
   && chmod +x /usr/local/bin/dcos-ui-docker-entrypoint \
@@ -55,5 +51,6 @@ RUN set -x \
 # Define entrypoint
 ENTRYPOINT [ "/bin/bash", "/usr/local/bin/dcos-ui-docker-entrypoint" ]
 
-# Export the working directory
+# Export mountable volumes
 VOLUME /dcos-ui
+VOLUME /dcos-ui-plugins

--- a/scripts/docker-entrypoint
+++ b/scripts/docker-entrypoint
@@ -3,20 +3,6 @@
 # runs any command within it. It's purpose is to check the if scaffolding
 # is needed and apply it.
 
-# The docker file has a cached version of the dependencies in a node_modules
-# folder in /var/lib. In oder to speed things up don't copy, just sym-link to
-# the user's mountpoint
-if [[ -a node_modules ]]; then
-  mv node_modules _node_modules
-fi
-ln -s /var/lib/node_modules
-
-# If the package.json has changed re-run npm install
-if ! sha512sum -c /var/lib/package.json.sha512 2>/dev/null >/dev/null; then
-  npm install
-  sha512sum package.json > /var/lib/package.json.sha512
-fi
-
 #
 # Define externalplugins if we have mounted such directory
 #
@@ -24,31 +10,5 @@ if [[ -d /dcos-ui-plugins ]]; then
   npm config set externalplugins ../dcos-ui-plugins
 fi
 
-#
-# Run preinstall if pre-install dependencies are missing. These are:
-#
-# - Marathon RAM Files
-#
-if [[ ! -d src/resources/raml/marathon ]]; then
-  ./scripts/pre-install
-fi
-
-#
-# Run scaffold if some files are missing:
-#
-# - src/js/config/Config.dev.js
-# - webpack/proxy.dev.js
-#
-if [[ ! -f ./src/js/config/Config.dev.js || ! -f ./webpack/proxy.dev.js ]]; then
-  npm run scaffold
-fi
-
 # Pass through everything else
-$*
-
-# Recover user's version of node_modules at exit
-rm node_modules
-if [[ -a _node_modules ]]; then
-  mv _node_modules node_modules
-fi
-
+eval $*


### PR DESCRIPTION
This PR modifies the `Dockerfile` in order to accommodate a few situations:

* It now includes `jre` so it can be used as a build agent for Jenkins
* It no longer uses the cached, internal `node_modules`, rather it relies on the user to do `npm install` and `npm scaffold`

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
