### PR TITLE
Add table row hover and remove highlighted column styling

### DIFF
--- a/plugins/nodes/src/js/components/HealthTab.js
+++ b/plugins/nodes/src/js/components/HealthTab.js
@@ -160,7 +160,7 @@ class HealthTab extends React.Component {
         </FilterBar>
         <Table
           className="table table-borderless-outer
-            table-borderless-inner-columns flush-bottom"
+            table-borderless-inner-columns table-hover flush-bottom"
           columns={this.getColumns()}
           colGroup={this.getColGroup()}
           containerSelector=".gm-scroll-view"

--- a/plugins/nodes/src/js/components/NodesTable.js
+++ b/plugins/nodes/src/js/components/NodesTable.js
@@ -192,7 +192,7 @@ var NodesTable = React.createClass({
     return (
       <Table
         buildRowOptions={this.getRowAttributes}
-        className="node-table table table-borderless-outer table-borderless-inner-columns flush-bottom"
+        className="node-table table table-borderless-outer table-borderless-inner-columns table-hover flush-bottom"
         colGroup={this.getColGroup()}
         columns={this.getColumns()}
         containerSelector=".gm-scroll-view"

--- a/plugins/services/src/js/components/DeclinedOffersTable.js
+++ b/plugins/services/src/js/components/DeclinedOffersTable.js
@@ -323,7 +323,7 @@ class DeclinedOffersTable extends React.Component {
     return (
       <MountService.Mount type="DeclinedOffersTable">
         <Table
-          className="table table-simple table-header-nowrap table-break-word flush-bottom"
+          className="table table-simple table-header-nowrap table-break-word table-hover flush-bottom"
           colGroup={this.getColGroup()}
           columns={this.getColumns()}
           data={offers}

--- a/plugins/services/src/js/components/TaskDirectoryTable.js
+++ b/plugins/services/src/js/components/TaskDirectoryTable.js
@@ -201,7 +201,7 @@ class TaskDirectoryTable extends React.Component {
   render() {
     return (
       <Table
-        className="table table-borderless-outer table-borderless-inner-columns flush-bottom"
+        className="table table-borderless-outer table-borderless-inner-columns table-hover flush-bottom"
         colGroup={this.getColGroup()}
         columns={this.getColumns()}
         containerSelector=".gm-scroll-view"

--- a/plugins/services/src/js/components/VolumeTable.js
+++ b/plugins/services/src/js/components/VolumeTable.js
@@ -164,7 +164,7 @@ class VolumeTable extends React.Component {
   render() {
     return (
       <Table
-        className="table table-borderless-outer table-borderless-inner-columns flush-bottom"
+        className="table table-borderless-outer table-borderless-inner-columns table-hover flush-bottom"
         columns={this.getColumns()}
         colGroup={this.getColGroup()}
         data={this.getData(this.props.service.getVolumes().getItems())}

--- a/plugins/services/src/js/containers/service-debug/TaskStatsTable.js
+++ b/plugins/services/src/js/containers/service-debug/TaskStatsTable.js
@@ -135,7 +135,7 @@ class TaskStatsTable extends React.Component {
   render() {
     return (
       <Table
-        className="table table-simple table-borderless-outer table-borderless-inner-columns flush-bottom"
+        className="table table-simple table-borderless-outer table-borderless-inner-columns table-hover flush-bottom"
         columns={this.getColumns()}
         colGroup={this.getColGroup()}
         data={this.props.taskStats.getList().getItems()}

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -472,7 +472,7 @@ class ServicesTable extends React.Component {
       <div>
         <Table
           buildRowOptions={this.getRowAttributes}
-          className="table service-table table-borderless-outer table-borderless-inner-columns flush-bottom"
+          className="table service-table table-borderless-outer table-borderless-inner-columns table-hover flush-bottom"
           columns={this.getColumns()}
           colGroup={this.getColGroup()}
           data={this.props.services.slice()}

--- a/src/js/components/CheckboxTable.js
+++ b/src/js/components/CheckboxTable.js
@@ -206,7 +206,7 @@ class CheckboxTable extends React.Component {
     const columns = this.getColumns();
 
     const tableClassSet = classNames(
-      "table table-borderless-outer table-borderless-inner-columns",
+      "table table-borderless-outer table-borderless-inner-columns table-hover",
       "flush-bottom",
       className
     );

--- a/src/js/components/ExpandingTable.js
+++ b/src/js/components/ExpandingTable.js
@@ -123,7 +123,7 @@ class ExpandingTable extends React.Component {
 
   render() {
     const { props } = this;
-    const classes = classNames(props.className, {
+    const classes = classNames("table-hover", props.className, {
       [`table-align-${props.alignCells}`]: props.alignCells != null
     });
     const TableComponent = props.tableComponent;

--- a/src/js/components/RepositoriesTable.js
+++ b/src/js/components/RepositoriesTable.js
@@ -216,7 +216,7 @@ class RepositoriesTable extends mixin(StoreMixin) {
     return (
       <div>
         <Table
-          className="table table-borderless-outer table-borderless-inner-columns flush-bottom"
+          className="table table-borderless-outer table-borderless-inner-columns flush-bottom table-hover"
           columns={this.getColumns()}
           colGroup={this.getColGroup()}
           data={props.repositories.getItems().slice()}

--- a/src/js/components/UnitHealthNodesTable.js
+++ b/src/js/components/UnitHealthNodesTable.js
@@ -114,7 +114,7 @@ class UnitHealthNodesTable extends React.Component {
     return (
       <Table
         className="table table-borderless-outer
-          table-borderless-inner-columns flush-bottom"
+          table-borderless-inner-columns table-hover flush-bottom"
         columns={this.getColumns()}
         colGroup={this.getColGroup()}
         containerSelector=".gm-scroll-view"

--- a/src/js/pages/jobs/JobsTable.js
+++ b/src/js/pages/jobs/JobsTable.js
@@ -236,7 +236,7 @@ class JobsTable extends React.Component {
   render() {
     return (
       <Table
-        className="table table-borderless-outer table-borderless-inner-columns flush-bottom"
+        className="table table-borderless-outer table-borderless-inner-columns table-hover flush-bottom"
         colGroup={this.getColGroup()}
         columns={this.getColumns()}
         data={this.getData()}

--- a/src/js/pages/network/VirtualNetworksTable.js
+++ b/src/js/pages/network/VirtualNetworksTable.js
@@ -88,7 +88,7 @@ class VirtualNetworksTable extends React.Component {
   render() {
     return (
       <Table
-        className="table table-borderless-outer table-borderless-inner-columns flush-bottom"
+        className="table table-borderless-outer table-borderless-inner-columns table-hover flush-bottom"
         columns={this.getColumns()}
         colGroup={this.getColGroup()}
         data={this.props.overlays.getItems()}

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
@@ -299,7 +299,7 @@ class VirtualNetworkTaskTab extends mixin(StoreMixin) {
           />
         </FilterBar>
         <Table
-          className="table table-borderless-outer table-borderless-inner-columns flush-bottom"
+          className="table table-borderless-outer table-borderless-inner-columns table-hover flush-bottom"
           columns={this.getColumns()}
           colGroup={this.getColGroup()}
           data={filteredTasks}

--- a/src/js/pages/system/OrganizationTab.js
+++ b/src/js/pages/system/OrganizationTab.js
@@ -498,7 +498,7 @@ class OrganizationTab extends mixin(StoreMixin, InternalStorageMixin) {
             <Table
               buildRowOptions={this.getTableRowOptions}
               className="table table-borderless-outer
-                table-borderless-inner-columns flush-bottom"
+                table-borderless-inner-columns table-hover flush-bottom"
               columns={this.getColumns()}
               colGroup={this.getColGroup()}
               containerSelector=".gm-scroll-view"

--- a/src/js/pages/system/UnitsHealthTab.js
+++ b/src/js/pages/system/UnitsHealthTab.js
@@ -212,7 +212,7 @@ class UnitsHealthTab extends mixin(StoreMixin) {
           <div className="page-body-content-fill flex-grow flex-container-col">
             <Table
               className="table table-borderless-outer
-                table-borderless-inner-columns flush-bottom"
+                table-borderless-inner-columns table-hover flush-bottom"
               columns={this.getColumns()}
               colGroup={this.getColGroup()}
               containerSelector=".gm-scroll-view"

--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -1,12 +1,30 @@
 & when (@table-enabled) {
 
+  .table {
+
+    th {
+
+      &.active {
+        background-color: inherit;
+      }
+    }
+
+    td {
+
+      &.active {
+        background-color: inherit;
+      }
+    }
+  }
+
   tr,
   .table-row {
 
     &:hover {
 
-      td {
-        background: @table-cell-hover-color;
+      td,
+      td.active {
+        background-color: @table-cell-hover-color;
       }
 
       .table-display-on-row-hover {
@@ -65,6 +83,16 @@
     font-size: 0.9rem;
     text-transform: uppercase;
     vertical-align: middle;
+
+    &.clickable {
+
+      &:hover {
+
+        .caret {
+          display: inline-block;
+        }
+      }
+    }
   }
 
   td {
@@ -72,6 +100,10 @@
     // property. http://stackoverflow.com/questions/9789723/css-text-overflow-in-a-table-cell
     max-width: 0;
     vertical-align: middle;
+
+    &.active {
+      background-color: inherit;
+    }
   }
 
   .table-header-title {

--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -5,6 +5,10 @@
 
     &:hover {
 
+      td {
+        background: @table-cell-hover-color;
+      }
+
       .table-display-on-row-hover {
         visibility: visible;
       }

--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -2,13 +2,7 @@
 
   .table {
 
-    th {
-
-      &.active {
-        background-color: inherit;
-      }
-    }
-
+    th,
     td {
 
       &.active {

--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -9,25 +9,27 @@
         background-color: inherit;
       }
     }
+
+    // Remove active styling from row hover state
+    &.table-hover {
+
+      tr {
+
+        &:hover {
+
+          td {
+
+            &.active {
+              background-color: @table-cell-hover-background-color;
+            }
+          }
+        }
+      }
+    }
   }
 
   tr,
   .table-row {
-
-    &:hover {
-
-      td {
-
-        &,
-        &.active {
-          background-color: inherit;
-        }
-      }
-
-      .table-display-on-row-hover {
-        visibility: visible;
-      }
-    }
 
     &.inactive {
 

--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -16,9 +16,12 @@
 
     &:hover {
 
-      td,
-      td.active {
-        background-color: @table-cell-hover-color;
+      td {
+
+        &,
+        &.active {
+          background-color: @table-cell-hover-color;
+        }
       }
 
       .table-display-on-row-hover {

--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -20,7 +20,7 @@
 
         &,
         &.active {
-          background-color: @table-cell-hover-color;
+          background-color: inherit;
         }
       }
 

--- a/src/styles/content/tables/variables.less
+++ b/src/styles/content/tables/variables.less
@@ -5,4 +5,4 @@
  */
 
 @table-cell-highlight-color: @neutral;
-@table-cell-hover-color: #f9f9fa;
+@table-cell-hover-color: color-lighten(@neutral, 97);

--- a/src/styles/content/tables/variables.less
+++ b/src/styles/content/tables/variables.less
@@ -5,3 +5,4 @@
  */
 
 @table-cell-highlight-color: @neutral;
+@table-cell-hover-color: #f9f9fa;

--- a/src/styles/content/tables/variables.less
+++ b/src/styles/content/tables/variables.less
@@ -5,4 +5,3 @@
  */
 
 @table-cell-highlight-color: @neutral;
-@table-cell-hover-color: color-lighten(@neutral, 97);


### PR DESCRIPTION
Proposal to improve table styling.

1. Add a row hover style. Why?  Improves usability by visually highlighting the row the user is looking at so they can see the related data and columns.

2. Remove the highlighted active column. Why? Don't think this is adding value (as the caret already shows the active column) and it looks odd whenever there are just two columns.

3. Show the sorting caret on hover. Why? So the user knows they can interact with and sort the table.

Before
https://cl.ly/3Z40263T2c1y

After
https://cl.ly/0U05022x2M3p

cc @ashenden 