### PR TITLE
DCOS-14759: deprecate marathon Healthcheck protocols

### DIFF
--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -100,6 +100,9 @@ const APP_VALIDATORS = [
   MarathonAppValidators.mustContainImageOnDocker,
   MarathonAppValidators.validateConstraints,
   MarathonAppValidators.mustNotContainUris,
+  MarathonAppValidators.mustNotContainMarathonHTTPSHealthChecks,
+  MarathonAppValidators.mustNotContainMarathonHTTPHealthChecks,
+  MarathonAppValidators.mustNotContainMarathonTCPHealthChecks,
   VipLabelsValidators.mustContainPort
 ];
 

--- a/plugins/services/src/js/utils/HealthCheckUtil.js
+++ b/plugins/services/src/js/utils/HealthCheckUtil.js
@@ -2,6 +2,13 @@ import HealthCheckProtocols from "../constants/HealthCheckProtocols";
 
 module.exports = {
   isKnownProtocol(protocol) {
-    return ["", ...Object.values(HealthCheckProtocols)].includes(protocol);
+    return [
+      "",
+      ...[
+        HealthCheckProtocols.MESOS_HTTP,
+        HealthCheckProtocols.MESOS_HTTPS,
+        HealthCheckProtocols.COMMAND
+      ]
+    ].includes(protocol);
   }
 };

--- a/plugins/services/src/js/utils/__tests__/HealthCheckUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/HealthCheckUtil-test.js
@@ -7,9 +7,23 @@ describe("HealthCheckUtil", function() {
       expect(HealthCheckUtil.isKnownProtocol("")).toEqual(true);
     });
 
-    Object.values(HealthCheckProtocols).forEach(protocol => {
+    [
+      HealthCheckProtocols.MESOS_HTTP,
+      HealthCheckProtocols.MESOS_HTTPS,
+      HealthCheckProtocols.COMMAND
+    ].forEach(protocol => {
       it(`should return true for ${protocol}`, function() {
         expect(HealthCheckUtil.isKnownProtocol(protocol)).toEqual(true);
+      });
+    });
+
+    [
+      HealthCheckProtocols.HTTP,
+      HealthCheckProtocols.HTTPS,
+      HealthCheckProtocols.TCP
+    ].forEach(protocol => {
+      it(`should return false for deprecated ${protocol}`, function() {
+        expect(HealthCheckUtil.isKnownProtocol(protocol)).toEqual(false);
       });
     });
 

--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -1,5 +1,6 @@
 import ValidatorUtil from "#SRC/js/utils/ValidatorUtil";
 import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
+import { HTTP, HTTPS, TCP } from "../constants/HealthCheckProtocols";
 import {
   PROP_CONFLICT,
   PROP_DEPRECATED,
@@ -208,6 +209,84 @@ const MarathonAppValidators = {
       };
 
       return [{ path: ["uris"], message, type, variables }];
+    }
+
+    // No errors
+    return [];
+  },
+
+  /**
+   * @param {Object} app - The data to validate
+   * @returns {Array} Returns an array with validation errors
+   */
+  mustNotContainMarathonHTTPHealthChecks(app) {
+    if (
+      ValidatorUtil.isDefined(app.healthChecks) &&
+      app.healthChecks.find(function(healthCheck) {
+        return HTTP === healthCheck.protocol;
+      })
+    ) {
+      const message =
+        "Marathon protocols `HTTP` deprecated. Please use" +
+        " `MESOS_HTTP instead";
+      const type = PROP_DEPRECATED;
+      const variables = {
+        name: "healthChecks"
+      };
+
+      return [{ path: ["healthChecks"], message, type, variables }];
+    }
+
+    // No errors
+    return [];
+  },
+
+  /**
+   * @param {Object} app - The data to validate
+   * @returns {Array} Returns an array with validation errors
+   */
+  mustNotContainMarathonHTTPSHealthChecks(app) {
+    if (
+      ValidatorUtil.isDefined(app.healthChecks) &&
+      app.healthChecks.find(function(healthCheck) {
+        return HTTPS === healthCheck.protocol;
+      })
+    ) {
+      const message =
+        "Marathon protocols `HTTPS` deprecated. Please use" +
+        " `MESOS_HTTPS instead";
+      const type = PROP_DEPRECATED;
+      const variables = {
+        name: "healthChecks"
+      };
+
+      return [{ path: ["healthChecks"], message, type, variables }];
+    }
+
+    // No errors
+    return [];
+  },
+
+  /**
+   * @param {Object} app - The data to validate
+   * @returns {Array} Returns an array with validation errors
+   */
+  mustNotContainMarathonTCPHealthChecks(app) {
+    if (
+      ValidatorUtil.isDefined(app.healthChecks) &&
+      app.healthChecks.find(function(healthCheck) {
+        return TCP === healthCheck.protocol;
+      })
+    ) {
+      const message =
+        "Marathon protocols `TCP` deprecated. Please use" +
+        " `MESOS_TCP instead";
+      const type = PROP_DEPRECATED;
+      const variables = {
+        name: "healthChecks"
+      };
+
+      return [{ path: ["healthChecks"], message, type, variables }];
     }
 
     // No errors


### PR DESCRIPTION
**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

This PR is deprecating Marathon healthcheck protocols `http`, `https` and `tcp`. And also ensures that unsupported health checks do not break the ui:

![image](https://cloud.githubusercontent.com/assets/156010/25185034/716f7282-251c-11e7-80b4-346813968567.png)


For testing purposes here is a JSON:

```JSON
{
  "id": "/myapp",
  "cmd": "sleep 1000;",
  "instances": 1,
  "cpus": 1,
  "mem": 2048,
  "healthChecks": [
    {
      "path": "/status",
      "portIndex": 0,
      "protocol": "HTTP",
      "gracePeriodSeconds": 300,
      "intervalSeconds": 60,
      "timeoutSeconds": 20,
      "maxConsecutiveFailures": 3,
      "ignoreHttp1xx": false
    }
  ],
  "portDefinitions": [
    {
      "protocol": "tcp",
      "port": 0
    }
  ]
}
```

Closes DCOS-14759