### PR TITLE
[marathon 1.5] Make docker network transactions JSON paths agnostic

### DIFF
--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -473,7 +473,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
       .join(", ");
 
     const selections = (
-      <FieldSelect name="container.docker.network" value={network}>
+      <FieldSelect name="networks.0.mode" value={network}>
         <option disabled={Boolean(disabledMap[HOST])} value={HOST}>
           Host
         </option>
@@ -664,7 +664,7 @@ NetworkingFormSection.configReducers = {
   networkType(state, { type, path = [], value }) {
     const joinedPath = path.join(".");
 
-    if (type === SET && joinedPath === "container.docker.network") {
+    if (type === SET && joinedPath === "networks.0.mode") {
       return value;
     }
 

--- a/plugins/services/src/js/reducers/serviceForm/Docker.js
+++ b/plugins/services/src/js/reducers/serviceForm/Docker.js
@@ -47,7 +47,7 @@ module.exports = combineReducers({
       return null;
     }
 
-    if (type === SET && joinedPath === "container.docker.network") {
+    if (type === SET && joinedPath === "networks.0.mode") {
       return Networking.type[value.split(".")[0]];
     }
 
@@ -70,7 +70,7 @@ module.exports = combineReducers({
       this.containerType = value;
     }
 
-    if (joinedPath === "container.docker.network" && Boolean(value)) {
+    if (joinedPath === "networks.0.mode" && Boolean(value)) {
       this.appState.networkType = value.split(".")[0];
     }
 

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/IpAddress.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/IpAddress.js
@@ -23,7 +23,7 @@ module.exports = {
       this.internalState.labels = value;
     }
 
-    if (type === SET && joinedPath === "container.docker.network") {
+    if (type === SET && joinedPath === "networks.0.mode") {
       const networkName = value.split(".")[1];
       if (networkName != null) {
         return {

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/IpAddress-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/IpAddress-test.js
@@ -6,7 +6,7 @@ describe("IpAddress", function() {
   describe("#JSONReducer", function() {
     it("emits correct JSON", function() {
       const batch = new Batch([
-        new Transaction(["container", "docker", "network"], "USER.dcos")
+        new Transaction(["networks", 0, "mode"], "USER.dcos")
       ]);
 
       expect(batch.reduce(IpAddress.JSONReducer.bind({}), {})).toEqual({
@@ -20,7 +20,7 @@ describe("IpAddress", function() {
     it("should have the right discovery value", function() {
       const batch = new Batch([
         new Transaction(["ipAddress", "discovery"], "STS-133"),
-        new Transaction(["container", "docker", "network"], "USER.dcos")
+        new Transaction(["networks", 0, "mode"], "USER.dcos")
       ]);
 
       expect(batch.reduce(IpAddress.JSONReducer.bind({}), {})).toEqual({
@@ -34,7 +34,7 @@ describe("IpAddress", function() {
     it("should have the right groups value", function() {
       const batch = new Batch([
         new Transaction(["ipAddress", "groups"], "admins"),
-        new Transaction(["container", "docker", "network"], "USER.dcos")
+        new Transaction(["networks", 0, "mode"], "USER.dcos")
       ]);
 
       expect(batch.reduce(IpAddress.JSONReducer.bind({}), {})).toEqual({
@@ -48,7 +48,7 @@ describe("IpAddress", function() {
     it("should have the right labels value", function() {
       const batch = new Batch([
         new Transaction(["ipAddress", "labels"], "no:labels"),
-        new Transaction(["container", "docker", "network"], "USER.dcos")
+        new Transaction(["networks", 0, "mode"], "USER.dcos")
       ]);
 
       expect(batch.reduce(IpAddress.JSONReducer.bind({}), {})).toEqual({

--- a/plugins/services/src/js/reducers/serviceForm/Network.js
+++ b/plugins/services/src/js/reducers/serviceForm/Network.js
@@ -29,7 +29,7 @@ module.exports = {
     if (networkName != null && networkType != null) {
       transactions.push(
         new Transaction(
-          ["container", "docker", "network"],
+          ["networks", 0, "mode"],
           `${networkType}.${networkName}`
         )
       );
@@ -55,9 +55,7 @@ module.exports = {
         );
       }
     } else {
-      transactions.push(
-        new Transaction(["container", "docker", "network"], networkType)
-      );
+      transactions.push(new Transaction(["networks", 0, "mode"], networkType));
     }
 
     return transactions;

--- a/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
+++ b/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
@@ -35,7 +35,7 @@ module.exports = {
     }
 
     const joinedPath = path.join(".");
-    if (joinedPath === "container.docker.network" && Boolean(value)) {
+    if (joinedPath === "networks.0.mode" && Boolean(value)) {
       this.appState.networkType = value;
     }
 

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -337,9 +337,7 @@ describe("Container", function() {
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
         );
-        batch = batch.add(
-          new Transaction(["container", "docker", "network"], USER, SET)
-        );
+        batch = batch.add(new Transaction(["networks", 0, "mode"], USER, SET));
         batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
         batch = batch.add(
           new Transaction(["portDefinitions", 0, "portMapping"], true)
@@ -372,9 +370,7 @@ describe("Container", function() {
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
         );
-        batch = batch.add(
-          new Transaction(["container", "docker", "network"], USER, SET)
-        );
+        batch = batch.add(new Transaction(["networks", 0, "mode"], USER, SET));
         // This is default
         // batch = batch.add(
         //   new Transaction(['portDefinitions', 0, 'portMapping'], false)
@@ -415,7 +411,7 @@ describe("Container", function() {
           new Transaction(["container", "type"], "DOCKER", SET)
         );
         batch = batch.add(
-          new Transaction(["container", "docker", "network"], BRIDGE, SET)
+          new Transaction(["networks", 0, "mode"], BRIDGE, SET)
         );
         // This is default
         // batch = batch.add(
@@ -463,7 +459,7 @@ describe("Container", function() {
           new Transaction(["container", "type"], "DOCKER", SET)
         );
         batch = batch.add(
-          new Transaction(["container", "docker", "network"], BRIDGE, SET)
+          new Transaction(["networks", 0, "mode"], BRIDGE, SET)
         );
         batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
         batch = batch.add(
@@ -514,7 +510,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], HOST, SET)
+            new Transaction(["networks", 0, "mode"], HOST, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(
@@ -540,7 +536,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(new Transaction(["portDefinitions"], 1, ADD_ITEM));
@@ -587,7 +583,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(
@@ -625,7 +621,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(
@@ -666,7 +662,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(
@@ -708,7 +704,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(
@@ -749,7 +745,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(new Transaction(["portDefinitions"], 1, ADD_ITEM));
@@ -799,7 +795,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(new Transaction(["portDefinitions"], 1, ADD_ITEM));
@@ -852,7 +848,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
@@ -908,7 +904,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
@@ -977,7 +973,7 @@ describe("Container", function() {
           );
           batch = batch.add(new Transaction(["id"], "foo"));
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
 
           expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
@@ -1016,7 +1012,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "MESOS", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Network-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Network-test.js
@@ -17,7 +17,7 @@ describe("Network", function() {
         {
           type: SET,
           value: "USER.dcos",
-          path: ["container", "docker", "network"]
+          path: ["networks", 0, "mode"]
         }
       ]);
     });
@@ -31,7 +31,7 @@ describe("Network", function() {
         }
       };
       expect(Network.JSONParser(state)).toEqual([
-        { type: SET, value: "BRIDGE", path: ["container", "docker", "network"] }
+        { type: SET, value: "BRIDGE", path: ["networks", 0, "mode"] }
       ]);
     });
 
@@ -44,7 +44,7 @@ describe("Network", function() {
         }
       };
       expect(Network.JSONParser(state)).toEqual([
-        { type: SET, value: "HOST", path: ["container", "docker", "network"] }
+        { type: SET, value: "HOST", path: ["networks", 0, "mode"] }
       ]);
     });
 
@@ -70,7 +70,7 @@ describe("Network", function() {
         {
           type: SET,
           value: "USER.dcos",
-          path: ["container", "docker", "network"]
+          path: ["networks", 0, "mode"]
         },
         { type: SET, value: ["group1"], path: ["ipAddress", "groups"] },
         {

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
@@ -19,7 +19,7 @@ describe("PortDefinitions", function() {
 
     it("Should return null if networkType is not HOST", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["container.docker.network"], BRIDGE));
+      batch = batch.add(new Transaction(["networks", 0, "mode"], BRIDGE));
       batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual(
@@ -29,7 +29,7 @@ describe("PortDefinitions", function() {
 
     it("Should return null if networkType is not USER", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["container.docker.network"], USER));
+      batch = batch.add(new Transaction(["networks", 0, "mode"], USER));
       batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual(
@@ -48,9 +48,7 @@ describe("PortDefinitions", function() {
 
     it("should create default portDefinition configurations for BRIDGE network", function() {
       let batch = new Batch();
-      batch = batch.add(
-        new Transaction(["container", "docker", "network"], BRIDGE, SET)
-      );
+      batch = batch.add(new Transaction(["networks", 0, "mode"], BRIDGE, SET));
       batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual(
@@ -60,9 +58,7 @@ describe("PortDefinitions", function() {
 
     it("shouldn't create portDefinitions for USER", function() {
       let batch = new Batch();
-      batch = batch.add(
-        new Transaction(["container", "docker", "network"], USER, SET)
-      );
+      batch = batch.add(new Transaction(["networks", 0, "mode"], USER, SET));
       batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual(
@@ -221,9 +217,7 @@ describe("PortDefinitions", function() {
 
     it("should store portDefinitions even if network is USER when recorded", function() {
       let batch = new Batch();
-      batch = batch.add(
-        new Transaction(["container", "docker", "network"], USER, SET)
-      );
+      batch = batch.add(new Transaction(["networks", 0, "mode"], USER, SET));
       batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
       batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
       batch = batch.add(
@@ -233,9 +227,7 @@ describe("PortDefinitions", function() {
         new Transaction(["portDefinitions", 1, "loadBalanced"], true)
       );
       batch = batch.add(new Transaction(["id"], "foo"));
-      batch = batch.add(
-        new Transaction(["container", "docker", "network"], HOST, SET)
-      );
+      batch = batch.add(new Transaction(["networks", 0, "mode"], HOST, SET));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual([
         { name: null, port: 0, protocol: "tcp", labels: null },

--- a/tests/_fixtures/marathon-1-task-with-volumes/groups.json
+++ b/tests/_fixtures/marathon-1-task-with-volumes/groups.json
@@ -6,7 +6,7 @@
       "args": null,
       "user": null,
       "env": {
-
+        
       },
       "instances": 1,
       "cpus": 1,
@@ -15,16 +15,16 @@
       "gpus": 0,
       "executor": "",
       "constraints": [
-
+        
       ],
       "uris": [
-
+        
       ],
       "fetch": [
-
+        
       ],
       "storeUrls": [
-
+        
       ],
       "backoffSeconds": 1,
       "backoffFactor": 1.15,
@@ -59,20 +59,20 @@
         ]
       },
       "healthChecks": [
-
+        
       ],
       "readinessChecks": [
-
+        
       ],
       "dependencies": [
-
+        
       ],
       "upgradeStrategy": {
         "minimumHealthCapacity": 0.5,
         "maximumOverCapacity": 0
       },
       "labels": {
-
+        
       },
       "ipAddress": null,
       "version": "2017-02-10T17:02:51.890Z",
@@ -81,7 +81,7 @@
         "taskLostBehavior": "WAIT_FOREVER"
       },
       "secrets": {
-
+        
       },
       "taskKillGracePeriodSeconds": null,
       "unreachableStrategy": {
@@ -97,7 +97,7 @@
           "port": 10000,
           "protocol": "tcp",
           "labels": {
-
+            
           }
         }
       ],
@@ -111,7 +111,7 @@
       "tasksHealthy": 0,
       "tasksUnhealthy": 0,
       "deployments": [
-
+        
       ],
       "tasks": [
         {
@@ -195,7 +195,7 @@
     }
   ],
   "groups": [
-
+    
   ],
   "id": "/"
 }

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -839,9 +839,7 @@ describe("Service Form Modal", function() {
           setRuntime("Docker Engine");
           clickNetworkingTab();
 
-          cy
-            .get('select[name="container.docker.network"]')
-            .as("containerDockerNetwork");
+          cy.get('select[name="networks.0.mode"]').as("containerDockerNetwork");
 
           // HOST
           cy
@@ -876,9 +874,7 @@ describe("Service Form Modal", function() {
           setRuntime("Mesos Runtime");
           clickNetworkingTab();
 
-          cy
-            .get('select[name="container.docker.network"]')
-            .as("containerDockerNetwork");
+          cy.get('select[name="networks.0.mode"]').as("containerDockerNetwork");
 
           // HOST
           cy
@@ -913,9 +909,7 @@ describe("Service Form Modal", function() {
           setRuntime("Universal Container Runtime");
           clickNetworkingTab();
 
-          cy
-            .get('select[name="container.docker.network"]')
-            .as("containerDockerNetwork");
+          cy.get('select[name="networks.0.mode"]').as("containerDockerNetwork");
 
           // HOST
           cy
@@ -1031,7 +1025,7 @@ describe("Service Form Modal", function() {
 
         context("type: HOST", function() {
           it('should hide "Container Port"', function() {
-            cy.get('select[name="container.docker.network"]').select("HOST");
+            cy.get('select[name="networks.0.mode"]').select("HOST");
 
             cy
               .get("@tabView")
@@ -1074,7 +1068,7 @@ describe("Service Form Modal", function() {
 
         context("type: BRIDGE", function() {
           it('should show "Container Port" and "Protocol"', function() {
-            cy.get('select[name="container.docker.network"]').select("BRIDGE");
+            cy.get('select[name="networks.0.mode"]').select("BRIDGE");
 
             cy
               .get("@tabView")
@@ -1117,9 +1111,7 @@ describe("Service Form Modal", function() {
 
         context("type: USER (Virtual Network: dcos)", function() {
           it('should hide "Host Port" and "Protocol"', function() {
-            cy
-              .get('select[name="container.docker.network"]')
-              .select("USER.dcos-1");
+            cy.get('select[name="networks.0.mode"]').select("USER.dcos-1");
 
             cy
               .get("@tabView")
@@ -1160,9 +1152,7 @@ describe("Service Form Modal", function() {
           });
 
           it('should not hide "Host Port" and "Protocol" when "Port Mapping" is enabled', function() {
-            cy
-              .get('select[name="container.docker.network"]')
-              .select("USER.dcos-1");
+            cy.get('select[name="networks.0.mode"]').select("USER.dcos-1");
 
             // Enable port mapping
             cy


### PR DESCRIPTION
**TL;DR** Batch transaction paths `container.docker.network` -> `networks.0.mode`

This PR prepares the base for the new Network API.

Currently Batch transactions paths reflect JSON structure and with this PR we are switching them to be more generic.

As a start of the migration, we switch from a single network to an array of networks hardcoded to handle the first element only.

## Background

Currently the UI supports only one network for a single container app, defined in `container.docker.network` there's a migration coming with marathon 1.5, networking API will be unified with Pods allowing a user to have more than one network per app. To achieve this, Marathon team reorganized the app definition moving networking information from `container.docker.network` on the top level and making it to be an array.

Ioannis created a [doc](https://docs.google.com/document/d/1CpUq51q5_AsZubmcWVXu5pAGaS2D7NXXhrwmWtPAyXU) to describe all the differences.

> While transactions still look to be bound to the JSON structure the JSON structure itself will become more generic, therefore transactions are not about _where_ the data resides but about _what_ it describes.

