### PR TITLE
DCOS_OSS-858: Update Marathon RAML

### DIFF
--- a/scripts/pre-install
+++ b/scripts/pre-install
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
-MARATHON_VERSION="1.4.0-RC4"
+MARATHON_VERSION="1.4.2"
 
 # Import utils
 source ${SCRIPT_PATH}/utils/git


### PR DESCRIPTION
Adjust the pre-install script to install the Marathon 1.4.2 RAML specs. This change will resolve issues related to wrong validation warnings due
to outdated specs.

Closes DCOS_OSS-858

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
