### PR TITLE
fix(AddButton&&AdvancedSectionLabel): Wrap text nodes in spans for proper margins

### DIFF
--- a/src/js/components/form/AddButton.js
+++ b/src/js/components/form/AddButton.js
@@ -12,7 +12,9 @@ function AddButton({ children, className, icon, onClick }) {
   return (
     <a className={classes} onClick={onClick}>
       {icon}
-      {children}
+      <span>
+        {children}
+      </span>
     </a>
   );
 }

--- a/src/js/components/form/AdvancedSectionLabel.js
+++ b/src/js/components/form/AdvancedSectionLabel.js
@@ -22,7 +22,9 @@ const AdvancedSectionLabel = ({ className, children, isExpanded, onClick }) => {
   return (
     <a className={classes} onClick={onClick}>
       {getStateIndicator(isExpanded)}
-      {children}
+      <span>
+        {children}
+      </span>
     </a>
   );
 };


### PR DESCRIPTION
This PR fixes a regression where the icons in buttons didn't have margins. CNVS applies margins to _all_ adjacent DOM nodes inside buttons, and with the upgrade to React 15, the text nodes were no longer being wrapped in `span` elements. So this PR adds them explicitly.

Before:
![](https://cl.ly/1R3X1S2V191H/Screen%20Shot%202017-05-12%20at%2012.44.10%20PM.png)

After:
![](https://cl.ly/1z1W1U1Q1l0j/Screen%20Shot%202017-05-12%20at%2012.43.10%20PM.png)

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
