### PR TITLE
fix(DCOS-14880): Remove docker from container if needed

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/Container.js
+++ b/plugins/services/src/js/reducers/serviceForm/Container.js
@@ -154,7 +154,7 @@ module.exports = {
     this.internalState = newState;
 
     if (ValidatorUtil.isEmpty(newState.docker)) {
-      delete newState.docker;
+      newState.docker = null;
     }
 
     if (ValidatorUtil.isEmpty(newState.type)) {


### PR DESCRIPTION
Instead of deleting docker we are now overwriting
docker with null if it should *not* be present. This
will ensure that the base config will be
overwritten.

Error description:

In 1.9, create an app definition with a docker containerizer container such as alpine and a command of sleep 1000, save, then edit, then remove docker image and switch to mesos containerizer. GUI will show error 
There is an error with your configuration
container.type: Must be defined
Switching to json mode and it shows the alpine container still:
```
container": {
"docker": {
"privileged": false,
"forcePullImage": false,
"image": "alpine"
}
},
```

Closes DCOS-14880

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
