### PR TITLE
Remove scaffolded system test files

### DIFF
--- a/system-tests/services/_scripts/teardown-packages
+++ b/system-tests/services/_scripts/teardown-packages
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Remove the service group for the test
-dcos marathon group remove --force /$TEST_UUID
-# Remove kafka because we deployed it with 1 click deploy
-dcos marathon app remove --force kafka

--- a/system-tests/services/test-packages.js
+++ b/system-tests/services/test-packages.js
@@ -1,1 +1,0 @@
-describe("Packages", function() {});

--- a/system-tests/services/tests.yml
+++ b/system-tests/services/tests.yml
@@ -22,14 +22,3 @@
       setup: ./services/_scripts/setup
       run: cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec services/test-environment.js --spec services/test-pods.js
       teardown: ./services/_scripts/teardown
-  - name: services.packages
-    title: Packages
-    cluster:
-      features: []
-    results:
-      junit: "cypress/results.xml"
-      assets:
-        - cypress
-    scripts:
-      run: cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec services/test-environment.js --spec services/test-packages.js
-      teardown: ./services/_scripts/teardown-packages


### PR DESCRIPTION
Removing previously scaffolded test files till we have time to write actual tests.

The teardown file will error out as `kafka` is not a valid app installed - so lets remove! This code was introduced in https://github.com/dcos/dcos-ui/pull/2168

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
