### PR TITLE
DCOS-12470: feat(ServiceStatusWarning): Link to debug tab

### DIFF
--- a/plugins/services/src/js/components/ServiceStatusWarning.js
+++ b/plugins/services/src/js/components/ServiceStatusWarning.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { Link } from "react-router";
 import { Tooltip } from "reactjs-components";
 
 import DateUtil from "#SRC/js/utils/DateUtil";
@@ -52,6 +53,13 @@ class ServiceStatusWarning extends Component {
   }
 
   getTooltip(content) {
+    let icon = <Icon color="red" id="yield" size="mini" />;
+
+    if (this.props.item instanceof Service) {
+      const servicePath = encodeURIComponent(this.props.item.getId());
+      icon = <Link to={`/services/detail/${servicePath}/debug`}>{icon}</Link>;
+    }
+
     return (
       <Tooltip
         content={content}
@@ -59,7 +67,7 @@ class ServiceStatusWarning extends Component {
         wrapText={true}
         wrapperClassName="tooltip-wrapper status-waiting-indicator"
       >
-        <Icon color="red" id="yield" size="mini" />
+        {icon}
       </Tooltip>
     );
   }


### PR DESCRIPTION
This PR wraps the service status warning icon in a link to the debug tab. We wanted this from the beginning, but the service detail tabs weren't routed until recently.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
