### PR TITLE
fix(DCOS_OSS-1287): update broken container docs link

### DIFF
--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -13,7 +13,6 @@ import FormGroupHeadingContent
   from "#SRC/js/components/form/FormGroupHeadingContent";
 import FormRow from "#SRC/js/components/form/FormRow";
 import Icon from "#SRC/js/components/Icon";
-import MetadataStore from "#SRC/js/stores/MetadataStore";
 
 import {
   FormReducer as ContainerReducer
@@ -97,9 +96,7 @@ class ContainerServiceFormSection extends Component {
           " to find more. You can also enter an image from your private registry. "
         }
         <a
-          href={MetadataStore.buildDocsURI(
-            "/usage/tutorials/registry/#docs-article"
-          )}
+          href="https://github.com/dcos/examples/tree/master/registry/1.8"
           target="_blank"
         >
           More information


### PR DESCRIPTION
Updated using [this](https://github.com/dcos/dcos-website/blob/develop/redirect-files) mapping. Test this PR by navigating to create a service, and hover over the "container image" tooltip, then clicking the link to the docs within this tooltip.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
