### PR TITLE
feat(CosmosPackagesActions): update cosmos describe API to use v3

### DIFF
--- a/src/js/events/CosmosPackagesActions.js
+++ b/src/js/events/CosmosPackagesActions.js
@@ -121,14 +121,14 @@ const CosmosPackagesActions = {
   fetchPackageDescription(packageName, packageVersion) {
     RequestUtil.json({
       contentType: getContentType("describe", "request", "v1"),
-      headers: { Accept: getContentType("describe", "response") },
+      headers: { Accept: getContentType("describe", "response", "v3") },
       method: "POST",
       url: `${Config.rootUrl}${Config.cosmosAPIPrefix}/describe`,
       data: JSON.stringify({ packageName, packageVersion }),
-      success(cosmosPackage) {
+      success(response) {
+        const cosmosPackage = response.package;
         if (!cosmosPackage.currentVersion && cosmosPackage.version) {
           cosmosPackage.currentVersion = cosmosPackage.version;
-          delete cosmosPackage.version;
         }
         AppDispatcher.handleServerAction({
           type: REQUEST_COSMOS_PACKAGE_DESCRIBE_SUCCESS,

--- a/src/js/events/__tests__/CosmosPackagesActions-test.js
+++ b/src/js/events/__tests__/CosmosPackagesActions-test.js
@@ -236,7 +236,7 @@ describe("CosmosPackagesActions", function() {
         );
       });
 
-      this.configuration.success({ bar: "baz" });
+      this.configuration.success({ package: { bar: "baz" } });
     });
 
     it("dispatches with the correct data when successful", function() {
@@ -246,7 +246,7 @@ describe("CosmosPackagesActions", function() {
         expect(action.data).toEqual({ bar: "baz" });
       });
 
-      this.configuration.success({ bar: "baz" });
+      this.configuration.success({ package: { bar: "baz" } });
     });
 
     it("dispatches the correct action when unsuccessful", function() {

--- a/src/js/stores/__tests__/CosmosPackagesStore-test.js
+++ b/src/js/stores/__tests__/CosmosPackagesStore-test.js
@@ -133,9 +133,9 @@ describe("CosmosPackagesStore", function() {
     it("should return the packageDetails it was given", function() {
       CosmosPackagesStore.fetchPackageDescription("foo", "bar");
       var pkg = CosmosPackagesStore.getPackageDetails();
-      expect(pkg.getName()).toEqual(this.packageDescribeFixture.name);
+      expect(pkg.getName()).toEqual(this.packageDescribeFixture.package.name);
       expect(pkg.getCurrentVersion()).toEqual(
-        this.packageDescribeFixture.version
+        this.packageDescribeFixture.package.version
       );
     });
 

--- a/src/js/stores/__tests__/fixtures/MockPackageDescribeResponse.json
+++ b/src/js/stores/__tests__/fixtures/MockPackageDescribeResponse.json
@@ -1,5 +1,7 @@
 {
-  "packagingVersion": "2.0",
-  "name": "marathon",
-  "version": "0.11.1"
+  "package": {
+    "packagingVersion": "2.0",
+    "name": "marathon",
+    "version": "0.11.1"
+  }
 }

--- a/tests/_fixtures/cosmos/package-describe.json
+++ b/tests/_fixtures/cosmos/package-describe.json
@@ -1,410 +1,412 @@
 {
-  "packagingVersion": "2.0",
-  "name": "marathon",
-  "version": "0.11.1",
-  "maintainer": "help@dcos.io",
-  "description": "A cluster-wide init and control system for services in cgroups or Docker containers.",
-  "tags": [
-    "init",
-    "long-running"
-  ],
-  "scm": "https://github.com/mesosphere/marathon.git",
-  "website": null,
-  "framework": true,
-  "preInstallNotes": "We recommend a minimum of one node with at least 2 CPU's and 1GB of RAM available for the Marathon Service.",
-  "postInstallNotes": "Marathon DCOS Service has been successfully installed!\n\n\tDocumentation: https://mesosphere.github.io/marathon\n\tIssues: https://github.com/mesosphere/marathon/issues\n",
-  "postUninstallNotes": "The Marathon DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at http://docs.mesosphere.com/services/marathon/#uninstall to clean up any persisted state",
-  "licenses": [
-    {
-      "name": "Apache License Version 2.0",
-      "url": "https://github.com/mesosphere/marathon/blob/master/LICENSE"
-    }
-  ],
-  "marathon": {
-    "v2AppMustacheTemplate": "{\n  \"id\": \"{{marathon.framework-name}}\",\n  \"cpus\": {{marathon.cpus}},\n  \"mem\": {{marathon.mem}},\n  \"instances\": {{marathon.instances}},\n  \"constraints\": [[\"hostname\", \"UNIQUE\"]],\n  \"ports\": [\n    {{marathon.http-port}}\n    , 0\n    {{#marathon.enable-https}}\n    , {{marathon.https-port}}\n    {{/marathon.enable-https}}\n  ],\n  \"uris\": {{marathon.uris}},\n  \"healthChecks\": [\n    {\n      \"gracePeriodSeconds\": 120,\n      \"intervalSeconds\": 10,\n      \"maxConsecutiveFailures\": 3,\n      \"path\": \"/v2/info\",\n      \"portIndex\": 0,\n      \"protocol\": \"HTTP\",\n      \"timeoutSeconds\": 5\n    }\n  ],\n  \"container\": {\n    \"type\": \"DOCKER\",\n    \"docker\": {\n      \"image\": \"{{resource.assets.container.docker.5e187be16235}}\",\n      \"network\": \"HOST\"\n    }\n  },\n  \"env\": {\n    \"JVM_OPTS\": \"-Xms{{marathon.jvm-heap-min}}m -Xmx{{marathon.jvm-heap-max}}m\"\n  },\n  \"cmd\": \"LIBPROCESS_PORT=$PORT1 && ./bin/start --master {{mesos.master}} {{#marathon.access-control-allow-origin}} --access_control_allow_origin {{marathon.access-control-allow-origin}} {{/marathon.access-control-allow-origin}} {{#marathon.artifact-store}} --artifact_store {{marathon.artifact-store}} {{/marathon.artifact-store}} {{#marathon.checkpoint}} --checkpoint {{/marathon.checkpoint}} {{#marathon.decline-offer-duration}} --decline_offer_duration {{marathon.decline-offer-duration}} {{/marathon.decline-offer-duration}} {{#marathon.default-accepted-resource-roles}} --default_accepted_resource_roles {{marathon.default-accepted-resource-roles}} {{/marathon.default-accepted-resource-roles}} {{#marathon.disable-http}} --disable_http {{/marathon.disable-http}} --http_port $PORT0 {{#marathon.enable-https}}   --https_port $PORT2   {{#marathon.ssl-keystore-password}} --ssl_keystore_password {{marathon.ssl-keystore-password}} {{/marathon.ssl-keystore-password}}      {{#marathon.ssl-keystore-path}} --ssl_keystore_path {{marathon.ssl-keystore-path}} {{/marathon.ssl-keystore-path}}     {{/marathon.enable-https}} {{#marathon.disable-metrics}} --disable_metrics {{/marathon.disable-metrics}} {{#marathon.enable-tracing}} --enable_tracing {{/marathon.enable-tracing}} {{#marathon.env-vars-prefix}} --env_vars_prefix {{marathon.env-vars-prefix}} {{/marathon.env-vars-prefix}} {{#marathon.event-stream-max-outstanding-messages}} --event_stream_max_outstanding_messages {{marathon.event-stream-max-outstanding-messages}} {{/marathon.event-stream-max-outstanding-messages}} {{#marathon.event-subscriber}} --event_subscriber {{marathon.event-subscriber}} {{/marathon.event-subscriber}} {{#marathon.executor}} --executor {{marathon.executor}} {{/marathon.executor}} {{#marathon.failover-timeout}} --failover_timeout {{marathon.failover-timeout}} {{/marathon.failover-timeout}} {{#marathon.framework-name}} --framework_name {{marathon.framework-name}} {{/marathon.framework-name}} {{#marathon.ha}} --ha {{/marathon.ha}} {{#marathon.http-credentials}} --http_credentials {{marathon.http-credentials}} {{/marathon.http-credentials}} {{#marathon.http-endpoints}} --http_endpoints {{marathon.http-endpoints}} {{/marathon.http-endpoints}} {{#marathon.http-max-concurrent-requests}} --http_max_concurrent_requests {{marathon.http-max-concurrent-requests}} {{/marathon.http-max-concurrent-requests}} {{#marathon.leader-proxy-connection-timeout}} --leader_proxy_connection_timeout {{marathon.leader-proxy-connection-timeout}} {{/marathon.leader-proxy-connection-timeout}} {{#marathon.leader-proxy-read-timeout}} --leader_proxy_read_timeout {{marathon.leader-proxy-read-timeout}} {{/marathon.leader-proxy-read-timeout}} {{#marathon.local-port-max}} --local_port_max {{marathon.local-port-max}} {{/marathon.local-port-max}} {{#marathon.local-port-min}} --local_port_min {{marathon.local-port-min}} {{/marathon.local-port-min}} {{#marathon.mesos-role}} --mesos_role {{marathon.mesos-role}} {{/marathon.mesos-role}} {{#marathon.marathon-store-timeout}} --marathon_store_timeout {{marathon.marathon-store-timeout}} {{/marathon.marathon-store-timeout}} {{#marathon.max-tasks-per-offer}} --max_tasks_per_offer {{marathon.max-tasks-per-offer}} {{/marathon.max-tasks-per-offer}} {{#marathon.max-tasks-per-offer-cycle}} --max_tasks_per_offer_cycle {{marathon.max-tasks-per-offer-cycle}} {{/marathon.max-tasks-per-offer-cycle}} {{#marathon.mesos-authentication-principal}} --mesos_authentication_principal {{marathon.mesos-authentication-principal}} {{/marathon.mesos-authentication-principal}} {{#marathon.mesos-authentication-secret-file}} --mesos_authentication_secret_file {{marathon.mesos-authentication-secret-file}} {{/marathon.mesos-authentication-secret-file}} {{#marathon.min-revive-offers-interval}} --min_revive_offers_interval {{marathon.min-revive-offers-interval}} {{/marathon.min-revive-offers-interval}} {{#marathon.reconciliation-initial-delay}} --reconciliation_initial_delay {{marathon.reconciliation-initial-delay}} {{/marathon.reconciliation-initial-delay}} {{#marathon.reconciliation-interval}} --reconciliation_interval {{marathon.reconciliation-interval}} {{/marathon.reconciliation-interval}} {{#marathon.revive-offers-for-new-apps}} --revive_offers_for_new_apps {{/marathon.revive-offers-for-new-apps}} {{#marathon.scale-apps-initial-delay}} --scale_apps_initial_delay {{marathon.scale-apps-initial-delay}} {{/marathon.scale-apps-initial-delay}} {{#marathon.scale-apps-interval}} --scale_apps_interval {{marathon.scale-apps-interval}} {{/marathon.scale-apps-interval}} {{#marathon.zk-max-versions}} --zk_max_versions {{marathon.zk-max-versions}} {{/marathon.zk-max-versions}} {{#marathon.zk-session-timeout}} --zk_session_timeout {{marathon.zk-session-timeout}} {{/marathon.zk-session-timeout}} {{#marathon.zk-timeout}} --zk_timeout {{marathon.zk-timeout}} {{/marathon.zk-timeout}} --zk {{marathon.zk}} {{#marathon.mesos-leader-ui-url}} --mesos_leader_ui_url {{marathon.mesos-leader-ui-url}} {{/marathon.mesos-leader-ui-url}} {{#marathon.zk-compression}} --zk_compression {{/marathon.zk-compression}} {{^marathon.zk-compression}} --disable_zk_compression {{/marathon.zk-compression}} --zk_compression_threshold {{marathon.zk-compression-threshold}} {{#marathon.max-apps}} --max_apps {{marathon.max.apps}} {{/marathon.max-apps}}\"\n}\n"
-  },
-  "command": null,
-  "config": {
-    "properties": {
-      "service": {
-        "properties": {
-          "name": {
-            "default": "marathon-user",
-            "title": "Name",
-            "type": "string"
-          }
+  "package": {
+    "packagingVersion": "2.0",
+    "name": "marathon",
+    "version": "0.11.1",
+    "maintainer": "help@dcos.io",
+    "description": "A cluster-wide init and control system for services in cgroups or Docker containers.",
+    "tags": [
+      "init",
+      "long-running"
+    ],
+    "scm": "https://github.com/mesosphere/marathon.git",
+    "website": null,
+    "framework": true,
+    "preInstallNotes": "We recommend a minimum of one node with at least 2 CPU's and 1GB of RAM available for the Marathon Service.",
+    "postInstallNotes": "Marathon DCOS Service has been successfully installed!\n\n\tDocumentation: https://mesosphere.github.io/marathon\n\tIssues: https://github.com/mesosphere/marathon/issues\n",
+    "postUninstallNotes": "The Marathon DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at http://docs.mesosphere.com/services/marathon/#uninstall to clean up any persisted state",
+    "licenses": [
+      {
+        "name": "Apache License Version 2.0",
+        "url": "https://github.com/mesosphere/marathon/blob/master/LICENSE"
+      }
+    ],
+    "marathon": {
+      "v2AppMustacheTemplate": "{\n  \"id\": \"{{marathon.framework-name}}\",\n  \"cpus\": {{marathon.cpus}},\n  \"mem\": {{marathon.mem}},\n  \"instances\": {{marathon.instances}},\n  \"constraints\": [[\"hostname\", \"UNIQUE\"]],\n  \"ports\": [\n    {{marathon.http-port}}\n    , 0\n    {{#marathon.enable-https}}\n    , {{marathon.https-port}}\n    {{/marathon.enable-https}}\n  ],\n  \"uris\": {{marathon.uris}},\n  \"healthChecks\": [\n    {\n      \"gracePeriodSeconds\": 120,\n      \"intervalSeconds\": 10,\n      \"maxConsecutiveFailures\": 3,\n      \"path\": \"/v2/info\",\n      \"portIndex\": 0,\n      \"protocol\": \"HTTP\",\n      \"timeoutSeconds\": 5\n    }\n  ],\n  \"container\": {\n    \"type\": \"DOCKER\",\n    \"docker\": {\n      \"image\": \"{{resource.assets.container.docker.5e187be16235}}\",\n      \"network\": \"HOST\"\n    }\n  },\n  \"env\": {\n    \"JVM_OPTS\": \"-Xms{{marathon.jvm-heap-min}}m -Xmx{{marathon.jvm-heap-max}}m\"\n  },\n  \"cmd\": \"LIBPROCESS_PORT=$PORT1 && ./bin/start --master {{mesos.master}} {{#marathon.access-control-allow-origin}} --access_control_allow_origin {{marathon.access-control-allow-origin}} {{/marathon.access-control-allow-origin}} {{#marathon.artifact-store}} --artifact_store {{marathon.artifact-store}} {{/marathon.artifact-store}} {{#marathon.checkpoint}} --checkpoint {{/marathon.checkpoint}} {{#marathon.decline-offer-duration}} --decline_offer_duration {{marathon.decline-offer-duration}} {{/marathon.decline-offer-duration}} {{#marathon.default-accepted-resource-roles}} --default_accepted_resource_roles {{marathon.default-accepted-resource-roles}} {{/marathon.default-accepted-resource-roles}} {{#marathon.disable-http}} --disable_http {{/marathon.disable-http}} --http_port $PORT0 {{#marathon.enable-https}}   --https_port $PORT2   {{#marathon.ssl-keystore-password}} --ssl_keystore_password {{marathon.ssl-keystore-password}} {{/marathon.ssl-keystore-password}}      {{#marathon.ssl-keystore-path}} --ssl_keystore_path {{marathon.ssl-keystore-path}} {{/marathon.ssl-keystore-path}}     {{/marathon.enable-https}} {{#marathon.disable-metrics}} --disable_metrics {{/marathon.disable-metrics}} {{#marathon.enable-tracing}} --enable_tracing {{/marathon.enable-tracing}} {{#marathon.env-vars-prefix}} --env_vars_prefix {{marathon.env-vars-prefix}} {{/marathon.env-vars-prefix}} {{#marathon.event-stream-max-outstanding-messages}} --event_stream_max_outstanding_messages {{marathon.event-stream-max-outstanding-messages}} {{/marathon.event-stream-max-outstanding-messages}} {{#marathon.event-subscriber}} --event_subscriber {{marathon.event-subscriber}} {{/marathon.event-subscriber}} {{#marathon.executor}} --executor {{marathon.executor}} {{/marathon.executor}} {{#marathon.failover-timeout}} --failover_timeout {{marathon.failover-timeout}} {{/marathon.failover-timeout}} {{#marathon.framework-name}} --framework_name {{marathon.framework-name}} {{/marathon.framework-name}} {{#marathon.ha}} --ha {{/marathon.ha}} {{#marathon.http-credentials}} --http_credentials {{marathon.http-credentials}} {{/marathon.http-credentials}} {{#marathon.http-endpoints}} --http_endpoints {{marathon.http-endpoints}} {{/marathon.http-endpoints}} {{#marathon.http-max-concurrent-requests}} --http_max_concurrent_requests {{marathon.http-max-concurrent-requests}} {{/marathon.http-max-concurrent-requests}} {{#marathon.leader-proxy-connection-timeout}} --leader_proxy_connection_timeout {{marathon.leader-proxy-connection-timeout}} {{/marathon.leader-proxy-connection-timeout}} {{#marathon.leader-proxy-read-timeout}} --leader_proxy_read_timeout {{marathon.leader-proxy-read-timeout}} {{/marathon.leader-proxy-read-timeout}} {{#marathon.local-port-max}} --local_port_max {{marathon.local-port-max}} {{/marathon.local-port-max}} {{#marathon.local-port-min}} --local_port_min {{marathon.local-port-min}} {{/marathon.local-port-min}} {{#marathon.mesos-role}} --mesos_role {{marathon.mesos-role}} {{/marathon.mesos-role}} {{#marathon.marathon-store-timeout}} --marathon_store_timeout {{marathon.marathon-store-timeout}} {{/marathon.marathon-store-timeout}} {{#marathon.max-tasks-per-offer}} --max_tasks_per_offer {{marathon.max-tasks-per-offer}} {{/marathon.max-tasks-per-offer}} {{#marathon.max-tasks-per-offer-cycle}} --max_tasks_per_offer_cycle {{marathon.max-tasks-per-offer-cycle}} {{/marathon.max-tasks-per-offer-cycle}} {{#marathon.mesos-authentication-principal}} --mesos_authentication_principal {{marathon.mesos-authentication-principal}} {{/marathon.mesos-authentication-principal}} {{#marathon.mesos-authentication-secret-file}} --mesos_authentication_secret_file {{marathon.mesos-authentication-secret-file}} {{/marathon.mesos-authentication-secret-file}} {{#marathon.min-revive-offers-interval}} --min_revive_offers_interval {{marathon.min-revive-offers-interval}} {{/marathon.min-revive-offers-interval}} {{#marathon.reconciliation-initial-delay}} --reconciliation_initial_delay {{marathon.reconciliation-initial-delay}} {{/marathon.reconciliation-initial-delay}} {{#marathon.reconciliation-interval}} --reconciliation_interval {{marathon.reconciliation-interval}} {{/marathon.reconciliation-interval}} {{#marathon.revive-offers-for-new-apps}} --revive_offers_for_new_apps {{/marathon.revive-offers-for-new-apps}} {{#marathon.scale-apps-initial-delay}} --scale_apps_initial_delay {{marathon.scale-apps-initial-delay}} {{/marathon.scale-apps-initial-delay}} {{#marathon.scale-apps-interval}} --scale_apps_interval {{marathon.scale-apps-interval}} {{/marathon.scale-apps-interval}} {{#marathon.zk-max-versions}} --zk_max_versions {{marathon.zk-max-versions}} {{/marathon.zk-max-versions}} {{#marathon.zk-session-timeout}} --zk_session_timeout {{marathon.zk-session-timeout}} {{/marathon.zk-session-timeout}} {{#marathon.zk-timeout}} --zk_timeout {{marathon.zk-timeout}} {{/marathon.zk-timeout}} --zk {{marathon.zk}} {{#marathon.mesos-leader-ui-url}} --mesos_leader_ui_url {{marathon.mesos-leader-ui-url}} {{/marathon.mesos-leader-ui-url}} {{#marathon.zk-compression}} --zk_compression {{/marathon.zk-compression}} {{^marathon.zk-compression}} --disable_zk_compression {{/marathon.zk-compression}} --zk_compression_threshold {{marathon.zk-compression-threshold}} {{#marathon.max-apps}} --max_apps {{marathon.max.apps}} {{/marathon.max-apps}}\"\n}\n"
+    },
+    "command": null,
+    "config": {
+      "properties": {
+        "service": {
+          "properties": {
+            "name": {
+              "default": "marathon-user",
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          "title": "Service"
         },
-        "title": "Service"
-      },
-      "marathon": {
-        "additionalProperties": false,
-        "description": "Marathon specific configuration properties",
-        "properties": {
-          "access-control-allow-origin": {
-            "description": "The origin(s) to allow in Marathon. Not set by default. Example values are \"'*'\", or \"http://localhost:8888,http://domain.com\"",
-            "type": "string"
-          },
-          "artifact-store": {
-            "description": "URL to the artifact store. Examples: \"hdfs://localhost:54310/path/to/store\", \"file:///var/log/store\". For details, see the artifact store docs: https://mesosphere.github.io/marathon/docs/artifact-store.html.",
-            "type": "string"
-          },
-          "checkpoint": {
-            "default": true,
-            "description": "Enable checkpointing of tasks. Requires checkpointing enabled on slaves. Allows tasks to continue running during mesos-slave restarts and Marathon scheduler failover.",
-            "type": "boolean"
-          },
-          "decline-offer-duration": {
-            "default": 5000,
-            "description": "The duration (milliseconds) for which to decline offers by default",
-            "minimum": 100,
-            "type": "integer"
-          },
-          "cpus": {
-            "default": 2.0,
-            "description": "CPU shares to allocate to each Marathon instance.",
-            "minimum": 0.0,
-            "type": "number"
-          },
-          "default-accepted-resource-roles": {
-            "description": "Default for the defaultAcceptedResourceRoles attribute of all app definitions as a comma-separated list of strings. This defaults to all roles for which this Marathon instance is configured to receive offers.",
-            "type": "string"
-          },
-          "disable-http": {
-            "default": false,
-            "description": "Disable listening for HTTP requests completely. HTTPS is unaffected.",
-            "type": "boolean"
-          },
-          "disable_metrics": {
-            "default": false,
-            "description": "Disable metric measurement of service method calls",
-            "type": "boolean"
-          },
-          "enable-https": {
-            "default": false,
-            "description": "Enables the HTTPS protocol. Use in conjunction with ssl-keystore-path and ssl-keystore-password.",
-            "type": "boolean"
-          },
-          "enable-tracing": {
-            "default": false,
-            "description": "Enable trace logging of service method calls",
-            "type": "boolean"
-          },
-          "env-vars-prefix": {
-            "default": "",
-            "description": "Prefix to use for environment variables",
-            "type": "string"
-          },
-          "event-stream-max-outstanding-messages": {
-            "default": 50,
-            "minimum": 10,
-            "description": "The event stream buffers events, that are not already consumed by clients. This number defines the number of events that get buffered on the server side, before messages are dropped.",
-            "type": "integer"
-          },
-          "event-subscriber": {
-            "description": "Event subscriber module to enable. Currently the only valid value is \"http_callback\".",
-            "type": "string"
-          },
-          "executor": {
-            "description": "Executor to use when none is specified.",
-            "type": "string"
-          },
-          "failover-timeout": {
-            "default": 604800,
-            "description": "The failover_timeout for Mesos in seconds. If a new Marathon instance has not re-registered with Mesos this long after a failover, Mesos will shut down all running tasks started by Marathon. Requires checkpointing to be enabled.",
-            "minimum": 0,
-            "type": "integer"
-          },
-          "framework-name": {
-            "default": "marathon-user",
-            "description": "The framework name to register with Mesos.",
-            "type": "string",
-            "pattern": "^/?(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$"
-          },
-          "ha": {
-            "default": true,
-            "description": "Runs Marathon in high-availability mode with leader election. Allows starting an arbitrary number of other Marathons but all need to be started in HA mode. This mode requires a running ZooKeeper.",
-            "type": "boolean"
-          },
-          "http-credentials": {
-            "description": "Credentials for accessing the HTTP service in the format of username:password. The username may not contain a colon (:).",
-            "type": "string"
-          },
-          "http-endpoints": {
-            "description": "Pre-configured http callback URLs. Valid only in conjunction with --event_subscriber http_callback. Additional callback URLs may also be set dynamically via the REST API.",
-            "type": "string"
-          },
-          "http-max-concurrent-requests": {
-            "description": "The number of concurrent http requests, that are allowed before rejecting.",
-            "minimum": 1,
-            "type": "integer"
-          },
-          "http-port": {
-            "default": 0,
-            "description": "The port on which to listen for HTTP requests.",
-            "minimum": 0,
-            "type": "integer"
-          },
-          "https-port": {
-            "default": 0,
-            "description": "The port on which to listen for HTTPS requests.",
-            "minimum": 0,
-            "type": "integer"
-          },
-          "instances": {
-            "default": 1,
-            "description": "Number of Marathon instances to run.",
-            "minimum": 0,
-            "type": "integer"
-          },
-          "jvm-heap-min": {
-            "default": 256,
-            "description": "Memory (MB) start size for the JVM heap. This number should be be less or equals than the jvm-heap-max.",
-            "minimum": 0,
-            "type": "number"
-          },
-          "jvm-heap-max": {
-            "default": 768,
-            "description": "Memory (MB) max size for the JVM heap. This number should be be less than the absolute memory.",
-            "minimum": 0,
-            "type": "number"
-          },
-          "leader-proxy-connection-timeout": {
-            "default": 5000,
-            "description": "Maximum time, in milliseconds, to wait for connecting to the current Marathon leader from another Marathon instance.",
-            "minimum": 0,
-            "type": "integer"
-          },
-          "leader-proxy-read-timeout": {
-            "default": 10000,
-            "description": "Maximum time, in milliseconds, for reading from the current Marathon leader.",
-            "minimum": 0,
-            "type": "integer"
-          },
-          "local-port-max": {
-            "description": "Maximum port number to use when assigning service ports to apps.",
-            "maximum": 65535,
-            "minimum": 0,
-            "default": 20000,
-            "type": "integer"
-          },
-          "local-port-min": {
-            "description": "Minimum port number to use when assigning service ports to apps.",
-            "maximum": 65535,
-            "minimum": 0,
-            "default": 10000,
-            "type": "integer"
-          },
-          "marathon-store-timeout": {
-            "description": "Maximum time in milliseconds, to wait for persistent storage operations to complete.",
-            "minimum": 0,
-            "default": 2000,
-            "type": "integer"
-          },
-          "max-apps": {
-            "description": "The maximum number of applications that may be created.",
-            "minimum": 0,
-            "type": "integer"
-          },
-          "max-tasks-per-offer": {
-            "default": 1,
-            "description": "Maximally launch this number of tasks per offer.",
-            "minimum": 1,
-            "type": "integer"
-          },
-          "max-tasks-per-offer-cycle": {
-            "default": 1000,
-            "description": "Maximally launch this number of tasks per offer cycle.",
-            "minimum": 1,
-            "type": "integer"
-          },
-          "mem": {
-            "default": 1024.0,
-            "description": "Memory (MB) to allocate to each Marathon task.",
-            "minimum": 512.0,
-            "type": "number"
-          },
-          "mesos-authentication-principal": {
-            "description": "The Mesos principal used for authentication.",
-            "type": "string"
-          },
-          "mesos-authentication-secret-file": {
-            "description": "The path to the Mesos secret file containing the authentication secret.",
-            "type": "string"
-          },
-          "mesos-role": {
-            "description": "Mesos role for this framework.",
-            "type": "string"
-          },
-          "mesos-leader-ui-url": {
-            "default": "/mesos",
-            "description": "The host and port (e.g. http://mesos_host:5050) of the Mesos master.",
-            "type": "string"
-          },
-          "min-revive-offers-interval": {
-            "default": 5000,
-            "description": "Do not ask for all offers (also already seen ones) more often than this interval (ms).",
-            "minimum": 200,
-            "type": "integer"
-          },
-          "reconciliation-initial-delay": {
-            "description": "The delay, in milliseconds, before Marathon begins to periodically perform task reconciliation operations.",
-            "minimum": 0,
-            "type": "integer"
-          },
-          "reconciliation-interval": {
-            "description": "The period, in milliseconds, between task reconciliation operations.",
-            "minimum": 0,
-            "type": "integer"
-          },
-          "revive-offers-for-new-apps": {
-            "default": true,
-            "description": "Whether to call reviveOffers for new or changed apps.",
-            "type": "boolean"
-          },
-          "scale-apps-initial-delay": {
-            "default": 15000,
-            "description": "This is the length of time, in milliseconds, before Marathon begins to periodically attempt to scale apps",
-            "minimum": 0,
-            "type": "integer"
-          },
-          "scale-apps-interval": {
-            "default": 300000,
-            "description": "This is the length of time, in milliseconds, between task scale apps.",
-            "minimum": 1000,
-            "type": "integer"
-          },
-          "ssl-keystore-password": {
-            "description": "Password for the keystore supplied with the marathon/ssl-keystore-path option.",
-            "type": "string"
-          },
-          "ssl-keystore-path": {
-            "description": "Path to the SSL keystore. SSL will be enabled if this option is supplied. The keystore can be downloaded into Marathon's working directory by using the uris property.",
-            "type": "string"
-          },
-          "uris": {
-            "default": [
-              
-            ],
-            "description": "List of URIs that will be download and made available in the current working directory of Marathon. For example this can be used to download a Java keystore file for SSL configuration.",
-            "items": {
-              "pattern": "^[\\w]+",
+        "marathon": {
+          "additionalProperties": false,
+          "description": "Marathon specific configuration properties",
+          "properties": {
+            "access-control-allow-origin": {
+              "description": "The origin(s) to allow in Marathon. Not set by default. Example values are \"'*'\", or \"http://localhost:8888,http://domain.com\"",
               "type": "string"
             },
-            "type": "array"
+            "artifact-store": {
+              "description": "URL to the artifact store. Examples: \"hdfs://localhost:54310/path/to/store\", \"file:///var/log/store\". For details, see the artifact store docs: https://mesosphere.github.io/marathon/docs/artifact-store.html.",
+              "type": "string"
+            },
+            "checkpoint": {
+              "default": true,
+              "description": "Enable checkpointing of tasks. Requires checkpointing enabled on slaves. Allows tasks to continue running during mesos-slave restarts and Marathon scheduler failover.",
+              "type": "boolean"
+            },
+            "decline-offer-duration": {
+              "default": 5000,
+              "description": "The duration (milliseconds) for which to decline offers by default",
+              "minimum": 100,
+              "type": "integer"
+            },
+            "cpus": {
+              "default": 2.0,
+              "description": "CPU shares to allocate to each Marathon instance.",
+              "minimum": 0.0,
+              "type": "number"
+            },
+            "default-accepted-resource-roles": {
+              "description": "Default for the defaultAcceptedResourceRoles attribute of all app definitions as a comma-separated list of strings. This defaults to all roles for which this Marathon instance is configured to receive offers.",
+              "type": "string"
+            },
+            "disable-http": {
+              "default": false,
+              "description": "Disable listening for HTTP requests completely. HTTPS is unaffected.",
+              "type": "boolean"
+            },
+            "disable_metrics": {
+              "default": false,
+              "description": "Disable metric measurement of service method calls",
+              "type": "boolean"
+            },
+            "enable-https": {
+              "default": false,
+              "description": "Enables the HTTPS protocol. Use in conjunction with ssl-keystore-path and ssl-keystore-password.",
+              "type": "boolean"
+            },
+            "enable-tracing": {
+              "default": false,
+              "description": "Enable trace logging of service method calls",
+              "type": "boolean"
+            },
+            "env-vars-prefix": {
+              "default": "",
+              "description": "Prefix to use for environment variables",
+              "type": "string"
+            },
+            "event-stream-max-outstanding-messages": {
+              "default": 50,
+              "minimum": 10,
+              "description": "The event stream buffers events, that are not already consumed by clients. This number defines the number of events that get buffered on the server side, before messages are dropped.",
+              "type": "integer"
+            },
+            "event-subscriber": {
+              "description": "Event subscriber module to enable. Currently the only valid value is \"http_callback\".",
+              "type": "string"
+            },
+            "executor": {
+              "description": "Executor to use when none is specified.",
+              "type": "string"
+            },
+            "failover-timeout": {
+              "default": 604800,
+              "description": "The failover_timeout for Mesos in seconds. If a new Marathon instance has not re-registered with Mesos this long after a failover, Mesos will shut down all running tasks started by Marathon. Requires checkpointing to be enabled.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "framework-name": {
+              "default": "marathon-user",
+              "description": "The framework name to register with Mesos.",
+              "type": "string",
+              "pattern": "^/?(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$"
+            },
+            "ha": {
+              "default": true,
+              "description": "Runs Marathon in high-availability mode with leader election. Allows starting an arbitrary number of other Marathons but all need to be started in HA mode. This mode requires a running ZooKeeper.",
+              "type": "boolean"
+            },
+            "http-credentials": {
+              "description": "Credentials for accessing the HTTP service in the format of username:password. The username may not contain a colon (:).",
+              "type": "string"
+            },
+            "http-endpoints": {
+              "description": "Pre-configured http callback URLs. Valid only in conjunction with --event_subscriber http_callback. Additional callback URLs may also be set dynamically via the REST API.",
+              "type": "string"
+            },
+            "http-max-concurrent-requests": {
+              "description": "The number of concurrent http requests, that are allowed before rejecting.",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "http-port": {
+              "default": 0,
+              "description": "The port on which to listen for HTTP requests.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "https-port": {
+              "default": 0,
+              "description": "The port on which to listen for HTTPS requests.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "instances": {
+              "default": 1,
+              "description": "Number of Marathon instances to run.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "jvm-heap-min": {
+              "default": 256,
+              "description": "Memory (MB) start size for the JVM heap. This number should be be less or equals than the jvm-heap-max.",
+              "minimum": 0,
+              "type": "number"
+            },
+            "jvm-heap-max": {
+              "default": 768,
+              "description": "Memory (MB) max size for the JVM heap. This number should be be less than the absolute memory.",
+              "minimum": 0,
+              "type": "number"
+            },
+            "leader-proxy-connection-timeout": {
+              "default": 5000,
+              "description": "Maximum time, in milliseconds, to wait for connecting to the current Marathon leader from another Marathon instance.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "leader-proxy-read-timeout": {
+              "default": 10000,
+              "description": "Maximum time, in milliseconds, for reading from the current Marathon leader.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "local-port-max": {
+              "description": "Maximum port number to use when assigning service ports to apps.",
+              "maximum": 65535,
+              "minimum": 0,
+              "default": 20000,
+              "type": "integer"
+            },
+            "local-port-min": {
+              "description": "Minimum port number to use when assigning service ports to apps.",
+              "maximum": 65535,
+              "minimum": 0,
+              "default": 10000,
+              "type": "integer"
+            },
+            "marathon-store-timeout": {
+              "description": "Maximum time in milliseconds, to wait for persistent storage operations to complete.",
+              "minimum": 0,
+              "default": 2000,
+              "type": "integer"
+            },
+            "max-apps": {
+              "description": "The maximum number of applications that may be created.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "max-tasks-per-offer": {
+              "default": 1,
+              "description": "Maximally launch this number of tasks per offer.",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "max-tasks-per-offer-cycle": {
+              "default": 1000,
+              "description": "Maximally launch this number of tasks per offer cycle.",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "mem": {
+              "default": 1024.0,
+              "description": "Memory (MB) to allocate to each Marathon task.",
+              "minimum": 512.0,
+              "type": "number"
+            },
+            "mesos-authentication-principal": {
+              "description": "The Mesos principal used for authentication.",
+              "type": "string"
+            },
+            "mesos-authentication-secret-file": {
+              "description": "The path to the Mesos secret file containing the authentication secret.",
+              "type": "string"
+            },
+            "mesos-role": {
+              "description": "Mesos role for this framework.",
+              "type": "string"
+            },
+            "mesos-leader-ui-url": {
+              "default": "/mesos",
+              "description": "The host and port (e.g. http://mesos_host:5050) of the Mesos master.",
+              "type": "string"
+            },
+            "min-revive-offers-interval": {
+              "default": 5000,
+              "description": "Do not ask for all offers (also already seen ones) more often than this interval (ms).",
+              "minimum": 200,
+              "type": "integer"
+            },
+            "reconciliation-initial-delay": {
+              "description": "The delay, in milliseconds, before Marathon begins to periodically perform task reconciliation operations.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "reconciliation-interval": {
+              "description": "The period, in milliseconds, between task reconciliation operations.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "revive-offers-for-new-apps": {
+              "default": true,
+              "description": "Whether to call reviveOffers for new or changed apps.",
+              "type": "boolean"
+            },
+            "scale-apps-initial-delay": {
+              "default": 15000,
+              "description": "This is the length of time, in milliseconds, before Marathon begins to periodically attempt to scale apps",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "scale-apps-interval": {
+              "default": 300000,
+              "description": "This is the length of time, in milliseconds, between task scale apps.",
+              "minimum": 1000,
+              "type": "integer"
+            },
+            "ssl-keystore-password": {
+              "description": "Password for the keystore supplied with the marathon/ssl-keystore-path option.",
+              "type": "string"
+            },
+            "ssl-keystore-path": {
+              "description": "Path to the SSL keystore. SSL will be enabled if this option is supplied. The keystore can be downloaded into Marathon's working directory by using the uris property.",
+              "type": "string"
+            },
+            "uris": {
+              "default": [
+
+              ],
+              "description": "List of URIs that will be download and made available in the current working directory of Marathon. For example this can be used to download a Java keystore file for SSL configuration.",
+              "items": {
+                "pattern": "^[\\w]+",
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "zk": {
+              "default": "zk://master.mesos:2181/universe",
+              "description": "Parent ZooKeeper URL for storing state. The framework name is joined to the path of this value. Format: zk://host1:port1,host2:port2,.../path",
+              "type": "string"
+            },
+            "zk-compression": {
+              "default": true,
+              "description": "Enable compression of zk nodes, if the size of the node is bigger than the configured threshold.",
+              "type": "boolean"
+            },
+            "zk-compression-threshold": {
+              "description": "Threshold in bytes, when compression is applied to the zk node (Default: 64 KB).",
+              "minimum": 0,
+              "default": 65536,
+              "type": "integer"
+            },
+            "zk-max-versions": {
+              "description": "Limit the number of versions stored for one entity.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "zk-session-timeout": {
+              "default": 1800000,
+              "description": "The timeout for zookeeper sessions in milliseconds.",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "zk-timeout": {
+              "description": "Timeout for ZooKeeper in milliseconds.",
+              "minimum": 0,
+              "type": "integer"
+            }
           },
-          "zk": {
-            "default": "zk://master.mesos:2181/universe",
-            "description": "Parent ZooKeeper URL for storing state. The framework name is joined to the path of this value. Format: zk://host1:port1,host2:port2,.../path",
-            "type": "string"
-          },
-          "zk-compression": {
-            "default": true,
-            "description": "Enable compression of zk nodes, if the size of the node is bigger than the configured threshold.",
-            "type": "boolean"
-          },
-          "zk-compression-threshold": {
-            "description": "Threshold in bytes, when compression is applied to the zk node (Default: 64 KB).",
-            "minimum": 0,
-            "default": 65536,
-            "type": "integer"
-          },
-          "zk-max-versions": {
-            "description": "Limit the number of versions stored for one entity.",
-            "minimum": 0,
-            "type": "integer"
-          },
-          "zk-session-timeout": {
-            "default": 1800000,
-            "description": "The timeout for zookeeper sessions in milliseconds.",
-            "minimum": 0,
-            "type": "integer"
-          },
-          "zk-timeout": {
-            "description": "Timeout for ZooKeeper in milliseconds.",
-            "minimum": 0,
-            "type": "integer"
-          }
+          "required": [
+            "cpus",
+            "framework-name",
+            "http-port",
+            "instances",
+            "mem",
+            "uris",
+            "zk"
+          ],
+          "type": "object"
         },
-        "required": [
-          "cpus",
-          "framework-name",
-          "http-port",
-          "instances",
-          "mem",
-          "uris",
-          "zk"
-        ],
-        "type": "object"
-      },
-      "mesos": {
-        "description": "Mesos specific configuration properties",
-        "properties": {
-          "master": {
-            "default": "zk://master.mesos:2181/mesos",
-            "description": "The URL of the Mesos master. The format is a comma-delimited list of hosts like zk://host1:port,host2:port/mesos. If using ZooKeeper, pay particular attention to the leading zk:// and trailing /mesos! If not using ZooKeeper, standard host:port patterns, like localhost:5050 or 10.0.0.5:5050,10.0.0.6:5050, are also acceptable.",
-            "type": "string"
-          }
+        "mesos": {
+          "description": "Mesos specific configuration properties",
+          "properties": {
+            "master": {
+              "default": "zk://master.mesos:2181/mesos",
+              "description": "The URL of the Mesos master. The format is a comma-delimited list of hosts like zk://host1:port,host2:port/mesos. If using ZooKeeper, pay particular attention to the leading zk:// and trailing /mesos! If not using ZooKeeper, standard host:port patterns, like localhost:5050 or 10.0.0.5:5050,10.0.0.6:5050, are also acceptable.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "master"
+          ],
+          "type": "object"
         },
-        "required": [
-          "master"
-        ],
-        "type": "object"
-      },
-      "nested-properties": {
-        "description": "This is how nested properties looks. We can even have a title!",
-        "title": "Nested Properties",
-        "type": "object",
-        "properties": {
-          "level0": {
-            "description": "This is a top level property. levelsDeep === 0",
-            "title": "Configuration at Level 0",
-            "type": "object",
-            "properties": {
-              "level1": {
-                "description": "Many options, levelsDeep === 1",
-                "title": "Next Level Deep",
-                "type": "object",
-                "properties": {
-                  "enabled": {
-                    "type": "string",
-                    "default": "hello",
-                    "title": "Yes"
-                  },
-                  "level2": {
-                    "description": "levelsDeep === 2",
-                    "type": "object",
-                    "properties": {
-                      "potato": {
-                        "description": "Yet another level, levelsDeep === 3",
-                        "title": "Grammatical freedom",
-                        "type": "string",
-                        "properties": {
-                          "heavy-potato": {
-                            "description": "Yet another level, levelsDeep === 4",
-                            "title": "Heavy Potato",
-                            "default": "very heavy",
-                            "type": "string"
+        "nested-properties": {
+          "description": "This is how nested properties looks. We can even have a title!",
+          "title": "Nested Properties",
+          "type": "object",
+          "properties": {
+            "level0": {
+              "description": "This is a top level property. levelsDeep === 0",
+              "title": "Configuration at Level 0",
+              "type": "object",
+              "properties": {
+                "level1": {
+                  "description": "Many options, levelsDeep === 1",
+                  "title": "Next Level Deep",
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "string",
+                      "default": "hello",
+                      "title": "Yes"
+                    },
+                    "level2": {
+                      "description": "levelsDeep === 2",
+                      "type": "object",
+                      "properties": {
+                        "potato": {
+                          "description": "Yet another level, levelsDeep === 3",
+                          "title": "Grammatical freedom",
+                          "type": "string",
+                          "properties": {
+                            "heavy-potato": {
+                              "description": "Yet another level, levelsDeep === 4",
+                              "title": "Heavy Potato",
+                              "default": "very heavy",
+                              "type": "string"
+                            }
                           }
                         }
                       }
                     }
                   }
-                }
-              },
-              "authentication": {
-                "description": "Mesos scheduler dcos-oauth configuration. levelsDeep === 1",
-                "type": "object",
-                "properties": {
-                  "secret-name": {
-                    "description": "Path to a service-account credential in the secret store. levelsDeep === 2",
-                    "title": "Secret Name!",
-                    "type": "string",
-                    "properties": {
-                      "many-options": {
-                        "default": "semicolon",
-                        "description": "Yet another level, levelsDeep === 3",
-                        "title": "Grammatical freedom",
-                        "type": "string"
+                },
+                "authentication": {
+                  "description": "Mesos scheduler dcos-oauth configuration. levelsDeep === 1",
+                  "type": "object",
+                  "properties": {
+                    "secret-name": {
+                      "description": "Path to a service-account credential in the secret store. levelsDeep === 2",
+                      "title": "Secret Name!",
+                      "type": "string",
+                      "properties": {
+                        "many-options": {
+                          "default": "semicolon",
+                          "description": "Yet another level, levelsDeep === 3",
+                          "title": "Grammatical freedom",
+                          "type": "string"
+                        }
                       }
                     }
                   }
@@ -413,36 +415,36 @@
             }
           }
         }
-      }
+      },
+      "required": [
+        "marathon",
+        "mesos"
+      ],
+      "type": "object"
     },
-    "required": [
-      "marathon",
-      "mesos"
-    ],
-    "type": "object"
-  },
-  "resource": {
-    "assets": {
-      "uris": null,
-      "container": {
-        "docker": {
-          "5e187be16235": "docker.io/mesosphere/marathon:v0.11.1"
+    "resource": {
+      "assets": {
+        "uris": null,
+        "container": {
+          "docker": {
+            "5e187be16235": "docker.io/mesosphere/marathon:v0.11.1"
+          }
         }
+      },
+      "images": {
+        "icon-small": "https://downloads.dcos.io/marathon/assets/icon-service-marathon-small.png",
+        "icon-medium": "https://downloads.dcos.io/marathon/assets/icon-service-marathon-medium.png",
+        "icon-large": "https://downloads.dcos.io/marathon/assets/icon-service-marathon-large.png",
+        "screenshots": [
+          "https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/marathon-0.6.0/mesosphere-marathon-app-list.png",
+          "https://beingasysadmin.files.wordpress.com/2014/06/marathon2.png",
+          "https://mesosphere.github.io/presentations/mug-ericsson-2014/assets/marathon-logo.jpg",
+          "https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/marathon-0.6.0/mesosphere-marathon-app-list.png",
+          "http://www.clker.com/cliparts/0/f/d/b/12917289761851255679earth-map-huge.jpg",
+          "https://mesosphere.github.io/presentations/mug-ericsson-2014/assets/marathon-logo.jpg",
+          "http://33.media.tumblr.com/9ff4e10667237a30d89f55f13fc5b45b/tumblr_inline_mksdnegnw31qz4rgp.gif"
+        ]
       }
-    },
-    "images": {
-      "icon-small": "https://downloads.dcos.io/marathon/assets/icon-service-marathon-small.png",
-      "icon-medium": "https://downloads.dcos.io/marathon/assets/icon-service-marathon-medium.png",
-      "icon-large": "https://downloads.dcos.io/marathon/assets/icon-service-marathon-large.png",
-      "screenshots": [
-        "https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/marathon-0.6.0/mesosphere-marathon-app-list.png",
-        "https://beingasysadmin.files.wordpress.com/2014/06/marathon2.png",
-        "https://mesosphere.github.io/presentations/mug-ericsson-2014/assets/marathon-logo.jpg",
-        "https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/marathon-0.6.0/mesosphere-marathon-app-list.png",
-        "http://www.clker.com/cliparts/0/f/d/b/12917289761851255679earth-map-huge.jpg",
-        "https://mesosphere.github.io/presentations/mug-ericsson-2014/assets/marathon-logo.jpg",
-        "http://33.media.tumblr.com/9ff4e10667237a30d89f55f13fc5b45b/tumblr_inline_mksdnegnw31qz4rgp.gif"
-      ]
     }
   }
 }


### PR DESCRIPTION
New cosmos packages will be built and served over v3 of the describe endpoint.

Only real change is the new version of the API returns the object nested one level deeper in the response under the key "package".

Closes DCOS-16073

Test by navigating to the package detail view and verifying it shows the package.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
