### PR TITLE
DCOS-14854: Remove edit link on service config page

### DIFF
--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -185,7 +185,7 @@ class ServiceConfiguration extends mixin(StoreMixin) {
   }
 
   render() {
-    const {errors, onEditClick, service} = this.props;
+    const {errors, service} = this.props;
     const {selectedVersionID} = this.state;
     const config = service.getVersions().get(selectedVersionID);
     let content = null;
@@ -193,12 +193,7 @@ class ServiceConfiguration extends mixin(StoreMixin) {
     if (config == null) {
       content = <Loader />;
     } else {
-      content = (
-        <ServiceConfigDisplay
-          appConfig={config}
-          errors={errors}
-          onEditClick={onEditClick} />
-        );
+      content = <ServiceConfigDisplay appConfig={config} errors={errors} />;
     }
 
     return (

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
@@ -44,9 +44,9 @@ ServiceConfigurationContainer.defaultProps = {
 };
 
 ServiceConfigurationContainer.propTypes = {
-  onEditClick: React.PropTypes.func.isRequired,
+  onEditClick: React.PropTypes.func,
   errors: React.PropTypes.array,
-  service: React.PropTypes.instanceOf(Service).isRequired
+  service: React.PropTypes.instanceOf(Service)
 };
 
 module.exports = ServiceConfigurationContainer;

--- a/plugins/services/src/js/containers/service-configuration/__tests__/ServiceConfigurationContainer-test.js
+++ b/plugins/services/src/js/containers/service-configuration/__tests__/ServiceConfigurationContainer-test.js
@@ -52,6 +52,16 @@ describe('ServiceConfigurationContainer', function () {
       expect(serviceSpecView).toBeDefined();
     });
 
+    it('doesn\'t pass down onEditClick to ServiceConfigDisplay', function () {
+      var serviceSpecView = TestUtils
+        .findRenderedComponentWithType(this.instance, ServiceConfigDisplay);
+
+      // We should not pass down onEditClick as it will make the `EDIT` button
+      // display. We only want this for the service edit/create flow to jump
+      // back to the form
+      expect(serviceSpecView.props.onEditClick).not.toBeDefined();
+    });
+
   });
 
 });

--- a/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
+++ b/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
@@ -107,7 +107,7 @@ ServiceConfigDisplay.defaultProps = {
 ServiceConfigDisplay.propTypes = {
   appConfig: React.PropTypes.object.isRequired,
   errors: React.PropTypes.array,
-  onEditClick: React.PropTypes.func.isRequired
+  onEditClick: React.PropTypes.func
 };
 
 module.exports = ServiceConfigDisplay;


### PR DESCRIPTION
This PR is the same as this: https://github.com/dcos/dcos-ui/pull/2075, it just backports it to relase 1.9 branch.

PR #1957 wrongly added onEditClick to this view. This PR reverts that effort and adds a test to guard against it

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
