### PR TITLE
DCOS-15921 (2 of 4): Tabs for Design System Code Example

### DIFF
--- a/plugins/design-system/components/component-example/CodeExampleTabButton.js
+++ b/plugins/design-system/components/component-example/CodeExampleTabButton.js
@@ -1,0 +1,82 @@
+import classNames from "classnames/dedupe";
+import React, { Component } from "react";
+
+const METHODS_TO_BIND = ["handleClick"];
+
+class CodeExampleTabButton extends Component {
+  constructor() {
+    super(...arguments);
+
+    METHODS_TO_BIND.forEach(method => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  getChildren() {
+    const { activeTab, children, onClick } = this.props;
+
+    return React.Children.map(children, tabChild => {
+      if (tabChild.type === CodeExampleTabButton) {
+        return React.cloneElement(tabChild, { activeTab, onClick });
+      }
+
+      return tabChild;
+    });
+  }
+
+  handleClick(event) {
+    event.stopPropagation();
+
+    if (this.props.onClick) {
+      this.props.onClick(this.props.id);
+    }
+  }
+
+  render() {
+    const {
+      active,
+      activeTab,
+      className,
+      label,
+      labelClassName,
+      id
+    } = this.props;
+    const classes = classNames(
+      "code-example-tabbed-item",
+      {
+        active: active || activeTab === id
+      },
+      className
+    );
+    const labelClasses = classNames(
+      "code-example-tabbed-item-label",
+      labelClassName
+    );
+
+    return (
+      <div className={classes} onClick={this.handleClick}>
+        <span className={labelClasses}>
+          {label}
+        </span>
+        {this.getChildren()}
+      </div>
+    );
+  }
+}
+
+const classProps = React.PropTypes.oneOfType([
+  React.PropTypes.array,
+  React.PropTypes.object,
+  React.PropTypes.string
+]);
+
+CodeExampleTabButton.propTypes = {
+  active: React.PropTypes.bool,
+  children: React.PropTypes.node,
+  className: classProps,
+  id: React.PropTypes.string.isRequired,
+  label: React.PropTypes.node,
+  labelClassName: classProps
+};
+
+module.exports = CodeExampleTabButton;

--- a/plugins/design-system/components/component-example/CodeExampleTabButtonList.js
+++ b/plugins/design-system/components/component-example/CodeExampleTabButtonList.js
@@ -1,0 +1,52 @@
+import classNames from "classnames/dedupe";
+import React from "react";
+
+class CodeExampleTabButtonList extends React.Component {
+  getChildren() {
+    const { activeTab, children, onChange } = this.props;
+
+    return React.Children.map(children, (tab, index) => {
+      if (tab === null) {
+        return tab;
+      }
+      const tabProps = { activeTab, onClick: onChange };
+
+      if (tab.props.id === activeTab || (!activeTab && index === 0)) {
+        tabProps.active = true;
+      }
+
+      return React.cloneElement(tab, tabProps);
+    });
+  }
+
+  render() {
+    const { className, vertical } = this.props;
+    const classes = classNames(
+      "code-example-heading",
+      {
+        "code-example-heading-vertical": vertical
+      },
+      className
+    );
+
+    return (
+      <div className={classes}>
+        {this.getChildren()}
+      </div>
+    );
+  }
+}
+
+CodeExampleTabButtonList.propTypes = {
+  activeTab: React.PropTypes.string,
+  children: React.PropTypes.node,
+  className: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ]),
+  onChange: React.PropTypes.func,
+  vertical: React.PropTypes.bool
+};
+
+module.exports = CodeExampleTabButtonList;

--- a/plugins/design-system/components/component-example/CodeExampleTabView.js
+++ b/plugins/design-system/components/component-example/CodeExampleTabView.js
@@ -1,0 +1,29 @@
+import classNames from "classnames/dedupe";
+import React from "react";
+
+class CodeExampleTabView extends React.Component {
+  render() {
+    const classes = classNames(
+      "code-example-tabbed-view",
+      this.props.className
+    );
+
+    return (
+      <div className={classes}>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+CodeExampleTabView.propTypes = {
+  children: React.PropTypes.node,
+  className: React.PropTypes.oneOf([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ]),
+  id: React.PropTypes.string.isRequired
+};
+
+module.exports = CodeExampleTabView;

--- a/plugins/design-system/components/component-example/CodeExampleTabViewList.js
+++ b/plugins/design-system/components/component-example/CodeExampleTabViewList.js
@@ -1,0 +1,41 @@
+import classNames from "classnames";
+import React from "react";
+
+class CodeExampleTabViewList extends React.Component {
+  getChildren() {
+    const { activeTab, children } = this.props;
+
+    return React.Children.map(children, (tab, index) => {
+      if (tab.props.id === activeTab || (!activeTab && index === 0)) {
+        return tab;
+      }
+
+      return null;
+    });
+  }
+
+  render() {
+    const classes = classNames(
+      "code-example-tabbed-view-container",
+      this.props.classNames
+    );
+
+    return (
+      <div className={classes}>
+        {this.getChildren()}
+      </div>
+    );
+  }
+}
+
+CodeExampleTabViewList.propTypes = {
+  activeTab: React.PropTypes.string,
+  children: React.PropTypes.node,
+  className: React.PropTypes.oneOf([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ])
+};
+
+module.exports = CodeExampleTabViewList;

--- a/plugins/design-system/components/component-example/CodeExampleTabs.js
+++ b/plugins/design-system/components/component-example/CodeExampleTabs.js
@@ -1,0 +1,52 @@
+import classNames from "classnames/dedupe";
+import React from "react";
+
+import CodeExampleTabButtonList from "./CodeExampleTabButtonList";
+
+class CodeExampleTabs extends React.Component {
+  getChildren() {
+    const { props } = this;
+
+    return React.Children.map(props.children, tabElement => {
+      const newTabProps = { activeTab: props.activeTab };
+
+      if (tabElement.type === CodeExampleTabButtonList) {
+        newTabProps.onChange = props.handleTabChange;
+        newTabProps.vertical = props.vertical;
+      }
+
+      return React.cloneElement(tabElement, newTabProps);
+    });
+  }
+
+  render() {
+    const classes = classNames(
+      "code-example-tabbed-container",
+      this.props.className,
+      {
+        "code-example-tabbed-container-vertical": this.props.vertical
+      }
+    );
+
+    return (
+      <div className={classes}>
+        {this.getChildren()}
+      </div>
+    );
+  }
+}
+
+CodeExampleTabs.propTypes = {
+  // Optional variable to set active tab from owner component
+  activeTab: React.PropTypes.string,
+  children: React.PropTypes.node.isRequired,
+  className: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ]),
+  handleTabChange: React.PropTypes.func.isRequired,
+  vertical: React.PropTypes.bool
+};
+
+module.exports = CodeExampleTabs;


### PR DESCRIPTION
This PR adds the tab components needed for the design system code example component. It is essentially a rehash of our existing `Tabs` component and its associated subcomponents, but with a different styling.

****To Test:****
- See branch `tommy/design-system/component-example-ace-editor` for the complete implementation.
- In the UI: `Design System` --> `Components` --> `Checkboxes` --> `Code Tab`
- The tabs are working correctly

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
