### PR TITLE
DCOS-14756: Add Default size to the local volumes

### DIFF
--- a/plugins/services/src/js/constants/LocalVolumes.js
+++ b/plugins/services/src/js/constants/LocalVolumes.js
@@ -1,0 +1,3 @@
+module.exports = {
+  DEFAULT_SIZE: 10
+};

--- a/plugins/services/src/js/reducers/serviceForm/LocalVolumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/LocalVolumes.js
@@ -15,20 +15,20 @@ module.exports = {
       .filter(item => item.external == null)
       .reduce(function(memo, item, index) {
         /**
-       * For the localVolumes we have a special case as all the volumes
-       * are present in the `container.volumes` But in this parser we only
-       * want to parse the local volumes. which means that we first filter
-       * those and only keep local volumes (decision based on if
-       * persistent is set). After that we do get all the values even
-       * stuff which we do not handle in the form yet. These steps are:
-       * 1) Add a new Item to the path with the index equal to index.
-       * 2) Set the size from `volume.persistent.size`on the path
-       *    `localVolumes.${index}.size`.
-       * 3) Set the containerPath from `volume.containerPath on the path
-       *    `localVolumes.${index}.containerPath`
-       * 4) Set the mode from `volume.mode` on the path
-       *    `localVolumes.${index}.mode`
-       */
+         * For the localVolumes we have a special case as all the volumes
+         * are present in the `container.volumes` But in this parser we only
+         * want to parse the local volumes. which means that we first filter
+         * those and only keep local volumes (decision based on if
+         * persistent is set). After that we do get all the values even
+         * stuff which we do not handle in the form yet. These steps are:
+         * 1) Add a new Item to the path with the index equal to index.
+         * 2) Set the size from `volume.persistent.size`on the path
+         *    `localVolumes.${index}.size`.
+         * 3) Set the containerPath from `volume.containerPath on the path
+         *    `localVolumes.${index}.containerPath`
+         * 4) Set the mode from `volume.mode` on the path
+         *    `localVolumes.${index}.mode`
+         */
         memo.push(new Transaction(["localVolumes"], index, ADD_ITEM));
 
         if (item.persistent != null && item.persistent.size != null) {

--- a/plugins/services/src/js/reducers/serviceForm/LocalVolumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/LocalVolumes.js
@@ -1,6 +1,9 @@
 import { ADD_ITEM, REMOVE_ITEM, SET } from "#SRC/js/constants/TransactionTypes";
 import { parseIntValue } from "#SRC/js/utils/ReducerUtil";
 import Transaction from "#SRC/js/structs/Transaction";
+import {
+  DEFAULT_SIZE as LOCAL_VOLUME_DEFAULT_SIZE
+} from "../../constants/LocalVolumes";
 
 module.exports = {
   JSONParser(state) {
@@ -12,20 +15,20 @@ module.exports = {
       .filter(item => item.external == null)
       .reduce(function(memo, item, index) {
         /**
-         * For the localVolumes we have a special case as all the volumes
-         * are present in the `container.volumes` But in this parser we only
-         * want to parse the local volumes. which means that we first filter
-         * those and only keep local volumes (decision based on if
-         * persistent is set). After that we do get all the values even
-         * stuff which we do not handle in the form yet. These steps are:
-         * 1) Add a new Item to the path with the index equal to index.
-         * 2) Set the size from `volume.persistent.size`on the path
-         *    `localVolumes.${index}.size`.
-         * 3) Set the containerPath from `volume.containerPath on the path
-         *    `localVolumes.${index}.containerPath`
-         * 4) Set the mode from `volume.mode` on the path
-         *    `localVolumes.${index}.mode`
-         */
+       * For the localVolumes we have a special case as all the volumes
+       * are present in the `container.volumes` But in this parser we only
+       * want to parse the local volumes. which means that we first filter
+       * those and only keep local volumes (decision based on if
+       * persistent is set). After that we do get all the values even
+       * stuff which we do not handle in the form yet. These steps are:
+       * 1) Add a new Item to the path with the index equal to index.
+       * 2) Set the size from `volume.persistent.size`on the path
+       *    `localVolumes.${index}.size`.
+       * 3) Set the containerPath from `volume.containerPath on the path
+       *    `localVolumes.${index}.containerPath`
+       * 4) Set the mode from `volume.mode` on the path
+       *    `localVolumes.${index}.mode`
+       */
         memo.push(new Transaction(["localVolumes"], index, ADD_ITEM));
 
         if (item.persistent != null && item.persistent.size != null) {
@@ -45,13 +48,15 @@ module.exports = {
             new Transaction(["localVolumes", index, "type"], "HOST", SET)
           );
 
-          memo.push(
-            new Transaction(
-              ["localVolumes", index, "hostPath"],
-              item.hostPath,
-              SET
-            )
-          );
+          if (item.hostPath != null) {
+            memo.push(
+              new Transaction(
+                ["localVolumes", index, "hostPath"],
+                item.hostPath,
+                SET
+              )
+            );
+          }
         }
 
         if (item.containerPath != null) {
@@ -85,7 +90,11 @@ module.exports = {
       if (joinedPath === "localVolumes") {
         switch (type) {
           case ADD_ITEM:
-            state.push({ containerPath: null, size: null, mode: "RW" });
+            state.push({
+              containerPath: null,
+              size: LOCAL_VOLUME_DEFAULT_SIZE,
+              mode: "RW"
+            });
             break;
           case REMOVE_ITEM:
             state = state.filter((item, index) => {

--- a/plugins/services/src/js/reducers/serviceForm/Volumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/Volumes.js
@@ -1,6 +1,10 @@
 import { parseIntValue } from "#SRC/js/utils/ReducerUtil";
 import { ADD_ITEM, REMOVE_ITEM, SET } from "#SRC/js/constants/TransactionTypes";
 
+import {
+  DEFAULT_SIZE as LOCAL_VOLUME_DEFAULT_SIZE
+} from "../../constants/LocalVolumes";
+
 const mapLocalVolumes = function(volume) {
   if (volume.type === "PERSISTENT") {
     return {
@@ -126,7 +130,7 @@ function reduceVolumes(state, { type, path, value }) {
         case ADD_ITEM:
           this.localVolumes.push({
             containerPath: null,
-            persistent: { size: null },
+            persistent: { size: LOCAL_VOLUME_DEFAULT_SIZE },
             mode: "RW"
           });
           break;

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -10,6 +10,9 @@ const {
   type: { BRIDGE, HOST, USER }
 } = require("#SRC/js/constants/Networking");
 
+const LOCAL_VOLUME_DEFAULT_SIZE = require("../../../constants/LocalVolumes")
+  .DEFAULT_SIZE;
+
 describe("Container", function() {
   describe("#JSONReducer", function() {
     it("should return a null container as default object", function() {
@@ -1076,7 +1079,7 @@ describe("Container", function() {
             {
               containerPath: null,
               persistent: {
-                size: null
+                size: LOCAL_VOLUME_DEFAULT_SIZE
               },
               mode: "RW"
             }
@@ -1136,7 +1139,7 @@ describe("Container", function() {
             {
               containerPath: null,
               persistent: {
-                size: null
+                size: LOCAL_VOLUME_DEFAULT_SIZE
               },
               mode: "RW"
             },

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/LocalVolumes-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/LocalVolumes-test.js
@@ -7,6 +7,9 @@ const {
   SET
 } = require("#SRC/js/constants/TransactionTypes");
 
+const LOCAL_VOLUME_DEFAULT_SIZE = require("../../../constants/LocalVolumes")
+  .DEFAULT_SIZE;
+
 describe("LocalVolumes", function() {
   describe("#FormReducer", function() {
     it("should return an Array with one item", function() {
@@ -14,7 +17,12 @@ describe("LocalVolumes", function() {
         .add(new Transaction(["localVolumes"], 0, ADD_ITEM))
         .add(new Transaction(["localVolumes", 0, "type"], "PERSISTENT"));
       expect(batch.reduce(LocalVolumes.FormReducer, [])).toEqual([
-        { size: null, containerPath: null, mode: "RW", type: "PERSISTENT" }
+        {
+          size: LOCAL_VOLUME_DEFAULT_SIZE,
+          containerPath: null,
+          mode: "RW",
+          type: "PERSISTENT"
+        }
       ]);
     });
 

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Volumes-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Volumes-test.js
@@ -7,6 +7,9 @@ const {
   SET
 } = require("#SRC/js/constants/TransactionTypes");
 
+const LOCAL_VOLUME_DEFAULT_SIZE = require("../../../constants/LocalVolumes")
+  .DEFAULT_SIZE;
+
 describe("Volumes", function() {
   describe("#JSONReducer", function() {
     it("should return an empty array if no volumes are set", function() {
@@ -27,7 +30,7 @@ describe("Volumes", function() {
         {
           containerPath: null,
           persistent: {
-            size: null
+            size: LOCAL_VOLUME_DEFAULT_SIZE
           },
           mode: "RW"
         }
@@ -152,7 +155,7 @@ describe("Volumes", function() {
         {
           containerPath: null,
           persistent: {
-            size: null
+            size: LOCAL_VOLUME_DEFAULT_SIZE
           },
           mode: "RW"
         },


### PR DESCRIPTION
**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

Local Volumes now will get a default size of 10 so
if they get rendered into the JSON they will have
a `persistent:{size:DEFAULT_SIZE}` and they can be
parsed back.

Closes DCOS-14756