### PR TITLE
[marathon 1.5] DCOS-14703: UCR Improvements

### DIFF
--- a/plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js
@@ -22,18 +22,20 @@ import ArtifactsSection from "./ArtifactsSection";
 import ContainerConstants from "../../constants/ContainerConstants";
 import PodSpec from "../../structs/PodSpec";
 
-const { DOCKER } = ContainerConstants.type;
+const { DOCKER, MESOS } = ContainerConstants.type;
 
 const containerSettings = {
   privileged: {
+    runtimes: [DOCKER],
     label: "Grant Runtime Privileges",
     helpText: "By default, containers are “unprivileged” and cannot, for example, run a Docker daemon inside a Docker container.",
-    dockerOnly: "Grant runtime privileges is only supported in Docker Runtime."
+    unavailableText: "Grant runtime privileges option isn't supported by selected runtime."
   },
   forcePullImage: {
+    runtimes: [DOCKER, MESOS],
     label: "Force Pull Image On Launch",
     helpText: "Force Docker to pull the image before launching each instance.",
-    dockerOnly: "Force pull image on launch is only supported in Docker Runtime."
+    unavailableText: "Force pull image on launch option isn't supported by selected runtime."
   }
 };
 
@@ -145,10 +147,12 @@ class ContainerServiceFormAdvancedSection extends Component {
     const selections = Object.keys(
       containerSettings
     ).map((settingName, index) => {
-      const { helpText, label, dockerOnly } = containerSettings[settingName];
+      const { runtimes, helpText, label, unavailableText } = containerSettings[
+        settingName
+      ];
       const settingsPath = this.getFieldPath(path, settingName);
       const checked = findNestedPropertyInObject(data, settingsPath);
-      const isDisabled = containerType !== DOCKER;
+      const isDisabled = !runtimes.includes(containerType);
       const labelNodeClasses = classNames({
         "disabled muted": isDisabled,
         "flush-bottom": index === sectionCount - 1
@@ -171,7 +175,7 @@ class ContainerServiceFormAdvancedSection extends Component {
       if (isDisabled) {
         labelNode = (
           <Tooltip
-            content={dockerOnly}
+            content={unavailableText}
             key={`tooltip.${index}`}
             position="top"
             width={300}

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -468,12 +468,6 @@ class NetworkingFormSection extends mixin(StoreMixin) {
         "BRIDGE networking is not compatible with the Mesos runtime";
     }
 
-    // Runtime is Universal Container Runtime
-    if (type === MESOS) {
-      disabledMap[BRIDGE] =
-        "BRIDGE networking is not compatible with the Universal Container Runtime";
-    }
-
     const tooltipContent = Object.keys(disabledMap)
       .filter(function(key) {
         return disabledMap[key];
@@ -519,7 +513,6 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     const isMesosRuntime = !type || type === NONE;
     const isUniversalContainerizer = !type || type === MESOS;
     const isVirtualNetwork = networkType && networkType.startsWith(CONTAINER);
-    const isBridgeNetwork = networkType && networkType.startsWith(BRIDGE);
 
     const serviceEndpointsDocsURI = MetadataStore.buildDocsURI(
       "/usage/service-discovery/load-balancing-vips/virtual-ip-addresses/"
@@ -554,10 +547,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     );
 
     // Mesos Runtime doesn't support Service Endpoints for the USER network
-    if (
-      (isMesosRuntime || isUniversalContainerizer) &&
-      (isVirtualNetwork || isBridgeNetwork)
-    ) {
+    if ((isMesosRuntime || isUniversalContainerizer) && isVirtualNetwork) {
       const tooltipMessage = `Service Endpoints are not available in the ${ContainerConstants.labelMap[type]}`;
 
       return (

--- a/plugins/services/src/js/components/forms/VolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/VolumesFormSection.js
@@ -178,33 +178,8 @@ class VolumesFormSection extends Component {
     );
   }
 
-  getHostOption(dockerImage) {
-    if (dockerImage == null || dockerImage === "") {
-      return null;
-    }
-
-    return (
-      <option value="HOST">
-        Host Volume
-
-      </option>
-    );
-  }
-
   getLocalVolumesLines(data) {
-    const dockerImage =
-      this.props.data.container &&
-      this.props.data.container.docker &&
-      this.props.data.container.docker.image;
-
     return data.map((volume, key) => {
-      if (
-        volume.type === "HOST" &&
-        (dockerImage == null || dockerImage === "")
-      ) {
-        return null;
-      }
-
       const typeError = errorsLens.at(key, {}).get(this.props.errors).type;
 
       return (
@@ -229,7 +204,9 @@ class VolumesFormSection extends Component {
                 value={volume.type}
               >
                 <option>Select...</option>
-                {this.getHostOption(dockerImage)}
+                <option value="HOST">
+                  Host Volume
+                </option>
                 <option value="PERSISTENT">Persistent Volume</option>
               </FieldSelect>
             </FormGroup>

--- a/plugins/services/src/js/reducers/serviceForm/Container.js
+++ b/plugins/services/src/js/reducers/serviceForm/Container.js
@@ -131,12 +131,15 @@ const containerJSONReducer = combineReducers({
     // Store the change no matter what network type we have
     this.portDefinitions = networkingReducer(this.portDefinitions, action);
 
-    // Universal containerizer does not support portMappings
-    if (this.containerType !== DOCKER) {
+    // Universal containerizer does not support portMappings for CONTAINER
+    if (
+      this.containerType !== DOCKER &&
+      this.appState.networkType === CONTAINER
+    ) {
       return null;
     }
 
-    // We only want portMappings for networks of type BRIDGE or USER
+    // We only want portMappings for networks of type BRIDGE or CONTAINER
     if (
       this.appState.networkType !== BRIDGE &&
       this.appState.networkType !== CONTAINER

--- a/plugins/services/src/js/reducers/serviceForm/Docker.js
+++ b/plugins/services/src/js/reducers/serviceForm/Docker.js
@@ -24,6 +24,6 @@ function getContainerSettingsReducer(name) {
 
 module.exports = combineReducers({
   privileged: getContainerSettingsReducer("privileged"),
-  forcePullImage: getContainerSettingsReducer("forcePullImage"),
+  forcePullImage: simpleReducer("container.docker.forcePullImage", null),
   image: simpleReducer("container.docker.image", "")
 });

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Volumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Volumes.js
@@ -17,10 +17,6 @@ const mapLocalVolumes = function(volume) {
   };
 };
 
-const filterHostVolumes = function(volume) {
-  return volume.type !== "HOST" || this.docker;
-};
-
 // NB: This is being used as FormReducer and JSONReducer
 function reduceVolumes(state, { type, path, value }) {
   if (path == null) {
@@ -88,9 +84,7 @@ function reduceVolumes(state, { type, path, value }) {
        * mapping them to the common structure
        */
       return [].concat(
-        this.localVolumes
-          .filter(filterHostVolumes.bind(this))
-          .map(mapLocalVolumes),
+        this.localVolumes.map(mapLocalVolumes),
         this.externalVolumes
       );
     }
@@ -138,9 +132,7 @@ function reduceVolumes(state, { type, path, value }) {
       }
 
       return [].concat(
-        this.localVolumes
-          .filter(filterHostVolumes.bind(this))
-          .map(mapLocalVolumes),
+        this.localVolumes.map(mapLocalVolumes),
         this.externalVolumes
       );
     }
@@ -164,7 +156,7 @@ function reduceVolumes(state, { type, path, value }) {
   }
 
   return [].concat(
-    this.localVolumes.filter(filterHostVolumes.bind(this)).map(mapLocalVolumes),
+    this.localVolumes.map(mapLocalVolumes),
     this.externalVolumes
   );
 }

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -213,7 +213,7 @@ describe("Container", function() {
       });
     });
 
-    it("removes forcePullImage when runtime is changed", function() {
+    it("should not remove forcePullImage when runtime is changed", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["container", "type"], "DOCKER", SET));
       batch = batch.add(
@@ -226,9 +226,9 @@ describe("Container", function() {
 
       expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
         docker: {
-          forcePullImage: null,
-          privileged: null,
-          image: "foo"
+          forcePullImage: true,
+          image: "foo",
+          privileged: null
         },
         portMappings: null,
         type: "MESOS",

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -1,4 +1,3 @@
-const Container = require("../Container");
 const Batch = require("#SRC/js/structs/Batch");
 const Transaction = require("#SRC/js/structs/Transaction");
 const {
@@ -9,6 +8,8 @@ const {
 const {
   type: { BRIDGE, HOST, CONTAINER }
 } = require("#SRC/js/constants/Networking");
+
+const Container = require("../Container");
 
 describe("Container", function() {
   describe("#JSONReducer", function() {
@@ -471,63 +472,548 @@ describe("Container", function() {
           type: "DOCKER",
           volumes: []
         });
+      });
 
-        it("shouldn't create portMappings by default", function() {
-          let batch = new Batch();
-          batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+      it("shouldn't create portMappings by default", function() {
+        let batch = new Batch();
+        batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
 
-          expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-            docker: {
-              forcePullImage: null,
-              image: "",
-              privileged: null
-            },
-            portMappings: null,
-            type: null,
-            volumes: []
-          });
+        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+          docker: {
+            forcePullImage: null,
+            image: "",
+            privileged: null
+          },
+          portMappings: null,
+          type: null,
+          volumes: []
         });
+      });
 
-        it("shouldn't create portMappings for HOST", function() {
+      it("shouldn't create portMappings for HOST", function() {
+        let batch = new Batch();
+        batch = batch.add(
+          new Transaction(["container", "type"], "DOCKER", SET)
+        );
+        batch = batch.add(new Transaction(["networks", 0, "mode"], HOST, SET));
+        batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "portMapping"], true)
+        );
+
+        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+          docker: {
+            forcePullImage: null,
+            image: "",
+            privileged: null
+          },
+          portMappings: null,
+          type: "DOCKER",
+          volumes: []
+        });
+      });
+
+      it("should create two default portDefinition configurations", function() {
+        let batch = new Batch();
+        batch = batch.add(
+          new Transaction(["container", "type"], "DOCKER", SET)
+        );
+        batch = batch.add(
+          new Transaction(["networks", 0, "mode"], CONTAINER, SET)
+        );
+        batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+        batch = batch.add(new Transaction(["portDefinitions"], 1, ADD_ITEM));
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "portMapping"], true)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 1, "portMapping"], true)
+        );
+
+        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+          docker: {
+            forcePullImage: null,
+            image: "",
+            privileged: null
+          },
+          portMappings: [
+            {
+              containerPort: 0,
+              hostPort: 0,
+              labels: null,
+              name: null,
+              protocol: "tcp",
+              servicePort: null
+            },
+            {
+              containerPort: 0,
+              hostPort: 0,
+              labels: null,
+              name: null,
+              protocol: "tcp",
+              servicePort: null
+            }
+          ],
+          type: "DOCKER",
+          volumes: []
+        });
+      });
+
+      it("should set the name value", function() {
+        let batch = new Batch();
+        batch = batch.add(
+          new Transaction(["container", "type"], "DOCKER", SET)
+        );
+        batch = batch.add(
+          new Transaction(["networks", 0, "mode"], CONTAINER, SET)
+        );
+        batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "portMapping"], true)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "name"], "foo")
+        );
+
+        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+          docker: {
+            forcePullImage: null,
+            image: "",
+            privileged: null
+          },
+          portMappings: [
+            {
+              containerPort: 0,
+              hostPort: 0,
+              labels: null,
+              name: "foo",
+              protocol: "tcp",
+              servicePort: null
+            }
+          ],
+          type: "DOCKER",
+          volumes: []
+        });
+      });
+
+      it("should set the port value", function() {
+        let batch = new Batch();
+        batch = batch.add(
+          new Transaction(["container", "type"], "DOCKER", SET)
+        );
+        batch = batch.add(
+          new Transaction(["networks", 0, "mode"], CONTAINER, SET)
+        );
+        batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "portMapping"], true)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "automaticPort"], false)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "hostPort"], 100)
+        );
+
+        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+          docker: {
+            forcePullImage: null,
+            image: "",
+            privileged: null
+          },
+          portMappings: [
+            {
+              containerPort: 0,
+              hostPort: 100,
+              labels: null,
+              name: null,
+              protocol: "tcp",
+              servicePort: null
+            }
+          ],
+          type: "DOCKER",
+          volumes: []
+        });
+      });
+
+      it("should default port value to 0 if automaticPort", function() {
+        let batch = new Batch();
+        batch = batch.add(
+          new Transaction(["container", "type"], "DOCKER", SET)
+        );
+        batch = batch.add(
+          new Transaction(["networks", 0, "mode"], CONTAINER, SET)
+        );
+        batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "portMapping"], true)
+        );
+        // This is default behavior
+        // batch = batch.add(
+        //  new Transaction(['portDefinitions', 0, 'automaticPort'], true)
+        // );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "hostPort"], 100)
+        );
+
+        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+          docker: {
+            forcePullImage: null,
+            image: "",
+            privileged: null
+          },
+          portMappings: [
+            {
+              containerPort: 0,
+              hostPort: 0,
+              labels: null,
+              name: null,
+              protocol: "tcp",
+              servicePort: null
+            }
+          ],
+          type: "DOCKER",
+          volumes: []
+        });
+      });
+
+      it("should set the protocol value", function() {
+        let batch = new Batch();
+        batch = batch.add(
+          new Transaction(["container", "type"], "DOCKER", SET)
+        );
+        batch = batch.add(
+          new Transaction(["networks", 0, "mode"], CONTAINER, SET)
+        );
+        batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "portMapping"], true)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "protocol", "tcp"], true)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "protocol", "udp"], true)
+        );
+
+        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+          docker: {
+            forcePullImage: null,
+            image: "",
+            privileged: null
+          },
+          portMappings: [
+            {
+              containerPort: 0,
+              hostPort: 0,
+              labels: null,
+              name: null,
+              protocol: "udp,tcp",
+              servicePort: null
+            }
+          ],
+          type: "DOCKER",
+          volumes: []
+        });
+      });
+
+      it("should add the labels key if the portDefinition is load balanced", function() {
+        let batch = new Batch();
+        batch = batch.add(
+          new Transaction(["container", "type"], "DOCKER", SET)
+        );
+        batch = batch.add(
+          new Transaction(["networks", 0, "mode"], CONTAINER, SET)
+        );
+        batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+        batch = batch.add(new Transaction(["portDefinitions"], 1, ADD_ITEM));
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "portMapping"], true)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 1, "portMapping"], true)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 1, "loadBalanced"], true)
+        );
+
+        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+          docker: {
+            forcePullImage: null,
+            image: "",
+            privileged: null
+          },
+          portMappings: [
+            {
+              containerPort: 0,
+              hostPort: 0,
+              labels: null,
+              name: null,
+              protocol: "tcp",
+              servicePort: null
+            },
+            {
+              containerPort: 0,
+              hostPort: 0,
+              labels: { VIP_1: ":0" },
+              name: null,
+              protocol: "tcp",
+              servicePort: null
+            }
+          ],
+          type: "DOCKER",
+          volumes: []
+        });
+      });
+
+      it("should add the index of the portDefinition to the VIP keys", function() {
+        let batch = new Batch();
+        batch = batch.add(
+          new Transaction(["container", "type"], "DOCKER", SET)
+        );
+        batch = batch.add(
+          new Transaction(["networks", 0, "mode"], CONTAINER, SET)
+        );
+        batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+        batch = batch.add(new Transaction(["portDefinitions"], 1, ADD_ITEM));
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "portMapping"], true)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 1, "portMapping"], true)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "loadBalanced"], true)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 1, "loadBalanced"], true)
+        );
+
+        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+          docker: {
+            forcePullImage: null,
+            image: "",
+            privileged: null
+          },
+          portMappings: [
+            {
+              containerPort: 0,
+              hostPort: 0,
+              name: null,
+              protocol: "tcp",
+              labels: { VIP_0: ":0" },
+              servicePort: null
+            },
+            {
+              containerPort: 0,
+              hostPort: 0,
+              name: null,
+              protocol: "tcp",
+              labels: { VIP_1: ":0" },
+              servicePort: null
+            }
+          ],
+          type: "DOCKER",
+          volumes: []
+        });
+      });
+
+      it("should add the port to the VIP string", function() {
+        let batch = new Batch();
+        batch = batch.add(
+          new Transaction(["container", "type"], "DOCKER", SET)
+        );
+        batch = batch.add(
+          new Transaction(["networks", 0, "mode"], CONTAINER, SET)
+        );
+        batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+        batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "portMapping"], true)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 1, "portMapping"], true)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "automaticPort"], false)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "hostPort"], 300)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "loadBalanced"], true)
+        );
+
+        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+          docker: {
+            forcePullImage: null,
+            image: "",
+            privileged: null
+          },
+          portMappings: [
+            {
+              containerPort: 0,
+              hostPort: 300,
+              name: null,
+              protocol: "tcp",
+              labels: { VIP_0: ":300" },
+              servicePort: null
+            },
+            {
+              containerPort: 0,
+              hostPort: 0,
+              labels: null,
+              name: null,
+              protocol: "tcp",
+              servicePort: null
+            }
+          ],
+          type: "DOCKER",
+          volumes: []
+        });
+      });
+
+      it("should add the app ID to the VIP string when it is defined", function() {
+        let batch = new Batch();
+        batch = batch.add(
+          new Transaction(["container", "type"], "DOCKER", SET)
+        );
+        batch = batch.add(
+          new Transaction(["networks", 0, "mode"], CONTAINER, SET)
+        );
+        batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+        batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "portMapping"], true)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 1, "portMapping"], true)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "automaticPort"], false)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 1, "loadBalanced"], true)
+        );
+        batch = batch.add(new Transaction(["id"], "foo"));
+
+        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+          docker: {
+            forcePullImage: null,
+            image: "",
+            privileged: null
+          },
+          portMappings: [
+            {
+              containerPort: 0,
+              hostPort: 0,
+              labels: null,
+              name: null,
+              protocol: "tcp",
+              servicePort: null
+            },
+            {
+              containerPort: 0,
+              hostPort: 0,
+              name: null,
+              protocol: "tcp",
+              labels: { VIP_1: "foo:0" },
+              servicePort: null
+            }
+          ],
+          type: "DOCKER",
+          volumes: []
+        });
+      });
+
+      it("should store portDefinitions even if network is HOST when recorded", function() {
+        let batch = new Batch();
+        batch = batch.add(
+          new Transaction(["container", "type"], "DOCKER", SET)
+        );
+        batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+        batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "portMapping"], true)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 1, "portMapping"], true)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "automaticPort"], false)
+        );
+        batch = batch.add(
+          new Transaction(["portDefinitions", 1, "loadBalanced"], true)
+        );
+        batch = batch.add(new Transaction(["id"], "foo"));
+        batch = batch.add(
+          new Transaction(["networks", 0, "mode"], CONTAINER, SET)
+        );
+
+        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+          docker: {
+            forcePullImage: null,
+            image: "",
+            privileged: null
+          },
+          portMappings: [
+            {
+              containerPort: 0,
+              hostPort: 0,
+              labels: null,
+              name: null,
+              protocol: "tcp",
+              servicePort: null
+            },
+            {
+              containerPort: 0,
+              hostPort: 0,
+              name: null,
+              protocol: "tcp",
+              labels: { VIP_1: "foo:0" },
+              servicePort: null
+            }
+          ],
+          type: "DOCKER",
+          volumes: []
+        });
+      });
+
+      it("should't create portMappings when container.type is MESOS", function() {
+        let batch = new Batch();
+        batch = batch.add(new Transaction(["container", "type"], "MESOS", SET));
+        batch = batch.add(
+          new Transaction(["networks", 0, "mode"], CONTAINER, SET)
+        );
+        batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+        batch = batch.add(
+          new Transaction(["portDefinitions", 0, "portMapping"], true)
+        );
+
+        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+          docker: {
+            forcePullImage: null,
+            image: "",
+            privileged: null
+          },
+          portMappings: null,
+          type: "MESOS",
+          volumes: []
+        });
+      });
+
+      describe("UCR - BRDIGE", function() {
+        it("should create portMappings when container.type is MESOS", function() {
           let batch = new Batch();
           batch = batch.add(
-            new Transaction(["container", "type"], "DOCKER", SET)
+            new Transaction(["container", "type"], "MESOS", SET)
           );
           batch = batch.add(
-            new Transaction(["networks", 0, "mode"], HOST, SET)
+            new Transaction(["networks", 0, "mode"], BRIDGE, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(
             new Transaction(["portDefinitions", 0, "portMapping"], true)
-          );
-
-          expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-            docker: {
-              forcePullImage: null,
-              image: "",
-              privileged: null
-            },
-            portMappings: null,
-            type: "DOCKER",
-            volumes: []
-          });
-        });
-
-        it("should create two default portDefinition configurations", function() {
-          let batch = new Batch();
-          batch = batch.add(
-            new Transaction(["container", "type"], "DOCKER", SET)
-          );
-          batch = batch.add(
-            new Transaction(["networks", 0, "mode"], CONTAINER, SET)
-          );
-          batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(["portDefinitions"], 1, ADD_ITEM));
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "portMapping"], true)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 1, "portMapping"], true)
           );
 
           expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
@@ -544,69 +1030,31 @@ describe("Container", function() {
                 name: null,
                 protocol: "tcp",
                 servicePort: null
-              },
-              {
-                containerPort: 0,
-                hostPort: 0,
-                labels: null,
-                name: null,
-                protocol: "tcp",
-                servicePort: null
               }
             ],
-            type: "DOCKER",
+            type: "MESOS",
             volumes: []
           });
         });
 
-        it("should set the name value", function() {
+        it("should include hostPort or protocol when not enabled for BRIDGE", function() {
           let batch = new Batch();
           batch = batch.add(
-            new Transaction(["container", "type"], "DOCKER", SET)
+            new Transaction(["container", "type"], "MESOS", SET)
           );
           batch = batch.add(
-            new Transaction(["networks", 0, "mode"], CONTAINER, SET)
+            new Transaction(["networks", 0, "mode"], BRIDGE, SET)
           );
+          // This is default
+          // batch = batch.add(
+          //   new Transaction(['portDefinitions',0,'portMapping'], false)
+          // );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(
-            new Transaction(["portDefinitions", 0, "portMapping"], true)
+            new Transaction(["portDefinitions", 0, "protocol", "tcp"], false)
           );
           batch = batch.add(
-            new Transaction(["portDefinitions", 0, "name"], "foo")
-          );
-
-          expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-            docker: {
-              forcePullImage: null,
-              image: "",
-              privileged: null
-            },
-            portMappings: [
-              {
-                containerPort: 0,
-                hostPort: 0,
-                labels: null,
-                name: "foo",
-                protocol: "tcp",
-                servicePort: null
-              }
-            ],
-            type: "DOCKER",
-            volumes: []
-          });
-        });
-
-        it("should set the port value", function() {
-          let batch = new Batch();
-          batch = batch.add(
-            new Transaction(["container", "type"], "DOCKER", SET)
-          );
-          batch = batch.add(
-            new Transaction(["networks", 0, "mode"], CONTAINER, SET)
-          );
-          batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "portMapping"], true)
+            new Transaction(["portDefinitions", 0, "protocol", "udp"], true)
           );
           batch = batch.add(
             new Transaction(["portDefinitions", 0, "automaticPort"], false)
@@ -627,365 +1075,22 @@ describe("Container", function() {
                 hostPort: 100,
                 labels: null,
                 name: null,
-                protocol: "tcp",
+                protocol: "udp",
                 servicePort: null
               }
             ],
-            type: "DOCKER",
+            type: "MESOS",
             volumes: []
           });
         });
 
-        it("should default port value to 0 if automaticPort", function() {
-          let batch = new Batch();
-          batch = batch.add(
-            new Transaction(["container", "type"], "DOCKER", SET)
-          );
-          batch = batch.add(
-            new Transaction(["networks", 0, "mode"], CONTAINER, SET)
-          );
-          batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "portMapping"], true)
-          );
-          // This is default behavior
-          // batch = batch.add(
-          //  new Transaction(['portDefinitions', 0, 'automaticPort'], true)
-          // );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "hostPort"], 100)
-          );
-
-          expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-            docker: {
-              forcePullImage: null,
-              image: "",
-              privileged: null
-            },
-            portMappings: [
-              {
-                containerPort: 0,
-                hostPort: 0,
-                labels: null,
-                name: null,
-                protocol: "tcp",
-                servicePort: null
-              }
-            ],
-            type: "DOCKER",
-            volumes: []
-          });
-        });
-
-        it("should set the protocol value", function() {
-          let batch = new Batch();
-          batch = batch.add(
-            new Transaction(["container", "type"], "DOCKER", SET)
-          );
-          batch = batch.add(
-            new Transaction(["networks", 0, "mode"], CONTAINER, SET)
-          );
-          batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "portMapping"], true)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "protocol", "tcp"], true)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "protocol", "udp"], true)
-          );
-
-          expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-            docker: {
-              forcePullImage: null,
-              image: "",
-              privileged: null
-            },
-            portMappings: [
-              {
-                containerPort: 0,
-                hostPort: 0,
-                labels: null,
-                name: null,
-                protocol: "udp,tcp",
-                servicePort: null
-              }
-            ],
-            type: "DOCKER",
-            volumes: []
-          });
-        });
-
-        it("should add the labels key if the portDefinition is load balanced", function() {
-          let batch = new Batch();
-          batch = batch.add(
-            new Transaction(["container", "type"], "DOCKER", SET)
-          );
-          batch = batch.add(
-            new Transaction(["networks", 0, "mode"], CONTAINER, SET)
-          );
-          batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(["portDefinitions"], 1, ADD_ITEM));
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "portMapping"], true)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 1, "portMapping"], true)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 1, "loadBalanced"], true)
-          );
-
-          expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-            docker: {
-              forcePullImage: null,
-              image: "",
-              privileged: null
-            },
-            portMappings: [
-              {
-                containerPort: 0,
-                hostPort: 0,
-                labels: null,
-                name: null,
-                protocol: "tcp",
-                servicePort: null
-              },
-              {
-                containerPort: 0,
-                hostPort: 0,
-                labels: { VIP_1: ":0" },
-                name: null,
-                protocol: "tcp",
-                servicePort: null
-              }
-            ],
-            type: "DOCKER",
-            volumes: []
-          });
-        });
-
-        it("should add the index of the portDefinition to the VIP keys", function() {
-          let batch = new Batch();
-          batch = batch.add(
-            new Transaction(["container", "type"], "DOCKER", SET)
-          );
-          batch = batch.add(
-            new Transaction(["networks", 0, "mode"], CONTAINER, SET)
-          );
-          batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(["portDefinitions"], 1, ADD_ITEM));
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "portMapping"], true)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 1, "portMapping"], true)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "loadBalanced"], true)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 1, "loadBalanced"], true)
-          );
-
-          expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-            docker: {
-              forcePullImage: null,
-              image: "",
-              privileged: null
-            },
-            portMappings: [
-              {
-                containerPort: 0,
-                hostPort: 0,
-                name: null,
-                protocol: "tcp",
-                labels: { VIP_0: ":0" },
-                servicePort: null
-              },
-              {
-                containerPort: 0,
-                hostPort: 0,
-                name: null,
-                protocol: "tcp",
-                labels: { VIP_1: ":0" },
-                servicePort: null
-              }
-            ],
-            type: "DOCKER",
-            volumes: []
-          });
-        });
-
-        it("should add the port to the VIP string", function() {
-          let batch = new Batch();
-          batch = batch.add(
-            new Transaction(["container", "type"], "DOCKER", SET)
-          );
-          batch = batch.add(
-            new Transaction(["networks", 0, "mode"], CONTAINER, SET)
-          );
-          batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "portMapping"], true)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 1, "portMapping"], true)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "automaticPort"], false)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "hostPort"], 300)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "loadBalanced"], true)
-          );
-
-          expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-            docker: {
-              forcePullImage: null,
-              image: "",
-              privileged: null
-            },
-            portMappings: [
-              {
-                containerPort: 0,
-                hostPort: 300,
-                name: null,
-                protocol: "tcp",
-                labels: { VIP_0: ":300" },
-                servicePort: null
-              },
-              {
-                containerPort: 0,
-                hostPort: 0,
-                labels: null,
-                name: null,
-                protocol: "tcp",
-                servicePort: null
-              }
-            ],
-            type: "DOCKER",
-            volumes: []
-          });
-        });
-
-        it("should add the app ID to the VIP string when it is defined", function() {
-          let batch = new Batch();
-          batch = batch.add(
-            new Transaction(["container", "type"], "DOCKER", SET)
-          );
-          batch = batch.add(
-            new Transaction(["networks", 0, "mode"], CONTAINER, SET)
-          );
-          batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "portMapping"], true)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 1, "portMapping"], true)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "automaticPort"], false)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 1, "loadBalanced"], true)
-          );
-          batch = batch.add(new Transaction(["id"], "foo"));
-
-          expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-            docker: {
-              forcePullImage: null,
-              image: "",
-              privileged: null
-            },
-            portMappings: [
-              {
-                containerPort: 0,
-                hostPort: 0,
-                labels: null,
-                name: null,
-                protocol: "tcp",
-                servicePort: null
-              },
-              {
-                containerPort: 0,
-                hostPort: 0,
-                name: null,
-                protocol: "tcp",
-                labels: { VIP_1: "foo:0" },
-                servicePort: null
-              }
-            ],
-            type: "DOCKER",
-            volumes: []
-          });
-        });
-
-        it("should store portDefinitions even if network is HOST when recorded", function() {
-          let batch = new Batch();
-          batch = batch.add(
-            new Transaction(["container", "type"], "DOCKER", SET)
-          );
-          batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-          batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "portMapping"], true)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 1, "portMapping"], true)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 0, "automaticPort"], false)
-          );
-          batch = batch.add(
-            new Transaction(["portDefinitions", 1, "loadBalanced"], true)
-          );
-          batch = batch.add(new Transaction(["id"], "foo"));
-          batch = batch.add(
-            new Transaction(["networks", 0, "mode"], CONTAINER, SET)
-          );
-
-          expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-            docker: {
-              forcePullImage: null,
-              image: "",
-              privileged: null
-            },
-            portMappings: [
-              {
-                containerPort: 0,
-                hostPort: 0,
-                labels: null,
-                name: null,
-                protocol: "tcp",
-                servicePort: null
-              },
-              {
-                containerPort: 0,
-                hostPort: 0,
-                name: null,
-                protocol: "tcp",
-                labels: { VIP_1: "foo:0" },
-                servicePort: null
-              }
-            ],
-            type: "DOCKER",
-            volumes: []
-          });
-        });
-
-        it("should't create portMappings when container.type is MESOS", function() {
+        it("should create default portDefinition configurations", function() {
           let batch = new Batch();
           batch = batch.add(
             new Transaction(["container", "type"], "MESOS", SET)
           );
           batch = batch.add(
-            new Transaction(["networks", 0, "mode"], CONTAINER, SET)
+            new Transaction(["networks", 0, "mode"], BRIDGE, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(
@@ -998,148 +1103,157 @@ describe("Container", function() {
               image: "",
               privileged: null
             },
-            portMappings: null,
+            portMappings: [
+              {
+                containerPort: 0,
+                hostPort: 0,
+                labels: null,
+                name: null,
+                protocol: "tcp",
+                servicePort: null
+              }
+            ],
             type: "MESOS",
             volumes: []
           });
         });
       });
     });
+  });
 
-    describe("Volumes", function() {
-      it("should return an empty array if no volumes are set", function() {
-        const batch = new Batch();
+  describe("Volumes", function() {
+    it("should return an empty array if no volumes are set", function() {
+      const batch = new Batch();
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-          docker: {
-            forcePullImage: null,
-            image: "",
-            privileged: null
-          },
-          portMappings: null,
-          type: null,
-          volumes: []
-        });
+      expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+        docker: {
+          forcePullImage: null,
+          image: "",
+          privileged: null
+        },
+        portMappings: null,
+        type: null,
+        volumes: []
       });
+    });
 
-      it("should return a local volume", function() {
-        let batch = new Batch();
+    it("should return a local volume", function() {
+      let batch = new Batch();
 
-        batch = batch.add(new Transaction(["localVolumes"], 0, ADD_ITEM));
-        batch = batch.add(
-          new Transaction(["localVolumes", 0, "type"], "PERSISTENT", SET)
-        );
+      batch = batch.add(new Transaction(["localVolumes"], 0, ADD_ITEM));
+      batch = batch.add(
+        new Transaction(["localVolumes", 0, "type"], "PERSISTENT", SET)
+      );
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-          docker: {
-            forcePullImage: null,
-            image: "",
-            privileged: null
-          },
-          portMappings: null,
-          type: "MESOS",
-          volumes: [
-            {
-              containerPath: null,
-              persistent: {
-                size: null
-              },
-              mode: "RW"
-            }
-          ]
-        });
-      });
-
-      it("should return an external volume", function() {
-        let batch = new Batch();
-
-        batch = batch.add(new Transaction(["externalVolumes"], 0, ADD_ITEM));
-
-        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-          docker: {
-            forcePullImage: null,
-            image: "",
-            privileged: null
-          },
-          portMappings: null,
-          type: "MESOS",
-          volumes: [
-            {
-              containerPath: null,
-              external: {
-                name: null,
-                provider: "dvdi",
-                options: {
-                  "dvdi/driver": "rexray"
-                }
-              },
-              mode: "RW"
-            }
-          ]
-        });
-      });
-
-      it("should return a local and an external volume", function() {
-        let batch = new Batch();
-
-        batch = batch.add(new Transaction(["externalVolumes"], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(["localVolumes"], 0, ADD_ITEM));
-        batch = batch.add(
-          new Transaction(["localVolumes", 0, "type"], "PERSISTENT", SET)
-        );
-
-        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-          docker: {
-            forcePullImage: null,
-            image: "",
-            privileged: null
-          },
-          portMappings: null,
-          type: "MESOS",
-          volumes: [
-            {
-              containerPath: null,
-              persistent: {
-                size: null
-              },
-              mode: "RW"
+      expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+        docker: {
+          forcePullImage: null,
+          image: "",
+          privileged: null
+        },
+        portMappings: null,
+        type: "MESOS",
+        volumes: [
+          {
+            containerPath: null,
+            persistent: {
+              size: null
             },
-            {
-              containerPath: null,
-              external: {
-                name: null,
-                provider: "dvdi",
-                options: {
-                  "dvdi/driver": "rexray"
-                }
-              },
-              mode: "RW"
-            }
-          ]
-        });
+            mode: "RW"
+          }
+        ]
       });
+    });
 
-      it("should return an empty array if all volumes have been removed", function() {
-        let batch = new Batch();
+    it("should return an external volume", function() {
+      let batch = new Batch();
 
-        batch = batch.add(new Transaction(["localVolumes"], 0, ADD_ITEM));
-        batch = batch.add(
-          new Transaction(["localVolumes", 0, "type"], "PERSISTENT", SET)
-        );
-        batch = batch.add(new Transaction(["externalVolumes"], 0, ADD_ITEM));
-        batch = batch.add(new Transaction(["externalVolumes"], 0, REMOVE_ITEM));
-        batch = batch.add(new Transaction(["localVolumes"], 0, REMOVE_ITEM));
+      batch = batch.add(new Transaction(["externalVolumes"], 0, ADD_ITEM));
 
-        expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-          docker: {
-            forcePullImage: null,
-            image: "",
-            privileged: null
+      expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+        docker: {
+          forcePullImage: null,
+          image: "",
+          privileged: null
+        },
+        portMappings: null,
+        type: "MESOS",
+        volumes: [
+          {
+            containerPath: null,
+            external: {
+              name: null,
+              provider: "dvdi",
+              options: {
+                "dvdi/driver": "rexray"
+              }
+            },
+            mode: "RW"
+          }
+        ]
+      });
+    });
+
+    it("should return a local and an external volume", function() {
+      let batch = new Batch();
+
+      batch = batch.add(new Transaction(["externalVolumes"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["localVolumes"], 0, ADD_ITEM));
+      batch = batch.add(
+        new Transaction(["localVolumes", 0, "type"], "PERSISTENT", SET)
+      );
+
+      expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+        docker: {
+          forcePullImage: null,
+          image: "",
+          privileged: null
+        },
+        portMappings: null,
+        type: "MESOS",
+        volumes: [
+          {
+            containerPath: null,
+            persistent: {
+              size: null
+            },
+            mode: "RW"
           },
-          portMappings: null,
-          type: null,
-          volumes: []
-        });
+          {
+            containerPath: null,
+            external: {
+              name: null,
+              provider: "dvdi",
+              options: {
+                "dvdi/driver": "rexray"
+              }
+            },
+            mode: "RW"
+          }
+        ]
+      });
+    });
+
+    it("should return an empty array if all volumes have been removed", function() {
+      let batch = new Batch();
+
+      batch = batch.add(new Transaction(["localVolumes"], 0, ADD_ITEM));
+      batch = batch.add(
+        new Transaction(["localVolumes", 0, "type"], "PERSISTENT", SET)
+      );
+      batch = batch.add(new Transaction(["externalVolumes"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["externalVolumes"], 0, REMOVE_ITEM));
+      batch = batch.add(new Transaction(["localVolumes"], 0, REMOVE_ITEM));
+
+      expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
+        docker: {
+          forcePullImage: null,
+          image: "",
+          privileged: null
+        },
+        portMappings: null,
+        type: null,
+        volumes: []
       });
     });
   });

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -909,7 +909,7 @@ describe("Service Form Modal", function() {
             .should("not.have.attr", "disabled");
         });
 
-        it("should disable bridge networking when Universal Container Runtime selected", function() {
+        it("should not disable bridge networking when Universal Container Runtime selected", function() {
           setRuntime("Universal Container Runtime");
           clickNetworkingTab();
 
@@ -929,7 +929,7 @@ describe("Service Form Modal", function() {
             .get("@containerDockerNetwork")
             .children("option:eq(1)")
             .should("have.value", "BRIDGE")
-            .should("have.attr", "disabled");
+            .should("not.have.attr", "disabled");
 
           // CONTAINER.dcos-1
           cy


### PR DESCRIPTION
How to test this:

Launch a cluster with a custom configuration specifying **`testing/pull/1481`** to use the snapshot release https://github.com/dcos/dcos/pull/1481/files 

This release though doesn't accept the old definition of a BRIDGE network for UCR, 
it supports the new version instead: 

```javascript
{
  "networks": [
    {
      "mode": "container/bridge"
    }
  ]
}
```

and it returns updated definition in the new format.

Host volumes and force Pull Image work as expected.

Having said that we've concluded to run this PR against the integration branch `integrate/marathon-1.5` that will be merged to master once all the respective changes are merged in Marathon/DCOS.