### PR TITLE
feature(Loaders): Allow flipping loading indicators horizontally

### DIFF
--- a/src/js/components/Loader.js
+++ b/src/js/components/Loader.js
@@ -50,7 +50,7 @@ class Loader extends React.Component {
   }
 
   render() {
-    const { className, innerClassName, size, type } = this.props;
+    const { className, innerClassName, flip, size, type } = this.props;
     const config = typeMap[type] || typeMap.ballScale;
     const classes = classNames("loader horizontal-center", className);
 
@@ -58,7 +58,8 @@ class Loader extends React.Component {
       config.className,
       {
         "loader--small": size === "small",
-        "loader--mini": size === "mini"
+        "loader--mini": size === "mini",
+        [`loader--flip-${flip}`]: flip != null
       },
       innerClassName
     );
@@ -87,6 +88,7 @@ const classPropType = React.PropTypes.oneOfType([
 
 Loader.propTypes = {
   className: classPropType,
+  flip: React.PropTypes.oneOf(["horizontal"]),
   innerClassName: classPropType,
   size: React.PropTypes.oneOf(["small", "mini"]),
   type: React.PropTypes.oneOf([

--- a/src/styles/components/loaders/styles.less
+++ b/src/styles/components/loaders/styles.less
@@ -30,5 +30,20 @@
         width: 34.5px;
       }
     }
+
+    &--flip-horizontal {
+      transform: rotate3d(0, 1, 0, 180deg);
+
+      &.loader {
+
+        &--mini {
+          transform: scale(0.25, 0.25) rotate3d(0, 1, 0, 180deg);
+        }
+
+        &--small {
+          transform: scale(0.5, 0.5) rotate3d(0, 1, 0, 180deg);
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PRs allows us to flip the loading indicators horizontally. This is a lot easier than modifying the timing of the animations for each loading indicator.

An example use case...

Without flipping:
![](https://cl.ly/1V1j0V0c3K3T/Screen%20Recording%202017-05-09%20at%2012.00%20PM.gif)

With flipping:
![](https://cl.ly/0T080h2x3c06/Screen%20Recording%202017-05-09%20at%2012.01%20PM.gif)

**Checklist**
- [ ] Did you add new unit tests?
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?