### PR TITLE
[System Tests]: Re-trying teardown

### DIFF
--- a/system-tests/services/_scripts/teardown
+++ b/system-tests/services/_scripts/teardown
@@ -1,4 +1,11 @@
 #!/bin/bash
 
-# Remove the service group for the test
-dcos marathon group remove --force /$TEST_UUID
+# Retry 3 times to remove the service (for an unknown reason this operation
+# times out some times)
+for I in {1..3}; do
+  dcos marathon group remove --force /$TEST_UUID
+  [ $? -eq 0 ] && exit 0
+done
+
+# Fail
+exit 1


### PR DESCRIPTION
Retry 3 times when tearing down services group, since some times
the operation with the cluster times out.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
