### PR TITLE
DCOS-14370: Remove scrollContainer prop from Tooltip

### DIFF
--- a/plugins/services/src/js/components/forms/ArtifactsSection.js
+++ b/plugins/services/src/js/components/forms/ArtifactsSection.js
@@ -31,7 +31,6 @@ class ArtifactsSection extends Component {
           content={tooltipContent}
           interactive={true}
           maxWidth={300}
-          scrollContainer=".gm-scroll-view"
           wrapText={true}>
           <Icon color="grey" id="circle-question" size="mini" />
         </Tooltip>

--- a/plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js
@@ -101,7 +101,6 @@ class ContainerServiceFormAdvancedSection extends Component {
           content="Docker Engine does not support GPU resources, please select Universal Container Runtime if you want to use GPU resources."
           interactive={true}
           maxWidth={300}
-          scrollContainer=".gm-scroll-view"
           wrapText={true}
           wrapperClassName="tooltip-wrapper tooltip-block-wrapper">
           {inputNode}
@@ -163,7 +162,6 @@ class ContainerServiceFormAdvancedSection extends Component {
             content={dockerOnly}
             key={`tooltip.${index}`}
             position="top"
-            scrollContainer=".gm-scroll-view"
             width={300}
             wrapperClassName="tooltip-wrapper tooltip-block-wrapper"
             wrapText={true}>

--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -70,8 +70,7 @@ class ContainerServiceFormSection extends Component {
               content={tooltipContent}
               interactive={true}
               wrapText={true}
-              maxWidth={300}
-              scrollContainer=".gm-scroll-view">
+              maxWidth={300}>
               <Icon color="grey" id="circle-question" size="mini" />
             </Tooltip>
           </FormGroupHeadingContent>
@@ -107,8 +106,7 @@ class ContainerServiceFormSection extends Component {
               content={tooltipContent}
               interactive={true}
               wrapText={true}
-              maxWidth={300}
-              scrollContainer=".gm-scroll-view">
+              maxWidth={300}>
               <Icon color="grey" id="circle-question" size="mini" />
             </Tooltip>
           </FormGroupHeadingContent>
@@ -170,7 +168,6 @@ class ContainerServiceFormSection extends Component {
         <Tooltip
           content="Mesos Runtime does not support container images, please select Docker Runtime or Universal Container Runtime if you want to use container images."
           width={300}
-          scrollContainer=".gm-scroll-view"
           wrapperClassName="tooltip-wrapper tooltip-block-wrapper text-align-center"
           wrapText={true}>
           {inputNode}

--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -187,7 +187,6 @@ class EnvironmentFormSection extends Component {
                 content={envTooltipContent}
                 interactive={true}
                 maxWidth={300}
-                scrollContainer=".gm-scroll-view"
                 wrapText={true}>
                 <Icon color="grey" id="circle-question" size="mini" />
               </Tooltip>
@@ -218,7 +217,6 @@ class EnvironmentFormSection extends Component {
                 content={labelsTooltipContent}
                 interactive={true}
                 maxWidth={300}
-                scrollContainer=".gm-scroll-view"
                 wrapText={true}>
                 <Icon color="grey" id="circle-question" size="mini" />
               </Tooltip>

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -77,7 +77,6 @@ function placementConstraintLabel(name, tooltipText, options = {}) {
             content={tooltipContent}
             interactive={true}
             maxWidth={300}
-            scrollContainer=".gm-scroll-view"
             wrapText={true}>
             <Icon color="grey" id="circle-question" size="mini" />
           </Tooltip>
@@ -250,7 +249,6 @@ class GeneralServiceFormSection extends Component {
                 content={placementTooltipContent}
                 interactive={true}
                 maxWidth={300}
-                scrollContainer=".gm-scroll-view"
                 wrapText={true}>
                 <Icon color="grey" id="circle-question" size="mini" />
               </Tooltip>
@@ -420,7 +418,6 @@ class GeneralServiceFormSection extends Component {
                 content={runtimeTooltipContent}
                 interactive={true}
                 maxWidth={300}
-                scrollContainer=".gm-scroll-view"
                 wrapText={true}>
                 <Icon color="grey" id="circle-question" size="mini" />
               </Tooltip>
@@ -479,7 +476,6 @@ class GeneralServiceFormSection extends Component {
             interactive={true}
             key={index}
             maxWidth={300}
-            scrollContainer=".gm-scroll-view"
             wrapText={true}>
             {field}
           </Tooltip>
@@ -547,7 +543,6 @@ class GeneralServiceFormSection extends Component {
                     content={idTooltipContent}
                     interactive={true}
                     maxWidth={300}
-                    scrollContainer=".gm-scroll-view"
                     wrapText={true}>
                     <Icon color="grey" id="circle-question" size="mini" />
                   </Tooltip>

--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -83,7 +83,6 @@ class HealthChecksFormSection extends Component {
                       content={gracePeriodHelpText}
                       interactive={true}
                       maxWidth={300}
-                      scrollContainer=".gm-scroll-view"
                       wrapText={true}>
                       <Icon color="grey" id="circle-question" size="mini" />
                     </Tooltip>
@@ -111,7 +110,6 @@ class HealthChecksFormSection extends Component {
                       content={intervalHelpText}
                       interactive={true}
                       maxWidth={300}
-                      scrollContainer=".gm-scroll-view"
                       wrapText={true}>
                       <Icon color="grey" id="circle-question" size="mini" />
                     </Tooltip>
@@ -139,7 +137,6 @@ class HealthChecksFormSection extends Component {
                       content={timeoutHelpText}
                       interactive={true}
                       maxWidth={300}
-                      scrollContainer=".gm-scroll-view"
                       wrapText={true}>
                       <Icon color="grey" id="circle-question" size="mini" />
                     </Tooltip>
@@ -167,7 +164,6 @@ class HealthChecksFormSection extends Component {
                       content={failuresHelpText}
                       interactive={true}
                       maxWidth={300}
-                      scrollContainer=".gm-scroll-view"
                       wrapText={true}>
                       <Icon color="grey" id="circle-question" size="mini" />
                     </Tooltip>
@@ -261,7 +257,6 @@ class HealthChecksFormSection extends Component {
                   content={endpointHelpText}
                   interactive={true}
                   maxWidth={300}
-                  scrollContainer=".gm-scroll-view"
                   wrapperClassName="tooltip-wrapper tooltip-block-wrapper text-align-center"
                   wrapText={true}>
                   <Icon color="grey" id="circle-question" size="mini" />
@@ -289,7 +284,6 @@ class HealthChecksFormSection extends Component {
                   content={pathHelpText}
                   interactive={true}
                   maxWidth={300}
-                  scrollContainer=".gm-scroll-view"
                   wrapText={true}>
                   <Icon color="grey" id="circle-question" size="mini" />
                 </Tooltip>
@@ -372,7 +366,6 @@ class HealthChecksFormSection extends Component {
                       content={tooltipContent}
                       interactive={true}
                       maxWidth={300}
-                      scrollContainer=".gm-scroll-view"
                       wrapperClassName="tooltip-wrapper text-align-center"
                       wrapText={true}>
                       <Icon color="grey" id="circle-question" size="mini" />
@@ -425,7 +418,6 @@ class HealthChecksFormSection extends Component {
                 content={tooltipContent}
                 interactive={true}
                 maxWidth={300}
-                scrollContainer=".gm-scroll-view"
                 wrapperClassName="tooltip-wrapper text-align-center"
                 wrapText={true}>
                 <Icon color="grey" id="circle-question" size="mini" />

--- a/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
@@ -73,7 +73,6 @@ class MultiContainerHealthChecksFormSection extends Component {
                       content={gracePeriodHelpText}
                       interactive={true}
                       maxWidth={300}
-                      scrollContainer=".gm-scroll-view"
                       wrapText={true}>
                       <Icon color="grey" id="circle-question" size="mini" />
                     </Tooltip>
@@ -101,7 +100,6 @@ class MultiContainerHealthChecksFormSection extends Component {
                       content={intervalHelpText}
                       interactive={true}
                       maxWidth={300}
-                      scrollContainer=".gm-scroll-view"
                       wrapText={true}>
                       <Icon color="grey" id="circle-question" size="mini" />
                     </Tooltip>
@@ -129,7 +127,6 @@ class MultiContainerHealthChecksFormSection extends Component {
                       content={timeoutHelpText}
                       interactive={true}
                       maxWidth={300}
-                      scrollContainer=".gm-scroll-view"
                       wrapText={true}>
                       <Icon color="grey" id="circle-question" size="mini" />
                     </Tooltip>
@@ -157,7 +154,6 @@ class MultiContainerHealthChecksFormSection extends Component {
                       content={failuresHelpText}
                       interactive={true}
                       maxWidth={300}
-                      scrollContainer=".gm-scroll-view"
                       wrapText={true}>
                       <Icon color="grey" id="circle-question" size="mini" />
                     </Tooltip>
@@ -259,7 +255,6 @@ class MultiContainerHealthChecksFormSection extends Component {
                   content={endpointHelpText}
                   interactive={true}
                   maxWidth={300}
-                  scrollContainer=".gm-scroll-view"
                   wrapperClassName="tooltip-wrapper tooltip-block-wrapper text-align-center"
                   wrapText={true}>
                   <Icon color="grey" id="circle-question" size="mini" />
@@ -287,7 +282,6 @@ class MultiContainerHealthChecksFormSection extends Component {
                   content={pathHelpText}
                   interactive={true}
                   maxWidth={300}
-                  scrollContainer=".gm-scroll-view"
                   wrapText={true}>
                   <Icon color="grey" id="circle-question" size="mini" />
                 </Tooltip>
@@ -391,7 +385,6 @@ class MultiContainerHealthChecksFormSection extends Component {
                     content={tooltipContent}
                     interactive={true}
                     maxWidth={300}
-                    scrollContainer=".gm-scroll-view"
                     wrapperClassName="tooltip-wrapper text-align-center"
                     wrapText={true}>
                     <Icon color="grey" id="circle-question" size="mini" />
@@ -463,7 +456,6 @@ class MultiContainerHealthChecksFormSection extends Component {
             content={tooltipContent}
             interactive={true}
             maxWidth={300}
-            scrollContainer=".gm-scroll-view"
             wrapperClassName="tooltip-wrapper text-align-center"
             wrapText={true}>
             <Icon color="grey" id="circle-question" size="mini" />

--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -125,7 +125,6 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
                 content={tooltipContent}
                 interactive={true}
                 maxWidth={300}
-                scrollContainer=".gm-scroll-view"
                 wrapText={true}>
                 <Icon color="grey" id="circle-question" size="mini" />
               </Tooltip>
@@ -218,7 +217,6 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
                   content={loadBalancerTooltipContent}
                   interactive={true}
                   maxWidth={300}
-                  scrollContainer=".gm-scroll-view"
                   wrapperClassName="tooltip-wrapper text-align-center"
                   wrapText={true}>
                   <Icon color="grey" id="circle-question" size="mini" />
@@ -261,7 +259,6 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
                 content={assignTooltip}
                 interactive={true}
                 maxWidth={300}
-                scrollContainer=".gm-scroll-view"
                 wrapText={true}>
                 <Icon color="grey" id="circle-question" size="mini" />
               </Tooltip>
@@ -474,7 +471,6 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
                     content={networkTypeTooltipContent}
                     interactive={true}
                     maxWidth={300}
-                    scrollContainer=".gm-scroll-view"
                     wrapText={true}>
                     <Icon color="grey" id="circle-question" size="mini" />
                   </Tooltip>
@@ -498,7 +494,6 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
                 content={serviceEndpointsTooltipContent}
                 interactive={true}
                 maxWidth={300}
-                scrollContainer=".gm-scroll-view"
                 wrapperClassName="tooltip-wrapper text-align-center"
                 wrapText={true}>
                 <Icon color="grey" id="circle-question" size="mini" />

--- a/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
@@ -133,7 +133,6 @@ class MultiContainerVolumesFormSection extends Component {
               content={tooltipContent}
               interactive={true}
               maxWidth={300}
-              scrollContainer=".gm-scroll-view"
               wrapText={true}>
               <Icon color="grey" id="circle-question" size="mini" />
             </Tooltip>

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -95,7 +95,6 @@ class NetworkingFormSection extends mixin(StoreMixin) {
                 content={tooltipContent}
                 interactive={true}
                 maxWidth={300}
-                scrollContainer=".gm-scroll-view"
                 wrapText={true}>
                 <Icon color="grey" id="circle-question" size="mini" />
               </Tooltip>
@@ -201,7 +200,6 @@ class NetworkingFormSection extends mixin(StoreMixin) {
                   content={loadBalancerTooltipContent}
                   interactive={true}
                   maxWidth={300}
-                  scrollContainer=".gm-scroll-view"
                   wrapperClassName="tooltip-wrapper text-align-center"
                   wrapText={true}>
                   <Icon color="grey" id="circle-question" size="mini" />
@@ -247,7 +245,6 @@ class NetworkingFormSection extends mixin(StoreMixin) {
                 content={assignHelpText}
                 interactive={true}
                 maxWidth={300}
-                scrollContainer=".gm-scroll-view"
                 wrapText={true}>
                 <Icon color="grey" id="circle-question" size="mini" />
               </Tooltip>
@@ -392,7 +389,6 @@ class NetworkingFormSection extends mixin(StoreMixin) {
                       content="Name your endpoint to search for it by a meaningful name, rather than the port number."
                       interactive={true}
                       maxWidth={300}
-                      scrollContainer=".gm-scroll-view"
                       wrapperClassName="tooltip-wrapper text-align-center"
                       wrapText={true}>
                       <Icon color="grey" id="circle-question" size="mini" />
@@ -485,7 +481,6 @@ class NetworkingFormSection extends mixin(StoreMixin) {
         content={tooltipContent + '.'}
         interactive={true}
         maxWidth={300}
-        scrollContainer=".gm-scroll-view"
         wrapperClassName="tooltip-wrapper tooltip-block-wrapper text-align-center"
         wrapText={true}>
         {selections}
@@ -521,7 +516,6 @@ class NetworkingFormSection extends mixin(StoreMixin) {
             content={serviceEndpointsTooltipContent}
             interactive={true}
             maxWidth={300}
-            scrollContainer=".gm-scroll-view"
             wrapperClassName="tooltip-wrapper text-align-center"
             wrapText={true}>
             <Icon color="grey" id="circle-question" size="mini" />
@@ -539,7 +533,6 @@ class NetworkingFormSection extends mixin(StoreMixin) {
         <Tooltip
           content={tooltipMessage}
           maxWidth={500}
-          scrollContainer=".gm-scroll-view"
           wrapperClassName="tooltip-wrapper tooltip-block-wrapper"
           wrapText={true}>
           <h3 className="short-bottom muted" key="service-endpoints-header">
@@ -615,7 +608,6 @@ class NetworkingFormSection extends mixin(StoreMixin) {
                     content={tooltipContent}
                     interactive={true}
                     maxWidth={300}
-                    scrollContainer=".gm-scroll-view"
                     wrapText={true}>
                     <Icon color="grey" id="circle-question" size="mini" />
                   </Tooltip>

--- a/plugins/services/src/js/components/forms/VolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/VolumesFormSection.js
@@ -76,7 +76,6 @@ class VolumesFormSection extends Component {
                   content={tooltipContent}
                   interactive={true}
                   maxWidth={300}
-                  scrollContainer=".gm-scroll-view"
                   wrapText={true}>
                   <Icon color="grey" id="circle-question" size="mini" />
                 </Tooltip>
@@ -143,7 +142,6 @@ class VolumesFormSection extends Component {
                   content={tooltipContent}
                   interactive={true}
                   maxWidth={300}
-                  scrollContainer=".gm-scroll-view"
                   wrapText={true}>
                   <Icon color="grey" id="circle-question" size="mini" />
                 </Tooltip>
@@ -353,7 +351,6 @@ class VolumesFormSection extends Component {
                 content={tooltipContent}
                 interactive={true}
                 maxWidth={300}
-                scrollContainer=".gm-scroll-view"
                 wrapText={true}>
                 <Icon color="grey" id="circle-question" size="mini" />
               </Tooltip>

--- a/plugins/services/src/js/components/modals/ServiceFormModal.js
+++ b/plugins/services/src/js/components/modals/ServiceFormModal.js
@@ -460,8 +460,7 @@ class ServiceFormModal extends React.Component {
             wrapperClassName="tooltip-wrapper media-object-item json-editor-help"
             wrapText={true}
             maxWidth={300}
-            position="left"
-            scrollContainer=".gm-scroll-view">
+            position="left">
             <Icon color="grey" id="circle-question" size="mini" />
           </Tooltip>
         </div>

--- a/src/js/components/SchemaForm.js
+++ b/src/js/components/SchemaForm.js
@@ -290,8 +290,7 @@ class SchemaForm extends mixin(StoreMixin, InternalStorageMixin) {
           content={description}
           wrapperClassName="tooltip-wrapper flush-bottom short-top media-object-item"
           wrapText={true}
-          maxWidth={300}
-          scrollContainer=".gm-scroll-view">
+          maxWidth={300}>
           <Icon color="grey" id="circle-question" size="mini" />
         </Tooltip>
       );
@@ -328,8 +327,7 @@ class SchemaForm extends mixin(StoreMixin, InternalStorageMixin) {
         wrapperClassName="tooltip-wrapper media-object-item"
         wrapText={true}
         maxWidth={300}
-        interactive={true}
-        scrollContainer=".gm-scroll-view">
+        interactive={true}>
         <Icon color="grey" id="circle-question" size="mini" />
       </Tooltip>
     );

--- a/src/js/components/TabForm.js
+++ b/src/js/components/TabForm.js
@@ -117,8 +117,7 @@ class TabForm extends mixin(InternalStorageMixin) {
               interactive={true}
               wrapperClassName="tooltip-wrapper media-object-item"
               wrapText={true}
-              maxWidth={300}
-              scrollContainer=".gm-scroll-view">
+              maxWidth={300}>
               <Icon color="grey" id="circle-question" size="mini" />
             </Tooltip>
           </div>

--- a/src/js/components/form/DeleteRowButton.js
+++ b/src/js/components/form/DeleteRowButton.js
@@ -10,7 +10,6 @@ const DeleteRowButton = ({onClick}) => {
     <Tooltip content={StringUtil.capitalize(UserActions.DELETE)}
       interactive={false}
       maxWidth={300}
-      scrollContainer=".gm-scroll-view"
       wrapText={true}>
       <a className="button button-link button-narrow"
         onClick={onClick}>

--- a/src/js/components/form/FormGroupContainer.js
+++ b/src/js/components/form/FormGroupContainer.js
@@ -12,7 +12,6 @@ const FormGroupContainer = (props) => {
       <div className="form-group-container-action-button-group">
         <Tooltip content={StringUtil.capitalize(UserActions.DELETE)}
           maxWidth={300}
-          scrollContainer=".gm-scroll-view"
           wrapText={true}>
           <a className="button button-primary-link"
             onClick={props.onRemove}>


### PR DESCRIPTION
~~**Relies on https://github.com/mesosphere/reactjs-components/pull/399**. The `hold merge` label should remain until a new version of `reactjs-components` is released and the dependency is updated in DC/OS UI.~~ [The update PR](https://github.com/dcos/dcos-ui/pull/2103) landed.

This PR removes the `scrollContainer` prop from the `Tooltip` component, as it is no longer needed due to the way the event listener is added.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?