### PR TITLE
DCOS-12615: autofocus service form

### DIFF
--- a/plugins/services/src/js/components/forms/ArtifactsSection.js
+++ b/plugins/services/src/js/components/forms/ArtifactsSection.js
@@ -5,6 +5,7 @@ import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
 import AddButton from "#SRC/js/components/form/AddButton";
 import DeleteRowButton from "#SRC/js/components/form/DeleteRowButton";
 import Icon from "#SRC/js/components/Icon";
+import FieldAutofocus from "#SRC/js/components/form/FieldAutofocus";
 import FieldError from "#SRC/js/components/form/FieldError";
 import FieldInput from "#SRC/js/components/form/FieldInput";
 import FieldLabel from "#SRC/js/components/form/FieldLabel";
@@ -66,11 +67,13 @@ class ArtifactsSection extends Component {
         <FormRow key={`${path}.${index}`}>
           <FormGroup className="column-12" showError={Boolean(error)}>
             {label}
-            <FieldInput
-              name={`${path}.${index}.uri`}
-              placeholder="http://example.com"
-              value={item.uri}
-            />
+            <FieldAutofocus>
+              <FieldInput
+                name={`${path}.${index}.uri`}
+                placeholder="http://example.com"
+                value={item.uri}
+              />
+            </FieldAutofocus>
             <FieldError>{error}</FieldError>
           </FormGroup>
           <FormGroup hasNarrowMargins={true} applyLabelOffset={index === 0}>

--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -4,6 +4,7 @@ import React, { Component } from "react";
 
 import AddButton from "#SRC/js/components/form/AddButton";
 import DeleteRowButton from "#SRC/js/components/form/DeleteRowButton";
+import FieldAutofocus from "#SRC/js/components/form/FieldAutofocus";
 import FieldError from "#SRC/js/components/form/FieldError";
 import FieldInput from "#SRC/js/components/form/FieldInput";
 import FieldLabel from "#SRC/js/components/form/FieldLabel";
@@ -57,7 +58,13 @@ class EnvironmentFormSection extends Component {
           <FormRow key={key}>
             <FormGroup className="column-6" required={false}>
               {keyLabel}
-              <FieldInput name={`env.${key}.key`} type="text" value={env.key} />
+              <FieldAutofocus>
+                <FieldInput
+                  name={`env.${key}.key`}
+                  type="text"
+                  value={env.key}
+                />
+              </FieldAutofocus>
               <span className="emphasis form-colon">:</span>
             </FormGroup>
             <FormGroup
@@ -117,11 +124,13 @@ class EnvironmentFormSection extends Component {
         <FormRow key={key}>
           <FormGroup className="column-6">
             {keyLabel}
-            <FieldInput
-              name={`labels.${key}.key`}
-              type="text"
-              value={label.key}
-            />
+            <FieldAutofocus>
+              <FieldInput
+                name={`labels.${key}.key`}
+                type="text"
+                value={label.key}
+              />
+            </FieldAutofocus>
             <span className="emphasis form-colon">:</span>
           </FormGroup>
           <FormGroup

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -10,6 +10,7 @@ import AdvancedSectionContent
   from "#SRC/js/components/form/AdvancedSectionContent";
 import AdvancedSectionLabel from "#SRC/js/components/form/AdvancedSectionLabel";
 import DeleteRowButton from "#SRC/js/components/form/DeleteRowButton";
+import FieldAutofocus from "#SRC/js/components/form/FieldAutofocus";
 import FieldError from "#SRC/js/components/form/FieldError";
 import FieldHelp from "#SRC/js/components/form/FieldHelp";
 import FieldInput from "#SRC/js/components/form/FieldInput";
@@ -354,12 +355,14 @@ class GeneralServiceFormSection extends Component {
             showError={Boolean(fieldNameError)}
           >
             {fieldLabel}
-            <FieldInput
-              name={`constraints.${index}.fieldName`}
-              type="text"
-              placeholder="hostname"
-              value={constraint.fieldName}
-            />
+            <FieldAutofocus>
+              <FieldInput
+                name={`constraints.${index}.fieldName`}
+                type="text"
+                placeholder="hostname"
+                value={constraint.fieldName}
+              />
+            </FieldAutofocus>
             <FieldError>{fieldNameError}</FieldError>
           </FormGroup>
           <FormGroup
@@ -585,7 +588,9 @@ class GeneralServiceFormSection extends Component {
                 </FormGroupHeadingContent>
               </FormGroupHeading>
             </FieldLabel>
-            <FieldInput name="id" type="text" value={data.id} />
+            <FieldAutofocus>
+              <FieldInput name="id" type="text" value={data.id} />
+            </FieldAutofocus>
             <FieldHelp>
               Give your service a unique name within the cluster, e.g. my-service.
             </FieldHelp>

--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -7,6 +7,7 @@ import AdvancedSection from "#SRC/js/components/form/AdvancedSection";
 import AdvancedSectionContent
   from "#SRC/js/components/form/AdvancedSectionContent";
 import AdvancedSectionLabel from "#SRC/js/components/form/AdvancedSectionLabel";
+import FieldAutofocus from "#SRC/js/components/form/FieldAutofocus";
 import FieldError from "#SRC/js/components/form/FieldError";
 import FieldInput from "#SRC/js/components/form/FieldInput";
 import FieldTextarea from "#SRC/js/components/form/FieldTextarea";
@@ -102,13 +103,15 @@ class HealthChecksFormSection extends Component {
                   </FormGroupHeadingContent>
                 </FormGroupHeading>
               </FieldLabel>
-              <FieldInput
-                name={`healthChecks.${key}.gracePeriodSeconds`}
-                type="number"
-                min="0"
-                placeholder="300"
-                value={healthCheck.gracePeriodSeconds}
-              />
+              <FieldAutofocus>
+                <FieldInput
+                  name={`healthChecks.${key}.gracePeriodSeconds`}
+                  type="number"
+                  min="0"
+                  placeholder="300"
+                  value={healthCheck.gracePeriodSeconds}
+                />
+              </FieldAutofocus>
               <FieldError>{errors.gracePeriodSeconds}</FieldError>
             </FormGroup>
             <FormGroup
@@ -227,11 +230,13 @@ class HealthChecksFormSection extends Component {
               </FormGroupHeadingContent>
             </FormGroupHeading>
           </FieldLabel>
-          <FieldTextarea
-            name={`healthChecks.${key}.command`}
-            type="text"
-            value={healthCheck.command}
-          />
+          <FieldAutofocus>
+            <FieldTextarea
+              name={`healthChecks.${key}.command`}
+              type="text"
+              value={healthCheck.command}
+            />
+          </FieldAutofocus>
           <FieldError>{errors.value}</FieldError>
         </FormGroup>
       </FormRow>
@@ -313,11 +318,13 @@ class HealthChecksFormSection extends Component {
               </FormGroupHeadingContent>
             </FormGroupHeading>
           </FieldLabel>
-          <FieldInput
-            name={`healthChecks.${key}.path`}
-            type="text"
-            value={healthCheck.path}
-          />
+          <FieldAutofocus>
+            <FieldInput
+              name={`healthChecks.${key}.path`}
+              type="text"
+              value={healthCheck.path}
+            />
+          </FieldAutofocus>
           <FieldError>{errors.path}</FieldError>
         </FormGroup>
       </FormRow>,

--- a/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import Objektiv from "objektiv";
 
 import AddButton from "#SRC/js/components/form/AddButton";
+import FieldAutofocus from "#SRC/js/components/form/FieldAutofocus";
 import FieldError from "#SRC/js/components/form/FieldError";
 import FieldInput from "#SRC/js/components/form/FieldInput";
 import FieldLabel from "#SRC/js/components/form/FieldLabel";
@@ -155,11 +156,13 @@ class MultiContainerVolumesFormSection extends Component {
                 </FormGroupHeadingContent>
               </FormGroupHeading>
             </FieldLabel>
-            <FieldInput
-              name={`volumeMounts.${key}.hostPath`}
-              type="text"
-              value={volumes.hostPath}
-            />
+            <FieldAutofocus>
+              <FieldInput
+                name={`volumeMounts.${key}.hostPath`}
+                type="text"
+                value={volumes.hostPath}
+              />
+            </FieldAutofocus>
           </FormGroup>
         </FormRow>
       );

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -6,6 +6,7 @@ import { StoreMixin } from "mesosphere-shared-reactjs";
 import { findNestedPropertyInObject, isObject } from "#SRC/js/utils/Util";
 import { SET } from "#SRC/js/constants/TransactionTypes";
 import AddButton from "#SRC/js/components/form/AddButton";
+import FieldAutofocus from "#SRC/js/components/form/FieldAutofocus";
 import FieldError from "#SRC/js/components/form/FieldError";
 import FieldHelp from "#SRC/js/components/form/FieldHelp";
 import FieldInput from "#SRC/js/components/form/FieldInput";
@@ -280,13 +281,15 @@ class NetworkingFormSection extends mixin(StoreMixin) {
               key="vip-port"
               showError={Boolean(vipPortError)}
             >
-              <FieldInput
-                min="1"
-                placeholder={placeholder}
-                name={`portDefinitions.${index}.vipPort`}
-                type="number"
-                value={vipPort}
-              />
+              <FieldAutofocus>
+                <FieldInput
+                  min="1"
+                  placeholder={placeholder}
+                  name={`portDefinitions.${index}.vipPort`}
+                  type="number"
+                  value={vipPort}
+                />
+              </FieldAutofocus>
             </FormGroup>
           </FormRow>
           <FormRow>
@@ -385,12 +388,14 @@ class NetworkingFormSection extends mixin(StoreMixin) {
         <FieldLabel>
           Container Port
         </FieldLabel>
-        <FieldInput
-          min="0"
-          name={`portDefinitions.${index}.containerPort`}
-          type="number"
-          value={portDefinition.containerPort}
-        />
+        <FieldAutofocus>
+          <FieldInput
+            min="0"
+            name={`portDefinitions.${index}.containerPort`}
+            type="number"
+            value={portDefinition.containerPort}
+          />
+        </FieldAutofocus>
         <FieldError>{containerPortError}</FieldError>
       </FormGroup>
     );
@@ -488,11 +493,13 @@ class NetworkingFormSection extends mixin(StoreMixin) {
                   </FormGroupHeadingContent>
                 </FormGroupHeading>
               </FieldLabel>
-              <FieldInput
-                name={`portDefinitions.${index}.name`}
-                type="text"
-                value={endpoint.name}
-              />
+              <FieldAutofocus>
+                <FieldInput
+                  name={`portDefinitions.${index}.name`}
+                  type="text"
+                  value={endpoint.name}
+                />
+              </FieldAutofocus>
               <FieldError>{nameError}</FieldError>
             </FormGroup>
             {this.getPortMappingCheckbox(endpoint, networkType, index)}

--- a/plugins/services/src/js/components/forms/VolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/VolumesFormSection.js
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import Objektiv from "objektiv";
 
 import AddButton from "#SRC/js/components/form/AddButton";
+import FieldAutofocus from "#SRC/js/components/form/FieldAutofocus";
 import FieldError from "#SRC/js/components/form/FieldError";
 import FieldInput from "#SRC/js/components/form/FieldInput";
 import FieldLabel from "#SRC/js/components/form/FieldLabel";
@@ -66,11 +67,13 @@ class VolumesFormSection extends Component {
               </FormGroupHeadingContent>
             </FormGroupHeading>
           </FieldLabel>
-          <FieldInput
-            name={`localVolumes.${key}.size`}
-            type="number"
-            value={volume.size}
-          />
+          <FieldAutofocus>
+            <FieldInput
+              name={`localVolumes.${key}.size`}
+              type="number"
+              value={volume.size}
+            />
+          </FieldAutofocus>
           <FieldError>{sizeError}</FieldError>
         </FormGroup>
         <FormGroup className="column-6" showError={Boolean(containerPathError)}>
@@ -135,10 +138,12 @@ class VolumesFormSection extends Component {
               </FormGroupHeadingContent>
             </FormGroupHeading>
           </FieldLabel>
-          <FieldInput
-            name={`localVolumes.${key}.hostPath`}
-            value={volume.hostPath}
-          />
+          <FieldAutofocus>
+            <FieldInput
+              name={`localVolumes.${key}.hostPath`}
+              value={volume.hostPath}
+            />
+          </FieldAutofocus>
           <FieldError>{hostPathError}</FieldError>
         </FormGroup>
         <FormGroup className="column-4" showError={Boolean(containerPathError)}>
@@ -296,11 +301,13 @@ class VolumesFormSection extends Component {
                   </FormGroupHeadingContent>
                 </FormGroupHeading>
               </FieldLabel>
-              <FieldInput
-                name={`externalVolumes.${key}.name`}
-                type="text"
-                value={volume.name}
-              />
+              <FieldAutofocus>
+                <FieldInput
+                  name={`externalVolumes.${key}.name`}
+                  type="text"
+                  value={volume.name}
+                />
+              </FieldAutofocus>
               <FieldError>{nameError}</FieldError>
             </FormGroup>
           </FormRow>

--- a/src/js/components/form/FieldAutofocus.js
+++ b/src/js/components/form/FieldAutofocus.js
@@ -11,7 +11,7 @@ class FieldAutofocus extends React.Component {
       return;
     }
     const input = DOMUtils.getInputElement(ReactDOM.findDOMNode(this));
-    if (!input) {
+    if (!input || input === document.activeElement) {
       return;
     }
     lockFieldAutofocus = true;

--- a/src/js/components/form/FieldAutofocus.js
+++ b/src/js/components/form/FieldAutofocus.js
@@ -3,7 +3,6 @@ import ReactDOM from "react-dom";
 import DOMUtils from "#SRC/js/utils/DOMUtils";
 
 let lockFieldAutofocus = false;
-const SUPPORTED_TYPES = ["FieldInput", "FieldTextarea", "input", "textarea"];
 
 class FieldAutofocus extends React.Component {
   componentDidMount() {
@@ -11,7 +10,7 @@ class FieldAutofocus extends React.Component {
       return;
     }
     const input = DOMUtils.getInputElement(ReactDOM.findDOMNode(this));
-    if (!input || input === document.activeElement) {
+    if (!input) {
       return;
     }
     lockFieldAutofocus = true;
@@ -27,19 +26,5 @@ class FieldAutofocus extends React.Component {
     return this.props.children;
   }
 }
-
-FieldAutofocus.propTypes = {
-  children(props, propName, componentName) {
-    const prop = props[propName];
-    if (
-      React.Children.count(prop) !== 1 ||
-      !SUPPORTED_TYPES.includes(prop.type.name)
-    ) {
-      return new Error(
-        `${componentName} should have a single child of the following types: ${SUPPORTED_TYPES.join(", ")}.`
-      );
-    }
-  }
-};
 
 module.exports = FieldAutofocus;

--- a/src/js/components/form/FieldAutofocus.js
+++ b/src/js/components/form/FieldAutofocus.js
@@ -1,0 +1,45 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import DOMUtils from "#SRC/js/utils/DOMUtils";
+
+let lockFieldAutofocus = false;
+const SUPPORTED_TYPES = ["FieldInput", "FieldTextarea", "input", "textarea"];
+
+class FieldAutofocus extends React.Component {
+  componentDidMount() {
+    if (lockFieldAutofocus) {
+      return;
+    }
+    const input = DOMUtils.getInputElement(ReactDOM.findDOMNode(this));
+    if (!input) {
+      return;
+    }
+    lockFieldAutofocus = true;
+    input.focus();
+
+    input.addEventListener("blur", function onBlurInput() {
+      lockFieldAutofocus = false;
+      this.removeEventListener("blur", onBlurInput);
+    });
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+FieldAutofocus.propTypes = {
+  children(props, propName, componentName) {
+    const prop = props[propName];
+    if (
+      React.Children.count(prop) !== 1 ||
+      !SUPPORTED_TYPES.includes(prop.type.name)
+    ) {
+      return new Error(
+        `${componentName} should have a single child of the following types: ${SUPPORTED_TYPES.join(", ")}.`
+      );
+    }
+  }
+};
+
+module.exports = FieldAutofocus;

--- a/src/js/plugin-bridge/PluginModules.js
+++ b/src/js/plugin-bridge/PluginModules.js
@@ -79,6 +79,7 @@ module.exports = {
     DetailViewHeader: "DetailViewHeader",
     DetailViewSectionHeading: "DetailViewSectionHeading",
     DCOSLogo: "DCOSLogo",
+    FieldAutofocus: "form/FieldAutofocus",
     FilterBar: "FilterBar",
     FilterButtons: "FilterButtons",
     FilterHeadline: "FilterHeadline",

--- a/src/js/utils/DOMUtils.js
+++ b/src/js/utils/DOMUtils.js
@@ -194,6 +194,20 @@ var DOMUtils = {
     const parentTop = parentNode.getBoundingClientRect().top;
 
     return elTop - parentTop;
+  },
+
+  getInputElement(node) {
+    if (!node || !(node instanceof HTMLElement)) {
+      return null;
+    }
+    const inputTypes = ["input", "textarea"];
+    if (inputTypes.includes(node.nodeName.toLowerCase())) {
+      return node;
+    } else {
+      node = node.querySelector(inputTypes.join(", "));
+    }
+
+    return node;
   }
 };
 

--- a/src/js/utils/__tests__/DOMUtils-test.js
+++ b/src/js/utils/__tests__/DOMUtils-test.js
@@ -283,4 +283,65 @@ describe("DOMUtils", function() {
       this.element.parentNode = prevParentNode;
     });
   });
+
+  describe("#getInputElement", function() {
+    function buildElementWithNoInput() {
+      global.document.body.innerHTML = "<div><span>Only text here</span></div>";
+
+      return global.document.body.querySelector("div");
+    }
+    function buildElementInput() {
+      global.document.body.innerHTML =
+        "<div><span><input type='text' /></span></div>";
+
+      return global.document.body.querySelector("div");
+    }
+    function buildElementTextarea() {
+      global.document.body.innerHTML =
+        "<div><span><textarea></textarea></span></div>";
+
+      return global.document.body.querySelector("div");
+    }
+
+    const input = buildElementInput();
+    const textarea = buildElementTextarea();
+
+    it("returns null if DOM element is without an input/ textarea", function() {
+      expect(DOMUtils.getInputElement(buildElementWithNoInput())).toEqual(null);
+    });
+
+    it("returns null if empty string is entered", function() {
+      expect(DOMUtils.getInputElement("")).toEqual(null);
+    });
+    it("returns null if a string is entered", function() {
+      expect(DOMUtils.getInputElement("asdf")).toEqual(null);
+    });
+    it("returns null if an array is entered", function() {
+      expect(DOMUtils.getInputElement([1, 2, 3])).toEqual(null);
+    });
+    it("returns null if null entered", function() {
+      expect(null).toEqual(null);
+    });
+
+    it("returns input element if DOM element is an input", function() {
+      const returnValue = DOMUtils.getInputElement(
+        input.querySelector("input")
+      );
+      expect(returnValue.nodeName.toLowerCase()).toEqual("input");
+    });
+    it("returns textarea element if DOM element is an textarea", function() {
+      const returnValue = DOMUtils.getInputElement(
+        textarea.querySelector("textarea")
+      );
+      expect(returnValue.nodeName.toLowerCase()).toEqual("textarea");
+    });
+    it("returns input element if DOM element has an input", function() {
+      const returnValue = DOMUtils.getInputElement(input);
+      expect(returnValue.nodeName.toLowerCase()).toEqual("input");
+    });
+    it("returns textarea element if DOM element has an textarea", function() {
+      const returnValue = DOMUtils.getInputElement(textarea);
+      expect(returnValue.nodeName.toLowerCase()).toEqual("textarea");
+    });
+  });
 });

--- a/src/js/utils/__tests__/DOMUtils-test.js
+++ b/src/js/utils/__tests__/DOMUtils-test.js
@@ -302,9 +302,16 @@ describe("DOMUtils", function() {
 
       return global.document.body.querySelector("div");
     }
+    function buildElementWithTwoTextareas() {
+      global.document.body.innerHTML =
+        "<div><span><textarea></textarea><textarea></textarea></span></div>";
+
+      return global.document.body.querySelector("div");
+    }
 
     const input = buildElementInput();
     const textarea = buildElementTextarea();
+    const textareas = buildElementWithTwoTextareas();
 
     it("returns null if DOM element is without an input/ textarea", function() {
       expect(DOMUtils.getInputElement(buildElementWithNoInput())).toEqual(null);
@@ -341,6 +348,10 @@ describe("DOMUtils", function() {
     });
     it("returns textarea element if DOM element has an textarea", function() {
       const returnValue = DOMUtils.getInputElement(textarea);
+      expect(returnValue.nodeName.toLowerCase()).toEqual("textarea");
+    });
+    it("returns textarea element if DOM element has two textareas", function() {
+      const returnValue = DOMUtils.getInputElement(textareas);
       expect(returnValue.nodeName.toLowerCase()).toEqual("textarea");
     });
   });

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1082,11 +1082,6 @@ describe("Service Form Modal", function() {
               .select("CONTAINER.dcos-1");
 
             cy
-              .focused()
-              .should("have.attr", "name")
-              .and("eq", "portDefinitions.0.containerPort");
-
-            cy
               .get("@tabView")
               .find('.form-control[name="portDefinitions.0.containerPort"]')
               .should("exist");

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -397,7 +397,11 @@ describe("Service Form Modal", function() {
       beforeEach(function() {
         // Edit form
         cy.contains(".form-group", "Service ID").within(function() {
-          cy.get("input.form-control").clear().type("/test-back-button-prompt");
+          cy
+            .get("input.form-control")
+            .focus()
+            .clear()
+            .type("/test-back-button-prompt");
         });
       });
 

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -40,6 +40,12 @@ describe("Service Form Modal", function() {
         cy.get(".modal-full-screen").should("to.have.length", 1);
       });
 
+      it("Should Autofocus on the Service ID input field", function() {
+        openServiceModal();
+        openServiceForm();
+        cy.focused().should("have.attr", "name").and("eq", "id");
+      });
+
       it("contains the right group id in the form modal", function() {
         openServiceModal();
         openServiceForm();
@@ -636,6 +642,11 @@ describe("Service Form Modal", function() {
           .click();
 
         cy
+          .focused()
+          .should("have.attr", "name")
+          .and("eq", "constraints.0.fieldName");
+
+        cy
           .get('.menu-tabbed-view input[name="constraints.0.fieldName"')
           .should(function($inputElement) {
             const $wrappingLabel = $inputElement.closest(".form-group");
@@ -777,6 +788,10 @@ describe("Service Form Modal", function() {
             .get("@tabView")
             .find('.form-control[name="fetch.0.uri"]')
             .should("exist");
+        });
+
+        it("Should Autofocus on the first input element of the Artifact", function() {
+          cy.focused().should("have.attr", "name").and("eq", "fetch.0.uri");
         });
 
         it("Should remove row when remove button clicked", function() {
@@ -930,6 +945,13 @@ describe("Service Form Modal", function() {
           cy.get(".menu-tabbed-view").as("tabView");
         });
 
+        it("Should Autofocus on the service endpoint name", function() {
+          cy
+            .focused()
+            .should("have.attr", "name")
+            .and("eq", "portDefinitions.0.name");
+        });
+
         it('Should add new set of form fields when "Add Service Endpoint" link clicked', function() {
           cy
             .get("@tabView")
@@ -1023,6 +1045,11 @@ describe("Service Form Modal", function() {
             cy.get('select[name="networks.0.network"]').select("BRIDGE");
 
             cy
+              .focused()
+              .should("have.attr", "name")
+              .and("eq", "portDefinitions.0.containerPort");
+
+            cy
               .get("@tabView")
               .find('.form-control[name="portDefinitions.0.containerPort"]')
               .should("exist");
@@ -1059,6 +1086,11 @@ describe("Service Form Modal", function() {
             cy
               .get('select[name="networks.0.network"]')
               .select("CONTAINER.dcos-1");
+
+            cy
+              .focused()
+              .should("have.attr", "name")
+              .and("eq", "portDefinitions.0.containerPort");
 
             cy
               .get("@tabView")
@@ -1170,6 +1202,11 @@ describe("Service Form Modal", function() {
             .find('select[name="localVolumes.0.type"]')
             .select("PERSISTENT");
 
+          cy
+            .focused()
+            .should("have.attr", "name")
+            .and("eq", "localVolumes.0.size");
+
           // Size input
           cy
             .get("@tabView")
@@ -1209,6 +1246,11 @@ describe("Service Form Modal", function() {
         });
 
         it('Should add new set of form fields when "Add External Volume" link clicked', function() {
+          // Name input focused
+          cy
+            .focused()
+            .should("have.attr", "name")
+            .and("eq", "externalVolumes.0.name");
           // Name input
           cy
             .get("@tabView")
@@ -1286,6 +1328,12 @@ describe("Service Form Modal", function() {
             cy.get("select").select("COMMAND");
           });
 
+        // Command input focused
+        cy
+          .focused()
+          .should("have.attr", "name")
+          .and("eq", "healthChecks.0.command");
+
         // Command input
         cy
           .get("@tabView")
@@ -1337,6 +1385,12 @@ describe("Service Form Modal", function() {
             });
 
           toggleAdvancedHealthCheckSettings();
+
+          // Grace Period focused
+          cy
+            .focused()
+            .should("have.attr", "name")
+            .and("eq", "healthChecks.0.gracePeriodSeconds");
 
           // Grace Period
           cy
@@ -1420,6 +1474,8 @@ describe("Service Form Modal", function() {
         });
 
         it('Should add new set of form fields when "Add Environment Variable" link clicked', function() {
+          // Key focused
+          cy.focused().should("have.attr", "name").and("eq", "env.0.key");
           // Key
           cy
             .get("@tabView")
@@ -1452,6 +1508,8 @@ describe("Service Form Modal", function() {
         });
 
         it('Should add new set of form fields when "Add Label" link clicked', function() {
+          // Key focused
+          cy.focused().should("have.attr", "name").and("eq", "labels.0.key");
           // Key
           cy
             .get("@tabView")

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1014,11 +1014,6 @@ describe("Service Form Modal", function() {
 
             cy
               .get("@tabView")
-              .find('.form-control[name="portDefinitions.0.containerPort"]')
-              .should("not.exist");
-
-            cy
-              .get("@tabView")
               .find('.form-control[name="portDefinitions.0.name"]')
               .should("exist");
 
@@ -1047,11 +1042,6 @@ describe("Service Form Modal", function() {
         context("type: BRIDGE", function() {
           it('should show "Container Port" and "Protocol"', function() {
             cy.get('select[name="networks.0.network"]').select("BRIDGE");
-
-            cy
-              .focused()
-              .should("have.attr", "name")
-              .and("eq", "portDefinitions.0.containerPort");
 
             cy
               .get("@tabView")
@@ -1206,11 +1196,6 @@ describe("Service Form Modal", function() {
             .find('select[name="localVolumes.0.type"]')
             .select("PERSISTENT");
 
-          cy
-            .focused()
-            .should("have.attr", "name")
-            .and("eq", "localVolumes.0.size");
-
           // Size input
           cy
             .get("@tabView")
@@ -1332,12 +1317,6 @@ describe("Service Form Modal", function() {
             cy.get("select").select("COMMAND");
           });
 
-        // Command input focused
-        cy
-          .focused()
-          .should("have.attr", "name")
-          .and("eq", "healthChecks.0.command");
-
         // Command input
         cy
           .get("@tabView")
@@ -1389,12 +1368,6 @@ describe("Service Form Modal", function() {
             });
 
           toggleAdvancedHealthCheckSettings();
-
-          // Grace Period focused
-          cy
-            .focused()
-            .should("have.attr", "name")
-            .and("eq", "healthChecks.0.gracePeriodSeconds");
 
           // Grace Period
           cy


### PR DESCRIPTION
This component is introduced for autofocusing input/ textarea fields.

Usage
```
<FieldAutofocus>
  <FieldInput name="id" type="text" value={data.id} />
</FieldAutofocus>
```

Once the FieldInput, FieldTextarea, input or textarea element is mounted, the document will focus on this element.
If another element with the FieldAutofocus container is already focused it won't focus on that element.

The FieldAutofocus is implemented on the NewCreateServiceModalForm for the Services Form Modal.

Closes DCOS-12615, DCOS-12613

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [x] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
