### PR TITLE
Adjust the creates job with schedule system test

### DIFF
--- a/system-tests/jobs/test-jobs.js
+++ b/system-tests/jobs/test-jobs.js
@@ -398,6 +398,9 @@ describe("Jobs", function() {
     // Specify a schedule
     cy.root().getFormGroupInputFor("Cron Schedule *").type("* * * * *");
 
+    // Enable schedule
+    cy.contains("Enable").click();
+
     // Check JSON mode
     cy.contains("JSON mode").click();
 


### PR DESCRIPTION
This PR adds the missing "enable schedule" step. Use the following command to run the test:

```bash 
docker run -it -v $(pwd):/dcos-ui -e CLUSTER_URL=${CLUSTER_URL} mesosphere/dcos-ui dcos-system-test-driver -j=1 ./system-tests/driver-config/dev.sh
```