### PR TITLE
DCOS-14844, DCOS-14756: refactor(services): remove applyPatch function

### DIFF
--- a/plugins/services/src/js/components/forms/ArtifactsSection.js
+++ b/plugins/services/src/js/components/forms/ArtifactsSection.js
@@ -87,7 +87,7 @@ class ArtifactsSection extends Component {
   }
 
   render() {
-    const { data, path } = this.props;
+    const { path } = this.props;
 
     return (
       <div className="form-section">
@@ -96,8 +96,7 @@ class ArtifactsSection extends Component {
           <FormGroup className="column-12">
             <AddButton
               onClick={this.props.onAddItem.bind(this, {
-                path,
-                value: data.length
+                path
               })}
             >
               Add Artifact

--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -217,7 +217,6 @@ class EnvironmentFormSection extends Component {
           <FormGroup className="column-12">
             <AddButton
               onClick={this.props.onAddItem.bind(this, {
-                value: data.env.length,
                 path: "env"
               })}
             >

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -199,7 +199,6 @@ class GeneralServiceFormSection extends Component {
         {containerElements}
         <AddButton
           onClick={this.props.onAddItem.bind(this, {
-            value: 0,
             path: "containers"
           })}
         >
@@ -276,7 +275,6 @@ class GeneralServiceFormSection extends Component {
           <FormGroup className="column-12">
             <AddButton
               onClick={this.props.onAddItem.bind(this, {
-                value: data.constraints.length,
                 path: "constraints"
               })}
             >

--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -474,7 +474,6 @@ class HealthChecksFormSection extends Component {
           <FormGroup className="column-12">
             <AddButton
               onClick={this.props.onAddItem.bind(this, {
-                value: data.healthChecks.length,
                 path: "healthChecks"
               })}
             >

--- a/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
@@ -362,9 +362,7 @@ class MultiContainerHealthChecksFormSection extends Component {
     if (healthCheck == null) {
       return (
         <div>
-          <AddButton
-            onClick={this.props.onAddItem.bind(this, { path, value: index })}
-          >
+          <AddButton onClick={this.props.onAddItem.bind(this, { path })}>
             Add Health Check
           </AddButton>
         </div>

--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -388,7 +388,6 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
           <div>
             <AddButton
               onClick={this.props.onAddItem.bind(this, {
-                value: endpoints.length,
                 path: `containers.${index}.endpoints`
               })}
             >

--- a/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
@@ -224,7 +224,6 @@ class MultiContainerVolumesFormSection extends Component {
         <div>
           <AddButton
             onClick={this.props.onAddItem.bind(this, {
-              value: data.volumeMounts.length,
               path: "volumeMounts"
             })}
           >

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -574,7 +574,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
   }
 
   getServiceEndpointsSection() {
-    const { portDefinitions, container, networkType } = this.props.data;
+    const { container, networkType } = this.props.data;
     const type = findNestedPropertyInObject(container, "type");
     const isMesosRuntime = !type || type === MESOS;
     const isUserNetwork = networkType && networkType.startsWith(USER);
@@ -647,7 +647,6 @@ class NetworkingFormSection extends mixin(StoreMixin) {
           <FormGroup className="column-12">
             <AddButton
               onClick={this.props.onAddItem.bind(this, {
-                value: portDefinitions.length,
                 path: "portDefinitions"
               })}
             >

--- a/plugins/services/src/js/components/forms/VolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/VolumesFormSection.js
@@ -388,7 +388,6 @@ class VolumesFormSection extends Component {
         <div>
           <AddButton
             onClick={this.props.onAddItem.bind(this, {
-              value: data.localVolumes.length,
               path: "localVolumes"
             })}
           >
@@ -423,7 +422,6 @@ class VolumesFormSection extends Component {
           <FormGroup className="column-12">
             <AddButton
               onClick={this.props.onAddItem.bind(this, {
-                value: data.localVolumes.length,
                 path: "externalVolumes"
               })}
             >

--- a/plugins/services/src/js/reducers/__tests__/JSONMultiContainer-test.js
+++ b/plugins/services/src/js/reducers/__tests__/JSONMultiContainer-test.js
@@ -75,7 +75,9 @@ describe("JSONMultiContainer", function() {
 
       const reducers = combineReducers(JSONMultiContainerReducers).bind({});
       const parser = combineParsers(JSONMultiContainerParser);
-      const batch = parser(podDefinition).reduce(function(batch, item) {
+      const batch = parser(
+        JSON.parse(JSON.stringify(podDefinition))
+      ).reduce(function(batch, item) {
         return batch.add(item);
       }, new Batch());
       const jsonFromBatch = batch.reduce(reducers, {});

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/Artifacts.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/Artifacts.js
@@ -10,7 +10,7 @@ function processTransaction(state, { type, path, value }) {
   let newState = state.slice();
 
   if (type === ADD_ITEM) {
-    newState.push({ uri: null });
+    newState.push(value || { uri: null });
   }
 
   if (type === REMOVE_ITEM) {
@@ -19,7 +19,7 @@ function processTransaction(state, { type, path, value }) {
     });
   }
 
-  if (type === SET) {
+  if (type === SET && index != null && name != null) {
     newState[index][name] = value;
   }
 

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/ExternalVolumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/ExternalVolumes.js
@@ -13,7 +13,7 @@ module.exports = {
       if (joinedPath === "externalVolumes") {
         switch (type) {
           case ADD_ITEM:
-            state.push({
+            const defaultVolume = {
               containerPath: null,
               name: null,
               provider: "dvdi",
@@ -21,7 +21,8 @@ module.exports = {
                 "dvdi/driver": "rexray"
               },
               mode: "RW"
-            });
+            };
+            state.push(Object.assign({}, value || defaultVolume));
             break;
           case REMOVE_ITEM:
             state = state.filter((item, index) => {

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/HealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/HealthChecks.js
@@ -38,7 +38,7 @@ module.exports = {
       if (joinedPath === "healthChecks") {
         switch (type) {
           case ADD_ITEM:
-            state.push({});
+            state.push(value || {});
             break;
           case REMOVE_ITEM:
             state = state.filter((item, index) => {

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/LocalVolumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/LocalVolumes.js
@@ -13,7 +13,12 @@ module.exports = {
       if (joinedPath === "localVolumes") {
         switch (type) {
           case ADD_ITEM:
-            state.push({ containerPath: null, size: null, mode: "RW" });
+            const defaultVolume = {
+              containerPath: null,
+              size: null,
+              mode: "RW"
+            };
+            state.push(Object.assign({}, value || defaultVolume));
             break;
           case REMOVE_ITEM:
             state = state.filter((item, index) => {

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/SingleContainerPortDefinitionsReducer.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/SingleContainerPortDefinitionsReducer.js
@@ -28,19 +28,21 @@ function SingleContainerPortDefinitionsReducer(state = [], action) {
     if (joinedPath === "portDefinitions") {
       switch (type) {
         case ADD_ITEM:
-          state.push({
-            hostPort: null,
-            labels: null,
-            loadBalanced: false,
-            name: null,
-            protocol: {
-              tcp: true,
-              udp: false
-            },
-            servicePort: null,
-            vip: null,
-            vipPort: null
-          });
+          state.push(
+            value || {
+              hostPort: null,
+              labels: null,
+              loadBalanced: false,
+              name: null,
+              protocol: {
+                tcp: true,
+                udp: false
+              },
+              servicePort: null,
+              vip: null,
+              vipPort: null
+            }
+          );
           break;
         case REMOVE_ITEM:
           state = state.filter(function(item, index) {

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/SingleContainerPortMappingsReducer.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/SingleContainerPortMappingsReducer.js
@@ -31,22 +31,24 @@ function SingleContainerPortMappingsReducer(state = [], action) {
     if (joinedPath === "portDefinitions") {
       switch (type) {
         case ADD_ITEM:
-          state.push({
-            automaticPort: true,
-            containerPort: null,
-            hostPort: null,
-            labels: null,
-            loadBalanced: false,
-            name: null,
-            portMapping: false,
-            protocol: {
-              tcp: true,
-              udp: false
-            },
-            servicePort: null,
-            vip: null,
-            vipPort: null
-          });
+          state.push(
+            value || {
+              automaticPort: true,
+              containerPort: null,
+              hostPort: null,
+              labels: null,
+              loadBalanced: false,
+              name: null,
+              portMapping: false,
+              protocol: {
+                tcp: true,
+                udp: false
+              },
+              servicePort: null,
+              vip: null,
+              vipPort: null
+            }
+          );
           break;
         case REMOVE_ITEM:
           state = state.filter(function(item, index) {

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Artifacts-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Artifacts-test.js
@@ -7,15 +7,15 @@ describe("Artifacts", function() {
   describe("#FromReducer", function() {
     it("emits correct JSON", function() {
       const batch = new Batch([
-        new Transaction(["fetch"], 0, ADD_ITEM),
-        new Transaction(["fetch", 0, "uri"], "http://mesosphere.io", SET),
-        new Transaction(["fetch"], 1, ADD_ITEM),
-        new Transaction(["fetch", 1, "uri"], "http://mesosphere.com", SET)
+        new Transaction(["fetch"], { uri: "http://example.io" }, ADD_ITEM),
+        new Transaction(["fetch", 0, "uri"], "http://example.io", SET),
+        new Transaction(["fetch"], { uri: "http://example.com" }, ADD_ITEM),
+        new Transaction(["fetch", 1, "uri"], "http://example.com", SET)
       ]);
 
       expect(batch.reduce(Artifacts.FormReducer.bind({}), [])).toEqual([
-        { uri: "http://mesosphere.io" },
-        { uri: "http://mesosphere.com" }
+        { uri: "http://example.io" },
+        { uri: "http://example.com" }
       ]);
     });
   });

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Constraints-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Constraints-test.js
@@ -7,7 +7,7 @@ describe("Constraints", function() {
   describe("#FormReducer", function() {
     it("creates constraint objects for the form", function() {
       const batch = new Batch([
-        new Transaction(["constraints"], 0, ADD_ITEM),
+        new Transaction(["constraints"], null, ADD_ITEM),
         new Transaction(["constraints", 0, "fieldName"], "hostname", SET),
         new Transaction(["constraints", 0, "operator"], "JOIN", SET),
         new Transaction(["constraints", 0, "value"], "param", SET)
@@ -20,7 +20,7 @@ describe("Constraints", function() {
 
     it("includes optional value even if not set", function() {
       const batch = new Batch([
-        new Transaction(["constraints"], 0, ADD_ITEM),
+        new Transaction(["constraints"], null, ADD_ITEM),
         new Transaction(["constraints", 0, "fieldName"], "hostname", SET),
         new Transaction(["constraints", 0, "operator"], "JOIN", SET)
       ]);
@@ -32,7 +32,7 @@ describe("Constraints", function() {
 
     it("doesn't process non-array states", function() {
       const batch = new Batch([
-        new Transaction(["constraints"], 0, ADD_ITEM),
+        new Transaction(["constraints"], null, ADD_ITEM),
         new Transaction(["constraints", 0, "fieldName"], "hostname", SET),
         new Transaction(["constraints", 0, "operator"], "JOIN", SET)
       ]);

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/ExternalVolumes-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/ExternalVolumes-test.js
@@ -47,7 +47,7 @@ describe("External Volumes", function() {
 
     it("should parse wrong typed values correctly", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["externalVolumes"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["externalVolumes"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["externalVolumes", 0, "name"], 123));
       batch = batch.add(
         new Transaction(["externalVolumes", 0, "provider"], 123)
@@ -75,8 +75,8 @@ describe("External Volumes", function() {
 
     it("should contain two full external Volumes items", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["externalVolumes"], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(["externalVolumes"], 1, ADD_ITEM));
+      batch = batch.add(new Transaction(["externalVolumes"], null, ADD_ITEM));
+      batch = batch.add(new Transaction(["externalVolumes"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["externalVolumes", 0, "name"], "null")
       );
@@ -111,8 +111,8 @@ describe("External Volumes", function() {
 
     it("should remove the right row.", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["externalVolumes"], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(["externalVolumes"], 1, ADD_ITEM));
+      batch = batch.add(new Transaction(["externalVolumes"], null, ADD_ITEM));
+      batch = batch.add(new Transaction(["externalVolumes"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["externalVolumes", 0, "name"], "null")
       );
@@ -140,7 +140,7 @@ describe("External Volumes", function() {
 
     it("should set the right options.", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["externalVolumes"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["externalVolumes"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["externalVolumes", 0, "containerPath"], "/dev/null")
       );
@@ -167,7 +167,7 @@ describe("External Volumes", function() {
     });
     it("should set the right provider.", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["externalVolumes"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["externalVolumes"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["externalVolumes", 0, "containerPath"], "/dev/null")
       );

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/HealthChecks-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/HealthChecks-test.js
@@ -3,18 +3,18 @@ const Batch = require("#SRC/js/structs/Batch");
 const Transaction = require("#SRC/js/structs/Transaction");
 const HealthChecks = require("../HealthChecks");
 
-describe("Labels", function() {
+describe("HealthChecks", function() {
   describe("#FormReducer", function() {
     it("should return an Array", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["healthChecks"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
 
       expect(batch.reduce(HealthChecks.FormReducer.bind({}), [])).toEqual([{}]);
     });
 
     it("should set the protocol", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["healthChecks"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["healthChecks", 0, "protocol"], "COMMAND")
       );
@@ -28,7 +28,7 @@ describe("Labels", function() {
 
     it("should set the right Command", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["healthChecks"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["healthChecks", 0, "protocol"], "COMMAND")
       );
@@ -46,7 +46,7 @@ describe("Labels", function() {
 
     it("should set the right path", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["healthChecks"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
       );
@@ -62,7 +62,7 @@ describe("Labels", function() {
 
     it("should have a fully fledged health check object", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["healthChecks"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
       );
@@ -98,7 +98,7 @@ describe("Labels", function() {
         " protocol",
       function() {
         let batch = new Batch();
-        batch = batch.add(new Transaction(["healthChecks"], 0, ADD_ITEM));
+        batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
         batch = batch.add(
           new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
         );
@@ -135,7 +135,7 @@ describe("Labels", function() {
 
     it("should keep https after switching protocol back to HTTP", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["healthChecks"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
       );
@@ -156,7 +156,7 @@ describe("Labels", function() {
 
     it("should set protocol to http if https was set", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["healthChecks"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
       );

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/LocalVolumes-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/LocalVolumes-test.js
@@ -7,7 +7,7 @@ describe("LocalVolumes", function() {
   describe("#FormReducer", function() {
     it("should return an Array with one item", function() {
       const batch = new Batch()
-        .add(new Transaction(["localVolumes"], 0, ADD_ITEM))
+        .add(new Transaction(["localVolumes"], null, ADD_ITEM))
         .add(new Transaction(["localVolumes", 0, "type"], "PERSISTENT"));
       expect(batch.reduce(LocalVolumes.FormReducer, [])).toEqual([
         { size: null, containerPath: null, mode: "RW", type: "PERSISTENT" }
@@ -16,7 +16,7 @@ describe("LocalVolumes", function() {
 
     it("should contain one full local Volumes item", function() {
       const batch = new Batch()
-        .add(new Transaction(["localVolumes"], 0, ADD_ITEM))
+        .add(new Transaction(["localVolumes"], null, ADD_ITEM))
         .add(new Transaction(["localVolumes", 0, "type"], "PERSISTENT"))
         .add(new Transaction(["localVolumes", 0, "size"], 1024))
         .add(
@@ -34,7 +34,7 @@ describe("LocalVolumes", function() {
 
     it("should parse wrong typed values correctly", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["localVolumes"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["localVolumes"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["localVolumes", 0, "type"], 123));
       batch = batch.add(new Transaction(["localVolumes", 0, "hostPath"], 123));
       batch = batch.add(
@@ -55,8 +55,8 @@ describe("LocalVolumes", function() {
 
     it("should contain two full local Volumes items", function() {
       const batch = new Batch()
-        .add(new Transaction(["localVolumes"], 0, ADD_ITEM))
-        .add(new Transaction(["localVolumes"], 1, ADD_ITEM))
+        .add(new Transaction(["localVolumes"], null, ADD_ITEM))
+        .add(new Transaction(["localVolumes"], null, ADD_ITEM))
         .add(new Transaction(["localVolumes", 0, "type"], "PERSISTENT"))
         .add(new Transaction(["localVolumes", 1, "type"], "PERSISTENT"))
         .add(new Transaction(["localVolumes", 0, "size"], 1024))
@@ -83,8 +83,8 @@ describe("LocalVolumes", function() {
 
     it("should remove the right row.", function() {
       const batch = new Batch()
-        .add(new Transaction(["localVolumes"], 0, ADD_ITEM))
-        .add(new Transaction(["localVolumes"], 1, ADD_ITEM))
+        .add(new Transaction(["localVolumes"], null, ADD_ITEM))
+        .add(new Transaction(["localVolumes"], null, ADD_ITEM))
         .add(new Transaction(["localVolumes", 0, "type"], "PERSISTENT"))
         .add(new Transaction(["localVolumes", 1, "type"], "PERSISTENT"))
         .add(new Transaction(["localVolumes", 0, "size"], 1024))
@@ -105,7 +105,7 @@ describe("LocalVolumes", function() {
 
     it("should set the right mode.", function() {
       const batch = new Batch()
-        .add(new Transaction(["localVolumes"], 0, ADD_ITEM))
+        .add(new Transaction(["localVolumes"], null, ADD_ITEM))
         .add(new Transaction(["localVolumes", 0, "type"], "PERSISTENT"))
         .add(new Transaction(["localVolumes", 0, "size"], 1024))
         .add(new Transaction(["localVolumes", 0, "containerPath"], "/dev/null"))

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Artifacts.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Artifacts.js
@@ -16,7 +16,7 @@ function processTransaction(state, { type, path, value }) {
   let newState = state.slice();
 
   if (type === ADD_ITEM) {
-    newState.push({ uri: null });
+    newState.push(value || { uri: null });
   }
 
   if (type === REMOVE_ITEM) {
@@ -25,7 +25,7 @@ function processTransaction(state, { type, path, value }) {
     });
   }
 
-  if (type === SET) {
+  if (type === SET && index != null && name != null) {
     newState[index][name] = value;
   }
 
@@ -39,7 +39,7 @@ module.exports = {
     }
 
     return state.fetch.reduce(function(memo, item, index) {
-      memo.push(new Transaction(["fetch"], index, ADD_ITEM));
+      memo.push(new Transaction(["fetch"], item, ADD_ITEM));
       Object.keys(item).forEach(function(key) {
         memo.push(new Transaction(["fetch", index, key], item[key], SET));
       });

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/ExternalVolumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/ExternalVolumes.js
@@ -29,7 +29,7 @@ module.exports = {
        * 6) Set the mode from `volume.mode` on the path
        *    `externalVolumes.${index}.mode`
        */
-        memo.push(new Transaction(["externalVolumes"], index, ADD_ITEM));
+        memo.push(new Transaction(["externalVolumes"], item, ADD_ITEM));
 
         if (item.external.name != null) {
           memo.push(

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/HealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/HealthChecks.js
@@ -66,7 +66,7 @@ module.exports = {
       if (joinedPath === "healthChecks") {
         switch (type) {
           case ADD_ITEM:
-            this.healthChecks.push({});
+            this.healthChecks.push(value || {});
             break;
           case REMOVE_ITEM:
             this.healthChecks = this.healthChecks.filter((item, index) => {
@@ -131,7 +131,7 @@ module.exports = {
       if (item.protocol == null) {
         return memo;
       }
-      memo.push(new Transaction(["healthChecks"], index, ADD_ITEM));
+      memo.push(new Transaction(["healthChecks"], item, ADD_ITEM));
       memo.push(
         new Transaction(
           ["healthChecks", index, "protocol"],

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/LocalVolumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/LocalVolumes.js
@@ -25,7 +25,7 @@ module.exports = {
          * 4) Set the mode from `volume.mode` on the path
          *    `localVolumes.${index}.mode`
          */
-        memo.push(new Transaction(["localVolumes"], index, ADD_ITEM));
+        memo.push(new Transaction(["localVolumes"], item, ADD_ITEM));
 
         if (item.persistent != null && item.persistent.size != null) {
           memo.push(
@@ -47,7 +47,7 @@ module.exports = {
           memo.push(
             new Transaction(
               ["localVolumes", index, "hostPath"],
-              item.hostPath,
+              item.hostPath || "",
               SET
             )
           );

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/PortDefinitionsReducer.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/PortDefinitionsReducer.js
@@ -11,6 +11,21 @@ const FIELDS = [
   "vipPort"
 ];
 
+function transformPortDefinition(definition) {
+  if (
+    definition != null &&
+    definition.protocol != null &&
+    typeof definition.protocol === "string"
+  ) {
+    definition.protocol = {
+      tcp: definition.protocol.search("tcp"),
+      udp: definition.protocol.search("udp")
+    };
+  }
+
+  return definition;
+}
+
 /**
  * @param {Object[]} state
  * @param {Object} action
@@ -28,19 +43,21 @@ function PortDefinitionsReducer(state = [], action) {
     if (joinedPath === "portDefinitions") {
       switch (type) {
         case ADD_ITEM:
-          state.push({
-            hostPort: null,
-            labels: null,
-            loadBalanced: false,
-            name: null,
-            protocol: {
-              tcp: true,
-              udp: false
-            },
-            servicePort: null,
-            vip: null,
-            vipPort: null
-          });
+          state.push(
+            transformPortDefinition(value) || {
+              hostPort: null,
+              labels: null,
+              loadBalanced: false,
+              name: null,
+              protocol: {
+                tcp: true,
+                udp: false
+              },
+              servicePort: null,
+              vip: null,
+              vipPort: null
+            }
+          );
           break;
         case REMOVE_ITEM:
           state = state.filter(function(item, index) {

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/PortMappingsReducer.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/PortMappingsReducer.js
@@ -31,22 +31,24 @@ function PortMappingsReducer(state = [], action) {
     if (joinedPath === "portDefinitions") {
       switch (type) {
         case ADD_ITEM:
-          state.push({
-            automaticPort: true,
-            containerPort: null,
-            hostPort: null,
-            labels: null,
-            loadBalanced: false,
-            name: null,
-            portMapping: false,
-            protocol: {
-              tcp: true,
-              udp: false
-            },
-            servicePort: null,
-            vip: null,
-            vipPort: null
-          });
+          state.push(
+            value || {
+              automaticPort: true,
+              containerPort: null,
+              hostPort: null,
+              labels: null,
+              loadBalanced: false,
+              name: null,
+              portMapping: false,
+              protocol: {
+                tcp: true,
+                udp: false
+              },
+              servicePort: null,
+              vip: null,
+              vipPort: null
+            }
+          );
           break;
         case REMOVE_ITEM:
           state = state.filter(function(item, index) {

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Volumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Volumes.js
@@ -63,15 +63,17 @@ function reduceVolumes(state, { type, path, value }) {
     if (joinedPath === "externalVolumes") {
       switch (type) {
         case ADD_ITEM:
-          this.externalVolumes.push({
-            containerPath: null,
-            external: {
-              name: null,
-              provider: "dvdi",
-              options: { "dvdi/driver": "rexray" }
-            },
-            mode: "RW"
-          });
+          this.externalVolumes.push(
+            value || {
+              containerPath: null,
+              external: {
+                name: null,
+                provider: "dvdi",
+                options: { "dvdi/driver": "rexray" }
+              },
+              mode: "RW"
+            }
+          );
           break;
         case REMOVE_ITEM:
           this.externalVolumes = this.externalVolumes.filter((item, index) => {
@@ -128,11 +130,13 @@ function reduceVolumes(state, { type, path, value }) {
     if (joinedPath === "localVolumes") {
       switch (type) {
         case ADD_ITEM:
-          this.localVolumes.push({
-            containerPath: null,
-            persistent: { size: null },
-            mode: "RW"
-          });
+          this.localVolumes.push(
+            value || {
+              containerPath: null,
+              persistent: { size: null },
+              mode: "RW"
+            }
+          );
           break;
         case REMOVE_ITEM:
           this.localVolumes = this.localVolumes.filter((item, index) => {
@@ -151,6 +155,9 @@ function reduceVolumes(state, { type, path, value }) {
 
     const index = path[1];
     if (type === SET && `localVolumes.${index}.size` === joinedPath) {
+      if (this.localVolumes[index].persistent == null) {
+        this.localVolumes[index].persistent = { size: null };
+      }
       this.localVolumes[index].persistent.size = parseIntValue(value);
     }
     if (type === SET && `localVolumes.${index}.type` === joinedPath) {

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Artifacts-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Artifacts-test.js
@@ -8,16 +8,21 @@ describe("Artifacts", function() {
     it("parses JSON correctly", function() {
       expect(
         Artifacts.JSONParser({
-          fetch: [
-            { uri: "http://mesosphere.io" },
-            { uri: "http://mesosphere.com" }
-          ]
+          fetch: [{ uri: "http://example.io" }, { uri: "http://example.com" }]
         })
       ).toEqual([
-        { type: ADD_ITEM, path: ["fetch"], value: 0 },
-        { type: SET, path: ["fetch", 0, "uri"], value: "http://mesosphere.io" },
-        { type: ADD_ITEM, path: ["fetch"], value: 1 },
-        { type: SET, path: ["fetch", 1, "uri"], value: "http://mesosphere.com" }
+        {
+          type: ADD_ITEM,
+          path: ["fetch"],
+          value: { uri: "http://example.io" }
+        },
+        { type: SET, path: ["fetch", 0, "uri"], value: "http://example.io" },
+        {
+          type: ADD_ITEM,
+          path: ["fetch"],
+          value: { uri: "http://example.com" }
+        },
+        { type: SET, path: ["fetch", 1, "uri"], value: "http://example.com" }
       ]);
     });
   });
@@ -25,15 +30,15 @@ describe("Artifacts", function() {
   describe("#JSONReducer", function() {
     it("emits correct JSON", function() {
       const batch = new Batch([
-        new Transaction(["fetch"], 0, ADD_ITEM),
-        new Transaction(["fetch", 0, "uri"], "http://mesosphere.io", SET),
-        new Transaction(["fetch"], 1, ADD_ITEM),
-        new Transaction(["fetch", 1, "uri"], "http://mesosphere.com", SET)
+        new Transaction(["fetch"], { uri: "http://example.io" }, ADD_ITEM),
+        new Transaction(["fetch", 0, "uri"], "http://example.io", SET),
+        new Transaction(["fetch"], { uri: "http://example.com" }, ADD_ITEM),
+        new Transaction(["fetch", 1, "uri"], "http://example.com", SET)
       ]);
 
       expect(batch.reduce(Artifacts.JSONReducer.bind({}), {})).toEqual([
-        { uri: "http://mesosphere.io" },
-        { uri: "http://mesosphere.com" }
+        { uri: "http://example.io" },
+        { uri: "http://example.com" }
       ]);
     });
   });

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Constraints-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Constraints-test.js
@@ -7,7 +7,7 @@ describe("Constraints", function() {
   describe("#JSONReducer", function() {
     it("emits correct JSON", function() {
       const batch = new Batch([
-        new Transaction(["constraints"], 0, ADD_ITEM),
+        new Transaction(["constraints"], null, ADD_ITEM),
         new Transaction(["constraints", 0, "fieldName"], "hostname", SET),
         new Transaction(["constraints", 0, "operator"], "JOIN", SET),
         new Transaction(["constraints", 0, "value"], "param", SET)
@@ -20,7 +20,7 @@ describe("Constraints", function() {
 
     it("skips value required to be empty after operator was set", function() {
       const batch = new Batch([
-        new Transaction(["constraints"], 0, ADD_ITEM),
+        new Transaction(["constraints"], null, ADD_ITEM),
         new Transaction(["constraints", 0, "fieldName"], "hostname", SET),
         new Transaction(["constraints", 0, "operator"], "UNIQUE", SET),
         new Transaction(["constraints", 0, "value"], "foo", SET)
@@ -33,7 +33,7 @@ describe("Constraints", function() {
 
     it("skips value required to be empty before operator was set", function() {
       const batch = new Batch([
-        new Transaction(["constraints"], 0, ADD_ITEM),
+        new Transaction(["constraints"], null, ADD_ITEM),
         new Transaction(["constraints", 0, "fieldName"], "hostname", SET),
         new Transaction(["constraints", 0, "value"], "foo", SET),
         new Transaction(["constraints", 0, "operator"], "UNIQUE", SET)
@@ -52,7 +52,7 @@ describe("Constraints", function() {
           constraints: [["hostname", "JOIN", "param"]]
         })
       ).toEqual([
-        new Transaction(["constraints"], 0, ADD_ITEM),
+        new Transaction(["constraints"], null, ADD_ITEM),
         new Transaction(["constraints", 0, "fieldName"], "hostname", SET),
         new Transaction(["constraints", 0, "operator"], "JOIN", SET),
         new Transaction(["constraints", 0, "value"], "param", SET)
@@ -91,7 +91,7 @@ describe("Constraints", function() {
           constraints: [["hostname", "JOIN"]]
         })
       ).toEqual([
-        new Transaction(["constraints"], 0, ADD_ITEM),
+        new Transaction(["constraints"], null, ADD_ITEM),
         new Transaction(["constraints", 0, "fieldName"], "hostname", SET),
         new Transaction(["constraints", 0, "operator"], "JOIN", SET)
       ]);

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/ExternalVolumes-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/ExternalVolumes-test.js
@@ -41,7 +41,21 @@ describe("External Volumes", function() {
         }
       };
       expect(ExternalVolumes.JSONParser(state)).toEqual([
-        { type: ADD_ITEM, value: 0, path: ["externalVolumes"] },
+        {
+          type: ADD_ITEM,
+          value: {
+            containerPath: "/dev/null",
+            external: {
+              name: "null",
+              provider: "dvdi",
+              options: {
+                "dvdi/driver": "rexray"
+              }
+            },
+            mode: "RW"
+          },
+          path: ["externalVolumes"]
+        },
         { type: SET, value: "null", path: ["externalVolumes", 0, "name"] },
         {
           type: SET,
@@ -84,7 +98,21 @@ describe("External Volumes", function() {
         }
       };
       expect(ExternalVolumes.JSONParser(state)).toEqual([
-        { type: ADD_ITEM, value: 0, path: ["externalVolumes"] },
+        {
+          type: ADD_ITEM,
+          value: {
+            containerPath: "/dev/null",
+            external: {
+              name: "null",
+              provider: "dvdi",
+              options: {
+                "dvdi/driver": "rexray"
+              }
+            },
+            mode: "RW"
+          },
+          path: ["externalVolumes"]
+        },
         { type: SET, value: "null", path: ["externalVolumes", 0, "name"] },
         {
           type: SET,
@@ -122,7 +150,21 @@ describe("External Volumes", function() {
         }
       };
       expect(ExternalVolumes.JSONParser(state)).toEqual([
-        { type: ADD_ITEM, value: 0, path: ["externalVolumes"] },
+        {
+          type: ADD_ITEM,
+          value: {
+            containerPath: "/dev/null",
+            external: {
+              name: "null",
+              provider: "provider",
+              options: {
+                "dvdi/driver": "rexray"
+              }
+            },
+            mode: "RW"
+          },
+          path: ["externalVolumes"]
+        },
         { type: SET, value: "null", path: ["externalVolumes", 0, "name"] },
         {
           type: SET,
@@ -164,7 +206,21 @@ describe("External Volumes", function() {
         }
       };
       expect(ExternalVolumes.JSONParser(state)).toEqual([
-        { type: ADD_ITEM, value: 0, path: ["externalVolumes"] },
+        {
+          type: ADD_ITEM,
+          value: {
+            containerPath: "/dev/null",
+            external: {
+              name: "null",
+              provider: "provider",
+              options: {
+                someValue: true
+              }
+            },
+            mode: "RW"
+          },
+          path: ["externalVolumes"]
+        },
         { type: SET, value: "null", path: ["externalVolumes", 0, "name"] },
         {
           type: SET,
@@ -207,7 +263,22 @@ describe("External Volumes", function() {
         }
       };
       expect(ExternalVolumes.JSONParser(state)).toEqual([
-        { type: ADD_ITEM, value: 0, path: ["externalVolumes"] },
+        {
+          type: ADD_ITEM,
+          value: {
+            containerPath: "/dev/null",
+            external: {
+              size: 1024,
+              name: "null",
+              provider: "dvdi",
+              options: {
+                "dvdi/driver": "rexray"
+              }
+            },
+            mode: "RW"
+          },
+          path: ["externalVolumes"]
+        },
         { type: SET, value: "null", path: ["externalVolumes", 0, "name"] },
         { type: SET, value: 1024, path: ["externalVolumes", 0, "size"] },
         {

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/HealthChecks-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/HealthChecks-test.js
@@ -7,18 +7,18 @@ const Batch = require("#SRC/js/structs/Batch");
 const Transaction = require("#SRC/js/structs/Transaction");
 const HealthChecks = require("../HealthChecks");
 
-describe("Labels", function() {
+describe("HealthChecks", function() {
   describe("#JSONReducer", function() {
     it("should return an Array", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["healthChecks"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
 
       expect(batch.reduce(HealthChecks.JSONReducer.bind({}), {})).toEqual([{}]);
     });
 
     it("should set the protocol", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["healthChecks"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["healthChecks", 0, "protocol"], "COMMAND")
       );
@@ -32,7 +32,7 @@ describe("Labels", function() {
 
     it("should set the right Command", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["healthChecks"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["healthChecks", 0, "protocol"], "COMMAND")
       );
@@ -52,7 +52,7 @@ describe("Labels", function() {
 
     it("should set the right path", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["healthChecks"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
       );
@@ -68,7 +68,7 @@ describe("Labels", function() {
 
     it("should have a fully fledged health check object", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["healthChecks"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
       );
@@ -101,8 +101,8 @@ describe("Labels", function() {
 
     it("should remove the right item", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["healthChecks"], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(["healthChecks"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["healthChecks", 0, "protocol"], "COMMAND")
       );
@@ -128,7 +128,7 @@ describe("Labels", function() {
         " protocol",
       function() {
         let batch = new Batch();
-        batch = batch.add(new Transaction(["healthChecks"], 0, ADD_ITEM));
+        batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
         batch = batch.add(
           new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTPS")
         );
@@ -181,7 +181,15 @@ describe("Labels", function() {
       ).toEqual([
         {
           type: ADD_ITEM,
-          value: 0,
+          value: {
+            path: "/api/health",
+            portIndex: 0,
+            protocol: "MESOS_HTTP",
+            gracePeriodSeconds: 300,
+            intervalSeconds: 60,
+            timeoutSeconds: 20,
+            maxConsecutiveFailures: 3
+          },
           path: ["healthChecks"]
         },
         {

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/LocalVolumes-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/LocalVolumes-test.js
@@ -41,7 +41,15 @@ describe("LocalVolumes", function() {
         }
       };
       expect(LocalVolumes.JSONParser(state)).toEqual([
-        { type: ADD_ITEM, value: 0, path: ["localVolumes"] },
+        {
+          type: ADD_ITEM,
+          value: {
+            containerPath: "/dev/null",
+            persistent: { size: 1024 },
+            mode: "RW"
+          },
+          path: ["localVolumes"]
+        },
         { type: SET, value: "PERSISTENT", path: ["localVolumes", 0, "type"] },
         { type: SET, value: 1024, path: ["localVolumes", 0, "size"] },
         {
@@ -77,7 +85,15 @@ describe("LocalVolumes", function() {
         }
       };
       expect(LocalVolumes.JSONParser(state)).toEqual([
-        { type: ADD_ITEM, value: 0, path: ["localVolumes"] },
+        {
+          type: ADD_ITEM,
+          value: {
+            containerPath: "/dev/null",
+            persistent: { size: 1024 },
+            mode: "RW"
+          },
+          path: ["localVolumes"]
+        },
         { type: SET, value: "PERSISTENT", path: ["localVolumes", 0, "type"] },
         { type: SET, value: 1024, path: ["localVolumes", 0, "size"] },
         {
@@ -102,7 +118,15 @@ describe("LocalVolumes", function() {
         }
       };
       expect(LocalVolumes.JSONParser(state)).toEqual([
-        { type: ADD_ITEM, value: 0, path: ["localVolumes"] },
+        {
+          type: ADD_ITEM,
+          value: {
+            containerPath: "/dev/null",
+            persistent: { size: 1024 },
+            mode: "READ"
+          },
+          path: ["localVolumes"]
+        },
         { type: SET, value: "PERSISTENT", path: ["localVolumes", 0, "type"] },
         { type: SET, value: 1024, path: ["localVolumes", 0, "size"] },
         {

--- a/plugins/services/src/js/reducers/serviceForm/MultiContainerNetwork.js
+++ b/plugins/services/src/js/reducers/serviceForm/MultiContainerNetwork.js
@@ -12,12 +12,12 @@ module.exports = {
     const newState = state.slice();
     if (path[0] === "networks") {
       if (type === ADD_ITEM && index !== 0) {
-        newState.push({ mode: Networking.type.HOST.toLowerCase() });
+        newState.push(value || { mode: Networking.type.HOST.toLowerCase() });
 
         return newState;
       }
 
-      if (type === SET) {
+      if (type === SET && typeof value === "string") {
         const [mode, name] = value.split(".");
 
         if (mode === Networking.type.CONTAINER) {
@@ -49,13 +49,13 @@ module.exports = {
 
     if (state.networks.length === 0) {
       return [
-        new Transaction(["networks"], 0, ADD_ITEM),
+        new Transaction(["networks"], {}, ADD_ITEM),
         new Transaction(["networks", 0], Networking.type.HOST)
       ];
     }
 
     return state.networks.reduce((memo, network, index) => {
-      memo.push(new Transaction(["networks"], index, ADD_ITEM));
+      memo.push(new Transaction(["networks"], network, ADD_ITEM));
 
       if (network.mode == null) {
         return memo;
@@ -89,7 +89,7 @@ module.exports = {
         return newState;
       }
 
-      if (type === SET) {
+      if (type === SET && typeof value === "string") {
         const [mode, name] = value.split(".");
 
         if (mode === Networking.type.CONTAINER) {

--- a/plugins/services/src/js/reducers/serviceForm/MultiContainerVolumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/MultiContainerVolumes.js
@@ -20,7 +20,11 @@ function transformContainers(memo, container, containerIndex) {
 }
 
 module.exports = {
-  JSONReducer(state = [], { type, path, value }) {
+  JSONReducer(state = [], { type, path, value }, counterIndex) {
+    if (counterIndex === 0) {
+      state = [];
+    }
+
     const [base, index, name] = path;
 
     if (this.hostPaths == null) {

--- a/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
+++ b/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
@@ -98,7 +98,7 @@ module.exports = {
 
     // Look at portDefinitions and add accepted fields
     return state.portDefinitions.reduce(function(memo, item, index) {
-      memo.push(new Transaction(["portDefinitions"], index, ADD_ITEM));
+      memo.push(new Transaction(["portDefinitions"], item, ADD_ITEM));
 
       if (item.name != null) {
         memo.push(

--- a/plugins/services/src/js/reducers/serviceForm/PortMappings.js
+++ b/plugins/services/src/js/reducers/serviceForm/PortMappings.js
@@ -24,13 +24,9 @@ module.exports = {
     // than in portDefinitions
     const length = portMappings.length - portDefinitionsLength;
     const addTransactions = [];
-    Array.from({ length }).forEach((_, index) => {
+    Array.from({ length }).forEach(() => {
       addTransactions.push(
-        new Transaction(
-          ["portDefinitions"],
-          portMappings.length + index - 1,
-          ADD_ITEM
-        )
+        new Transaction(["portDefinitions"], null, ADD_ITEM)
       );
     });
 

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Containers-test.js
@@ -18,7 +18,9 @@ describe("Containers", function() {
 
     it("returns an array as default with a container path Transaction", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+      batch = batch.add(
+        new Transaction(["containers"], DEFAULT_POD_CONTAINER, ADD_ITEM)
+      );
 
       expect(batch.reduce(Containers.JSONReducer.bind({}))).toEqual([
         DEFAULT_POD_CONTAINER
@@ -29,7 +31,7 @@ describe("Containers", function() {
       it("contains a container with image", function() {
         let batch = new Batch();
 
-        batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+        batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
         batch = batch.add(
           new Transaction(["containers", 0, "image", "id"], "alpine", SET)
         );
@@ -37,7 +39,6 @@ describe("Containers", function() {
         expect(batch.reduce(Containers.JSONReducer.bind({}))).toEqual([
           {
             name: "container-1",
-            endpoints: [],
             image: {
               kind: "DOCKER",
               id: "alpine"
@@ -53,7 +54,7 @@ describe("Containers", function() {
       it("doesn't contain the image object", function() {
         let batch = new Batch();
 
-        batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+        batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
         batch = batch.add(
           new Transaction(["containers", 0, "image", "id"], "alpine", SET)
         );
@@ -70,7 +71,6 @@ describe("Containers", function() {
         expect(batch.reduce(Containers.JSONReducer.bind({}))).toEqual([
           {
             name: "container-1",
-            endpoints: [],
             resources: {
               cpus: 0.2,
               disk: "",
@@ -86,10 +86,10 @@ describe("Containers", function() {
         it("should have one endpoint", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           expect(batch.reduce(Containers.JSONReducer.bind({}))).toEqual([
@@ -114,10 +114,10 @@ describe("Containers", function() {
         it("should have one endpoint with name", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -146,9 +146,9 @@ describe("Containers", function() {
         it("should keep custom labels", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
           batch = batch.add(
             new Transaction(["containers", 0, "endpoints", 0, "labels"], {
@@ -178,12 +178,12 @@ describe("Containers", function() {
         it("should have one endpoint with name and a hostport", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "HOST"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -223,12 +223,12 @@ describe("Containers", function() {
         it("should set the protocol right", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "HOST"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -260,12 +260,12 @@ describe("Containers", function() {
         it("should set protocol to unknown value", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "HOST"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -299,12 +299,12 @@ describe("Containers", function() {
         it("should have one endpoint", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           expect(batch.reduce(Containers.JSONReducer.bind({}))).toEqual([
@@ -330,12 +330,12 @@ describe("Containers", function() {
         it("should have one endpoint with name", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -365,10 +365,10 @@ describe("Containers", function() {
         it("should keep custom labels", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
           batch = batch.add(
             new Transaction(["containers", 0, "endpoints", 0, "labels"], {
@@ -399,12 +399,12 @@ describe("Containers", function() {
         it("should have one endpoint with name and a hostport", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -445,12 +445,12 @@ describe("Containers", function() {
         it("should set the protocol right", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -483,12 +483,12 @@ describe("Containers", function() {
         it("should set protocol to unknown value", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -521,12 +521,12 @@ describe("Containers", function() {
         it("should set the right container Port", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -559,13 +559,13 @@ describe("Containers", function() {
         it("should set the right vip", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
           batch = batch.add(new Transaction(["id"], "/foobar"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -607,13 +607,13 @@ describe("Containers", function() {
         it("should set the right custom vip", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
           batch = batch.add(new Transaction(["id"], "/foobar"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -662,13 +662,13 @@ describe("Containers", function() {
         it("should set the right vip after id change", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
           batch = batch.add(new Transaction(["id"], "/foobar"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -712,13 +712,13 @@ describe("Containers", function() {
         it("should set the right custom vip even after id change", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
           batch = batch.add(new Transaction(["id"], "/foobar"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -771,21 +771,21 @@ describe("Containers", function() {
     describe("artifacts", function() {
       it("omits artifacts with empty uris", function() {
         const batch = new Batch([
-          new Transaction(["containers"], 0, ADD_ITEM),
-          new Transaction(["containers", 0, "artifacts"], 0, ADD_ITEM),
+          new Transaction(["containers"], null, ADD_ITEM),
+          new Transaction(["containers", 0, "artifacts"], null, ADD_ITEM),
           new Transaction(
             ["containers", 0, "artifacts", 0, "uri"],
             "http://mesosphere.io",
             SET
           ),
-          new Transaction(["containers", 0, "artifacts"], 1, ADD_ITEM),
-          new Transaction(["containers", 0, "artifacts"], 2, ADD_ITEM),
+          new Transaction(["containers", 0, "artifacts"], null, ADD_ITEM),
+          new Transaction(["containers", 0, "artifacts"], null, ADD_ITEM),
           new Transaction(
             ["containers", 0, "artifacts", 2, "uri"],
             "http://mesosphere.com",
             SET
           ),
-          new Transaction(["containers", 0, "artifacts"], 3, ADD_ITEM)
+          new Transaction(["containers", 0, "artifacts"], null, ADD_ITEM)
         ]);
 
         expect(batch.reduce(Containers.JSONReducer.bind({}))).toEqual([
@@ -794,7 +794,6 @@ describe("Containers", function() {
               { uri: "http://mesosphere.io" },
               { uri: "http://mesosphere.com" }
             ],
-            endpoints: [],
             name: "container-1",
             resources: {
               cpus: 0.1,
@@ -808,17 +807,16 @@ describe("Containers", function() {
     describe("volumes", function() {
       it("removes volumeMounts when there's no volumes left", function() {
         const batch = new Batch([
-          new Transaction(["containers"], 0, ADD_ITEM),
-          new Transaction(["volumeMounts"], 0, ADD_ITEM),
+          new Transaction(["containers"], null, ADD_ITEM),
+          new Transaction(["volumeMounts"], null, ADD_ITEM),
           new Transaction(["volumeMounts", 0, "name"], "extvol", SET),
-          new Transaction(["volumeMounts", 0, "mountPath"], 0, ADD_ITEM),
+          new Transaction(["volumeMounts", 0, "mountPath"], null, ADD_ITEM),
           new Transaction(["volumeMounts", 0, "mountPath", 0], "mount", SET),
           new Transaction(["volumeMounts"], 0, REMOVE_ITEM)
         ]);
 
         expect(batch.reduce(Containers.JSONReducer.bind({}))).toEqual([
           {
-            endpoints: [],
             name: "container-1",
             resources: {
               cpus: 0.1,
@@ -832,6 +830,25 @@ describe("Containers", function() {
   });
 
   describe("#JSONParser", function() {
+    it("keeps random value", function() {
+      expect(
+        Containers.JSONParser({
+          containers: [
+            {
+              Random: "value"
+            }
+          ]
+        })
+      ).toEqual([
+        new Transaction(
+          ["containers"],
+          {
+            Random: "value"
+          },
+          ADD_ITEM
+        )
+      ]);
+    });
     describe("artifacts", function() {
       it("parses JSON correctly", function() {
         expect(
@@ -847,15 +864,33 @@ describe("Containers", function() {
             ]
           })
         ).toEqual([
-          new Transaction(["containers"], 0, ADD_ITEM),
-          new Transaction(["containers", 0, "artifacts"], 0, ADD_ITEM),
+          new Transaction(
+            ["containers"],
+            {
+              artifacts: [
+                { uri: "http://mesosphere.io" },
+                null,
+                { uri: "http://mesosphere.com" }
+              ]
+            },
+            ADD_ITEM
+          ),
+          new Transaction(
+            ["containers", 0, "artifacts"],
+            { uri: "http://mesosphere.io" },
+            ADD_ITEM
+          ),
           new Transaction(
             ["containers", 0, "artifacts", 0, "uri"],
             "http://mesosphere.io",
             SET
           ),
-          new Transaction(["containers", 0, "artifacts"], 1, ADD_ITEM),
-          new Transaction(["containers", 0, "artifacts"], 2, ADD_ITEM),
+          new Transaction(["containers", 0, "artifacts"], null, ADD_ITEM),
+          new Transaction(
+            ["containers", 0, "artifacts"],
+            { uri: "http://mesosphere.com" },
+            ADD_ITEM
+          ),
           new Transaction(
             ["containers", 0, "artifacts", 2, "uri"],
             "http://mesosphere.com",
@@ -872,10 +907,10 @@ describe("Containers", function() {
         it("should have one endpoint", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           expect(batch.reduce(Containers.FormReducer.bind({}))).toEqual([
@@ -908,10 +943,10 @@ describe("Containers", function() {
         it("should have one endpoint with name", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -948,10 +983,10 @@ describe("Containers", function() {
         it("should have one endpoint with name and a hostport", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -999,12 +1034,12 @@ describe("Containers", function() {
         it("should set the protocol right", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "HOST"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -1044,12 +1079,12 @@ describe("Containers", function() {
         it("should set protocol to unknown value", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "HOST"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -1092,12 +1127,12 @@ describe("Containers", function() {
         it("should have one endpoint", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           expect(batch.reduce(Containers.FormReducer.bind({}))).toEqual([
@@ -1130,12 +1165,12 @@ describe("Containers", function() {
         it("should have one endpoint with name", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -1172,12 +1207,12 @@ describe("Containers", function() {
         it("should have one endpoint with name and a hostport", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -1225,12 +1260,12 @@ describe("Containers", function() {
         it("should set the protocol right", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -1270,12 +1305,12 @@ describe("Containers", function() {
         it("should set protocol to unknown value", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -1316,12 +1351,12 @@ describe("Containers", function() {
         it("should set the right container Port", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -1361,13 +1396,13 @@ describe("Containers", function() {
         it("should set the right vip", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
           batch = batch.add(new Transaction(["id"], "/foobar"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -1414,13 +1449,13 @@ describe("Containers", function() {
         it("should set the right custom vip", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
           batch = batch.add(new Transaction(["id"], "/foobar"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -1474,13 +1509,13 @@ describe("Containers", function() {
         it("should set the right vip after id change", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
           batch = batch.add(new Transaction(["id"], "/foobar"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -1529,13 +1564,13 @@ describe("Containers", function() {
         it("should set the right custom vip even after id change", function() {
           let batch = new Batch();
 
-          batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
+          batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
 
           batch = batch.add(new Transaction(["networks", 0], "CONTAINER.foo"));
           batch = batch.add(new Transaction(["id"], "/foobar"));
 
           batch = batch.add(
-            new Transaction(["containers", 0, "endpoints"], 0, ADD_ITEM)
+            new Transaction(["containers", 0, "endpoints"], null, ADD_ITEM)
           );
 
           batch = batch.add(
@@ -1593,21 +1628,21 @@ describe("Containers", function() {
     describe("artifacts", function() {
       it("emits correct form data", function() {
         const batch = new Batch([
-          new Transaction(["containers"], 0, ADD_ITEM),
-          new Transaction(["containers", 0, "artifacts"], 0, ADD_ITEM),
+          new Transaction(["containers"], null, ADD_ITEM),
+          new Transaction(["containers", 0, "artifacts"], null, ADD_ITEM),
           new Transaction(
             ["containers", 0, "artifacts", 0, "uri"],
             "http://mesosphere.io",
             SET
           ),
-          new Transaction(["containers", 0, "artifacts"], 1, ADD_ITEM),
+          new Transaction(["containers", 0, "artifacts"], null, ADD_ITEM),
           new Transaction(
             ["containers", 0, "artifacts", 1, "uri"],
             "http://mesosphere.com",
             SET
           ),
-          new Transaction(["containers", 0, "artifacts"], 2, ADD_ITEM),
-          new Transaction(["containers", 0, "artifacts"], 3, ADD_ITEM)
+          new Transaction(["containers", 0, "artifacts"], null, ADD_ITEM),
+          new Transaction(["containers", 0, "artifacts"], null, ADD_ITEM)
         ]);
 
         expect(batch.reduce(Containers.FormReducer.bind({}))).toEqual([

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/MulitContainerConstraints-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/MulitContainerConstraints-test.js
@@ -7,7 +7,7 @@ describe("MultiContainerConstraints", function() {
   describe("#JSONReducer", function() {
     it("emits correct JSON", function() {
       const batch = new Batch([
-        new Transaction(["constraints"], 0, ADD_ITEM),
+        new Transaction(["constraints"], null, ADD_ITEM),
         new Transaction(["constraints", 0, "fieldName"], "hostname", SET),
         new Transaction(["constraints", 0, "operator"], "JOIN", SET),
         new Transaction(["constraints", 0, "value"], "param", SET)
@@ -22,7 +22,7 @@ describe("MultiContainerConstraints", function() {
 
     it("skips optional value", function() {
       const batch = new Batch([
-        new Transaction(["constraints"], 0, ADD_ITEM),
+        new Transaction(["constraints"], null, ADD_ITEM),
         new Transaction(["constraints", 0, "fieldName"], "hostname", SET),
         new Transaction(["constraints", 0, "operator"], "JOIN", SET)
       ]);
@@ -48,7 +48,7 @@ describe("MultiContainerConstraints", function() {
           }
         })
       ).toEqual([
-        new Transaction(["constraints"], 0, ADD_ITEM),
+        new Transaction(["constraints"], null, ADD_ITEM),
         new Transaction(["constraints", 0, "fieldName"], "hostname", SET),
         new Transaction(["constraints", 0, "operator"], "JOIN", SET),
         new Transaction(["constraints", 0, "value"], "param", SET)
@@ -81,7 +81,7 @@ describe("MultiContainerConstraints", function() {
           }
         })
       ).toEqual([
-        new Transaction(["constraints"], 0, ADD_ITEM),
+        new Transaction(["constraints"], null, ADD_ITEM),
         new Transaction(["constraints", 0, "fieldName"], "hostname", SET),
         new Transaction(["constraints", 0, "operator"], "JOIN", SET)
       ]);
@@ -91,7 +91,7 @@ describe("MultiContainerConstraints", function() {
   describe("#FormReducer", function() {
     it("creates constraint objects for the form", function() {
       const batch = new Batch([
-        new Transaction(["constraints"], 0, ADD_ITEM),
+        new Transaction(["constraints"], null, ADD_ITEM),
         new Transaction(["constraints", 0, "fieldName"], "hostname", SET),
         new Transaction(["constraints", 0, "operator"], "JOIN", SET),
         new Transaction(["constraints", 0, "value"], "param", SET)
@@ -104,7 +104,7 @@ describe("MultiContainerConstraints", function() {
 
     it("includes optional value even if not set", function() {
       const batch = new Batch([
-        new Transaction(["constraints"], 0, ADD_ITEM),
+        new Transaction(["constraints"], null, ADD_ITEM),
         new Transaction(["constraints", 0, "fieldName"], "hostname", SET),
         new Transaction(["constraints", 0, "operator"], "JOIN", SET)
       ]);

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
@@ -10,7 +10,7 @@ describe("PortDefinitions", function() {
   describe("#JSONReducer", function() {
     it("should return normal config if networkType is  HOST", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual([
         { name: null, port: 0, protocol: "tcp", labels: null }
@@ -20,7 +20,7 @@ describe("PortDefinitions", function() {
     it("Should return null if networkType is not HOST", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["networks", 0, "mode"], BRIDGE));
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual(
         null
@@ -30,7 +30,7 @@ describe("PortDefinitions", function() {
     it("Should return null if networkType is not USER", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["networks", 0, "mode"], USER));
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual(
         null
@@ -39,7 +39,7 @@ describe("PortDefinitions", function() {
 
     it("should create default portDefinition configurations", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual([
         { name: null, port: 0, protocol: "tcp", labels: null }
@@ -49,7 +49,7 @@ describe("PortDefinitions", function() {
     it("should create default portDefinition configurations for BRIDGE network", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["networks", 0, "mode"], BRIDGE, SET));
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual(
         null
@@ -59,7 +59,7 @@ describe("PortDefinitions", function() {
     it("shouldn't create portDefinitions for USER", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["networks", 0, "mode"], USER, SET));
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual(
         null
@@ -68,8 +68,8 @@ describe("PortDefinitions", function() {
 
     it("should create two default portDefinition configurations", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual([
         { name: null, port: 0, protocol: "tcp", labels: null },
@@ -79,7 +79,7 @@ describe("PortDefinitions", function() {
 
     it("should set the name value", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["portDefinitions", 0, "name"], "foo"));
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual([
@@ -89,7 +89,7 @@ describe("PortDefinitions", function() {
 
     it("should set the port value", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["portsAutoAssign"], false));
       batch = batch.add(
         new Transaction(["portDefinitions", 0, "hostPort"], 100)
@@ -102,7 +102,7 @@ describe("PortDefinitions", function() {
 
     it("should default port value to 0 if portsAutoAssign", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["portsAutoAssign"], true));
       batch = batch.add(
         new Transaction(["portDefinitions", 0, "hostPort"], 100)
@@ -115,7 +115,7 @@ describe("PortDefinitions", function() {
 
     it("should set the protocol value", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["portDefinitions", 0, "protocol", "tcp"], false)
       );
@@ -130,7 +130,7 @@ describe("PortDefinitions", function() {
 
     it("should set the complex protocol value", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["portDefinitions", 0, "protocol", "udp"], true)
       );
@@ -145,8 +145,8 @@ describe("PortDefinitions", function() {
 
     it("should add the labels key if the portDefinition is load balanced", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(["portDefinitions"], 1, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["portDefinitions", 1, "loadBalanced"], true)
       );
@@ -159,8 +159,8 @@ describe("PortDefinitions", function() {
 
     it("should add the index of the portDefinition to the VIP keys", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(["portDefinitions"], 1, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["portDefinitions", 0, "loadBalanced"], true)
       );
@@ -176,8 +176,8 @@ describe("PortDefinitions", function() {
 
     it("should add the port to the VIP string", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(["portDefinitions"], 1, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["portsAutoAssign"], false));
       batch = batch.add(
         new Transaction(["portDefinitions", 0, "hostPort"], 300)
@@ -194,8 +194,8 @@ describe("PortDefinitions", function() {
 
     it("should add the app ID to the VIP string when it is defined", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(["portDefinitions"], 1, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["portsAutoAssign"], false));
       batch = batch.add(
         new Transaction(["portDefinitions", 1, "loadBalanced"], true)
@@ -211,8 +211,8 @@ describe("PortDefinitions", function() {
     it("should store portDefinitions even if network is USER when recorded", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["networks", 0, "mode"], USER, SET));
-      batch = batch.add(new Transaction(["portDefinitions"], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(["portDefinitions"], 1, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
+      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["portsAutoAssign"], false));
       batch = batch.add(
         new Transaction(["portDefinitions", 1, "loadBalanced"], true)

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/PortMappings-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/PortMappings-test.js
@@ -25,7 +25,7 @@ describe("#JSONParser", function() {
           }
         })
       ).toEqual([
-        new Transaction(["portDefinitions"], 0, ADD_ITEM),
+        new Transaction(["portDefinitions"], null, ADD_ITEM),
         new Transaction(["portDefinitions", 0, "name"], "foo"),
         new Transaction(["portDefinitions", 0, "automaticPort"], true),
         new Transaction(["portDefinitions", 0, "portMapping"], true),
@@ -86,7 +86,7 @@ describe("#JSONParser", function() {
           }
         })
       ).toEqual([
-        new Transaction(["portDefinitions"], 0, ADD_ITEM),
+        new Transaction(["portDefinitions"], null, ADD_ITEM),
         new Transaction(["portDefinitions", 0, "automaticPort"], false),
         new Transaction(["portDefinitions", 0, "portMapping"], true),
         new Transaction(["portDefinitions", 0, "hostPort"], 10)
@@ -111,7 +111,7 @@ describe("#JSONParser", function() {
           }
         })
       ).toEqual([
-        new Transaction(["portDefinitions"], 0, ADD_ITEM),
+        new Transaction(["portDefinitions"], null, ADD_ITEM),
         new Transaction(["portDefinitions", 0, "portMapping"], false),
         new Transaction(["portDefinitions", 0, "loadBalanced"], true),
         new Transaction(["portDefinitions", 0, "vip"], "/:0"),
@@ -138,7 +138,7 @@ describe("#JSONParser", function() {
           }
         })
       ).toEqual([
-        new Transaction(["portDefinitions"], 0, ADD_ITEM),
+        new Transaction(["portDefinitions"], null, ADD_ITEM),
         new Transaction(["portDefinitions", 0, "portMapping"], false),
         new Transaction(["portDefinitions", 0, "labels"], { VIP_1: "/:0" })
       ]);
@@ -160,7 +160,7 @@ describe("#JSONParser", function() {
           }
         })
       ).toEqual([
-        new Transaction(["portDefinitions"], 0, ADD_ITEM),
+        new Transaction(["portDefinitions"], null, ADD_ITEM),
         new Transaction(["portDefinitions", 0, "portMapping"], false),
         new Transaction(["portDefinitions", 0, "protocol", "udp"], true),
         new Transaction(["portDefinitions", 0, "protocol", "tcp"], false)
@@ -202,7 +202,7 @@ describe("#JSONParser", function() {
           ]
         })
       ).toEqual([
-        new Transaction(["portDefinitions"], 1, ADD_ITEM),
+        new Transaction(["portDefinitions"], null, ADD_ITEM),
         new Transaction(["portDefinitions", 0, "name"], "foo"),
         new Transaction(["portDefinitions", 0, "automaticPort"], true),
         new Transaction(["portDefinitions", 0, "portMapping"], true),

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Volumes-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Volumes-test.js
@@ -18,7 +18,7 @@ describe("Volumes", function() {
     it("should return a local volume", function() {
       let batch = new Batch();
 
-      batch = batch.add(new Transaction(["localVolumes"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["localVolumes"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["localVolumes", 0, "type"], "PERSISTENT", SET)
       );
@@ -37,7 +37,7 @@ describe("Volumes", function() {
     it("should parse wrong values in local volume", function() {
       let batch = new Batch();
 
-      batch = batch.add(new Transaction(["localVolumes"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["localVolumes"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["localVolumes", 0, "size"], "123", SET)
       );
@@ -63,7 +63,7 @@ describe("Volumes", function() {
     it("should parse wrong values in local volume", function() {
       let batch = new Batch();
 
-      batch = batch.add(new Transaction(["localVolumes"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["localVolumes"], null, ADD_ITEM));
       // Ignores wrong type
       batch = batch.add(new Transaction(["localVolumes", 0, "type"], 123, SET));
       batch = batch.add(new Transaction(["localVolumes", 0, "mode"], 123, SET));
@@ -86,7 +86,7 @@ describe("Volumes", function() {
     it("should return an external volume", function() {
       let batch = new Batch();
 
-      batch = batch.add(new Transaction(["externalVolumes"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["externalVolumes"], null, ADD_ITEM));
 
       expect(batch.reduce(Volumes.JSONReducer.bind({}), [])).toEqual([
         {
@@ -106,7 +106,7 @@ describe("Volumes", function() {
     it("should parse wrong values in external volume", function() {
       let batch = new Batch();
 
-      batch = batch.add(new Transaction(["externalVolumes"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["externalVolumes"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["externalVolumes", 0, "provider"], 123, SET)
       );
@@ -142,8 +142,8 @@ describe("Volumes", function() {
     it("should return a local and an external volume", function() {
       let batch = new Batch();
 
-      batch = batch.add(new Transaction(["externalVolumes"], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(["localVolumes"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["externalVolumes"], null, ADD_ITEM));
+      batch = batch.add(new Transaction(["localVolumes"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["localVolumes", 0, "type"], "PERSISTENT", SET)
       );
@@ -173,7 +173,7 @@ describe("Volumes", function() {
     it("should return a fully filled local volume", function() {
       let batch = new Batch();
 
-      batch = batch.add(new Transaction(["localVolumes"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["localVolumes"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["localVolumes", 0, "type"], "PERSISTENT", SET)
       );
@@ -201,7 +201,7 @@ describe("Volumes", function() {
     it("should return a fully filled external volume", function() {
       let batch = new Batch();
 
-      batch = batch.add(new Transaction(["externalVolumes"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["externalVolumes"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(
           ["externalVolumes", 0, "containerPath"],
@@ -245,8 +245,8 @@ describe("Volumes", function() {
     it("should remove the right local volume", function() {
       let batch = new Batch();
 
-      batch = batch.add(new Transaction(["localVolumes"], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(["localVolumes"], 1, ADD_ITEM));
+      batch = batch.add(new Transaction(["localVolumes"], null, ADD_ITEM));
+      batch = batch.add(new Transaction(["localVolumes"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["localVolumes", 0, "type"], "PERSISTENT", SET)
       );
@@ -282,8 +282,8 @@ describe("Volumes", function() {
     it("should remove the right external volume", function() {
       let batch = new Batch();
 
-      batch = batch.add(new Transaction(["externalVolumes"], 0, ADD_ITEM));
-      batch = batch.add(new Transaction(["externalVolumes"], 1, ADD_ITEM));
+      batch = batch.add(new Transaction(["externalVolumes"], null, ADD_ITEM));
+      batch = batch.add(new Transaction(["externalVolumes"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(
           ["externalVolumes", 0, "containerPath"],
@@ -335,7 +335,7 @@ describe("Volumes", function() {
       let batch = new Batch();
 
       // Add the first external Volume
-      batch = batch.add(new Transaction(["externalVolumes"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["externalVolumes"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(
           ["externalVolumes", 0, "containerPath"],
@@ -357,7 +357,7 @@ describe("Volumes", function() {
         new Transaction(["externalVolumes", 0, "provider"], "provider", SET)
       );
       // Add the first local Volume
-      batch = batch.add(new Transaction(["localVolumes"], 0, ADD_ITEM));
+      batch = batch.add(new Transaction(["localVolumes"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["localVolumes", 0, "type"], "PERSISTENT", SET)
       );
@@ -371,7 +371,7 @@ describe("Volumes", function() {
         new Transaction(["localVolumes", 0, "mode"], "READ", SET)
       );
       // Add the second external Volume
-      batch = batch.add(new Transaction(["externalVolumes"], 1, ADD_ITEM));
+      batch = batch.add(new Transaction(["externalVolumes"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(
           ["externalVolumes", 1, "containerPath"],
@@ -383,7 +383,7 @@ describe("Volumes", function() {
         new Transaction(["externalVolumes", 1, "name"], "one", SET)
       );
       // Add the second local Volume
-      batch = batch.add(new Transaction(["localVolumes"], 1, ADD_ITEM));
+      batch = batch.add(new Transaction(["localVolumes"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["localVolumes", 1, "type"], "PERSISTENT", SET)
       );

--- a/plugins/services/src/js/reducers/serviceForm/common/Constraints.js
+++ b/plugins/services/src/js/reducers/serviceForm/common/Constraints.js
@@ -51,7 +51,7 @@ module.exports = {
       }
 
       const { fieldName, operator, value } = item;
-      memo.push(new Transaction(["constraints"], index, ADD_ITEM));
+      memo.push(new Transaction(["constraints"], null, ADD_ITEM));
       memo.push(
         new Transaction(["constraints", index, "fieldName"], fieldName, SET)
       );

--- a/src/js/components/JSONEditor.js
+++ b/src/js/components/JSONEditor.js
@@ -143,6 +143,7 @@ class JSONEditor extends React.Component {
       this.jsonValue,
       nextProps.value
     );
+
     const jsonText = JSON.stringify(value, null, 2);
 
     // Update local state with the new, computed text

--- a/src/js/utils/ReducerUtil.js
+++ b/src/js/utils/ReducerUtil.js
@@ -42,7 +42,7 @@ module.exports = {
 
         const reducer = reducers[key];
 
-        if (index === 0 || !context.has(reducer)) {
+        if (index === 0 || (reducer && !context.has(reducer))) {
           context.set(reducer, {});
         }
 


### PR DESCRIPTION
This is mostly the work of @nLight from #2081 Which has been rebased to current Master and squashed into one commit. 

As this PR is introducing a MAYOR refactoring. Please give this PR some serious testing before approving to the changes.

This PR will introduce a mayor change in the way we parse / reduce application configurations in the service form. Now the ADD_ITEM transaction will hold null or a complete object of the item instead of the index. We do this so that we can keep unknown fields from the JSON. Right now this also is
creating redundancy because all the transactions after the ADD_ITEM are just reseting the same
value.

E.G. :

The following JSON is parsed:
```JSON
{
  "array": [{
    "id": "1234",
    "unknownField": "withoutTransaction"
  }]
}
```
And will create the following Transactions:
 - `ADD_ITEM, {id: "1234", unknownField:
   "withoutTransaction", ["array"]}`
 - `SET, ['array', 0, 'id'], "1234"`

But in this case this redundancy is good,in some places we are depending on the separate Transactions.

Closes DCOS-14844, DCOS-14756

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
