### PR TITLE
DCOS-14845: DeclinedOffers now default to 0 for undefined scalar values

### DIFF
--- a/plugins/services/src/js/utils/DeclinedOffersUtil.js
+++ b/plugins/services/src/js/utils/DeclinedOffersUtil.js
@@ -201,14 +201,14 @@ const DeclinedOffersUtil = {
         unmatchedResource: declinedOffer.reason,
         offered: resources.reduce(
           (accumulator, resource) => {
-            const { name, role } = resource;
+            const { name, role, scalar = 0 } = resource;
 
             if (name === "ports") {
               const { ranges = [] } = resource;
 
               accumulator[name] = ranges.reduce(rangeReducer, []);
             } else {
-              accumulator[name] = resource.scalar;
+              accumulator[name] = scalar;
             }
 
             // Accumulate all roles.

--- a/plugins/services/src/js/utils/DeclinedOffersUtil.js
+++ b/plugins/services/src/js/utils/DeclinedOffersUtil.js
@@ -201,7 +201,11 @@ const DeclinedOffersUtil = {
         unmatchedResource: declinedOffer.reason,
         offered: resources.reduce(
           (accumulator, resource) => {
-            const { name, role, scalar = 0 } = resource;
+            let { name, role, scalar } = resource;
+
+            if (scalar == null) {
+              scalar = 0;
+            }
 
             if (name === "ports") {
               const { ranges = [] } = resource;

--- a/plugins/services/src/js/utils/__tests__/DeclinedOffersUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/DeclinedOffersUtil-test.js
@@ -438,6 +438,61 @@ describe("DeclinedOffersUtil", function() {
       ]);
     });
 
+    it("defaults null scalar values to 0", function() {
+      const unusedOffers = DeclinedOffersUtil.getOffersFromQueue({
+        lastUnusedOffers: [
+          {
+            offer: {
+              id: "offer_123",
+              agentId: "slave_123",
+              hostname: "1.2.3.4",
+              resources: [
+                {
+                  name: "cpus",
+                  scalar: null,
+                  ranges: [
+                    {
+                      begin: 1,
+                      end: 5
+                    }
+                  ],
+                  set: ["a", "b"],
+                  role: "*"
+                }
+              ],
+              attributes: [
+                {
+                  name: "foo",
+                  ranges: [
+                    {
+                      begin: 1,
+                      end: 5
+                    }
+                  ],
+                  set: ["a", "b"]
+                }
+              ]
+            },
+            timestamp: "2016-02-28T16:41:41.090Z",
+            reason: ["InsufficientMemory"]
+          }
+        ]
+      });
+
+      expect(unusedOffers).toEqual([
+        {
+          hostname: "1.2.3.4",
+          timestamp: "2016-02-28T16:41:41.090Z",
+          unmatchedResource: ["InsufficientMemory"],
+          offered: {
+            constraints: "foo:1 – 5",
+            cpus: 0,
+            roles: ["*"]
+          }
+        }
+      ]);
+    });
+
     it("returns an array of offer details from API response", function() {
       const unusedOffers = DeclinedOffersUtil.getOffersFromQueue({
         lastUnusedOffers: [

--- a/plugins/services/src/js/utils/__tests__/DeclinedOffersUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/DeclinedOffersUtil-test.js
@@ -384,6 +384,60 @@ describe("DeclinedOffersUtil", function() {
       ).toEqual(null);
     });
 
+    it("defaults undefined scalar values to 0", function() {
+      const unusedOffers = DeclinedOffersUtil.getOffersFromQueue({
+        lastUnusedOffers: [
+          {
+            offer: {
+              id: "offer_123",
+              agentId: "slave_123",
+              hostname: "1.2.3.4",
+              resources: [
+                {
+                  name: "cpus",
+                  ranges: [
+                    {
+                      begin: 1,
+                      end: 5
+                    }
+                  ],
+                  set: ["a", "b"],
+                  role: "*"
+                }
+              ],
+              attributes: [
+                {
+                  name: "foo",
+                  ranges: [
+                    {
+                      begin: 1,
+                      end: 5
+                    }
+                  ],
+                  set: ["a", "b"]
+                }
+              ]
+            },
+            timestamp: "2016-02-28T16:41:41.090Z",
+            reason: ["InsufficientMemory"]
+          }
+        ]
+      });
+
+      expect(unusedOffers).toEqual([
+        {
+          hostname: "1.2.3.4",
+          timestamp: "2016-02-28T16:41:41.090Z",
+          unmatchedResource: ["InsufficientMemory"],
+          offered: {
+            constraints: "foo:1 – 5",
+            cpus: 0,
+            roles: ["*"]
+          }
+        }
+      ]);
+    });
+
     it("returns an array of offer details from API response", function() {
       const unusedOffers = DeclinedOffersUtil.getOffersFromQueue({
         lastUnusedOffers: [


### PR DESCRIPTION
**This is the same commit as https://github.com/dcos/dcos-ui/pull/2110, but now Prettier** 😄 

This PR fixes a bug where an offered resource's `scalar` value might be displayed as `NaN` when the API omits this value. Now the `scalar` value is default assigned to `0`.

Before:
![](https://cl.ly/2R2r0j2X423u/Screen%20Shot%202017-04-17%20at%2010.56.55%20AM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [x] If this is a regression, did you write a test to catch this in the future?