### PR TITLE
Remove unused method from job tree struct

### DIFF
--- a/src/js/structs/JobTree.js
+++ b/src/js/structs/JobTree.js
@@ -48,16 +48,6 @@ module.exports = class JobTree extends Tree {
     return this.id;
   }
 
-  /**
-   * @param {string} id
-   * @return {Job|JobTree} matching item
-   */
-  findItemById(id) {
-    return this.findItem(function(item) {
-      return item.getId() === id;
-    });
-  }
-
   getName() {
     return this.getId().split(".").pop();
   }

--- a/src/js/structs/__tests__/JobTree-test.js
+++ b/src/js/structs/__tests__/JobTree-test.js
@@ -36,20 +36,4 @@ describe("JobTree", function() {
       expect(this.instance.getItems()[2] instanceof Job).toEqual(true);
     });
   });
-  describe("#findItemById", function() {
-    beforeEach(function() {
-      this.instance = new JobTree({
-        id: "",
-        items: [{ id: "foo", items: [] }, { id: "alpha" }]
-      });
-    });
-
-    it("should find matching item", function() {
-      expect(this.instance.findItemById("alpha").getId()).toEqual("alpha");
-    });
-
-    it("should find matching subtree", function() {
-      expect(this.instance.findItemById("foo").getId()).toEqual("foo");
-    });
-  });
 });


### PR DESCRIPTION
---
ℹ️   _This branch includes changes that will be introduced with #2251. For a list of changes please see: https://github.com/dcos/dcos-ui/compare/orlandohohmeier/fix/DCOS_OSS-1033-adjust-jobs-handling...orlandohohmeier/chore/remove-unused-method-from-job-tree-struct_ 

---

Remove `findItemById` from JobTree struct as the method is no longer in use.