### PR TITLE
DCOS_OSS-1132: Adjust the constraints validation to fix validation errors

### DIFF
--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -337,8 +337,10 @@ const MarathonAppValidators = {
           variables
         });
       }
+
       const isValueDefinedAndRequiredEmpty =
-        PlacementConstraintsUtil.requiresEmptyValue(operator) && value != null;
+        PlacementConstraintsUtil.requiresEmptyValue(operator) &&
+        !ValidatorUtil.isEmpty(value);
 
       if (isValueDefinedAndRequiredEmpty) {
         errors.push({
@@ -348,8 +350,10 @@ const MarathonAppValidators = {
           variables
         });
       }
+
       const isValueNotAStringNumberWhenRequired =
         PlacementConstraintsUtil.stringNumberValue(operator) &&
+        !ValidatorUtil.isEmpty(value) &&
         !ValidatorUtil.isStringInteger(value);
 
       if (isValueNotAStringNumberWhenRequired) {

--- a/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
@@ -449,6 +449,13 @@ describe("MarathonAppValidators", function() {
       ]);
     });
 
+    it("shouldn't return an error for empty optional fields", function() {
+      const spec = {
+        constraints: [["hostname", "GROUP_BY"]]
+      };
+      expect(MarathonAppValidators.validateConstraints(spec)).toEqual([]);
+    });
+
     it("returns an error when wrong characters are applied", function() {
       const spec = {
         constraints: [["CPUS", "MAX_PER", "foo"]]


### PR DESCRIPTION
Change the placements constraints validation to not return errors for
optional fields.

Closes DCOS_OSS-1132