### PR TITLE
fix(DCOS-16539): Fix incorrect tooltip state on health check

### DIFF
--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -322,15 +322,11 @@ class TaskTable extends React.Component {
 
     const dangerState = TaskStates[state].stateTypes.includes("failure");
     const activeState = TaskStates[state].stateTypes.includes("active");
+    const transitional = ["TASK_KILLING"].includes(state);
 
     const healthy = task.health === TaskHealthStates.HEALTHY;
     const unhealthy = task.health === TaskHealthStates.UNHEALTHY;
     const unknown = task.health === TaskHealthStates.UNKNOWN;
-
-    const failing = ["TASK_ERROR", "TASK_FAILED", "TASK_KILLING"].includes(
-      state
-    );
-    const running = ["TASK_RUNNING", "TASK_STARTING"].includes(state);
 
     let tooltipContent = TaskHealthStates.HEALTHY;
 
@@ -338,14 +334,17 @@ class TaskTable extends React.Component {
       tooltipContent = TaskHealthStates.UNHEALTHY;
     }
 
-    if (!activeState || unknown || failing) {
+    if (!activeState || unknown || transitional) {
       tooltipContent = "No health checks available";
     }
+
+    const failing = ["TASK_ERROR", "TASK_FAILED"].includes(state);
+    const running = ["TASK_RUNNING", "TASK_STARTING"].includes(state);
 
     const statusClass = classNames({
       dot: true,
       flush: true,
-      inactive: !activeState,
+      inactive: !activeState || transitional,
       success: healthy && running,
       running: unknown && running,
       danger: dangerState || unhealthy || failing

--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -322,7 +322,7 @@ class TaskTable extends React.Component {
 
     const dangerState = TaskStates[state].stateTypes.includes("failure");
     const activeState = TaskStates[state].stateTypes.includes("active");
-    const transitional = ["TASK_KILLING"].includes(state);
+    const transitional = ["TASK_KILLING", "TASK_STARTING", "TASK_STAGING"].includes(state);
 
     const healthy = task.health === TaskHealthStates.HEALTHY;
     const unhealthy = task.health === TaskHealthStates.UNHEALTHY;

--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -327,18 +327,20 @@ class TaskTable extends React.Component {
     const unhealthy = task.health === TaskHealthStates.UNHEALTHY;
     const unknown = task.health === TaskHealthStates.UNKNOWN;
 
+    const failing = ["TASK_ERROR", "TASK_FAILED", "TASK_KILLING"].includes(
+      state
+    );
+    const running = ["TASK_RUNNING", "TASK_STARTING"].includes(state);
+
     let tooltipContent = TaskHealthStates.HEALTHY;
 
     if (unhealthy) {
       tooltipContent = TaskHealthStates.UNHEALTHY;
     }
 
-    if (!activeState || unknown) {
+    if (!activeState || unknown || failing) {
       tooltipContent = "No health checks available";
     }
-
-    const failing = ["TASK_ERROR", "TASK_FAILED"].includes(state);
-    const running = ["TASK_RUNNING", "TASK_STARTING"].includes(state);
 
     const statusClass = classNames({
       dot: true,

--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -322,7 +322,11 @@ class TaskTable extends React.Component {
 
     const dangerState = TaskStates[state].stateTypes.includes("failure");
     const activeState = TaskStates[state].stateTypes.includes("active");
-    const transitional = ["TASK_KILLING", "TASK_STARTING", "TASK_STAGING"].includes(state);
+    const transitional = [
+      "TASK_KILLING",
+      "TASK_STARTING",
+      "TASK_STAGING"
+    ].includes(state);
 
     const healthy = task.health === TaskHealthStates.HEALTHY;
     const unhealthy = task.health === TaskHealthStates.UNHEALTHY;


### PR DESCRIPTION
**DCOS-16539**

Fix tooltip on health status when state is `killing`.

Steps to reproduce the issue:
Create a service with a health check where is `healthy` 
Then suspend the service
Now the `status` should be `killing` and the health should be `red dot` but with `Healthy` on the tooltip.

**before**
<img width="1151" alt="screen shot 2017-06-29 at 11 26 47" src="https://user-images.githubusercontent.com/549394/28019553-a5ec949a-6581-11e7-9a1d-ef53efec4ad8.png">

**after**
<img width="517" alt="screen shot 2017-07-10 at 5 07 37 pm" src="https://user-images.githubusercontent.com/549394/28025061-a254ffd2-6592-11e7-97a8-5c1b646fc3ff.png">



**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
