### PR TITLE
DCOS_OSS-1033: Adjust jobs handling

### DIFF
--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -28,10 +28,10 @@ const METHODS_TO_BIND = [
 
 // TODO remove
 const HIDE_BREADCRUMBS = [
-  "/jobs/:id/tasks/:taskID/details",
-  "/jobs/:id/tasks/:taskID/logs",
-  "/jobs/:id/tasks/:taskID/logs/:filePath",
-  "/jobs/:id/tasks/:taskID/files/view(/:filePath(/:innerPath))",
+  "/jobs/detail/:id/tasks/:taskID/details",
+  "/jobs/detail/:id/tasks/:taskID/logs",
+  "/jobs/detail/:id/tasks/:taskID/logs/:filePath",
+  "/jobs/detail/:id/tasks/:taskID/files/view(/:filePath(/:innerPath))",
 
   "/networking/networks/:overlayName/tasks/:taskID/details",
   "/networking/networks/:overlayName/tasks/:taskID/logs",

--- a/src/js/components/breadcrumbs/JobsBreadcrumbs.js
+++ b/src/js/components/breadcrumbs/JobsBreadcrumbs.js
@@ -73,11 +73,14 @@ function getItemSchedule(item) {
 function getBreadcrumb(item, details = true) {
   const id = item.getId();
   const name = item.getName();
+  const link = item instanceof Job
+    ? `/jobs/detail/${id}`
+    : `/jobs/overview/${id}`;
 
   return (
     <Breadcrumb key={id} title="Jobs">
       <BreadcrumbTextContent>
-        <Link to={`/jobs/${id}`}>
+        <Link to={link}>
           {name === "" ? "Jobs" : name}
         </Link>
       </BreadcrumbTextContent>
@@ -90,7 +93,11 @@ function getBreadcrumb(item, details = true) {
 const JobsBreadcrumbs = ({ tree, item, children, details = true }) => {
   const elements = tree
     .filterItems(function(currentItem) {
-      return item != null && item.getId() === currentItem.getId();
+      return (
+        item != null &&
+        item.getId() === currentItem.getId() &&
+        item.constructor === currentItem.constructor
+      );
     })
     .reduceItems(function(acc, currentItem) {
       return acc.concat(getBreadcrumb(currentItem, details));

--- a/src/js/components/breadcrumbs/JobsBreadcrumbs.js
+++ b/src/js/components/breadcrumbs/JobsBreadcrumbs.js
@@ -90,11 +90,14 @@ function getBreadcrumb(item, details = true) {
   );
 }
 
-const JobsBreadcrumbs = ({ tree, item, children, details = true }) => {
-  const elements = tree
+function getBreadcrumbList(tree, item, details) {
+  if (item == null) {
+    return [];
+  }
+
+  return tree
     .filterItems(function(currentItem) {
       return (
-        item != null &&
         item.getId() === currentItem.getId() &&
         item.constructor === currentItem.constructor
       );
@@ -102,10 +105,12 @@ const JobsBreadcrumbs = ({ tree, item, children, details = true }) => {
     .reduceItems(function(acc, currentItem) {
       return acc.concat(getBreadcrumb(currentItem, details));
     }, []);
+}
 
+const JobsBreadcrumbs = ({ tree, item, children, details = true }) => {
   const breadcrumbs = [].concat(
     getBreadcrumb(tree, details),
-    elements,
+    getBreadcrumbList(tree, item, details),
     React.Children.toArray(children)
   );
 

--- a/src/js/pages/jobs/JobDetailPage.js
+++ b/src/js/pages/jobs/JobDetailPage.js
@@ -8,7 +8,6 @@ import React from "react";
 import { routerShape } from "react-router";
 
 import { StoreMixin } from "mesosphere-shared-reactjs";
-import DCOSStore from "#SRC/js/stores/DCOSStore";
 
 import Icon from "../../components/Icon";
 import JobConfiguration from "./JobConfiguration";
@@ -219,7 +218,7 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
     return (
       <Page>
         <Page.Header
-          breadcrumbs={<JobsBreadcrumbs tree={DCOSStore.jobTree} />}
+          breadcrumbs={<JobsBreadcrumbs tree={MetronomeStore.jobTree} />}
         />
         <RequestErrorMsg />
       </Page>
@@ -230,7 +229,7 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
     return (
       <Page>
         <Page.Header
-          breadcrumbs={<JobsBreadcrumbs tree={DCOSStore.jobTree} />}
+          breadcrumbs={<JobsBreadcrumbs tree={MetronomeStore.jobTree} />}
         />
         <Loader />
       </Page>
@@ -412,7 +411,9 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
       <Page>
         <Page.Header
           actions={this.getActions()}
-          breadcrumbs={<JobsBreadcrumbs tree={DCOSStore.jobTree} item={job} />}
+          breadcrumbs={
+            <JobsBreadcrumbs tree={MetronomeStore.jobTree} item={job} />
+          }
           tabs={this.getTabs()}
         />
         {this.tabs_getTabView(job)}

--- a/src/js/pages/jobs/JobRunHistoryTable.js
+++ b/src/js/pages/jobs/JobRunHistoryTable.js
@@ -248,7 +248,7 @@ class JobRunHistoryTable extends React.Component {
         <div className="expanding-table-primary-cell-heading text-overflow">
           <Link
             className="table-cell-link-secondary text-overflow"
-            to={`/jobs/${id}/tasks/${taskID}`}
+            to={`/jobs/detail/${id}/tasks/${taskID}`}
             title={taskID}
           >
             <CollapsingString endLength={15} string={taskID} />

--- a/src/js/pages/jobs/JobTaskDetailPage.js
+++ b/src/js/pages/jobs/JobTaskDetailPage.js
@@ -19,7 +19,7 @@ class JobTaskDetailPage extends React.Component {
     const { location, params, routes } = this.props;
     const { id, taskID } = params;
 
-    const routePrefix = `/jobs/${encodeURIComponent(id)}/tasks/${encodeURIComponent(taskID)}`;
+    const routePrefix = `/jobs/detail/${encodeURIComponent(id)}/tasks/${encodeURIComponent(taskID)}`;
     const tabs = [
       { label: "Details", routePath: routePrefix + "/details" },
       { label: "Files", routePath: routePrefix + "/files" },
@@ -38,7 +38,7 @@ class JobTaskDetailPage extends React.Component {
         <JobsBreadcrumbs tree={DCOSStore.jobTree} item={job} details={false}>
           <Breadcrumb key="task-name" title={task.getName()}>
             <BreadcrumbTextContent>
-              <Link to={`/jobs/${id}/tasks/${task.getId()}`}>
+              <Link to={`/jobs/detail/${id}/tasks/${task.getId()}`}>
                 {task.getName()}
               </Link>
             </BreadcrumbTextContent>

--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -211,11 +211,6 @@ class JobsTab extends mixin(StoreMixin) {
       return this.getJobTreeView(item, modal);
     }
 
-    // JobDetailPage
-    if (this.props.params.id) {
-      return this.props.children;
-    }
-
     // Render empty panel
     return (
       <Page>
@@ -235,11 +230,11 @@ class JobsTab extends mixin(StoreMixin) {
   }
 
   render() {
-    let { id } = this.props.params;
-    id = decodeURIComponent(id);
-
-    // Find item in root tree and default to root tree if there is no match
-    const item = DCOSStore.jobTree.findItemById(id) || DCOSStore.jobTree;
+    const id = decodeURIComponent(this.props.params.id);
+    const jobTree =
+      DCOSStore.jobTree.findItem(function(item) {
+        return item instanceof JobTree && item.id === id;
+      }) || DCOSStore.jobTree;
 
     const modal = (
       <JobFormModal
@@ -248,7 +243,7 @@ class JobsTab extends mixin(StoreMixin) {
       />
     );
 
-    return this.getContents(item, modal);
+    return this.getContents(jobTree, modal);
   }
 }
 

--- a/src/js/pages/jobs/JobsTable.js
+++ b/src/js/pages/jobs/JobsTable.js
@@ -116,27 +116,26 @@ class JobsTable extends React.Component {
   }
 
   renderHeadline(prop, job) {
-    let { id, isGroup, name, schedules } = job;
-    let itemImage = null;
+    const { id, isGroup, name, schedules } = job;
     let scheduleIcon = null;
-
-    id = encodeURIComponent(id);
+    let url = `/jobs/detail/${encodeURIComponent(id)}`;
+    let itemImage = (
+      <Icon
+        className="icon-margin-right"
+        color="grey"
+        id="page-document"
+        size="mini"
+      />
+    );
 
     if (isGroup) {
+      url = `/jobs/overview/${encodeURIComponent(id)}`;
+
       itemImage = (
         <Icon
           className="icon-margin-right"
           color="grey"
           id="folder"
-          size="mini"
-        />
-      );
-    } else {
-      itemImage = (
-        <Icon
-          className="icon-margin-right"
-          color="grey"
-          id="page-document"
           size="mini"
         />
       );
@@ -162,11 +161,11 @@ class JobsTable extends React.Component {
     return (
       <div className="job-table-heading flex-box
         flex-box-align-vertical-center table-cell-flex-box">
-        <Link to={`/jobs/${id}`} className="table-cell-icon">
+        <Link to={url} className="table-cell-icon">
           {itemImage}
         </Link>
         <Link
-          to={`/jobs/${id}`}
+          to={url}
           className="table-cell-link-primary table-cell-value flex-box flex-box-col"
         >
           <span className="text-overflow">

--- a/src/js/routes/jobs.js
+++ b/src/js/routes/jobs.js
@@ -18,87 +18,100 @@ import TaskFileViewer
 import TaskLogsContainer
   from "../../../plugins/services/src/js/pages/task-details/TaskLogsContainer";
 
-const jobsRoutes = {
-  type: Route,
-  component: JobsPage,
-  path: "jobs",
-  category: "root",
-  isInSidebar: true,
-  children: [
-    {
-      type: IndexRoute,
-      component: JobsTab
-    },
-    {
-      type: Route,
-      component: JobsTab,
-      children: [
-        {
-          type: Route,
-          component: JobDetailPage,
-          path: ":id",
-          children: [
-            {
-              type: Redirect,
-              path: "/jobs/:id/tasks/:taskID",
-              to: "/jobs/:id/tasks/:taskID/details"
-            },
-            {
-              type: Route,
-              path: "tasks/:taskID",
-              component: JobsTaskDetailPage,
-              hideHeaderNavigation: true,
-              children: [
-                {
-                  component: TaskDetailsTab,
-                  isTab: true,
-                  path: "details",
-                  title: "Details",
-                  type: Route
-                },
-                {
-                  hideHeaderNavigation: true,
-                  component: TaskFilesTab,
-                  isTab: true,
-                  path: "files",
-                  title: "Files",
-                  type: Route,
-                  children: [
-                    {
-                      component: TaskFileBrowser,
-                      fileViewerRoutePath: "/jobs/:id/tasks/:taskID/files/view(/:filePath(/:innerPath))",
-                      hideHeaderNavigation: true,
-                      type: IndexRoute
-                    },
-                    {
-                      component: TaskFileViewer,
-                      hideHeaderNavigation: true,
-                      path: "view(/:filePath(/:innerPath))",
-                      type: Route
-                    }
-                  ]
-                },
-                {
-                  component: TaskLogsContainer,
-                  hideHeaderNavigation: true,
-                  isTab: true,
-                  path: "logs",
-                  title: "Logs",
-                  type: Route,
-                  children: [
-                    {
-                      path: ":filePath",
-                      type: Route
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
-};
+const jobsRoutes = [
+  {
+    type: Redirect,
+    from: "/jobs",
+    to: "/jobs/overview"
+  },
+  {
+    type: Route,
+    component: JobsPage,
+    path: "jobs",
+    category: "root",
+    isInSidebar: true,
+    children: [
+      {
+        type: Route,
+        component: JobsTab,
+        path: "overview",
+        children: [
+          {
+            type: Route,
+            path: ":id"
+          }
+        ]
+      },
+      {
+        type: Redirect,
+        from: "/job/detail/:id",
+        to: "/job/detail/:id/tasks"
+      },
+      {
+        type: Route,
+        component: JobDetailPage,
+        path: "detail/:id",
+        children: [
+          {
+            type: Redirect,
+            path: "/jobs/detail/:id/tasks/:taskID",
+            to: "/jobs/detail/:id/tasks/:taskID/details"
+          },
+          {
+            type: Route,
+            path: "tasks/:taskID",
+            component: JobsTaskDetailPage,
+            hideHeaderNavigation: true,
+            children: [
+              {
+                component: TaskDetailsTab,
+                isTab: true,
+                path: "details",
+                title: "Details",
+                type: Route
+              },
+              {
+                hideHeaderNavigation: true,
+                component: TaskFilesTab,
+                isTab: true,
+                path: "files",
+                title: "Files",
+                type: Route,
+                children: [
+                  {
+                    component: TaskFileBrowser,
+                    fileViewerRoutePath: "/jobs/detail/:id/tasks/:taskID/files/view(/:filePath(/:innerPath))",
+                    hideHeaderNavigation: true,
+                    type: IndexRoute
+                  },
+                  {
+                    component: TaskFileViewer,
+                    hideHeaderNavigation: true,
+                    path: "view(/:filePath(/:innerPath))",
+                    type: Route
+                  }
+                ]
+              },
+              {
+                component: TaskLogsContainer,
+                hideHeaderNavigation: true,
+                isTab: true,
+                path: "logs",
+                title: "Logs",
+                type: Route,
+                children: [
+                  {
+                    path: ":filePath",
+                    type: Route
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+];
 
 module.exports = jobsRoutes;

--- a/src/js/utils/__tests__/MetronomeUtil-test.js
+++ b/src/js/utils/__tests__/MetronomeUtil-test.js
@@ -3,7 +3,7 @@ const MetronomeUtil = require("../MetronomeUtil");
 describe("MetronomeUtil", function() {
   describe("#parseJobs", function() {
     beforeEach(function() {
-      this.instance = MetronomeUtil.parseJobs([
+      this.jobs = MetronomeUtil.parseJobs([
         { id: "group" },
         { id: "group.foo" },
         { id: "group.bar" },
@@ -27,17 +27,17 @@ describe("MetronomeUtil", function() {
     });
 
     it("adds a job to the tree", function() {
-      var instance = MetronomeUtil.parseJobs({ id: "alpha" });
+      var jobs = MetronomeUtil.parseJobs({ id: "alpha" });
 
-      expect(instance.items[0].id).toEqual("alpha");
+      expect(jobs.items[0].id).toEqual("alpha");
     });
 
     it("adds nested items at the correct location based on id/path matching", function() {
-      var instance = MetronomeUtil.parseJobs({ id: "group.foo.bar" });
+      var jobs = MetronomeUtil.parseJobs({ id: "group.foo.bar" });
 
-      expect(instance.items[0].id).toEqual("group");
-      expect(instance.items[0].items[0].id).toEqual("group.foo");
-      expect(instance.items[0].items[0].items[0].id).toEqual("group.foo.bar");
+      expect(jobs.items[0].id).toEqual("group");
+      expect(jobs.items[0].items[0].id).toEqual("group.foo");
+      expect(jobs.items[0].items[0].items[0].id).toEqual("group.foo.bar");
     });
 
     it("should throw error if item is not an object with id", function() {
@@ -53,48 +53,48 @@ describe("MetronomeUtil", function() {
     });
 
     it("should return root group if empty array is passed", function() {
-      var instance = MetronomeUtil.parseJobs([]);
-      expect(instance.id).toEqual("");
-      expect(instance.items).toEqual(undefined);
+      var jobs = MetronomeUtil.parseJobs([]);
+      expect(jobs.id).toEqual("");
+      expect(jobs.items).toEqual(undefined);
     });
 
     it("nests everything under root", function() {
-      expect(this.instance.id).toEqual("");
+      expect(this.jobs.id).toEqual("");
     });
 
     it("consolidates jobs into common parent", function() {
-      expect(this.instance.items.length).toEqual(1);
-      expect(this.instance.items[0].id).toEqual("group");
+      expect(this.jobs.items.length).toEqual(1);
+      expect(this.jobs.items[0].id).toEqual("group");
     });
 
     it("defaults id to empty string (root group id)", function() {
-      const tree = MetronomeUtil.parseJobs([]);
-      expect(tree.id).toEqual("");
+      const jobs = MetronomeUtil.parseJobs([]);
+      expect(jobs.id).toEqual("");
     });
 
     it("sets correct tree id", function() {
-      expect(this.instance.items[0].id).toEqual("group");
+      expect(this.jobs.items[0].id).toEqual("group");
     });
 
     it("accepts nested trees (groups)", function() {
-      expect(this.instance.items[0].items[4].items.length).toEqual(1);
+      expect(this.jobs.items[0].items[4].items.length).toEqual(1);
     });
 
     it("doesn't add items to jobs with no nested items", function() {
-      expect(this.instance.items[0].items[2].items).toEqual(undefined);
+      expect(this.jobs.items[0].items[2].items).toEqual(undefined);
     });
 
     it("converts a single item into a subitem of root", function() {
-      const instance = MetronomeUtil.parseJobs({ id: "group.job" });
+      const jobs = MetronomeUtil.parseJobs({ id: "group.job" });
 
-      expect(instance.id).toEqual("");
-      expect(instance.items[0].id).toEqual("group");
-      expect(instance.items[0].items[0].id).toEqual("group.job");
+      expect(jobs.id).toEqual("");
+      expect(jobs.items[0].id).toEqual("group");
+      expect(jobs.items[0].items[0].id).toEqual("group.job");
     });
 
     it("merges data of items that are defined multiple times", function() {
-      const result = this.instance.items[0].items[3];
-      expect(result).toEqual({
+      const jobs = this.jobs.items[0].items[3];
+      expect(jobs).toEqual({
         id: "group.beta",
         cmd: ">beta",
         label: "Beta",

--- a/src/js/utils/__tests__/MetronomeUtil-test.js
+++ b/src/js/utils/__tests__/MetronomeUtil-test.js
@@ -1,7 +1,19 @@
 const MetronomeUtil = require("../MetronomeUtil");
 
 describe("MetronomeUtil", function() {
-  describe("#addJob", function() {
+  describe("#parseJobs", function() {
+    beforeEach(function() {
+      this.instance = MetronomeUtil.parseJobs([
+        { id: "group" },
+        { id: "group.foo" },
+        { id: "group.bar" },
+        { id: "group.alpha" },
+        { id: "group.beta", cmd: ">beta", description: "First beta" },
+        { id: "group.beta", label: "Beta", description: "Second beta" },
+        { id: "group.wibble.wobble" }
+      ]);
+    });
+
     it("should throw error if the provided id  starts with a dot", function() {
       expect(function() {
         MetronomeUtil.parseJobs({ id: ".malformed.id" });
@@ -44,20 +56,6 @@ describe("MetronomeUtil", function() {
       var instance = MetronomeUtil.parseJobs([]);
       expect(instance.id).toEqual("");
       expect(instance.items).toEqual(undefined);
-    });
-  });
-
-  describe("#parseJobs", function() {
-    beforeEach(function() {
-      this.instance = MetronomeUtil.parseJobs([
-        { id: "group" },
-        { id: "group.foo" },
-        { id: "group.bar" },
-        { id: "group.alpha" },
-        { id: "group.beta", cmd: ">beta", description: "First beta" },
-        { id: "group.beta", label: "Beta", description: "Second beta" },
-        { id: "group.wibble.wobble" }
-      ]);
     });
 
     it("nests everything under root", function() {

--- a/system-tests/jobs/test-jobs.js
+++ b/system-tests/jobs/test-jobs.js
@@ -13,7 +13,7 @@ describe("Jobs", function() {
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
 
     // Visit jobs
-    cy.visitUrl("jobs");
+    cy.visitUrl("jobs/overview");
 
     // Click 'Create a job'
     // Note: The current group contains no jobs
@@ -55,7 +55,7 @@ describe("Jobs", function() {
     cy.contains("Create Job").click();
 
     // Switch to the group that will contain the service
-    cy.visitUrl(`jobs/${Cypress.env("TEST_UUID")}`);
+    cy.visitUrl(`jobs/overview/${Cypress.env("TEST_UUID")}`);
 
     // Wait for the table and the service to appear
     cy
@@ -90,7 +90,7 @@ describe("Jobs", function() {
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
 
     // Visit jobs
-    cy.visitUrl("jobs");
+    cy.visitUrl("jobs/overview");
 
     // Click 'Create a job'
     // Note: The current group contains the previous job
@@ -145,7 +145,7 @@ describe("Jobs", function() {
     cy.contains("Create Job").click();
 
     // Switch to the group that will contain the service
-    cy.visitUrl(`jobs/${Cypress.env("TEST_UUID")}`);
+    cy.visitUrl(`jobs/overview/${Cypress.env("TEST_UUID")}`);
 
     // Wait for the table and the service to appear
     cy
@@ -195,7 +195,7 @@ describe("Jobs", function() {
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
 
     // Visit jobs
-    cy.visitUrl("jobs");
+    cy.visitUrl("jobs/overview");
 
     // Click 'Create a job'
     // Note: The current group contains the previous jobs
@@ -276,7 +276,7 @@ describe("Jobs", function() {
     cy.contains("Create Job").click();
 
     // Switch to the group that will contain the service
-    cy.visitUrl(`jobs/${Cypress.env("TEST_UUID")}`);
+    cy.visitUrl(`jobs/overview/${Cypress.env("TEST_UUID")}`);
 
     // Wait for the table and the service to appear
     cy
@@ -364,7 +364,7 @@ describe("Jobs", function() {
     const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
 
     // Visit jobs
-    cy.visitUrl("jobs");
+    cy.visitUrl("jobs/overview");
 
     // Click 'Create a job'
     // Note: The current group contains the previous jobs
@@ -429,7 +429,7 @@ describe("Jobs", function() {
     cy.contains("Create Job").click();
 
     // Switch to the group that will contain the service
-    cy.visitUrl(`jobs/${Cypress.env("TEST_UUID")}`);
+    cy.visitUrl(`jobs/overview/${Cypress.env("TEST_UUID")}`);
 
     // Wait for the table and the service to appear
     cy

--- a/tests/pages/jobs/JobActions-cy.js
+++ b/tests/pages/jobs/JobActions-cy.js
@@ -6,7 +6,7 @@ describe("Job Actions", function() {
         mesos: "1-for-each-health",
         nodeHealth: true
       });
-      cy.visitUrl({ url: "/jobs/foo" });
+      cy.visitUrl({ url: "/jobs/detail/foo" });
 
       cy.get(".page-header-actions .dropdown").click();
       cy.get(".dropdown-menu-items").contains("Edit").click();

--- a/tests/pages/jobs/JobDetails-cy.js
+++ b/tests/pages/jobs/JobDetails-cy.js
@@ -5,7 +5,7 @@ describe("Job Details", function() {
       mesos: "1-for-each-health",
       nodeHealth: true
     });
-    cy.visitUrl({ url: "/jobs/foo" });
+    cy.visitUrl({ url: "/jobs/detail/foo" });
   });
 
   context("Job Details Header", function() {

--- a/tests/pages/jobs/JobsFilter-cy.js
+++ b/tests/pages/jobs/JobsFilter-cy.js
@@ -5,7 +5,7 @@ describe("Job Search Filters", function() {
         mesos: "1-for-each-health",
         nodeHealth: true
       });
-      cy.visitUrl({ url: "/jobs" });
+      cy.visitUrl({ url: "/jobs/overview" });
     });
 
     it("filters correctly on search string", function() {

--- a/tests/pages/jobs/JobsOverview-cy.js
+++ b/tests/pages/jobs/JobsOverview-cy.js
@@ -5,7 +5,7 @@ describe("Jobs Overview", function() {
         mesos: "1-for-each-health",
         nodeHealth: true
       });
-      cy.visitUrl({ url: "/jobs" });
+      cy.visitUrl({ url: "/jobs/overview" });
     });
 
     it("displays jobs overview page", function() {


### PR DESCRIPTION
---
ℹ️   _This branch depends on features that will be introduced with ~#2267~ and ~#2268~, thus it will fail until the respective branches get merged._

↩️   _I will back-port the fix to `release/1.9` once the changes are approved._

---

Change the jobs parsing to properly parse jobs into namespaces and adjust the routing and view logic to handle namespaces and jobs properly, so that the routes don't collide. This allows jobs and
namespaces to have the same id without being collapsed into one object. An array of jobs like the following would be parsed into a job named "foo" and a namespace "foo" which will include the "foo.bar" job.

```
[
  { id: "foo" },
  { id: "foo.bar" }
]
```

```
[
   { id: "foo" },
   { id: "foo",
      items: [
        { id: "foo.bar" }
      ]
   }
]
```

These changes addresses issues with jobs that were accidentally merged with namespaces.

BREAKING CHANGE: The `MetronomeUtil.parseJobs` output as well as the job routing has changed to address issues with the job/namespace representation.

Implementations relying on `MetronomeUtil.parseJobs` need to be adjusted
to handle namespace and jobs with the same id.

To migrate links and bookmarks to job details and namespaces please
adjust the URLs as illustrated below:

Before
* Job Detail: `/jobs/${jobId}`
* Overview: `/jobs`
* Namespace: `/jobs/${namespaceId}`

After
* Job Detail:: `/jobs/detail/${jobId}`
* Overview: `/jobs/overview`
* Namespace: `/jobs/overview/${namespaceId}`

Closes DCOS_OSS-1033