### PR TITLE
DCOS-15568: show warning on multiple networks

### DIFF
--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -608,6 +608,8 @@ class NetworkingFormSection extends mixin(StoreMixin) {
       "networks"
     );
 
+    let { networks } = this.props.data;
+
     const tooltipContent = (
       <span>
         {
@@ -621,6 +623,29 @@ class NetworkingFormSection extends mixin(StoreMixin) {
         </a> for more information.
       </span>
     );
+
+    if (networks != null && networks.length > 1) {
+      networks = networks.map(function({ mode, name }) {
+        return {
+          name,
+          mode: Networking.internalToJson[mode]
+        };
+      });
+
+      return (
+        <div>
+          <h2 className="flush-top short-bottom">
+            Networking
+          </h2>
+          <FieldLabel>
+            Unable to edit Networking
+          </FieldLabel>
+          <pre>
+            {JSON.stringify(networks, null, 2)}
+          </pre>
+        </div>
+      );
+    }
 
     return (
       <div>

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -637,9 +637,11 @@ class NetworkingFormSection extends mixin(StoreMixin) {
           <h2 className="flush-top short-bottom">
             Networking
           </h2>
-          <FieldLabel>
-            Unable to edit Networking
-          </FieldLabel>
+          <p>
+            {"This service has advanced networking configuration, which we" +
+              " don't currently support in the UI. Please use the JSON editor" +
+              " to make changes."}
+          </p>
           <pre>
             {JSON.stringify(networks, null, 2)}
           </pre>

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/Networks.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/Networks.js
@@ -1,23 +1,38 @@
-import { SET } from "#SRC/js/constants/TransactionTypes";
+import { ADD_ITEM, SET, REMOVE_ITEM } from "#SRC/js/constants/TransactionTypes";
 
 module.exports = {
   FormReducer(state, { type, path = [], value }) {
+    if (path == null) {
+      return state;
+    }
+
     if (this.networks == null) {
-      this.networks = [{}];
+      this.networks = [];
     }
 
-    const joinedPath = path.join(".");
-    if (type === SET && joinedPath === "networks.0.network") {
-      const [mode, name] = value.split(".");
+    const [base, index, field] = path;
 
-      this.networks[0].mode = mode;
-      this.networks[0].name = name;
-    }
-    if (type === SET && joinedPath === "networks.0.mode") {
-      this.networks[0].mode = value;
-    }
-    if (type === SET && joinedPath === "networks.0.name") {
-      this.networks[0].name = value;
+    if (base === "networks") {
+      if (type === ADD_ITEM) {
+        this.networks.push({});
+      }
+      if (type === REMOVE_ITEM) {
+        this.networks = this.networks.filter((item, index) => {
+          return index !== value;
+        });
+      }
+      if (type === SET && field === "network") {
+        const [mode, name] = value.split(".");
+        this.networks[index] = {};
+        this.networks[index].mode = mode;
+        this.networks[index].name = name;
+      }
+      if (type === SET && field === "name") {
+        this.networks[index].name = value;
+      }
+      if (type === SET && field === "mode") {
+        this.networks[index].mode = value;
+      }
     }
 
     return this.networks;


### PR DESCRIPTION
Disable the networking form if more then one
network is set. If this happens the form section
will only show the JSON from `networks`.

![image](https://cloud.githubusercontent.com/assets/156010/25848412/8cb4a956-34ba-11e7-9a14-aa505bab4bd9.png)



**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

Closes DCOS-15568
