### PR TITLE
fix(TimeSeriesGraphs): Hide mouse coordinate axis lines on mouse out

### DIFF
--- a/src/js/components/charts/TimeSeriesMouseOver.js
+++ b/src/js/components/charts/TimeSeriesMouseOver.js
@@ -72,6 +72,7 @@ var TimeSeriesMouseOver = React.createClass({
 
     d3
       .select(this.refs.xMousePosition)
+      .style("opacity", 1)
       .transition()
       .duration(50)
       .attr("x1", mouse.x)
@@ -79,6 +80,7 @@ var TimeSeriesMouseOver = React.createClass({
 
     d3
       .select(this.refs.yMousePosition)
+      .style("opacity", 1)
       .transition()
       .duration(50)
       .attr("y1", props.yScale(firstDataSet.values[index][props.y]))
@@ -123,8 +125,8 @@ var TimeSeriesMouseOver = React.createClass({
   },
 
   handleMouseOut() {
-    d3.select(this.refs.yMousePosition).interrupt();
-    d3.select(this.refs.xMousePosition).interrupt();
+    d3.select(this.refs.yMousePosition).interrupt().style("opacity", 0);
+    d3.select(this.refs.xMousePosition).interrupt().style("opacity", 0);
     d3.select(this.refs.xAxisCurrent).text("");
     d3.select(this.refs.yAxisCurrent).text("");
   },
@@ -157,12 +159,14 @@ var TimeSeriesMouseOver = React.createClass({
         <line
           className="chart-cursor-position-marker"
           ref="xMousePosition"
+          style={{ opacity: 0 }}
           y1={0}
           y2={height}
         />
         <line
           className="chart-cursor-position-marker"
           ref="yMousePosition"
+          style={{ opacity: 0 }}
           x1={0}
           x2={this.props.width}
         />


### PR DESCRIPTION
This PR hides the mouse coordinate axis lines on initial render and when the cursor leaves the time series graph. Previously the lines were rendered on the graph at all times; at mount they were visible at the top and left edges, and were not hidden when the mouse left the graph.

Before:
![](https://cl.ly/3k0d2G1p2t3p/Screen%20Recording%202017-06-07%20at%2002.17%20PM.gif)

After:
![](https://cl.ly/0t1F1r1z1P3z/Screen%20Recording%202017-06-07%20at%2002.20%20PM.gif)

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?