### PR TITLE
DCOS-16009: fix(ServiceActionsModal): Remove duplicated word 'documentation'

### DIFF
--- a/src/js/translations/en-US.json
+++ b/src/js/translations/en-US.json
@@ -75,6 +75,6 @@
   "SERVICES.DEPLOYMENT_MODAL_HEADING": "{deploymentsCount} Active {deploymentsCount, plural, =1 {Deployment} other {Deployments}}",
   "SERVICE_ACTIONS.DELETE_SERVICE": "In order to delete ",
   "SERVICE_ACTIONS.DELETE_SERVICE_2": " please type service name.",
-  "SERVICE_ACTIONS.DELETE_SERVICE_FRAMEWORK": "In order to delete a service, you must use the DC/OS CLI to perform this command. Refer to the documentation ",
+  "SERVICE_ACTIONS.DELETE_SERVICE_FRAMEWORK": "In order to delete a service, you must use the DC/OS CLI to perform this command. Refer to the ",
   "SERVICE_ACTIONS.DELETE_SERVICE_FRAMEWORK_2": " for complete instructions or copy and paste this command into your CLI."
 }


### PR DESCRIPTION
This PR just removes the duplicated word `documentation` in the service actions modal.

Before:
![](https://cl.ly/2y2C2h1n3X15/Screen%20Shot%202017-06-21%20at%2011.13.32%20AM.png)

After:
![](https://cl.ly/3U0l0k1q2p0J/Screen%20Shot%202017-06-21%20at%2011.13.45%20AM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?