### PR TITLE
fix(InstallPackageModal): add tighter constraints for auto-install

### DIFF
--- a/src/js/components/modals/InstallPackageModal.js
+++ b/src/js/components/modals/InstallPackageModal.js
@@ -79,6 +79,12 @@ class InstallPackageModal
   componentWillReceiveProps(nextProps) {
     super.componentWillReceiveProps(...arguments);
     const { props } = this;
+
+    // Return early if open prop did not change
+    if (props.open === nextProps.open) {
+      return;
+    }
+
     // If closing
     if (props.open && !nextProps.open) {
       this.internalStorage_set({
@@ -95,6 +101,8 @@ class InstallPackageModal
 
       return;
     }
+
+    // If opening
 
     if (nextProps.isBetaPackage) {
       this.setState({


### PR DESCRIPTION
**Problem:**
Package will attempt to auto-install if window is resized while viewing the package detail page.

**Solution:**
InstallPackageModal `#componentwillReceiveProps` get's called when browser resize occurs. We only care about setting new component state if modal is opening or closing. We do **not** care if the modal is not in a transition. So we return early in the method if the component is not in a state of "transition" [opening/closing].

**Testing:**
Navigate to package detail page from catalog and resize window. Package previously attempted to send an API request for install when resizing but it **should no longer do this**.

**Note:**
I would love to clean this component up including the logic in `#componentwillReceiveProps`, however we don't have time to boy-scout this one.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
