### PR TITLE
[System Tests] Using correct dist folder on jenkins config

### DIFF
--- a/system-tests/driver-config/jenkins.sh
+++ b/system-tests/driver-config/jenkins.sh
@@ -29,7 +29,7 @@ targets:
       PATH: "/usr/local/bin:$PATH"
 
     scripts:
-      proxy: http-server --proxy-secure=false -p 4201 -P \$CLUSTER_URL dist
+      proxy: http-server --proxy-secure=false -p 4201 -P \$CLUSTER_URL ../../dist
       auth: ../_scripts/auth-open.py
 
 secrets:


### PR DESCRIPTION
This PR ensures that the locally-served files are correctly found by the `http-server`.

The bugs caused by this are quite tricky, since if `http-server` fails to locate the `dist` folder it will just forward every requests to the upstream server. Until this is merged, the Jenkins job will be effectively using the UI served from the server and not the development version.