### PR TITLE
Adjust job breadcrumb generation

### DIFF
--- a/src/js/pages/jobs/JobDetailPage.js
+++ b/src/js/pages/jobs/JobDetailPage.js
@@ -8,6 +8,7 @@ import React from "react";
 import { routerShape } from "react-router";
 
 import { StoreMixin } from "mesosphere-shared-reactjs";
+import DCOSStore from "#SRC/js/stores/DCOSStore";
 
 import Icon from "../../components/Icon";
 import JobConfiguration from "./JobConfiguration";
@@ -217,7 +218,9 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
   getErrorScreen() {
     return (
       <Page>
-        <Page.Header breadcrumbs={<JobsBreadcrumbs />} />
+        <Page.Header
+          breadcrumbs={<JobsBreadcrumbs tree={DCOSStore.jobTree} />}
+        />
         <RequestErrorMsg />
       </Page>
     );
@@ -226,7 +229,9 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
   getLoadingScreen() {
     return (
       <Page>
-        <Page.Header breadcrumbs={<JobsBreadcrumbs />} />
+        <Page.Header
+          breadcrumbs={<JobsBreadcrumbs tree={DCOSStore.jobTree} />}
+        />
         <Loader />
       </Page>
     );
@@ -250,27 +255,6 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
     if (schedule.enabled) {
       return prettycron.toString(schedule.cron);
     }
-  }
-
-  getJobStatus(job) {
-    let longestRunningTask = null;
-    const longestRunningActiveRun = job
-      .getActiveRuns()
-      .getLongestRunningActiveRun();
-
-    if (longestRunningActiveRun != null) {
-      longestRunningTask = longestRunningActiveRun
-        .getTasks()
-        .getLongestRunningTask();
-    }
-
-    if (longestRunningTask == null) {
-      return null;
-    }
-
-    const status = TaskStates[longestRunningTask.getStatus()];
-
-    return status.displayName;
   }
 
   getSubTitle(job) {
@@ -423,22 +407,12 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
     }
 
     const job = MetronomeStore.getJob(this.props.params.id);
-    const jobStatus = this.getJobStatus(job);
-    const jobSchedules = job.getSchedules();
-
-    const breadcrumbs = (
-      <JobsBreadcrumbs
-        jobID={job.getId()}
-        jobSchedules={jobSchedules}
-        jobStatus={jobStatus}
-      />
-    );
 
     return (
       <Page>
         <Page.Header
           actions={this.getActions()}
-          breadcrumbs={breadcrumbs}
+          breadcrumbs={<JobsBreadcrumbs tree={DCOSStore.jobTree} item={job} />}
           tabs={this.getTabs()}
         />
         {this.tabs_getTabView(job)}

--- a/src/js/pages/jobs/JobTaskDetailPage.js
+++ b/src/js/pages/jobs/JobTaskDetailPage.js
@@ -1,10 +1,16 @@
 import React from "react";
+import { Link } from "react-router";
+
+import DCOSStore from "#SRC/js/stores/DCOSStore";
 
 import TaskDetail
   from "../../../../plugins/services/src/js/pages/task-details/TaskDetail";
 import MesosStateStore from "../../stores/MesosStateStore";
+import MetronomeStore from "../../stores/MetronomeStore";
 import JobsBreadcrumbs from "../../components/breadcrumbs/JobsBreadcrumbs";
 import Page from "../../components/Page";
+import Breadcrumb from "../../components/Breadcrumb";
+import BreadcrumbTextContent from "../../components/BreadcrumbTextContent";
 
 const dontScrollRoutes = [/\/files\/view.*$/, /\/logs.*$/];
 
@@ -20,19 +26,25 @@ class JobTaskDetailPage extends React.Component {
       { label: "Logs", routePath: routePrefix + "/logs" }
     ];
 
+    const job = MetronomeStore.getJob(id);
     const task = MesosStateStore.getTaskFromTaskID(taskID);
 
-    let breadcrumbs;
+    let breadcrumbs = (
+      <JobsBreadcrumbs tree={DCOSStore.jobTree} item={job} details={false} />
+    );
+
     if (task != null) {
       breadcrumbs = (
-        <JobsBreadcrumbs
-          jobID={id}
-          taskID={task.getId()}
-          taskName={task.getName()}
-        />
+        <JobsBreadcrumbs tree={DCOSStore.jobTree} item={job} details={false}>
+          <Breadcrumb key="task-name" title={task.getName()}>
+            <BreadcrumbTextContent>
+              <Link to={`/jobs/${id}/tasks/${task.getId()}`}>
+                {task.getName()}
+              </Link>
+            </BreadcrumbTextContent>
+          </Breadcrumb>
+        </JobsBreadcrumbs>
       );
-    } else {
-      breadcrumbs = <JobsBreadcrumbs />;
     }
 
     const dontScroll = dontScrollRoutes.some(regex => {

--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -164,7 +164,7 @@ class JobsTab extends mixin(StoreMixin) {
             label: "Create a job",
             onItemSelect: this.handleOpenJobFormModal
           }}
-          breadcrumbs={<JobsBreadcrumbs jobID={item.id} />}
+          breadcrumbs={<JobsBreadcrumbs tree={DCOSStore.jobTree} item={item} />}
         />
         <div className="flex-grow">
           {this.getHeadline(item, filteredJobs)}
@@ -199,7 +199,9 @@ class JobsTab extends mixin(StoreMixin) {
     if (!DCOSStore.jobDataReceived) {
       return (
         <Page>
-          <Page.Header breadcrumbs={<JobsBreadcrumbs />} />
+          <Page.Header
+            breadcrumbs={<JobsBreadcrumbs tree={DCOSStore.jobTree} />}
+          />
           <Loader />
         </Page>
       );
@@ -217,7 +219,9 @@ class JobsTab extends mixin(StoreMixin) {
     // Render empty panel
     return (
       <Page>
-        <Page.Header breadcrumbs={<JobsBreadcrumbs />} />
+        <Page.Header
+          breadcrumbs={<JobsBreadcrumbs tree={DCOSStore.jobTree} />}
+        />
         <AlertPanel>
           <AlertPanelHeader>No active jobs</AlertPanelHeader>
           <p className="tall">


### PR DESCRIPTION
Utilize the  job tree structure for the breadcrumb generation instead of relying on a rather error prone string based mechanism. This change is a prerequisite for the job tree structure   adjustments to align the UI with the way Metronome handles IDs and namespaces.