### PR TITLE
DCOS-15173: Fix incorrect running task count

### DIFF
--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -129,13 +129,19 @@ class ServiceBreadcrumbs extends React.Component {
       return null;
     }
 
+    let taskCountDetails = `(${runningTasksCount})`;
+
+    if (runningTasksCount !== instancesCount) {
+      taskCountDetails = `(${runningTasksCount} of ${instancesCount})`;
+    }
+
     return (
       <BreadcrumbSupplementalContent
         ref={ref => (this.breadcrumbStatusRef = ref)}
       >
         <BreadcrumbSupplementalContent>
           <span className="muted">
-            {serviceStatus} ({runningTasksCount} of {instancesCount})
+            {serviceStatus} {taskCountDetails}
           </span>
           <ServiceStatusWarningWithDebugInformation item={service} />
         </BreadcrumbSupplementalContent>

--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -129,11 +129,9 @@ class ServiceBreadcrumbs extends React.Component {
       return null;
     }
 
-    let taskCountDetails = `(${runningTasksCount})`;
-
-    if (runningTasksCount !== instancesCount) {
-      taskCountDetails = `(${runningTasksCount} of ${instancesCount})`;
-    }
+    const taskCountDetails = runningTasksCount === instancesCount
+      ? `(${runningTasksCount})`
+      : `(${runningTasksCount} of ${instancesCount})`;
 
     return (
       <BreadcrumbSupplementalContent

--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -121,7 +121,7 @@ class ServiceBreadcrumbs extends React.Component {
 
     const serviceStatus = service.getStatus();
     const tasksSummary = service.getTasksSummary();
-    const runningTasksCount = tasksSummary.tasksRunning;
+    const runningTasksCount = service.getTaskCount();
     const instancesCount = service.getInstancesCount();
     const isDeploying = serviceStatus === "Deploying";
 

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -269,13 +269,13 @@ class ServicesTable extends React.Component {
     const tasksRunning = service.getTaskCount();
     const isDeploying = serviceStatus === "Deploying";
 
-    let conciseOverview = ` (${tasksRunning})`;
-    let verboseOverview = ` (${tasksRunning} ${StringUtil.pluralize("Instance", tasksRunning)})`;
+    const conciseOverview = tasksRunning === instancesCount
+      ? ` (${tasksRunning})`
+      : ` (${tasksRunning}/${instancesCount})`;
 
-    if (tasksRunning !== instancesCount) {
-      conciseOverview = ` (${tasksRunning}/${instancesCount})`;
-      verboseOverview = ` (${tasksRunning} of ${instancesCount} Instances)`;
-    }
+    const verboseOverview = tasksRunning === instancesCount
+      ? ` (${tasksRunning} ${StringUtil.pluralize("Instance", tasksRunning)})`
+      : ` (${tasksRunning} of ${instancesCount} Instances)`;
 
     return (
       <div className="status-bar-wrapper">

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -269,9 +269,11 @@ class ServicesTable extends React.Component {
     const tasksRunning = service.getTaskCount();
     const isDeploying = serviceStatus === "Deploying";
 
-    const conciseOverview = ` (${tasksRunning}/${instancesCount})`;
+    let conciseOverview = ` (${tasksRunning})`;
     let verboseOverview = ` (${tasksRunning} ${StringUtil.pluralize("Instance", tasksRunning)})`;
+
     if (tasksRunning !== instancesCount) {
+      conciseOverview = ` (${tasksRunning}/${instancesCount})`;
       verboseOverview = ` (${tasksRunning} of ${instancesCount} Instances)`;
     }
 

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -266,8 +266,7 @@ class ServicesTable extends React.Component {
     const serviceStatus = service.getStatus();
     const serviceStatusClassSet = StatusMapping[serviceStatus] || "";
     const tasksSummary = service.getTasksSummary();
-    const { tasksRunning } = tasksSummary;
-
+    const tasksRunning = service.getTaskCount();
     const isDeploying = serviceStatus === "Deploying";
 
     const conciseOverview = ` (${tasksRunning}/${instancesCount})`;

--- a/plugins/services/src/js/structs/Service.js
+++ b/plugins/services/src/js/structs/Service.js
@@ -64,6 +64,10 @@ module.exports = class Service extends Item {
     return 0;
   }
 
+  getTaskCount() {
+    return (this.get("tasks") || []).length;
+  }
+
   getTasksSummary() {
     return {
       tasksHealthy: 0,

--- a/plugins/services/src/js/structs/ServiceTree.js
+++ b/plugins/services/src/js/structs/ServiceTree.js
@@ -388,6 +388,10 @@ module.exports = class ServiceTree extends Tree {
 
   getTaskCount() {
     return this.flattenItems().getItems().reduce(function(memo, service) {
+      if (service instanceof ServiceTree) {
+        return memo;
+      }
+
       return memo + service.getTaskCount();
     }, 0);
   }

--- a/plugins/services/src/js/structs/ServiceTree.js
+++ b/plugins/services/src/js/structs/ServiceTree.js
@@ -386,6 +386,12 @@ module.exports = class ServiceTree extends Tree {
     );
   }
 
+  getTaskCount() {
+    return this.flattenItems().getItems().reduce(function(memo, service) {
+      return memo + service.getTaskCount();
+    }, 0);
+  }
+
   getFrameworks() {
     return this.reduceItems(function(frameworks, item) {
       if (item instanceof Framework) {

--- a/plugins/services/src/js/structs/__tests__/Service-test.js
+++ b/plugins/services/src/js/structs/__tests__/Service-test.js
@@ -32,6 +32,32 @@ describe("Service", function() {
     });
   });
 
+  describe("#getTaskCount", function() {
+    it("returns the number of reported tasks", function() {
+      const service = new Service({
+        tasks: [{ foo: "bar" }, { bar: "baz" }]
+      });
+
+      expect(service.getTaskCount()).toEqual(2);
+    });
+
+    it("returns the number of reported tasks", function() {
+      const service = new Service({
+        tasks: []
+      });
+
+      expect(service.getTaskCount()).toEqual(0);
+    });
+
+    it("defaults to 0 if the tasks key is omitted", function() {
+      const service = new Service({
+        id: "/foo/bar"
+      });
+
+      expect(service.getTaskCount()).toEqual(0);
+    });
+  });
+
   describe("#toJSON", function() {
     it("returns a object with the values in _itemData", function() {
       const item = new Service({ foo: "bar", baz: "qux" });

--- a/plugins/services/src/js/structs/__tests__/Service-test.js
+++ b/plugins/services/src/js/structs/__tests__/Service-test.js
@@ -41,7 +41,7 @@ describe("Service", function() {
       expect(service.getTaskCount()).toEqual(2);
     });
 
-    it("returns the number of reported tasks", function() {
+    it("returns 0 when the tasks array is empty", function() {
       const service = new Service({
         tasks: []
       });

--- a/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
+++ b/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
@@ -764,6 +764,26 @@ describe("ServiceTree", function() {
     });
   });
 
+  describe("#getTaskCount", function() {
+    const fooService = new Application();
+    const barService = new Application({
+      tasks: [{ foo: "bar" }, { bar: "baz" }]
+    });
+    const bazService = new Application({
+      tasks: [{ foo: "bar" }]
+    });
+
+    it("returns the total number of reported tasks", function() {
+      const serviceTree = new ServiceTree();
+
+      serviceTree.add(fooService);
+      serviceTree.add(barService);
+      serviceTree.add(bazService);
+
+      expect(serviceTree.getTaskCount()).toEqual(3);
+    });
+  });
+
   describe("#getTasksSummary", function() {
     beforeEach(function() {
       this.instance = new ServiceTree();

--- a/tests/components/PageHeader.js
+++ b/tests/components/PageHeader.js
@@ -39,7 +39,7 @@ describe("Page Header Component", function() {
         const beforeLastItem = $breadcrumbs[$breadcrumbs.length - 3];
 
         expect(beforeLastItem.textContent).to.equal("group-with-pods");
-        expect(lastItem.textContent).to.equal("podEFGHDeploying (1 of 10)");
+        expect(lastItem.textContent).to.equal("podEFGHDeploying (0 of 10)");
       });
     });
 


### PR DESCRIPTION
This PR...
* introduces a `getTaskCount` method on the `Service` and `ServiceTree` structs which tallies the number of tasks as reported by Marathon
* implements the `getTaskCount` method for the `ServiceTable` and `ServiceBreadcrumbs` components

Before:
![](https://cl.ly/110x3G0A2Y0E/Screen%20Shot%202017-05-09%20at%203.42.56%20PM.png)
![](https://cl.ly/0J1l3p073N3d/Screen%20Shot%202017-05-09%20at%203.42.45%20PM.png)

After:
![](https://cl.ly/1x1m3z0s2S2i/Screen%20Shot%202017-05-09%20at%203.41.27%20PM.png)
![](https://cl.ly/3q0O1S1w3H1P/Screen%20Shot%202017-05-09%20at%203.41.59%20PM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
