### PR TITLE
⬅️ DCOS_OSS-858: Update Marathon RAML

### DIFF
--- a/scripts/pre-install
+++ b/scripts/pre-install
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
-MARATHON_VERSION="1.4.0-RC4"
+MARATHON_VERSION="1.4.2"
 
 # Import utils
 source ${SCRIPT_PATH}/utils/git


### PR DESCRIPTION
---
⚠️  _This PR back-ports a fix to release/1.9 introduced with #2054._

---

Adjust the pre-install script to install the Marathon 1.4.2 RAML specs. This change will resolve issues related to wrong validation warnings due to outdated specs.