### PR TITLE
fix(TasksView): improve is deploying to accommodate Node tasks

### DIFF
--- a/plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.js
+++ b/plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.js
@@ -66,13 +66,7 @@ class ServiceInstancesContainer extends mixin(StoreMixin) {
     const { service } = this.props;
     const tasks = MesosStateStore.getTasksByService(service);
 
-    return (
-      <TasksContainer
-        params={this.props.params}
-        service={service}
-        tasks={tasks}
-      />
-    );
+    return <TasksContainer params={this.props.params} tasks={tasks} />;
   }
 
   render() {

--- a/plugins/services/src/js/containers/tasks/TasksContainer.js
+++ b/plugins/services/src/js/containers/tasks/TasksContainer.js
@@ -5,7 +5,6 @@ import ContainerUtil from "#SRC/js/utils/ContainerUtil";
 
 import ActionKeys from "../../constants/ActionKeys";
 import MarathonActions from "../../events/MarathonActions";
-import Service from "../../structs/Service";
 import ServiceActionItem from "../../constants/ServiceActionItem";
 import TaskModals from "../../components/modals/TaskModals";
 import TasksView from "./TasksView";
@@ -181,11 +180,7 @@ class TasksContainer extends React.Component {
   render() {
     return (
       <div>
-        <TasksView
-          service={this.props.service}
-          params={this.props.params}
-          tasks={this.props.tasks}
-        />
+        <TasksView params={this.props.params} tasks={this.props.tasks} />
         {this.getModals()}
       </div>
     );
@@ -201,7 +196,6 @@ TasksContainer.childContextTypes = {
 };
 
 TasksContainer.propTypes = {
-  service: PropTypes.instanceOf(Service).isRequired,
   tasks: PropTypes.array.isRequired,
   params: PropTypes.object.isRequired
 };

--- a/plugins/services/src/js/containers/tasks/TasksView.js
+++ b/plugins/services/src/js/containers/tasks/TasksView.js
@@ -3,6 +3,7 @@ import mixin from "reactjs-mixin";
 import { Tooltip } from "reactjs-components";
 import React from "react";
 
+import DCOSStore from "#SRC/js/stores/DCOSStore";
 import FilterBar from "#SRC/js/components/FilterBar";
 import FilterButtons from "#SRC/js/components/FilterButtons";
 import FilterHeadline from "#SRC/js/components/FilterHeadline";
@@ -11,7 +12,6 @@ import Icon from "#SRC/js/components/Icon";
 import SaveStateMixin from "#SRC/js/mixins/SaveStateMixin";
 import StringUtil from "#SRC/js/utils/StringUtil";
 
-import Service from "../../structs/Service";
 import ServiceStatusTypes from "../../constants/ServiceStatusTypes";
 import GraphQLTaskUtil from "../../utils/GraphQLTaskUtil";
 import TaskStates from "../../constants/TaskStates";
@@ -147,16 +147,20 @@ class TasksView extends mixin(SaveStateMixin) {
   }
 
   getStopButtons() {
-    const { service, tasks } = this.props;
+    const { tasks } = this.props;
     const { checkedItems } = this.state;
 
-    if (!Object.keys(checkedItems).length || service == null) {
+    if (!Object.keys(checkedItems).length) {
       return null;
     }
 
     // Only allow restarting the task if the service isn't deploying.
-    const isDeploying =
-      service.getServiceStatus().key === ServiceStatusTypes.DEPLOYING;
+    const isDeploying = Object.keys(checkedItems).some(function(taskId) {
+      const service = DCOSStore.serviceTree.getServiceFromTaskID(taskId);
+
+      return service.getServiceStatus().key === ServiceStatusTypes.DEPLOYING;
+    });
+
     // Only show Stop if a scheduler task isn't selected
     const hasSchedulerTask = tasks.some(
       task => task.id in checkedItems && task.schedulerTask
@@ -286,7 +290,6 @@ TasksView.propTypes = {
   params: React.PropTypes.object.isRequired,
   inverseStyle: React.PropTypes.bool,
   itemID: React.PropTypes.string,
-  service: React.PropTypes.instanceOf(Service).isRequired,
   tasks: React.PropTypes.array
 };
 

--- a/plugins/services/src/js/containers/tasks/TasksView.js
+++ b/plugins/services/src/js/containers/tasks/TasksView.js
@@ -150,7 +150,7 @@ class TasksView extends mixin(SaveStateMixin) {
     const { service, tasks } = this.props;
     const { checkedItems } = this.state;
 
-    if (!Object.keys(checkedItems).length) {
+    if (!Object.keys(checkedItems).length || service == null) {
       return null;
     }
 


### PR DESCRIPTION
This PR fixes the TypeError when selecting a task (via checkbox) on the node tasks page.

**DCOS_OSS-1350**

**Details**:
Remove dependency on the use of service struct for Services and Nodes instead start using require`DCOSStore.serviceTree` in `TasksView`.

**How to test:**
When selecting a task on Service/Node page if it's not deploying you should be able to see the `restart` and `stop` buttons, if one of the services selected is deploying `restart` should be disabled. Should not throw a `TypeError`.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
