### PR TITLE
DCOS-14868: fix(ServicesVersions) Clean VersionsJSON

### DIFF
--- a/plugins/services/src/js/components/modals/NewCreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModal.js
@@ -819,7 +819,9 @@ class NewCreateServiceModal extends Component {
     }
 
     if (isEdit && isSpecificVersion) {
-      serviceSpec = service.getVersions().get(params.version);
+      serviceSpec = service
+        .constructor(service.getVersions().get(params.version))
+        .getSpec();
     }
 
     const newState = {


### PR DESCRIPTION
If selecting a version now only a cleaned JSON is given to the
serviceForm.

Closes DCOS-14868

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

