### PR TITLE
Update CNVS to 1.1.8

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1235,9 +1235,9 @@
       "resolved": "https://registry.npmjs.org/closest/-/closest-0.0.1.tgz"
     },
     "cnvs": {
-      "version": "1.1.6",
-      "from": "cnvs@1.1.6",
-      "resolved": "https://registry.npmjs.org/cnvs/-/cnvs-1.1.6.tgz"
+      "version": "1.1.8",
+      "from": "cnvs@1.1.8",
+      "resolved": "https://registry.npmjs.org/cnvs/-/cnvs-1.1.8.tgz"
     },
     "co": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "browser-info": "0.4.0",
     "classnames": "2.2.3",
     "clipboard": "1.5.10",
-    "cnvs": "1.1.6",
+    "cnvs": "1.1.8",
     "cookie": "0.2.3",
     "d3": "3.5.16",
     "dcos-dygraphs": "1.1.0-beta.3",

--- a/src/styles/components/dropdown-menus/styles.less
+++ b/src/styles/components/dropdown-menus/styles.less
@@ -16,14 +16,6 @@
     display: inline-block;
     white-space: nowrap;
 
-    &,
-    &.button {
-
-      &:after {
-        margin-top: @button-dropdown-caret-margin-top / -2;
-      }
-    }
-
     &.button-split-content {
 
       &:after {


### PR DESCRIPTION
This PR updates CNVS to 1.1.8. So far I found that the dropdown caret alignment was broken, which I've fixed in this PR as well.

@ashenden can you provide some information about what's changed since 1.1.6?