### PR TITLE
fix(ServiceDestroyModal): Reset text when closing

### DIFF
--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -127,7 +127,7 @@ class ServiceDestroyModal extends React.Component {
     const { router } = this.context;
 
     // Close the modal and redirect after the close animation has completed
-    this.props.onClose();
+    this.handleModalClose();
     setTimeout(() => {
       router.push({ pathname: "/services/overview" });
     }, REDIRECT_DELAY);


### PR DESCRIPTION
This fixes a small bug where the text in the `ServiceDestroyModal` didn't reset when closing the modal. It is fixed by calling `this.handleModalClose` instead of `this.props.onClose`.