### PR TITLE
Change jest config to generate Cobertura coverage reports

### DIFF
--- a/jest/gen-config.js
+++ b/jest/gen-config.js
@@ -30,6 +30,7 @@ var config = {
     '/.module-cache/'
   ],
   'timers': 'fake',
+  'coverageReporters': ["json", "lcov", "cobertura", "text"],
   // We need this to override jest's default ['/node_modules/']
   'preprocessorIgnorePatterns' : [],
   'unmockedModulePathPatterns': [


### PR DESCRIPTION
Explicitly configure `coverageReporters ` to include the defaults  ("json", "lcov", "text") as well as `cobertura` to generate Cobertura coverage reports. This change will allow us to collect and publish code coverage metrics in Jenkins.

Closes DCOS-16515