### PR TITLE
DCOS-16589: fix(MultiContainerNetwork): Adjust (JSON|Form)Reducer

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/MultiContainerNetwork.js
+++ b/plugins/services/src/js/reducers/serviceForm/MultiContainerNetwork.js
@@ -7,12 +7,24 @@ module.exports = {
     state = [{ mode: Networking.type.HOST.toLowerCase() }],
     { type, path, value }
   ) {
-    const index = path[1] || 0;
+    const [element, index = 0, field] = path;
 
     const newState = state.slice();
-    if (path[0] === "networks") {
+    if (element === "networks") {
       if (type === ADD_ITEM && index !== 0) {
         newState.push(value || { mode: Networking.type.HOST.toLowerCase() });
+
+        return newState;
+      }
+
+      if (type === SET && field === "name") {
+        newState[index].name = value;
+
+        return newState;
+      }
+
+      if (type === SET && field === "mode") {
+        newState[index].mode = value.toLowerCase();
 
         return newState;
       }
@@ -79,12 +91,24 @@ module.exports = {
   },
 
   FormReducer(state = [{ mode: Networking.type.HOST }], { type, path, value }) {
-    const index = path[1] || 0;
+    const [element, index = 0, field] = path;
 
     const newState = state.slice();
-    if (path[0] === "networks") {
+    if (element === "networks") {
       if (type === ADD_ITEM && index !== 0) {
-        newState.push({ mode: Networking.type.HOST });
+        newState.push(value || { mode: Networking.type.HOST });
+
+        return newState;
+      }
+
+      if (type === SET && field === "name") {
+        newState[index].name = value;
+
+        return newState;
+      }
+
+      if (type === SET && field === "mode") {
+        newState[index].mode = value;
 
         return newState;
       }

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerNetwork-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerNetwork-test.js
@@ -1,6 +1,7 @@
 const MultiContainerNetwork = require("../MultiContainerNetwork");
 const Networking = require("#SRC/js/constants/Networking");
 const Batch = require("#SRC/js/structs/Batch");
+const { ADD_ITEM } = require("#SRC/js/constants/TransactionTypes");
 const Transaction = require("#SRC/js/structs/Transaction");
 
 describe("MultiContainerNetwork", function() {
@@ -45,6 +46,53 @@ describe("MultiContainerNetwork", function() {
 
       expect(batch.reduce(MultiContainerNetwork.JSONReducer.bind({}))).toEqual([
         { mode: "host" }
+      ]);
+    });
+
+    it("creates the right network object", function() {
+      let batch = new Batch();
+
+      batch = batch.add(
+        new Transaction(
+          ["networks", 0],
+          { mode: Networking.type.CONTAINER, name: "foo" },
+          ADD_ITEM
+        )
+      );
+      batch = batch.add(
+        new Transaction(["networks", 0, "mode"], `${Networking.type.CONTAINER}`)
+      );
+      batch = batch.add(new Transaction(["networks", 0, "name"], "foo"));
+
+      expect(batch.reduce(MultiContainerNetwork.JSONReducer.bind({}))).toEqual([
+        {
+          mode: "container",
+          name: "foo"
+        }
+      ]);
+    });
+  });
+  describe("#FORMReducer", function() {
+    it("creates the right network object", function() {
+      let batch = new Batch();
+
+      batch = batch.add(
+        new Transaction(
+          ["networks", 0],
+          { mode: Networking.type.CONTAINER, name: "foo" },
+          ADD_ITEM
+        )
+      );
+      batch = batch.add(
+        new Transaction(["networks", 0, "mode"], `${Networking.type.CONTAINER}`)
+      );
+      batch = batch.add(new Transaction(["networks", 0, "name"], "foo"));
+
+      expect(batch.reduce(MultiContainerNetwork.FormReducer.bind({}))).toEqual([
+        {
+          mode: "CONTAINER",
+          name: "foo"
+        }
       ]);
     });
   });


### PR DESCRIPTION
... to handle name and mode transactions


The json and form reducer now also handles name and mode transactions which is fixing the behaviour
of the network select field and the name and the mode is set in a container network.
<details>
<summary>TEST this commit</summary>

- To test this commit go to the service create form
- Select Multi container
- Open JSON editor
- go to Network section
- Select Container network
- go to JSON editor change something
- Select field should stay on the `CONTAINER` network
- Go to Review screen
- Return to form
- Select field should still be right
- JSON should still contain mode and name
</details>

Closes DCOS-16589

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
