### PR TITLE
[Running Task Count: 1 of 2]: DCOS-15173: Add #getTaskCount methods

### DIFF
--- a/plugins/services/src/js/structs/Service.js
+++ b/plugins/services/src/js/structs/Service.js
@@ -64,6 +64,10 @@ module.exports = class Service extends Item {
     return 0;
   }
 
+  getTaskCount() {
+    return (this.get("tasks") || []).length;
+  }
+
   getTasksSummary() {
     return {
       tasksHealthy: 0,

--- a/plugins/services/src/js/structs/ServiceTree.js
+++ b/plugins/services/src/js/structs/ServiceTree.js
@@ -386,6 +386,12 @@ module.exports = class ServiceTree extends Tree {
     );
   }
 
+  getTaskCount() {
+    return this.flattenItems().getItems().reduce(function(memo, service) {
+      return memo + service.getTaskCount();
+    }, 0);
+  }
+
   getFrameworks() {
     return this.reduceItems(function(frameworks, item) {
       if (item instanceof Framework) {

--- a/plugins/services/src/js/structs/__tests__/Service-test.js
+++ b/plugins/services/src/js/structs/__tests__/Service-test.js
@@ -32,6 +32,32 @@ describe("Service", function() {
     });
   });
 
+  describe("#getTaskCount", function() {
+    it("returns the number of reported tasks", function() {
+      const service = new Service({
+        tasks: [{ foo: "bar" }, { bar: "baz" }]
+      });
+
+      expect(service.getTaskCount()).toEqual(2);
+    });
+
+    it("returns the number of reported tasks", function() {
+      const service = new Service({
+        tasks: []
+      });
+
+      expect(service.getTaskCount()).toEqual(0);
+    });
+
+    it("defaults to 0 if the tasks key is omitted", function() {
+      const service = new Service({
+        id: "/foo/bar"
+      });
+
+      expect(service.getTaskCount()).toEqual(0);
+    });
+  });
+
   describe("#toJSON", function() {
     it("returns a object with the values in _itemData", function() {
       const item = new Service({ foo: "bar", baz: "qux" });

--- a/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
+++ b/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
@@ -764,6 +764,26 @@ describe("ServiceTree", function() {
     });
   });
 
+  describe("#getTaskCount", function() {
+    const fooService = new Application();
+    const barService = new Application({
+      tasks: [{ foo: "bar" }, { bar: "baz" }]
+    });
+    const bazService = new Application({
+      tasks: [{ foo: "bar" }]
+    });
+
+    it("returns the total number of reported tasks", function() {
+      const serviceTree = new ServiceTree();
+
+      serviceTree.add(fooService);
+      serviceTree.add(barService);
+      serviceTree.add(bazService);
+
+      expect(serviceTree.getTaskCount()).toEqual(3);
+    });
+  });
+
   describe("#getTasksSummary", function() {
     beforeEach(function() {
       this.instance = new ServiceTree();


### PR DESCRIPTION
This PR adds `getTaskCount` methods to the `Service` and `ServiceTree` structs to retrieve the number of tasks as reported by Marathon.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
