### PR TITLE
↩️ [1.9] DCOS-16147: default portDefinitions to an empty array

### DIFF
--- a/plugins/services/src/js/constants/DefaultApp.js
+++ b/plugins/services/src/js/constants/DefaultApp.js
@@ -5,7 +5,7 @@ const { DOCKER } = ContainerConstants.type;
 const DEFAULT_APP_RESOURCES = { cpus: 0.1, mem: 128 };
 const DEFAULT_APP_CONTAINER = { container: { type: DOCKER } };
 const DEFAULT_APP_SPEC = Object.assign(
-  { instances: 1 },
+  { instances: 1, portDefinitions: [] },
   DEFAULT_APP_CONTAINER,
   DEFAULT_APP_RESOURCES
 );

--- a/plugins/services/src/js/utils/CreateServiceModalFormUtil.js
+++ b/plugins/services/src/js/utils/CreateServiceModalFormUtil.js
@@ -20,12 +20,18 @@ const CreateServiceModalFormUtil = {
     }
 
     return Object.keys(object).reduce(function(memo, key) {
-      if (!ValidatorUtil.isEmpty(object[key]) && !Number.isNaN(object[key])) {
+      if (
+        (!ValidatorUtil.isEmpty(object[key]) && !Number.isNaN(object[key])) ||
+        Array.isArray(object[key])
+      ) {
         // Apply the strip function recursively and keep only non-empty values
         const value = CreateServiceModalFormUtil.stripEmptyProperties(
           object[key]
         );
-        if (!ValidatorUtil.isEmpty(value) && !Number.isNaN(value)) {
+        if (
+          (!ValidatorUtil.isEmpty(value) && !Number.isNaN(value)) ||
+          Array.isArray(value)
+        ) {
           memo[key] = value;
         }
       }

--- a/plugins/services/src/js/utils/__tests__/CreateServiceModalFormUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/CreateServiceModalFormUtil-test.js
@@ -1,6 +1,6 @@
 const CreateServiceModalFormUtil = require("../CreateServiceModalFormUtil");
 
-const EMPTY_TYPES = [null, undefined, {}, [], "", NaN];
+const EMPTY_TYPES = [null, undefined, {}, "", NaN];
 const NUMERICAL_VALUE_TYPES = [0, 1234];
 const NON_NUMERICAL_VALUE_TYPES = ["foo", { a: "b" }, ["a"]];
 const VALUE_TYPES = [].concat(NUMERICAL_VALUE_TYPES, NON_NUMERICAL_VALUE_TYPES);
@@ -213,16 +213,16 @@ describe("CreateServiceModalFormUtil", function() {
         it(`should remove ${emptyTypeStr} along with empty deep arrays`, function() {
           const data = { a: [] };
           const patch = {
-            a: [[emptyType, emptyType, [emptyType, [emptyType]]]]
+            a: [[[[emptyType], emptyType], emptyType, emptyType]]
           };
           const patched = CreateServiceModalFormUtil.applyPatch(data, patch);
-          expect(patched).toEqual({ a: [] });
+          expect(patched).toEqual({ a: [[[[]]]] });
         });
 
         it(`should remove ${emptyTypeStr} along with mixed empty structures`, function() {
           const data = { a: [] };
           const patch = {
-            a: [{ b: emptyType }, [emptyType, { c: emptyType }]]
+            a: [[{ c: emptyType }, emptyType], { b: emptyType }]
           };
           const patched = CreateServiceModalFormUtil.applyPatch(data, patch);
           expect(patched).toEqual({ a: [] });

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -151,6 +151,7 @@ describe("Service Form Modal", function() {
     const SERVICE_SPEC = {
       id: "/sleep",
       cmd: "sleep 3000",
+      constraints: [],
       instances: 1,
       cpus: 1,
       mem: 128,
@@ -207,7 +208,12 @@ describe("Service Form Modal", function() {
           protocol: "tcp"
         }
       ],
-      requirePorts: false
+      requirePorts: false,
+      storeUrls: [],
+      readinessChecks: [],
+      healthChecks: [],
+      fetch: [],
+      dependencies: []
     };
 
     beforeEach(function() {


### PR DESCRIPTION
This is a back port of https://github.com/dcos/dcos-ui/pull/2244
I had to adjust `applyPatch` tests since it uses `stripEmptyProperties` that I had to update so it doesn't remove empty arrays and objects.

To test: launch 1.9 cluster, go and create an app, verify that `portDefinitions: []`. Without the fix you won't see `portDefinitions` at all and because of that Marathon will create a port by default.