### PR TITLE
DCOS-15172: fix(healthBar): Include framework tasks in bar

### DIFF
--- a/plugins/services/src/js/structs/__tests__/Framework-test.js
+++ b/plugins/services/src/js/structs/__tests__/Framework-test.js
@@ -124,6 +124,69 @@ describe("Framework", function() {
         tasksOverCapacity: 0
       });
     });
+
+    it("aggregates the right number of tasks", function() {
+      MesosStateStore.getTasksByService = function() {
+        return [
+          {
+            id: "/fake_1",
+            isStartedByMarathon: true,
+            state: "TASK_RUNNING",
+            resources: { cpus: 0.2, mem: 300, gpus: 0, disk: 0 }
+          },
+          {
+            id: "/fake_2",
+            state: "TASK_RUNNING",
+            statuses: [
+              {
+                healthy: true
+              }
+            ],
+            resources: { cpus: 0.8, mem: 700, gpus: 0, disk: 0 }
+          },
+          {
+            id: "/fake_2",
+            state: "TASK_RUNNING",
+            statuses: [
+              {
+                healthy: false
+              }
+            ],
+            resources: { cpus: 0.8, mem: 700, gpus: 0, disk: 0 }
+          },
+          {
+            id: "/fake_3",
+            state: "TASK_FINISHED",
+            statuses: [
+              {
+                healthy: false
+              }
+            ],
+            resources: { cpus: 0.8, mem: 700, gpus: 0, disk: 0 }
+          }
+        ];
+      };
+
+      const service = new Framework({
+        instances: 1,
+        TASK_RUNNING: 2,
+        tasksHealthy: 1,
+        tasksRunning: 1,
+        tasksStaged: 0,
+        tasksUnhealthy: 0,
+        cpus: 1,
+        mem: 1000
+      });
+
+      expect(service.getTasksSummary()).toEqual({
+        tasksHealthy: 2,
+        tasksRunning: 3,
+        tasksStaged: 0,
+        tasksUnhealthy: 1,
+        tasksOverCapacity: 0,
+        tasksUnknown: 0
+      });
+    });
   });
 
   describe("#getInstancesCount", function() {


### PR DESCRIPTION
Use data from mesosStateStore to aggregate
healthstatus for a framework.

![image](https://cloud.githubusercontent.com/assets/156010/26582172/5f23bab8-4540-11e7-89d8-cbde58f85137.png)


Closes DCOS-15172

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
