### PR TITLE
[System Tests] Fix external volumes test from "MiB" to "GiB"

### DIFF
--- a/system-tests/jobs/_scripts/teardown
+++ b/system-tests/jobs/_scripts/teardown
@@ -4,7 +4,7 @@ import json
 from subprocess import check_output
 
 # Remove jobs that share this prefix
-jobs = json.loads(check_output('dcos job list --json', shell=True))
+jobs = json.loads(check_output('dcos job list --json', shell=True).decode('utf-8'))
 for job in jobs:
   if job['id'].startswith("%s." % os.environ['TEST_UUID']):
     print("Removing job %s" % job['id'])

--- a/system-tests/services/test-apps.js
+++ b/system-tests/services/test-apps.js
@@ -858,7 +858,7 @@ describe('Services', function () {
         .type(volumeName);
       cy
         .root()
-        .getFormGroupInputFor('Size (MiB)')
+        .getFormGroupInputFor('Size (GiB)')
         .type('1');
       cy
         .root()
@@ -948,7 +948,7 @@ describe('Services', function () {
         .getTableColumn('Size')
         .contents()
         .should('deep.equal', [
-          '1 MiB'
+          '1 GiB'
         ]);
       cy
         .root()


### PR DESCRIPTION
---
~⚠️  Depends on #2114~

---

This PR is fixing the `test-apps` system test that was testing against the previous (buggy) version of the UI where the external volume units were "MiB" instead of "GiB"

To test, use:
<pre>
docker run -it --rm --ipc=host \
  -e CLUSTER_URL=<strong>$OPEN_CLUSTER_URL</strong>  \
  -v `pwd`:/dcos-ui \
  mesosphere/dcos-ui dcos-system-test-driver \
  ./system-tests/driver-config/dev.sh
</pre>