### PR TITLE
feature(DeploymentsModal): Hide actions dropdown if for SDK deployments

### DIFF
--- a/plugins/services/src/js/components/DeploymentsModal.js
+++ b/plugins/services/src/js/components/DeploymentsModal.js
@@ -18,6 +18,7 @@ import Image from "#SRC/js/components/Image";
 import Loader from "#SRC/js/components/Loader";
 import ModalHeading from "#SRC/js/components/modals/ModalHeading";
 import ResourceTableUtil from "#SRC/js/utils/ResourceTableUtil";
+import ServiceUtil from "#SRC/js/utils/ServiceUtil";
 import StatusBar from "#SRC/js/components/StatusBar";
 import StringUtil from "#SRC/js/utils/StringUtil";
 import TimeAgo from "#SRC/js/components/TimeAgo";
@@ -242,7 +243,17 @@ class DeploymentsModal extends mixin(StoreMixin) {
   }
 
   renderActionsMenu(prop, deployment, rowOptions) {
-    if (rowOptions.isParent && deployment != null) {
+    const { children = [] } = deployment;
+
+    const doesDeploymentContainSDKService = children.some(function(service) {
+      return ServiceUtil.isSDKService(service);
+    });
+
+    if (
+      !doesDeploymentContainSDKService &&
+      rowOptions.isParent &&
+      deployment != null
+    ) {
       let actionText = "Rollback";
       if (deployment.isStarting()) {
         actionText = `${actionText} & ${StringUtil.capitalize(UserActions.DELETE)}`;


### PR DESCRIPTION
This PR removes the actions dropdown for deployments that contain SDK services.

![](https://cl.ly/0h2d0W1z0F17/Screen%20Shot%202017-05-09%20at%204.43.37%20PM.png)

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?