### PR TITLE
feat(ServiceConfiguration) Make edit button in service configuration visible

### DIFF
--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -90,12 +90,6 @@ class ServiceConfiguration extends mixin(StoreMixin) {
   }
 
   getVersionsActions() {
-    const versions = this.props.service.getVersions();
-
-    if (versions.size < 2) {
-      return null;
-    }
-
     return (
       <div className="pod flush-top flush-right flush-left">
         <div className="button-collection">
@@ -109,9 +103,19 @@ class ServiceConfiguration extends mixin(StoreMixin) {
   getRollbackButtons() {
     const { service } = this.props;
     const { selectedVersionID } = this.state;
+    let applyButton = null;
 
-    if (service.getVersion() === selectedVersionID) {
-      return null;
+    if (service.getVersion() !== selectedVersionID) {
+      applyButton = (
+        <button
+          className="button button-stroke"
+          disabled={isSDKService(service)}
+          key="version-button-apply"
+          onClick={() => this.handleApplyButtonClick()}
+        >
+          Apply
+        </button>
+      );
     }
 
     return [
@@ -123,20 +127,17 @@ class ServiceConfiguration extends mixin(StoreMixin) {
       >
         Edit
       </button>,
-      <button
-        className="button button-stroke"
-        disabled={isSDKService(service)}
-        key="version-button-apply"
-        onClick={() => this.handleApplyButtonClick()}
-      >
-        Apply
-      </button>
+      applyButton
     ];
   }
 
   getVersionsDropdown() {
     const { service } = this.props;
     const versions = service.getVersions();
+
+    if (versions.size < 2) {
+      return null;
+    }
 
     const versionItems = Array.from(versions.keys())
       .sort((a, b) => {

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -135,10 +135,6 @@ class ServiceConfiguration extends mixin(StoreMixin) {
     const { service } = this.props;
     const versions = service.getVersions();
 
-    if (versions.size < 2) {
-      return null;
-    }
-
     const versionItems = Array.from(versions.keys())
       .sort((a, b) => {
         return new Date(a) - new Date(b);

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -202,13 +202,21 @@ class ServiceConfiguration extends mixin(StoreMixin) {
     );
   }
 
+  getLoader() {
+    return (
+      <div className="container">
+        <Loader />
+      </div>
+    );
+  }
+
   render() {
     const { errors, service } = this.props;
     const { selectedVersionID } = this.state;
     const config = service.getVersions().get(selectedVersionID);
 
     if (config == null) {
-      return <Loader />;
+      return this.getLoader();
     }
 
     return (

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -108,7 +108,7 @@ class ServiceConfiguration extends mixin(StoreMixin) {
     if (service.getVersion() !== selectedVersionID) {
       applyButton = (
         <button
-          className="button button-stroke"
+          className="button button-primary-link"
           disabled={isSDKService(service)}
           key="version-button-apply"
           onClick={() => this.handleApplyButtonClick()}
@@ -120,7 +120,7 @@ class ServiceConfiguration extends mixin(StoreMixin) {
 
     return [
       <button
-        className="button button-stroke"
+        className="button button-primary-link"
         disabled={isSDKService(service)}
         key="version-button-edit"
         onClick={() => this.handleEditButtonClick()}

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -103,12 +103,7 @@ class ServiceConfiguration extends mixin(StoreMixin) {
   getRollbackButtons() {
     const { service } = this.props;
     const { selectedVersionID } = this.state;
-    const config = service.getVersions().get(selectedVersionID);
     let applyButton = null;
-
-    if (config == null) {
-      return null;
-    }
 
     if (service.getVersion() !== selectedVersionID) {
       applyButton = (
@@ -215,18 +210,15 @@ class ServiceConfiguration extends mixin(StoreMixin) {
     const { errors, service } = this.props;
     const { selectedVersionID } = this.state;
     const config = service.getVersions().get(selectedVersionID);
-    let content = null;
 
     if (config == null) {
-      content = <Loader />;
-    } else {
-      content = <ServiceConfigDisplay appConfig={config} errors={errors} />;
+      return <Loader />;
     }
 
     return (
       <div className="container">
         {this.getVersionsActions()}
-        {content}
+        <ServiceConfigDisplay appConfig={config} errors={errors} />
       </div>
     );
   }

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -202,21 +202,17 @@ class ServiceConfiguration extends mixin(StoreMixin) {
     );
   }
 
-  getLoader() {
-    return (
-      <div className="container">
-        <Loader />
-      </div>
-    );
-  }
-
   render() {
     const { errors, service } = this.props;
     const { selectedVersionID } = this.state;
     const config = service.getVersions().get(selectedVersionID);
 
     if (config == null) {
-      return this.getLoader();
+      return (
+        <div className="container">
+          <Loader />
+        </div>
+      );
     }
 
     return (

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -103,7 +103,12 @@ class ServiceConfiguration extends mixin(StoreMixin) {
   getRollbackButtons() {
     const { service } = this.props;
     const { selectedVersionID } = this.state;
+    const config = service.getVersions().get(selectedVersionID);
     let applyButton = null;
+
+    if (config == null) {
+      return null;
+    }
 
     if (service.getVersion() !== selectedVersionID) {
       applyButton = (


### PR DESCRIPTION
**DCOS_OSS-744** This PR makes the edit button always visible in the service configuration page, this also updates to show apply when the user change to older versions.

**before**
<img width="665" alt="screen shot 2017-07-10 at 4 32 48 pm" src="https://user-images.githubusercontent.com/549394/28023196-72825444-658d-11e7-8a74-fb8e245599b1.png">

**after**
<img width="716" alt="screen shot 2017-07-10 at 4 21 56 pm" src="https://user-images.githubusercontent.com/549394/28023212-7e4a916a-658d-11e7-831f-5e09ae49962f.png">


**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
