### PR TITLE
fix(DCOS-15288): override uppercase key for mesos agent attributes

### DIFF
--- a/src/js/components/ConfigurationMapLabel.js
+++ b/src/js/components/ConfigurationMapLabel.js
@@ -1,12 +1,10 @@
+import classNames from "classnames";
 import React from "react";
 
 const ConfigurationMapLabel = props => {
-  let labelClasses;
-  if (props.isAttribute) {
-    labelClasses = "configuration-map-label configuration-map-attribute-label";
-  } else {
-    labelClasses = "configuration-map-label";
-  }
+  const labelClasses = classNames("configuration-map-label", {
+    "configuration-map-attribute-label": props.isAttribute
+  });
 
   return (
     <div className={labelClasses}>

--- a/src/js/components/ConfigurationMapLabel.js
+++ b/src/js/components/ConfigurationMapLabel.js
@@ -1,11 +1,22 @@
 import React from "react";
 
 const ConfigurationMapLabel = props => {
+  let labelClasses;
+  if (props.isAttribute) {
+    labelClasses = "configuration-map-label configuration-map-attribute-label";
+  } else {
+    labelClasses = "configuration-map-label";
+  }
+
   return (
-    <div className="configuration-map-label">
+    <div className={labelClasses}>
       {props.children}
     </div>
   );
+};
+
+ConfigurationMapLabel.propTypes = {
+  isAttribute: React.PropTypes.bool
 };
 
 module.exports = ConfigurationMapLabel;

--- a/src/js/components/ConfigurationMapLabel.js
+++ b/src/js/components/ConfigurationMapLabel.js
@@ -3,7 +3,7 @@ import React from "react";
 
 const ConfigurationMapLabel = props => {
   const labelClasses = classNames("configuration-map-label", {
-    "configuration-map-attribute-label": props.isAttribute
+    "configuration-map-label-no-text-transform": props.keepTextCase
   });
 
   return (
@@ -14,7 +14,7 @@ const ConfigurationMapLabel = props => {
 };
 
 ConfigurationMapLabel.propTypes = {
-  isAttribute: React.PropTypes.bool
+  keepTextCase: React.PropTypes.bool
 };
 
 module.exports = ConfigurationMapLabel;

--- a/src/js/components/HashMapDisplay.js
+++ b/src/js/components/HashMapDisplay.js
@@ -72,7 +72,7 @@ class HashMapDisplay extends React.Component {
 
       return (
         <ConfigurationMapRow key={index}>
-          <ConfigurationMapLabel isAttribute={isAttribute}>
+          <ConfigurationMapLabel keepTextCase={isAttribute}>
             {key}
           </ConfigurationMapLabel>
           <ConfigurationMapValue>{value}</ConfigurationMapValue>

--- a/src/js/components/HashMapDisplay.js
+++ b/src/js/components/HashMapDisplay.js
@@ -68,9 +68,13 @@ class HashMapDisplay extends React.Component {
         key = renderKeys[key];
       }
 
+      const isAttribute = this.props.headline === "Attributes";
+
       return (
         <ConfigurationMapRow key={index}>
-          <ConfigurationMapLabel>{key}</ConfigurationMapLabel>
+          <ConfigurationMapLabel isAttribute={isAttribute}>
+            {key}
+          </ConfigurationMapLabel>
           <ConfigurationMapValue>{value}</ConfigurationMapValue>
         </ConfigurationMapRow>
       );

--- a/src/styles/components/configuration-map/styles.less
+++ b/src/styles/components/configuration-map/styles.less
@@ -87,7 +87,7 @@
       text-transform: uppercase;
     }
 
-    &-attribute-label {
+    &-label-no-text-transform {
       text-transform: none;
     }
 

--- a/src/styles/components/configuration-map/styles.less
+++ b/src/styles/components/configuration-map/styles.less
@@ -87,6 +87,10 @@
       text-transform: uppercase;
     }
 
+    &-attribute-label {
+      text-transform: none;
+    }
+
     &-value {
       flex: 1 1 auto;
 


### PR DESCRIPTION
**DCOS-15288**: fixes capitalized mesos agent attributes. It does this by introducing a new class `"configuration-map-attribute-label"` that resets the CSS text-transform.

**before**:

![screen shot 2017-06-14 at 1 40 23 pm](https://user-images.githubusercontent.com/1527504/27153644-1dc8c9aa-5107-11e7-91e5-3f816228e6bf.png)

**after**:

![screen shot 2017-06-14 at 1 39 21 pm](https://user-images.githubusercontent.com/1527504/27153642-166d866e-5107-11e7-839b-bf18e4fbb055.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?