### PR TITLE
feat(DCOS-12849): Defaults services logs to stderr

### DIFF
--- a/plugins/services/src/js/pages/task-details/TaskFileViewer.js
+++ b/plugins/services/src/js/pages/task-details/TaskFileViewer.js
@@ -155,7 +155,7 @@ class TaskFileViewer extends React.Component {
 
     return (
       files.find(function(file) {
-        return file.getName() === "stdout";
+        return file.getName() === "stderr";
       }) || files[0]
     );
   }


### PR DESCRIPTION
**DCOS-12849** This PR defaults the logs to `stderr` that way decreasing the number of clicks the user needs to do before seeing the logs.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
