### PR TITLE
feature(ExpandingTable): Allow rows to be expanded on mount

### DIFF
--- a/src/js/components/ExpandingTable.js
+++ b/src/js/components/ExpandingTable.js
@@ -7,10 +7,42 @@ import Util from "../utils/Util";
 const WHITESPACE = "\u00A0";
 
 class ExpandingTable extends React.Component {
-  constructor() {
-    super(...arguments);
+  constructor(props) {
+    super(props);
 
-    this.state = { expandedRows: {} };
+    let initialState = { expandedRows: {} };
+
+    if (props.expandRowsByDefault) {
+      initialState = props.data.reduce(
+        function(memo, deployment) {
+          memo.expandedRows[deployment.id] = true;
+
+          return memo;
+        },
+        { expandedRows: {} }
+      );
+    }
+
+    this.state = initialState;
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // Check for new rows and expand them if expandRowsByDefault is true.
+    if (nextProps.expandRowsByDefault) {
+      let shouldSetState = false;
+      const nextExpandedRows = this.state.expandedRows;
+
+      nextProps.data.forEach(function(deployment) {
+        if (nextExpandedRows[deployment.id] == null) {
+          shouldSetState = true;
+          nextExpandedRows[deployment.id] = true;
+        }
+      });
+
+      if (shouldSetState) {
+        this.setState({ expandedRows: nextExpandedRows });
+      }
+    }
   }
 
   defaultRenderer(prop, row) {
@@ -23,7 +55,7 @@ class ExpandingTable extends React.Component {
 
     // If the selected row is already expanded, then we want to collapse it.
     if (expandedRows[rowID]) {
-      delete expandedRows[rowID];
+      expandedRows[rowID] = false;
     } else {
       expandedRows[rowID] = true;
     }
@@ -110,6 +142,7 @@ ExpandingTable.defaultProps = {
   alignCells: "top",
   childRowClassName: "text-overflow",
   expandAll: false,
+  expandRowsByDefault: false,
   tableComponent: Table
 };
 
@@ -122,6 +155,7 @@ ExpandingTable.propTypes = {
     React.PropTypes.string
   ]),
   expandAll: React.PropTypes.bool,
+  expandRowsByDefault: React.PropTypes.bool,
   tableComponent: React.PropTypes.func
 };
 

--- a/src/js/components/ExpandingTable.js
+++ b/src/js/components/ExpandingTable.js
@@ -14,8 +14,8 @@ class ExpandingTable extends React.Component {
 
     if (props.expandRowsByDefault) {
       initialState = props.data.reduce(
-        function(memo, deployment) {
-          memo.expandedRows[deployment.id] = true;
+        function(memo, row) {
+          memo.expandedRows[row.id] = true;
 
           return memo;
         },
@@ -32,10 +32,10 @@ class ExpandingTable extends React.Component {
       let shouldSetState = false;
       const nextExpandedRows = this.state.expandedRows;
 
-      nextProps.data.forEach(function(deployment) {
-        if (nextExpandedRows[deployment.id] == null) {
+      nextProps.data.forEach(function(row) {
+        if (nextExpandedRows[row.id] == null) {
           shouldSetState = true;
-          nextExpandedRows[deployment.id] = true;
+          nextExpandedRows[row.id] = true;
         }
       });
 

--- a/src/js/components/__tests__/ExpandingTable-test.js
+++ b/src/js/components/__tests__/ExpandingTable-test.js
@@ -54,6 +54,26 @@ describe("ExpandingTable", function() {
         expect(instance.state.expandedRows["foo"]).toBeTruthy();
         expect(instance.state.expandedRows["bar"]).toBeTruthy();
       });
+
+      it("should expand all rows on mount when expandRowsByDefault is true", function() {
+        const instance = ReactDOM.render(
+          <ExpandingTable
+            columns={this.columns}
+            data={this.rows}
+            expandRowsByDefault={true}
+          />,
+          this.container
+        );
+
+        expect(instance.state.expandedRows["foo"]).toBeTruthy();
+        expect(instance.state.expandedRows["bar"]).toBeTruthy();
+
+        instance.expandRow(this.rows[0]);
+        instance.expandRow(this.rows[1]);
+
+        expect(instance.state.expandedRows["foo"]).toBeFalsy();
+        expect(instance.state.expandedRows["bar"]).toBeFalsy();
+      });
     });
 
     describe("#getRenderer", function() {

--- a/tests/pages/services/DeploymentsModal-cy.js
+++ b/tests/pages/services/DeploymentsModal-cy.js
@@ -83,8 +83,7 @@ describe("Deployments Modal", function() {
       });
     });
 
-    it("should expand to show services", function() {
-      cy.get(".modal tbody tr:visible td .is-expandable").click();
+    it("should be auto-expanded to show services", function() {
       cy
         .get(
           ".modal tbody tr:visible td .expanding-table-child .table-cell-value"


### PR DESCRIPTION
This PR extends the functionality of `ExpandingTable` by allowing the user to have all rows expanded when the component mounts (and when new rows are added that are not currently collapsed).

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?