### PR TITLE
[foundation 1 of ?] DCOS-14745: Expose ResourcesTableUtil on the SDK

### DIFF
--- a/src/js/plugin-bridge/Loader.js
+++ b/src/js/plugin-bridge/Loader.js
@@ -18,6 +18,7 @@ const requireForm = require.context('../components/form', false);
 // Foundation
 const requireRouting = require.context('../../../foundation-ui/routing', false);
 const requireNavigation = require.context('../../../foundation-ui/navigation', false);
+const requireFoundationUtils = require.context('../../../foundation-ui/utils', false);
 const requireFoundation = require.context('../../../foundation-ui', false);
 let requireExternalPlugin = function () {
   return {};
@@ -102,6 +103,8 @@ function requireModule(dir, name) {
       return requireEvents(path);
     case 'routing':
       return requireRouting(path);
+    case 'foundation-utils':
+      return requireFoundationUtils(path);
     case 'foundation-ui':
       return requireFoundation(path);
     case 'systemPages':

--- a/src/js/plugin-bridge/PluginModules.js
+++ b/src/js/plugin-bridge/PluginModules.js
@@ -119,6 +119,9 @@ module.exports = {
   'foundation-ui': {
     'foundation-ui': 'index'
   },
+  'foundation-utils': {
+    ResourceTableUtil: 'ResourceTableUtil'
+  },
   internalPlugin: {
     services: 'services/index'
   }


### PR DESCRIPTION
List of PRs: https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+author%3AnLight+foundation

This interim PR exposes ResourcesTableUtil on the SDK so that it is available via foundation and SDK. It will eventually go to the SDK here https://github.com/dcos/dcos-ui/pull/2041

We need this to merge plugins and dcos separately.