### PR TITLE
↩️  DCOS_OSS-1132: Adjust the constraints validation

### DIFF
--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -250,10 +250,10 @@ const MarathonAppValidators = {
           variables
         });
       }
-      const isValueDefinedAndRequiredEmpty = (
+
+      const isValueDefinedAndRequiredEmpty =
         PlacementConstraintsUtil.requiresEmptyValue(operator) &&
-        value != null
-      );
+        !ValidatorUtil.isEmpty(value);
 
       if (isValueDefinedAndRequiredEmpty) {
         errors.push({
@@ -263,10 +263,11 @@ const MarathonAppValidators = {
           variables
         });
       }
-      const isValueNotAStringNumberWhenRequired = (
+
+      const isValueNotAStringNumberWhenRequired =
         PlacementConstraintsUtil.stringNumberValue(operator) &&
-        !ValidatorUtil.isStringInteger(value)
-      );
+        !ValidatorUtil.isEmpty(value) &&
+        !ValidatorUtil.isStringInteger(value);
 
       if (isValueNotAStringNumberWhenRequired) {
         errors.push({

--- a/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
@@ -449,6 +449,13 @@ describe('MarathonAppValidators', function () {
       }]);
     });
 
+    it('shouldn\'t return an error for empty optional fields', function () {
+      const spec = {
+        constraints: [['hostname', 'GROUP_BY']]
+      };
+      expect(MarathonAppValidators.validateConstraints(spec)).toEqual([]);
+    });
+
     it('returns an error when wrong characters are applied', function () {
       const spec = {
         constraints: [


### PR DESCRIPTION
---
⚠️  _This PR back-ports a fix to release/1.9 introduced with #2204._

---

Change the placements constraints validation to not return errors for optional fields.

Closes DCOS_OSS-1132