### PR TITLE
DCOS-14842: Change size label from MiB to GiB for external vols

### DIFF
--- a/plugins/services/src/js/components/forms/VolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/VolumesFormSection.js
@@ -297,7 +297,7 @@ class VolumesFormSection extends Component {
               <FieldLabel className="text-no-transform">
                 <FormGroupHeading>
                   <FormGroupHeadingContent primary={true}>
-                    SIZE (MiB)
+                    SIZE (GiB)
                   </FormGroupHeadingContent>
                 </FormGroupHeading>
               </FieldLabel>

--- a/plugins/services/src/js/containers/volume-detail/VolumeDetail.js
+++ b/plugins/services/src/js/containers/volume-detail/VolumeDetail.js
@@ -15,6 +15,15 @@ import ServiceBreadcrumbs from '../../components/ServiceBreadcrumbs';
 import VolumeStatus from '../../constants/VolumeStatus';
 
 class VolumeDetail extends React.Component {
+
+  getSizeLabel() {
+    if (this.props.volume.type === 'External') {
+      return 'Size (GiB)';
+    }
+
+    return 'Size (MiB)';
+  }
+
   renderSubHeader() {
     const {volume} = this.props;
 
@@ -81,7 +90,7 @@ class VolumeDetail extends React.Component {
             </ConfigurationMapRow>
             <ConfigurationMapRow>
               <ConfigurationMapLabel>
-                Size (MiB)
+                {this.getSizeLabel()}
               </ConfigurationMapLabel>
               <ConfigurationMapValue>
                 {volume.getSize()}

--- a/plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js
@@ -64,10 +64,15 @@ class ServiceStorageConfigSection extends ServiceConfigBaseSectionDisplay {
                 heading: getColumnHeadingFn('Size'),
                 prop: 'size',
                 render(prop, row) {
-                  const value = row[prop];
+                  let value = row[prop];
 
                   if (value == null) {
                     return getDisplayValue(value, row.isHostVolume);
+                  }
+
+                  if (row.type.join(' ') === 'External' && !row.isHostVolume) {
+                    // External volumes specify size in GiB
+                    value = value * 1024;
                   }
 
                   return formatResource('disk', value);


### PR DESCRIPTION
This PR changes label from MiB to GiB for external volumes. Please not just review it, test it 🙇 

Marathon treats size value for External volumes as it is in GiB and sends this data to Mesos.
This is going to be fixed (changed to MiB) in 1.10 to align it with other volumes. 

But in the 1.9 we want to show the right label.

https://jira.mesosphere.com/browse/DCOS-14842