### PR TITLE
fix(DeleteRowButton): fix alignment of DeleteRowButton instances

### DIFF
--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -70,7 +70,7 @@ class EnvironmentFormSection extends Component {
               value={env.value}/>
             <FieldError>{errors[env.key]}</FieldError>
           </FormGroup>
-          <FormGroup hasNarrowMargins={true}>
+          <FormGroup hasNarrowMargins={true} applyLabelOffset={key === 0}>
             <DeleteRowButton
               onClick={this.props.onRemoveItem.bind(
                 this, {value: key, path: 'env'}
@@ -130,7 +130,7 @@ class EnvironmentFormSection extends Component {
               value={label.value}/>
             <FieldError>{errors[label.key]}</FieldError>
           </FormGroup>
-          <FormGroup hasNarrowMargins={true}>
+          <FormGroup hasNarrowMargins={true} applyLabelOffset={key === 0}>
             <DeleteRowButton
               onClick={this.props.onRemoveItem.bind(
                 this, {value: key, path: 'labels'}

--- a/src/js/components/form/FormGroup.js
+++ b/src/js/components/form/FormGroup.js
@@ -26,7 +26,6 @@ const FormGroup = (props) => {
     {
       [errorClassName]: showError,
       'form-group-without-top-label': applyLabelOffset,
-      // 'flex-item-align-end': applyLabelOffset && hasNarrowMargins,
       'column-auto flush-left flush-right': hasNarrowMargins
     },
     'form-group',


### PR DESCRIPTION
This PR fixes the lack of label offset for `DeleteRowButton` and removes a comment I accidentally committed.

Before:
![](https://cl.ly/2E2n3a2n1C0e/Screen%20Shot%202017-04-03%20at%201.56.10%20PM.png)

After:
![](https://cl.ly/3h2g0A2j1G1I/Screen%20Shot%202017-04-03%20at%201.55.26%20PM.png)