### PR TITLE
[System Tests] Adding cleanup after every test

### DIFF
--- a/system-tests/jobs/test-jobs.js
+++ b/system-tests/jobs/test-jobs.js
@@ -1,6 +1,12 @@
 const { Timeouts } = require("../_support/constants");
 
 describe("Jobs", function() {
+  afterEach(() => {
+    cy.window().then(win => {
+      win.location.href = "about:blank";
+    });
+  });
+
   it("Create a simple job", function() {
     const jobName = "job-with-inline-shell-script";
     const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;

--- a/system-tests/services/test-apps.js
+++ b/system-tests/services/test-apps.js
@@ -10,6 +10,12 @@ describe("Services", function() {
       cy.visitUrl(`services/overview/%2F${Cypress.env("TEST_UUID")}/create`);
     });
 
+    afterEach(() => {
+      cy.window().then(win => {
+        win.location.href = "about:blank";
+      });
+    });
+
     function selectMesosRuntime() {
       cy.contains("More Settings").click();
       cy.contains("Mesos Runtime").click();

--- a/system-tests/services/test-environment.js
+++ b/system-tests/services/test-environment.js
@@ -7,6 +7,12 @@ describe("Services", function() {
       cy.visitUrl(`services/overview/%2F${Cypress.env("TEST_UUID")}`);
     });
 
+    afterEach(() => {
+      cy.window().then(win => {
+        win.location.href = "about:blank";
+      });
+    });
+
     it("should contain no running services", function() {
       // We should have the 'No running services' panel
       cy.contains("No running services").should("exist");

--- a/system-tests/services/test-pods.js
+++ b/system-tests/services/test-pods.js
@@ -10,6 +10,12 @@ describe("Services", function() {
       cy.visitUrl(`services/overview/%2F${Cypress.env("TEST_UUID")}/create`);
     });
 
+    afterEach(() => {
+      cy.window().then(win => {
+        win.location.href = "about:blank";
+      });
+    });
+
     it("Create a simple pod", function() {
       const serviceName = "pod-with-inline-shell-script";
       const command = "while true ; do echo 'test' ; sleep 100 ;";


### PR DESCRIPTION
This commit adds an afterEach hook to the system tests, that forces
cypress to visit 'about:blank', effectively cleaning-up the previous
state. This way we can avoid stale XHR requests from previous tests
to affect the next tests.

This PR fixes a bug that causes some tests unexpectedly to be blocked by the _Login_ screen.

