### PR TITLE
DCOS-15173: fix(frameworks): Show task count running

### DIFF
--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -10,6 +10,7 @@ import BreadcrumbTextContent from "#SRC/js/components/BreadcrumbTextContent";
 import PageHeaderBreadcrumbs from "#SRC/js/components/PageHeaderBreadcrumbs";
 import Util from "#SRC/js/utils/Util";
 
+import Framework from "../structs/Framework";
 import HealthBar from "./HealthBar";
 import ServiceStatusWarningWithDebugInformation
   from "./ServiceStatusWarningWithDebugInstruction";
@@ -129,9 +130,11 @@ class ServiceBreadcrumbs extends React.Component {
       return null;
     }
 
-    const taskCountDetails = runningTasksCount === instancesCount
-      ? `(${runningTasksCount})`
-      : `(${runningTasksCount} of ${instancesCount})`;
+    let taskCountDetails = `(${runningTasksCount} of ${instancesCount})`;
+
+    if (service instanceof Framework || runningTasksCount === instancesCount) {
+      taskCountDetails = `(${runningTasksCount})`;
+    }
 
     return (
       <BreadcrumbSupplementalContent

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -13,6 +13,7 @@ import TableUtil from "#SRC/js/utils/TableUtil";
 import Units from "#SRC/js/utils/Units";
 import { isSDKService } from "#SRC/js/utils/ServiceUtil";
 
+import Framework from "../../structs/Framework";
 import HealthBar from "../../components/HealthBar";
 import Pod from "../../structs/Pod";
 import Service from "../../structs/Service";
@@ -333,15 +334,17 @@ class ServicesTable extends React.Component {
     const serviceStatusClassSet = StatusMapping[serviceStatus] || "";
     const tasksSummary = service.getTasksSummary();
     const tasksRunning = service.getTaskCount();
+
     const isDeploying = serviceStatus === "Deploying";
 
-    const conciseOverview = tasksRunning === instancesCount
-      ? ` (${tasksRunning})`
-      : ` (${tasksRunning}/${instancesCount})`;
+    let conciseOverview = ` (${tasksRunning}/${instancesCount})`;
 
-    const verboseOverview = tasksRunning === instancesCount
-      ? ` (${tasksRunning} ${StringUtil.pluralize("Instance", tasksRunning)})`
-      : ` (${tasksRunning} of ${instancesCount} Instances)`;
+    let verboseOverview = ` (${tasksRunning} of ${instancesCount} Instances)`;
+
+    if (service instanceof Framework || tasksRunning === instancesCount) {
+      conciseOverview = ` (${tasksRunning})`;
+      verboseOverview = ` (${tasksRunning} ${StringUtil.pluralize("Instance", tasksRunning)})`;
+    }
 
     return (
       <div className="status-bar-wrapper">

--- a/plugins/services/src/js/structs/Framework.js
+++ b/plugins/services/src/js/structs/Framework.js
@@ -41,6 +41,17 @@ module.exports = class Framework extends Application {
     return tasksSummary;
   }
 
+  getTaskCount() {
+    // TODO: Circular reference workaround DCOS_OSS-783
+    const MesosStateStore = require("#SRC/js/stores/MesosStateStore");
+
+    const tasks = MesosStateStore.getTasksByService(this) || [];
+
+    return tasks.filter(function(task) {
+      return task.state === "TASK_RUNNING";
+    }).length;
+  }
+
   getUsageStats(resource) {
     const value = this.get("used_resources")[resource];
 


### PR DESCRIPTION
This fix changes the way taskcount is displayedfor frameworks. For Frameworks it is better to display all the tasks running instead of instances.

![image](https://cloud.githubusercontent.com/assets/156010/26553038/2715a818-448a-11e7-9e82-ed55695246fe.png)
![image](https://cloud.githubusercontent.com/assets/156010/26553047/330b9402-448a-11e7-8609-7ec639952171.png)


Closes DCOS-15173

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
