### PR TITLE
DCOS-14184: Always show declined offers data if available

### DIFF
--- a/plugins/services/src/js/containers/pod-debug/PodDebugContainer.js
+++ b/plugins/services/src/js/containers/pod-debug/PodDebugContainer.js
@@ -15,7 +15,6 @@ import TimeAgo from "#SRC/js/components/TimeAgo";
 
 import DeclinedOffersHelpText from "../../constants/DeclinedOffersHelpText";
 import DeclinedOffersTable from "../../components/DeclinedOffersTable";
-import DeclinedOffersUtil from "../../utils/DeclinedOffersUtil";
 import MarathonStore from "../../stores/MarathonStore";
 import Pod from "../../structs/Pod";
 import PodContainerTerminationTable from "./PodContainerTerminationTable";
@@ -44,10 +43,7 @@ class PodDebugTabView extends React.Component {
     const { pod } = this.props;
     const queue = pod.getQueue();
 
-    if (
-      !DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(pod) ||
-      queue.declinedOffers.offers == null
-    ) {
+    if (queue == null || queue.declinedOffers.offers == null) {
       return null;
     }
 
@@ -179,10 +175,7 @@ class PodDebugTabView extends React.Component {
     let mainContent = null;
     let offerCount = null;
 
-    if (
-      DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(pod) &&
-      queue.declinedOffers.summary != null
-    ) {
+    if (queue != null && queue.declinedOffers.summary != null) {
       const { declinedOffers: { summary } } = queue;
       const { roles: { offers = 0 } } = summary;
 

--- a/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
+++ b/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
@@ -1,25 +1,27 @@
 import React from "react";
 import { routerShape } from "react-router";
 
-import Alert from "#SRC/js/components/Alert";
-import ConfigurationMap from "#SRC/js/components/ConfigurationMap";
+import Alert from "../../../../../../src/js/components/Alert";
+import ConfigurationMap
+  from "../../../../../../src/js/components/ConfigurationMap";
 import ConfigurationMapHeading
-  from "#SRC/js/components/ConfigurationMapHeading";
-import ConfigurationMapLabel from "#SRC/js/components/ConfigurationMapLabel";
-import ConfigurationMapRow from "#SRC/js/components/ConfigurationMapRow";
+  from "../../../../../../src/js/components/ConfigurationMapHeading";
+import ConfigurationMapLabel
+  from "../../../../../../src/js/components/ConfigurationMapLabel";
+import ConfigurationMapRow
+  from "../../../../../../src/js/components/ConfigurationMapRow";
 import ConfigurationMapSection
-  from "#SRC/js/components/ConfigurationMapSection";
-import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
-import DateUtil from "#SRC/js/utils/DateUtil";
-import TimeAgo from "#SRC/js/components/TimeAgo";
-
+  from "../../../../../../src/js/components/ConfigurationMapSection";
+import ConfigurationMapValue
+  from "../../../../../../src/js/components/ConfigurationMapValue";
+import DateUtil from "../../../../../../src/js/utils/DateUtil";
 import DeclinedOffersHelpText from "../../constants/DeclinedOffersHelpText";
 import DeclinedOffersTable from "../../components/DeclinedOffersTable";
-import DeclinedOffersUtil from "../../utils/DeclinedOffersUtil";
 import MarathonStore from "../../stores/MarathonStore";
 import RecentOffersSummary from "../../components/RecentOffersSummary";
 import Service from "../../structs/Service";
 import TaskStatsTable from "./TaskStatsTable";
+import TimeAgo from "../../../../../../src/js/components/TimeAgo";
 
 const METHODS_TO_BIND = ["handleJumpToRecentOffersClick"];
 
@@ -335,11 +337,9 @@ class ServiceDebugContainer extends React.Component {
 
   shouldSuppressDeclinedOfferDetails() {
     const { service } = this.props;
+    const queue = service.getQueue();
 
-    return (
-      this.isFramework(service) ||
-      !DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(service)
-    );
+    return queue == null || this.isFramework(service);
   }
 
   render() {


### PR DESCRIPTION
This PR changes the behavior of declined offers to always show the declined offers summary & table when the data is available. Previously the summary & table were hidden until the resource had been waiting more than 5 minutes.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?