### PR TITLE
fix(test-apps.js): Fix external volume assertions

### DIFF
--- a/system-tests/services/test-apps.js
+++ b/system-tests/services/test-apps.js
@@ -666,7 +666,7 @@ describe("Services", function() {
       // Add an environment variable
       cy.contains("Add External Volume").click();
       cy.root().getFormGroupInputFor("Name").type(volumeName);
-      cy.root().getFormGroupInputFor("Size (GiB)").type("1");
+      cy.root().getFormGroupInputFor("Size (MiB)").type("1");
       cy.root().getFormGroupInputFor("Container Path").type("test");
 
       // Check JSON view
@@ -743,7 +743,7 @@ describe("Services", function() {
         .children("table")
         .getTableColumn("Size")
         .contents()
-        .should("deep.equal", ["1 GiB"]);
+        .should("deep.equal", ["1 MiB"]);
       cy
         .root()
         .configurationSection("Storage")


### PR DESCRIPTION
This PR fixes an assertion in the system tests which looks for the wrong units for the volume size.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?