### PR TITLE
DCOS-14913: Rename "remove" and "destroy" to "delete"

### DIFF
--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -9,6 +9,8 @@ import ModalHeading from '../../../../../../src/js/components/modals/ModalHeadin
 import Pod from '../../structs/Pod';
 import Service from '../../structs/Service';
 import ServiceTree from '../../structs/ServiceTree';
+import StringUtil from '../../../../../../src/js/utils/StringUtil';
+import UserActions from '../../../../../../src/js/constants/UserActions';
 
 // This needs to be at least equal to @modal-animation-duration
 const REDIRECT_DELAY = 300;
@@ -91,14 +93,14 @@ class ServiceDestroyModal extends React.Component {
     if (service instanceof Framework) {
       return (
         <p>
-          This will only destroy the package scheduler for <span className="emphasize">{serviceName}</span>. Any tasks that were started by this scheduler will persist in the system. Are you sure you want to continue?
+          This will only {UserActions.DELETE} the package scheduler for <span className="emphasize">{serviceName}</span>. Any tasks that were started by this scheduler will persist in the system. Are you sure you want to continue?
         </p>
       );
     }
 
     return (
       <p>
-        Destroying <span className="emphasize">{serviceName}</span> is irreversible. Are you sure you want to continue?
+        {StringUtil.capitalize(UserActions.DELETING)} <span className="emphasize">{serviceName}</span> is irreversible. Are you sure you want to continue?
       </p>
     );
   }
@@ -151,7 +153,7 @@ class ServiceDestroyModal extends React.Component {
 
     const heading = (
       <ModalHeading className="text-danger">
-        Destroy {itemText}
+        {StringUtil.capitalize(UserActions.DELETE)} {itemText}
       </ModalHeading>
     );
 
@@ -163,7 +165,7 @@ class ServiceDestroyModal extends React.Component {
         onClose={onClose}
         leftButtonText="Cancel"
         leftButtonCallback={onClose}
-        rightButtonText={`Destroy ${itemText}`}
+        rightButtonText={`${StringUtil.capitalize(UserActions.DELETE)} ${itemText}`}
         rightButtonClassName="button button-danger"
         rightButtonCallback={this.handleRightButtonClick}
         showHeader={true}>

--- a/plugins/services/src/js/components/modals/ServiceModals.js
+++ b/plugins/services/src/js/components/modals/ServiceModals.js
@@ -68,7 +68,7 @@ class ServiceModals extends React.Component {
         deleteItem={deleteItem}
         errors={actionErrors[key]}
         isPending={!!pendingActions[key]}
-        open={modalProps.id === ServiceActionItem.DESTROY}
+        open={modalProps.id === ServiceActionItem.DELETE}
         onClose={() => onClose(key)}
         service={service} />
     );

--- a/plugins/services/src/js/constants/PodActionItem.js
+++ b/plugins/services/src/js/constants/PodActionItem.js
@@ -1,6 +1,8 @@
+import UserActions from '../../../../../src/js/constants/UserActions';
+
 const PodActionItem = {
   EDIT: 'edit',
-  DESTROY: 'destroy',
+  DESTROY: UserActions.DELETE,
   SCALE: 'scale',
   SUSPEND: 'suspend'
 };

--- a/plugins/services/src/js/constants/PodActionItem.js
+++ b/plugins/services/src/js/constants/PodActionItem.js
@@ -2,7 +2,7 @@ import UserActions from '../../../../../src/js/constants/UserActions';
 
 const PodActionItem = {
   EDIT: 'edit',
-  DESTROY: UserActions.DELETE,
+  DELETE: UserActions.DELETE,
   SCALE: 'scale',
   SUSPEND: 'suspend'
 };

--- a/plugins/services/src/js/constants/ServiceActionItem.js
+++ b/plugins/services/src/js/constants/ServiceActionItem.js
@@ -1,8 +1,10 @@
+import UserActions from '../../../../../src/js/constants/UserActions';
+
 const ServiceActionItem = {
   CREATE: 'create',
   CREATE_GROUP: 'create_group',
   EDIT: 'edit',
-  DESTROY: 'destroy',
+  DESTROY: UserActions.DELETE,
   RESTART: 'restart',
   RESUME: 'resume',
   SCALE: 'scale',

--- a/plugins/services/src/js/constants/ServiceActionItem.js
+++ b/plugins/services/src/js/constants/ServiceActionItem.js
@@ -4,7 +4,7 @@ const ServiceActionItem = {
   CREATE: 'create',
   CREATE_GROUP: 'create_group',
   EDIT: 'edit',
-  DESTROY: UserActions.DELETE,
+  DELETE: UserActions.DELETE,
   RESTART: 'restart',
   RESUME: 'resume',
   SCALE: 'scale',

--- a/plugins/services/src/js/containers/pod-detail/PodDetail.js
+++ b/plugins/services/src/js/containers/pod-detail/PodDetail.js
@@ -10,6 +10,8 @@ import PodDebugContainer from '../pod-debug/PodDebugContainer';
 import PodHeader from './PodHeader';
 import PodInstancesContainer from '../pod-instances/PodInstancesContainer';
 import TabsMixin from '../../../../../../src/js/mixins/TabsMixin';
+import StringUtil from '../../../../../../src/js/utils/StringUtil';
+import UserActions from '../../../../../../src/js/constants/UserActions';
 
 const METHODS_TO_BIND = [
   'handleActionDestroy',
@@ -104,7 +106,7 @@ class PodDetail extends mixin(TabsMixin) {
 
     actions.push({
       className: 'text-danger',
-      label: 'Destroy',
+      label: StringUtil.capitalize(UserActions.DELETE),
       onItemSelect: this.handleActionDestroy
     });
 

--- a/plugins/services/src/js/containers/pod-detail/PodHeader.js
+++ b/plugins/services/src/js/containers/pod-detail/PodHeader.js
@@ -9,6 +9,7 @@ import ServiceStatus from '../../constants/ServiceStatus';
 import StatusMapping from '../../constants/StatusMapping';
 import PodActionItem from '../../constants/PodActionItem';
 import StringUtil from '../../../../../../src/js/utils/StringUtil';
+import UserActions from '../../../../../../src/js/constants/UserActions';
 
 const METHODS_TO_BIND = [
   'handleDropdownAction'
@@ -43,7 +44,11 @@ class PodHeader extends React.Component {
       },
       {
         id: PodActionItem.DESTROY,
-        html: <span className="text-danger">Destroy</span>
+        html: (
+          <span className="text-danger">
+            {StringUtil.capitalize(UserActions.DELETE)}
+          </span>
+        )
       }
     ];
 

--- a/plugins/services/src/js/containers/pod-detail/PodHeader.js
+++ b/plugins/services/src/js/containers/pod-detail/PodHeader.js
@@ -43,7 +43,7 @@ class PodHeader extends React.Component {
         html: 'Suspend'
       },
       {
-        id: PodActionItem.DESTROY,
+        id: PodActionItem.DELETE,
         html: (
           <span className="text-danger">
             {StringUtil.capitalize(UserActions.DELETE)}
@@ -87,7 +87,7 @@ class PodHeader extends React.Component {
         this.props.onSuspend();
         break;
 
-      case PodActionItem.DESTROY:
+      case PodActionItem.DELETE:
         this.props.onDestroy();
         break;
     }

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -73,7 +73,7 @@ class ServiceDetail extends mixin(TabsMixin) {
       case ServiceActionItem.SUSPEND:
         modalHandlers.suspendService({service});
         break;
-      case ServiceActionItem.DESTROY:
+      case ServiceActionItem.DELETE:
         modalHandlers.deleteService({service});
         break;
     }

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -11,7 +11,9 @@ import ServiceActionItem from '../../constants/ServiceActionItem';
 import ServiceConfigurationContainer from '../service-configuration/ServiceConfigurationContainer';
 import ServiceDebugContainer from '../service-debug/ServiceDebugContainer';
 import ServiceTasksContainer from '../tasks/ServiceTasksContainer';
+import StringUtil from '../../../../../../src/js/utils/StringUtil';
 import TabsMixin from '../../../../../../src/js/mixins/TabsMixin';
+import UserActions from '../../../../../../src/js/constants/UserActions';
 import VolumeTable from '../../components/VolumeTable';
 
 const METHODS_TO_BIND = [
@@ -172,7 +174,7 @@ class ServiceDetail extends mixin(TabsMixin) {
 
     actions.push({
       className: 'text-danger',
-      label: 'Destroy',
+      label: StringUtil.capitalize(UserActions.DELETE),
       onItemSelect: modalHandlers.deleteService
     });
 

--- a/plugins/services/src/js/containers/service-detail/ServiceInfo.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceInfo.js
@@ -32,7 +32,7 @@ class ServiceInfo extends React.Component {
       id: ServiceActionItem.SUSPEND,
       html: 'Suspend'
     }, {
-      id: ServiceActionItem.DESTROY,
+      id: ServiceActionItem.DELETE,
       html: (
         <span className="text-danger">
           {StringUtil.capitalize(UserActions.DELETE)}

--- a/plugins/services/src/js/containers/service-detail/ServiceInfo.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceInfo.js
@@ -8,6 +8,7 @@ import Service from '../../structs/Service';
 import ServiceActionItem from '../../constants/ServiceActionItem';
 import StatusMapping from '../../constants/StatusMapping';
 import StringUtil from '../../../../../../src/js/utils/StringUtil';
+import UserActions from '../../../../../../src/js/constants/UserActions';
 
 class ServiceInfo extends React.Component {
   getActionButtons() {
@@ -32,7 +33,11 @@ class ServiceInfo extends React.Component {
       html: 'Suspend'
     }, {
       id: ServiceActionItem.DESTROY,
-      html: <span className="text-danger">Destroy</span>
+      html: (
+        <span className="text-danger">
+          {StringUtil.capitalize(UserActions.DELETE)}
+        </span>
+      )
     }];
 
     const actionButtons = [

--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -393,7 +393,7 @@ class ServicesContainer extends React.Component {
     return {
       createGroup: () => set(ServiceActionItem.CREATE_GROUP),
       // All methods below work on ServiceTree and Service types
-      deleteService: (props) => set(ServiceActionItem.DESTROY, props),
+      deleteService: (props) => set(ServiceActionItem.DELETE, props),
       editService: (props) => set(ServiceActionItem.EDIT, props),
       restartService: (props) => set(ServiceActionItem.RESTART, props),
       resumeService: (props) => set(ServiceActionItem.RESUME, props),

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -18,6 +18,7 @@ import ServiceTree from '../../structs/ServiceTree';
 import StringUtil from '../../../../../../src/js/utils/StringUtil';
 import TableUtil from '../../../../../../src/js/utils/TableUtil';
 import Units from '../../../../../../src/js/utils/Units';
+import UserActions from '../../../../../../src/js/constants/UserActions';
 
 const StatusMapping = {
   'Running': 'running-state'
@@ -204,7 +205,11 @@ class ServicesTable extends React.Component {
       },
       {
         id: ServiceActionItem.DESTROY,
-        html: <span className="text-danger">Destroy</span>
+        html: (
+          <span className="text-danger">
+            {StringUtil.capitalize(UserActions.DELETE)}
+          </span>
+        )
       }
     ];
 

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -88,7 +88,7 @@ class ServicesTable extends React.Component {
       case ServiceActionItem.SUSPEND:
         modalHandlers.suspendService({service});
         break;
-      case ServiceActionItem.DESTROY:
+      case ServiceActionItem.DELETE:
         modalHandlers.deleteService({service});
         break;
     }
@@ -204,7 +204,7 @@ class ServicesTable extends React.Component {
         html: 'Resume'
       },
       {
-        id: ServiceActionItem.DESTROY,
+        id: ServiceActionItem.DELETE,
         html: (
           <span className="text-danger">
             {StringUtil.capitalize(UserActions.DELETE)}

--- a/plugins/services/src/js/pages/__tests__/DeploymentsTab-test.js
+++ b/plugins/services/src/js/pages/__tests__/DeploymentsTab-test.js
@@ -69,7 +69,7 @@ describe('DeploymentsTab', function () {
         affectedServices: [new Application({name: 'app1'})],
         steps: [{actions: [{type: 'StartApplication'}]}]
       }));
-      expect(text).toContain('remove the affected service');
+      expect(text).toContain('delete the affected service');
     });
 
     it('should return a revert message when passed a non-starting deployment', function () {

--- a/plugins/services/src/js/pages/services/DeploymentsTab.js
+++ b/plugins/services/src/js/pages/services/DeploymentsTab.js
@@ -22,6 +22,7 @@ import Page from '../../../../../../src/js/components/Page';
 import StatusBar from '../../../../../../src/js/components/StatusBar';
 import StringUtil from '../../../../../../src/js/utils/StringUtil';
 import TimeAgo from '../../../../../../src/js/components/TimeAgo';
+import UserActions from '../../../../../../src/js/constants/UserActions';
 
 const columnHeading = ResourceTableUtil.renderHeading({
   id: 'AFFECTED SERVICES',
@@ -244,7 +245,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
     if (deployment != null) {
       let linkText = 'Rollback';
       if (deployment.isStarting()) {
-        linkText = linkText + ' & Remove';
+        linkText = `${linkText} & ${StringUtil.capitalize(UserActions.DELETE)}`;
       }
 
       return (
@@ -408,8 +409,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
     const version = StringUtil.pluralize('version', serviceCount);
 
     if (deploymentToRollback.isStarting()) {
-      return `This will stop the current deployment of ${listOfServiceNames}
-              and start a new deployment to remove the affected ${service}.`;
+      return `This will stop the current deployment of ${listOfServiceNames} and start a new deployment to ${UserActions.DELETE} the affected ${service}.`;
     }
 
     return `This will stop the current deployment of ${listOfServiceNames} and

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Labels-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Labels-test.js
@@ -27,7 +27,7 @@ describe('Labels', function () {
       expect(batch.reduce(Labels.JSONReducer.bind({}), {}))
         .toEqual({key: 'value2'});
     });
-    it('should keep remove the first item', function () {
+    it('should remove the first item', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['labels'], 0, ADD_ITEM));
       batch = batch.add(new Transaction(['labels', 0, 'key'], 'first'));
@@ -66,7 +66,7 @@ describe('Labels', function () {
         {key: 'key', value: 'value2'}
       ]);
     });
-    it('should keep remove the first item', function () {
+    it('should remove the first item', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['labels'], 0, ADD_ITEM));
       batch = batch.add(new Transaction(['labels', 0, 'key'], 'first'));

--- a/src/js/components/RepositoriesTable.js
+++ b/src/js/components/RepositoriesTable.js
@@ -229,7 +229,7 @@ class RepositoriesTable extends mixin(StoreMixin) {
           leftButtonCallback={this.handleDeleteCancel}
           rightButtonCallback={this.handleDeleteRepository}
           rightButtonClassName="button button-danger"
-          rightButtonText={`${UserActions.DELETE} Repository`}
+          rightButtonText={`${StringUtil.capitalize(UserActions.DELETE)} Repository`}
           showHeader={true}>
           {this.getRemoveModalContent()}
         </Confirm>

--- a/src/js/components/RepositoriesTable.js
+++ b/src/js/components/RepositoriesTable.js
@@ -13,7 +13,9 @@ import CosmosPackagesStore from '../stores/CosmosPackagesStore';
 import List from '../structs/List';
 import ModalHeading from './modals/ModalHeading';
 import RepositoriesTableHeaderLabels from '../constants/RepositoriesTableHeaderLabels';
+import StringUtil from '../utils/StringUtil';
 import TableUtil from '../utils/TableUtil';
+import UserActions from '../constants/UserActions';
 
 const METHODS_TO_BIND = [
   'getHeadline',
@@ -171,7 +173,7 @@ class RepositoriesTable extends mixin(StoreMixin) {
         <a
           className="button button-link button-danger table-display-on-row-hover"
           onClick={this.handleOpenConfirm.bind(this, repositoryToRemove)}>
-          Remove
+          {StringUtil.capitalize(UserActions.DELETE)}
         </a>
       </div>
     );
@@ -195,7 +197,7 @@ class RepositoriesTable extends mixin(StoreMixin) {
     return (
       <div className="text-align-center">
         <p>
-          {`Repository (${repositoryLabel}) will be removed from ${Config.productName}. You will not be able to install any packages belonging to that repository anymore.`}
+          {`Repository (${repositoryLabel}) will be ${UserActions.DELETED} from ${Config.productName}. You will not be able to install any packages belonging to that repository anymore.`}
         </p>
         {error}
       </div>
@@ -227,7 +229,7 @@ class RepositoriesTable extends mixin(StoreMixin) {
           leftButtonCallback={this.handleDeleteCancel}
           rightButtonCallback={this.handleDeleteRepository}
           rightButtonClassName="button button-danger"
-          rightButtonText="Remove Repository"
+          rightButtonText={`${UserActions.DELETE} Repository`}
           showHeader={true}>
           {this.getRemoveModalContent()}
         </Confirm>

--- a/src/js/components/form/DeleteRowButton.js
+++ b/src/js/components/form/DeleteRowButton.js
@@ -2,10 +2,12 @@ import React from 'react';
 import {Tooltip} from 'reactjs-components';
 
 import Icon from '../Icon';
+import StringUtil from '../../utils/StringUtil';
+import UserActions from '../../constants/UserActions';
 
 const DeleteRowButton = ({onClick}) => {
   return (
-    <Tooltip content="Delete"
+    <Tooltip content={StringUtil.capitalize(UserActions.DELETE)}
       interactive={false}
       maxWidth={300}
       scrollContainer=".gm-scroll-view"

--- a/src/js/components/form/FormGroupContainer.js
+++ b/src/js/components/form/FormGroupContainer.js
@@ -2,13 +2,15 @@ import React from 'react';
 import {Tooltip} from 'reactjs-components';
 
 import Icon from '../Icon';
+import StringUtil from '../../utils/StringUtil';
+import UserActions from '../../constants/UserActions';
 
 const FormGroupContainer = (props) => {
   let removeButton = null;
   if (props.onRemove != null) {
     removeButton = (
       <div className="form-group-container-action-button-group">
-        <Tooltip content="Delete"
+        <Tooltip content={StringUtil.capitalize(UserActions.DELETE)}
           maxWidth={300}
           scrollContainer=".gm-scroll-view"
           wrapText={true}>

--- a/src/js/constants/BulkOptions.js
+++ b/src/js/constants/BulkOptions.js
@@ -2,12 +2,19 @@
 import React from 'react';
 /* eslint-enable no-unused-vars */
 
+import StringUtil from '../utils/StringUtil';
+import UserActions from './UserActions';
+
 const BulkOptions = {
   user: {
     delete: {
-      dropdownOption: <span className="text-danger">Delete</span>,
+      dropdownOption: (
+        <span className="text-danger">
+          {StringUtil.capitalize(UserActions.DELETE)}
+        </span>
+      ),
       title: 'Are you sure?',
-      actionPhrase: 'will be deleted'
+      actionPhrase: `will be ${UserActions.DELETED}`
     }
   }
 };

--- a/src/js/constants/UserActions.js
+++ b/src/js/constants/UserActions.js
@@ -1,0 +1,5 @@
+module.exports = {
+  DELETE: 'delete',
+  DELETED: 'deleted',
+  DELETING: 'deleting'
+};

--- a/src/js/pages/jobs/JobDetailPage.js
+++ b/src/js/pages/jobs/JobDetailPage.js
@@ -22,6 +22,7 @@ import StringUtil from '../../utils/StringUtil';
 import TabsMixin from '../../mixins/TabsMixin';
 import TimeAgo from '../../components/TimeAgo';
 import TaskStates from '../../../../plugins/services/src/js/constants/TaskStates';
+import UserActions from '../../constants/UserActions';
 
 const METHODS_TO_BIND = [
   'closeDialog',
@@ -172,21 +173,20 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
     const {id} = this.props.params;
     const {disabledDialog, jobActionDialog, errorMsg} = this.state;
     let stopCurrentJobRuns = false;
-    let actionButtonLabel = 'Destroy Job';
-    let message = `Are you sure you want to destroy ${id}? ` +
+    let actionButtonLabel = `${StringUtil.capitalize(UserActions.DELETE)} Job`;
+    let message = `Are you sure you want to ${UserActions.DELETE} ${id}? ` +
       'This action is irreversible.';
 
     if (/stopCurrentJobRuns=true/.test(errorMsg)) {
-      actionButtonLabel = 'Stop Current Runs and Destroy Job';
+      actionButtonLabel = `Stop Current Runs and ${StringUtil.capitalize(UserActions.DELETE)} Job`;
       stopCurrentJobRuns = true;
-      message = `Couldn't destroy ${id} as there are currently active job ` +
-        'runs. Do you want to stop all runs and destroy the job?';
+      message = `Couldn't ${UserActions.DELETE} ${id} as there are currently active job runs. Do you want to stop all runs and ${UserActions.DELETE} the job?`;
     }
 
     const content = (
       <div>
         <h2 className="text-danger text-align-center flush-top">
-          Destroy Job
+          {StringUtil.capitalize(UserActions.DELETE)} Job
         </h2>
         <p>{message}</p>
       </div>
@@ -366,7 +366,7 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
 
     actions.push({
       className: 'text-danger',
-      label: 'Destroy',
+      label: StringUtil.capitalize(UserActions.DELETE),
       onItemSelect: this.handleDestroyButtonClick
     });
 

--- a/src/js/plugin-bridge/PluginModules.js
+++ b/src/js/plugin-bridge/PluginModules.js
@@ -3,7 +3,8 @@ module.exports = {
   constants: {
     EventTypes: 'EventTypes',
     HTTPStatusCodes: 'HTTPStatusCodes',
-    TransactionTypes: 'TransactionTypes'
+    TransactionTypes: 'TransactionTypes',
+    UserActions: 'UserActions'
   },
   events: {
     SidebarActions: 'SidebarActions'

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -104,7 +104,7 @@ describe('Service Actions', function () {
         });
 
         cy.visitUrl({url: '/services/overview/%2Fsleep'});
-        clickHeaderAction('Destroy');
+        clickHeaderAction('Delete');
       });
 
       it('opens the correct service destroy dialog', function () {

--- a/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
+++ b/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
@@ -72,7 +72,7 @@ describe('Add Repository Form Modal', function () {
         .click({force: true});
       cy
         .get('.modal .modal-footer .button.button-danger')
-        .contains('Remove Repository')
+        .contains('Delete Repository')
         .click();
     });
   });

--- a/tests/pages/system/overview/repositories/RepositoriesTab-cy.js
+++ b/tests/pages/system/overview/repositories/RepositoriesTab-cy.js
@@ -52,7 +52,7 @@ describe('Installed Packages Tab', function () {
     cy.get('.button.button-link.button-danger').eq(0).invoke('show').click({force: true});
     cy
       .get('.modal .modal-footer .button.button-danger')
-      .should('contain', 'Remove Repository');
+      .should('contain', 'Delete Repository');
   });
 
 });


### PR DESCRIPTION
This PR introduces a constants file named `UserActions` which is meant to contain actions that DC/OS UI users can perform. So far this includes `delete`, `deleted`, and `deleting`. This PR implements it in place of every instance of "remove," "destroy," and "delete."

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?