### PR TITLE
fix(ServiceUtil): Fix a bug when matching Mesos task IDs to Marathon services

### DIFF
--- a/plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.js
+++ b/plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.js
@@ -48,7 +48,7 @@ class TaskVolumeContainer extends React.Component {
   render() {
     const { taskID, volumeID } = this.props.params;
     const task = MesosStateStore.getTaskFromTaskID(taskID);
-    const service = DCOSStore.serviceTree.findItemById(task.getServiceId());
+    const service = DCOSStore.serviceTree.getServiceFromTaskID(task.getId());
     const volumeId = decodeURIComponent(volumeID);
 
     if (this.state.isLoading) {

--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -230,7 +230,7 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
       return null;
     }
 
-    const service = DCOSStore.serviceTree.findItemById(task.getServiceId());
+    const service = DCOSStore.serviceTree.getServiceFromTaskID(task.getId());
     const taskIcon = <img src={task.getImages()["icon-large"]} />;
     const filePath = (selectedLogFile && selectedLogFile.get("path")) || null;
     const params = Object.assign({ filePath }, this.props.params);
@@ -330,7 +330,7 @@ class TaskDetail extends mixin(InternalStorageMixin, TabsMixin, StoreMixin) {
     if (!directory || !task) {
       return this.getLoadingScreen();
     }
-    const service = DCOSStore.serviceTree.findItemById(task.getServiceId());
+    const service = DCOSStore.serviceTree.getServiceFromTaskID(task.getId());
 
     return (
       <div className="flex flex-direction-top-to-bottom flex-item-grow-1 flex-item-shrink-1">

--- a/plugins/services/src/js/structs/ServiceTree.js
+++ b/plugins/services/src/js/structs/ServiceTree.js
@@ -84,7 +84,7 @@ module.exports = class ServiceTree extends Tree {
   }
 
   getServiceFromTaskID(taskID) {
-    return this.findServiceByName(ServiceUtil.getServiceNameFromTaskID(taskID));
+    return this.findItemById(ServiceUtil.getServiceIDFromTaskID(taskID));
   }
 
   getTaskFromTaskID(taskID) {

--- a/plugins/services/src/js/structs/Task.js
+++ b/plugins/services/src/js/structs/Task.js
@@ -13,22 +13,4 @@ module.exports = class Task extends Item {
   getName() {
     return this.get("name");
   }
-
-  /**
-   * Get corresponding service id
-   *
-   * @return {string} service id
-   */
-  getServiceId() {
-    // Parse the task id (e.g. foo_bar.abc-123) to get the corresponding
-    // service id parts (foo, bar)
-    const parts = this.getId().match(/([^_]+)(?=[_.])/g);
-
-    // Join service id parts and prepend with a slash to form a valid id
-    if (parts) {
-      return `/${parts.join("/")}`;
-    }
-
-    return "";
-  }
 };

--- a/plugins/services/src/js/structs/__tests__/Task-test.js
+++ b/plugins/services/src/js/structs/__tests__/Task-test.js
@@ -36,28 +36,4 @@ describe("Task", function() {
       expect(task.getName()).toEqual("foo.bar.baz");
     });
   });
-
-  describe("#getServiceId", function() {
-    it("returns correct service id for a service in root", function() {
-      const task = new Task({
-        id: "test.a1f67e90-1c86-11e6-ae46-0ed0cffa3d76"
-      });
-
-      expect(task.getServiceId()).toEqual("/test");
-    });
-
-    it("returns correct service id for a service in a group", function() {
-      const task = new Task({
-        id: "group_test.a1f67e90-1c86-11e6-ae46-0ed0cffa3d76"
-      });
-
-      expect(task.getServiceId()).toEqual("/group/test");
-    });
-
-    it("returns empty string if id is undefined", function() {
-      const task = new Task({});
-
-      expect(task.getServiceId()).toEqual("");
-    });
-  });
 });

--- a/plugins/services/src/js/utils/ServiceUtil.js
+++ b/plugins/services/src/js/utils/ServiceUtil.js
@@ -110,6 +110,25 @@ const ServiceUtil = {
     return service;
   },
 
+  /**
+   * Get corresponding service ID
+   *
+   * @param  {string} taskID - the tasks' ID
+   * @return {string} service ID
+   */
+  getServiceIDFromTaskID(taskID = "") {
+    // Parse the task id (e.g. foo_bar.abc-123) to get the corresponding
+    // service id parts (foo, bar)
+    const parts = taskID.match(/([^_]+)(?=[_.])/g);
+
+    // Join service id parts and prepend with a slash to form a valid id
+    if (parts) {
+      return `/${parts.join("/")}`;
+    }
+
+    return "";
+  },
+
   getServiceNameFromTaskID(taskID) {
     const serviceName = taskID.split(".")[0].split("_");
 

--- a/plugins/services/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceUtil-test.js
@@ -210,4 +210,26 @@ describe("ServiceUtil", function() {
       expect(ServiceUtil.isSDKService(service)).toEqual(false);
     });
   });
+
+  describe("#getServiceIDFromTaskID", function() {
+    it("returns correct service id for a service in root", function() {
+      expect(
+        ServiceUtil.getServiceIDFromTaskID(
+          "test.a1f67e90-1c86-11e6-ae46-0ed0cffa3d76"
+        )
+      ).toEqual("/test");
+    });
+
+    it("returns correct service id for a service in a group", function() {
+      expect(
+        ServiceUtil.getServiceIDFromTaskID(
+          "group_test.a1f67e90-1c86-11e6-ae46-0ed0cffa3d76"
+        )
+      ).toEqual("/group/test");
+    });
+
+    it("returns empty string if id is undefined", function() {
+      expect(ServiceUtil.getServiceIDFromTaskID()).toEqual("");
+    });
+  });
 });


### PR DESCRIPTION
Previously we were inferring a service's name based on the task ID (e.g. for task ID `foo_bar_baz`, we assumed a service name of `baz`), then finding the Marathon service by this name. This caused collisions when services shared the same name at different paths (e.g. `/foo/bar/baz` and `/corgly/baz`).

With this PR, we'll infer a service's full ID based on the task ID (e.g. for task ID `foo_bar_baz`, we assume a service ID of `/foo/bar/baz`) and then find the Marathon service with this ID.

To accomplish this, I did the following:
1. I moved `#getServiceId` from the `Task` struct to the `ServiceUtil` and renamed to `#getServiceIDFromTaskID` (to match the `#getServiceNameFromTaskID` method)
2. I implemented `#getServiceIDFromTaskID` in `ServiceTree#getServiceFromTaskID`
3. I implemented `ServiceTree#getServiceFromTaskID` everywhere that used `Task#getServiceId`, all of which incidentally used this method to find a service by task ID.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?