### PR TITLE
DCOS-15838: Switch to DCOS_PACKAGE_NAME for a Framework package name

### DIFF
--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -148,7 +148,7 @@ class ServiceDestroyModal extends React.Component {
 
   getDestroyFrameworkModal() {
     const { open, service, intl } = this.props;
-    const serviceName = service.getId();
+    const packageName = service.getPackageName();
 
     return (
       <Modal
@@ -185,7 +185,7 @@ class ServiceDestroyModal extends React.Component {
             <pre className="prettyprint flush-bottom">
               dcos package uninstall
               {" "}
-              {serviceName.replace("/", "")} --app-id={serviceName}
+              {packageName} --app-id={service.getId()}
             </pre>
           </ClickToSelect>
         </div>

--- a/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
+++ b/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
@@ -212,8 +212,7 @@ class ServiceDebugContainer extends React.Component {
     const { service } = this.props;
 
     if (this.isFramework(service)) {
-      const { labels = {} } = service;
-      const frameworkName = labels.DCOS_PACKAGE_FRAMEWORK_NAME;
+      const frameworkName = service.getPackageName();
 
       return this.getRecentOfferSummaryDisabledText(frameworkName);
     }

--- a/plugins/services/src/js/stores/MarathonStore.js
+++ b/plugins/services/src/js/stores/MarathonStore.js
@@ -82,7 +82,7 @@ import {
   MARATHON_TASK_KILL_SUCCESS,
   VISIBILITY_CHANGE
 } from "../constants/EventTypes";
-import Service from "../structs/Service";
+import Framework from "../structs/Framework";
 import ServiceImages from "../constants/ServiceImages";
 import ServiceTree from "../structs/ServiceTree";
 
@@ -472,8 +472,8 @@ class MarathonStore extends GetSetBaseStore {
     const groups = new ServiceTree(data);
 
     const apps = groups.reduceItems(function(map, item) {
-      if (item instanceof Service) {
-        map[item.getName().toLowerCase()] = {
+      if (item instanceof Framework) {
+        map[item.getFrameworkName().toLowerCase()] = {
           health: item.getHealth(),
           images: item.getImages(),
           snapshot: item.get()

--- a/plugins/services/src/js/structs/Framework.js
+++ b/plugins/services/src/js/structs/Framework.js
@@ -8,13 +8,12 @@ import Application from "./Application";
 import FrameworkSpec from "./FrameworkSpec";
 
 module.exports = class Framework extends Application {
-  getName() {
-    const labels = this.getLabels();
-    if (labels && labels.DCOS_PACKAGE_FRAMEWORK_NAME) {
-      return labels.DCOS_PACKAGE_FRAMEWORK_NAME;
-    }
+  getPackageName() {
+    return this.getLabels().DCOS_PACKAGE_NAME;
+  }
 
-    return super.getName();
+  getFrameworkName() {
+    return this.getLabels().DCOS_PACKAGE_FRAMEWORK_NAME;
   }
 
   getNodeIDs() {

--- a/plugins/services/src/js/structs/__tests__/Framework-test.js
+++ b/plugins/services/src/js/structs/__tests__/Framework-test.js
@@ -45,24 +45,45 @@ describe("Framework", function() {
     });
   });
 
-  describe("#getName", function() {
+  describe("#getPackageName", function() {
     it("returns correct name", function() {
       const service = new Framework({
         id: "/test/framework",
         labels: {
-          DCOS_PACKAGE_FRAMEWORK_NAME: "Framework"
+          DCOS_PACKAGE_NAME: "Framework"
         }
       });
 
-      expect(service.getName()).toEqual("Framework");
+      expect(service.getPackageName()).toEqual("Framework");
     });
 
-    it("returns basename if framework name is undefined", function() {
+    it("returns undefined if package name is undefined", function() {
       const service = new Framework({
         id: "/test/framework"
       });
 
-      expect(service.getName()).toEqual("framework");
+      expect(service.getPackageName()).toEqual(undefined);
+    });
+  });
+
+  describe("#getFrameworkName", function() {
+    it("returns correct name", function() {
+      const service = new Framework({
+        id: "/test/framework",
+        labels: {
+          DCOS_PACKAGE_FRAMEWORK_NAME: "group/Framework"
+        }
+      });
+
+      expect(service.getFrameworkName()).toEqual("group/Framework");
+    });
+
+    it("returns undefined if package name is undefined", function() {
+      const service = new Framework({
+        id: "/test/framework"
+      });
+
+      expect(service.getFrameworkName()).toEqual(undefined);
     });
   });
 


### PR DESCRIPTION
This PR adresses an issue comming from improper Framework package name resolution.

## Running frameworks in groups

The reported issue was that one cannot run a catalog app in a group like `/group/blop/kafka`

> Full disclosure: that shouldn't be allowed to do at first place, and you can't run marathon in a group, but for some reason validation for at least `kafka` works the other way.

## Framework deletion dialog

While working on the fix for groups I discovered that our framework deletion dialog shows wrong information because of a bug in the framework package name discovery. That one is addressed as well.

## Testing

Go to the Catalog and click on kafka, then click Configure and change its name to something with groups like `/some/group/not-even-kafka` and launch it. It should work (consult the ticket regarding the current state) then try to delete kafka _not_ the group! In the dialog you should see `kafka` as a package name even though we change the name.

## Appendix

While fixing this I realised that if you just delete a group that contains a framework it will be just gone, no framework deletion dialog will be shown. I filed a separate JIRA for that.

## NB

```diff
- if (item instanceof Service) { 
+ if (item instanceof Framework) { 
```
may look confusing, but if you go to the history of the file you'll notice that it used to be for Frameworks and you you trace how the CompositeState is using this data you'll notice that it copies it over to `frameworks`. So it looks like it was long time broken but nobody really used the functionality.