### PR TITLE
fix(DCOS_OSS-1108): Fix jobs status display

### DIFF
--- a/src/js/pages/jobs/JobsTable.js
+++ b/src/js/pages/jobs/JobsTable.js
@@ -226,8 +226,7 @@ class JobsTable extends React.Component {
 
     const statusClasses = classNames({
       "text-success": jobState.stateTypes.includes("success"),
-      "text-danger": jobState.stateTypes.includes("failure"),
-      "text-color-white": jobState.stateTypes.includes("active")
+      "text-danger": jobState.stateTypes.includes("failure")
     });
 
     return <span className={statusClasses}>{jobState.displayName}</span>;


### PR DESCRIPTION
**DCOS_OSS-1108** Remove class on status label which was blending the color with background and making the text not visible to users.

**before**
![screen shot 2017-05-26 at 10 39 42 am](https://cloud.githubusercontent.com/assets/549394/26505984/af3014d2-41ff-11e7-9610-09e885ccc044.png)


**after**
![screen shot 2017-05-26 at 10 37 34 am](https://cloud.githubusercontent.com/assets/549394/26505952/8b23bc42-41ff-11e7-930d-4855cc42de8d.png)



**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
