### PR TITLE
[Route Service Tabs 1 of 2] DCOS-14508: Splitting routes into overview and detail

### DIFF
--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -147,7 +147,7 @@ class ServiceBreadcrumbs extends React.Component {
 
     return (
       <BreadcrumbSupplementalContent>
-        <Link to={`/services/overview/${serviceLink}`}>
+        <Link to={serviceLink}>
           <span className="icon icon-small icon-image-container icon-app-container">
             <img src={service.getImages()['icon-small']}/>
           </span>
@@ -177,12 +177,13 @@ class ServiceBreadcrumbs extends React.Component {
         let serviceImage = null;
 
         aggregateIDs += encodeURIComponent(`/${id}`);
-
+        let routePath = '/services/overview/' + aggregateIDs;
         if (index === ids.length - 1) {
+          routePath = '/services/detail/' + aggregateIDs;
           const service = DCOSStore.serviceTree.findItemById(serviceID);
 
           breadcrumbHealth = this.getHealthStatus(service);
-          serviceImage = this.getServiceImage(service, aggregateIDs);
+          serviceImage = this.getServiceImage(service, routePath);
         }
 
         return (
@@ -192,7 +193,7 @@ class ServiceBreadcrumbs extends React.Component {
             {serviceImage}
             <BreadcrumbTextContent
               ref={(ref) => this.primaryBreadcrumbTextRef = ref}>
-              <Link to={`/services/overview/${aggregateIDs}`}>
+              <Link to={routePath}>
                 {id}
               </Link>
             </BreadcrumbTextContent>
@@ -212,7 +213,7 @@ class ServiceBreadcrumbs extends React.Component {
           title={taskID}>
           <BreadcrumbTextContent>
             <Link
-              to={`/services/overview/${aggregateIDs}/tasks/${encodedTaskID}`}
+              to={`/services/detail/${aggregateIDs}/tasks/${encodedTaskID}`}
               index={taskID}>
               {taskName}
             </Link>

--- a/plugins/services/src/js/components/ServiceList.js
+++ b/plugins/services/src/js/components/ServiceList.js
@@ -44,7 +44,7 @@ const ServiceList = React.createClass({
     const id = encodeURIComponent(service.getId());
     // Modifier key not pressed or service didn't have a web URL, open detail
     event.preventDefault();
-    this.context.router.push(`/services/overview/${id}`);
+    this.context.router.push(`/services/detail/${id}`);
   },
 
   getServices(services, healthProcessed) {

--- a/plugins/services/src/js/components/VolumeTable.js
+++ b/plugins/services/src/js/components/VolumeTable.js
@@ -137,10 +137,10 @@ class VolumeTable extends React.Component {
     const currentroutePath = reconstructPathFromRoutes(this.props.routes);
     let routePath = null;
 
-    if (currentroutePath === '/services/overview/:id') {
-      routePath = `/services/overview/${serviceID}/volumes/${volumeID}`;
-    } else if (currentroutePath === '/services/overview/:id/tasks/:taskID/volumes') {
-      routePath = `/services/overview/${serviceID}/tasks/${taskID}/volumes/${volumeID}`;
+    if (currentroutePath === '/services/detail/:id') {
+      routePath = `/services/detail/${serviceID}/volumes/${volumeID}`;
+    } else if (currentroutePath === '/services/detail/:id/tasks/:taskID/volumes') {
+      routePath = `/services/detail/${serviceID}/tasks/${taskID}/volumes/${volumeID}`;
     } else if (currentroutePath === '/nodes/:nodeID/tasks/:taskID/volumes') {
       routePath = `/nodes/${nodeID}/tasks/${taskID}/volumes/${volumeID}`;
     }

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -158,7 +158,15 @@ class NewCreateServiceModal extends Component {
     const shouldClose = requestCompleted && !nextState.apiErrors.length;
 
     if (shouldClose) {
-      this.context.router.push(`/services/overview/${encodeURIComponent(nextProps.params.id)}`);
+      const {path} = nextProps.route;
+      const routePrefix = path.startsWith('edit') ?
+        // When edit: navigate to the detail of the service which was edited
+        '/services/detail/' :
+        // When create: navigate to the group service was created in
+        '/services/overview/';
+      this.context.router.push(
+        routePrefix + encodeURIComponent(nextProps.params.id)
+      );
     }
   }
 

--- a/plugins/services/src/js/containers/pod-detail/PodDetail.js
+++ b/plugins/services/src/js/containers/pod-detail/PodDetail.js
@@ -47,7 +47,7 @@ class PodDetail extends mixin(TabsMixin) {
   handleActionEdit() {
     const {pod} = this.props;
     this.context.router.push(
-      `/services/overview/${encodeURIComponent(pod.getId())}/edit/`
+      `/services/detail/${encodeURIComponent(pod.getId())}/edit/`
     );
   }
 

--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
@@ -311,7 +311,7 @@ class PodInstancesTable extends React.Component {
         <div className="expanding-table-primary-cell-heading text-overflow">
           <Link
             className="table-cell-link-secondary text-overflow"
-            to={`/services/overview/${id}/tasks/${taskID}`}
+            to={`/services/detail/${id}/tasks/${taskID}`}
             title={taskName}>
             <CollapsingString string={taskName} />
           </Link>
@@ -341,7 +341,7 @@ class PodInstancesTable extends React.Component {
 
     return (
       <Link
-        to={`/services/overview/${id}/tasks/${taskID}/logs`}
+        to={`/services/detail/${id}/tasks/${taskID}/logs`}
         title={row.name}>
         <Icon color="grey" id="page-document" size="mini" />
       </Link>

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -74,7 +74,7 @@ class ServiceConfiguration extends mixin(StoreMixin) {
     const {selectedVersionID} = this.state;
 
     this.context.router.push(
-      `/services/overview/${serviceID}/edit/${selectedVersionID}`
+      `/services/detail/${serviceID}/edit/${selectedVersionID}`
     );
   }
 

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -61,7 +61,7 @@ class ServiceDetail extends mixin(TabsMixin) {
     switch (actionItem.id) {
       case ServiceActionItem.EDIT:
         router.push(
-          `/services/overview/${encodeURIComponent(service.getId())}/edit/`
+          `/services/detail/${encodeURIComponent(service.getId())}/edit/`
         );
         break;
       case ServiceActionItem.SCALE:
@@ -140,7 +140,7 @@ class ServiceDetail extends mixin(TabsMixin) {
       label: 'Edit',
       onItemSelect() {
         router.push(
-          `/services/overview/${encodeURIComponent(service.getId())}/edit/`
+          `/services/detail/${encodeURIComponent(service.getId())}/edit/`
         );
       }
     });
@@ -183,7 +183,7 @@ class ServiceDetail extends mixin(TabsMixin) {
 
   getTabs() {
     const {service:{id}} = this.props;
-    const routePrefix = `/services/overview/${encodeURIComponent(id)}`;
+    const routePrefix = `/services/detail/${encodeURIComponent(id)}`;
 
     const tabs = [];
     const activeTab = this.state.currentTab;

--- a/plugins/services/src/js/containers/services/ServiceTreeView.js
+++ b/plugins/services/src/js/containers/services/ServiceTreeView.js
@@ -71,10 +71,13 @@ class ServiceTreeView extends React.Component {
     } = this.props;
 
     const {modalHandlers} = this.context;
+    // Only add id if service is not root
+    const routePath = serviceTree.id === '/' ?
+      '/services/overview/create' :
+      `/services/overview/${encodeURIComponent(serviceTree.id)}/create`;
+
     const createService = () => {
-      this.context.router.push(
-        `/services/overview/${encodeURIComponent(serviceTree.id)}/create`
-      );
+      this.context.router.push(routePath);
     };
 
     if (isEmpty) {

--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -22,6 +22,7 @@ import Icon from '../../../../../../src/js/components/Icon';
 import Loader from '../../../../../../src/js/components/Loader';
 import Page from '../../../../../../src/js/components/Page';
 import RequestErrorMsg from '../../../../../../src/js/components/RequestErrorMsg';
+import {reconstructPathFromRoutes} from '../../../../../../src/js/utils/RouterUtil';
 
 import DSLExpression from '../../../../../../src/js/structs/DSLExpression';
 import DSLFilterList from '../../../../../../src/js/structs/DSLFilterList';
@@ -474,34 +475,21 @@ class ServicesContainer extends React.Component {
       return <RequestErrorMsg />;
     }
 
-    if (item instanceof Pod) {
-      return (
-        <PodDetail
-          actions={this.getActions()}
-          pod={item}>
-          {this.getModals(item)}
-          {children}
-        </PodDetail>
-      );
-    }
-
-    if (item instanceof Service) {
-      return (
-        <ServiceDetail
-          actions={this.getActions()}
-          errors={this.state.actionErrors}
-          clearError={this.clearActionError}
-          params={params}
-          routes={routes}
-          service={item}>
-          {this.getModals(item)}
-          {children}
-        </ServiceDetail>
-      );
-    }
-
     // Show Tree
-    if (item instanceof ServiceTree) {
+    const currentroutePath = reconstructPathFromRoutes(routes);
+    if (currentroutePath.startsWith('/services/overview')) {
+
+      if (!(item instanceof ServiceTree)) {
+        // Not found
+        return (
+          <Page>
+            <Page.Header breadcrumbs={<ServiceBreadcrumbs />} />
+            <ServiceItemNotFound
+              message={`The group with the ID of "${itemId}" could not be found.`} />
+          </Page>
+        );
+      }
+
       const isEmpty = (item.getItems().length === 0);
       let filteredServices = item;
 
@@ -525,6 +513,32 @@ class ServicesContainer extends React.Component {
           {this.getModals(item)}
           {children}
         </ServiceTreeView>
+      );
+    }
+
+    if (item instanceof Pod) {
+      return (
+        <PodDetail
+          actions={this.getActions()}
+          pod={item}>
+          {this.getModals(item)}
+          {children}
+        </PodDetail>
+      );
+    }
+
+    if (item instanceof Service) {
+      return (
+        <ServiceDetail
+          actions={this.getActions()}
+          errors={this.state.actionErrors}
+          clearError={this.clearActionError}
+          params={params}
+          routes={routes}
+          service={item}>
+          {this.getModals(item)}
+          {children}
+        </ServiceDetail>
       );
     }
 
@@ -565,7 +579,7 @@ ServicesContainer.contextTypes = {
 ServicesContainer.routeConfig = {
   label: 'Services',
   icon: <Icon id="services" size="small" family="product" />,
-  matches: /^\/services\/overview/
+  matches: /^\/services\/(detail|overview)/
 };
 
 module.exports = ServicesContainer;

--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -433,26 +433,100 @@ class ServicesContainer extends React.Component {
     );
   }
 
-  render() {
-    // TODO react-router: Temp hack if we are deeper than overview/:id we should render child routes
-    if (Object.keys(this.props.params).length > 1) {
-      return this.props.children;
+  getEmpyPage(itemType) {
+    const {itemId} = this.state;
+
+    return (
+      <Page>
+        <Page.Header breadcrumbs={<ServiceBreadcrumbs />} />
+        <ServiceItemNotFound
+          message={`The ${itemType} with the ID of "${itemId}" could not be found.`} />
+      </Page>
+    );
+  }
+
+  getLoadingScreen() {
+    const {itemId} = this.state;
+
+    return (
+      <Page>
+        <Page.Header breadcrumbs={<ServiceBreadcrumbs serviceID={itemId} />} />
+        <Loader />
+      </Page>
+    );
+  }
+
+  getPodDetail(item) {
+    const {children} = this.props;
+
+    return (
+      <PodDetail
+        actions={this.getActions()}
+        pod={item}>
+        {children}
+        {this.getModals(item)}
+      </PodDetail>
+    );
+  }
+
+  getServiceDetail(item) {
+    const {children, params, routes} = this.props;
+
+    return (
+      <ServiceDetail
+        actions={this.getActions()}
+        errors={this.state.actionErrors}
+        clearError={this.clearActionError}
+        params={params}
+        routes={routes}
+        service={item}>
+        {children}
+        {this.getModals(item)}
+      </ServiceDetail>
+    );
+  }
+
+  getServiceTree(item) {
+    const {children, params, routes} = this.props;
+    const {filterExpression} = this.state;
+
+    const isEmpty = (item.getItems().length === 0);
+    let filteredServices = item;
+
+    if (filterExpression.defined) {
+      filteredServices = filterExpression.filter(
+        SERVICE_FILTERS, filteredServices.flattenItems()
+      );
     }
 
-    const {children, params, routes} = this.props;
-    const {
-      fetchErrors,
-      filterExpression,
-      isLoading,
-      itemId
-    } = this.state;
+    // TODO: move modals to Page
+    return (
+      <ServiceTreeView
+        filters={SERVICE_FILTERS}
+        filterExpression={filterExpression}
+        isEmpty={isEmpty}
+        onFilterExpressionChange={this.handleFilterExpressionChange}
+        params={params}
+        routes={routes}
+        services={filteredServices.getItems()}
+        serviceTree={item}>
+        {children}
+        {this.getModals(item)}
+      </ServiceTreeView>
+    );
+  }
 
-    let item;
-    // Find item in root tree
-    if (itemId === '/') {
-      item = DCOSStore.serviceTree;
-    } else {
-      item = DCOSStore.serviceTree.findItemById(itemId);
+  render() {
+    const {children, params, routes} = this.props;
+    const {fetchErrors, isLoading, itemId} = this.state;
+    // TODO react-router: Temp hack if we are deeper than overview/:id we should render child routes
+    if (Object.keys(params).length > 1) {
+      return children;
+    }
+
+    // Still Loading
+    if (isLoading) {
+      return this.getLoadingScreen();
     }
 
     // Check if a single endpoint has failed more than 3 times
@@ -460,96 +534,39 @@ class ServicesContainer extends React.Component {
       return errorCount > 3;
     });
 
-    // Still Loading
-    if (isLoading) {
-      return (
-        <Page>
-          <Page.Header breadcrumbs={<ServiceBreadcrumbs />} />
-          <Loader />
-        </Page>
-      );
-    }
-
     // API Failures
     if (fetchError) {
       return <RequestErrorMsg />;
     }
 
+    // Find item in root tree
+    const item = itemId === '/' ?
+      DCOSStore.serviceTree :
+      DCOSStore.serviceTree.findItemById(itemId);
+
     // Show Tree
-    const currentroutePath = reconstructPathFromRoutes(routes);
-    if (currentroutePath.startsWith('/services/overview')) {
+    const currentRoutePath = reconstructPathFromRoutes(routes);
+    if (currentRoutePath.startsWith('/services/overview')) {
 
+      // Not found
       if (!(item instanceof ServiceTree)) {
-        // Not found
-        return (
-          <Page>
-            <Page.Header breadcrumbs={<ServiceBreadcrumbs />} />
-            <ServiceItemNotFound
-              message={`The group with the ID of "${itemId}" could not be found.`} />
-          </Page>
-        );
+        return this.getEmpyPage('group');
       }
 
-      const isEmpty = (item.getItems().length === 0);
-      let filteredServices = item;
-
-      if (filterExpression.defined) {
-        filteredServices = filterExpression.filter(
-          SERVICE_FILTERS, filteredServices.flattenItems()
-        );
-      }
-
-      // TODO move modals to Page
-      return (
-        <ServiceTreeView
-          filters={SERVICE_FILTERS}
-          filterExpression={filterExpression}
-          isEmpty={isEmpty}
-          onFilterExpressionChange={this.handleFilterExpressionChange}
-          params={params}
-          routes={routes}
-          services={filteredServices.getItems()}
-          serviceTree={item}>
-          {this.getModals(item)}
-          {children}
-        </ServiceTreeView>
-      );
+      // TODO: move modals to Page
+      return this.getServiceTree(item);
     }
 
     if (item instanceof Pod) {
-      return (
-        <PodDetail
-          actions={this.getActions()}
-          pod={item}>
-          {this.getModals(item)}
-          {children}
-        </PodDetail>
-      );
+      return this.getPodDetail(item);
     }
 
     if (item instanceof Service) {
-      return (
-        <ServiceDetail
-          actions={this.getActions()}
-          errors={this.state.actionErrors}
-          clearError={this.clearActionError}
-          params={params}
-          routes={routes}
-          service={item}>
-          {this.getModals(item)}
-          {children}
-        </ServiceDetail>
-      );
+      return this.getServiceDetail(item);
     }
 
     // Not found
-    return (
-      <Page>
-        <Page.Header breadcrumbs={<ServiceBreadcrumbs />} />
-        <ServiceItemNotFound
-          message={`The service with the ID of "${itemId}" could not be found.`} />
-      </Page>
-    );
+    return this.getEmpyPage('service');
   }
 }
 

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -96,6 +96,10 @@ class ServicesTable extends React.Component {
 
   getServiceLink(service) {
     const id = encodeURIComponent(service.getId());
+    const isGroup = service instanceof ServiceTree;
+    const serviceLink = isGroup ?
+      `/services/overview/${id}` :
+      `/services/detail/${id}`;
 
     if (this.props.isFiltered) {
       return (
@@ -110,7 +114,7 @@ class ServicesTable extends React.Component {
     return (
       <Link
         className="table-cell-link-primary text-overflow"
-        to={`/services/overview/${id}`}>
+        to={serviceLink}>
         {service.getName()}
       </Link>
     );
@@ -138,13 +142,17 @@ class ServicesTable extends React.Component {
 
   renderHeadline(prop, service) {
     const id = encodeURIComponent(service.getId());
+    const isGroup = service instanceof ServiceTree;
+    const serviceLink = isGroup ?
+      `/services/overview/${id}` :
+      `/services/detail/${id}`;
 
     return (
       <div className="service-table-heading flex-box
         flex-box-align-vertical-center table-cell-flex-box">
         <Link
           className="table-cell-icon"
-          to={`/services/overview/${id}`}>
+          to={serviceLink}>
           {this.getImage(service)}
         </Link>
         <span className="table-cell-value table-cell-flex-box">
@@ -160,10 +168,7 @@ class ServicesTable extends React.Component {
     const isPod = service instanceof Pod;
     const isSingleInstanceApp = service.getLabels().MARATHON_SINGLE_INSTANCE_APP;
     const instancesCount = service.getInstancesCount();
-    let scaleText = 'Scale';
-    if (isGroup) {
-      scaleText = 'Scale By';
-    }
+    const scaleText = isGroup ? 'Scale By' : 'Scale';
 
     const dropdownItems = [
       {

--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -236,7 +236,7 @@ class TaskTable extends React.Component {
       const title = task[prop];
       const {id, nodeID} = this.props.params;
 
-      let linkTo = `/services/overview/${encodeURIComponent(id)}/tasks/${task.id}`;
+      let linkTo = `/services/detail/${encodeURIComponent(id)}/tasks/${task.id}`;
       if (nodeID != null) {
         linkTo = `/nodes/${nodeID}/tasks/${task.id}`;
       }
@@ -261,7 +261,7 @@ class TaskTable extends React.Component {
     const title = task.name || task.id;
     const {id, nodeID} = this.props.params;
 
-    let linkTo = `/services/overview/${encodeURIComponent(id)}/tasks/${task.id}/logs`;
+    let linkTo = `/services/detail/${encodeURIComponent(id)}/tasks/${task.id}/logs`;
     if (nodeID != null) {
       linkTo = `/nodes/${nodeID}/tasks/${task.id}/logs`;
     }

--- a/plugins/services/src/js/containers/volume-detail/VolumeDetail.js
+++ b/plugins/services/src/js/containers/volume-detail/VolumeDetail.js
@@ -47,7 +47,7 @@ class VolumeDetail extends React.Component {
       <Breadcrumb key={-1} title="Services">
         <BreadcrumbTextContent>
           <Link
-            to={`/services/overview/${encodedServiceId}/volumes/${volumeId}`}
+            to={`/services/detail/${encodedServiceId}/volumes/${volumeId}`}
             key="volume">
 
             {volumeId}

--- a/plugins/services/src/js/pages/ServicesPage.js
+++ b/plugins/services/src/js/pages/ServicesPage.js
@@ -51,6 +51,11 @@ var ServicesPage = React.createClass({
     if (currentTab === '/services/overview/:id' || currentTab == null) {
       currentTab = '/services/overview';
     }
+    // Disguise `/services/detail` tab under `/services/overview`
+    // eventhough it is an actual sibling
+    if (currentTab === '/services/detail/:id' || currentTab == null) {
+      currentTab = '/services/overview';
+    }
 
     if (this.state.currentTab !== currentTab) {
       this.setState({currentTab});

--- a/plugins/services/src/js/pages/services/DeploymentsTab.js
+++ b/plugins/services/src/js/pages/services/DeploymentsTab.js
@@ -149,7 +149,7 @@ class DeploymentsTab extends mixin(StoreMixin) {
       return (
         <dd key={`service_${id}`}>
           <Link
-            to={`/services/overview/${id}`}
+            to={`/services/detail/${id}`}
             className="deployment-service-name table-cell-link-primary">
             <span className="icon icon-mini icon-image-container icon-app-container deployment-service-icon">
               <img src={image} />

--- a/plugins/services/src/js/pages/task-details/ServiceTaskDetailPage.js
+++ b/plugins/services/src/js/pages/task-details/ServiceTaskDetailPage.js
@@ -15,7 +15,7 @@ class ServiceTaskDetailPage extends React.Component {
     const {location, params, routes} = this.props;
     const {id, taskID} = params;
 
-    const routePrefix = `/services/overview/${encodeURIComponent(id)}/tasks/${encodeURIComponent(taskID)}`;
+    const routePrefix = `/services/detail/${encodeURIComponent(id)}/tasks/${encodeURIComponent(taskID)}`;
     const tabs = [
       {label: 'Details', routePath: routePrefix + '/details'},
       {label: 'Files', routePath: routePrefix + '/files'},

--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -42,10 +42,10 @@ const HIDE_BREADCRUMBS = [
   '/nodes/:nodeID/tasks/:taskID/logs/:filePath',
   '/nodes/:nodeID/tasks/:taskID/files/view(/:filePath(/:innerPath))',
 
-  '/services/overview/:id/tasks/:taskID/details',
-  '/services/overview/:id/tasks/:taskID/logs',
-  '/services/overview/:id/tasks/:taskID/logs/:filePath',
-  '/services/overview/:id/tasks/:taskID/files/view(/:filePath(/:innerPath))'
+  '/services/detail/:id/tasks/:taskID/details',
+  '/services/detail/:id/tasks/:taskID/logs',
+  '/services/detail/:id/tasks/:taskID/logs/:filePath',
+  '/services/detail/:id/tasks/:taskID/files/view(/:filePath(/:innerPath))'
 ];
 
 class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
@@ -239,7 +239,7 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
     if (!this.hasVolumes(service)) {
       tabsArray = tabsArray.filter(function (tab) {
         if (tab.key === '/nodes/:nodeID/tasks/:taskID/volumes(/:volumeID)'
-          || tab.key === '/services/overview/:id/tasks/:taskID/volumes') {
+          || tab.key === '/services/detail/:id/tasks/:taskID/volumes') {
           return false;
         }
 

--- a/plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.js
+++ b/plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.js
@@ -37,7 +37,7 @@ describe('TaskDetail', function () {
       TaskDetail,
       {
         params: this.params,
-        routes: [{path: '/services/overview/:id/tasks/:taskID'}]
+        routes: [{path: '/services/detail/:id/tasks/:taskID'}]
       },
       this.container,
       {}
@@ -172,7 +172,7 @@ describe('TaskDetail', function () {
         TaskDetail,
         {
           params: this.params,
-          routes: [{path: '/services/overview/:id/tasks/:taskID'}]
+          routes: [{path: '/services/detail/:id/tasks/:taskID'}]
         },
         this.container,
         {}

--- a/plugins/services/src/js/routes/services.js
+++ b/plugins/services/src/js/routes/services.js
@@ -55,9 +55,8 @@ const serviceRoutes = [
         component: ServicesContainer,
         path: 'overview',
         // TODO: Remove this when moving to use NavigationService directly,
-        // where we can register with any path and not only using the `path`
-        // key here in the route defintion
-        sidebarPath: '',
+        // where we can register with sidebarActiveRegex option
+        sidebarActiveRegex: /(overview|detail)/,
         isInSidebar: true,
         buildBreadCrumb() {
           return {

--- a/src/js/components/NestedServiceLinks.js
+++ b/src/js/components/NestedServiceLinks.js
@@ -12,7 +12,7 @@ class NestedServiceLinks extends React.Component {
         <div className={minorLinkClasses}>
           <Link
             className={minorLinkAnchorClasses}
-            to={`/services/overview/${params.id}`}
+            to={`/services/detail/${params.id}`}
             title={label}>
             {label}
           </Link>
@@ -86,10 +86,10 @@ class NestedServiceLinks extends React.Component {
 
     if (taskID != null) {
       label = taskID;
-      routePath = `/services/overview/${serviceID}/tasks/${taskID}`;
+      routePath = `/services/detail/${serviceID}/tasks/${taskID}`;
     } else {
       label = this.getServicePathParts().pop();
-      routePath = `/services/overview/${encodeURIComponent(serviceID)}`;
+      routePath = `/services/detail/${encodeURIComponent(serviceID)}`;
     }
 
     return (

--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -231,7 +231,9 @@ var Sidebar = React.createClass({
 
     const menuItems = filteredChildRoutes.reduce(
       (children, currentChild, index) => {
-        const isActive = pathname.startsWith(currentChild.path);
+        const isActive = currentChild.options.isActiveRegex != null ?
+          currentChild.options.isActiveRegex.test(pathname) :
+          pathname.startsWith(currentChild.path);
 
         const menuItemClasses = classNames({selected: isActive});
 

--- a/src/js/utils/NavigationServiceUtil.js
+++ b/src/js/utils/NavigationServiceUtil.js
@@ -43,17 +43,11 @@ const NavigationServiceUtil = {
         childRoutes
           .filter(({isInSidebar}) => isInSidebar)
           .forEach((childRoute) => {
-            // TODO: Temporary fix to allow routes to register under a different
-            // path than their path definition. Used only in the service routes.
-            let childPath = childRoute.path;
-            if (childRoute.sidebarPath != null) {
-              childPath = childRoute.sidebarPath;
-            }
-
             NavigationService.registerSecondary(
               primaryPath,
-              childPath,
-              childRoute.component.routeConfig.label
+              childRoute.path,
+              childRoute.component.routeConfig.label,
+              {isActiveRegex: childRoute.sidebarActiveRegex}
             );
           });
       });

--- a/src/js/utils/NavigationServiceUtil.js
+++ b/src/js/utils/NavigationServiceUtil.js
@@ -40,13 +40,19 @@ const NavigationServiceUtil = {
           route.component.routeConfig.label,
           { category, icon }
         );
-
         childRoutes
           .filter(({isInSidebar}) => isInSidebar)
           .forEach((childRoute) => {
+            // TODO: Temporary fix to allow routes to register under a different
+            // path than their path definition. Used only in the service routes.
+            let childPath = childRoute.path;
+            if (childRoute.sidebarPath != null) {
+              childPath = childRoute.sidebarPath;
+            }
+
             NavigationService.registerSecondary(
               primaryPath,
-              childRoute.path,
+              childPath,
               childRoute.component.routeConfig.label
             );
           });

--- a/system-tests/services/test-apps.js
+++ b/system-tests/services/test-apps.js
@@ -10,7 +10,7 @@ describe('Services', function () {
 
     beforeEach(function () {
       cy
-        .visitUrl(`services/overview/%2F${Cypress.env('TEST_UUID')}/create`);
+        .visitUrl(`services/detail/%2F${Cypress.env('TEST_UUID')}/create`);
     });
 
     function selectMesosRuntime() {

--- a/system-tests/services/test-environment.js
+++ b/system-tests/services/test-environment.js
@@ -7,7 +7,7 @@ describe('Services', function () {
 
     beforeEach(function () {
       cy
-        .visitUrl(`services/overview/%2F${Cypress.env('TEST_UUID')}`);
+        .visitUrl(`services/detail/%2F${Cypress.env('TEST_UUID')}`);
     });
 
     it('should contain no running services', function () {

--- a/tests/_fixtures/marathon-1-group/groups.json
+++ b/tests/_fixtures/marathon-1-group/groups.json
@@ -4,7 +4,7 @@
   ],
   "groups": [
     {
-      "id": "/services",
+      "id": "/my-group",
       "dependencies": [
         
       ],

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -13,7 +13,7 @@ describe('Service Actions', function () {
       nodeHealth: true
     });
 
-    cy.visitUrl({url: '/services/overview/%2Fcassandra-healthy'});
+    cy.visitUrl({url: '/services/detail/%2Fcassandra-healthy'});
   });
 
   context('Edit Action', function () {
@@ -23,7 +23,7 @@ describe('Service Actions', function () {
 
     it('navigates to the correct route', function () {
       cy.location().its('hash')
-        .should('include', '#/services/overview/%2Fcassandra-healthy/edit');
+        .should('include', '#/services/detail/%2Fcassandra-healthy/edit');
     });
 
     it('opens the correct service edit modal', function () {
@@ -103,7 +103,7 @@ describe('Service Actions', function () {
           nodeHealth: true
         });
 
-        cy.visitUrl({url: '/services/overview/%2Fsleep'});
+        cy.visitUrl({url: '/services/detail/%2Fsleep'});
         clickHeaderAction('Delete');
       });
 

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -89,7 +89,7 @@ describe('Service Form Modal', function () {
     context('Group level', function () {
 
       beforeEach(function () {
-        cy.visitUrl({url: '/services/overview/%2Fservices'});
+        cy.visitUrl({url: '/services/overview/%2Fmy-group'});
       });
 
       it('Opens the right modal on click', function () {
@@ -101,14 +101,14 @@ describe('Service Form Modal', function () {
         clickRunService();
         openServiceForm();
         cy.get('.modal .menu-tabbed-view input[name="id"]')
-          .should('to.have.value', '/services/');
+          .should('to.have.value', '/my-group/');
       });
 
       it('contains the right JSON in the JSON editor', function () {
         clickRunService();
         openServiceJSON();
         cy.get('.ace_content').should(function (nodeList) {
-          expect(nodeList[0].textContent).to.contain('"id": "/services/"');
+          expect(nodeList[0].textContent).to.contain('"id": "/my-group/"');
         });
       });
     });
@@ -227,7 +227,7 @@ describe('Service Form Modal', function () {
         nodeHealth: true
       });
 
-      cy.visitUrl({url: '/services/overview/%2Fsleep'});
+      cy.visitUrl({url: '/services/detail/%2Fsleep'});
       cy.get('.page-header-actions .dropdown').click();
       cy.get('.dropdown-menu-items').contains('Edit').click();
     });

--- a/tests/pages/services/ServiceVersions-cy.js
+++ b/tests/pages/services/ServiceVersions-cy.js
@@ -7,7 +7,7 @@ describe('Service Versions', function () {
         nodeHealth: true
       });
 
-      cy.visitUrl({url: '/services/overview/%2Fsleep'});
+      cy.visitUrl({url: '/services/detail/%2Fsleep'});
       cy.get('.page-header-navigation .menu-tabbed-item')
         .contains('Configuration').click();
 

--- a/tests/pages/services/TasksTable-cy.js
+++ b/tests/pages/services/TasksTable-cy.js
@@ -9,7 +9,7 @@ describe('Tasks Table', function () {
     });
 
     it('displays task detail page on task click', function () {
-      cy.visitUrl({url: '/services/overview/%2Fcassandra'});
+      cy.visitUrl({url: '/services/detail/%2Fcassandra'});
       cy.get('a[title="server-0_10a"]')
         .click();
       cy.get('.page-header').should('contain', 'server-0');
@@ -19,7 +19,7 @@ describe('Tasks Table', function () {
 
       beforeEach(function () {
         cy.visitUrl({
-          url: '/services/overview/%2Fcassandra/tasks/server-0_10a'
+          url: '/services/detail/%2Fcassandra/tasks/server-0_10a'
         });
         cy.get('.page-header-navigation .menu-tabbed-item').contains('Files').click();
       });
@@ -47,7 +47,7 @@ describe('Tasks Table', function () {
         mesos: 'healthy-tasks-in-mesos-and-marathon'
       });
       cy.viewport('macbook-15');
-      cy.visitUrl({url: '/services/overview/%2Fconfluent-kafka'});
+      cy.visitUrl({url: '/services/detail/%2Fconfluent-kafka'});
     });
 
     context('Running task without healthcheck', function () {

--- a/tests/pages/services/VolumesTable-cy.js
+++ b/tests/pages/services/VolumesTable-cy.js
@@ -10,7 +10,7 @@ describe('Volumes', function () {
   context('Volumes Table', function () {
 
     beforeEach(function () {
-      cy.visitUrl({url: '/services/overview/%2Fsleep'});
+      cy.visitUrl({url: '/services/detail/%2Fsleep'});
       cy.get('.menu-tabbed-item').contains('Volumes').click();
     });
 
@@ -39,7 +39,7 @@ describe('Volumes', function () {
   context('Volume Details', function () {
 
     beforeEach(function () {
-      cy.visitUrl({url: '/services/overview/%2Fsleep'});
+      cy.visitUrl({url: '/services/detail/%2Fsleep'});
       cy.get('.menu-tabbed-item').contains('Volumes').click();
       cy.get('.table tbody tr a').contains('sleep#data-1#c1fbf257-efb2-11e6-a361-5edc614b8201').click();
     });


### PR DESCRIPTION
This PR will split routes into services/overview and services/detail routes, which will allow for different children for these routes, which is necessary when routing tabs.

Route Service Tabs 1 of 2: https://github.com/dcos/dcos-ui/pull/2079
Route Service Tabs 2 of 2: https://github.com/dcos/dcos-ui/pull/2058

![](https://cl.ly/0K0c1h1u0r15/Screen%20Recording%202017-04-06%20at%2016.48.gif)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
