### PR TITLE
[System Tests]: Fix faulty system tests

### DIFF
--- a/system-tests/services/test-pods.js
+++ b/system-tests/services/test-pods.js
@@ -965,10 +965,9 @@ describe("Services", function() {
 
       cy.get(".menu-tabbed-item").contains("Volumes").click();
 
-      cy.get(".button").contains("Add Ephemeral Volume").click();
-
+      cy.get(".button").contains("Add Volume").click();
+      cy.root().getFormGroupInputFor("Volume Type").select("Ephemeral Volume");
       cy.root().getFormGroupInputFor("Name").type("test");
-
       cy.root().getFormGroupInputFor("Container Path").type("test");
 
       cy.get("#brace-editor").contents().asJson().should("deep.equal", [
@@ -1178,7 +1177,7 @@ describe("Services", function() {
               mode: "host"
             }
           ],
-          env: {
+          environment: {
             camelCase: "test",
             snake_case: "test",
             lowercase: "test",

--- a/system-tests/services/test-pods.js
+++ b/system-tests/services/test-pods.js
@@ -1081,9 +1081,16 @@ describe("Services", function() {
       cy.root().configurationSection("Storage").then(function($storageSection) {
         const $tableRow = $storageSection.find("tbody tr:visible");
         const $tableCells = $tableRow.find("td");
-        const cellValues = ["test", "FALSE", "test", "container-1", "Edit"];
+        const cellValues = [
+          "test",
+          "EPHEMERAL",
+          "FALSE",
+          "test",
+          "container-1",
+          "Edit"
+        ];
 
-        expect($tableCells.length).to.equal(5);
+        expect($tableCells.length).to.equal(6);
 
         $tableCells.each(function(index) {
           expect(this.textContent.trim()).to.equal(cellValues[index]);


### PR DESCRIPTION
This PR fixes the underlaying issues that causes the latest nightly buillds to fail.

- Fixes `Create a pod with environment variable` that was checking
  for an `env` property instead of `environment` in the definition
- Fixes `Create a pod with ephemeral volume` that was using the old
  layout to create an ephemeral volume

To test, use:
<pre>
docker pull mesosphere/dcos-ui && \
docker run -it --rm --ipc=host \
  -e CLUSTER_URL=<strong>$OPEN_CLUSTER_URL</strong>  \
  -v `pwd`:/dcos-ui \
  mesosphere/dcos-ui dcos-system-test-driver \
  ./system-tests/driver-config/dev.sh
</pre>