### PR TITLE
↩️ Fix task table keys (Mesos task IDs are not unique)

### DIFF
--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -393,8 +393,7 @@ class TaskTable extends React.Component {
         onCheckboxChange={onCheckboxChange}
         sortBy={{prop: 'updated', order: 'desc'}}
         sortOrder="desc"
-        sortProp="updated"
-        uniqueProperty="id" />
+        sortProp="updated" />
     );
   }
 }

--- a/plugins/services/src/js/containers/tasks/__tests__/TaskTable-test.js
+++ b/plugins/services/src/js/containers/tasks/__tests__/TaskTable-test.js
@@ -9,8 +9,10 @@ jest.dontMock('moment');
 const React = require('react');
 /* eslint-enable no-unused-vars */
 const ReactDOM = require('react-dom');
+const TestUtils = require('react-addons-test-utils');
 const JestUtil = require('../../../../../../../src/js/utils/JestUtil');
 
+const CheckboxTable = require('../../../../../../../src/js/components/CheckboxTable');
 const DCOSStore = require('foundation-ui').DCOSStore;
 const MesosStateStore = require('../../../../../../../src/js/stores/MesosStateStore');
 const TaskTable = require('../TaskTable');
@@ -55,6 +57,16 @@ describe('TaskTable', function () {
         {id: '2', state: 'TASK_FINISHED', isStartedByMarathon: true}
       ];
       expect(this.taskTable.getDisabledItemsMap(tasks)).toEqual({'2': true});
+    });
+
+    it('it does not pass a uniqueProperty to CheckboxTable', function () {
+      const component = JestUtil.stubRouterContext(TaskTable, {params: {}});
+      const result = TestUtils.renderIntoDocument(component);
+      const table = TestUtils.findRenderedComponentWithType(result, CheckboxTable);
+      // TODO: Should not look at 'id' until tasks are sure to have unique IDs
+      // this test can be removed (and we can add 'id') once tasks IDs are sure
+      // to be unique
+      expect(table.props.uniqueProperty).toEqual(undefined);
     });
 
   });

--- a/src/js/components/CheckboxTable.js
+++ b/src/js/components/CheckboxTable.js
@@ -154,20 +154,13 @@ class CheckboxTable extends React.Component {
   }
 
   getTableRowOptions(row) {
-    const {
-      checkedItemsMap,
-      inactiveItemsMap,
-      uniqueProperty
-    } = this.props;
+    const {checkedItemsMap, uniqueProperty} = this.props;
 
+    const rowAttributes = {};
     // Override the key from index to our task ID to help React know, which
     // row was rendered where and make its optimizations
-    const rowAttributes = {
-      key: row[uniqueProperty]
-    };
-
-    if (inactiveItemsMap[row[uniqueProperty]]) {
-      return Object.assign(rowAttributes, {className: 'inactive'});
+    if (row[uniqueProperty]) {
+      rowAttributes.key = row[uniqueProperty];
     }
 
     if (checkedItemsMap[row[uniqueProperty]]) {


### PR DESCRIPTION
This PR is the same as this just pointing to release 1.9: https://github.com/dcos/dcos-ui/pull/2128

This PR fixes a bug that was introduced in this PR: https://github.com/dcos/dcos-ui/pull/2078

Mesos task IDs are not always unique (e.g. an app with a simple sleep will create instances with same ID) and therefore we cannot use this as a unique property in the table.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [x] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
