### PR TITLE
DCOS-15014: change the name of the control flag

### DIFF
--- a/plugins/services/src/js/events/MarathonActions.js
+++ b/plugins/services/src/js/events/MarathonActions.js
@@ -213,7 +213,7 @@ var MarathonActions = {
     let url = buildURI(`/apps/${service.getId()}`);
     const params = {
       force,
-      patchUpdate: false // Switching Marathon edit endpoint into proper PUT
+      partialUpdate: false // Switching Marathon edit endpoint into proper PUT
     };
 
     if (service instanceof Pod) {

--- a/plugins/services/src/js/events/__tests__/MarathonActions-test.js
+++ b/plugins/services/src/js/events/__tests__/MarathonActions-test.js
@@ -525,7 +525,7 @@ describe('MarathonActions', function () {
 
       it('sends data to the correct URL', function () {
         expect(this.configuration.url)
-            .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//test?patchUpdate=false`);
+            .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//test?partialUpdate=false`);
       });
 
       it('sends data to the' +
@@ -535,7 +535,7 @@ describe('MarathonActions', function () {
             this.configuration = RequestUtil.json.calls.mostRecent().args[0];
 
             expect(this.configuration.url)
-                .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//test?force=true&patchUpdate=false`);
+                .toEqual(`${Config.rootUrl}/service/marathon/v2/apps//test?force=true&partialUpdate=false`);
           });
 
       it('uses PUT for the request method', function () {
@@ -601,7 +601,7 @@ describe('MarathonActions', function () {
 
       it('sends data to the correct URL', function () {
         expect(this.configuration.url)
-            .toEqual(`${Config.rootUrl}/service/marathon/v2/pods//test?patchUpdate=false`);
+            .toEqual(`${Config.rootUrl}/service/marathon/v2/pods//test?partialUpdate=false`);
       });
 
       it('sends data to the correct URL with the force=true parameter',
@@ -610,7 +610,7 @@ describe('MarathonActions', function () {
             this.configuration = RequestUtil.json.calls.mostRecent().args[0];
 
             expect(this.configuration.url)
-                .toEqual(`${Config.rootUrl}/service/marathon/v2/pods//test?force=true&patchUpdate=false`);
+                .toEqual(`${Config.rootUrl}/service/marathon/v2/pods//test?force=true&partialUpdate=false`);
           });
 
       it('uses PUT for the request method', function () {

--- a/src/js/utils/__tests__/Util-test.js
+++ b/src/js/utils/__tests__/Util-test.js
@@ -410,8 +410,8 @@ describe('Util', function () {
     });
 
     it('returns correct query string', function () {
-      expect(Util.objectToGetParams({name: 'DCOS', patchUpdate: true}))
-        .toEqual('?name=DCOS&patchUpdate=true');
+      expect(Util.objectToGetParams({name: 'DCOS', partialUpdate: true}))
+        .toEqual('?name=DCOS&partialUpdate=true');
     });
 
     it('escapes both param and its value', function () {


### PR DESCRIPTION
⚠️  release/1.9 ⚠️ 

Fix for the master branch: https://github.com/dcos/dcos-ui/pull/2084

This PR changes the PATCH/PUT update control flag from `patchUpdate` to `partialUpdate`

`patchUpdate` was among the suggestions but never was implemented in fact it always was `partialUpdate`

Using the correct control flag fixes the issue in the ticket... and maybe few other issues.