### PR TITLE
Update reactjs-components 0.16.0-beta.18 (Prettier)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6986,9 +6986,9 @@
       "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz"
     },
     "reactjs-components": {
-      "version": "0.16.0-beta.17",
-      "from": "reactjs-components@0.16.0-beta.17",
-      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.16.0-beta.17.tgz"
+      "version": "0.16.0-beta.18",
+      "from": "reactjs-components@0.16.0-beta.18",
+      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.16.0-beta.18.tgz"
     },
     "reactjs-mixin": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-intl": "2.2.3",
     "react-redux": "4.4.6",
     "react-router": "2.8.1",
-    "reactjs-components": "0.16.0-beta.17",
+    "reactjs-components": "0.16.0-beta.18",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
     "tv4": "1.2.7"


### PR DESCRIPTION
This PR updates reactjs-components to version 0.16.0-beta.18.

PRs in this release of reactjs-components:
https://github.com/mesosphere/reactjs-components/pull/402

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
