### PR TITLE
DCOS-15164: Add #isSDKService to ServiceUtil

### DIFF
--- a/plugins/services/src/js/utils/ServiceUtil.js
+++ b/plugins/services/src/js/utils/ServiceUtil.js
@@ -530,6 +530,16 @@ const ServiceUtil = {
     }
 
     return Object.keys(labels).map((key) => ({key, value: labels[key]}));
+  },
+
+  isSDKService(service) {
+    if (!(service instanceof Service)) {
+      return false;
+    }
+
+    const labels = service.getLabels();
+
+    return labels.DCOS_COMMONS_API_VERSION != null;
   }
 };
 

--- a/plugins/services/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceUtil-test.js
@@ -1020,4 +1020,28 @@ describe('ServiceUtil', function () {
     });
   });
 
+  describe('#isSDKService', function () {
+    it('should return true if service does not have the proper label', function () {
+      const service = new Framework({
+        id: '/foo',
+        labels: {
+          DCOS_COMMONS_API_VERSION: 'v1'
+        }
+      });
+
+      expect(ServiceUtil.isSDKService(service)).toEqual(true);
+    });
+
+    it('should return false if service does not have the proper label', function () {
+      const service = new Framework({
+        id: '/foo',
+        labels: {
+          FOO_LABEL: 'foo value'
+        }
+      });
+
+      expect(ServiceUtil.isSDKService(service)).toEqual(false);
+    });
+  });
+
 });


### PR DESCRIPTION
This PR adds a method to `ServiceUtil` to determine when a service is an SDK service. It does this by checking for the existence of the label `DCOS_COMMONS_API_VERSION`.

cc @mlunoe 

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?