### PR TITLE
fix(DCOS-11519): correct alignment of form labels with tooltips

### DIFF
--- a/src/styles/components/form-elements/form-group/styles.less
+++ b/src/styles/components/form-elements/form-group/styles.less
@@ -29,6 +29,10 @@
           text-overflow: ellipsis;
           white-space: nowrap;
         }
+
+        .tooltip-wrapper {
+          max-height: 0.9rem;
+        }
       }
     }
   }

--- a/src/styles/components/form-elements/form-group/styles.less
+++ b/src/styles/components/form-elements/form-group/styles.less
@@ -31,7 +31,7 @@
         }
 
         .tooltip-wrapper {
-          max-height: 0.9rem;
+          max-height: @tooltip-font-size;
         }
       }
     }


### PR DESCRIPTION
This PR fixes a spacing issue with form elements with tooltips. 

**Fix:**
I think this is the best solution. It targets the specific use of tooltips in form headings
and sets the max-height to match the label font-size, which looks like it's always 0.9rem set by canvas. 

**Before: (misalignment of service id and container image sections)**
![screen shot 2017-07-05 at 10 53 02 am](https://user-images.githubusercontent.com/1527504/27877640-4e00e0ca-6170-11e7-9da2-b4bb5b8ca47f.png)

**After:**
![screen shot 2017-07-05 at 10 51 02 am](https://user-images.githubusercontent.com/1527504/27877620-3f630f16-6170-11e7-89d9-c86d6c72acc4.png)

**Testing**:
Open create service form. Look around the rest of the UI for regression. Toggle browser window size, and check mobile user agent.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
