### PR TITLE
DCOS-13054: click container in pod takes you to container config

### DIFF
--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -183,10 +183,9 @@ class GeneralServiceFormSection extends Component {
           key={index}
           onRemove={this.props.onRemoveItem.bind(this, {
             value: index,
-            path: "containers",
-            noPropagate: true
+            path: "containers"
           })}
-          onClick={this.props.onClickContainer.bind(this, `container${index}`)}
+          onClick={this.props.onClickItem.bind(this, `container${index}`)}
         >
           {item.name || `container-${index + 1}`}
         </FormGroupContainer>
@@ -671,7 +670,7 @@ GeneralServiceFormSection.propTypes = {
   errors: React.PropTypes.object,
   onAddItem: React.PropTypes.func,
   onRemoveItem: React.PropTypes.func,
-  onClickContainer: React.PropTypes.func
+  onClickItem: React.PropTypes.func
 };
 
 GeneralServiceFormSection.configReducers = General;

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -185,6 +185,7 @@ class GeneralServiceFormSection extends Component {
             value: index,
             path: "containers"
           })}
+          onClick={this.props.onClickContainer.bind(this, `container${index}`)}
         >
           {item.name || `container-${index + 1}`}
         </FormGroupContainer>
@@ -668,7 +669,8 @@ GeneralServiceFormSection.propTypes = {
   data: React.PropTypes.object,
   errors: React.PropTypes.object,
   onAddItem: React.PropTypes.func,
-  onRemoveItem: React.PropTypes.func
+  onRemoveItem: React.PropTypes.func,
+  onClickContainer: React.PropTypes.func
 };
 
 GeneralServiceFormSection.configReducers = General;

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -183,7 +183,8 @@ class GeneralServiceFormSection extends Component {
           key={index}
           onRemove={this.props.onRemoveItem.bind(this, {
             value: index,
-            path: "containers"
+            path: "containers",
+            noPropagate: true
           })}
           onClick={this.props.onClickContainer.bind(this, `container${index}`)}
         >

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -280,9 +280,13 @@ class NewCreateServiceModalForm extends Component {
     this.setState({ batch, appConfig: this.getAppConfig(batch) });
   }
 
-  handleRemoveItem(event) {
-    const { value, path } = event;
+  handleRemoveItem(event, e) {
+    const { value, path, noPropagate } = event;
     let { batch } = this.state;
+
+    if (noPropagate) {
+      e.stopPropagation();
+    }
 
     batch = batch.add(
       new Transaction(path.split("."), value, TransactionTypes.REMOVE_ITEM)

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -53,7 +53,8 @@ const METHODS_TO_BIND = [
   "handleFormChange",
   "handleJSONChange",
   "handleJSONPropertyChange",
-  "handleRemoveItem"
+  "handleRemoveItem",
+  "handleClickContainer"
 ];
 
 /**
@@ -288,6 +289,10 @@ class NewCreateServiceModalForm extends Component {
     );
 
     this.setState({ batch, appConfig: this.getAppConfig(batch) });
+  }
+
+  handleClickContainer(item) {
+    this.props.handleTabChange(item);
   }
 
   getAppConfig(batch = this.state.batch, baseConfig = this.state.baseConfig) {
@@ -680,6 +685,7 @@ class NewCreateServiceModalForm extends Component {
                         onConvertToPod={onConvertToPod}
                         service={service}
                         onRemoveItem={this.handleRemoveItem}
+                        onClickContainer={this.handleClickContainer}
                         onAddItem={this.handleAddItem}
                       />
                     </TabView>

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -54,7 +54,7 @@ const METHODS_TO_BIND = [
   "handleJSONChange",
   "handleJSONPropertyChange",
   "handleRemoveItem",
-  "handleClickContainer"
+  "handleClickItem"
 ];
 
 /**
@@ -280,13 +280,9 @@ class NewCreateServiceModalForm extends Component {
     this.setState({ batch, appConfig: this.getAppConfig(batch) });
   }
 
-  handleRemoveItem(event, e) {
-    const { value, path, noPropagate } = event;
+  handleRemoveItem(event) {
+    const { value, path } = event;
     let { batch } = this.state;
-
-    if (noPropagate) {
-      e.stopPropagation();
-    }
 
     batch = batch.add(
       new Transaction(path.split("."), value, TransactionTypes.REMOVE_ITEM)
@@ -295,7 +291,7 @@ class NewCreateServiceModalForm extends Component {
     this.setState({ batch, appConfig: this.getAppConfig(batch) });
   }
 
-  handleClickContainer(item) {
+  handleClickItem(item) {
     this.props.handleTabChange(item);
   }
 
@@ -688,8 +684,11 @@ class NewCreateServiceModalForm extends Component {
                         isEdit={isEdit}
                         onConvertToPod={onConvertToPod}
                         service={service}
-                        onRemoveItem={this.handleRemoveItem}
-                        onClickContainer={this.handleClickContainer}
+                        onRemoveItem={(options, event) => {
+                          event.stopPropagation();
+                          this.handleRemoveItem(options);
+                        }}
+                        onClickItem={this.handleClickItem}
                         onAddItem={this.handleAddItem}
                       />
                     </TabView>

--- a/src/js/components/form/FormGroupContainer.js
+++ b/src/js/components/form/FormGroupContainer.js
@@ -24,7 +24,7 @@ const FormGroupContainer = props => {
   }
 
   return (
-    <div className="panel pod-short">
+    <div className="panel pod-short" onClick={props.onClick}>
       <div className="pod-narrow pod-short">
         {removeButton}
         {props.children}
@@ -39,7 +39,8 @@ FormGroupContainer.defaultProps = {
 
 FormGroupContainer.propTypes = {
   children: React.PropTypes.node,
-  onRemove: React.PropTypes.func
+  onRemove: React.PropTypes.func,
+  onClick: React.PropTypes.func
 };
 
 module.exports = FormGroupContainer;

--- a/src/js/components/form/FormGroupContainer.js
+++ b/src/js/components/form/FormGroupContainer.js
@@ -24,7 +24,10 @@ const FormGroupContainer = props => {
   }
 
   return (
-    <div className="panel pod-short" onClick={props.onClick}>
+    <div
+      className="panel panel-interactive pod-short clickable"
+      onClick={props.onClick}
+    >
       <div className="pod-narrow pod-short">
         {removeButton}
         {props.children}

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1594,7 +1594,7 @@ describe("Service Form Modal", function() {
         cy.get(".pod-narrow.pod-short").should("to.have.length", 0);
       });
 
-      it.only("Should open container config when clicked", function() {
+      it("Should open container config when clicked", function() {
         cy.get(".pod-narrow.pod-short").eq(0).click();
         cy.get(".menu-tabbed-view").contains("Container Name");
       });

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1583,6 +1583,22 @@ describe("Service Form Modal", function() {
         cy.get(".pod-narrow.pod-short").should("to.have.length", 2);
       });
 
+      it("Should remove a container", function() {
+        cy.get(".pod-narrow.pod-short").should("to.have.length", 1);
+        cy
+          .get(
+            ".menu-tabbed-view .form-group-container-action-button-group .button.button-primary-link"
+          )
+          .eq(0)
+          .click();
+        cy.get(".pod-narrow.pod-short").should("to.have.length", 0);
+      });
+
+      it.only("Should open container config when clicked", function() {
+        cy.get(".pod-narrow.pod-short").eq(0).click();
+        cy.get(".menu-tabbed-view").contains("Container Name");
+      });
+
       it("Should contain two containers navigation under Services tab", function() {
         cy
           .get(".menu-tabbed-item-label")


### PR DESCRIPTION
Clicking a container in a pod now takes you to that container's config page. This was brought up in user testing [here](https://jira.mesosphere.com/browse/DCOS-13054). 

After:
https://cl.ly/2O1W453N072V

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [x] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
