### PR TITLE
Integration/1.5 refactoring extraction

### DIFF
--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -467,7 +467,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
       .join(", ");
 
     const selections = (
-      <FieldSelect name="container.docker.network" value={network}>
+      <FieldSelect name="networks.0.mode" value={network}>
         <option disabled={Boolean(disabledMap[HOST])} value={HOST}>
           Host
         </option>
@@ -654,7 +654,7 @@ NetworkingFormSection.configReducers = {
   networkType(state, { type, path = [], value }) {
     const joinedPath = path.join(".");
 
-    if (type === SET && joinedPath === "container.docker.network") {
+    if (type === SET && joinedPath === "networks.0.mode") {
       return value;
     }
 

--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -620,7 +620,16 @@ class NewCreateServiceModal extends Component {
       const { location } = this.props;
       const { showAllErrors } = this.state;
 
-      const SECTIONS = [
+      const SINGLE_CONTAINER_SECTIONS = [
+        ContainerServiceFormSection,
+        EnvironmentFormSection,
+        GeneralServiceFormSection,
+        HealthChecksFormSection,
+        NetworkingFormSection,
+        VolumesFormSection
+      ];
+
+      const MULTI_CONTAINER_SECTIONS = [
         ContainerServiceFormSection,
         EnvironmentFormSection,
         GeneralServiceFormSection,
@@ -653,7 +662,10 @@ class NewCreateServiceModal extends Component {
         inputConfigReducers = combineReducers(
           Hooks.applyFilter(
             "multiContainerInputConfigReducers",
-            Object.assign({}, ...SECTIONS.map(item => item.configReducers))
+            Object.assign(
+              {},
+              ...MULTI_CONTAINER_SECTIONS.map(item => item.configReducers)
+            )
           )
         );
       } else {
@@ -674,7 +686,10 @@ class NewCreateServiceModal extends Component {
         inputConfigReducers = combineReducers(
           Hooks.applyFilter(
             "serviceInputConfigReducers",
-            Object.assign({}, ...SECTIONS.map(item => item.configReducers))
+            Object.assign(
+              {},
+              ...SINGLE_CONTAINER_SECTIONS.map(item => item.configReducers)
+            )
           )
         );
       }

--- a/plugins/services/src/js/reducers/serviceForm/Docker.js
+++ b/plugins/services/src/js/reducers/serviceForm/Docker.js
@@ -47,7 +47,7 @@ module.exports = combineReducers({
       return null;
     }
 
-    if (type === SET && joinedPath === "container.docker.network") {
+    if (type === SET && joinedPath === "networks.0.mode") {
       return Networking.type[value.split(".")[0]];
     }
 
@@ -70,7 +70,7 @@ module.exports = combineReducers({
       this.containerType = value;
     }
 
-    if (joinedPath === "container.docker.network" && Boolean(value)) {
+    if (joinedPath === "networks.0.mode" && Boolean(value)) {
       this.appState.networkType = value.split(".")[0];
     }
 

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/IpAddress.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/IpAddress.js
@@ -23,7 +23,7 @@ module.exports = {
       this.internalState.labels = value;
     }
 
-    if (type === SET && joinedPath === "container.docker.network") {
+    if (type === SET && joinedPath === "networks.0.mode") {
       const networkName = value.split(".")[1];
       if (networkName != null) {
         return {

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/IpAddress-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/IpAddress-test.js
@@ -6,7 +6,7 @@ describe("IpAddress", function() {
   describe("#JSONReducer", function() {
     it("emits correct JSON", function() {
       const batch = new Batch([
-        new Transaction(["container", "docker", "network"], "USER.dcos")
+        new Transaction(["networks", 0, "mode"], "USER.dcos")
       ]);
 
       expect(batch.reduce(IpAddress.JSONReducer.bind({}), {})).toEqual({
@@ -20,7 +20,7 @@ describe("IpAddress", function() {
     it("should have the right discovery value", function() {
       const batch = new Batch([
         new Transaction(["ipAddress", "discovery"], "STS-133"),
-        new Transaction(["container", "docker", "network"], "USER.dcos")
+        new Transaction(["networks", 0, "mode"], "USER.dcos")
       ]);
 
       expect(batch.reduce(IpAddress.JSONReducer.bind({}), {})).toEqual({
@@ -34,7 +34,7 @@ describe("IpAddress", function() {
     it("should have the right groups value", function() {
       const batch = new Batch([
         new Transaction(["ipAddress", "groups"], "admins"),
-        new Transaction(["container", "docker", "network"], "USER.dcos")
+        new Transaction(["networks", 0, "mode"], "USER.dcos")
       ]);
 
       expect(batch.reduce(IpAddress.JSONReducer.bind({}), {})).toEqual({
@@ -48,7 +48,7 @@ describe("IpAddress", function() {
     it("should have the right labels value", function() {
       const batch = new Batch([
         new Transaction(["ipAddress", "labels"], "no:labels"),
-        new Transaction(["container", "docker", "network"], "USER.dcos")
+        new Transaction(["networks", 0, "mode"], "USER.dcos")
       ]);
 
       expect(batch.reduce(IpAddress.JSONReducer.bind({}), {})).toEqual({

--- a/plugins/services/src/js/reducers/serviceForm/Network.js
+++ b/plugins/services/src/js/reducers/serviceForm/Network.js
@@ -29,7 +29,7 @@ module.exports = {
     if (networkName != null && networkType != null) {
       transactions.push(
         new Transaction(
-          ["container", "docker", "network"],
+          ["networks", 0, "mode"],
           `${networkType}.${networkName}`
         )
       );
@@ -55,9 +55,7 @@ module.exports = {
         );
       }
     } else {
-      transactions.push(
-        new Transaction(["container", "docker", "network"], networkType)
-      );
+      transactions.push(new Transaction(["networks", 0, "mode"], networkType));
     }
 
     return transactions;

--- a/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
+++ b/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
@@ -35,7 +35,7 @@ module.exports = {
     }
 
     const joinedPath = path.join(".");
-    if (joinedPath === "container.docker.network" && Boolean(value)) {
+    if (joinedPath === "networks.0.mode" && Boolean(value)) {
       this.appState.networkType = value;
     }
 

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -337,9 +337,7 @@ describe("Container", function() {
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
         );
-        batch = batch.add(
-          new Transaction(["container", "docker", "network"], USER, SET)
-        );
+        batch = batch.add(new Transaction(["networks", 0, "mode"], USER, SET));
         batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
         batch = batch.add(
           new Transaction(["portDefinitions", 0, "portMapping"], true)
@@ -372,9 +370,7 @@ describe("Container", function() {
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
         );
-        batch = batch.add(
-          new Transaction(["container", "docker", "network"], USER, SET)
-        );
+        batch = batch.add(new Transaction(["networks", 0, "mode"], USER, SET));
         // This is default
         // batch = batch.add(
         //   new Transaction(['portDefinitions', 0, 'portMapping'], false)
@@ -415,7 +411,7 @@ describe("Container", function() {
           new Transaction(["container", "type"], "DOCKER", SET)
         );
         batch = batch.add(
-          new Transaction(["container", "docker", "network"], BRIDGE, SET)
+          new Transaction(["networks", 0, "mode"], BRIDGE, SET)
         );
         // This is default
         // batch = batch.add(
@@ -463,7 +459,7 @@ describe("Container", function() {
           new Transaction(["container", "type"], "DOCKER", SET)
         );
         batch = batch.add(
-          new Transaction(["container", "docker", "network"], BRIDGE, SET)
+          new Transaction(["networks", 0, "mode"], BRIDGE, SET)
         );
         batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
         batch = batch.add(
@@ -514,7 +510,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], HOST, SET)
+            new Transaction(["networks", 0, "mode"], HOST, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(
@@ -540,7 +536,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(new Transaction(["portDefinitions"], 1, ADD_ITEM));
@@ -587,7 +583,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(
@@ -625,7 +621,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(
@@ -666,7 +662,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(
@@ -708,7 +704,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(
@@ -749,7 +745,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(new Transaction(["portDefinitions"], 1, ADD_ITEM));
@@ -799,7 +795,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(new Transaction(["portDefinitions"], 1, ADD_ITEM));
@@ -852,7 +848,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
@@ -908,7 +904,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "DOCKER", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
@@ -977,7 +973,7 @@ describe("Container", function() {
           );
           batch = batch.add(new Transaction(["id"], "foo"));
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
 
           expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
@@ -1016,7 +1012,7 @@ describe("Container", function() {
             new Transaction(["container", "type"], "MESOS", SET)
           );
           batch = batch.add(
-            new Transaction(["container", "docker", "network"], USER, SET)
+            new Transaction(["networks", 0, "mode"], USER, SET)
           );
           batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
           batch = batch.add(

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Network-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Network-test.js
@@ -17,7 +17,7 @@ describe("Network", function() {
         {
           type: SET,
           value: "USER.dcos",
-          path: ["container", "docker", "network"]
+          path: ["networks", 0, "mode"]
         }
       ]);
     });
@@ -31,7 +31,7 @@ describe("Network", function() {
         }
       };
       expect(Network.JSONParser(state)).toEqual([
-        { type: SET, value: "BRIDGE", path: ["container", "docker", "network"] }
+        { type: SET, value: "BRIDGE", path: ["networks", 0, "mode"] }
       ]);
     });
 
@@ -44,7 +44,7 @@ describe("Network", function() {
         }
       };
       expect(Network.JSONParser(state)).toEqual([
-        { type: SET, value: "HOST", path: ["container", "docker", "network"] }
+        { type: SET, value: "HOST", path: ["networks", 0, "mode"] }
       ]);
     });
 
@@ -70,7 +70,7 @@ describe("Network", function() {
         {
           type: SET,
           value: "USER.dcos",
-          path: ["container", "docker", "network"]
+          path: ["networks", 0, "mode"]
         },
         { type: SET, value: ["group1"], path: ["ipAddress", "groups"] },
         {

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
@@ -19,7 +19,7 @@ describe("PortDefinitions", function() {
 
     it("Should return null if networkType is not HOST", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["container.docker.network"], BRIDGE));
+      batch = batch.add(new Transaction(["networks", 0, "mode"], BRIDGE));
       batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual(
@@ -29,7 +29,7 @@ describe("PortDefinitions", function() {
 
     it("Should return null if networkType is not USER", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["container.docker.network"], USER));
+      batch = batch.add(new Transaction(["networks", 0, "mode"], USER));
       batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual(
@@ -48,9 +48,7 @@ describe("PortDefinitions", function() {
 
     it("should create default portDefinition configurations for BRIDGE network", function() {
       let batch = new Batch();
-      batch = batch.add(
-        new Transaction(["container", "docker", "network"], BRIDGE, SET)
-      );
+      batch = batch.add(new Transaction(["networks", 0, "mode"], BRIDGE, SET));
       batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual(
@@ -60,9 +58,7 @@ describe("PortDefinitions", function() {
 
     it("shouldn't create portDefinitions for USER", function() {
       let batch = new Batch();
-      batch = batch.add(
-        new Transaction(["container", "docker", "network"], USER, SET)
-      );
+      batch = batch.add(new Transaction(["networks", 0, "mode"], USER, SET));
       batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual(
@@ -221,9 +217,7 @@ describe("PortDefinitions", function() {
 
     it("should store portDefinitions even if network is USER when recorded", function() {
       let batch = new Batch();
-      batch = batch.add(
-        new Transaction(["container", "docker", "network"], USER, SET)
-      );
+      batch = batch.add(new Transaction(["networks", 0, "mode"], USER, SET));
       batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
       batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
       batch = batch.add(
@@ -233,9 +227,7 @@ describe("PortDefinitions", function() {
         new Transaction(["portDefinitions", 1, "loadBalanced"], true)
       );
       batch = batch.add(new Transaction(["id"], "foo"));
-      batch = batch.add(
-        new Transaction(["container", "docker", "network"], HOST, SET)
-      );
+      batch = batch.add(new Transaction(["networks", 0, "mode"], HOST, SET));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual([
         { name: null, port: 0, protocol: "tcp", labels: null },

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -839,9 +839,7 @@ describe("Service Form Modal", function() {
           setRuntime("Docker Engine");
           clickNetworkingTab();
 
-          cy
-            .get('select[name="container.docker.network"]')
-            .as("containerDockerNetwork");
+          cy.get('select[name="networks.0.mode"]').as("containerDockerNetwork");
 
           // HOST
           cy
@@ -876,9 +874,7 @@ describe("Service Form Modal", function() {
           setRuntime("Mesos Runtime");
           clickNetworkingTab();
 
-          cy
-            .get('select[name="container.docker.network"]')
-            .as("containerDockerNetwork");
+          cy.get('select[name="networks.0.mode"]').as("containerDockerNetwork");
 
           // HOST
           cy
@@ -994,7 +990,7 @@ describe("Service Form Modal", function() {
 
         context("type: HOST", function() {
           it('should hide "Container Port"', function() {
-            cy.get('select[name="container.docker.network"]').select("HOST");
+            cy.get('select[name="networks.0.mode"]').select("HOST");
 
             cy
               .get("@tabView")
@@ -1037,7 +1033,7 @@ describe("Service Form Modal", function() {
 
         context("type: BRIDGE", function() {
           it('should show "Container Port" and "Protocol"', function() {
-            cy.get('select[name="container.docker.network"]').select("BRIDGE");
+            cy.get('select[name="networks.0.mode"]').select("BRIDGE");
 
             cy
               .get("@tabView")
@@ -1080,9 +1076,7 @@ describe("Service Form Modal", function() {
 
         context("type: USER (Virtual Network: dcos)", function() {
           it('should hide "Host Port" and "Protocol"', function() {
-            cy
-              .get('select[name="container.docker.network"]')
-              .select("USER.dcos-1");
+            cy.get('select[name="networks.0.mode"]').select("USER.dcos-1");
 
             cy
               .get("@tabView")
@@ -1123,9 +1117,7 @@ describe("Service Form Modal", function() {
           });
 
           it('should not hide "Host Port" and "Protocol" when "Port Mapping" is enabled', function() {
-            cy
-              .get('select[name="container.docker.network"]')
-              .select("USER.dcos-1");
+            cy.get('select[name="networks.0.mode"]').select("USER.dcos-1");
 
             // Enable port mapping
             cy


### PR DESCRIPTION
This is an extraction from #2200 

Since integration takes a bit longer and creates conflicts, let's merge this refactoring first to ease the pain of rebasing #2200 

- The first commit unties Batch transaction paths from JSON representation.
- The second one separates single and multi container form sections so that we effectively separate input reducers.