### PR TITLE
⬅️ DCOS-14894: Keep pod endpoints labels

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/Containers.js
@@ -412,7 +412,7 @@ module.exports = {
         'loadBalanced',
         'vip'
       ];
-      const numericalFiledNames = ['containerPort', 'hostPort'];
+      const numericalFieldNames = ['containerPort', 'hostPort'];
 
       if (type === SET && name === 'protocol') {
         this.endpoints[index].endpoints[secondIndex].protocol[subField] = value;
@@ -420,7 +420,7 @@ module.exports = {
       if (type === SET && fieldNames.includes(name)) {
         this.endpoints[index].endpoints[secondIndex][name] = value;
       }
-      if (type === SET && numericalFiledNames.includes(name)) {
+      if (type === SET && numericalFieldNames.includes(name)) {
         this.endpoints[index].endpoints[secondIndex][name] = parseIntValue(
           value
         );
@@ -581,7 +581,7 @@ module.exports = {
         'loadBalanced',
         'vip'
       ];
-      const numericalFiledNames = ['containerPort', 'hostPort'];
+      const numericalFieldNames = ['containerPort', 'hostPort'];
 
       if (type === SET && name === 'protocol') {
         newState[index].endpoints[secondIndex].protocol[subField] = value;
@@ -589,7 +589,7 @@ module.exports = {
       if (type === SET && fieldNames.includes(name)) {
         newState[index].endpoints[secondIndex][name] = value;
       }
-      if (type === SET && numericalFiledNames.includes(name)) {
+      if (type === SET && numericalFieldNames.includes(name)) {
         newState[index].endpoints[secondIndex][name] = parseIntValue(value);
       }
     }

--- a/plugins/services/src/js/reducers/serviceForm/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/Containers.js
@@ -93,7 +93,8 @@ function mapEndpoints(endpoints = [], networkType, appState) {
     return {
       name,
       hostPort,
-      protocol
+      protocol,
+      labels
     };
   });
 }
@@ -213,6 +214,12 @@ function containersParser(state) {
           )
         ]);
 
+        if (endpoint.labels != null) {
+          memo.push(new Transaction([
+            'containers', index, 'endpoints', endpointIndex, 'labels'
+          ], endpoint.labels));
+        }
+
         if (networkMode === CONTAINER.toLowerCase()) {
           memo.push(new Transaction(
             ['containers', index, 'endpoints', endpointIndex, 'containerPort'],
@@ -234,13 +241,6 @@ function containersParser(state) {
                 'vip'
               ], vip));
             }
-          }
-
-          if (item.labels != null) {
-            memo.push(new Transaction([
-              'containers', index, 'endpoints', endpointIndex,
-              'labels'
-            ], item.labels));
           }
         }
 
@@ -410,6 +410,7 @@ module.exports = {
         'name',
         'automaticPort',
         'loadBalanced',
+        'labels',
         'vip'
       ];
       const numericalFieldNames = ['containerPort', 'hostPort'];

--- a/plugins/services/src/js/reducers/serviceForm/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/Containers.js
@@ -183,12 +183,12 @@ function containersParser(state) {
     }
 
     if (item.endpoints != null && item.endpoints.length !== 0) {
-      item.endpoints.forEach((endpoint, endpointIndex) => {
-        const networkMode = findNestedPropertyInObject(
-          state,
-          'networks.0.mode'
-        );
+      const networkMode = findNestedPropertyInObject(
+        state,
+        'networks.0.mode'
+      );
 
+      item.endpoints.forEach((endpoint, endpointIndex) => {
         memo = memo.concat([
           new Transaction(
             ['containers', index, 'endpoints'],

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
@@ -50,6 +50,7 @@ describe('Containers', function () {
                 {
                   name: null,
                   hostPort: 0,
+                  labels: null,
                   protocol: [
                     'tcp'
                   ]
@@ -92,6 +93,42 @@ describe('Containers', function () {
                 {
                   name: 'foo',
                   hostPort: 0,
+                  labels: null,
+                  protocol: [
+                    'tcp'
+                  ]
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should keep custom labels', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+          batch = batch.add(
+            new Transaction(['containers', 0, 'endpoints'], 0, ADD_ITEM)
+          );
+          batch = batch.add(
+            new Transaction(['containers', 0, 'endpoints', 0, 'labels'], {
+              custom: 'label'
+            })
+          );
+
+          expect(batch.reduce(Containers.JSONReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container-1',
+              resources: {
+                cpus: 0.1,
+                mem: 128
+              },
+              endpoints: [
+                {
+                  name: null,
+                  hostPort: 0,
+                  labels: {custom: 'label'},
                   protocol: [
                     'tcp'
                   ]
@@ -154,6 +191,7 @@ describe('Containers', function () {
                 {
                   name: 'foo',
                   hostPort: 8080,
+                  labels: null,
                   protocol: [
                     'tcp'
                   ]
@@ -199,6 +237,7 @@ describe('Containers', function () {
                 {
                   name: null,
                   hostPort: 0,
+                  labels: null,
                   protocol: [
                     'tcp',
                     'udp'
@@ -245,6 +284,7 @@ describe('Containers', function () {
                 {
                   name: null,
                   hostPort: 0,
+                  labels: null,
                   protocol: [
                     'tcp',
                     'foo'
@@ -333,6 +373,43 @@ describe('Containers', function () {
                   containerPort: null,
                   labels: null,
                   hostPort: 0,
+                  protocol: [
+                    'tcp'
+                  ]
+                }
+              ]
+            }
+          ]);
+        });
+
+        it('should keep custom labels', function () {
+          let batch = new Batch();
+
+          batch = batch.add(new Transaction(['containers'], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(['networks', 0], 'CONTAINER.foo'));
+          batch = batch.add(
+            new Transaction(['containers', 0, 'endpoints'], 0, ADD_ITEM)
+          );
+          batch = batch.add(
+            new Transaction(['containers', 0, 'endpoints', 0, 'labels'], {
+              custom: 'label'
+            })
+          );
+
+          expect(batch.reduce(Containers.JSONReducer.bind({})))
+          .toEqual([
+            {
+              name: 'container-1',
+              resources: {
+                cpus: 0.1,
+                mem: 128
+              },
+              endpoints: [
+                {
+                  name: null,
+                  hostPort: 0,
+                  containerPort: null,
+                  labels: {custom: 'label'},
                   protocol: [
                     'tcp'
                   ]

--- a/plugins/services/src/js/utils/VipLabelUtil.js
+++ b/plugins/services/src/js/utils/VipLabelUtil.js
@@ -11,7 +11,12 @@ const VipLabelUtil = {
       }
 
       return Object.assign({}, labels, {[vipLabel]: vipValue});
-    } else if (labels) {
+    }
+
+    const labelsHadVip =
+      labels && Object.prototype.hasOwnProperty.call(labels, vipLabel);
+
+    if (labelsHadVip) {
       return Object.assign({}, labels, {[vipLabel]: undefined});
     }
 


### PR DESCRIPTION
---
⚠️  _This PR back-ports a fix to release/1.9 introduced with #2062._

---

Please test the fix using the Form (not the JSON only one) using the following example spec:

```
{
  "id": "/test-pod",
  "containers": [
    {
      "name": "healthtask1",
      "exec": {
        "command": {
          "shell": "sleep 1"
        }
      },
      "resources": {
        "cpus": 0.1,
        "mem": 32,
        "disk": 32,
        "gpus": 0
      },
      "endpoints": [
        {
          "name": "httpendpoint",
          "containerPort": 8080,
          "hostPort": 0,
          "protocol": [
            "tcp"
          ],
          "labels": {
            "custom_label": "custom"
          }
        }
      ],
      "image": {
        "kind": "DOCKER",
        "id": "alpine"
      }
    }
  ],
  "networks": [
    {
      "name": "dcos",
      "mode": "container"
    }
  ]
}```

