### PR TITLE
DCOS-14890: Always keep the http health checks scheme

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/MultiContainerHealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/MultiContainerHealthChecks.js
@@ -272,7 +272,9 @@ const MultiContainerHealthChecks = {
 
         case HTTP:
           delete newState.exec;
-          newState.http = {};
+          newState.http = {
+            scheme: HTTP
+          };
           delete newState.tcp;
           break;
 

--- a/plugins/services/src/js/reducers/serviceForm/MultiContainerHealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/MultiContainerHealthChecks.js
@@ -63,7 +63,7 @@ function reduceHttpHealthCheck(state, field, value) {
       if (value) {
         newState.http.scheme = HTTPS;
       } else {
-        newState.http.scheme = null;
+        newState.http.scheme = HTTP;
       }
       break;
   }

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerHealthChecks-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerHealthChecks-test.js
@@ -226,6 +226,23 @@ describe('MultiContainerHealthChecks', function () {
             }
           });
       });
+
+      it('Should populate http scheme on http', function () {
+        let batch = new Batch();
+        batch = batch.add(new Transaction([], {}));
+        batch = batch.add(new Transaction(['protocol'], HTTP));
+        batch = batch.add(new Transaction(['http', 'https'], false));
+
+        const state = {};
+        expect(batch.reduce(
+            MultiContainerHealthChecks.JSONSegmentReducer.bind({}), state
+          ))
+          .toEqual({
+            'http': {
+              'scheme': HTTP
+            }
+          });
+      });
     });
 
     describe('TCP', function () {

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerHealthChecks-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerHealthChecks-test.js
@@ -188,7 +188,8 @@ describe('MultiContainerHealthChecks', function () {
           ))
           .toEqual({
             'http': {
-              'endpoint': 'test'
+              'endpoint': 'test',
+              'scheme': 'HTTP'
             }
           });
       });
@@ -205,7 +206,8 @@ describe('MultiContainerHealthChecks', function () {
           ))
           .toEqual({
             'http': {
-              'path': 'test'
+              'path': 'test',
+              'scheme': 'HTTP'
             }
           });
       });
@@ -321,7 +323,8 @@ describe('MultiContainerHealthChecks', function () {
           ))
           .toEqual({
             'http': {
-              'endpoint': 'test'
+              'endpoint': 'test',
+              'scheme': 'HTTP'
             }
           });
       });


### PR DESCRIPTION
This PR ensures that the `scheme` property is always present in the resulting JSON. This fixes cases where the "scheme" property was initially present in the JSON, since the default behaviour was to remove it.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
