### PR TITLE
DCOS-14508: Service breadcrumbs: Use overview route for service groups

### DIFF
--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -141,14 +141,14 @@ class ServiceBreadcrumbs extends React.Component {
     );
   }
 
-  getServiceImage(service, serviceLink) {
+  getServiceImage(service, aggregateIDs) {
     if (service == null || service instanceof ServiceTree) {
       return null;
     }
 
     return (
       <BreadcrumbSupplementalContent>
-        <Link to={serviceLink}>
+        <Link to={'/services/detail/' + aggregateIDs}>
           <span className="icon icon-small icon-image-container icon-app-container">
             <img src={service.getImages()['icon-small']}/>
           </span>
@@ -180,11 +180,13 @@ class ServiceBreadcrumbs extends React.Component {
         aggregateIDs += encodeURIComponent(`/${id}`);
         let routePath = '/services/overview/' + aggregateIDs;
         if (index === ids.length - 1) {
-          routePath = '/services/detail/' + aggregateIDs;
           const service = DCOSStore.serviceTree.findItemById(serviceID);
-
+          // Make sure to change to detail route if service is not a group
+          if (!(service instanceof ServiceTree)) {
+            routePath = '/services/detail/' + aggregateIDs;
+          }
           breadcrumbHealth = this.getHealthStatus(service);
-          serviceImage = this.getServiceImage(service, routePath);
+          serviceImage = this.getServiceImage(service, aggregateIDs);
         }
 
         return (

--- a/plugins/services/src/js/components/__tests__/ServiceBreadcrumbs-test.js
+++ b/plugins/services/src/js/components/__tests__/ServiceBreadcrumbs-test.js
@@ -1,30 +1,34 @@
 jest.dontMock('../ServiceBreadcrumbs');
+jest.dontMock('#SRC/js/components/Breadcrumb');
+jest.dontMock('#SRC/js/components/BreadcrumbCaret');
+jest.dontMock('#SRC/js/components/BreadcrumbTextContent');
+jest.dontMock('#SRC/js/components/BreadcrumbSupplementalContent');
 jest.dontMock('#SRC/js/components/PageHeaderBreadcrumbs');
 jest.dontMock('../../structs/Service');
 /* eslint-disable no-unused-vars */
 const React = require('react');
 /* eslint-enable no-unused-vars */
 const TestUtils = require('react-addons-test-utils');
-const DCOSStore = require('../../../../../../src/js/stores/DCOSStore');
+const Link = require('react-router').Link;
+const DCOSStore = require('#SRC/js/stores/DCOSStore');
 const ServiceBreadcrumbs = require('../ServiceBreadcrumbs');
 const Service = require('../../structs/Service');
+const ServiceTree = require('../../structs/ServiceTree');
 
 const renderer = TestUtils.createRenderer();
-const service = new Service({
-  id: '/test'
-});
 
 describe('ServiceBreadcrumbs instance', function () {
 
   beforeEach(function () {
     DCOSStore.serviceTree = {
       findItemById() {
-        return service;
+        return new Service({id: '/test'});
       }
     };
   });
 
   describe('extra breadcrumbs', function () {
+
     it('does not render extra crumbs when there is none', function () {
       renderer.render(<ServiceBreadcrumbs serviceID="/test" />);
       const result = renderer.getRenderOutput();
@@ -44,5 +48,48 @@ describe('ServiceBreadcrumbs instance', function () {
       expect(result.props.breadcrumbs.length).toEqual(3);
       expect(result.props.breadcrumbs[2].props.children).toEqual('Dummy');
     });
+
   });
+
+  describe('route destination', function () {
+
+    it('provides overview route for a service that is a group', function () {
+      DCOSStore.serviceTree = {
+        findItemById() {
+          return new ServiceTree({id: '/foo', groups:[{id: '/foo/bar'}]});
+        }
+      };
+      var instance = TestUtils.renderIntoDocument(
+        <ServiceBreadcrumbs serviceID="/foo/bar" />
+      );
+
+      var links = TestUtils.scryRenderedComponentsWithType(instance, Link);
+      expect(links.length).toEqual(4);
+      // Icon
+      expect(links[0].props.to).toEqual('/services');
+
+      // Actual of breadcrumbs
+      expect(links[1].props.to).toEqual('/services');
+      expect(links[2].props.to).toEqual('/services/overview/%2Ffoo');
+      expect(links[3].props.to).toEqual('/services/overview/%2Ffoo%2Fbar');
+    });
+
+    it('provides detail route for a service that is not a group', function () {
+      var instance = TestUtils.renderIntoDocument(
+        <ServiceBreadcrumbs serviceID="/foo" />
+      );
+
+      var links = TestUtils.scryRenderedComponentsWithType(instance, Link);
+      expect(links.length).toEqual(4);
+      // Icon
+      expect(links[0].props.to).toEqual('/services');
+
+      // Actual of breadcrumbs
+      expect(links[1].props.to).toEqual('/services');
+      expect(links[2].props.to).toEqual('/services/detail/%2Ffoo');
+      expect(links[3].props.to).toEqual('/services/detail/%2Ffoo');
+    });
+
+  });
+
 });


### PR DESCRIPTION
This bug was introduced in this PR: #2079

This PR makes sure that we display `overview` route for service groups and a `detail` route for a service:
![](https://cl.ly/k2FQ/Screen%20Recording%202017-04-17%20at%2014.50.gif)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [x] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
