### PR TITLE
↩️ [release/1.9] DCOS_OSS-956: Implement a field for a load balanced port

### DIFF
--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -199,7 +199,11 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     const defaultVipPort = this.isHostNetwork()
       ? hostPort
       : containerPort;
-    const placeholder = defaultVipPort;
+
+    // clear placeholder when HOST network portsAutoAssign is true
+    const placeholder = this.isHostNetwork() && portsAutoAssign
+      ? ''
+      : defaultVipPort;
 
     let vipPortError = null;
     let loadBalancedError = findNestedPropertyInObject(

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -25,8 +25,9 @@ import FormRow from '../../../../../../src/js/components/form/FormRow';
 import Icon from '../../../../../../src/js/components/Icon';
 import MetadataStore from '../../../../../../src/js/stores/MetadataStore';
 import Networking from '../../../../../../src/js/constants/Networking';
-import ServiceConfigUtil from '../../utils/ServiceConfigUtil';
 import VirtualNetworksStore from '../../../../../../src/js/stores/VirtualNetworksStore';
+import ValidatorUtil from '../../../../../../src/js/utils/ValidatorUtil';
+import ServiceConfigUtil from '../../utils/ServiceConfigUtil';
 
 const {BRIDGE, HOST, USER} = Networking.type;
 const {MESOS, NONE} = ContainerConstants.type;
@@ -129,10 +130,9 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     ];
   }
 
-  getLoadBalancedServiceAddressField(portDefinition, index) {
-    const {errors, data: {id, portsAutoAssign}} = this.props;
-    const {containerPort, loadBalanced, vip} = portDefinition;
-    let {hostPort} = portDefinition;
+  getLoadBalancedServiceAddressField(endpoint, index) {
+    const {errors} = this.props;
+    const {loadBalanced} = endpoint;
     let vipPortError = null;
     let loadBalancedError = findNestedPropertyInObject(
       errors,
@@ -142,32 +142,9 @@ class NetworkingFormSection extends mixin(StoreMixin) {
       `container.docker.portMappings.${index}.labels`
     );
 
-    if (portsAutoAssign) {
-      hostPort = null;
-    }
-
     if (isObject(loadBalancedError)) {
       vipPortError = loadBalancedError[`VIP_${index}`];
       loadBalancedError = null;
-    }
-
-    let address = vip;
-    if (address == null) {
-      let port = '';
-      if (hostPort != null && hostPort !== '') {
-        port = hostPort;
-      }
-      if (containerPort != null && containerPort !== '') {
-        port = containerPort;
-      }
-      port = port || 0;
-
-      address = `${id}:${port}`;
-    }
-
-    let hostName = null;
-    if (!vipPortError) {
-      hostName = ServiceConfigUtil.buildHostNameFromVipLabel(address);
     }
 
     const loadBalancerDocsURI = MetadataStore.buildDocsURI('/usage/service-discovery/load-balancing-vips');
@@ -183,8 +160,8 @@ class NetworkingFormSection extends mixin(StoreMixin) {
       </span>
     );
 
-    return (
-      <FormRow>
+    return [
+      <FormRow key="lb-enable">
         <FormGroup
           className="column-12"
           showError={Boolean(vipPortError || loadBalancedError)}>
@@ -209,11 +186,105 @@ class NetworkingFormSection extends mixin(StoreMixin) {
                 </Tooltip>
               </FormGroupHeadingContent>
             </FormGroupHeading>
-            <FieldHelp>
-              Load balance this service internally at {hostName}
-            </FieldHelp>
           </FieldLabel>
-          <FieldError>{vipPortError || loadBalancedError}</FieldError>
+        </FormGroup>
+      </FormRow>,
+      (loadBalanced && this.getLoadBalancedPortField(endpoint, index))
+    ];
+  }
+
+  getLoadBalancedPortField(endpoint, index) {
+    const {errors, data: {id, portsAutoAssign}} = this.props;
+    const {hostPort, containerPort, vip, vipPort} = endpoint;
+    const defaultVipPort = this.isHostNetwork()
+      ? hostPort
+      : containerPort;
+    const placeholder = defaultVipPort;
+
+    let vipPortError = null;
+    let loadBalancedError = findNestedPropertyInObject(
+      errors,
+      `portDefinitions.${index}.labels`
+    ) || findNestedPropertyInObject(
+      errors,
+      `container.docker.portMappings.${index}.labels`
+    );
+
+    const tooltipContent = 'This port will be used to load balance this service address internally';
+    if (isObject(loadBalancedError)) {
+      vipPortError = loadBalancedError[`VIP_${index}`];
+      loadBalancedError = null;
+    }
+
+    let address = vip;
+
+    if (address == null) {
+      let port = '';
+      if (!portsAutoAssign && !ValidatorUtil.isEmpty(hostPort)) {
+        port = hostPort;
+      }
+      if (!ValidatorUtil.isEmpty(containerPort)) {
+        port = containerPort;
+      }
+      if (!ValidatorUtil.isEmpty(vipPort)) {
+        port = vipPort;
+      }
+
+      address = `${id}:${port}`;
+    }
+
+    let hostName = null;
+    if (!vipPortError) {
+      hostName = ServiceConfigUtil.buildHostNameFromVipLabel(address);
+    }
+
+    const helpText = (
+      <FieldHelp>
+        Load balance this service internally at {hostName}
+      </FieldHelp>
+    );
+
+    return (
+      <FormRow key="lb-port">
+        <FormGroup className="column-12">
+          <FieldLabel>
+            <FormGroupHeading>
+              <FormGroupHeadingContent primary={true}>
+                Load Balanced Port
+              </FormGroupHeadingContent>
+              <FormGroupHeadingContent>
+                <Tooltip
+                  content={tooltipContent}
+                  interactive={true}
+                  maxWidth={300}
+                  scrollContainer=".gm-scroll-view"
+                  wrapText={true}>
+                  <Icon color="grey" id="circle-question" size="mini" />
+                </Tooltip>
+              </FormGroupHeadingContent>
+            </FormGroupHeading>
+          </FieldLabel>
+          <FormRow>
+            <FormGroup
+              className="column-3"
+              key="vip-port"
+              showError={Boolean(vipPortError)}>
+              <FieldInput
+                min="1"
+                placeholder={placeholder}
+                name={`portDefinitions.${index}.vipPort`}
+                type="number"
+                value={vipPort} />
+            </FormGroup>
+          </FormRow>
+          <FormRow>
+            <FormGroup
+              className="column-12"
+              showError={Boolean(vipPortError)}>
+              <FieldError>{vipPortError}</FieldError>
+              {!vipPortError && helpText}
+            </FormGroup>
+          </FormRow>
         </FormGroup>
       </FormRow>
     );

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -599,7 +599,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
             checked={portsAutoAssignValue}
             name="portsAutoAssign"
             type="checkbox" />
-          Assign Ports Automatically
+          Assign Host Ports Automatically
         </FieldLabel>
       </div>
     );

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -65,6 +65,7 @@ const KEY_VALUE_FIELDS = [
 const CONSTANTLY_UNMUTED_ERRORS = [
   /^constraints\.[0-9]+\./,
   /^portDefinitions\.[0-9]+\./,
+  /^container.docker.portMappings\.[0-9]+\./,
   /^localVolumes\.[0-9]+\./
 ];
 

--- a/plugins/services/src/js/reducers/serviceForm/Docker.js
+++ b/plugins/services/src/js/reducers/serviceForm/Docker.js
@@ -95,8 +95,10 @@ module.exports = combineReducers({
     // Convert portDefinitions to portMappings
     return this.portDefinitions.map((portDefinition, index) => {
       const vipLabel = `VIP_${index}`;
+      const vipPort = Number(portDefinition.vipPort) || null;
       const containerPort = Number(portDefinition.containerPort) || 0;
       const servicePort = parseInt(portDefinition.servicePort, 10) || null;
+      const defaultVipPort = vipPort || containerPort;
       let hostPort = Number(portDefinition.hostPort) || 0;
       let protocol = PROTOCOLS.filter(function (protocol) {
         return portDefinition.protocol[protocol];
@@ -110,12 +112,11 @@ module.exports = combineReducers({
 
       // Prefer container port
       // because this is what a user would expect to get load balanced
-      const vipPort = containerPort || hostPort || 0;
       const labels = VipLabelUtil.generateVipLabel(
         this.appState.id,
         portDefinition,
         vipLabel,
-        vipPort
+        vipPort || defaultVipPort
       );
 
       return {

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/SingleContainerPortDefinitionsReducer.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/SingleContainerPortDefinitionsReducer.js
@@ -11,7 +11,8 @@ const FIELDS = [
   'loadBalanced',
   'name',
   'servicePort',
-  'vip'
+  'vip',
+  'vipPort'
 ];
 
 /**
@@ -41,7 +42,8 @@ function SingleContainerPortDefinitionsReducer(state = [], action) {
               udp: false
             },
             servicePort: null,
-            vip: null
+            vip: null,
+            vipPort: null
           });
           break;
         case REMOVE_ITEM:

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/SingleContainerPortMappingsReducer.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/SingleContainerPortMappingsReducer.js
@@ -14,7 +14,8 @@ const FIELDS = [
   'portMapping',
   'name',
   'servicePort',
-  'vip'
+  'vip',
+  'vipPort'
 ];
 
 /**
@@ -47,7 +48,8 @@ function SingleContainerPortMappingsReducer(state = [], action) {
               udp: false
             },
             servicePort: null,
-            vip: null
+            vip: null,
+            vipPort: null
           });
           break;
         case REMOVE_ITEM:

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/PortDefinitionsReducer.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/PortDefinitionsReducer.js
@@ -11,7 +11,8 @@ const FIELDS = [
   'loadBalanced',
   'name',
   'servicePort',
-  'vip'
+  'vip',
+  'vipPort'
 ];
 
 /**
@@ -41,7 +42,8 @@ function PortDefinitionsReducer(state = [], action) {
               udp: false
             },
             servicePort: null,
-            vip: null
+            vip: null,
+            vipPort: null
           });
           break;
         case REMOVE_ITEM:

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/PortMappingsReducer.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/PortMappingsReducer.js
@@ -14,7 +14,8 @@ const FIELDS = [
   'portMapping',
   'name',
   'servicePort',
-  'vip'
+  'vip',
+  'vipPort'
 ];
 
 /**
@@ -47,7 +48,8 @@ function PortMappingsReducer(state = [], action) {
               udp: false
             },
             servicePort: null,
-            vip: null
+            vip: null,
+            vipPort: null
           });
           break;
         case REMOVE_ITEM:

--- a/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
+++ b/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
@@ -65,6 +65,10 @@ module.exports = {
       const hostPort = this.appState.portsAutoAssign
         ? 0
         : Number(portDefinition.hostPort);
+      const defaultVipPort = hostPort !== 0
+        ? hostPort
+        : null;
+      const vipPort = portDefinition.vipPort || defaultVipPort;
       const protocol = PROTOCOLS.filter(function (protocol) {
         return portDefinition.protocol[protocol];
       }).join(',');
@@ -73,7 +77,7 @@ module.exports = {
         this.appState.id,
         portDefinition,
         vipLabel,
-        hostPort
+        vipPort
       );
 
       return {
@@ -144,6 +148,15 @@ module.exports = {
             index,
             'vip'
           ], vip, SET));
+        }
+
+        const vipPortMatch = vip.match(/.+:(\d+)/);
+        if (vipPortMatch) {
+          memo.push(new Transaction([
+            'portDefinitions',
+            index,
+            'vipPort'
+          ], vipPortMatch[1], SET));
         }
       }
 

--- a/plugins/services/src/js/reducers/serviceForm/PortMappings.js
+++ b/plugins/services/src/js/reducers/serviceForm/PortMappings.js
@@ -140,6 +140,15 @@ module.exports = {
             'vip'
           ], vip, SET));
         }
+
+        const vipPortMatch = vip.match(/.+:(\d+)/);
+        if (vipPortMatch) {
+          memo.push(new Transaction([
+            'portDefinitions',
+            index,
+            'vipPort'
+          ], vipPortMatch[1], SET));
+        }
       }
 
       if (item.labels != null) {

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
@@ -141,7 +141,7 @@ describe('PortDefinitions', function () {
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {}))
         .toEqual([
           {name: null, port: 0, protocol: 'tcp', labels: null},
-          {name: null, port: 0, protocol: 'tcp', labels: {'VIP_1': ':0'}}
+          {name: null, port: 0, protocol: 'tcp', labels: {'VIP_1': ':null'}}
         ]);
     });
 
@@ -154,8 +154,8 @@ describe('PortDefinitions', function () {
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {}))
         .toEqual([
-          {name: null, port: 0, protocol: 'tcp', labels: {VIP_0: ':0'}},
-          {name: null, port: 0, protocol: 'tcp', labels: {VIP_1: ':0'}}
+          {name: null, port: 0, protocol: 'tcp', labels: {VIP_0: ':null'}},
+          {name: null, port: 0, protocol: 'tcp', labels: {VIP_1: ':null'}}
         ]);
     });
 
@@ -185,7 +185,7 @@ describe('PortDefinitions', function () {
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {}))
         .toEqual([
           {name: null, port: 0, protocol: 'tcp', labels: null},
-          {name: null, port: 0, protocol: 'tcp', labels: {'VIP_1': 'foo:0'}}
+          {name: null, port: 0, protocol: 'tcp', labels: {'VIP_1': 'foo:null'}}
         ]);
     });
 
@@ -202,7 +202,7 @@ describe('PortDefinitions', function () {
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {}))
         .toEqual([
           {name: null, port: 0, protocol: 'tcp', labels: null},
-          {name: null, port: 0, protocol: 'tcp', labels: {'VIP_1': 'foo:0'}}
+          {name: null, port: 0, protocol: 'tcp', labels: {'VIP_1': 'foo:null'}}
         ]);
     });
 

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
@@ -135,7 +135,7 @@ describe('PortDefinitions', function () {
     it('should add the labels key if the portDefinition is load balanced', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(['portDefinitions'], 1, ADD_ITEM));
       batch = batch.add(new Transaction(['portDefinitions', 1, 'loadBalanced'], true));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {}))
@@ -148,7 +148,7 @@ describe('PortDefinitions', function () {
     it('should add the index of the portDefinition to the VIP keys', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(['portDefinitions'], 1, ADD_ITEM));
       batch = batch.add(new Transaction(['portDefinitions', 0, 'loadBalanced'], true));
       batch = batch.add(new Transaction(['portDefinitions', 1, 'loadBalanced'], true));
 
@@ -162,7 +162,7 @@ describe('PortDefinitions', function () {
     it('should add the port to the VIP string', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(['portDefinitions'], 1, ADD_ITEM));
       batch = batch.add(new Transaction(['portsAutoAssign'], false));
       batch = batch.add(new Transaction(['portDefinitions', 0, 'hostPort'], 300));
       batch = batch.add(new Transaction(['portDefinitions', 0, 'loadBalanced'], true));
@@ -177,7 +177,7 @@ describe('PortDefinitions', function () {
     it('should add the app ID to the VIP string when it is defined', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(['portDefinitions'], 1, ADD_ITEM));
       batch = batch.add(new Transaction(['portsAutoAssign'], false));
       batch = batch.add(new Transaction(['portDefinitions', 1, 'loadBalanced'], true));
       batch = batch.add(new Transaction(['id'], 'foo'));
@@ -193,7 +193,7 @@ describe('PortDefinitions', function () {
       let batch = new Batch();
       batch = batch.add(new Transaction(['container', 'docker', 'network'], USER, SET));
       batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(['portDefinitions'], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(['portDefinitions'], 1, ADD_ITEM));
       batch = batch.add(new Transaction(['portsAutoAssign'], false));
       batch = batch.add(new Transaction(['portDefinitions', 1, 'loadBalanced'], true));
       batch = batch.add(new Transaction(['id'], 'foo'));

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/PortMappings-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/PortMappings-test.js
@@ -109,6 +109,7 @@ describe('#JSONParser', function () {
         new Transaction(['portDefinitions', 0, 'portMapping'], false),
         new Transaction(['portDefinitions', 0, 'loadBalanced'], true),
         new Transaction(['portDefinitions', 0, 'vip'], '/:0'),
+        new Transaction(['portDefinitions', 0, 'vipPort'], '0'),
         new Transaction(['portDefinitions', 0, 'labels'], {VIP_0: '/:0'})
       ]);
     });
@@ -205,6 +206,7 @@ describe('#JSONParser', function () {
         new Transaction(['portDefinitions', 1, 'protocol', 'tcp'], true),
         new Transaction(['portDefinitions', 1, 'loadBalanced'], true),
         new Transaction(['portDefinitions', 1, 'vip'], '/:0'),
+        new Transaction(['portDefinitions', 1, 'vipPort'], '0'),
         new Transaction(['portDefinitions', 1, 'labels'], {VIP_1: '/:0'})
       ]);
     });

--- a/src/js/utils/NetworkValidatorUtil.js
+++ b/src/js/utils/NetworkValidatorUtil.js
@@ -3,7 +3,7 @@ import ValidatorUtil from './ValidatorUtil';
 const NetworkValidatorUtil = {
   isValidPort(value) {
     return ValidatorUtil.isInteger(value) &&
-      ValidatorUtil.isNumberInRange(value, {max: 65535});
+      ValidatorUtil.isNumberInRange(value, {min: 1, max: 65535});
   }
 };
 

--- a/src/js/utils/__tests__/NetworkValidatorUtil-test.js
+++ b/src/js/utils/__tests__/NetworkValidatorUtil-test.js
@@ -20,17 +20,17 @@ describe('NetworkValidatorUtil', function () {
     });
 
     it('should handle number like inputs', function () {
-      expect(NetworkValidatorUtil.isValidPort(0)).toBe(true);
-      expect(NetworkValidatorUtil.isValidPort('0')).toBe(true);
+      expect(NetworkValidatorUtil.isValidPort(0)).toBe(false);
+      expect(NetworkValidatorUtil.isValidPort('0')).toBe(false);
       expect(NetworkValidatorUtil.isValidPort(80)).toBe(true);
       expect(NetworkValidatorUtil.isValidPort('80')).toBe(true);
       expect(NetworkValidatorUtil.isValidPort(8080)).toBe(true);
       expect(NetworkValidatorUtil.isValidPort('8080')).toBe(true);
     });
 
-    it('should verify that port is greater or equal to 0', function () {
+    it('should verify that port is greater then 0', function () {
       expect(NetworkValidatorUtil.isValidPort(-1)).toBe(false);
-      expect(NetworkValidatorUtil.isValidPort(0)).toBe(true);
+      expect(NetworkValidatorUtil.isValidPort(0)).toBe(false);
       expect(NetworkValidatorUtil.isValidPort(8080)).toBe(true);
     });
 
@@ -43,4 +43,3 @@ describe('NetworkValidatorUtil', function () {
   });
 
 });
-


### PR DESCRIPTION
This PR adds a field for Load Balanced port that has meaningful default values. For HOST network it will be hostPort and for Bridge/User networks it will be container port

<img width="934" alt="screen shot 2017-05-24 at 13 39 02" src="https://cloud.githubusercontent.com/assets/186223/26401608/fd15471e-4086-11e7-943c-9e29ac34d157.png">
<img width="930" alt="screen shot 2017-05-24 at 13 39 13" src="https://cloud.githubusercontent.com/assets/186223/26401609/fde4c84a-4086-11e7-9f24-371f9e87573e.png">
