### PR TITLE
[System Tests] Automatically starting `npm testing` on dev.sh

### DIFF
--- a/system-tests/driver-config/dev.sh
+++ b/system-tests/driver-config/dev.sh
@@ -4,6 +4,12 @@
 # integration tests against the current development environment.
 #
 
+# Ensure CLUSTER_URL is specified
+if [ -z "$CLUSTER_URL" ]; then
+  echo "Error: Please specify the CLUSTER_URL environment variable"
+  exit 1
+fi
+
 cat <<EOF
 criteria: []
 suites:
@@ -11,13 +17,22 @@ suites:
 
 targets:
   - name: dev
-    title: NPM-Served Cluster (Open)
+    title: Development Cluster
     features: []
 
     type: static
     config:
-      url: http://127.0.0.1:4200
+      url: $CLUSTER_URL
+
+    env:
+      PROXIED_CLUSTER_URL: http://127.0.0.1:4200
 
     scripts:
       auth: ../_scripts/auth-open.py
+      proxy: (cd ../..; npm run testing)
+      setup: >
+        mv ../../webpack/proxy.dev.js ../../webpack/proxy.dev.js.bak;
+        echo "module.exports = {'*': '$CLUSTER_URL'};" > ../../webpack/proxy.dev.js
+      teardown: >
+        mv ../../webpack/proxy.dev.js.bak ../../webpack/proxy.dev.js
 EOF


### PR DESCRIPTION
This PR updates the `dev.sh` configuration script in order to automatically start a testing version of webpack and automatically configure `proxy.dev` to use the `CLUSTER_URL`  specified.

Effectively, using the `./system-tests/driver-config/dev.sh` driver configuration script you can serve the current branch's version without the need of building a `dist` first.

For example, you should now use the following to run the tests:

<pre>
docker run -it --rm --ipc=host \
  -v `pwd`:/dcos-ui \
  -e CLUSTER_URL=<strong>$OPEN_CLUSTER_URL</strong> \
  mesosphere/dcos-ui dcos-system-test-driver \
  ./system-tests/driver-config/dev.sh
</pre>