### PR TITLE
[SDK Actions 1 of 2] DCOS-14910: Disable sdk service actions

### DIFF
--- a/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
+++ b/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
@@ -1,0 +1,312 @@
+import React, { PropTypes } from "react";
+import { injectIntl } from "react-intl";
+import { Modal } from "reactjs-components";
+
+import ClipboardTrigger from "#SRC/js/components/ClipboardTrigger";
+import MetadataStore from "#SRC/js/stores/MetadataStore";
+import ModalHeading from "#SRC/js/components/modals/ModalHeading";
+import Pod from "../../structs/Pod";
+import Service from "../../structs/Service";
+import ServiceActionLabels from "../../constants/ServiceActionLabels";
+import ServiceTree from "../../structs/ServiceTree";
+import {
+  SCALE,
+  RESTART,
+  RESUME,
+  SUSPEND,
+  DELETE
+} from "../../constants/ServiceActionItem";
+
+const METHODS_TO_BIND = ["handleTextCopy"];
+
+class ServiceActionDisabledModal extends React.Component {
+  constructor() {
+    super(...arguments);
+
+    this.state = { isTextCopied: false };
+
+    METHODS_TO_BIND.forEach(method => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.open !== nextProps.open) {
+      this.setState({ isTextCopied: false });
+    }
+  }
+
+  handleTextCopy() {
+    this.setState({ isTextCopied: true });
+  }
+
+  getUpdateCommand() {
+    const { service } = this.props;
+    const serviceID = service.getId();
+    const packageName = service.getLabels().DCOS_PACKAGE_NAME;
+
+    return `dcos ${packageName} --name=${serviceID} update --options=<my-options>.json`;
+  }
+
+  getRestartCommand() {
+    const { service } = this.props;
+    const serviceID = service.getId();
+
+    return `dcos marathon app restart ${serviceID}`;
+  }
+
+  getDeleteCommand() {
+    const { service } = this.props;
+    const serviceID = service.getId();
+    const packageName = service.getLabels().DCOS_PACKAGE_NAME;
+
+    return `dcos package uninstall ${packageName} --app-id=${serviceID}`;
+  }
+
+  getRestartMessage() {
+    const { intl } = this.props;
+    const command = this.getRestartCommand();
+
+    return (
+      <div>
+        <p>
+          {intl.formatMessage({ id: "SERVICE_ACTIONS.SDK_SERVICE_RESTART" })}
+          {" "}
+          <a
+            href={MetadataStore.buildDocsURI(
+              "/cli/command-reference/dcos-marathon/dcos-marathon-app-restart/"
+            )}
+            target="_blank"
+          >
+            {intl.formatMessage({ id: "DOCS.MORE_INFORMATION" })}
+          </a>
+        </p>
+        {this.getClipboardTrigger(command)}
+      </div>
+    );
+  }
+
+  getSuspendMessage() {
+    const { intl } = this.props;
+    const command = this.getUpdateCommand();
+
+    return (
+      <div>
+        <p>
+          {intl.formatMessage({ id: "SERVICE_ACTIONS.SDK_SERVICE_SUSPEND" })}
+          {" "}
+          <a
+            href={MetadataStore.buildDocsURI(
+              "/deploying-services/config-universe-service/"
+            )}
+            target="_blank"
+          >
+            {intl.formatMessage({ id: "DOCS.MORE_INFORMATION" })}
+          </a>
+        </p>
+        {this.getClipboardTrigger(command)}
+      </div>
+    );
+  }
+
+  getResumeMessage() {
+    const { intl } = this.props;
+    const command = this.getUpdateCommand();
+
+    return (
+      <div>
+        <p>
+          {intl.formatMessage({ id: "SERVICE_ACTIONS.SDK_SERVICE_RESUME" })}
+          {" "}
+          <a
+            href={MetadataStore.buildDocsURI(
+              "/deploying-services/config-universe-service/"
+            )}
+            target="_blank"
+          >
+            {intl.formatMessage({ id: "DOCS.MORE_INFORMATION" })}
+          </a>
+        </p>
+        {this.getClipboardTrigger(command)}
+      </div>
+    );
+  }
+
+  getScaleMessage() {
+    const { intl } = this.props;
+    const command = this.getUpdateCommand();
+
+    return (
+      <div>
+        <p>
+          {intl.formatMessage({ id: "SERVICE_ACTIONS.SDK_SERVICE_SCALE" })}
+        </p>
+        <p>
+          <span className="emphasis">Note:</span>
+          {" "}
+          {intl.formatMessage({ id: "SERVICE_ACTIONS.SDK_SERVICE_SCALE_NOTE" })}
+          {" "}
+          <a
+            href={MetadataStore.buildDocsURI(
+              "/usage/managing-services/config-universe-service"
+            )}
+            target="_blank"
+          >
+            {intl.formatMessage({ id: "DOCS.MORE_INFORMATION" })}
+          </a>
+          {" "}
+        </p>
+        {this.getClipboardTrigger(command)}
+      </div>
+    );
+  }
+
+  getDeleteMessage() {
+    const { intl, service } = this.props;
+    const serviceID = service ? service.getId() : "";
+    const command = this.getDeleteCommand();
+
+    return (
+      <div>
+        <p>
+          {intl.formatMessage({
+            id: "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_1"
+          })}
+          {" "}
+          <span className="emphasis">{serviceID}</span>
+          {" "}
+          {intl.formatMessage({
+            id: "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_2"
+          })}
+
+          {" "}
+          <a
+            href={MetadataStore.buildDocsURI("/deploying-services/uninstall/")}
+            target="_blank"
+          >
+            {intl.formatMessage({ id: "DOCS.DOCUMENTATION" })}
+          </a> for complete instructions.{" "}
+        </p>
+        {this.getClipboardTrigger(command)}
+        <p>
+          {intl.formatMessage({
+            id: "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_3"
+          })}
+          {" "}
+          <a
+            href={MetadataStore.buildDocsURI(
+              "/usage/managing-services/uninstall/#framework-cleaner"
+            )}
+            target="_blank"
+          >
+            {intl.formatMessage({
+              id: "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_4"
+            })}
+          </a>
+          .
+        </p>
+      </div>
+    );
+  }
+
+  getMessage() {
+    const { actionID } = this.props;
+
+    switch (actionID) {
+      case RESTART:
+        return this.getRestartMessage();
+      case SUSPEND:
+        return this.getSuspendMessage();
+      case RESUME:
+        return this.getResumeMessage();
+      case SCALE:
+        return this.getScaleMessage();
+      case DELETE:
+        return this.getDeleteMessage();
+      default:
+        return <noscript />;
+    }
+  }
+
+  getClipboardTrigger(command) {
+    const { intl } = this.props;
+    const { isTextCopied } = this.state;
+    const copyID = isTextCopied ? "CLIPBOARD.COPIED" : "CLIPBOARD.COPY";
+
+    return [
+      <pre key="command">{command}</pre>,
+      <p key="copy-link">
+        <ClipboardTrigger
+          className="clickable"
+          copyText={command}
+          onTextCopy={this.handleTextCopy}
+        >
+          <a>{intl.formatMessage({ id: copyID })}</a>
+        </ClipboardTrigger>
+      </p>
+    ];
+  }
+
+  getHeading() {
+    const { actionID, service } = this.props;
+
+    let itemText = "Service";
+
+    if (service instanceof Pod) {
+      itemText = "Pod";
+    }
+
+    if (service instanceof ServiceTree) {
+      itemText = "Group";
+    }
+
+    return (
+      <ModalHeading>
+        {`${ServiceActionLabels[actionID]} ${itemText}`}
+      </ModalHeading>
+    );
+  }
+
+  getFooter() {
+    const { intl, onClose } = this.props;
+
+    return (
+      <div className="button-collection text-align-center flush-bottom">
+        <button className="button" onClick={onClose}>
+          {intl.formatMessage({ id: "BUTTON.CLOSE" })}
+        </button>
+      </div>
+    );
+  }
+
+  render() {
+    const { onClose, open } = this.props;
+
+    return (
+      <Modal
+        open={open}
+        onClose={onClose}
+        header={this.getHeading()}
+        modalClass="modal confirm-modal"
+        showCloseButton={false}
+        showHeader={true}
+        showFooter={true}
+        footer={this.getFooter()}
+      >
+        {this.getMessage()}
+      </Modal>
+    );
+  }
+}
+
+ServiceActionDisabledModal.propTypes = {
+  actionID: PropTypes.string,
+  onClose: PropTypes.func.isRequired,
+  open: PropTypes.bool.isRequired,
+  service: PropTypes.oneOfType([
+    PropTypes.instanceOf(ServiceTree),
+    PropTypes.instanceOf(Service)
+  ])
+};
+
+module.exports = injectIntl(ServiceActionDisabledModal);

--- a/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
+++ b/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
@@ -248,7 +248,7 @@ class ServiceActionDisabledModal extends React.Component {
   }
 
   getHeading() {
-    const { actionID, service } = this.props;
+    const { actionID, intl, service } = this.props;
 
     let itemText = "Service";
 
@@ -260,9 +260,13 @@ class ServiceActionDisabledModal extends React.Component {
       itemText = "Group";
     }
 
+    const action = actionID
+      ? intl.formatMessage({ id: ServiceActionLabels[actionID] })
+      : actionID;
+
     return (
       <ModalHeading>
-        {`${ServiceActionLabels[actionID]} ${itemText}`}
+        {`${action} ${itemText}`}
       </ModalHeading>
     );
   }

--- a/plugins/services/src/js/constants/ServiceActionLabels.js
+++ b/plugins/services/src/js/constants/ServiceActionLabels.js
@@ -1,0 +1,10 @@
+const ServiceActionLabels = {
+  delete: "Delete",
+  restart: "Restart",
+  resume: "Resume",
+  scale: "Scale",
+  scale_by: "Scale By",
+  suspend: "Suspend"
+};
+
+module.exports = ServiceActionLabels;

--- a/plugins/services/src/js/constants/ServiceActionLabels.js
+++ b/plugins/services/src/js/constants/ServiceActionLabels.js
@@ -1,10 +1,11 @@
 const ServiceActionLabels = {
-  delete: "Delete",
-  restart: "Restart",
-  resume: "Resume",
-  scale: "Scale",
-  scale_by: "Scale By",
-  suspend: "Suspend"
+  delete: "SERVICE_ACTIONS.DELETE",
+  restart: "SERVICE_ACTIONS.RESTART",
+  resume: "SERVICE_ACTIONS.RESUME",
+  open: "SERVICE_ACTIONS.OPEN",
+  scale: "SERVICE_ACTIONS.SCALE",
+  scale_by: "SERVICE_ACTIONS.SCALE_BY",
+  suspend: "SERVICE_ACTIONS.SUSPEND"
 };
 
 module.exports = ServiceActionLabels;

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -13,6 +13,7 @@ import ActionKeys from "../../constants/ActionKeys";
 import MarathonErrorUtil from "../../utils/MarathonErrorUtil";
 import Service from "../../structs/Service";
 import ServiceActionItem from "../../constants/ServiceActionItem";
+import ServiceActionLabels from "../../constants/ServiceActionLabels";
 import ServiceBreadcrumbs from "../../components/ServiceBreadcrumbs";
 import ServiceModals from "../../components/modals/ServiceModals";
 
@@ -119,7 +120,7 @@ class ServiceDetail extends mixin(TabsMixin) {
     ) {
       actions.push({
         label: this.props.intl.formatMessage({
-          id: "SERVICE_ACTIONS.OPEN_SERVICE"
+          id: ServiceActionLabels.open
         }),
         onItemSelect() {
           modalHandlers.openServiceUI({ service });

--- a/plugins/services/src/js/containers/service-detail/ServiceInfo.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceInfo.js
@@ -10,6 +10,7 @@ import UserActions from "#SRC/js/constants/UserActions";
 import HealthBar from "../../components/HealthBar";
 import Service from "../../structs/Service";
 import ServiceActionItem from "../../constants/ServiceActionItem";
+import ServiceActionLabels from "../../constants/ServiceActionLabels";
 import StatusMapping from "../../constants/StatusMapping";
 
 class ServiceInfo extends React.Component {
@@ -92,7 +93,7 @@ class ServiceInfo extends React.Component {
           target="_blank"
           title="Open in a new window"
         >
-          <FormattedMessage id="SERVICE_ACTIONS.OPEN_SERVICE" />
+          <FormattedMessage id={ServiceActionLabels.open} />
         </a>
       );
     }

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -216,7 +216,7 @@ class ServicesTable extends React.Component {
     const isSingleInstanceApp = service.getLabels()
       .MARATHON_SINGLE_INSTANCE_APP;
     const instancesCount = service.getInstancesCount();
-    const scaleText = isGroup
+    const scaleTextID = isGroup
       ? ServiceActionLabels.scale_by
       : ServiceActionLabels[SCALE];
 
@@ -232,43 +232,49 @@ class ServicesTable extends React.Component {
           hidden: !this.hasWebUI(service)
         }),
         id: OPEN,
-        html: this.props.intl.formatMessage({
-          id: "SERVICE_ACTIONS.OPEN_SERVICE"
-        })
+        html: this.props.intl.formatMessage({ id: ServiceActionLabels.open })
       },
       {
         className: classNames({
           hidden: (isGroup && instancesCount === 0) || isSingleInstanceApp
         }),
         id: SCALE,
-        html: scaleText
+        html: this.props.intl.formatMessage({ id: scaleTextID })
       },
       {
         className: classNames({
           hidden: isPod || isGroup || instancesCount === 0
         }),
         id: RESTART,
-        html: ServiceActionLabels[RESTART]
+        html: this.props.intl.formatMessage({
+          id: ServiceActionLabels[RESTART]
+        })
       },
       {
         className: classNames({
           hidden: instancesCount === 0
         }),
         id: SUSPEND,
-        html: ServiceActionLabels[SUSPEND]
+        html: this.props.intl.formatMessage({
+          id: ServiceActionLabels[SUSPEND]
+        })
       },
       {
         className: classNames({
           hidden: isGroup || instancesCount > 0
         }),
         id: RESUME,
-        html: ServiceActionLabels[RESUME]
+        html: this.props.intl.formatMessage({
+          id: ServiceActionLabels[RESUME]
+        })
       },
       {
         id: DELETE,
         html: (
           <span className="text-danger">
-            {ServiceActionLabels[DELETE]}
+            {this.props.intl.formatMessage({
+              id: ServiceActionLabels[DELETE]
+            })}
           </span>
         )
       }

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -4,20 +4,31 @@ import { injectIntl } from "react-intl";
 import { Link } from "react-router";
 import React, { PropTypes } from "react";
 
-import Links from "#SRC/js/constants/Links";
 import Icon from "#SRC/js/components/Icon";
+import Links from "#SRC/js/constants/Links";
 import NestedServiceLinks from "#SRC/js/components/NestedServiceLinks";
 import StringUtil from "#SRC/js/utils/StringUtil";
 import TableUtil from "#SRC/js/utils/TableUtil";
 import Units from "#SRC/js/utils/Units";
-import UserActions from "#SRC/js/constants/UserActions";
+import { isSDKService } from "#SRC/js/utils/ServiceUtil";
 
 import HealthBar from "../../components/HealthBar";
 import Pod from "../../structs/Pod";
 import ResourceTableUtil
   from "../../../../../../src/js/utils/ResourceTableUtil";
 import Service from "../../structs/Service";
-import ServiceActionItem from "../../constants/ServiceActionItem";
+import ServiceActionDisabledModal
+  from "../../components/modals/ServiceActionDisabledModal";
+import {
+  DELETE,
+  MORE,
+  OPEN,
+  RESTART,
+  RESUME,
+  SCALE,
+  SUSPEND
+} from "../../constants/ServiceActionItem";
+import ServiceActionLabels from "../../constants/ServiceActionLabels";
 import ServiceStatusWarning from "../../components/ServiceStatusWarning";
 import ServiceTableHeaderLabels from "../../constants/ServiceTableHeaderLabels";
 import ServiceTableUtil from "../../utils/ServiceTableUtil";
@@ -38,6 +49,9 @@ const columnClasses = {
 
 const METHODS_TO_BIND = [
   "onActionsItemSelection",
+  "handleServiceAction",
+  "handleActionDisabledModalOpen",
+  "handleActionDisabledModalClose",
   "renderHeadline",
   "renderStats",
   "renderStatus",
@@ -48,9 +62,53 @@ class ServicesTable extends React.Component {
   constructor() {
     super(...arguments);
 
+    this.state = { actionDisabledService: null };
+
     METHODS_TO_BIND.forEach(method => {
       this[method] = this[method].bind(this);
     });
+  }
+
+  onActionsItemSelection(service, actionItem) {
+    // We still want to support the `open` action to display the web view
+    if (actionItem.id !== OPEN && isSDKService(service)) {
+      this.handleActionDisabledModalOpen(service, actionItem.id);
+    } else {
+      this.handleServiceAction(service, actionItem.id);
+    }
+  }
+
+  handleServiceAction(service, actionID) {
+    const { modalHandlers } = this.context;
+
+    switch (actionID) {
+      case SCALE:
+        modalHandlers.scaleService({ service });
+        break;
+      case OPEN:
+        modalHandlers.openServiceUI({ service });
+        break;
+      case RESTART:
+        modalHandlers.restartService({ service });
+        break;
+      case RESUME:
+        modalHandlers.resumeService({ service });
+        break;
+      case SUSPEND:
+        modalHandlers.suspendService({ service });
+        break;
+      case DELETE:
+        modalHandlers.deleteService({ service });
+        break;
+    }
+  }
+
+  handleActionDisabledModalOpen(actionDisabledService, actionDisabledID) {
+    this.setState({ actionDisabledService, actionDisabledID });
+  }
+
+  handleActionDisabledModalClose() {
+    this.setState({ actionDisabledService: null, actionDisabledID: null });
   }
 
   getOpenInNewWindowLink(service) {
@@ -75,31 +133,6 @@ class ServicesTable extends React.Component {
         />
       </a>
     );
-  }
-
-  onActionsItemSelection(service, actionItem) {
-    const { modalHandlers } = this.context;
-
-    switch (actionItem.id) {
-      case ServiceActionItem.SCALE:
-        modalHandlers.scaleService({ service });
-        break;
-      case ServiceActionItem.OPEN:
-        modalHandlers.openServiceUI({ service });
-        break;
-      case ServiceActionItem.RESTART:
-        modalHandlers.restartService({ service });
-        break;
-      case ServiceActionItem.RESUME:
-        modalHandlers.resumeService({ service });
-        break;
-      case ServiceActionItem.SUSPEND:
-        modalHandlers.suspendService({ service });
-        break;
-      case ServiceActionItem.DELETE:
-        modalHandlers.deleteService({ service });
-        break;
-    }
   }
 
   getServiceLink(service) {
@@ -183,12 +216,14 @@ class ServicesTable extends React.Component {
     const isSingleInstanceApp = service.getLabels()
       .MARATHON_SINGLE_INSTANCE_APP;
     const instancesCount = service.getInstancesCount();
-    const scaleText = isGroup ? "Scale By" : "Scale";
+    const scaleText = isGroup
+      ? ServiceActionLabels.scale_by
+      : ServiceActionLabels[SCALE];
 
     const dropdownItems = [
       {
         className: "hidden",
-        id: ServiceActionItem.MORE,
+        id: MORE,
         html: "",
         selectedHtml: <Icon id="ellipsis-vertical" size="mini" />
       },
@@ -196,7 +231,7 @@ class ServicesTable extends React.Component {
         className: classNames({
           hidden: !this.hasWebUI(service)
         }),
-        id: ServiceActionItem.OPEN,
+        id: OPEN,
         html: this.props.intl.formatMessage({
           id: "SERVICE_ACTIONS.OPEN_SERVICE"
         })
@@ -205,35 +240,35 @@ class ServicesTable extends React.Component {
         className: classNames({
           hidden: (isGroup && instancesCount === 0) || isSingleInstanceApp
         }),
-        id: ServiceActionItem.SCALE,
+        id: SCALE,
         html: scaleText
       },
       {
         className: classNames({
           hidden: isPod || isGroup || instancesCount === 0
         }),
-        id: ServiceActionItem.RESTART,
-        html: "Restart"
+        id: RESTART,
+        html: ServiceActionLabels[RESTART]
       },
       {
         className: classNames({
           hidden: instancesCount === 0
         }),
-        id: ServiceActionItem.SUSPEND,
-        html: "Suspend"
+        id: SUSPEND,
+        html: ServiceActionLabels[SUSPEND]
       },
       {
         className: classNames({
           hidden: isGroup || instancesCount > 0
         }),
-        id: ServiceActionItem.RESUME,
-        html: "Resume"
+        id: RESUME,
+        html: ServiceActionLabels[RESUME]
       },
       {
-        id: ServiceActionItem.DELETE,
+        id: DELETE,
         html: (
           <span className="text-danger">
-            {StringUtil.capitalize(UserActions.DELETE)}
+            {ServiceActionLabels[DELETE]}
           </span>
         )
       }
@@ -249,7 +284,7 @@ class ServicesTable extends React.Component {
           dropdownMenuListItemClassName="clickable"
           wrapperClassName="dropdown flush-bottom table-cell-icon"
           items={dropdownItems}
-          persistentID={ServiceActionItem.MORE}
+          persistentID={MORE}
           onItemSelection={this.onActionsItemSelection.bind(this, service)}
           scrollContainer=".gm-scroll-view"
           scrollContainerParentSelector=".gm-prevented"
@@ -400,17 +435,27 @@ class ServicesTable extends React.Component {
   }
 
   render() {
+    const { actionDisabledService, actionDisabledID } = this.state;
+
     return (
-      <Table
-        buildRowOptions={this.getRowAttributes}
-        className="table service-table table-borderless-outer table-borderless-inner-columns flush-bottom"
-        columns={this.getColumns()}
-        colGroup={this.getColGroup()}
-        data={this.props.services.slice()}
-        itemHeight={TableUtil.getRowHeight()}
-        containerSelector=".gm-scroll-view"
-        sortBy={{ prop: "name", order: "asc" }}
-      />
+      <div>
+        <Table
+          buildRowOptions={this.getRowAttributes}
+          className="table service-table table-borderless-outer table-borderless-inner-columns flush-bottom"
+          columns={this.getColumns()}
+          colGroup={this.getColGroup()}
+          data={this.props.services.slice()}
+          itemHeight={TableUtil.getRowHeight()}
+          containerSelector=".gm-scroll-view"
+          sortBy={{ prop: "name", order: "asc" }}
+        />
+        <ServiceActionDisabledModal
+          actionID={actionDisabledID}
+          open={actionDisabledService != null}
+          onClose={this.handleActionDisabledModalClose}
+          service={actionDisabledService}
+        />
+      </div>
     );
   }
 }

--- a/plugins/services/src/js/containers/services/__tests__/ServicesTable-test.js
+++ b/plugins/services/src/js/containers/services/__tests__/ServicesTable-test.js
@@ -1,6 +1,8 @@
 jest.dontMock("#SRC/js/components/CollapsingString");
 jest.dontMock("../../../constants/HealthStatus");
 jest.dontMock("../ServicesTable");
+// Explicitly mock for react-intl
+jest.mock("../../../components/modals/ServiceActionDisabledModal");
 
 /* eslint-disable no-unused-vars */
 const React = require("react");

--- a/src/js/translations/en-US.json
+++ b/src/js/translations/en-US.json
@@ -17,7 +17,13 @@
   "DOCS.MORE_INFORMATION": "More information",
   "DOCS.DOCUMENTATION": "documentation",
 
-  "SERVICE_ACTIONS.OPEN_SERVICE": "Open Service",
+  "SERVICE_ACTIONS.DELETE": "Delete",
+  "SERVICE_ACTIONS.RESTART": "Restart",
+  "SERVICE_ACTIONS.RESUME": "Resume",
+  "SERVICE_ACTIONS.OPEN": "Open Service",
+  "SERVICE_ACTIONS.SCALE": "Scale",
+  "SERVICE_ACTIONS.SCALE_BY": "Scale By",
+  "SERVICE_ACTIONS.SUSPEND": "Suspend",
 
   "SERVICE_ACTIONS.SDK_SERVICE_RESTART": "Restart your service from the DC/OS CLI.",
   "SERVICE_ACTIONS.SDK_SERVICE_SUSPEND": "Suspend your service by scaling to 0 instances from the DC/OS CLI using an `options.json` file.",

--- a/src/js/translations/en-US.json
+++ b/src/js/translations/en-US.json
@@ -1,4 +1,10 @@
 {
+
+  "CLIPBOARD.COPY": "Copy",
+  "CLIPBOARD.COPIED": "Copied",
+
+  "BUTTON.CLOSE": "Close",
+
   "DASHBOARD.VIEW_ALL": "View all {servicesCount} Services",
   "DASHBOARD.PANEL_HEADING.CPU": "CPU Allocation",
   "DASHBOARD.PANEL_HEADING.MEMORY": "Memory Allocation",
@@ -8,5 +14,18 @@
   "DASHBOARD.PANEL_HEADING.COMPONENT_HEALTH": "Component Health",
   "DASHBOARD.PANEL_HEADING.NODES": "Nodes",
 
-  "SERVICE_ACTIONS.OPEN_SERVICE": "Open Service"
+  "DOCS.MORE_INFORMATION": "More information",
+  "DOCS.DOCUMENTATION": "documentation",
+
+  "SERVICE_ACTIONS.OPEN_SERVICE": "Open Service",
+
+  "SERVICE_ACTIONS.SDK_SERVICE_RESTART": "Restart your service from the DC/OS CLI.",
+  "SERVICE_ACTIONS.SDK_SERVICE_SUSPEND": "Suspend your service by scaling to 0 instances from the DC/OS CLI using an `options.json` file.",
+  "SERVICE_ACTIONS.SDK_SERVICE_RESUME": "Resume your service by scaling to 1 or more instances from the DC/OS CLI using an `options.json` file.",
+  "SERVICE_ACTIONS.SDK_SERVICE_SCALE": "Update the number of instances in your service's target configuration using an `options.json` file.",
+  "SERVICE_ACTIONS.SDK_SERVICE_SCALE_NOTE": "Scaling to fewer instances is not supported.",
+  "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_1": "You must delete",
+  "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_2": "via the DC/OS CLI. Copy and paste this command into the CLI. See the",
+  "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_3": "To clean up resources reserved by your service, run the",
+  "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_4": "framework cleaner script"
 }

--- a/tests/_fixtures/marathon-1-task/groups-sdk-services.json
+++ b/tests/_fixtures/marathon-1-task/groups-sdk-services.json
@@ -1,0 +1,62 @@
+{
+  "apps": [
+    {
+      "id": "/sleep",
+      "cmd": "sleep 3000",
+      "args": null,
+      "user": null,
+      "env": {
+        
+      },
+      "instances": 1,
+      "cpus": 0.1,
+      "mem": 16,
+      "disk": 0,
+      "executor": "",
+      "constraints": [
+        
+      ],
+      "uris": [
+        
+      ],
+      "storeUrls": [
+        
+      ],
+      "ports": [
+        10000
+      ],
+      "requirePorts": false,
+      "backoffSeconds": 1,
+      "backoffFactor": 1.15,
+      "maxLaunchDelaySeconds": 3600,
+      "container": null,
+      "healthChecks": [
+        
+      ],
+      "dependencies": [
+        
+      ],
+      "upgradeStrategy": {
+        "minimumHealthCapacity": 1,
+        "maximumOverCapacity": 1
+      },
+      "labels": {
+        "DCOS_COMMONS_API_VERSION": "v1",
+        "DCOS_PACKAGE_NAME": "test"
+      },
+      "acceptedResourceRoles": null,
+      "version": "2015-08-28T01:26:14.620Z",
+      "tasksStaged": 0,
+      "tasksRunning": 1,
+      "tasksHealthy": 0,
+      "tasksUnhealthy": 0,
+      "deployments": [
+        
+      ]
+    }
+  ],
+  "groups": [
+    
+  ],
+  "id": "/"
+}

--- a/tests/_fixtures/marathon-1-task/groups-suspended-sdk-services.json
+++ b/tests/_fixtures/marathon-1-task/groups-suspended-sdk-services.json
@@ -1,0 +1,62 @@
+{
+  "apps": [
+    {
+      "id": "/sleep",
+      "cmd": "sleep 3000",
+      "args": null,
+      "user": null,
+      "env": {
+        
+      },
+      "instances": 0,
+      "cpus": 0.1,
+      "mem": 16,
+      "disk": 0,
+      "executor": "",
+      "constraints": [
+        
+      ],
+      "uris": [
+        
+      ],
+      "storeUrls": [
+        
+      ],
+      "ports": [
+        10000
+      ],
+      "requirePorts": false,
+      "backoffSeconds": 1,
+      "backoffFactor": 1.15,
+      "maxLaunchDelaySeconds": 3600,
+      "container": null,
+      "healthChecks": [
+        
+      ],
+      "dependencies": [
+        
+      ],
+      "upgradeStrategy": {
+        "minimumHealthCapacity": 1,
+        "maximumOverCapacity": 1
+      },
+      "labels": {
+        "DCOS_COMMONS_API_VERSION": "v1",
+        "DCOS_PACKAGE_NAME": "test"
+      },
+      "acceptedResourceRoles": null,
+      "version": "2015-08-28T01:26:14.620Z",
+      "tasksStaged": 0,
+      "tasksRunning": 1,
+      "tasksHealthy": 0,
+      "tasksUnhealthy": 0,
+      "deployments": [
+        
+      ]
+    }
+  ],
+  "groups": [
+    
+  ],
+  "id": "/"
+}

--- a/tests/_fixtures/marathon-1-task/sdk-service-suspended.json
+++ b/tests/_fixtures/marathon-1-task/sdk-service-suspended.json
@@ -1,0 +1,58 @@
+{
+  "apps": [
+    {
+      "id": "/sleep",
+      "cmd": "sleep 3000",
+      "args": null,
+      "user": null,
+      "env": {
+
+      },
+      "instances": 0,
+      "cpus": 0.1,
+      "mem": 16,
+      "disk": 0,
+      "executor": "",
+      "constraints": [
+
+      ],
+      "uris": [
+
+      ],
+      "storeUrls": [
+
+      ],
+      "ports": [
+        10000
+      ],
+      "requirePorts": false,
+      "backoffSeconds": 1,
+      "backoffFactor": 1.15,
+      "maxLaunchDelaySeconds": 3600,
+      "container": null,
+      "healthChecks": [
+
+      ],
+      "dependencies": [
+
+      ],
+      "upgradeStrategy": {
+        "minimumHealthCapacity": 1,
+        "maximumOverCapacity": 1
+      },
+      "labels": {
+        "DCOS_COMMONS_API_VERSION": "v1",
+        "DCOS_PACKAGE_NAME": "test"
+      },
+      "acceptedResourceRoles": null,
+      "version": "2015-08-28T01:26:14.620Z",
+      "tasksStaged": 0,
+      "tasksRunning": 1,
+      "tasksHealthy": 0,
+      "tasksUnhealthy": 0,
+      "deployments": [
+
+      ]
+    }
+  ]
+}

--- a/tests/_fixtures/marathon-1-task/sdk-service.json
+++ b/tests/_fixtures/marathon-1-task/sdk-service.json
@@ -1,0 +1,58 @@
+{
+  "apps": [
+    {
+      "id": "/sleep",
+      "cmd": "sleep 3000",
+      "args": null,
+      "user": null,
+      "env": {
+
+      },
+      "instances": 1,
+      "cpus": 0.1,
+      "mem": 16,
+      "disk": 0,
+      "executor": "",
+      "constraints": [
+
+      ],
+      "uris": [
+
+      ],
+      "storeUrls": [
+
+      ],
+      "ports": [
+        10000
+      ],
+      "requirePorts": false,
+      "backoffSeconds": 1,
+      "backoffFactor": 1.15,
+      "maxLaunchDelaySeconds": 3600,
+      "container": null,
+      "healthChecks": [
+
+      ],
+      "dependencies": [
+
+      ],
+      "upgradeStrategy": {
+        "minimumHealthCapacity": 1,
+        "maximumOverCapacity": 1
+      },
+      "labels": {
+        "DCOS_COMMONS_API_VERSION": "v1",
+        "DCOS_PACKAGE_NAME": "test"
+      },
+      "acceptedResourceRoles": null,
+      "version": "2015-08-28T01:26:14.620Z",
+      "tasksStaged": 0,
+      "tasksRunning": 1,
+      "tasksHealthy": 0,
+      "tasksUnhealthy": 0,
+      "deployments": [
+
+      ]
+    }
+  ]
+}

--- a/tests/_support/index.js
+++ b/tests/_support/index.js
@@ -169,6 +169,43 @@ Cypress.addParentCommand("configureCluster", function(configuration) {
       .route(/state/, "fx:marathon-1-task/state");
   }
 
+  if (configuration.mesos === "1-sdk-service") {
+    router
+      .route(/service\/marathon\/v2\/apps/, "fx:marathon-1-task/sdk-service")
+      .route(
+        /service\/marathon\/v2\/groups/,
+        "fx:marathon-1-task/groups-sdk-services"
+      )
+      .route(
+        /service\/marathon\/v2\/deployments/,
+        "fx:marathon-1-task/deployments"
+      )
+      .route(/history\/minute/, "fx:marathon-1-task/history-minute")
+      .route(/history\/last/, "fx:marathon-1-task/summary")
+      .route(/state-summary/, "fx:marathon-1-task/summary")
+      .route(/state/, "fx:marathon-1-task/state");
+  }
+
+  if (configuration.mesos === "1-suspended-sdk-service") {
+    router
+      .route(
+        /service\/marathon\/v2\/apps/,
+        "fx:marathon-1-task/sdk-service-suspended"
+      )
+      .route(
+        /service\/marathon\/v2\/groups/,
+        "fx:marathon-1-task/groups-suspended-sdk-services"
+      )
+      .route(
+        /service\/marathon\/v2\/deployments/,
+        "fx:marathon-1-task/deployments"
+      )
+      .route(/history\/minute/, "fx:marathon-1-task/history-minute")
+      .route(/history\/last/, "fx:marathon-1-task/summary")
+      .route(/state-summary/, "fx:marathon-1-task/summary")
+      .route(/state/, "fx:marathon-1-task/state");
+  }
+
   if (configuration.mesos === "1-service-suspended-single-instance") {
     router
       .route(

--- a/tests/components/PageHeader.js
+++ b/tests/components/PageHeader.js
@@ -13,7 +13,7 @@ describe("Page Header Component", function() {
       cy.get(".breadcrumbs.breadcrumbs--is-truncated").should("not.exist");
     });
 
-    it.only("doesn't ellipsis breadcrumb items", function() {
+    it("doesn't ellipsis breadcrumb items", function() {
       cy.get(".breadcrumb").each(function($currentBreadcrumb) {
         expect(
           $currentBreadcrumb[0].classList.value.indexOf(

--- a/tests/components/PageHeader.js
+++ b/tests/components/PageHeader.js
@@ -13,7 +13,7 @@ describe("Page Header Component", function() {
       cy.get(".breadcrumbs.breadcrumbs--is-truncated").should("not.exist");
     });
 
-    it("doesn't ellipsis breadcrumb items", function() {
+    it.only("doesn't ellipsis breadcrumb items", function() {
       cy.get(".breadcrumb").each(function($currentBreadcrumb) {
         expect(
           $currentBreadcrumb[0].classList.value.indexOf(

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -6,83 +6,48 @@ describe("Service Actions", function() {
     cy.get(".dropdown-menu-items").contains(actionText).click();
   }
 
-  beforeEach(function() {
-    cy.configureCluster({
-      mesos: "1-for-each-health",
-      nodeHealth: true
-    });
-
-    cy.visitUrl({ url: "/services/detail/%2Fcassandra-healthy" });
-  });
-
   context("Open Service Action", function() {
-    context("Services Table", function() {
-      beforeEach(function() {
-        cy.visitUrl({ url: "/services/overview" });
+    beforeEach(function() {
+      cy.configureCluster({
+        mesos: "1-for-each-health",
+        nodeHealth: true
       });
 
-      it('displays the "Open Service" option for services that have a web UI', function() {
-        cy
-          .get(".table-cell-link-primary")
-          .contains("cassandra-healthy")
-          .closest("tr")
-          .find(".dropdown .button")
-          .click();
-
-        cy
-          .get(".dropdown-menu-items")
-          .contains("Open Service")
-          .should(function($menuItem) {
-            expect($menuItem.length).to.equal(1);
-          });
-      });
-
-      it('does not display the "Open Service" option for services that have a web UI', function() {
-        cy
-          .get(".table-cell-link-primary")
-          .contains("cassandra-unhealthy")
-          .closest("tr")
-          .find(".dropdown .button")
-          .click();
-
-        cy
-          .get(".dropdown-menu-items")
-          .contains("Open Service")
-          .should(function($menuItem) {
-            expect($menuItem.hasClass("hidden")).to.equal(true);
-          });
-      });
+      cy.visitUrl({ url: "/services/detail/%2Fcassandra-healthy" });
     });
 
-    context("Service Detail", function() {
-      it('displays the "Open Service" option for services that have a web UI', function() {
-        cy.visitUrl({ url: "/services/detail/%2Fcassandra-healthy" });
+    it('displays the "Open Service" option for services that have a web UI', function() {
+      cy.get(".page-header-actions .dropdown").click();
+      cy
+        .get(".dropdown-menu-items")
+        .contains("Open Service")
+        .should(function($menuItem) {
+          expect($menuItem.length).to.equal(1);
+        });
+    });
 
-        cy.get(".page-header-actions .dropdown").click();
-        cy
-          .get(".dropdown-menu-items")
-          .contains("Open Service")
-          .should(function($menuItem) {
-            expect($menuItem.length).to.equal(1);
-          });
-      });
+    it('does not display the "Open Service" option for services that have a web UI', function() {
+      cy.visitUrl({ url: "/services/detail/%2Fcassandra-unhealthy" });
 
-      it('does not display the "Open Service" option for services that have a web UI', function() {
-        cy.visitUrl({ url: "/services/detail/%2Fcassandra-unhealthy" });
-
-        cy.get(".page-header-actions .dropdown").click();
-        cy
-          .get(".dropdown-menu-items")
-          .contains("Open Service")
-          .should(function($menuItem) {
-            expect($menuItem.length).to.equal(0);
-          });
-      });
+      cy.get(".page-header-actions .dropdown").click();
+      cy
+        .get(".dropdown-menu-items")
+        .contains("Open Service")
+        .should(function($menuItem) {
+          expect($menuItem.length).to.equal(0);
+        });
     });
   });
 
   context("Edit Action", function() {
     beforeEach(function() {
+      cy.configureCluster({
+        mesos: "1-for-each-health",
+        nodeHealth: true
+      });
+
+      cy.visitUrl({ url: "/services/detail/%2Fcassandra-healthy" });
+
       clickHeaderAction("Edit");
     });
 
@@ -238,6 +203,12 @@ describe("Service Actions", function() {
 
   context("Scale Action", function() {
     beforeEach(function() {
+      cy.configureCluster({
+        mesos: "1-for-each-health",
+        nodeHealth: true
+      });
+
+      cy.visitUrl({ url: "/services/detail/%2Fcassandra-healthy" });
       clickHeaderAction("Scale");
     });
 
@@ -326,6 +297,12 @@ describe("Service Actions", function() {
 
   context("Suspend Action", function() {
     beforeEach(function() {
+      cy.configureCluster({
+        mesos: "1-for-each-health",
+        nodeHealth: true
+      });
+
+      cy.visitUrl({ url: "/services/detail/%2Fcassandra-healthy" });
       clickHeaderAction("Suspend");
     });
 
@@ -409,187 +386,6 @@ describe("Service Actions", function() {
         .contains("Cancel")
         .click();
       cy.get(".confirm-modal").should("to.have.length", 0);
-    });
-  });
-
-  context("Resume Action", function() {
-    function openDropdown() {
-      cy.get(".service-table-column-actions .dropdown .button").eq(0).click();
-    }
-
-    function clickResume() {
-      cy.get(".dropdown-menu-items li").contains("Resume").click();
-    }
-
-    function configureClusterWithSuspendedServiceAndVisitServices() {
-      cy.configureCluster({
-        mesos: "1-service-suspended",
-        nodeHealth: true
-      });
-
-      cy.visitUrl({ url: "/services/overview" });
-    }
-
-    it("hides the suspend option in the service action dropdown", function() {
-      configureClusterWithSuspendedServiceAndVisitServices();
-      openDropdown();
-
-      cy
-        .get(".dropdown-menu-items li")
-        .contains("Suspend")
-        .should("have.class", "hidden");
-    });
-
-    it("shows the resume option in the service action dropdown", function() {
-      configureClusterWithSuspendedServiceAndVisitServices();
-      openDropdown();
-
-      cy
-        .get(".dropdown-menu-items li")
-        .contains("Resume")
-        .should("not.have.class", "hidden");
-    });
-
-    it("opens the resume dialog", function() {
-      configureClusterWithSuspendedServiceAndVisitServices();
-      openDropdown();
-      clickResume();
-
-      cy
-        .get(".modal-header")
-        .contains("Resume Service")
-        .should("have.length", 1);
-    });
-
-    it("opens the resume dialog with the instances textbox if the single app instance label does not exist", function() {
-      configureClusterWithSuspendedServiceAndVisitServices();
-      openDropdown();
-      clickResume();
-
-      cy.get('input[name="instances"]').should("have.length", 1);
-    });
-
-    it("opens the resume dialog without the instances textbox if the single app instance label exists", function() {
-      cy.configureCluster({
-        mesos: "1-service-suspended-single-instance",
-        nodeHealth: true
-      });
-
-      cy.visitUrl({ url: "/services/overview" });
-
-      openDropdown();
-      clickResume();
-
-      cy.get('input[name="instances"]').should("have.length", 0);
-    });
-
-    it("disables button during API request", function() {
-      configureClusterWithSuspendedServiceAndVisitServices();
-
-      cy.route({
-        method: "PUT",
-        url: /marathon\/v2\/apps\/\/sleep/,
-        response: []
-      });
-
-      openDropdown();
-      clickResume();
-
-      cy
-        .get(".modal-footer .button-collection .button-primary")
-        .click()
-        .should("have.class", "disabled");
-    });
-
-    it("closes dialog on successful API request", function() {
-      configureClusterWithSuspendedServiceAndVisitServices();
-
-      cy.route({
-        method: "PUT",
-        url: /marathon\/v2\/apps\/\/sleep/,
-        response: []
-      });
-
-      openDropdown();
-      clickResume();
-
-      cy.get(".modal-footer .button-collection .button-primary").click();
-      cy.get(".modal-body").should("to.have.length", 0);
-    });
-
-    it("shows error message on conflict", function() {
-      configureClusterWithSuspendedServiceAndVisitServices();
-
-      cy.route({
-        method: "PUT",
-        status: 409,
-        url: /marathon\/v2\/apps\/\/sleep/,
-        response: {
-          message: "App is locked by one or more deployments."
-        }
-      });
-
-      openDropdown();
-      clickResume();
-
-      cy.get(".modal-footer .button-collection .button-primary").click();
-      cy
-        .get(".modal-body .text-danger")
-        .should("to.have.text", "App is locked by one or more deployments.");
-    });
-
-    it("shows error message on not authorized", function() {
-      configureClusterWithSuspendedServiceAndVisitServices();
-
-      cy.route({
-        method: "PUT",
-        status: 403,
-        url: /marathon\/v2\/apps\/\/sleep/,
-        response: {
-          message: "Not Authorized to perform this action!"
-        }
-      });
-
-      openDropdown();
-      clickResume();
-
-      cy.get(".modal-footer .button-collection .button-primary").click();
-      cy
-        .get(".modal-body .text-danger")
-        .should("to.have.text", "Not Authorized to perform this action!");
-    });
-
-    it("reenables button after faulty request", function() {
-      configureClusterWithSuspendedServiceAndVisitServices();
-
-      cy.route({
-        method: "PUT",
-        url: /marathon\/v2\/apps\/\/sleep/,
-        response: [],
-        delay: SERVER_RESPONSE_DELAY
-      });
-
-      openDropdown();
-      clickResume();
-
-      cy
-        .get(".modal-footer .button-collection .button-primary")
-        .as("primaryButton")
-        .click();
-      cy.get("@primaryButton").should("have.class", "disabled");
-      cy.get("@primaryButton").should("not.have.class", "disabled");
-    });
-
-    it("closes dialog on secondary button click", function() {
-      configureClusterWithSuspendedServiceAndVisitServices();
-      openDropdown();
-      clickResume();
-
-      cy
-        .get(".modal-footer .button-collection .button")
-        .contains("Cancel")
-        .click();
-      cy.get(".modal-body").should("to.have.length", 0);
     });
   });
 });

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -388,4 +388,148 @@ describe("Service Actions", function() {
       cy.get(".confirm-modal").should("to.have.length", 0);
     });
   });
+
+  context("Resume Action", function() {
+    beforeEach(function() {
+      cy.configureCluster({
+        mesos: "1-service-suspended",
+        nodeHealth: true
+      });
+
+      cy.visitUrl({ url: "/services/detail/%2Fsleep" });
+    });
+
+    it("hides the suspend option in the service action dropdown", function() {
+      cy.get(".page-header-actions .dropdown").click();
+
+      cy.get(".dropdown-menu-items li").should("not.contain", "Suspend");
+    });
+
+    it("shows the resume option in the service action dropdown", function() {
+      cy.get(".page-header-actions .dropdown").click();
+
+      cy
+        .get(".dropdown-menu-items li")
+        .contains("Resume")
+        .should("not.have.class", "hidden");
+    });
+
+    it("opens the resume dialog", function() {
+      clickHeaderAction("Resume");
+
+      cy
+        .get(".modal-header")
+        .contains("Resume Service")
+        .should("have.length", 1);
+    });
+
+    it("opens the resume dialog with the instances textbox if the single app instance label does not exist", function() {
+      clickHeaderAction("Resume");
+
+      cy.get('input[name="instances"]').should("have.length", 1);
+    });
+
+    it("opens the resume dialog without the instances textbox if the single app instance label exists", function() {
+      cy.configureCluster({
+        mesos: "1-service-suspended-single-instance",
+        nodeHealth: true
+      });
+
+      clickHeaderAction("Resume");
+
+      cy.get('input[name="instances"]').should("have.length", 0);
+    });
+
+    it("disables button during API request", function() {
+      cy.route({
+        method: "PUT",
+        url: /marathon\/v2\/apps\/\/sleep/,
+        response: []
+      });
+
+      clickHeaderAction("Resume");
+
+      cy
+        .get(".modal-footer .button-collection .button-primary")
+        .click()
+        .should("have.class", "disabled");
+    });
+
+    it("closes dialog on successful API request", function() {
+      cy.route({
+        method: "PUT",
+        url: /marathon\/v2\/apps\/\/sleep/,
+        response: []
+      });
+
+      clickHeaderAction("Resume");
+
+      cy.get(".modal-footer .button-collection .button-primary").click();
+      cy.get(".modal-body").should("to.have.length", 0);
+    });
+
+    it("shows error message on conflict", function() {
+      cy.route({
+        method: "PUT",
+        status: 409,
+        url: /marathon\/v2\/apps\/\/sleep/,
+        response: {
+          message: "App is locked by one or more deployments."
+        }
+      });
+
+      clickHeaderAction("Resume");
+
+      cy.get(".modal-footer .button-collection .button-primary").click();
+      cy
+        .get(".modal-body .text-danger")
+        .should("to.have.text", "App is locked by one or more deployments.");
+    });
+
+    it("shows error message on not authorized", function() {
+      cy.route({
+        method: "PUT",
+        status: 403,
+        url: /marathon\/v2\/apps\/\/sleep/,
+        response: {
+          message: "Not Authorized to perform this action!"
+        }
+      });
+
+      clickHeaderAction("Resume");
+
+      cy.get(".modal-footer .button-collection .button-primary").click();
+      cy
+        .get(".modal-body .text-danger")
+        .should("to.have.text", "Not Authorized to perform this action!");
+    });
+
+    it("reenables button after faulty request", function() {
+      cy.route({
+        method: "PUT",
+        url: /marathon\/v2\/apps\/\/sleep/,
+        response: [],
+        delay: SERVER_RESPONSE_DELAY
+      });
+
+      clickHeaderAction("Resume");
+
+      cy
+        .get(".modal-footer .button-collection .button-primary")
+        .as("primaryButton")
+        .click();
+      cy.get("@primaryButton").should("have.class", "disabled");
+      cy.get("@primaryButton").should("not.have.class", "disabled");
+    });
+
+    it("closes dialog on secondary button click", function() {
+      clickHeaderAction("Resume");
+
+      cy
+        .get(".modal-footer .button-collection .button")
+        .contains("Cancel")
+        .click();
+      cy.get(".modal-body").should("to.have.length", 0);
+    });
+  });
 });

--- a/tests/pages/services/ServiceTable-cy.js
+++ b/tests/pages/services/ServiceTable-cy.js
@@ -492,4 +492,107 @@ describe("Service Table", function() {
       cy.get(".modal-body").should("to.have.length", 0);
     });
   });
+
+  context("SDK Services", function() {
+    beforeEach(function() {
+      cy.configureCluster({
+        mesos: "1-sdk-service",
+        nodeHealth: true
+      });
+
+      cy.visitUrl({ url: "/services/overview" });
+    });
+
+    it("opens the destroy dialog", function() {
+      openDropdown("sleep");
+      clickDropdownAction("Delete");
+
+      cy
+        .get(".confirm-modal p span")
+        .contains("/sleep")
+        .should("to.have.length", 1);
+
+      cy
+        .get(".modal pre")
+        .contains("dcos package uninstall test --app-id=/sleep");
+
+      cy.get(".modal button").contains("Close").click();
+
+      cy.get(".modal").should("not.exist");
+    });
+
+    it("opens the scale dialog", function() {
+      openDropdown("sleep");
+      clickDropdownAction("Scale");
+
+      cy
+        .get(".modal-header")
+        .contains("Scale Service")
+        .should("to.have.length", 1);
+
+      cy
+        .get(".modal pre")
+        .contains("dcos test --name=/sleep update --options=<my-options>.json");
+
+      cy.get(".modal button").contains("Close").click();
+
+      cy.get(".modal").should("not.exist");
+    });
+
+    it("opens the suspend dialog", function() {
+      openDropdown("sleep");
+      clickDropdownAction("Suspend");
+
+      cy
+        .get(".modal-header")
+        .contains("Suspend Service")
+        .should("to.have.length", 1);
+
+      cy
+        .get(".modal pre")
+        .contains("dcos test --name=/sleep update --options=<my-options>.json");
+
+      cy.get(".modal button").contains("Close").click();
+
+      cy.get(".modal").should("not.exist");
+    });
+
+    it("opens the resume dialog", function() {
+      cy.configureCluster({
+        mesos: "1-suspended-sdk-service",
+        nodeHealth: true
+      });
+
+      openDropdown("sleep");
+      clickDropdownAction("Resume");
+
+      cy
+        .get(".modal-header")
+        .contains("Resume Service")
+        .should("have.length", 1);
+
+      cy
+        .get(".modal pre")
+        .contains("dcos test --name=/sleep update --options=<my-options>.json");
+
+      cy.get(".modal button").contains("Close").click();
+
+      cy.get(".modal").should("not.exist");
+    });
+
+    it("opens the restart dialog", function() {
+      openDropdown("sleep");
+      clickDropdownAction("Restart");
+
+      cy
+        .get(".modal-header")
+        .contains("Restart Service")
+        .should("have.length", 1);
+
+      cy.get(".modal pre").contains("dcos marathon app restart /sleep");
+      cy.get(".modal button").contains("Close").click();
+
+      cy.get(".modal").should("not.exist");
+    });
+  });
 });

--- a/tests/pages/services/ServiceTable-cy.js
+++ b/tests/pages/services/ServiceTable-cy.js
@@ -1,0 +1,207 @@
+import { SERVER_RESPONSE_DELAY } from "../../_support/constants/Timeouts";
+
+describe("Service Table", function() {
+  function openDropdown(serviceName) {
+    cy
+      .get(".service-table")
+      .contains(serviceName)
+      .closest("tr")
+      .find(".dropdown")
+      .click();
+  }
+
+  function clickDropdownAction(actionText) {
+    cy.get(".dropdown-menu-items").contains(actionText).click();
+  }
+
+  context("Open Service Action", function() {
+    beforeEach(function() {
+      cy.configureCluster({
+        mesos: "1-for-each-health",
+        nodeHealth: true
+      });
+
+      cy.visitUrl({ url: "/services/overview" });
+    });
+
+    it('displays the "Open Service" option for services that have a web UI', function() {
+      openDropdown("cassandra-healthy");
+
+      cy
+        .get(".dropdown-menu-items")
+        .contains("Open Service")
+        .should(function($menuItem) {
+          expect($menuItem.length).to.equal(1);
+        });
+    });
+
+    it('does not display the "Open Service" option for services that have a web UI', function() {
+      openDropdown("cassandra-unhealthy");
+
+      cy
+        .get(".dropdown-menu-items")
+        .contains("Open Service")
+        .should(function($menuItem) {
+          expect($menuItem.hasClass("hidden")).to.equal(true);
+        });
+    });
+  });
+
+  context("Resume Action", function() {
+    beforeEach(function() {
+      cy.configureCluster({
+        mesos: "1-service-suspended",
+        nodeHealth: true
+      });
+
+      cy.visitUrl({ url: "/services/overview" });
+    });
+
+    it("hides the suspend option in the service action dropdown", function() {
+      openDropdown("sleep");
+
+      cy
+        .get(".dropdown-menu-items li")
+        .contains("Suspend")
+        .should("have.class", "hidden");
+    });
+
+    it("shows the resume option in the service action dropdown", function() {
+      openDropdown("sleep");
+
+      cy
+        .get(".dropdown-menu-items li")
+        .contains("Resume")
+        .should("not.have.class", "hidden");
+    });
+
+    it("opens the resume dialog", function() {
+      openDropdown("sleep");
+      clickDropdownAction("Resume");
+
+      cy
+        .get(".modal-header")
+        .contains("Resume Service")
+        .should("have.length", 1);
+    });
+
+    it("opens the resume dialog with the instances textbox if the single app instance label does not exist", function() {
+      openDropdown("sleep");
+      clickDropdownAction("Resume");
+
+      cy.get('input[name="instances"]').should("have.length", 1);
+    });
+
+    it("opens the resume dialog without the instances textbox if the single app instance label exists", function() {
+      cy.configureCluster({
+        mesos: "1-service-suspended-single-instance",
+        nodeHealth: true
+      });
+
+      cy.visitUrl({ url: "/services/overview" });
+
+      openDropdown("sleep");
+      clickDropdownAction("Resume");
+
+      cy.get('input[name="instances"]').should("have.length", 0);
+    });
+
+    it("disables button during API request", function() {
+      cy.route({
+        method: "PUT",
+        url: /marathon\/v2\/apps\/\/sleep/,
+        response: []
+      });
+
+      openDropdown("sleep");
+      clickDropdownAction("Resume");
+
+      cy
+        .get(".modal-footer .button-collection .button-primary")
+        .click()
+        .should("have.class", "disabled");
+    });
+
+    it("closes dialog on successful API request", function() {
+      cy.route({
+        method: "PUT",
+        url: /marathon\/v2\/apps\/\/sleep/,
+        response: []
+      });
+
+      openDropdown("sleep");
+      clickDropdownAction("Resume");
+
+      cy.get(".modal-footer .button-collection .button-primary").click();
+      cy.get(".modal-body").should("to.have.length", 0);
+    });
+
+    it("shows error message on conflict", function() {
+      cy.route({
+        method: "PUT",
+        status: 409,
+        url: /marathon\/v2\/apps\/\/sleep/,
+        response: {
+          message: "App is locked by one or more deployments."
+        }
+      });
+
+      openDropdown("sleep");
+      clickDropdownAction("Resume");
+
+      cy.get(".modal-footer .button-collection .button-primary").click();
+      cy
+        .get(".modal-body .text-danger")
+        .should("to.have.text", "App is locked by one or more deployments.");
+    });
+
+    it("shows error message on not authorized", function() {
+      cy.route({
+        method: "PUT",
+        status: 403,
+        url: /marathon\/v2\/apps\/\/sleep/,
+        response: {
+          message: "Not Authorized to perform this action!"
+        }
+      });
+
+      openDropdown("sleep");
+      clickDropdownAction("Resume");
+
+      cy.get(".modal-footer .button-collection .button-primary").click();
+      cy
+        .get(".modal-body .text-danger")
+        .should("to.have.text", "Not Authorized to perform this action!");
+    });
+
+    it("reenables button after faulty request", function() {
+      cy.route({
+        method: "PUT",
+        url: /marathon\/v2\/apps\/\/sleep/,
+        response: [],
+        delay: SERVER_RESPONSE_DELAY
+      });
+
+      openDropdown("sleep");
+      clickDropdownAction("Resume");
+
+      cy
+        .get(".modal-footer .button-collection .button-primary")
+        .as("primaryButton")
+        .click();
+      cy.get("@primaryButton").should("have.class", "disabled");
+      cy.get("@primaryButton").should("not.have.class", "disabled");
+    });
+
+    it("closes dialog on secondary button click", function() {
+      openDropdown("sleep");
+      clickDropdownAction("Resume");
+
+      cy
+        .get(".modal-footer .button-collection .button")
+        .contains("Cancel")
+        .click();
+      cy.get(".modal-body").should("to.have.length", 0);
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces new modals for SDK services and applies them only to the services in the service table.

1 of 2: https://github.com/dcos/dcos-ui/pull/2144
2 of 2: https://github.com/dcos/dcos-ui/pull/2160

Test this by adding this repository for packages and installing the Hello Wolrd package:
https://infinity-artifacts.s3.amazonaws.com/autodelete7d/hello-world/20170501-114415-H2EXdmN1BlhErgpw/stub-universe-hello-world.zip

This PR merges to a feature branch and is not concerned with:
- group actions
- service detail actions
- pod detail actions
- service configuration
These will come in later PRs

![](https://cl.ly/kDyf/Screen%20Recording%202017-04-28%20at%2010.22.gif)
(Preview doesn't seem to work 😢  Here is the link: https://cl.ly/kDyf/Screen%20Recording%202017-04-28%20at%2010.22.gif)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [x] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
P.S. Don't be scared by the huge amount of additions. I took the liberty and created test for the service table with the same action tests that we already have for service detail.