### PR TITLE
[SDK Actions 3 of 3] DCOS-14910: Disable SDK service detail actions

### DIFF
--- a/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
+++ b/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
@@ -12,11 +12,12 @@ import Service from "../../structs/Service";
 import ServiceActionLabels from "../../constants/ServiceActionLabels";
 import ServiceTree from "../../structs/ServiceTree";
 import {
-  SCALE,
+  DELETE,
+  EDIT,
   RESTART,
   RESUME,
-  SUSPEND,
-  DELETE
+  SCALE,
+  SUSPEND
 } from "../../constants/ServiceActionItem";
 
 const METHODS_TO_BIND = ["handleTextCopy"];
@@ -217,6 +218,35 @@ class ServiceActionDisabledModal extends React.Component {
     );
   }
 
+  getServiceEditMessage() {
+    const { intl } = this.props;
+    const command = this.getUpdateCommand();
+
+    return (
+      <div>
+        <p>
+          {intl.formatMessage({
+            id: "SERVICE_ACTIONS.SDK_SERVICE_UPDATE_PART_1"
+          })}
+          {" "}
+          <a
+            href={MetadataStore.buildDocsURI(
+              "/usage/managing-services/config-universe-service"
+            )}
+            target="_blank"
+          >
+            {intl.formatMessage({ id: "DOCS.MORE_INFORMATION" })}
+          </a>
+          {" "}
+          {intl.formatMessage({
+            id: "SERVICE_ACTIONS.SDK_SERVICE_UPDATE_PART_2"
+          })}
+        </p>
+        {this.getClipboardTrigger(command)}
+      </div>
+    );
+  }
+
   getServiceMessage() {
     const { actionID } = this.props;
 
@@ -231,6 +261,8 @@ class ServiceActionDisabledModal extends React.Component {
         return this.getServiceScaleMessage();
       case DELETE:
         return this.getServiceDeleteMessage();
+      case EDIT:
+        return this.getServiceEditMessage();
       default:
         return <noscript />;
     }

--- a/plugins/services/src/js/constants/ServiceActionLabels.js
+++ b/plugins/services/src/js/constants/ServiceActionLabels.js
@@ -1,4 +1,5 @@
 const ServiceActionLabels = {
+  edit: "SERVICE_ACTIONS.EDIT",
   delete: "SERVICE_ACTIONS.DELETE",
   restart: "SERVICE_ACTIONS.RESTART",
   resume: "SERVICE_ACTIONS.RESUME",

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -7,6 +7,7 @@ import { StoreMixin } from "mesosphere-shared-reactjs";
 import DCOSStore from "#SRC/js/stores/DCOSStore";
 import Icon from "#SRC/js/components/Icon";
 import Loader from "#SRC/js/components/Loader";
+import { isSDKService } from "#SRC/js/utils/ServiceUtil";
 
 import ApplicationSpec from "../../structs/ApplicationSpec";
 import ServiceConfigDisplay
@@ -116,6 +117,7 @@ class ServiceConfiguration extends mixin(StoreMixin) {
     return [
       <button
         className="button button-stroke"
+        disabled={isSDKService(service)}
         key="version-button-edit"
         onClick={() => this.handleEditButtonClick()}
       >
@@ -123,6 +125,7 @@ class ServiceConfiguration extends mixin(StoreMixin) {
       </button>,
       <button
         className="button button-stroke"
+        disabled={isSDKService(service)}
         key="version-button-apply"
         onClick={() => this.handleApplyButtonClick()}
       >

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -8,16 +8,32 @@ import RouterUtil from "#SRC/js/utils/RouterUtil";
 import StringUtil from "#SRC/js/utils/StringUtil";
 import TabsMixin from "#SRC/js/mixins/TabsMixin";
 import UserActions from "#SRC/js/constants/UserActions";
+import { isSDKService } from "#SRC/js/utils/ServiceUtil";
 
 import ActionKeys from "../../constants/ActionKeys";
 import MarathonErrorUtil from "../../utils/MarathonErrorUtil";
 import Service from "../../structs/Service";
-import ServiceActionItem from "../../constants/ServiceActionItem";
+import ServiceTree from "../../structs/ServiceTree";
 import ServiceActionLabels from "../../constants/ServiceActionLabels";
 import ServiceBreadcrumbs from "../../components/ServiceBreadcrumbs";
 import ServiceModals from "../../components/modals/ServiceModals";
+import ServiceActionDisabledModal
+  from "../../components/modals/ServiceActionDisabledModal";
+import {
+  DELETE,
+  EDIT,
+  OPEN,
+  RESTART,
+  RESUME,
+  SCALE,
+  SUSPEND
+} from "../../constants/ServiceActionItem";
 
-const METHODS_TO_BIND = ["handleEditClearError", "onActionsItemSelection"];
+const METHODS_TO_BIND = [
+  "handleEditClearError",
+  "handleActionDisabledModalOpen",
+  "handleActionDisabledModalClose"
+];
 
 class ServiceDetail extends mixin(TabsMixin) {
   constructor() {
@@ -30,6 +46,8 @@ class ServiceDetail extends mixin(TabsMixin) {
     };
 
     this.state = {
+      actionDisabledID: null,
+      actionDisabledModalOpen: false,
       currentTab: Object.keys(this.tabs_tabs).shift()
     };
 
@@ -62,29 +80,63 @@ class ServiceDetail extends mixin(TabsMixin) {
     this.props.clearError(ActionKeys.SERVICE_EDIT);
   }
 
-  onActionsItemSelection(actionItem) {
+  onActionsItemSelection(actionID) {
+    const { service } = this.props;
+    const isGroup = service instanceof ServiceTree;
+    let containsSDKService = false;
+
+    if (isGroup) {
+      containsSDKService =
+        service.findItem(function(item) {
+          return item instanceof Service && isSDKService(item);
+        }) != null;
+    }
+
+    // We still want to support the `open` action to display the web view
+    if (actionID !== OPEN && (containsSDKService || isSDKService(service))) {
+      this.handleActionDisabledModalOpen(actionID);
+    } else {
+      this.handleServiceAction(actionID);
+    }
+  }
+
+  handleServiceAction(actionID) {
     const { modalHandlers, router } = this.context;
     const { service } = this.props;
 
-    switch (actionItem.id) {
-      case ServiceActionItem.EDIT:
+    switch (actionID) {
+      case EDIT:
         router.push(
           `/services/detail/${encodeURIComponent(service.getId())}/edit/`
         );
         break;
-      case ServiceActionItem.SCALE:
+      case SCALE:
         modalHandlers.scaleService({ service });
         break;
-      case ServiceActionItem.RESTART:
+      case OPEN:
+        modalHandlers.openServiceUI({ service });
+        break;
+      case RESTART:
         modalHandlers.restartService({ service });
         break;
-      case ServiceActionItem.SUSPEND:
+      case RESUME:
+        modalHandlers.resumeService({ service });
+        break;
+      case SUSPEND:
         modalHandlers.suspendService({ service });
         break;
-      case ServiceActionItem.DELETE:
+      case DELETE:
         modalHandlers.deleteService({ service });
         break;
     }
+  }
+
+  handleActionDisabledModalOpen(actionDisabledID) {
+    this.setState({ actionDisabledModalOpen: true, actionDisabledID });
+  }
+
+  handleActionDisabledModalClose() {
+    this.setState({ actionDisabledModalOpen: false, actionDisabledID: null });
   }
 
   hasVolumes() {
@@ -108,7 +160,6 @@ class ServiceDetail extends mixin(TabsMixin) {
 
   getActions() {
     const { service } = this.props;
-    const { modalHandlers, router } = this.context;
     const instanceCount = service.getInstancesCount();
 
     const actions = [];
@@ -122,52 +173,46 @@ class ServiceDetail extends mixin(TabsMixin) {
         label: this.props.intl.formatMessage({
           id: ServiceActionLabels.open
         }),
-        onItemSelect() {
-          modalHandlers.openServiceUI({ service });
-        }
+        onItemSelect: this.onActionsItemSelection.bind(this, OPEN)
       });
     }
 
     actions.push({
       label: "Edit",
-      onItemSelect() {
-        router.push(
-          `/services/detail/${encodeURIComponent(service.getId())}/edit/`
-        );
-      }
+      onItemSelect: this.onActionsItemSelection.bind(this, EDIT)
     });
 
     if (instanceCount > 0) {
       actions.push({
         label: "Restart",
-        onItemSelect: modalHandlers.restartService
+        onItemSelect: this.onActionsItemSelection.bind(this, RESTART)
       });
     }
     if (!service.getLabels().MARATHON_SINGLE_INSTANCE_APP) {
       actions.push({
         label: "Scale",
-        onItemSelect: modalHandlers.scaleService
+        onItemSelect: this.onActionsItemSelection.bind(this, SCALE)
       });
     }
 
     if (instanceCount > 0) {
       actions.push({
         label: "Suspend",
-        onItemSelect: modalHandlers.suspendService
+        onItemSelect: this.onActionsItemSelection.bind(this, SUSPEND)
       });
     }
 
     if (instanceCount === 0) {
       actions.push({
         label: "Resume",
-        onItemSelect: modalHandlers.resumeService
+        onItemSelect: this.onActionsItemSelection.bind(this, RESUME)
       });
     }
 
     actions.push({
       className: "text-danger",
       label: StringUtil.capitalize(UserActions.DELETE),
-      onItemSelect: modalHandlers.deleteService
+      onItemSelect: this.onActionsItemSelection.bind(this, DELETE)
     });
 
     return actions;
@@ -195,6 +240,7 @@ class ServiceDetail extends mixin(TabsMixin) {
 
   render() {
     const { children, actions, errors, params, routes, service } = this.props;
+    const { actionDisabledModalOpen, actionDisabledID } = this.state;
     const breadcrumbs = <ServiceBreadcrumbs serviceID={service.id} />;
     const clonedProps = {
       params,
@@ -225,6 +271,12 @@ class ServiceDetail extends mixin(TabsMixin) {
           iconID="services"
         />
         {clonedChildren}
+        <ServiceActionDisabledModal
+          actionID={actionDisabledID}
+          open={actionDisabledModalOpen}
+          onClose={this.handleActionDisabledModalClose}
+          service={service}
+        />
       </Page>
     );
   }

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import { Dropdown, Table, Tooltip } from "reactjs-components";
 import { injectIntl } from "react-intl";
-import { Link } from "react-router";
+import { Link, routerShape } from "react-router";
 import React, { PropTypes } from "react";
 
 import Icon from "#SRC/js/components/Icon";
@@ -20,6 +20,7 @@ import ServiceActionDisabledModal
   from "../../components/modals/ServiceActionDisabledModal";
 import {
   DELETE,
+  EDIT,
   MORE,
   OPEN,
   RESTART,
@@ -92,9 +93,14 @@ class ServicesTable extends React.Component {
   }
 
   handleServiceAction(service, actionID) {
-    const { modalHandlers } = this.context;
+    const { modalHandlers, router } = this.context;
 
     switch (actionID) {
+      case EDIT:
+        router.push(
+          `/services/detail/${encodeURIComponent(service.getId())}/edit/`
+        );
+        break;
       case SCALE:
         modalHandlers.scaleService({ service });
         break;
@@ -246,6 +252,10 @@ class ServicesTable extends React.Component {
         }),
         id: OPEN,
         html: this.props.intl.formatMessage({ id: ServiceActionLabels.open })
+      },
+      {
+        id: EDIT,
+        html: this.props.intl.formatMessage({ id: ServiceActionLabels.edit })
       },
       {
         className: classNames({
@@ -486,7 +496,8 @@ ServicesTable.contextTypes = {
     resumeService: PropTypes.func,
     suspendService: PropTypes.func,
     deleteService: PropTypes.func
-  }).isRequired
+  }).isRequired,
+  router: routerShape
 };
 
 ServicesTable.defaultProps = {

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -254,6 +254,7 @@ class ServicesTable extends React.Component {
         html: this.props.intl.formatMessage({ id: ServiceActionLabels.open })
       },
       {
+        className: classNames({ hidden: isGroup }),
         id: EDIT,
         html: this.props.intl.formatMessage({ id: ServiceActionLabels.edit })
       },

--- a/src/js/translations/en-US.json
+++ b/src/js/translations/en-US.json
@@ -17,6 +17,7 @@
   "DOCS.MORE_INFORMATION": "More information",
   "DOCS.DOCUMENTATION": "documentation",
 
+  "SERVICE_ACTIONS.EDIT": "Edit",
   "SERVICE_ACTIONS.DELETE": "Delete",
   "SERVICE_ACTIONS.RESTART": "Restart",
   "SERVICE_ACTIONS.RESUME": "Resume",
@@ -54,5 +55,7 @@
   "SERVICE_ACTIONS.SDK_SERVICE_SCALE_NOTE": "Scaling to fewer instances is not supported.",
   "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_1": "You must delete",
   "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_2": "via the DC/OS CLI. Copy and paste this command into the CLI. See the",
-  "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_3": "To clean up resources reserved by your service, run the"
+  "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_3": "To clean up resources reserved by your service, run the",
+  "SERVICE_ACTIONS.SDK_SERVICE_UPDATE_PART_1": "Update your service's target configuration. Include an `options.json file with your changes.",
+  "SERVICE_ACTIONS.SDK_SERVICE_UPDATE_PART_2": "on how to create an 'options.json' file."
 }

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -34,7 +34,7 @@ describe("ServiceUtil", function() {
   });
 
   describe("#isPackage", function() {
-    it("should return true if service does not have the proper label", function() {
+    it("should return true if service does have the proper label", function() {
       const service = {
         id: "/foo",
         getLabels() {

--- a/tests/_support/index.js
+++ b/tests/_support/index.js
@@ -179,6 +179,10 @@ Cypress.addParentCommand("configureCluster", function(configuration) {
         /service\/marathon\/v2\/deployments/,
         "fx:marathon-1-task/deployments"
       )
+      .route(
+        /service\/marathon\/v2\/apps\/\/services\/sdk-sleep\/versions/,
+        "fx:marathon-1-task/versions"
+      )
       .route(/history\/minute/, "fx:marathon-1-task/history-minute")
       .route(/history\/last/, "fx:marathon-1-task/summary")
       .route(/state-summary/, "fx:marathon-1-task/summary")

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -532,4 +532,129 @@ describe("Service Actions", function() {
       cy.get(".modal-body").should("to.have.length", 0);
     });
   });
+
+  context("SDK Services", function() {
+    beforeEach(function() {
+      cy.configureCluster({
+        mesos: "1-sdk-service",
+        nodeHealth: true
+      });
+
+      cy.visitUrl({ url: "/services/detail/%2Fservices%2Fsdk-sleep" });
+    });
+
+    it("opens the destroy dialog", function() {
+      clickHeaderAction("Delete");
+
+      cy
+        .get(".modal-header")
+        .contains("Delete Service")
+        .should("to.have.length", 1);
+
+      cy
+        .get(".modal pre")
+        .contains("dcos package uninstall test --app-id=/services/sdk-sleep");
+
+      cy.get(".modal button").contains("Close").click();
+
+      cy.get(".modal").should("not.exist");
+    });
+
+    it("opens the edit dialog", function() {
+      clickHeaderAction("Edit");
+
+      cy
+        .get(".modal-header")
+        .contains("Edit Service")
+        .should("to.have.length", 1);
+
+      cy
+        .get(".modal pre")
+        .contains(
+          "dcos test --name=/services/sdk-sleep update --options=test-options.json"
+        );
+
+      cy.get(".modal button").contains("Close").click();
+
+      cy.get(".modal").should("not.exist");
+    });
+
+    it("opens the scale dialog", function() {
+      clickHeaderAction("Scale");
+
+      cy
+        .get(".modal-header")
+        .contains("Scale Service")
+        .should("to.have.length", 1);
+
+      cy
+        .get(".modal pre")
+        .contains(
+          "dcos test --name=/services/sdk-sleep update --options=test-options.json"
+        );
+
+      cy.get(".modal button").contains("Close").click();
+
+      cy.get(".modal").should("not.exist");
+    });
+
+    it("opens the suspend dialog", function() {
+      clickHeaderAction("Suspend");
+
+      cy
+        .get(".modal-header")
+        .contains("Suspend Service")
+        .should("to.have.length", 1);
+
+      cy
+        .get(".modal pre")
+        .contains(
+          "dcos test --name=/services/sdk-sleep update --options=test-options.json"
+        );
+
+      cy.get(".modal button").contains("Close").click();
+
+      cy.get(".modal").should("not.exist");
+    });
+
+    it("opens the resume dialog", function() {
+      cy.configureCluster({
+        mesos: "1-suspended-sdk-service",
+        nodeHealth: true
+      });
+
+      clickHeaderAction("Resume");
+
+      cy
+        .get(".modal-header")
+        .contains("Resume Service")
+        .should("have.length", 1);
+
+      cy
+        .get(".modal pre")
+        .contains(
+          "dcos test --name=/services/sdk-sleep update --options=test-options.json"
+        );
+
+      cy.get(".modal button").contains("Close").click();
+
+      cy.get(".modal").should("not.exist");
+    });
+
+    it("opens the restart dialog", function() {
+      clickHeaderAction("Restart");
+
+      cy
+        .get(".modal-header")
+        .contains("Restart Service")
+        .should("have.length", 1);
+
+      cy
+        .get(".modal pre")
+        .contains("dcos marathon app restart /services/sdk-sleep");
+      cy.get(".modal button").contains("Close").click();
+
+      cy.get(".modal").should("not.exist");
+    });
+  });
 });

--- a/tests/pages/services/ServiceTable-cy.js
+++ b/tests/pages/services/ServiceTable-cy.js
@@ -519,6 +519,26 @@ describe("Service Table", function() {
       cy.get(".modal").should("not.exist");
     });
 
+    it.only("opens the edit dialog", function() {
+      openDropdown("sdk-sleep");
+      clickDropdownAction("Edit");
+
+      cy
+        .get(".modal-header")
+        .contains("Edit Service")
+        .should("to.have.length", 1);
+
+      cy
+        .get(".modal pre")
+        .contains(
+          "dcos test --name=/services/sdk-sleep update --options=test-options.json"
+        );
+
+      cy.get(".modal button").contains("Close").click();
+
+      cy.get(".modal").should("not.exist");
+    });
+
     it("opens the scale dialog", function() {
       openDropdown("sdk-sleep");
       clickDropdownAction("Scale");

--- a/tests/pages/services/ServiceTable-cy.js
+++ b/tests/pages/services/ServiceTable-cy.js
@@ -519,7 +519,7 @@ describe("Service Table", function() {
       cy.get(".modal").should("not.exist");
     });
 
-    it.only("opens the edit dialog", function() {
+    it("opens the edit dialog", function() {
       openDropdown("sdk-sleep");
       clickDropdownAction("Edit");
 

--- a/tests/pages/services/ServiceVersions-cy.js
+++ b/tests/pages/services/ServiceVersions-cy.js
@@ -1,100 +1,141 @@
 describe("Service Versions", function() {
   context("Configuration Tab", function() {
-    beforeEach(function() {
-      cy.configureCluster({
-        mesos: "1-task-healthy",
-        nodeHealth: true
+    context("Services", function() {
+      beforeEach(function() {
+        cy.configureCluster({
+          mesos: "1-task-healthy",
+          nodeHealth: true
+        });
+
+        cy.visitUrl({ url: "/services/detail/%2Fsleep" });
+        cy
+          .get(".page-header-navigation .menu-tabbed-item")
+          .contains("Configuration")
+          .click();
+
+        cy.get(".services-version-select button").as("dropdown");
       });
 
-      cy.visitUrl({ url: "/services/detail/%2Fsleep" });
-      cy
-        .get(".page-header-navigation .menu-tabbed-item")
-        .contains("Configuration")
-        .click();
-
-      cy.get(".services-version-select button").as("dropdown");
-    });
-
-    it("opens the current service version on default", function() {
-      cy.get("@dropdown").contains("Active");
-    });
-
-    it("renders the version dropdown with the current locale version as default", function() {
-      cy
-        .get(".page-body-content .dropdown .button span")
-        .contains(new Date("2015-08-28T01:26:14.620Z").toLocaleString())
-        .should("to.have.length", 1);
-    });
-
-    it("renders the selected service version", function() {
-      cy
-        .get("@dropdown")
-        .get(".button span")
-        .contains(new Date("2015-08-28T01:26:14.620Z").toLocaleString())
-        .parent()
-        .click();
-
-      cy
-        .get("@dropdown")
-        .get(".dropdown-menu-list ul li")
-        .contains(new Date("2015-02-28T05:12:12.221Z").toLocaleString())
-        .click();
-
-      cy
-        .get("@dropdown")
-        .contains(new Date("2015-02-28T05:12:12.221Z").toLocaleString());
-    });
-
-    it("applies the selected service version", function() {
-      cy.route({
-        method: "PUT",
-        url: /marathon\/v2\/apps\/\/sleep/,
-        response: {
-          deploymentId: "5ed4c0c5-9ff8-4a6f-a0cd-f57f59a34b43",
-          version: "2015-09-29T15:59:51.164Z"
-        },
-        delay: 0
+      it("opens the current service version on default", function() {
+        cy.get("@dropdown").contains("Active");
       });
 
-      cy
-        .get("@dropdown")
-        .get(".button span")
-        .contains(new Date("2015-08-28T01:26:14.620Z").toLocaleString())
-        .parent()
-        .click();
+      it("renders the version dropdown with the current locale version as default", function() {
+        cy
+          .get(".page-body-content .dropdown .button span")
+          .contains(new Date("2015-08-28T01:26:14.620Z").toLocaleString())
+          .should("to.have.length", 1);
+      });
 
-      cy
-        .get("@dropdown")
-        .get(".dropdown-menu-list ul li")
-        .contains(new Date("2015-02-28T05:12:12.221Z").toLocaleString())
-        .click();
+      it("renders the selected service version", function() {
+        cy
+          .get("@dropdown")
+          .get(".button span")
+          .contains(new Date("2015-08-28T01:26:14.620Z").toLocaleString())
+          .parent()
+          .click();
 
-      cy
-        .get("@dropdown")
-        .contains(new Date("2015-02-28T05:12:12.221Z").toLocaleString());
+        cy
+          .get("@dropdown")
+          .get(".dropdown-menu-list ul li")
+          .contains(new Date("2015-02-28T05:12:12.221Z").toLocaleString())
+          .click();
 
-      cy.get(".page-body-content .button").contains("Apply").click();
+        cy
+          .get("@dropdown")
+          .contains(new Date("2015-02-28T05:12:12.221Z").toLocaleString());
+      });
+
+      it("applies the selected service version", function() {
+        cy.route({
+          method: "PUT",
+          url: /marathon\/v2\/apps\/\/sleep/,
+          response: {
+            deploymentId: "5ed4c0c5-9ff8-4a6f-a0cd-f57f59a34b43",
+            version: "2015-09-29T15:59:51.164Z"
+          },
+          delay: 0
+        });
+
+        cy
+          .get("@dropdown")
+          .get(".button span")
+          .contains(new Date("2015-08-28T01:26:14.620Z").toLocaleString())
+          .parent()
+          .click();
+
+        cy
+          .get("@dropdown")
+          .get(".dropdown-menu-list ul li")
+          .contains(new Date("2015-02-28T05:12:12.221Z").toLocaleString())
+          .click();
+
+        cy
+          .get("@dropdown")
+          .contains(new Date("2015-02-28T05:12:12.221Z").toLocaleString());
+
+        cy.get(".page-body-content .button").contains("Apply").click();
+      });
+
+      it("opens correct edit modal of the selected service version", function() {
+        cy
+          .get("@dropdown")
+          .get(".button span")
+          .contains(new Date("2015-08-28T01:26:14.620Z").toLocaleString())
+          .parent()
+          .click();
+
+        cy
+          .get("@dropdown")
+          .get(".dropdown-menu-list ul li")
+          .contains(new Date("2015-02-28T05:12:12.221Z").toLocaleString())
+          .click();
+
+        cy.get(".page-body-content .button").contains("Edit").click();
+
+        cy
+          .get('.modal .menu-tabbed-view textarea[name="cmd"]')
+          .contains("sleep 1000");
+      });
     });
 
-    it("opens correct edit modal of the selected service version", function() {
-      cy
-        .get("@dropdown")
-        .get(".button span")
-        .contains(new Date("2015-08-28T01:26:14.620Z").toLocaleString())
-        .parent()
-        .click();
+    context("SDK Services", function() {
+      beforeEach(function() {
+        cy.configureCluster({
+          mesos: "1-sdk-service",
+          nodeHealth: true
+        });
+        cy.visitUrl({
+          url: "/services/detail/%2Fservices%2Fsdk-sleep/configuration"
+        });
 
-      cy
-        .get("@dropdown")
-        .get(".dropdown-menu-list ul li")
-        .contains(new Date("2015-02-28T05:12:12.221Z").toLocaleString())
-        .click();
+        cy.get(".services-version-select button").as("dropdown");
+      });
 
-      cy.get(".page-body-content .button").contains("Edit").click();
+      it("disables edit and apply buttons for sdk service", function() {
+        cy
+          .get("@dropdown")
+          .get(".button span")
+          .contains(new Date("2015-08-28T01:26:14.620Z").toLocaleString())
+          .parent()
+          .click();
 
-      cy
-        .get('.modal .menu-tabbed-view textarea[name="cmd"]')
-        .contains("sleep 1000");
+        cy
+          .get("@dropdown")
+          .get(".dropdown-menu-list ul li")
+          .contains(new Date("2015-02-28T05:12:12.221Z").toLocaleString())
+          .click();
+
+        cy
+          .get(".page-body-content .button")
+          .contains("Edit")
+          .should("have.attr", "disabled");
+
+        cy
+          .get(".page-body-content .button")
+          .contains("Apply")
+          .should("have.attr", "disabled");
+      });
     });
   });
 });


### PR DESCRIPTION
This PR introduces disabled modals for SDK services in the service and pod detail.

~~1 of 3: https://github.com/dcos/dcos-ui/pull/2144~~ Merged
~~2 of 3: https://github.com/dcos/dcos-ui/pull/2160~~ Merged
3 of 3: https://github.com/dcos/dcos-ui/pull/2163

Test this by adding a service with the two labels:
`DCOS_COMMONS_API_VERSION = "v1"` and
`DCOS_PACKAGE_NAME = "my-package"`

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [x] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->

~~Diff between the two PRs: https://github.com/dcos/dcos-ui/compare/mlunoe/DCOS-14910-disable-sdk-service-actions...mlunoe/DCOS-14910-disable-sdk-group-actions~~ Merged