### PR TITLE
DCOS-15137: Fix pods environment variables handling

### DIFF
--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -604,35 +604,46 @@ class NewCreateServiceModal extends Component {
         MultiContainerNetworkingFormSection
       ];
 
-      let jsonParserReducers = combineParsers(
-        Hooks.applyFilter('serviceCreateJsonParserReducers', JSONSingleContainerParser)
-      );
-
-      let jsonConfigReducers = combineReducers(
-        Hooks.applyFilter('serviceJsonConfigReducers', JSONSingleContainerReducers)
-      );
+      let jsonParserReducers;
+      let jsonConfigReducers;
+      let inputConfigReducers;
 
       if (serviceSpec instanceof PodSpec) {
         jsonParserReducers = combineParsers(
           Hooks.applyFilter(
-            'serviceCreateJsonParserReducers',
+            'multiContainerCreateJsonParserReducers',
             JSONMultiContainerParser
           )
         );
 
         jsonConfigReducers = combineReducers(
           Hooks.applyFilter(
-            'serviceJsonConfigReducers',
+            'multiContainerJsonConfigReducers',
             JSONMultiContainerReducers
           )
         );
-      }
 
-      const inputConfigReducers = combineReducers(
-        Hooks.applyFilter('serviceInputConfigReducers',
-          Object.assign({}, ...SECTIONS.map((item) => item.configReducers))
-        )
-      );
+        inputConfigReducers = combineReducers(
+          Hooks.applyFilter(
+            'multiContainerInputConfigReducers',
+            Object.assign({}, ...SECTIONS.map((item) => item.configReducers))
+          )
+        );
+      } else {
+        jsonParserReducers = combineParsers(
+          Hooks.applyFilter('serviceCreateJsonParserReducers', JSONSingleContainerParser)
+        );
+
+        jsonConfigReducers = combineReducers(
+          Hooks.applyFilter('serviceJsonConfigReducers', JSONSingleContainerReducers)
+        );
+
+        inputConfigReducers = combineReducers(
+          Hooks.applyFilter('serviceInputConfigReducers',
+            Object.assign({}, ...SECTIONS.map((item) => item.configReducers))
+          )
+        );
+      }
 
       return (
         <NewCreateServiceModalForm

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -52,6 +52,7 @@ const METHODS_TO_BIND = [
 
 const KEY_VALUE_FIELDS = [
   'env',
+  'environment',
   'labels'
 ];
 

--- a/plugins/services/src/js/reducers/JSONMultiContainerParser.js
+++ b/plugins/services/src/js/reducers/JSONMultiContainerParser.js
@@ -1,7 +1,7 @@
 import {JSONParser as container} from './serviceForm/Container';
 import {JSONParser as constraints} from './serviceForm/MultiContainerConstraints';
 import {JSONParser as fetch} from './serviceForm/Artifacts';
-import {JSONParser as environmentVariables} from './serviceForm/EnvironmentVariables';
+import {JSONParser as environmentVariables} from './serviceForm/MultiContainerEnvironmentVariables';
 import {JSONParser as externalVolumes} from './serviceForm/ExternalVolumes';
 import {JSONParser as healthChecks} from './serviceForm/HealthChecks';
 import {JSONParser as labels} from './serviceForm/Labels';

--- a/plugins/services/src/js/reducers/JSONMultiContainerReducers.js
+++ b/plugins/services/src/js/reducers/JSONMultiContainerReducers.js
@@ -1,6 +1,6 @@
 import {JSONReducer as constraints} from './serviceForm/MultiContainerConstraints';
 import {JSONReducer as containers} from './serviceForm/Containers';
-import {JSONReducer as env} from './serviceForm/EnvironmentVariables';
+import {JSONReducer as environment} from './serviceForm/EnvironmentVariables';
 import {JSONReducer as fetch} from './serviceForm/Artifacts';
 import {JSONReducer as scaling} from './serviceForm/MultiContainerScaling';
 import {JSONReducer as labels} from './serviceForm/Labels';
@@ -14,7 +14,7 @@ import {
 module.exports = {
   id: simpleReducer('id'),
   containers,
-  env,
+  environment,
   scaling,
   labels,
   scheduling(state, transaction) {

--- a/plugins/services/src/js/reducers/serviceForm/MultiContainerEnvironmentVariables.js
+++ b/plugins/services/src/js/reducers/serviceForm/MultiContainerEnvironmentVariables.js
@@ -1,0 +1,37 @@
+import {
+  ADD_ITEM,
+  SET
+} from '../../../../../../src/js/constants/TransactionTypes';
+import Transaction from '../../../../../../src/js/structs/Transaction';
+
+module.exports = {
+  JSONParser(state) {
+    if (state.environment == null) {
+      return [];
+    }
+
+    return Object.keys(state.environment).reduce(function (memo, key, index) {
+      /**
+       * For the environment variables which are a key => value based object
+       * we want to create a new item and fill it with the key and the
+       * value. So we need 3 transactions for each key value pair.
+       * 1) Add a new Item to the path with the index equal to index.
+       * 2) Set the key on the path `env.${index}.key`
+       * 3) Set the value on the path `env.${index}.value`
+       */
+      memo.push(new Transaction(['env'], index, ADD_ITEM));
+      memo.push(new Transaction([
+        'env',
+        index,
+        'key'
+      ], key, SET));
+      memo.push(new Transaction([
+        'env',
+        index,
+        'value'
+      ], state.environment[key], SET));
+
+      return memo;
+    }, []);
+  }
+};

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerEnvironmentVariables-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerEnvironmentVariables-test.js
@@ -1,0 +1,27 @@
+const MultiContainerEnvironmentVariables = require('../MultiContainerEnvironmentVariables');
+const {ADD_ITEM, SET} =
+  require('../../../../../../../src/js/constants/TransactionTypes');
+
+describe('Environment Variables', function () {
+  describe('#JSONParser', function () {
+    it('should return an empty array', function () {
+      expect(MultiContainerEnvironmentVariables.JSONParser({})).toEqual([]);
+    });
+
+    it('should return an array of transactions', function () {
+      expect(MultiContainerEnvironmentVariables.JSONParser({environment: {FOO: 'value'}})).toEqual([
+        {type: ADD_ITEM, value: 0, path: ['env']},
+        {type: SET, value: 'FOO', path: ['env', 0, 'key']},
+        {type: SET, value: 'value', path: ['env', 0, 'value']}
+      ]);
+    });
+
+    it('should keep complex values', function () {
+      expect(MultiContainerEnvironmentVariables.JSONParser({environment: {BAR: {secret: 'value'}}})).toEqual([
+        {type: ADD_ITEM, value: 0, path: ['env']},
+        {type: SET, value: 'BAR', path: ['env', 0, 'key']},
+        {type: SET, value: {secret: 'value'}, path: ['env', 0, 'value']}
+      ]);
+    });
+  });
+});

--- a/plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.js
@@ -24,29 +24,36 @@ const columns = [
 ];
 
 const PodEnvironmentVariablesConfigSection = ({appConfig, onEditClick}) => {
-  const {env = {}, containers = []} = appConfig;
+  const {environment = {}, containers = []} = appConfig;
 
-  if (!env || !containers) {
+  if (!environment || !containers) {
     return <noscript />;
   }
 
-  let combinedEnv = Object.keys(env).reduce((memo, key) => {
-    memo.push({
-      key: <code>{key}</code>,
-      value: env[key],
-      container: getSharedIconWithLabel()
-    });
+  let combinedEnv = Object.keys(environment)
+    .filter(function (key) {
+      return typeof environment[key] === 'string';
+    })
+    .reduce(
+      (memo, key) => {
+        memo.push({
+          key: <code>{key}</code>,
+          value: environment[key],
+          container: getSharedIconWithLabel()
+        });
 
-    return memo;
-  }, []);
+        return memo;
+      },
+      []
+    );
 
   combinedEnv = containers.reduce((memo, container) => {
-    const {env = {}} = container;
+    const {environment = {}} = container;
 
-    return Object.keys(env).reduce((cvMemo, key) => {
+    return Object.keys(environment).reduce((cvMemo, key) => {
       cvMemo.push({
         key: <code>{key}</code>,
-        value: env[key],
+        value: environment[key],
         container: getContainerNameWithIcon(container)
       });
 


### PR DESCRIPTION
Turns out multi container environment variables field is `environment` and not `env` as it is for single container services. This PR addresses the issue by splitting reducers and adjusting review screen.

Bonus track: fixing reducers uncovered one more bug in: `plugins/services/src/js/components/modals/NewCreateServiceModal.js`
where we applied single container hooks for multi container reducers 😅

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
