### PR TITLE
feat(DCOS-15395): Rename menu items

### DIFF
--- a/plugins/services/src/js/routes/services.js
+++ b/plugins/services/src/js/routes/services.js
@@ -63,7 +63,7 @@ const serviceRoutes = [
         path: "overview",
         // TODO: Remove this when moving to use NavigationService directly,
         // where we can register with sidebarActiveRegex option
-        sidebarActiveRegex: /(overview|detail)/,
+        sidebarActiveRegex: /(services\/overview|detail)/,
         isInSidebar: true,
         buildBreadCrumb() {
           return {

--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -27,7 +27,7 @@ const defaultMenuItems = [
   "/catalog",
   "/nodes",
   "/networking",
-  "/security",
+  "/secrets",
   "/overview",
   "/components",
   "/settings",

--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -28,7 +28,7 @@ const defaultMenuItems = [
   "/nodes",
   "/networking",
   "/security",
-  "/system-overview",
+  "/overview",
   "/components",
   "/settings",
   "/organization"

--- a/src/js/components/SidebarHeader.js
+++ b/src/js/components/SidebarHeader.js
@@ -109,11 +109,11 @@ class SidebarHeader extends mixin(StoreMixin) {
         onClick: this.handleItemSelect
       },
       {
-        html: "System Overview",
-        id: "system-overview",
+        html: "Overview",
+        id: "overview",
         onClick: () => {
           SidebarActions.close();
-          this.context.router.push("/system-overview");
+          this.context.router.push("/overview");
         }
       },
       {

--- a/src/js/pages/SystemOverviewPage.js
+++ b/src/js/pages/SystemOverviewPage.js
@@ -9,9 +9,9 @@ class SystemOverviewPage extends React.Component {
 }
 
 SystemOverviewPage.routeConfig = {
-  label: "System Overview",
+  label: "Overview",
   icon: <Icon id="cluster-inverse" size="small" family="product" />,
-  matches: /^\/system-overview/
+  matches: /^\/overview/
 };
 
 module.exports = SystemOverviewPage;

--- a/src/js/pages/system/OverviewDetailTab.js
+++ b/src/js/pages/system/OverviewDetailTab.js
@@ -34,7 +34,7 @@ const SystemOverviewBreadcrumbs = () => {
   const crumbs = [
     <Breadcrumb key={0} title="Cluster">
       <BreadcrumbTextContent>
-        <Link to="/system-overview">System Overview</Link>
+        <Link to="/overview">Overview</Link>
       </BreadcrumbTextContent>
     </Breadcrumb>
   ];
@@ -226,7 +226,7 @@ class OverviewDetailTab extends mixin(StoreMixin) {
 
 OverviewDetailTab.routeConfig = {
   label: "Overview",
-  matches: /^\/system-overview\/details/
+  matches: /^\/overview\/details/
 };
 
 module.exports = OverviewDetailTab;

--- a/src/js/routes/system-overview.js
+++ b/src/js/routes/system-overview.js
@@ -5,7 +5,7 @@ import OverviewDetailTab from "../pages/system/OverviewDetailTab";
 
 const systemOverviewRoutes = {
   type: Route,
-  path: "system-overview",
+  path: "overview",
   component: SystemOverviewPage,
   category: "system",
   isInSidebar: true,


### PR DESCRIPTION
⚠️  Should go together with https://github.com/mesosphere/dcos-ui-plugins-private/pull/586

(**DCOS-15395**) Rename `system-overview` menu to `overview` and rename `Security` to `Secrets`.

How to test it?
On the left sidebar navigation before you would see `system overview` with this PR you will see only `overview`. All links to `system overview` should go to `overview` now.

On the left sidebar navigation before you would see `security` and `secrets` below with this PR you will see only `secrets`. All links to `security` should go to `secrets` now.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
