### PR TITLE
fix(integration-test): Fix flaky integration test.

### DIFF
--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -131,7 +131,8 @@ describe('Service Actions', function () {
             url: /marathon\/v2\/apps\/\/sleep/,
             response: []
           });
-        cy.get('.confirm-modal .button-collection .button-danger').click();
+        cy.get('.confirm-modal .button-collection .button-danger')
+          .click();
         cy.get('.confirm-modal').should('to.have.length', 0);
       });
 
@@ -360,7 +361,8 @@ describe('Service Actions', function () {
   context('Resume Action', function () {
     function openDropdown() {
       cy.get('.service-table-column-actions .dropdown .button')
-        .click({force: true});
+        .eq(0)
+        .click();
     }
 
     function clickResume() {


### PR DESCRIPTION
This PR fixes a flaky integration test where in some cases was failing because the selector is returning multiple elements instead of one in which is causing the test to not being able to click.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?