### PR TITLE
fix(page header navigation): Fix page header navigation flex props

### DIFF
--- a/src/styles/components/page-header/navigation/styles.less
+++ b/src/styles/components/page-header/navigation/styles.less
@@ -95,6 +95,7 @@
 
         .page-header-content-section & {
           border-top: 1px solid @page-header-navigation-dropdown-border-color;
+          flex-grow: 1;
           margin-left: @page-header-navigation-dropdown-margin-left;
           margin-right: @page-header-navigation-dropdown-margin-right;
         }


### PR DESCRIPTION
This PR fixes a bug where the dropdown menu in the page header didn't fill its `flex` parent. It only applies to the dropdown within the `page-header-content-section` because of its `flex-direction`.

Before
![](https://cl.ly/090l1b3O4315/Screen%20Shot%202017-04-13%20at%203.59.47%20PM.png)

After:
![](https://cl.ly/2B2m0t441Q11/Screen%20Shot%202017-04-13%20at%203.59.25%20PM.png)