### PR TITLE
fix(DCOS-16008): Improve service confirmation modal.

### DIFF
--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -103,8 +103,7 @@ class ServiceDestroyModal extends React.Component {
 
   getIsRightButtonDisabled() {
     return (
-      this.getServiceName(this.props.service.getId()) !==
-      this.getServiceName(this.state.serviceNameConfirmationValue)
+      this.props.service.getName() !== this.state.serviceNameConfirmationValue
     );
   }
 
@@ -197,7 +196,7 @@ class ServiceDestroyModal extends React.Component {
 
   getDestroyServiceModal() {
     const { open, service, intl } = this.props;
-    const serviceName = this.getServiceName(service.getId());
+    const serviceName = service.getName();
 
     let itemText = `${StringUtil.capitalize(UserActions.DELETE)}`;
 
@@ -260,26 +259,6 @@ class ServiceDestroyModal extends React.Component {
       <p className="text-align-center flush-bottom">
         {this.props.subHeaderContent}
       </p>
-    );
-  }
-
-  /**
-   * Format serviceId to only the service name
-   * e.g path/to/service/name will only return name
-   *
-   * @param {String} serviceId
-   * @returns {String} formatted serviceId
-   *
-   * @memberof ServiceDestroyModal
-   */
-  getServiceName(serviceId) {
-    if (typeof serviceId !== "string") {
-      return null;
-    }
-
-    return serviceId.substring(
-      serviceId.lastIndexOf("/") + 1,
-      serviceId.length
     );
   }
 

--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -103,8 +103,8 @@ class ServiceDestroyModal extends React.Component {
 
   getIsRightButtonDisabled() {
     return (
-      this.formatServiceName(this.props.service.getId()) !==
-      this.formatServiceName(this.state.serviceNameConfirmationValue)
+      this.getServiceName(this.props.service.getId()) !==
+      this.getServiceName(this.state.serviceNameConfirmationValue)
     );
   }
 
@@ -197,7 +197,7 @@ class ServiceDestroyModal extends React.Component {
 
   getDestroyServiceModal() {
     const { open, service, intl } = this.props;
-    const serviceName = this.formatServiceName(service.getId());
+    const serviceName = this.getServiceName(service.getId());
 
     let itemText = `${StringUtil.capitalize(UserActions.DELETE)}`;
 
@@ -272,7 +272,7 @@ class ServiceDestroyModal extends React.Component {
    *
    * @memberof ServiceDestroyModal
    */
-  formatServiceName(serviceId) {
+  getServiceName(serviceId) {
     if (typeof serviceId !== "string") {
       return null;
     }

--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -103,7 +103,8 @@ class ServiceDestroyModal extends React.Component {
 
   getIsRightButtonDisabled() {
     return (
-      this.props.service.getId() !== this.state.serviceNameConfirmationValue
+      this.formatServiceName(this.props.service.getId()) !==
+      this.formatServiceName(this.state.serviceNameConfirmationValue)
     );
   }
 
@@ -196,7 +197,7 @@ class ServiceDestroyModal extends React.Component {
 
   getDestroyServiceModal() {
     const { open, service, intl } = this.props;
-    const serviceName = service.getId();
+    const serviceName = this.formatServiceName(service.getId());
 
     let itemText = `${StringUtil.capitalize(UserActions.DELETE)}`;
 
@@ -235,6 +236,7 @@ class ServiceDestroyModal extends React.Component {
           onChange={this.handleChangeInputFieldDestroy}
           type="text"
           value={this.state.serviceNameConfirmationValue}
+          autoFocus
         />
         {this.getErrorMessage()}
       </Confirm>
@@ -258,6 +260,26 @@ class ServiceDestroyModal extends React.Component {
       <p className="text-align-center flush-bottom">
         {this.props.subHeaderContent}
       </p>
+    );
+  }
+
+  /**
+   * Format serviceId to only the service name
+   * e.g path/to/service/name will only return name
+   *
+   * @param {String} serviceId
+   * @returns {String} formatted serviceId
+   *
+   * @memberof ServiceDestroyModal
+   */
+  formatServiceName(serviceId) {
+    if (typeof serviceId !== "string") {
+      return null;
+    }
+
+    return serviceId.substring(
+      serviceId.lastIndexOf("/") + 1,
+      serviceId.length
     );
   }
 

--- a/src/js/translations/en-US.json
+++ b/src/js/translations/en-US.json
@@ -74,7 +74,7 @@
   "SERVICES.DEPLOYMENT_COUNT": "{deploymentsCount} {deploymentsCount, plural, =1 {deployment} other {deployments}}",
   "SERVICES.DEPLOYMENT_MODAL_HEADING": "{deploymentsCount} Active {deploymentsCount, plural, =1 {Deployment} other {Deployments}}",
   "SERVICE_ACTIONS.DELETE_SERVICE": "In order to delete ",
-  "SERVICE_ACTIONS.DELETE_SERVICE_2": " please type service name",
+  "SERVICE_ACTIONS.DELETE_SERVICE_2": " please type service name.",
   "SERVICE_ACTIONS.DELETE_SERVICE_FRAMEWORK": "In order to delete a service, you must use the DC/OS CLI to perform this command. Refer to the documentation ",
-  "SERVICE_ACTIONS.DELETE_SERVICE_FRAMEWORK_2": " for complete instructions or copy and paste this command into your CLI"
+  "SERVICE_ACTIONS.DELETE_SERVICE_FRAMEWORK_2": " for complete instructions or copy and paste this command into your CLI."
 }

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -137,7 +137,7 @@ describe("Service Actions", function() {
           url: /marathon\/v2\/apps\/\/sleep/,
           response: []
         });
-        cy.get(".modal-body .filter-input-text").type("/sleep");
+        cy.get(".modal-body .filter-input-text").type("sleep");
         cy.get(".confirm-modal .button-collection .button-danger").click();
         cy.get(".confirm-modal").should("to.have.length", 0);
       });
@@ -149,7 +149,7 @@ describe("Service Actions", function() {
           url: /marathon\/v2\/apps\/\/sleep/,
           response: { message: "App is locked by one or more deployments." }
         });
-        cy.get(".modal-body .filter-input-text").type("/sleep");
+        cy.get(".modal-body .filter-input-text").type("sleep");
         cy.get(".confirm-modal .button-collection .button-danger").click();
         cy
           .get(".modal-body .text-danger")
@@ -163,7 +163,7 @@ describe("Service Actions", function() {
           url: /marathon\/v2\/apps\/\/sleep/,
           response: { message: "Not Authorized to perform this action!" }
         });
-        cy.get(".modal-body .filter-input-text").type("/sleep");
+        cy.get(".modal-body .filter-input-text").type("sleep");
         cy.get(".confirm-modal .button-collection .button-danger").click();
         cy
           .get(".modal-body .text-danger")
@@ -183,7 +183,7 @@ describe("Service Actions", function() {
         cy
           .get(".confirm-modal .button-collection .button-danger")
           .as("dangerButton");
-        cy.get(".modal-body .filter-input-text").type("/sleep");
+        cy.get(".modal-body .filter-input-text").type("sleep");
         cy.get("@dangerButton").should("not.have.class", "disabled");
       });
 

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -121,7 +121,7 @@ describe("Service Actions", function() {
       it("opens the correct service destroy dialog", function() {
         cy
           .get(".modal-body p strong")
-          .contains("/sleep")
+          .contains("sleep")
           .should("to.have.length", 1);
       });
 


### PR DESCRIPTION
**DCOS-16008** This PR improve the service confirmation modal where now we only display the path/service.
This PR also adds a couple of minor fixes to typos and input autofocus.

How to test:
Create a service container then click delete de service container which will bring the modal to type the service name. before the entire path was required to be typed now only the service name
e.g `path/to/service/name` in case you are in the name service you will only need to type `name`.

If in the `/service/` path you will need to type only `service` but whatever is under service will also be deleted.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
