### PR TITLE
DCOS-14894: Aggregate resources for running tasks only

### DIFF
--- a/plugins/services/src/js/structs/Framework.js
+++ b/plugins/services/src/js/structs/Framework.js
@@ -67,6 +67,9 @@ module.exports = class Framework extends Application {
     // resources of child frameworks won't be aggregated
     return tasks
       .filter(function (task) {
+        return task.state === 'TASK_RUNNING';
+      })
+      .filter(function (task) {
         return !task.isStartedByMarathon;
       })
       .reduce(function (memo, task) {

--- a/plugins/services/src/js/structs/Framework.js
+++ b/plugins/services/src/js/structs/Framework.js
@@ -67,10 +67,7 @@ module.exports = class Framework extends Application {
     // resources of child frameworks won't be aggregated
     return tasks
       .filter(function (task) {
-        return task.state === 'TASK_RUNNING';
-      })
-      .filter(function (task) {
-        return !task.isStartedByMarathon;
+        return task.state === 'TASK_RUNNING' && !task.isStartedByMarathon;
       })
       .reduce(function (memo, task) {
         const {cpus, mem, gpus, disk} = task.resources;

--- a/plugins/services/src/js/structs/__tests__/Framework-test.js
+++ b/plugins/services/src/js/structs/__tests__/Framework-test.js
@@ -7,7 +7,6 @@ JestUtil.unMockStores(['MesosStateStore']);
 const MesosStateStore = require('../../../../../../src/js/stores/MesosStateStore');
 
 const Framework = require('../Framework');
-const Task = require('../Task');
 
 describe('Framework', function () {
 
@@ -161,17 +160,22 @@ describe('Framework', function () {
     it('aggregates child task resources properly', function () {
       MesosStateStore.getTasksByService = function () {
         return [
-          new Task({
+          {
             id: '/fake_1',
             isStartedByMarathon: true,
             state: 'TASK_RUNNING',
             resources: {cpus: 0.2, mem: 300, gpus: 0, disk: 0}
-          }),
-          new Task({
+          },
+          {
             id: '/fake_2',
             state: 'TASK_RUNNING',
             resources: {cpus: 0.8, mem: 700, gpus: 0, disk: 0}
-          })
+          },
+          {
+            id: '/fake_2',
+            state: 'TASK_FINISHED',
+            resources: {cpus: 0.8, mem: 700, gpus: 0, disk: 0}
+          }
         ];
       };
 


### PR DESCRIPTION
This PR fixes the resources aggregation issue for Frameworks by taking into account running tasks only.

To test just run MoM and launch a task on Marathon that finishes in 5 seconds or so.
Observe that without the fix it will report growing number of resources in DC/OS UI

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
