### PR TITLE
fix(react@15): Address unsupported attributes warnings

### DIFF
--- a/src/js/components/Image.js
+++ b/src/js/components/Image.js
@@ -2,8 +2,6 @@ import classNames from "classnames/dedupe";
 import React from "react";
 import ReactDOM from "react-dom";
 
-import Util from "../utils/Util";
-
 const METHODS_TO_BIND = ["onImageError"];
 
 class Image extends React.Component {
@@ -57,17 +55,13 @@ class Image extends React.Component {
     );
 
     return (
-      <img
-        className={classes}
-        onError={this.onImageError}
-        {...Util.omit(props, ["className"])}
-      />
+      <img src={props.src} className={classes} onError={this.onImageError} />
     );
   }
 }
 
 Image.propTypes = {
-  src: React.PropTypes.string,
+  src: React.PropTypes.string.required,
   fallbackSrc: React.PropTypes.string,
 
   // Classes

--- a/src/js/components/TimeAgo.js
+++ b/src/js/components/TimeAgo.js
@@ -1,7 +1,6 @@
 import React from "react";
 
 import DateUtil from "../utils/DateUtil";
-import Util from "../utils/Util";
 
 const SECOND = 1000;
 const MINUTE = 60 * MINUTE;
@@ -71,9 +70,9 @@ class TimeAgo extends React.Component {
 
     return (
       <time
+        className={this.props.className}
         title={DateUtil.msToUTCDate(time)}
         dateTime={DateUtil.msToUTCDate(time)}
-        {...Util.omit(this.props, ["prefix", "suppressSuffix", "time"])}
       >
         {prefixString}{relativeTime}
       </time>
@@ -88,6 +87,7 @@ TimeAgo.defaultProps = {
 
 TimeAgo.propTypes = {
   autoUpdate: React.PropTypes.bool,
+  className: React.PropTypes.string,
   prefix: React.PropTypes.node,
   suppressSuffix: React.PropTypes.bool,
   time: React.PropTypes.oneOfType([


### PR DESCRIPTION
This is a dcos-ui part of addressing react@15 wrong html attributes warnings.
`reactjs-components` part: https://github.com/mesosphere/reactjs-components/pull/407

They can totally go separately.