### PR TITLE
fix(DCOS_OSS-1300): Flex wrap so it's visible on small screen

### DIFF
--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -295,7 +295,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
         />
         <div className="container">
           <div className="media-object-spacing-wrapper media-object-spacing-wide media-object-offset">
-            <div className="media-object media-object-align-top">
+            <div className="media-object media-object-align-top media-object-wrap">
               <div className="media-object-item">
                 <div className="icon icon-huge icon-image-container icon-app-container icon-app-container--borderless icon-default-white">
                   <Image


### PR DESCRIPTION
As mentioned in [DCOS_OSS-1300](https://jira.mesosphere.com/browse/DCOS_OSS-1300), make the install button visible on a small screen. 

This just uses the `media-object-wrap` class. The margin/padding isn't great on the second row. But this is within the flex item, and not sure if we should override this?

**After**:
https://cl.ly/1T2X3N1w0A1U

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

