### PR TITLE
DCOS-14845: Default to 0 for undefined scalar values in DeclinedOffersUtil

### DIFF
--- a/plugins/services/src/js/utils/DeclinedOffersUtil.js
+++ b/plugins/services/src/js/utils/DeclinedOffersUtil.js
@@ -200,14 +200,14 @@ const DeclinedOffersUtil = {
         timestamp,
         unmatchedResource: declinedOffer.reason,
         offered: resources.reduce((accumulator, resource) => {
-          const {name, role} = resource;
+          const {name, role, scalar = 0} = resource;
 
           if (name === 'ports') {
             const {ranges = []} = resource;
 
             accumulator[name] = ranges.reduce(rangeReducer, []);
           } else {
-            accumulator[name] = resource.scalar;
+            accumulator[name] = scalar;
           }
 
           // Accumulate all roles.

--- a/plugins/services/src/js/utils/__tests__/DeclinedOffersUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/DeclinedOffersUtil-test.js
@@ -381,6 +381,70 @@ describe('DeclinedOffersUtil', function () {
       })).toEqual(null);
     });
 
+    it('defaults undefined scalar values to 0', function () {
+      const unusedOffers = DeclinedOffersUtil.getOffersFromQueue({
+        lastUnusedOffers: [
+          {
+            offer: {
+              id: 'offer_123',
+              agentId: 'slave_123',
+              hostname: '1.2.3.4',
+              resources: [
+                {
+                  name: 'cpus',
+                  ranges: [
+                    {
+                      begin: 1,
+                      end: 5
+                    }
+                  ],
+                  set: [
+                    'a',
+                    'b'
+                  ],
+                  role: '*'
+                }
+              ],
+              attributes: [
+                {
+                  name: 'foo',
+                  ranges: [
+                    {
+                      begin: 1,
+                      end: 5
+                    }
+                  ],
+                  set: [
+                    'a',
+                    'b'
+                  ]
+                }
+              ]
+            },
+            timestamp: '2016-02-28T16:41:41.090Z',
+            reason: [
+              'InsufficientMemory'
+            ]
+          }
+        ]
+      });
+
+      expect(unusedOffers).toEqual(
+        [
+          {
+            hostname: '1.2.3.4',
+            timestamp: '2016-02-28T16:41:41.090Z',
+            unmatchedResource: ['InsufficientMemory'],
+            offered: {
+              constraints: 'foo:1 – 5',
+              cpus: 0,
+              roles: ['*']
+            }
+          }
+        ]
+      );
+    });
+
     it('returns an array of offer details from API response', function () {
       const unusedOffers = DeclinedOffersUtil.getOffersFromQueue({
         lastUnusedOffers: [


### PR DESCRIPTION
This PR fixes a bug where an offered resource's `scalar` value might be displayed as `NaN` when the API omits this value. Now the `scalar` value is default assigned to `0`.

Before:
![](https://cl.ly/2R2r0j2X423u/Screen%20Shot%202017-04-17%20at%2010.56.55%20AM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [x] If this is a regression, did you write a test to catch this in the future?