### PR TITLE
DCOS-16606: Fix the multi-container network config edit link

### DIFF
--- a/plugins/services/src/js/service-configuration/PodNetworkConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodNetworkConfigSection.js
@@ -104,7 +104,7 @@ class PodNetworkConfigSection extends React.Component {
             />
             <ConfigurationMapEditAction
               onEditClick={onEditClick}
-              tabViewID="multinetworking"
+              tabViewID="networking"
             />
           </ConfigurationMapRow>
 
@@ -117,7 +117,7 @@ class PodNetworkConfigSection extends React.Component {
             columns={this.getColumns()}
             data={endpoints}
             onEditClick={onEditClick}
-            tabViewID="multinetworking"
+            tabViewID="networking"
           />
 
         </ConfigurationMapSection>

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1678,5 +1678,19 @@ describe("Service Form Modal", function() {
         .siblings()
         .should("to.have.length", 2);
     });
+
+    it("Should show network form when clicking on Network Configuration Edit", function() {
+      cy.get(".menu-tabbed-item").contains("Networking").click();
+      cy.get(".menu-tabbed-view .button.button-primary-link").first().click();
+      cy.get('input[name="containers.0.endpoints.0.name"]').type("test");
+      // Click review and run
+      cy
+        .get(".modal-full-screen-actions")
+        .contains("button", "Review & Run")
+        .click();
+      // Click edit to view form
+      cy.get("a.button.button-link").eq(-1).click({ force: true });
+      cy.get(".menu-tabbed-view").contains("Networking");
+    });
   });
 });


### PR DESCRIPTION
Fix for the multi-container network config edit link.

Network "Edit" links don't work on the Multi-container Review screen.

Closes DCOS-16606

![review-network-edit-link-broken mov](https://user-images.githubusercontent.com/180432/27957822-6576c34e-6320-11e7-8d21-607eef514b73.gif)


**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [x] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
