### PR TITLE
DCOS-16010: fix(InstallPackageModal): Prevent overflowing text

### DIFF
--- a/src/styles/views/packages/styles.less
+++ b/src/styles/views/packages/styles.less
@@ -1,8 +1,9 @@
 & when (@packages-view-enabled) {
 
-  // Remove the bottom margin on the last element in the package notes.
   .install-package-modal-package-notes {
+    max-width: 100%;
 
+    // Remove the bottom margin on the last element in the package notes.
     & > * {
 
       &:last-child {


### PR DESCRIPTION
This PR prevents overflowing text in the post-install notes of the `InstallPackageModal`.

Before:
![](https://cl.ly/342C2K0h231Y/Screen%20Shot%202017-06-21%20at%2012.40.47%20PM.png)

After:
![](https://cl.ly/1M1k1L1B3e3x/Screen%20Shot%202017-06-21%20at%2012.40.41%20PM.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
