### PR TITLE
DCOS-14755: Fix 'read only' value alignment

### DIFF
--- a/plugins/services/src/js/service-configuration/PodStorageConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodStorageConfigSection.js
@@ -5,8 +5,6 @@ import ConfigurationMapHeading
 import ConfigurationMapSection
   from "#SRC/js/components/ConfigurationMapSection";
 
-import ConfigurationMapBooleanValue
-  from "../components/ConfigurationMapBooleanValue";
 import ConfigurationMapTable from "../components/ConfigurationMapTable";
 import ServiceConfigDisplayUtil from "../utils/ServiceConfigDisplayUtil";
 import VolumeConstants from "../constants/VolumeConstants";
@@ -35,12 +33,11 @@ class PodStorageConfigSection extends React.Component {
         heading: "Read Only",
         prop: "readOnly",
         render(prop, row) {
-          return (
-            <ConfigurationMapBooleanValue
-              options={BOOLEAN_OPTIONS}
-              value={row[prop]}
-            />
-          );
+          if (row[prop]) {
+            return BOOLEAN_OPTIONS.truthy;
+          }
+
+          return BOOLEAN_OPTIONS.falsy;
         }
       },
       {


### PR DESCRIPTION
This PR fixes the alignment of the "read only" value in `PodStorageConfigSection`. Before we were rendering an element with class `.configuration-map-value` inside a table cell which already has padding, so the padding was doubled up.

Before:
![](https://cl.ly/1Q0M0a041w1F/Screen%20Shot%202017-04-17%20at%2010.29.02%20AM.png)

After:
![](https://cl.ly/1U402e2v1a1Q/Screen%20Shot%202017-04-17%20at%2010.25.31%20AM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?