### PR TITLE
fix(DCOS-15234): Display service ports only when available

### DIFF
--- a/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
@@ -71,7 +71,8 @@ class ServiceNetworkingConfigSection extends ServiceConfigBaseSectionDisplay {
               name: "name",
               port: "port",
               protocol: "protocol",
-              labels: "labels"
+              labels: "labels",
+              service: "servicePort"
             };
 
             const networkType = getNetworkType(
@@ -86,6 +87,7 @@ class ServiceNetworkingConfigSection extends ServiceConfigBaseSectionDisplay {
               appDefinition,
               "container.docker.portMappings"
             );
+
             if (
               containerPortMappings != null &&
               containerPortMappings.length !== 0
@@ -161,6 +163,33 @@ class ServiceNetworkingConfigSection extends ServiceConfigBaseSectionDisplay {
               columns.splice(hostPortIndex, 0, {
                 heading: getColumnHeadingFn("Container Port"),
                 prop: "containerPort",
+                className: getColumnClassNameFn(),
+                render(prop, row) {
+                  return getDisplayValue(row[prop]);
+                },
+                sortable: true
+              });
+            }
+
+            const containsServicePorts = portDefinitions.filter(function(
+              portDefinition
+            ) {
+              const result = portDefinition.servicePort
+                ? portDefinition.servicePort !== 0
+                : false;
+
+              return result;
+            });
+
+            if (containsServicePorts.length > 0) {
+              const hostPortIndex = columns.findIndex(column => {
+                return column.prop === keys.port;
+              });
+              const servicePortsPosition = hostPortIndex + 1;
+
+              columns.splice(servicePortsPosition, 0, {
+                heading: getColumnHeadingFn("Service Port"),
+                prop: keys.service,
                 className: getColumnClassNameFn(),
                 render(prop, row) {
                   return getDisplayValue(row[prop]);

--- a/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
@@ -171,17 +171,15 @@ class ServiceNetworkingConfigSection extends ServiceConfigBaseSectionDisplay {
               });
             }
 
-            const containsServicePorts = portDefinitions.filter(function(
+            const containsServicePorts = portDefinitions.some(function(
               portDefinition
             ) {
-              const result = portDefinition.servicePort
-                ? portDefinition.servicePort !== 0
-                : false;
-
-              return result;
+              return (
+                portDefinition.servicePort && portDefinition.servicePort !== 0
+              );
             });
 
-            if (containsServicePorts.length > 0) {
+            if (containsServicePorts) {
               const hostPortIndex = columns.findIndex(column => {
                 return column.prop === keys.port;
               });

--- a/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
@@ -175,7 +175,8 @@ class ServiceNetworkingConfigSection extends ServiceConfigBaseSectionDisplay {
               portDefinition
             ) {
               return (
-                portDefinition.servicePort && portDefinition.servicePort !== 0
+                portDefinition.servicePort != null &&
+                portDefinition.servicePort !== 0
               );
             });
 


### PR DESCRIPTION
**DCOS-15234** Display service ports only when available under service configuration tab.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
