### PR TITLE
bug(Tables): Clean up table styling

### DIFF
--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -63,7 +63,7 @@ class TaskTable extends React.Component {
   getClassName(prop, sortBy, row) {
     return classNames(tableColumnClasses[prop], {
       highlight: prop === sortBy.prop,
-      clickable: row == null // this is a header
+      clickable: row == null && prop !== "logs" // this is a header
     });
   }
 
@@ -130,8 +130,7 @@ class TaskTable extends React.Component {
         heading,
         prop: "logs",
         render: this.renderLog,
-        sortable: false,
-        sortFunction
+        sortable: false
       },
       {
         cacheCell: true,

--- a/src/js/utils/ResourceTableUtil.js
+++ b/src/js/utils/ResourceTableUtil.js
@@ -15,8 +15,7 @@ const LEFT_ALIGN_PROPS = [
   "mem",
   "mtime",
   "priority",
-  "size",
-  "version"
+  "size"
 ];
 
 function leftAlignCaret(prop) {

--- a/src/styles/components/task-table/styles.less
+++ b/src/styles/components/task-table/styles.less
@@ -59,7 +59,12 @@
 
     &-cpus,
     &-mem {
-      text-align: right;
+
+      // Extra specificity is necessary to override external vendor styles.
+      td&,
+      th& {
+        text-align: right;
+      }
     }
   }
 }

--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -92,10 +92,15 @@
 
     &.clickable {
 
+      .caret {
+        display: inline-block;
+        visibility: hidden;
+      }
+
       &:hover {
 
         .caret {
-          display: inline-block;
+          visibility: visible;
         }
       }
     }


### PR DESCRIPTION
This PR fixes three small bugs related to table styling:
* toggle `visibility` instead of `display` property of sorting indicator carets
* right-align resource values in `TaskTable`
* remove sorting indicator for `logs` column

Before:
![](https://slack-imgs.com/?c=1&url=https%3A%2F%2Fcl.ly%2F3t24250f3006%2FScreen%2520Recording%25202017-06-21%2520at%252009.59%2520AM.gif)

After:
![](https://slack-imgs.com/?c=1&url=https%3A%2F%2Fcl.ly%2F2G363G0r192s%2FScreen%2520Recording%25202017-06-21%2520at%252010.41%2520AM.gif)

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?