### PR TITLE
DCOS-14185: chore(ServicesTable): Animate Waiting status

### DIFF
--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -29,6 +29,7 @@ import {
   SUSPEND
 } from "../../constants/ServiceActionItem";
 import ServiceActionLabels from "../../constants/ServiceActionLabels";
+import ServiceStatusTypes from "../../constants/ServiceStatusTypes";
 import ServiceStatusWarning from "../../components/ServiceStatusWarning";
 import ServiceTableHeaderLabels from "../../constants/ServiceTableHeaderLabels";
 import ServiceTableUtil from "../../utils/ServiceTableUtil";
@@ -329,11 +330,14 @@ class ServicesTable extends React.Component {
   renderStatus(prop, service) {
     const instancesCount = service.getInstancesCount();
     const serviceId = service.getId();
-    const serviceStatus = service.getStatus();
-    const serviceStatusClassSet = StatusMapping[serviceStatus] || "";
+    const serviceStatusText = service.getStatus();
+    const serviceStatusClassSet = StatusMapping[serviceStatusText] || "";
+    const { key: serviceStatusKey } = service.getServiceStatus();
     const tasksSummary = service.getTasksSummary();
     const tasksRunning = service.getTaskCount();
-    const isDeploying = serviceStatus === "Deploying";
+    const isDeploying =
+      serviceStatusKey === ServiceStatusTypes.WAITING ||
+      serviceStatusKey === ServiceStatusTypes.DEPLOYING;
 
     const conciseOverview = tasksRunning === instancesCount
       ? ` (${tasksRunning})`
@@ -354,7 +358,9 @@ class ServicesTable extends React.Component {
           />
         </span>
         <span className="status-bar-text">
-          <span className={serviceStatusClassSet}>{serviceStatus}</span>
+          <span className={serviceStatusClassSet}>
+            {serviceStatusText}
+          </span>
           <span className="hidden-large-down">{verboseOverview}</span>
           <span className="hidden-jumbo-up">{conciseOverview}</span>
           <ServiceStatusWarning item={service} />


### PR DESCRIPTION
This PR will render the animated health bar when a service's status is either `deploying` or `waiting`.

I also adjusted the way we determine the `isDeploying` property that's passed to `HealthBar`. Previously, we were comparing the displayed status string to a hard-coded string (`Deploying`). I've changed this to compare the status' `key` property to a constants file that maps to these keys.

It seems like we need to refactor the service status constants, as they are spread across multiple files, but this solves the issue and gets us closer to a more desirable solution, IMO.

Before:
![](https://cl.ly/1T3y15032W2u/Screen%20Recording%202017-06-21%20at%2001.26%20PM.gif)

After:
![](https://cl.ly/3V0z471w1v2h/Screen%20Recording%202017-06-21%20at%2001.26%20PM.gif)

```
<!-- Suplemental codeblock -->
```

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
