### PR TITLE
fix(DeploymentStatusIndicator): Reset modal open state when deployment count is 0

### DIFF
--- a/plugins/services/src/js/components/DeploymentStatusIndicator.js
+++ b/plugins/services/src/js/components/DeploymentStatusIndicator.js
@@ -33,6 +33,14 @@ class DeploymentStatusIndicator extends mixin(StoreMixin) {
     });
   }
 
+  componentWillReceiveProps() {
+    const deployments = DCOSStore.deploymentsList.getItems();
+
+    if (this.state.isOpen && deployments.length === 0) {
+      this.setState({ isOpen: false });
+    }
+  }
+
   handleDeploymentsButtonClick() {
     this.setState({ isOpen: true });
   }


### PR DESCRIPTION
This PR fixes a bug with the `DeploymentStatusIndicator`.

To reproduce, checkout `master` and do the following:
1. While a deployment is active, click the deployments button to show the deployments modal
2. In a second tab, destroy the deploying service
3. In the second tab, deploy another service. You should see the `DeploymentModal` appear in the first tab.

This PR fixes the bug by resetting the `isOpen` state in `DeploymentStatusIndicator` when the deployment count is 0.

Thanks @nLight for filing this issue!

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
