### PR TITLE
fix(tables): Fix .table-display-on-row-hover elements

### DIFF
--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -64,6 +64,13 @@
       visibility: hidden;
     }
 
+    &:hover {
+
+      .table-display-on-row-hover {
+        visibility: visible;
+      }
+    }
+
     // Because dropdown menus render at the root of the body tag, the :hover
     // pseudoclass doesn't apply when the user's mouse enters the dropdown.
     // This forces the button to stay visible while the dropdown menu is open.


### PR DESCRIPTION
This PR fixes a bug that was introduced in #2162. We accidentally removed the styles for `.table-display-on-row-hover` elements, which should be displayed in all tables once the row is hovered.

Before:
![](https://cl.ly/1W3W0T1s2r33/Screen%20Recording%202017-06-07%20at%2011.22%20AM.gif)

After:
![](https://cl.ly/0w343v0P1W3m/Screen%20Recording%202017-06-07%20at%2011.19%20AM.gif)

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
