### PR TITLE
DCOS-11685: Disallow leading/trailing whitespace chars in label keys

### DIFF
--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -98,6 +98,7 @@ const APP_VALIDATORS = [
   MarathonAppValidators.complyWithResidencyRules,
   MarathonAppValidators.mustContainImageOnDocker,
   MarathonAppValidators.validateConstraints,
+  MarathonAppValidators.validateLabels,
   MarathonAppValidators.mustNotContainUris,
   MarathonAppValidators.mustNotContainMarathonHTTPSHealthChecks,
   MarathonAppValidators.mustNotContainMarathonHTTPHealthChecks,

--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -324,6 +324,34 @@ const MarathonAppValidators = {
 
       return errors;
     }, []);
+  },
+
+  /**
+   * @param {Object} app - The data to validate
+   * @returns {Array} Returns an array with validation errors
+   */
+  validateLabels(app) {
+    if (ValidatorUtil.isDefined(app.labels)) {
+      return Object.keys(app.labels)
+        .reduce(function(accumulator, labelKey) {
+          if (/^\s|\s$/.test(labelKey)) {
+            accumulator.push(`labels.${labelKey}`);
+          }
+
+          return accumulator;
+        }, [])
+        .map(function(labelPath) {
+          return {
+            path: [labelPath],
+            message: "Keys must not start or end with whitespace characters",
+            type: SYNTAX_ERROR,
+            variables: { name: "labels" }
+          };
+        });
+    }
+
+    // No errors
+    return [];
   }
 };
 

--- a/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
@@ -394,4 +394,59 @@ describe("MarathonAppValidators", function() {
       expect(MarathonAppValidators.validateConstraints(spec)).toEqual([]);
     });
   });
+
+  describe("#validateLabels", function() {
+    it("should not return error if labels are not specified", function() {
+      const spec = {};
+      expect(MarathonAppValidators.validateLabels(spec)).toEqual([]);
+    });
+
+    it("should not return error if label keys do not start or end with spaces", function() {
+      const spec = {
+        labels: {
+          foo: "bar",
+          bar: "baz"
+        }
+      };
+      expect(MarathonAppValidators.validateLabels(spec)).toEqual([]);
+    });
+
+    it("should return errors if any label key starts with a space", function() {
+      const spec = {
+        labels: {
+          " foo": "bar",
+          bar: "baz"
+        }
+      };
+      expect(MarathonAppValidators.validateLabels(spec)).toEqual([
+        {
+          message: "Keys must not start or end with whitespace characters",
+          path: ["labels. foo"],
+          type: SYNTAX_ERROR,
+          variables: {
+            name: "labels"
+          }
+        }
+      ]);
+    });
+
+    it("should return errors if any label key ends with a space", function() {
+      const spec = {
+        labels: {
+          "foo ": "bar",
+          bar: "baz"
+        }
+      };
+      expect(MarathonAppValidators.validateLabels(spec)).toEqual([
+        {
+          message: "Keys must not start or end with whitespace characters",
+          path: ["labels.foo "],
+          type: SYNTAX_ERROR,
+          variables: {
+            name: "labels"
+          }
+        }
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
This PR disallows leading & trailing whitespace characters in label keys.

![](https://cl.ly/3T383C0R090K/Screen%20Shot%202017-06-09%20at%2012.10.43%20PM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?