### PR TITLE
fix(DCOS-16286): Fix task detail view marathon task status

### DIFF
--- a/plugins/services/src/js/components/MarathonTaskDetailsList.js
+++ b/plugins/services/src/js/components/MarathonTaskDetailsList.js
@@ -20,11 +20,11 @@ class MarathonTaskDetailsList extends React.Component {
   }
 
   getTaskStatus(task) {
-    if (task == null || task.status == null) {
+    if (task == null || task.state == null) {
       return "Unknown";
     }
 
-    return task.status;
+    return task.state;
   }
 
   getTimeField(time) {

--- a/plugins/services/src/js/components/MarathonTaskDetailsList.js
+++ b/plugins/services/src/js/components/MarathonTaskDetailsList.js
@@ -8,6 +8,7 @@ import ConfigurationMapRow from "#SRC/js/components/ConfigurationMapRow";
 import ConfigurationMapSection
   from "#SRC/js/components/ConfigurationMapSection";
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
+import TaskStates from "../constants/TaskStates";
 
 class MarathonTaskDetailsList extends React.Component {
   getTaskPorts(task) {
@@ -24,7 +25,7 @@ class MarathonTaskDetailsList extends React.Component {
       return "Unknown";
     }
 
-    return task.state;
+    return TaskStates[task.state].displayName;
   }
 
   getTimeField(time) {


### PR DESCRIPTION
This fixes [DCOS-16286](https://jira.mesosphere.com/browse/DCOS-16286) by changing the field name from `status` to `state`, and using the `TaskStates` map to render the proper display name.

**After**:
![screen shot 2017-06-16 at 2 31 22 pm](https://user-images.githubusercontent.com/1527504/27245467-8123e080-52a0-11e7-8b83-510a8f9242c6.png)



**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
