### PR TITLE
WIP: DCOS-12615: autofocus service form

### DIFF
--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -10,6 +10,7 @@ import AdvancedSectionContent
   from "#SRC/js/components/form/AdvancedSectionContent";
 import AdvancedSectionLabel from "#SRC/js/components/form/AdvancedSectionLabel";
 import DeleteRowButton from "#SRC/js/components/form/DeleteRowButton";
+import FieldAutofocus from "#SRC/js/components/form/FieldAutofocus";
 import FieldError from "#SRC/js/components/form/FieldError";
 import FieldHelp from "#SRC/js/components/form/FieldHelp";
 import FieldInput from "#SRC/js/components/form/FieldInput";
@@ -585,7 +586,9 @@ class GeneralServiceFormSection extends Component {
                 </FormGroupHeadingContent>
               </FormGroupHeading>
             </FieldLabel>
-            <FieldInput name="id" type="text" value={data.id} />
+            <FieldAutofocus>
+              <FieldInput name="id" type="text" value={data.id} />
+            </FieldAutofocus>
             <FieldHelp>
               Give your service a unique name within the cluster, e.g. my-service.
             </FieldHelp>

--- a/src/js/components/form/FieldAutofocus.js
+++ b/src/js/components/form/FieldAutofocus.js
@@ -1,0 +1,45 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import DOMUtils from "#SRC/js/utils/DOMUtils";
+
+let lockFieldAutofocus = false;
+const SUPPORTED_TYPES = ["FieldInput", "FieldTextarea", "input", "textarea"];
+
+class FieldAutofocus extends React.Component {
+  componentDidMount() {
+    if (lockFieldAutofocus) {
+      return;
+    }
+    const input = DOMUtils.getInputElement(ReactDOM.findDOMNode(this));
+    if (!input) {
+      return;
+    }
+    lockFieldAutofocus = true;
+    input.focus();
+
+    input.addEventListener("blur", function onBlurInput() {
+      lockFieldAutofocus = false;
+      this.removeEventListener("blur", onBlurInput);
+    });
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+FieldAutofocus.propTypes = {
+  children(props, propName, componentName) {
+    const prop = props[propName];
+    if (
+      React.Children.count(prop) !== 1 ||
+      !SUPPORTED_TYPES.includes(prop.type.name)
+    ) {
+      return new Error(
+        `${componentName} should have a single child of the following types: ${SUPPORTED_TYPES.join(", ")}.`
+      );
+    }
+  }
+};
+
+module.exports = FieldAutofocus;

--- a/src/js/utils/DOMUtils.js
+++ b/src/js/utils/DOMUtils.js
@@ -194,6 +194,26 @@ var DOMUtils = {
     const parentTop = parentNode.getBoundingClientRect().top;
 
     return elTop - parentTop;
+  },
+
+  /**
+   * Gets an input or textarea element from an HTML Element.
+   *
+   * @param {HTMLElement} node HTML Element that is or includes an input/ textarea.
+   * @return {HTMLElement} the input/ textarea element.
+   */
+  getInputElement(node) {
+    if (!node || !(node instanceof HTMLElement)) {
+      return null;
+    }
+    const inputTypes = ["input", "textarea"];
+    if (inputTypes.includes(node.nodeName.toLowerCase())) {
+      return node;
+    } else {
+      node = node.querySelector(inputTypes.join(", "));
+    }
+
+    return node;
   }
 };
 

--- a/src/js/utils/__tests__/DOMUtils-test.js
+++ b/src/js/utils/__tests__/DOMUtils-test.js
@@ -283,4 +283,64 @@ describe("DOMUtils", function() {
       this.element.parentNode = prevParentNode;
     });
   });
+  describe("#getInputElement", function() {
+    function buildElementWithNoInput() {
+      global.document.body.innerHTML = "<div><span>Only text here</span></div>";
+
+      return global.document.body.querySelector("div");
+    }
+    function buildElementInput() {
+      global.document.body.innerHTML =
+        "<div><span><input type='text' /></span></div>";
+
+      return global.document.body.querySelector("div");
+    }
+    function buildElementTextarea() {
+      global.document.body.innerHTML =
+        "<div><span><textarea></textarea></span></div>";
+
+      return global.document.body.querySelector("div");
+    }
+
+    const input = buildElementInput();
+    const textarea = buildElementTextarea();
+
+    it("returns null if DOM element is without an input/ textarea", function() {
+      expect(DOMUtils.getInputElement(buildElementWithNoInput())).toEqual(null);
+    });
+
+    it("returns null if empty string is entered", function() {
+      expect(DOMUtils.getInputElement("")).toEqual(null);
+    });
+    it("returns null if a string is entered", function() {
+      expect(DOMUtils.getInputElement("asdf")).toEqual(null);
+    });
+    it("returns null if an array is entered", function() {
+      expect(DOMUtils.getInputElement([1, 2, 3])).toEqual(null);
+    });
+    it("returns null if null entered", function() {
+      expect(null).toEqual(null);
+    });
+
+    it("returns input element if DOM element is an input", function() {
+      const returnValue = DOMUtils.getInputElement(
+        input.querySelector("input")
+      );
+      expect(returnValue.nodeName.toLowerCase()).toEqual("input");
+    });
+    it("returns textarea element if DOM element is an textarea", function() {
+      const returnValue = DOMUtils.getInputElement(
+        textarea.querySelector("textarea")
+      );
+      expect(returnValue.nodeName.toLowerCase()).toEqual("textarea");
+    });
+    it("returns input element if DOM element has an input", function() {
+      const returnValue = DOMUtils.getInputElement(input);
+      expect(returnValue.nodeName.toLowerCase()).toEqual("input");
+    });
+    it("returns textarea element if DOM element has an textarea", function() {
+      const returnValue = DOMUtils.getInputElement(textarea);
+      expect(returnValue.nodeName.toLowerCase()).toEqual("textarea");
+    });
+  });
 });


### PR DESCRIPTION
This is WIP for the autofocus service form.

This component is introduced for autofocusing input/ textarea fields.

Usage
```
<FieldAutofocus>
  <FieldInput name="id" type="text" value={data.id} />
</FieldAutofocus>
```

Once the FieldInput, FieldTextarea, input or textarea element is mounted, the document will focus on this element.
If another element with the FieldAutofocus container is already focused it won't focus on that element.

The FieldAutofocus is implemented on the NewCreateServiceModalForm for the Services Form Modal.

Closes DCOS-12615, DCOS-12613

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [x] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
