### PR TITLE
feat(DCOS-13976): Add effort to protect from clickjacking attack

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -38,7 +38,7 @@
 
     <script type="text/JavaScript">
     // old school Frame busting solution
-    // even though this solution has other way around it
+    // even though this solution has ways around it
     // the X-Frame-Options set in the HEADERS is the ideal
     if (top != self) { top.location.replace(self.location.href); }
     </script>

--- a/src/index.html
+++ b/src/index.html
@@ -35,6 +35,13 @@
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="./img/components/icons/favicon-apple-152x152.png">
     <script type="text/javascript">(function () {var PAGE_LOADED_TIME = Date.now(); window.getPageLoadedTime = function () {return PAGE_LOADED_TIME;}})();</script>
     <!--[if BOOTSTRAP-CSS]><![endif]-->
+
+    <script type="text/JavaScript">
+    // old school Frame busting solution
+    // even though this solution has other way around it
+    // the X-Frame-Options set in the HEADERS is the ideal
+    if (top != self) { top.location.replace(self.location.href); }
+    </script>
   </head>
 
   <body>


### PR DESCRIPTION
(**DCOS-13976**) This solution is outdated and there is many ways around it BUT we have no harm in having it (because it's so small having in the head is fine).
The ideal solution was implemented here https://github.com/dcos/dcos/pull/1506

For more info about it [Clickjacking Defense](https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet)

To test this create a index.html page and use iframe markup pointing to `https://52.41.194.202`. You should see this in the console `Refused to display 'https://52.41.194.202/' in a frame because it set 'X-Frame-Options' to 'deny'.`

Because security.
![security](https://cloud.githubusercontent.com/assets/549394/25540768/1341142c-2c01-11e7-8401-52309801f22e.gif)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
