### PR TITLE
[foundation 1.5 of 4] DCOS-14745: add foundation-utils to mocks

### DIFF
--- a/src/js/plugin-bridge/__mocks__/Loader.js
+++ b/src/js/plugin-bridge/__mocks__/Loader.js
@@ -58,6 +58,10 @@ function __requireModule(dir, name) {
     return require(path.resolve('./foundation-ui', `${dir}/${name}`));
   }
 
+  if (dir === 'foundation-utils') {
+    return require(path.resolve('./foundation-ui/utils', name));
+  }
+
   if (dir === 'internalPlugin') {
     return require(path.resolve(pluginsDir, name));
   }


### PR DESCRIPTION
This PR adds `foundation-utils` to mocks so that plugins tests pass. Sorry about that 😅 

List of PRs: https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+author%3AnLight+foundation