### PR TITLE
Change syntax highlight on README.md instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If you want to add a new npm package to 'node_modules':
 
 1. Add the following to your Sublime Text User Settings:
 
-  ```json
+  ```js
   {
     ...
     "rulers": [80], // lines no longer than 80 chars
@@ -95,7 +95,7 @@ If you want to add a new npm package to 'node_modules':
   * Open up the user configuration file for ApplySyntax: `Sublime Text` -> `Preferences` -> `Package Settings` -> `ApplySyntax` -> `Settings - User`
   * Replace the contents with this:
 
-    ```
+    ```js
     {
       // Put your custom syntax rules here:
       "syntaxes": [


### PR DESCRIPTION
This PR fixes the highlight of Sublime Text User Settings in the _Development Setup_ instructions

From:
![image](https://cloud.githubusercontent.com/assets/883486/24477279/51eecc4c-148b-11e7-9880-b255247da13c.png)

To:
![image](https://cloud.githubusercontent.com/assets/883486/24477292/592abb10-148b-11e7-8d02-6e0119054067.png)
