### PR TITLE
fix(DCOS-12243): Redirect user back to original relative path after logged-in

### DIFF
--- a/plugins/oauth/hooks.js
+++ b/plugins/oauth/hooks.js
@@ -74,7 +74,13 @@ module.exports = Object.assign({}, StoreMixin, {
   },
 
   redirectToLogin(nextState, replace) {
-    replace("/login");
+    const redirectTo = RouterUtil.getRedirectTo();
+    // Ignores relative path if redirect is present
+    if (redirectTo) {
+      replace(`/login?redirect=${redirectTo}`);
+    } else {
+      replace(`/login?relativePath=${nextState.location.pathname}`);
+    }
   },
 
   AJAXRequestError(xhr) {
@@ -194,11 +200,14 @@ module.exports = Object.assign({}, StoreMixin, {
       global.location.href = redirectTo;
     } else {
       ApplicationUtil.beginTemporaryPolling(() => {
+        const relativePath = RouterUtil.getRelativePath();
         const loginRedirectRoute = AuthStore.get("loginRedirectRoute");
 
-        if (loginRedirectRoute) {
+        if (loginRedirectRoute && !relativePath) {
           // Go to redirect route if it is present
           hashHistory.push(loginRedirectRoute);
+        } else if (relativePath) {
+          global.location.replace(`${global.location.origin}/#${relativePath}`);
         } else {
           // Go to home
           hashHistory.push("/");

--- a/src/js/utils/RouterUtil.js
+++ b/src/js/utils/RouterUtil.js
@@ -17,28 +17,63 @@ function findRedirect(queryString) {
 }
 
 const RouterUtil = {
-  isValidRedirect(url) {
-    const parsedUrl = Util.parseUrl(url);
-
-    return parsedUrl.hostname === global.location.hostname;
-  },
-
-  getRedirectTo() {
-    let redirectTo = false;
-
+  /**
+   * Parse the url and find the query string (?)
+   * before or after the #
+   *
+   * @returns {Boolean|Object} false or query string object
+   */
+  getQueryStringInUrl() {
+    let queryString = false;
     // This will match url instances like this:
     // /?redirect=SOME_ADDRESS#/login
     if (global.location.search) {
-      redirectTo = findRedirect(qs.parse(global.location.search));
+      queryString = qs.parse(global.location.search);
     }
 
     // This will match url instances like this:
     // /#/login?redirect=SOME_ADDRESS
-    if (!redirectTo && global.location.hash) {
-      redirectTo = findRedirect(qs.parse(global.location.hash));
+    if (!queryString && global.location.hash) {
+      queryString = qs.parse(global.location.hash);
     }
 
-    return redirectTo;
+    return queryString;
+  },
+
+  isValidRedirect(url) {
+    const parsedUrl = Util.parseUrl(url);
+
+    if (!parsedUrl) {
+      return false;
+    }
+
+    return parsedUrl.hostname === global.location.hostname;
+  },
+
+  /**
+   * Find relativePath query
+   * and keep it's original encoding
+   * the use of qs will decode the path
+   * making the path not found
+   *
+   * @returns {Boolean|String} False or path encodedURI
+   */
+  getRelativePath() {
+    const RELATIVE_PATH = "relativePath=";
+    const url = global.location.href;
+
+    if (!url.includes(RELATIVE_PATH)) {
+      return false;
+    }
+
+    const startPoint = url.indexOf(RELATIVE_PATH) + RELATIVE_PATH.length;
+    const endPoint = url.length;
+
+    return url.substring(startPoint, endPoint);
+  },
+
+  getRedirectTo() {
+    return findRedirect(this.getQueryStringInUrl());
   },
 
   /**

--- a/src/js/utils/Util.js
+++ b/src/js/utils/Util.js
@@ -226,6 +226,11 @@ const Util = {
       return null;
     }
 
+    // Add http/s otherwise browser/engine think it's relative path
+    if (!/http|https/.test(url)) {
+      url = `https://${url}`;
+    }
+
     // TODO: replace below with browser native API <new URL()>
     // when all browsers support are available
     const aElement = document.createElement("a");

--- a/src/js/utils/__tests__/RouterUtil-test.js
+++ b/src/js/utils/__tests__/RouterUtil-test.js
@@ -1,3 +1,4 @@
+jest.dontMock("query-string");
 jest.dontMock("../RouterUtil");
 
 const ReactRouter = require("react-router");
@@ -134,10 +135,23 @@ describe("RouterUtil", function() {
 
   describe("#redirect", function() {
     beforeEach(function() {
+      const searchQuery = "?redirect=http://www.google.com/&something=foo";
+
       // Overwrite jsdom global/window location mock
       Object.defineProperty(global.location, "hostname", {
         writable: true,
         value: "localhost"
+      });
+
+      Object.defineProperty(global.location, "href", {
+        writable: true,
+        value: "http://localhost:4200/#/login?relativePath=/services/detail/%2Fmlancaster/configuration"
+      });
+
+      // Overwrite jsdom global/window location mock
+      Object.defineProperty(global.location, "search", {
+        writable: true,
+        value: searchQuery
       });
     });
 
@@ -153,6 +167,48 @@ describe("RouterUtil", function() {
       const url = "http://malicious.domain.com/pwned?localhost:4200";
 
       expect(RouterUtil.isValidRedirect(url)).toEqual(expectedResult);
+    });
+
+    it("get relative path", function() {
+      const expectedResult = "/services/detail/%2Fmlancaster/configuration";
+
+      expect(RouterUtil.getRelativePath()).toEqual(expectedResult);
+    });
+
+    it("get redirectTo", function() {
+      const expectedResult = "http://www.google.com/";
+
+      expect(RouterUtil.getRedirectTo()).toEqual(expectedResult);
+    });
+  });
+
+  describe("#getQueryStringInUrl", function() {
+    const expectedResult = {
+      redirect: "http://www.google.com/",
+      something: "foo"
+    };
+
+    beforeEach(function() {
+      const searchQuery = "?redirect=http://www.google.com/&something=foo";
+
+      // Overwrite jsdom global/window location mock
+      Object.defineProperty(global.location, "search", {
+        writable: true,
+        value: searchQuery
+      });
+
+      Object.defineProperty(global.location, "hash", {
+        writable: true,
+        value: `#/some/path${searchQuery}`
+      });
+    });
+
+    it("get object from search query", function() {
+      expect(RouterUtil.getQueryStringInUrl()).toEqual(expectedResult);
+    });
+
+    it("get object from hash query", function() {
+      expect(RouterUtil.getQueryStringInUrl()).toEqual(expectedResult);
     });
   });
 });

--- a/src/js/utils/__tests__/Util-test.js
+++ b/src/js/utils/__tests__/Util-test.js
@@ -448,5 +448,12 @@ describe("Util", function() {
     it("should return null", function() {
       expect(Util.parseUrl(1)).toEqual(null);
     });
+
+    it("should return absolute url if doesn't have protocol", function() {
+      const parsedUrl = Util.parseUrl("www.google.com");
+      const expectedResult = "https://www.google.com/";
+
+      expect(parsedUrl.href).toEqual(expectedResult);
+    });
   });
 });


### PR DESCRIPTION
**DCOS-12243** If the user is logged out and try to go to a path e.g `http://localhost:4200/#/services/detail/%2Fsome-service/configuration`
we will redirect the user to login page but after the user log-in we do not send back to where the original path was.

This PR add the feat to redirect the user back to the relative path after logged-in.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
