### PR TITLE
fix(DCOS-15332): Validate redirect is the same domain as the original hostname

### DIFF
--- a/plugins/oauth/hooks.js
+++ b/plugins/oauth/hooks.js
@@ -201,8 +201,9 @@ module.exports = Object.assign({}, StoreMixin, {
 
   userLoginSuccess() {
     const redirectTo = RouterUtil.getRedirectTo();
+    const isValidRedirect = RouterUtil.isValidRedirect(redirectTo);
 
-    if (redirectTo) {
+    if (isValidRedirect) {
       global.location.href = redirectTo;
     } else {
       ApplicationUtil.beginTemporaryPolling(() => {

--- a/src/js/utils/RouterUtil.js
+++ b/src/js/utils/RouterUtil.js
@@ -17,12 +17,10 @@ function findRedirect(queryString) {
 }
 
 const RouterUtil = {
-  isValidRedirect(domain) {
-    if (!Util.isString(domain)) {
-      return false;
-    }
+  isValidRedirect(url) {
+    const parsedUrl = Util.parseUrl(url);
 
-    return domain.includes(global.location.hostname);
+    return parsedUrl.hostname === global.location.hostname;
   },
 
   getRedirectTo() {

--- a/src/js/utils/RouterUtil.js
+++ b/src/js/utils/RouterUtil.js
@@ -17,6 +17,14 @@ function findRedirect(queryString) {
 }
 
 const RouterUtil = {
+  isValidRedirect(domain) {
+    if (!Util.isString(domain)) {
+      return false;
+    }
+
+    return domain.includes(global.location.hostname);
+  },
+
   getRedirectTo() {
     let redirectTo = false;
 

--- a/src/js/utils/Util.js
+++ b/src/js/utils/Util.js
@@ -212,6 +212,38 @@ const Util = {
 
   isString(str) {
     return typeof str === "string";
+  },
+
+  /**
+   * Parse url string
+   * and returns its object representation
+   *
+   * @param {String} url
+   * @returns {Object} url representation
+   */
+  parseUrl(url) {
+    if (!Util.isString(url)) {
+      return null;
+    }
+
+    // TODO: replace below with browser native API <new URL()>
+    // when all browsers support are available
+    const aElement = document.createElement("a");
+    aElement.href = url;
+
+    return {
+      hash: aElement.hash,
+      host: aElement.host,
+      hostname: aElement.hostname,
+      href: aElement.href,
+      origin: aElement.origin,
+      password: aElement.password,
+      pathname: aElement.pathname,
+      port: aElement.port,
+      protocol: aElement.protocol,
+      search: aElement.search,
+      username: aElement.username
+    };
   }
 };
 

--- a/src/js/utils/Util.js
+++ b/src/js/utils/Util.js
@@ -208,6 +208,10 @@ const Util = {
     }
 
     return item;
+  },
+
+  isString(str) {
+    return typeof str === "string";
   }
 };
 

--- a/src/js/utils/__tests__/RouterUtil-test.js
+++ b/src/js/utils/__tests__/RouterUtil-test.js
@@ -133,4 +133,28 @@ describe("RouterUtil", function() {
       expect(path).toEqual("/foo/:id/:bar/baz");
     });
   });
+
+  describe("#redirect", function() {
+    beforeEach(function() {
+      // Overwrite jsdom global/window location mock
+      Object.defineProperty(global.location, "hostname", {
+        writable: true,
+        value: "localhost"
+      });
+    });
+
+    it("domain in redirect is valid", function() {
+      const expectedResult = true;
+      const domain = "http://localhost:4200/";
+
+      expect(RouterUtil.isValidRedirect(domain)).toEqual(expectedResult);
+    });
+
+    it("domain in redirect is invalid", function() {
+      const expectedResult = false;
+      const domain = "http://google.com:/";
+
+      expect(RouterUtil.isValidRedirect(domain)).toEqual(expectedResult);
+    });
+  });
 });

--- a/src/js/utils/__tests__/RouterUtil-test.js
+++ b/src/js/utils/__tests__/RouterUtil-test.js
@@ -145,16 +145,16 @@ describe("RouterUtil", function() {
 
     it("domain in redirect is valid", function() {
       const expectedResult = true;
-      const domain = "http://localhost:4200/";
+      const url = "http://localhost:4200/";
 
-      expect(RouterUtil.isValidRedirect(domain)).toEqual(expectedResult);
+      expect(RouterUtil.isValidRedirect(url)).toEqual(expectedResult);
     });
 
     it("domain in redirect is invalid", function() {
       const expectedResult = false;
-      const domain = "http://google.com:/";
+      const url = "http://malicious.domain.com/pwned?localhost:4200";
 
-      expect(RouterUtil.isValidRedirect(domain)).toEqual(expectedResult);
+      expect(RouterUtil.isValidRedirect(url)).toEqual(expectedResult);
     });
   });
 });

--- a/src/js/utils/__tests__/Util-test.js
+++ b/src/js/utils/__tests__/Util-test.js
@@ -424,4 +424,29 @@ describe("Util", function() {
       expect(Util.isString(1)).toEqual(false);
     });
   });
+
+  describe("#parseUrl", function() {
+    it("should return url object representation", function() {
+      const expectedResult = {
+        hash: "",
+        host: "google.com",
+        hostname: "google.com",
+        href: "http://google.com/",
+        origin: "http://google.com",
+        password: "",
+        pathname: "/",
+        port: "",
+        protocol: "http:",
+        search: "",
+        username: ""
+      };
+      const url = "http://google.com";
+
+      expect(Util.parseUrl(url)).toEqual(expectedResult);
+    });
+
+    it("should return null", function() {
+      expect(Util.parseUrl(1)).toEqual(null);
+    });
+  });
 });

--- a/src/js/utils/__tests__/Util-test.js
+++ b/src/js/utils/__tests__/Util-test.js
@@ -414,4 +414,14 @@ describe("Util", function() {
       expect(Util.toUpperCaseIfString(value)).toEqual(value);
     });
   });
+
+  describe("#isString", function() {
+    it("should return true when argument is type string", function() {
+      expect(Util.isString("Name")).toEqual(true);
+    });
+
+    it("should return false when argument is NOT type string", function() {
+      expect(Util.isString(1)).toEqual(false);
+    });
+  });
 });


### PR DESCRIPTION
(**DCOS-15332**) This PR removes the ability to use the redirect in the client side for security reasons.

This is like-a-proposal because I personally did not find any use for it yet after looking in the code and in the jira tickets so I'm assuming this is safe to delete.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
