### PR TITLE
fix(DCOS-14146): Fix sorting for health status in a couple of places.

### DIFF
--- a/plugins/nodes/src/js/components/HealthTab.js
+++ b/plugins/nodes/src/js/components/HealthTab.js
@@ -60,6 +60,7 @@ class HealthTab extends React.Component {
       role: 'ROLE'
     });
     const sortFunction = UnitHealthUtil.getHealthSortFunction;
+    const getHealthSorting = TableUtil.getHealthSortingOrder;
 
     return [
       {
@@ -69,7 +70,7 @@ class HealthTab extends React.Component {
         prop: 'health',
         render: this.renderHealth,
         sortable: true,
-        sortFunction
+        sortFunction: getHealthSorting
       },
       {
         className: classNameFn,

--- a/plugins/nodes/src/js/components/NodesTable.js
+++ b/plugins/nodes/src/js/components/NodesTable.js
@@ -94,6 +94,7 @@ var NodesTable = React.createClass({
   getColumns() {
     const className = ResourceTableUtil.getClassName;
     const heading = ResourceTableUtil.renderHeading(NodesTableHeaderLabels);
+    const getHealthSorting = TableUtil.getHealthSortingOrder;
     const sortFunction = TableUtil.getSortFunction('hostname',
       function (node, prop) {
         if (prop === 'cpus' || prop === 'mem' || prop === 'disk') {
@@ -124,7 +125,7 @@ var NodesTable = React.createClass({
         prop: 'health',
         render: this.renderHealth,
         sortable: true,
-        sortFunction,
+        sortFunction: getHealthSorting,
         heading: ResourceTableUtil.renderHeading({health: 'HEALTH'})
       },
       {

--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -70,7 +70,7 @@ class TaskTable extends React.Component {
     var className = this.getClassName;
     var heading = ResourceTableUtil.renderHeading(TaskTableHeaderLabels);
     const sortFunction = TaskTableUtil.getSortFunction('id');
-    const getHealthSorting = TaskTableUtil.getHealthSorting;
+    const getHealthSorting = TableUtil.getHealthSortingOrder;
 
     return [
       {

--- a/plugins/services/src/js/utils/TaskTableUtil.js
+++ b/plugins/services/src/js/utils/TaskTableUtil.js
@@ -1,8 +1,6 @@
 /* eslint-disable no-unused-vars */
 import React from 'react';
 /* eslint-enable no-unused-vars */
-
-import HealthSorting from '../constants/HealthSorting';
 import TableUtil from '../../../../../src/js/utils/TableUtil';
 import TaskStatusSortingOrder from '../constants/TaskStatusSortingOrder';
 import Util from '../../../../../src/js/utils/Util';
@@ -14,66 +12,6 @@ function getUpdatedTimestamp(model) {
 }
 
 const TaskTableUtil = {
-  /**
-   * Normalize param received and try mapping to HealthSorting
-   * if not able to mapping default to HealthSorting.NA
-   *
-   * @param {String} name
-   * @returns {Number} HealthSorting value
-   */
-  getHealthValueByName(name) {
-    let match;
-    name = Util.toUpperCaseIfString(name);
-    match = HealthSorting[name];
-
-    // defaults to NA if can't map to a HealthTypes key
-    if ( typeof match !== 'number' ) {
-      match = HealthSorting.NA;
-    }
-
-    return match;
-  },
-
-  /**
-   * Order health status
-   * based on HealthSorting mapping value
-   * where lowest (0) (top of the list) is most important for visibility
-   * and highest (3) (bottom of the list) 3 is least important for visibility
-   *
-   * @param {Object} a
-   * @param {Object} b
-   * @returns {Number} item position
-   */
-  sortHealthValues(a, b) {
-    const aTieBreaker = Util.toLowerCaseIfString(a.id);
-    const bTieBreaker = Util.toLowerCaseIfString(b.id);
-
-    a = TaskTableUtil.getHealthValueByName(a.health);
-    b = TaskTableUtil.getHealthValueByName(b.health);
-
-    if (a === b) {
-      a = aTieBreaker;
-      b = bTieBreaker;
-    }
-
-    if (a > b) {
-      return 1;
-    }
-    if (a < b) {
-      return -1;
-    }
-
-    return 0;
-  },
-
-/**
- *
- * @returns {Function} sortHealthValues
- */
-  getHealthSorting() {
-    return TaskTableUtil.sortHealthValues;
-  },
-
   getSortFunction(tieBreakerProp) {
     return TableUtil.getSortFunction(tieBreakerProp, function (item, prop) {
       const hasGetter = typeof item.get === 'function';

--- a/plugins/services/src/js/utils/__tests__/TaskTableUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/TaskTableUtil-test.js
@@ -1,9 +1,7 @@
-jest.dontMock('../../constants/HealthSorting');
 jest.dontMock('../TaskTableUtil');
 
 const Service = require('../../structs/Service');
 const TaskTableUtil = require('../TaskTableUtil');
-const HealthSorting = require('../../constants/HealthSorting');
 
 describe('TaskTableUtil', function () {
   beforeEach(function () {
@@ -45,50 +43,7 @@ describe('TaskTableUtil', function () {
       }
     });
 
-    this.tasks = [{
-      'id': 'task-healthy.111',
-      'name': 'task-healthy',
-      'state': 'TASK_RUNNING',
-      'health': 'Healthy'
-    },
-    {
-      'id': 'task-unhealthy.222',
-      'name': 'task-unhealthy',
-      'state': 'TASK_STAGING',
-      'health': 'Unhealthy'
-    }];
-
     this.getComparator = TaskTableUtil.getSortFunction('name');
-  });
-
-  describe('#getHealthValueByName', function () {
-    it('should get default health (NA) value when param is not number', function () {
-      expect(TaskTableUtil.getHealthValueByName('invalid')).toEqual(HealthSorting.NA);
-    });
-
-    it('should get health value by type/name', function () {
-      expect(TaskTableUtil.getHealthValueByName('Healthy')).toEqual(HealthSorting.HEALTHY);
-    });
-  });
-
-  describe('#sortHealthValues', function () {
-    it('should order health status by most important visible', function () {
-      const expectedOrder = [{
-        'id': 'task-unhealthy.222',
-        'name': 'task-unhealthy',
-        'state': 'TASK_STAGING',
-        'health': 'Unhealthy'
-      },
-      {
-        'id': 'task-healthy.111',
-        'name': 'task-healthy',
-        'state': 'TASK_RUNNING',
-        'health': 'Healthy'
-      }];
-      const sortingResult = this.tasks.sort(TaskTableUtil.sortHealthValues);
-
-      expect(sortingResult).toEqual(expectedOrder);
-    });
   });
 
   describe('#getSortFunction for regular items', function () {

--- a/src/js/components/ComponentList.js
+++ b/src/js/components/ComponentList.js
@@ -48,8 +48,13 @@ class ComponentList extends React.Component {
  */
   getSortedHealthValues(items) {
     items.sort(function (a, b) {
-      const aHealthScore = a.getHealth().sortingValue;
-      const bHealthScore = b.getHealth().sortingValue;
+      let aHealthScore = a.getHealth().sortingValue;
+      let bHealthScore = b.getHealth().sortingValue;
+
+      if (aHealthScore === bHealthScore) {
+        aHealthScore = a.getTitle();
+        bHealthScore = b.getTitle();
+      }
 
       if (aHealthScore > bHealthScore) {
         return 1;

--- a/src/js/components/ComponentList.js
+++ b/src/js/components/ComponentList.js
@@ -3,8 +3,6 @@ import {Link} from 'react-router';
 import {List} from 'reactjs-components';
 import React from 'react';
 
-import HealthTypes from '../../../plugins/services/src/js/constants/HealthTypes';
-
 class ComponentList extends React.Component {
 
   getComponentListContent(units) {
@@ -39,30 +37,46 @@ class ComponentList extends React.Component {
     });
   }
 
-  getVisibleComponents(units, displayCount) {
-    // HealthTypes gives the sorting weight.
-    units = units.sort(function (a, b) {
-      const aHealth = a.getHealth().title.toUpperCase();
-      const bHealth = b.getHealth().title.toUpperCase();
-      const comparison = HealthTypes[aHealth] - HealthTypes[bHealth];
+ /**
+ * Order health status
+ * based on HealthSorting mapping value
+ * where lowest (0) (top of the list) is most important for visibility
+ * and highest (3) (bottom of the list) 3 is least important for visibility
+ *
+ * @param {Array} items
+ * @returns {Number} item position
+ */
+  getSortedHealthValues(items) {
+    items.sort(function (a, b) {
+      const aHealthScore = a.getHealth().sortingValue;
+      const bHealthScore = b.getHealth().sortingValue;
 
-      if (comparison === 0) {
-        const aTitle = a.getTitle();
-        const bTitle = b.getTitle();
-
-        if (aTitle > bTitle) {
-          return 1;
-        }
-
-        if (aTitle < bTitle) {
-          return -1;
-        }
-
-        return 0;
+      if (aHealthScore > bHealthScore) {
+        return 1;
       }
 
-      return comparison;
+      if (aHealthScore < bHealthScore) {
+        return -1;
+      }
+
+      return 0;
     });
+
+    return items;
+  }
+
+  /**
+   * Check if the number of units is greater
+   * than the number of possible visible units
+   * return the only what can be visible
+   *
+   * @param {Array} units
+   * @returns {Array} only units visible
+   *
+   * @memberOf ComponentList
+   */
+  getVisibleComponents(units) {
+    const {displayCount} = this.props;
 
     if (units.length > displayCount) {
       return units.slice(0, displayCount);
@@ -81,14 +95,15 @@ class ComponentList extends React.Component {
   }
 
   render() {
-    const units = this.props.units.getItems();
+    let {units} = this.props;
+    units = units.getItems();
+
     if (units.length === 0) {
       return this.getErrorMessage();
     }
 
-    const {displayCount} = this.props;
-    const visibleUnits = this.getVisibleComponents(units, displayCount);
-
+    const sortedUnits = this.getSortedHealthValues(units);
+    const visibleUnits = this.getVisibleComponents(sortedUnits);
     const content = this.getComponentListContent(visibleUnits);
 
     return (

--- a/src/js/components/__tests__/ComponentList-test.js
+++ b/src/js/components/__tests__/ComponentList-test.js
@@ -37,17 +37,17 @@ describe('#ComponentList', function () {
           'id': 'dcos-mesos-dns.service', 'health': 1, 'name': 'Mesos DNS'}
         },
         { 'id': 'log-rotate', 'health': 3, 'name': 'Log Rotate', _itemData: {
-          'id': 'log-rotate', 'health': 3, 'name': 'Log Rotate'
-        } },
-        { 'id': 'dcos-marathon.service', 'health': 0, 'name': 'Marathon', _itemData: {
-          'id': 'dcos-marathon.service', 'health': 0, 'name': 'Marathon'
-        } },
-        { 'id': 'dcos-mesos-master.service', 'health': 0, _itemData: {
-          'id': 'dcos-mesos-master.service', 'health': 0
-        } },
+          'id': 'log-rotate', 'health': 3, 'name': 'Log Rotate'}
+        },
         { 'id': 'dcos-signal.service', 'health': 0, 'name': 'A Signal Service', _itemData: {
-          'id': 'dcos-signal.service', 'health': 0, 'name': 'A Signal Service'
-        } }];
+          'id': 'dcos-signal.service', 'health': 0, 'name': 'A Signal Service'}
+        },
+        { 'id': 'dcos-marathon.service', 'health': 0, 'name': 'Marathon', _itemData: {
+          'id': 'dcos-marathon.service', 'health': 0, 'name': 'Marathon'}
+        },
+        { 'id': 'dcos-mesos-master.service', 'health': 0, _itemData: {
+          'id': 'dcos-mesos-master.service', 'health': 0}
+        }];
 
       expect(sortedUnits).toEqual(expectedResult);
     });

--- a/src/js/components/__tests__/ComponentList-test.js
+++ b/src/js/components/__tests__/ComponentList-test.js
@@ -1,0 +1,63 @@
+jest.dontMock('../ComponentList');
+/* eslint-disable no-unused-vars */
+const React = require('react');
+/* eslint-enable no-unused-vars */
+const TestUtils = require('react-addons-test-utils');
+const ComponentList = require('../ComponentList');
+const HealthUnitsList = require('../../structs/HealthUnitsList');
+
+describe('#ComponentList', function () {
+  var healthUnits;
+
+  beforeEach(function () {
+    healthUnits = new HealthUnitsList({
+      items: [
+      { 'id': 'dcos-marathon.service', 'health': 0, 'name': 'Marathon' },
+      { 'id': 'dcos-mesos-dns.service', 'health': 1, 'name': 'Mesos DNS' },
+      { 'id': 'dcos-mesos-master.service', 'health': 0 },
+      { 'id': 'dcos-signal.service', 'health': 0, 'name': 'A Signal Service' },
+      { 'id': 'log-rotate', 'health': 3, 'name': 'Log Rotate' }]
+    });
+    const displayCount = 2;
+
+    this.component = TestUtils.renderIntoDocument(<ComponentList
+      displayCount={displayCount}
+      units={healthUnits} />);
+  });
+
+  describe('#getSortedHealthValues', function () {
+    it('should sort health units by visibility importance', function () {
+      /**
+       * health status visibility importance order top to bottom
+       * unhealthy > NA > warn/idle > healthy
+       */
+      const sortedUnits = this.component.getSortedHealthValues(healthUnits.getItems());
+      const expectedResult = [
+        { 'id': 'dcos-mesos-dns.service', 'health': 1, 'name': 'Mesos DNS', _itemData: {
+          'id': 'dcos-mesos-dns.service', 'health': 1, 'name': 'Mesos DNS'}
+        },
+        { 'id': 'log-rotate', 'health': 3, 'name': 'Log Rotate', _itemData: {
+          'id': 'log-rotate', 'health': 3, 'name': 'Log Rotate'
+        } },
+        { 'id': 'dcos-marathon.service', 'health': 0, 'name': 'Marathon', _itemData: {
+          'id': 'dcos-marathon.service', 'health': 0, 'name': 'Marathon'
+        } },
+        { 'id': 'dcos-mesos-master.service', 'health': 0, _itemData: {
+          'id': 'dcos-mesos-master.service', 'health': 0
+        } },
+        { 'id': 'dcos-signal.service', 'health': 0, 'name': 'A Signal Service', _itemData: {
+          'id': 'dcos-signal.service', 'health': 0, 'name': 'A Signal Service'
+        } }];
+
+      expect(sortedUnits).toEqual(expectedResult);
+    });
+  });
+
+  describe('#getVisibleComponents', function () {
+    it('should only return the number of visible units', function () {
+      const unitsVisible = this.component.getVisibleComponents(healthUnits.getItems());
+
+      expect(unitsVisible.length).toEqual(2);
+    });
+  });
+});

--- a/src/js/constants/UnitHealthStatus.js
+++ b/src/js/constants/UnitHealthStatus.js
@@ -1,23 +1,52 @@
+/**
+ * Values for health value defined in the server
+ */
+const SERVER_HEALTHY = 0;
+const SERVER_UNHEALTHY = 1;
+const SERVER_WARN = 2;
+const SERVER_NA = 3;
+
+/**
+ * sortingValue = Order health types by it's label and number value
+ * This will depend on the sorting method/function
+ * suggested use is ascending 0 meaning ((top of the list)) more important
+ * visibility and 3 meaning least important (bottom of the order)
+ */
 const UnitHealthStatus = {
-  HEALTHY: {
+  [SERVER_HEALTHY]: {
     title: 'Healthy',
-    value: 0,
-    classNames: 'text-success'
+    key: 'HEALTHY',
+    classNames: 'text-success',
+    sortingValue: 3,
+    value: SERVER_HEALTHY
   },
-  UNHEALTHY: {
+  [SERVER_UNHEALTHY]: {
     title: 'Unhealthy',
-    value: 1,
-    classNames: 'text-danger'
+    key: 'UNHEALTHY',
+    classNames: 'text-danger',
+    sortingValue: 0,
+    value: SERVER_UNHEALTHY
   },
-  WARN: {
+  [SERVER_WARN]: {
     title: 'Warning',
-    value: 2,
-    classNames: 'text-warning'
+    key: 'WAR',
+    classNames: 'text-warning',
+    sortingValue: 2,
+    value: SERVER_WARN
+  },
+  [SERVER_NA]: {
+    title: 'N/A',
+    key: 'NA',
+    classNames: 'text-mute',
+    sortingValue: 1,
+    value: SERVER_NA
   },
   NA: {
     title: 'N/A',
-    value: 3,
-    classNames: 'text-mute'
+    key: 'NA',
+    classNames: 'text-mute',
+    sortingValue: 1,
+    value: SERVER_NA
   }
 };
 

--- a/src/js/constants/UnitHealthStatus.js
+++ b/src/js/constants/UnitHealthStatus.js
@@ -1,10 +1,9 @@
-/**
- * Values for health value defined in the server
- */
-const SERVER_HEALTHY = 0;
-const SERVER_UNHEALTHY = 1;
-const SERVER_WARN = 2;
-const SERVER_NA = 3;
+import {
+  SERVER_HEALTHY,
+  SERVER_NA,
+  SERVER_UNHEALTHY,
+  SERVER_WARN
+} from './UnitHealthTypes';
 
 /**
  * sortingValue = Order health types by it's label and number value
@@ -35,13 +34,6 @@ const UnitHealthStatus = {
     value: SERVER_WARN
   },
   [SERVER_NA]: {
-    title: 'N/A',
-    key: 'NA',
-    classNames: 'text-mute',
-    sortingValue: 1,
-    value: SERVER_NA
-  },
-  NA: {
     title: 'N/A',
     key: 'NA',
     classNames: 'text-mute',

--- a/src/js/constants/UnitHealthTypes.js
+++ b/src/js/constants/UnitHealthTypes.js
@@ -1,0 +1,9 @@
+/**
+ * Values for health value defined in the server
+ */
+module.exports = {
+  SERVER_HEALTHY:0,
+  SERVER_UNHEALTHY:1,
+  SERVER_WARN: 2,
+  SERVER_NA: 3
+};

--- a/src/js/pages/system/UnitsHealthTab.js
+++ b/src/js/pages/system/UnitsHealthTab.js
@@ -123,7 +123,7 @@ class UnitsHealthTab extends mixin(StoreMixin) {
   getColumns() {
     const classNameFn = ResourceTableUtil.getClassName;
     const sortFunction = UnitHealthUtil.getHealthSortFunction;
-    const getHealthSortingOrder = UnitHealthUtil.getHealthSortingOrder;
+    const getHealthSortingOrder = TableUtil.getHealthSortingOrder;
 
     return [
       {

--- a/src/js/pages/system/UnitsHealthTab.js
+++ b/src/js/pages/system/UnitsHealthTab.js
@@ -123,6 +123,7 @@ class UnitsHealthTab extends mixin(StoreMixin) {
   getColumns() {
     const classNameFn = ResourceTableUtil.getClassName;
     const sortFunction = UnitHealthUtil.getHealthSortFunction;
+    const getHealthSortingOrder = UnitHealthUtil.getHealthSortingOrder;
 
     return [
       {
@@ -141,7 +142,7 @@ class UnitsHealthTab extends mixin(StoreMixin) {
         prop: 'health',
         render: this.renderHealth,
         sortable: true,
-        sortFunction
+        sortFunction: getHealthSortingOrder
       }
     ];
   }

--- a/src/js/structs/__tests__/HealthUnit-test.js
+++ b/src/js/structs/__tests__/HealthUnit-test.js
@@ -15,7 +15,9 @@ describe('HealthUnit', function () {
       });
 
       expect(healthItem.getHealth()).toEqual({
+        key: 'UNHEALTHY',
         title: 'Unhealthy',
+        sortingValue: 0,
         value: 1,
         classNames: 'text-danger'
       });

--- a/src/js/structs/__tests__/HealthUnit-test.js
+++ b/src/js/structs/__tests__/HealthUnit-test.js
@@ -2,6 +2,7 @@ jest.dontMock('../../constants/UnitHealthStatus');
 
 const HealthUnit = require('../HealthUnit');
 const UnitHealthStatus = require('../../constants/UnitHealthStatus');
+const UnitHealthTypes = require('../../constants/UnitHealthTypes');
 
 describe('HealthUnit', function () {
 
@@ -25,7 +26,7 @@ describe('HealthUnit', function () {
 
     it('returns NA when healthType not found', function () {
       var healthItem = new HealthUnit({});
-      expect(healthItem.getHealth()).toEqual(UnitHealthStatus.NA);
+      expect(healthItem.getHealth()).toEqual(UnitHealthStatus[UnitHealthTypes.SERVER_NA]);
     });
 
   });

--- a/src/js/utils/TableUtil.js
+++ b/src/js/utils/TableUtil.js
@@ -1,4 +1,5 @@
 import HealthSorting from '../../../plugins/services/src/js/constants/HealthSorting';
+import UnitHealthStatus from '../constants/UnitHealthStatus';
 import Util from './Util';
 
 var TableUtil = {
@@ -78,16 +79,23 @@ var TableUtil = {
    * Normalize param received and try mapping to HealthSorting
    * if not able to mapping default to HealthSorting.NA
    *
-   * @param {String} name
+   * @param {String|Number} healthValue
    * @returns {Number} HealthSorting value
    */
-  getHealthValueByName(name) {
+  getHealthSortingValue(healthValue) {
     let match;
-    name = Util.toUpperCaseIfString(name);
-    match = HealthSorting[name];
 
-    // defaults to NA if can't map to a HealthTypes key
-    if ( typeof match !== 'number' ) {
+    if (typeof healthValue == 'number') {
+      match = UnitHealthStatus[healthValue].sortingValue;
+    }
+
+    if ( typeof healthValue == 'string' ) {
+      healthValue = Util.toUpperCaseIfString(healthValue);
+      match = HealthSorting[healthValue];
+    }
+
+    // defaults to NA if can't map to a health sorting value
+    if (typeof match === 'undefined') {
       match = HealthSorting.NA;
     }
 
@@ -108,8 +116,8 @@ var TableUtil = {
     const aTieBreaker = Util.toLowerCaseIfString(a.id);
     const bTieBreaker = Util.toLowerCaseIfString(b.id);
 
-    a = TableUtil.getHealthValueByName(a.health);
-    b = TableUtil.getHealthValueByName(b.health);
+    a = TableUtil.getHealthSortingValue(a.health);
+    b = TableUtil.getHealthSortingValue(b.health);
 
     if (a === b) {
       a = aTieBreaker;

--- a/src/js/utils/TableUtil.js
+++ b/src/js/utils/TableUtil.js
@@ -1,3 +1,4 @@
+import HealthSorting from '../../../plugins/services/src/js/constants/HealthSorting';
 import Util from './Util';
 
 var TableUtil = {
@@ -71,6 +72,66 @@ var TableUtil = {
         );
       };
     };
+  },
+
+  /**
+   * Normalize param received and try mapping to HealthSorting
+   * if not able to mapping default to HealthSorting.NA
+   *
+   * @param {String} name
+   * @returns {Number} HealthSorting value
+   */
+  getHealthValueByName(name) {
+    let match;
+    name = Util.toUpperCaseIfString(name);
+    match = HealthSorting[name];
+
+    // defaults to NA if can't map to a HealthTypes key
+    if ( typeof match !== 'number' ) {
+      match = HealthSorting.NA;
+    }
+
+    return match;
+  },
+
+  /**
+   * Sort health status
+   * based on HealthSorting mapping value
+   * where lowest (0) (top of the list) is most important for visibility
+   * and highest (3) (bottom of the list) 3 is least important for visibility
+   *
+   * @param {Object} a
+   * @param {Object} b
+   * @returns {Number} item position
+   */
+  sortHealthValues(a, b) {
+    const aTieBreaker = Util.toLowerCaseIfString(a.id);
+    const bTieBreaker = Util.toLowerCaseIfString(b.id);
+
+    a = TableUtil.getHealthValueByName(a.health);
+    b = TableUtil.getHealthValueByName(b.health);
+
+    if (a === b) {
+      a = aTieBreaker;
+      b = bTieBreaker;
+    }
+
+    if (a > b) {
+      return 1;
+    }
+    if (a < b) {
+      return -1;
+    }
+
+    return 0;
+  },
+
+/**
+ *
+ * @returns {Function} sortHealthValues
+ */
+  getHealthSortingOrder() {
+    return TableUtil.sortHealthValues;
   }
 };
 

--- a/src/js/utils/TableUtil.js
+++ b/src/js/utils/TableUtil.js
@@ -89,7 +89,7 @@ var TableUtil = {
       match = UnitHealthStatus[healthValue].sortingValue;
     }
 
-    if ( typeof healthValue == 'string' ) {
+    if (typeof healthValue == 'string') {
       healthValue = Util.toUpperCaseIfString(healthValue);
       match = HealthSorting[healthValue];
     }

--- a/src/js/utils/TableUtil.js
+++ b/src/js/utils/TableUtil.js
@@ -113,8 +113,8 @@ var TableUtil = {
    * @returns {Number} item position
    */
   sortHealthValues(a, b) {
-    const aTieBreaker = Util.toLowerCaseIfString(a.id);
-    const bTieBreaker = Util.toLowerCaseIfString(b.id);
+    const aTieBreaker = Util.toLowerCaseIfString(a.name);
+    const bTieBreaker = Util.toLowerCaseIfString(b.name);
 
     a = TableUtil.getHealthSortingValue(a.health);
     b = TableUtil.getHealthSortingValue(b.health);

--- a/src/js/utils/UnitHealthUtil.js
+++ b/src/js/utils/UnitHealthUtil.js
@@ -1,5 +1,6 @@
 import UnitHealthStatus from '../constants/UnitHealthStatus';
 import TableUtil from '../utils/TableUtil';
+import Util from '../utils/Util';
 
 const UnitHealthUtil = {
   getHealthSortFunction(...args) {
@@ -42,14 +43,18 @@ const UnitHealthUtil = {
    * @return {Array}        - Array of filtered objects.
    */
   filterByHealth(items, health) {
-    health = health.toLowerCase();
+    health = Util.toLowerCaseIfString(health);
 
     if (health === 'all') {
       return items;
     }
 
     return items.filter(function (datum) {
-      return datum.getHealth().title.toLowerCase() === health;
+      if (health.length > 1) {
+        return Util.toLowerCaseIfString(datum.getHealth().title) === health;
+      }
+
+      return datum.getHealth().value === +health;
     });
   }
 

--- a/src/js/utils/UnitHealthUtil.js
+++ b/src/js/utils/UnitHealthUtil.js
@@ -1,4 +1,5 @@
 import UnitHealthStatus from '../constants/UnitHealthStatus';
+import UnitHealthTypes from '../constants/UnitHealthTypes';
 import TableUtil from '../utils/TableUtil';
 import Util from '../utils/Util';
 
@@ -33,7 +34,7 @@ const UnitHealthUtil = {
       return (UnitHealthStatus[key].value === health);
     });
 
-    return UnitHealthStatus[healthKey] || UnitHealthStatus.NA;
+    return UnitHealthStatus[healthKey] || UnitHealthStatus[UnitHealthTypes.SERVER_NA];
   },
 
   /**

--- a/src/js/utils/UnitHealthUtil.js
+++ b/src/js/utils/UnitHealthUtil.js
@@ -1,9 +1,11 @@
 import UnitHealthStatus from '../constants/UnitHealthStatus';
 import TableUtil from '../utils/TableUtil';
+import Util from '../utils/Util';
 
 const UnitHealthUtil = {
   getHealthSortFunction(...args) {
     return TableUtil.getSortFunction('id', function (item, prop) {
+      // TODO: Deprecate sorting conditions by prop
       if (prop === 'health') {
         return UnitHealthUtil.getHealthSorting(item);
       }
@@ -50,6 +52,61 @@ const UnitHealthUtil = {
     return items.filter(function (datum) {
       return datum.getHealth().title.toLowerCase() === health;
     });
+  },
+
+  /**
+   * Map original health status to sorting health value
+   * or return default NA
+   *
+   * @param {Number} healthValue
+   * @returns {Number} Health Sorting value
+   */
+  getSortingValueByhealthValue(healthValue) {
+    if (typeof healthValue !== 'number') {
+      return UnitHealthStatus.NA.sortingValue;
+    }
+
+    return UnitHealthStatus[healthValue].sortingValue;
+  },
+
+  /**
+   * Order health status
+   * based on HealthSorting mapping value
+   * where lowest (0) (top of the list) is most important for visibility
+   * and highest (3) (bottom of the list) 3 is least important for visibility
+   *
+   * @param {Object} a
+   * @param {Object} b
+   * @returns {Number} item position
+   */
+  sortHealthValues(a, b) {
+    const aTieBreaker = Util.toLowerCaseIfString(a.id);
+    const bTieBreaker = Util.toLowerCaseIfString(b.id);
+
+    a = UnitHealthUtil.getSortingValueByhealthValue(a.health);
+    b = UnitHealthUtil.getSortingValueByhealthValue(b.health);
+
+    if (a === b) {
+      a = aTieBreaker;
+      b = bTieBreaker;
+    }
+
+    if (a > b) {
+      return 1;
+    }
+    if (a < b) {
+      return -1;
+    }
+
+    return 0;
+  },
+
+/**
+ *
+ * @returns {Function} sortHealthValues
+ */
+  getHealthSortingOrder() {
+    return UnitHealthUtil.sortHealthValues;
   }
 
 };

--- a/src/js/utils/UnitHealthUtil.js
+++ b/src/js/utils/UnitHealthUtil.js
@@ -1,6 +1,5 @@
 import UnitHealthStatus from '../constants/UnitHealthStatus';
 import TableUtil from '../utils/TableUtil';
-import Util from '../utils/Util';
 
 const UnitHealthUtil = {
   getHealthSortFunction(...args) {
@@ -52,61 +51,6 @@ const UnitHealthUtil = {
     return items.filter(function (datum) {
       return datum.getHealth().title.toLowerCase() === health;
     });
-  },
-
-  /**
-   * Map original health status to sorting health value
-   * or return default NA
-   *
-   * @param {Number} healthValue
-   * @returns {Number} Health Sorting value
-   */
-  getSortingValueByhealthValue(healthValue) {
-    if (typeof healthValue !== 'number') {
-      return UnitHealthStatus.NA.sortingValue;
-    }
-
-    return UnitHealthStatus[healthValue].sortingValue;
-  },
-
-  /**
-   * Order health status
-   * based on HealthSorting mapping value
-   * where lowest (0) (top of the list) is most important for visibility
-   * and highest (3) (bottom of the list) 3 is least important for visibility
-   *
-   * @param {Object} a
-   * @param {Object} b
-   * @returns {Number} item position
-   */
-  sortHealthValues(a, b) {
-    const aTieBreaker = Util.toLowerCaseIfString(a.id);
-    const bTieBreaker = Util.toLowerCaseIfString(b.id);
-
-    a = UnitHealthUtil.getSortingValueByhealthValue(a.health);
-    b = UnitHealthUtil.getSortingValueByhealthValue(b.health);
-
-    if (a === b) {
-      a = aTieBreaker;
-      b = bTieBreaker;
-    }
-
-    if (a > b) {
-      return 1;
-    }
-    if (a < b) {
-      return -1;
-    }
-
-    return 0;
-  },
-
-/**
- *
- * @returns {Function} sortHealthValues
- */
-  getHealthSortingOrder() {
-    return UnitHealthUtil.sortHealthValues;
   }
 
 };

--- a/src/js/utils/__tests__/TableUtil-test.js
+++ b/src/js/utils/__tests__/TableUtil-test.js
@@ -3,6 +3,7 @@ jest.dontMock('../TableUtil');
 const MarathonStore = require('../../../../plugins/services/src/js/stores/MarathonStore');
 const TableUtil = require('../TableUtil');
 const Util = require('../Util');
+const HealthSorting = require('../../../../plugins/services/src/js/constants/HealthSorting');
 
 describe('TableUtil', function () {
   beforeEach(function () {
@@ -25,7 +26,6 @@ describe('TableUtil', function () {
   });
 
   describe('#getSortFunction', function () {
-
     beforeEach(function () {
       this.getProp = function (obj, prop) {
         if (prop === 'timestamp') {
@@ -75,4 +75,39 @@ describe('TableUtil', function () {
 
   });
 
+  describe('#getHealthSortingOrder', function () {
+    it('should return a function', function () {
+      expect(typeof TableUtil.getHealthSortingOrder()).toEqual('function');
+    });
+  });
+
+  describe('#getHealthValueByName', function () {
+    it('should return sorting value for health status', function () {
+      const healthStatus = 'Unhealthy';
+
+      expect(TableUtil.getHealthValueByName(healthStatus)).toEqual(HealthSorting.UNHEALTHY);
+    });
+  });
+
+  describe('#sortHealthValues', function () {
+   /**
+   * sort health status by visibility importance order top to bottom
+   * unhealthy > NA > warn/idle > healthy
+   */
+    it('should return health sorted by visibility importance', function () {
+      const units = [
+        { id: 'aa', health: 'NA' },
+        { id: 'bb', health: 'Healthy' },
+        { id: 'cc', health: 'Unhealthy' }
+      ];
+      const expectedResult = [
+        { id: 'cc', health: 'Unhealthy' },
+        { id: 'aa', health: 'NA' },
+        { id: 'bb', health: 'Healthy' }
+      ];
+      const sortingResult = units.sort(TableUtil.sortHealthValues);
+
+      expect(sortingResult).toEqual(expectedResult);
+    });
+  });
 });

--- a/src/js/utils/__tests__/TableUtil-test.js
+++ b/src/js/utils/__tests__/TableUtil-test.js
@@ -81,20 +81,34 @@ describe('TableUtil', function () {
     });
   });
 
-  describe('#getHealthValueByName', function () {
-    it('should return sorting value for health status', function () {
+  describe('#getHealthSortingValue', function () {
+    it('should return sorting value when receives string value', function () {
       const healthStatus = 'Unhealthy';
 
-      expect(TableUtil.getHealthValueByName(healthStatus)).toEqual(HealthSorting.UNHEALTHY);
+      expect(TableUtil.getHealthSortingValue(healthStatus)).toEqual(HealthSorting.UNHEALTHY);
+    });
+
+    it('should return sorting value when receives number value', function () {
+      const expectedSortingValue = 0;
+      const healthStatus = 1;
+      const getHealthSortingValueResult = TableUtil.getHealthSortingValue(healthStatus);
+
+      expect(getHealthSortingValueResult).toEqual(expectedSortingValue);
+    });
+
+    it('should return default sorting value', function () {
+      const healthStatus = 'nada';
+
+      expect(TableUtil.getHealthSortingValue(healthStatus)).toEqual(HealthSorting.NA);
     });
   });
 
-  describe('#sortHealthValues', function () {
-   /**
+  /**
    * sort health status by visibility importance order top to bottom
    * unhealthy > NA > warn/idle > healthy
    */
-    it('should return health sorted by visibility importance', function () {
+  describe('#sortHealthValues', function () {
+    it('should return health sorted by visibility importance when health is string', function () {
       const units = [
         { id: 'aa', health: 'NA' },
         { id: 'bb', health: 'Healthy' },
@@ -104,6 +118,22 @@ describe('TableUtil', function () {
         { id: 'cc', health: 'Unhealthy' },
         { id: 'aa', health: 'NA' },
         { id: 'bb', health: 'Healthy' }
+      ];
+      const sortingResult = units.sort(TableUtil.sortHealthValues);
+
+      expect(sortingResult).toEqual(expectedResult);
+    });
+
+    it('should return health sorted by visibility importance when health is number', function () {
+      const units = [
+        { id: 'aa', health: 3 },
+        { id: 'bb', health: 0 },
+        { id: 'cc', health: 1 }
+      ];
+      const expectedResult = [
+        { id: 'cc', health: 1 },
+        { id: 'aa', health: 3 },
+        { id: 'bb', health: 0 }
       ];
       const sortingResult = units.sort(TableUtil.sortHealthValues);
 

--- a/src/js/utils/__tests__/UnitHealthUtil-test.js
+++ b/src/js/utils/__tests__/UnitHealthUtil-test.js
@@ -39,7 +39,6 @@ describe('UnitHealthUnit', function () {
   });
 
   describe('#filterByHealth', function () {
-
     it('filters by unit health title', function () {
       const items = [
         {id: 'food', health: 0},
@@ -53,46 +52,4 @@ describe('UnitHealthUnit', function () {
       expect(filteredList[1].get('id')).toEqual('bard');
     });
   });
-
-  describe('#getSortingValueByhealthValue', function () {
-    it('should get sorting value by health value', function () {
-      /**
-       * health status visibility importance order top to bottom
-       * unhealthy > NA > warn/idle > healthy
-       */
-      const originalUnhealthyValue = 1;
-      const sortingValue = 0;
-
-      expect(UnitHealthUtil.getSortingValueByhealthValue(originalUnhealthyValue)).toEqual(sortingValue);
-    });
-  });
-
-  describe('#sortHealthValues', function () {
-    it('should sort health status by order of importance', function () {
-      const units = [
-        { id: 'aa', health: 0 },
-        { id: 'bb', health: 1 },
-        { id: 'cc', health: 3 }
-      ];
-      const expectedResult = [
-        { id: 'bb', health: 1 },
-        { id: 'cc', health: 3 },
-        { id: 'aa', health: 0 }
-      ];
-      const sortingResult = units.sort(UnitHealthUtil.sortHealthValues);
-
-      expect(sortingResult).toEqual(expectedResult);
-    });
-  });
-
-  describe('#getHealthSortingOrder', function () {
-    beforeEach(function () {
-      this.healthSorting = UnitHealthUtil.getHealthSortingOrder();
-    });
-
-    it('should return a function', function () {
-      expect(typeof this.healthSorting).toEqual('function');
-    });
-  });
-
 });

--- a/src/js/utils/__tests__/UnitHealthUtil-test.js
+++ b/src/js/utils/__tests__/UnitHealthUtil-test.js
@@ -16,7 +16,6 @@ describe('UnitHealthUnit', function () {
     it('should return a number', function () {
       expect(typeof this.healthWeight).toEqual('number');
     });
-
   });
 
   describe('#getHealth', function () {
@@ -25,7 +24,9 @@ describe('UnitHealthUnit', function () {
       var health = 1;
 
       expect(UnitHealthUtil.getHealth(health)).toEqual({
+        key: 'UNHEALTHY',
         title: 'Unhealthy',
+        sortingValue: 0,
         value: 1,
         classNames: 'text-danger'
       });
@@ -35,7 +36,6 @@ describe('UnitHealthUnit', function () {
       var health = 'wtf';
       expect(UnitHealthUtil.getHealth(health)).toEqual(UnitHealthStatus.NA);
     });
-
   });
 
   describe('#filterByHealth', function () {

--- a/src/js/utils/__tests__/UnitHealthUtil-test.js
+++ b/src/js/utils/__tests__/UnitHealthUtil-test.js
@@ -2,6 +2,7 @@ jest.dontMock('../../constants/UnitHealthStatus');
 
 const HealthUnit = require('../../structs/HealthUnit');
 const UnitHealthStatus = require('../../constants/UnitHealthStatus');
+const UnitHealthTypes = require('../../constants/UnitHealthTypes');
 const UnitHealthUtil = require('../../utils/UnitHealthUtil');
 const NodesList = require('../../structs/NodesList');
 
@@ -34,7 +35,7 @@ describe('UnitHealthUnit', function () {
 
     it('returns NA when health not valid', function () {
       var health = 'wtf';
-      expect(UnitHealthUtil.getHealth(health)).toEqual(UnitHealthStatus.NA);
+      expect(UnitHealthUtil.getHealth(health)).toEqual(UnitHealthStatus[UnitHealthTypes.SERVER_NA]);
     });
   });
 

--- a/src/js/utils/__tests__/UnitHealthUtil-test.js
+++ b/src/js/utils/__tests__/UnitHealthUtil-test.js
@@ -54,4 +54,45 @@ describe('UnitHealthUnit', function () {
     });
   });
 
+  describe('#getSortingValueByhealthValue', function () {
+    it('should get sorting value by health value', function () {
+      /**
+       * health status visibility importance order top to bottom
+       * unhealthy > NA > warn/idle > healthy
+       */
+      const originalUnhealthyValue = 1;
+      const sortingValue = 0;
+
+      expect(UnitHealthUtil.getSortingValueByhealthValue(originalUnhealthyValue)).toEqual(sortingValue);
+    });
+  });
+
+  describe('#sortHealthValues', function () {
+    it('should sort health status by order of importance', function () {
+      const units = [
+        { id: 'aa', health: 0 },
+        { id: 'bb', health: 1 },
+        { id: 'cc', health: 3 }
+      ];
+      const expectedResult = [
+        { id: 'bb', health: 1 },
+        { id: 'cc', health: 3 },
+        { id: 'aa', health: 0 }
+      ];
+      const sortingResult = units.sort(UnitHealthUtil.sortHealthValues);
+
+      expect(sortingResult).toEqual(expectedResult);
+    });
+  });
+
+  describe('#getHealthSortingOrder', function () {
+    beforeEach(function () {
+      this.healthSorting = UnitHealthUtil.getHealthSortingOrder();
+    });
+
+    it('should return a function', function () {
+      expect(typeof this.healthSorting).toEqual('function');
+    });
+  });
+
 });


### PR DESCRIPTION
This PR fixes a variety of health sorting issues included in the Jira ticket (DCOS-14146), where now those places the health sorting weight is based on visibility importance, meaning `Unhealthy, NA, Idle/Warn, Healthy`.

Be aware that some places at first loading the sort is selected to be in another field e.g `name`, that being said you will need to select the health field.

- Dashboard pane
- Node Components tab
- Components page
- Node components
- Services (task detail)

To accomplish the fix a couple of refactoring work was needed to be done around how the higher order functions handle the sorting, In summary I have split/removed the complexity in to smaller functions easier to understand and enabling more precise unit tests.

The work in this PR also refactors the work in #2001 which was/is related.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?