### PR TITLE
[System Tests]: Fixing a couple of typos

### DIFF
--- a/system-tests/cypress.json
+++ b/system-tests/cypress.json
@@ -1,5 +1,5 @@
 {
-  "defaultCommandTimeout": 6000,
+  "defaultCommandTimeout": 60000,
   "integrationFolder": ".",
   "projectId": "a209b1cd-e44f-47a4-b22c-d8f26649f43f",
   "supportFile": "_support",

--- a/system-tests/jobs/test-jobs.js
+++ b/system-tests/jobs/test-jobs.js
@@ -244,7 +244,7 @@ describe('Jobs', function () {
     cy
       .get('.clickable')
       .contains('Add Label')
-      .click();
+      .click({force: true});
 
     // Fill-in the second label
     cy
@@ -262,7 +262,7 @@ describe('Jobs', function () {
     cy
       .get('.clickable')
       .contains('Add Label')
-      .click();
+      .click({force: true});
 
     // Fill-in the third label
     cy
@@ -280,7 +280,7 @@ describe('Jobs', function () {
     cy
       .get('.clickable')
       .contains('Add Label')
-      .click();
+      .click({force: true});
 
     // Fill-in the fourth label
     cy

--- a/system-tests/services/test-apps.js
+++ b/system-tests/services/test-apps.js
@@ -112,7 +112,7 @@ describe('Services', function () {
 
       // Wait for the table and the service to appear
       cy
-        .get('.page-body-content table')
+        .get('.page-body-content table', {timeout: Timeouts.SERVICE_DEPLOYMENT_TIMEOUT})
         .contains(serviceName, {timeout: Timeouts.SERVICE_DEPLOYMENT_TIMEOUT})
         .should('exist');
 

--- a/system-tests/services/test-apps.js
+++ b/system-tests/services/test-apps.js
@@ -10,7 +10,7 @@ describe('Services', function () {
 
     beforeEach(function () {
       cy
-        .visitUrl(`services/detail/%2F${Cypress.env('TEST_UUID')}/create`);
+        .visitUrl(`services/overview/%2F${Cypress.env('TEST_UUID')}/create`);
     });
 
     function selectMesosRuntime() {
@@ -113,7 +113,7 @@ describe('Services', function () {
       // Wait for the table and the service to appear
       cy
         .get('.page-body-content table')
-        .contains(serviceName)
+        .contains(serviceName, {timeout: Timeouts.SERVICE_DEPLOYMENT_TIMEOUT})
         .should('exist');
 
       // Wait for the table and the service to appear
@@ -268,7 +268,7 @@ describe('Services', function () {
       // Wait for the table and the service to appear
       cy
         .get('.page-body-content table')
-        .contains(serviceName)
+        .contains(serviceName, {timeout: Timeouts.SERVICE_DEPLOYMENT_TIMEOUT})
         .should('exist');
 
     });
@@ -443,7 +443,7 @@ describe('Services', function () {
       // Wait for the table and the service to appear
       cy
         .get('.page-body-content table')
-        .contains(serviceName)
+        .contains(serviceName, {timeout: Timeouts.SERVICE_DEPLOYMENT_TIMEOUT})
         .should('exist');
 
       // Get the table row and look for health
@@ -611,7 +611,7 @@ describe('Services', function () {
       // Wait for the table and the service to appear
       cy
         .get('.page-body-content table')
-        .contains(serviceName)
+        .contains(serviceName, {timeout: Timeouts.SERVICE_DEPLOYMENT_TIMEOUT})
         .should('exist');
 
       // Get the table row and wait until it's Running
@@ -796,7 +796,7 @@ describe('Services', function () {
       // Wait for the table and the service to appear
       cy
         .get('.page-body-content table')
-        .contains(serviceName)
+        .contains(serviceName, {timeout: Timeouts.SERVICE_DEPLOYMENT_TIMEOUT})
         .should('exist');
 
       // Get the table row and wait until it's Running
@@ -978,7 +978,7 @@ describe('Services', function () {
       // Wait for the table and the service to appear
       cy
         .get('.page-body-content table')
-        .contains(serviceName)
+        .contains(serviceName, {timeout: Timeouts.SERVICE_DEPLOYMENT_TIMEOUT})
         .should('exist');
 
       // Get the table row and wait until it's Running
@@ -1190,7 +1190,7 @@ describe('Services', function () {
       // Wait for the table and the service to appear
       cy
         .get('.page-body-content table')
-        .contains(serviceName)
+        .contains(serviceName, {timeout: Timeouts.SERVICE_DEPLOYMENT_TIMEOUT})
         .should('exist');
 
       // Get the table row and look for health
@@ -1554,7 +1554,7 @@ describe('Services', function () {
       // Wait for the table and the service to appear
       cy
         .get('.page-body-content table')
-        .contains(serviceName)
+        .contains(serviceName, {timeout: Timeouts.SERVICE_DEPLOYMENT_TIMEOUT})
         .should('exist');
 
       // Get the table row and wait until it's Running

--- a/system-tests/services/test-environment.js
+++ b/system-tests/services/test-environment.js
@@ -7,7 +7,7 @@ describe('Services', function () {
 
     beforeEach(function () {
       cy
-        .visitUrl(`services/detail/%2F${Cypress.env('TEST_UUID')}`);
+        .visitUrl(`services/overview/%2F${Cypress.env('TEST_UUID')}`);
     });
 
     it('should contain no running services', function () {

--- a/system-tests/services/test-pods.js
+++ b/system-tests/services/test-pods.js
@@ -197,7 +197,7 @@ describe('Services', function () {
 
       cy
         .get('.page-body-content table')
-        .contains(serviceName)
+        .contains(serviceName, {timeout: Timeouts.SERVICE_DEPLOYMENT_TIMEOUT})
         .should('exist');
 
       cy
@@ -674,7 +674,7 @@ describe('Services', function () {
 
       cy
         .get('.page-body-content table')
-        .contains(serviceName)
+        .contains(serviceName, {timeout: Timeouts.SERVICE_DEPLOYMENT_TIMEOUT})
         .should('exist');
 
       cy


### PR DESCRIPTION
This PR fixes a couple of typos and silly mistakes in the system tests. Namely:

* Changing forgotten `services/details` url to `services/overview`
* Adding `{force: true}` to job's `Add Label` click to mitigate the
  cypress complaints about zero-height
* Adding the correct timeout when waiting for service/job deployment
* Increased the default command timeout to 1 minute, which seems to fix all the instability issues.

**It's OK to have the following failure. It's addressed on #2088:**

```
✘ Services Applications Create an app with external volume
```

To test, use:
<pre>
docker run -it --rm --ipc=host \
  -e CLUSTER_URL=<strong>$OPEN_CLUSTER_URL</strong>  \
  -v `pwd`:/dcos-ui \
  mesosphere/dcos-ui dcos-system-test-driver \
  ./system-tests/driver-config/dev.sh
</pre>