### PR TITLE
↩️ [1.9] DCOS-16191: Skip non-string values in env var parsers

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/EnvironmentVariables.js
+++ b/plugins/services/src/js/reducers/serviceForm/EnvironmentVariables.js
@@ -67,21 +67,27 @@ module.exports = {
       return [];
     }
 
-    return Object.keys(state.env).reduce(function(memo, key, index) {
-      /**
-       * For the environment variables which are a key => value based object
-       * we want to create a new item and fill it with the key and the
-       * value. So we need 3 transactions for each key value pair.
-       * 1) Add a new Item to the path with the index equal to index.
-       * 2) Set the key on the path `env.${index}.key`
-       * 3) Set the value on the path `env.${index}.value`
-       */
-      memo.push(new Transaction(["env"], index, ADD_ITEM));
-      memo.push(new Transaction(["env", index, "key"], key, SET));
-      memo.push(new Transaction(["env", index, "value"], state.env[key], SET));
+    return Object.keys(state.env)
+      .filter(function(key) {
+        return typeof state.env[key] === "string";
+      })
+      .reduce(function(memo, key, index) {
+        /**
+         * For the environment variables which are a key => value based object
+         * we want to create a new item and fill it with the key and the
+         * value. So we need 3 transactions for each key value pair.
+         * 1) Add a new Item to the path with the index equal to index.
+         * 2) Set the key on the path `env.${index}.key`
+         * 3) Set the value on the path `env.${index}.value`
+         */
+        memo.push(new Transaction(["env"], index, ADD_ITEM));
+        memo.push(new Transaction(["env", index, "key"], key, SET));
+        memo.push(
+          new Transaction(["env", index, "value"], state.env[key], SET)
+        );
 
-      return memo;
-    }, []);
+        return memo;
+      }, []);
   },
 
   FormReducer(state = [], { type, path, value }) {

--- a/plugins/services/src/js/reducers/serviceForm/MultiContainerEnvironmentVariables.js
+++ b/plugins/services/src/js/reducers/serviceForm/MultiContainerEnvironmentVariables.js
@@ -10,22 +10,26 @@ module.exports = {
       return [];
     }
 
-    return Object.keys(state.environment).reduce(function(memo, key, index) {
-      /**
-       * For the environment variables which are a key => value based object
-       * we want to create a new item and fill it with the key and the
-       * value. So we need 3 transactions for each key value pair.
-       * 1) Add a new Item to the path with the index equal to index.
-       * 2) Set the key on the path `env.${index}.key`
-       * 3) Set the value on the path `env.${index}.value`
-       */
-      memo.push(new Transaction(["env"], index, ADD_ITEM));
-      memo.push(new Transaction(["env", index, "key"], key, SET));
-      memo.push(
-        new Transaction(["env", index, "value"], state.environment[key], SET)
-      );
+    return Object.keys(state.environment)
+      .filter(function(key) {
+        return typeof state.environment[key] === "string";
+      })
+      .reduce(function(memo, key, index) {
+        /**
+         * For the environment variables which are a key => value based object
+         * we want to create a new item and fill it with the key and the
+         * value. So we need 3 transactions for each key value pair.
+         * 1) Add a new Item to the path with the index equal to index.
+         * 2) Set the key on the path `env.${index}.key`
+         * 3) Set the value on the path `env.${index}.value`
+         */
+        memo.push(new Transaction(["env"], index, ADD_ITEM));
+        memo.push(new Transaction(["env", index, "key"], key, SET));
+        memo.push(
+          new Transaction(["env", index, "value"], state.environment[key], SET)
+        );
 
-      return memo;
-    }, []);
+        return memo;
+      }, []);
   }
 };

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/EnvironmentVariables-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/EnvironmentVariables-test.js
@@ -110,14 +110,8 @@ describe("Environment Variables", function() {
       ]);
     });
 
-    it("should keep complex values", function() {
-      expect(
-        EnvironmentVariables.JSONParser({ env: { foo: { secret: "value" } } })
-      ).toEqual([
-        { type: ADD_ITEM, value: 0, path: ["env"] },
-        { type: SET, value: "foo", path: ["env", 0, "key"] },
-        { type: SET, value: { secret: "value" }, path: ["env", 0, "value"] }
-      ]);
+    it("should skip complex values", function() {
+      expect(EnvironmentVariables.JSONParser({ env: { foo: {} } })).toEqual([]);
     });
   });
 });

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerEnvironmentVariables-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerEnvironmentVariables-test.js
@@ -22,16 +22,12 @@ describe("Environment Variables", function() {
       ]);
     });
 
-    it("should keep complex values", function() {
+    it("should skip complex values", function() {
       expect(
         MultiContainerEnvironmentVariables.JSONParser({
-          environment: { BAR: { secret: "value" } }
+          environment: { BAR: {} }
         })
-      ).toEqual([
-        { type: ADD_ITEM, value: 0, path: ["env"] },
-        { type: SET, value: "BAR", path: ["env", 0, "key"] },
-        { type: SET, value: { secret: "value" }, path: ["env", 0, "value"] }
-      ]);
+      ).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
---
ℹ️  This is a back port of #2253 

---

This PR makes DC/OS parsers to parse string values for environment variables and let the plugins parse/reduce the rest.

To test:
Create a secret and give it a hard time with a lot of Env vars and secrets. Switching between JSON editor and form. Add a var in the form edit in the JSON, delete in the form, add in the JSON. You know the grind.