### PR TITLE
DCOS-15921 (3 of 4): Implement ComponentExample component for design system

### DIFF
--- a/plugins/design-system/components/component-example/CodeExample.js
+++ b/plugins/design-system/components/component-example/CodeExample.js
@@ -1,0 +1,67 @@
+import React, { Component } from "react";
+import AceEditor from "react-ace";
+import ReactDOM from "react-dom";
+
+import "brace/mode/jsx";
+import "brace/mode/html";
+import "brace/theme/tomorrow_night";
+
+class CodeExample extends Component {
+  updateCode(newCode) {
+    this.setState({
+      code: newCode
+    });
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return (
+      this.props.lang !== nextProps.lang ||
+      this.props.height !== nextProps.height ||
+      (nextState != null && this.state.code !== nextState.code)
+    );
+  }
+
+  setMaxHeight(container, editor) {
+    var lineHeight = editor.renderer.lineHeight;
+    var doc = editor.getSession().getDocument();
+    container.style.height = lineHeight * doc.getLength() + "px";
+  }
+
+  setHeight(ref) {
+    if (ref != null) {
+      const editor = ref.editor;
+      const container = ReactDOM.findDOMNode(this);
+      this.setMaxHeight(container, editor);
+
+      const { height, handleCanExpand } = this.props;
+
+      if (container.clientHeight > height) {
+        container.style.height = `${height}px`;
+        handleCanExpand(true);
+      } else {
+        handleCanExpand(false);
+      }
+
+      editor.resize();
+    }
+  }
+
+  render() {
+    const { lang } = this.props;
+    const theme = "tomorrow_night";
+
+    return (
+      <AceEditor
+        ref={this.setHeight.bind(this)}
+        value={this.props.children}
+        onChange={this.updateCode}
+        mode={lang}
+        theme={theme}
+        width="100%"
+        readOnly={true}
+      />
+    );
+  }
+}
+
+module.exports = CodeExample;

--- a/plugins/design-system/components/component-example/CodeExampleFooter.js
+++ b/plugins/design-system/components/component-example/CodeExampleFooter.js
@@ -1,0 +1,73 @@
+import classNames from "classnames/dedupe";
+import React, { Component } from "react";
+
+const defaultClasses = {
+  panel: "code-example-wrapper footer",
+  content: "code-example-footer-content"
+};
+
+class CodeExampleFooter extends Component {
+  getNode(nodeName) {
+    const { props } = this;
+    const node = props[nodeName];
+
+    if (!node) {
+      return null;
+    }
+
+    const classes = classNames(
+      defaultClasses[nodeName],
+      props[nodeName + "Class"]
+    );
+
+    return (
+      <div className={classes}>
+        {node}
+      </div>
+    );
+  }
+
+  render() {
+    const { props } = this;
+    const contentClasses = classNames(
+      defaultClasses.content,
+      props.contentClass
+    );
+    const panelClasses = classNames(defaultClasses.panel, props.className);
+
+    return (
+      <div className={panelClasses} onClick={this.props.onClick}>
+        {this.getNode("heading")}
+        <div className={contentClasses}>
+          {props.children}
+        </div>
+        {this.getNode("footer")}
+      </div>
+    );
+  }
+}
+
+CodeExampleFooter.propTypes = {
+  heading: React.PropTypes.node,
+  footer: React.PropTypes.node,
+
+  contentClass: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ]),
+  headingClass: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ]),
+  footerClass: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ]),
+
+  onClick: React.PropTypes.func
+};
+
+module.exports = CodeExampleFooter;

--- a/plugins/design-system/components/component-example/CodeExampleHeader.js
+++ b/plugins/design-system/components/component-example/CodeExampleHeader.js
@@ -1,0 +1,73 @@
+import classNames from "classnames/dedupe";
+import React, { Component } from "react";
+
+const defaultClasses = {
+  panel: "code-example-wrapper header",
+  content: "code-example-header-content"
+};
+
+class CodeExampleHeader extends Component {
+  getNode(nodeName) {
+    const { props } = this;
+    const node = props[nodeName];
+
+    if (!node) {
+      return null;
+    }
+
+    const classes = classNames(
+      defaultClasses[nodeName],
+      props[nodeName + "Class"]
+    );
+
+    return (
+      <div className={classes}>
+        {node}
+      </div>
+    );
+  }
+
+  render() {
+    const { props } = this;
+    const contentClasses = classNames(
+      defaultClasses.content,
+      props.contentClass
+    );
+    const panelClasses = classNames(defaultClasses.panel, props.className);
+
+    return (
+      <div className={panelClasses} onClick={this.props.onClick}>
+        {this.getNode("heading")}
+        <div className={contentClasses}>
+          {props.children}
+        </div>
+        {this.getNode("footer")}
+      </div>
+    );
+  }
+}
+
+CodeExampleHeader.propTypes = {
+  heading: React.PropTypes.node,
+  footer: React.PropTypes.node,
+
+  contentClass: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ]),
+  headingClass: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ]),
+  footerClass: React.PropTypes.oneOfType([
+    React.PropTypes.array,
+    React.PropTypes.object,
+    React.PropTypes.string
+  ]),
+
+  onClick: React.PropTypes.func
+};
+
+module.exports = CodeExampleHeader;

--- a/plugins/design-system/components/component-example/ComponentExample.js
+++ b/plugins/design-system/components/component-example/ComponentExample.js
@@ -1,0 +1,217 @@
+import React, { Component } from "react";
+import ReactDOMServer from "react-dom/server";
+import JSBeautify from "js-beautify";
+import reactElementToJSXString from "react-element-to-jsx-string";
+
+import ClipboardTrigger from "#SRC/js/components/ClipboardTrigger";
+import Icon from "#SRC/js/components/Icon";
+
+import CodeExample from "./CodeExample";
+import CodeExampleFooter from "./CodeExampleFooter";
+import CodeExampleHeader from "./CodeExampleHeader";
+
+import CodeExampleTabButtonList from "./CodeExampleTabButtonList";
+import CodeExampleTabs from "./CodeExampleTabs";
+import CodeExampleTabView from "./CodeExampleTabView";
+import CodeExampleTabViewList from "./CodeExampleTabViewList";
+
+import CodeExampleTabButton from "./CodeExampleTabButton";
+
+import ComponentExampleConstants from "../../constants/ComponentExample";
+
+const DEFAULT_HEIGHT = 205;
+
+const REACT_STRING_OPTIONS = {
+  showDefaultProps: false,
+  useBooleanShorthandSyntax: false
+};
+
+const METHODS_TO_BIND = [
+  "expandCollapseToggle",
+  "handleTabChange",
+  "handleCodeCopy",
+  "handleCanExpand"
+];
+
+const { REACT, HTML, PREVIEW } = ComponentExampleConstants;
+
+class ComponentExample extends Component {
+  constructor() {
+    super(...arguments);
+
+    this.state = {
+      isExpanded: false,
+      isCodeCopied: false,
+      canExpand: false
+    };
+
+    if (this.hasTabs()) {
+      this.state.activeTab = this.props.activeTab || REACT;
+    }
+
+    this.defaultHeight = this.props.defaultHeight || DEFAULT_HEIGHT;
+
+    METHODS_TO_BIND.forEach(method => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  isReactCode() {
+    return this.isReactOnly() || this.state.activeTab === REACT;
+  }
+
+  isReactOnly() {
+    return this.props.only === REACT;
+  }
+
+  isHtmlOnly() {
+    return this.props.only === HTML;
+  }
+
+  isSingleCodeType() {
+    return this.isReactOnly() || this.isHtmlOnly();
+  }
+
+  hasTabs() {
+    return !this.isSingleCodeType();
+  }
+
+  isPreviewOnly() {
+    return this.props.only === PREVIEW;
+  }
+
+  expandCollapseToggle() {
+    this.setState({ isExpanded: !this.state.isExpanded });
+  }
+
+  handleTabChange(activeTab) {
+    this.setState({ activeTab });
+    this.setState({ isExpanded: false });
+  }
+
+  handleCanExpand(canExpand) {
+    this.setState({ canExpand });
+  }
+
+  handleCodeCopy() {
+    this.setState({ isCodeCopied: true });
+  }
+
+  parse(code) {
+    const { maxLines } = this.props;
+    if (maxLines) {
+      return code.split("\n").slice(0, maxLines).join("\n").concat("\n...");
+    }
+
+    return code;
+  }
+
+  generateCodeExample(lang, code) {
+    return (
+      <CodeExample
+        lang={lang}
+        height={this.state.isExpanded ? "100%" : this.defaultHeight}
+        handleCanExpand={this.handleCanExpand}
+      >
+        {`${this.parse(code)}`}
+      </CodeExample>
+    );
+  }
+
+  generateFooter() {
+    const expandButton = (
+      <button
+        className="button button-link"
+        type="button"
+        onClick={this.expandCollapseToggle}
+      >
+        {this.state.isExpanded ? "Show less" : "Show more"}
+        <Icon
+          size="mini"
+          id={this.state.isExpanded ? "caret-up" : "caret-down"}
+        />
+      </button>
+    );
+
+    return (
+      <CodeExampleFooter>
+        {this.state.isExpanded || this.state.canExpand ? expandButton : ""}
+      </CodeExampleFooter>
+    );
+  }
+
+  render() {
+    const code = this.props.children;
+    const header = (
+      <CodeExampleHeader>
+        {code}
+      </CodeExampleHeader>
+    );
+
+    if (this.isPreviewOnly()) {
+      return header;
+    }
+
+    const reactCode = reactElementToJSXString(code, REACT_STRING_OPTIONS);
+    const htmlCode = JSBeautify.html(ReactDOMServer.renderToStaticMarkup(code));
+
+    const clipboard = (
+      <ClipboardTrigger
+        className="clickable"
+        copyText={this.isReactCode() ? reactCode : htmlCode}
+        onTextCopy={this.handleCodeCopy}
+        useTooltip={true}
+      >
+        <Icon size="small" id="clipboard" />
+      </ClipboardTrigger>
+    );
+
+    const reactCodeExample = this.generateCodeExample("jsx", reactCode);
+    const htmlCodeExample = this.generateCodeExample("html", htmlCode);
+
+    const codeBody = (
+      <div>
+        <div className="code-example-heading single">
+          {clipboard}
+        </div>
+        {this.isReactOnly() ? reactCodeExample : htmlCodeExample}
+      </div>
+    );
+
+    const tabsBody = (
+      <CodeExampleTabs
+        handleTabChange={this.handleTabChange}
+        activeTab={this.state.activeTab}
+      >
+        <CodeExampleTabButtonList className="tabs">
+          <CodeExampleTabButton id={REACT} label={REACT.toUpperCase()} />
+          <CodeExampleTabButton id={HTML} label={HTML.toUpperCase()} />
+          {clipboard}
+        </CodeExampleTabButtonList>
+        <CodeExampleTabViewList>
+          <CodeExampleTabView id={REACT}>
+            {reactCodeExample}
+          </CodeExampleTabView>
+          <CodeExampleTabView id={HTML}>
+            {htmlCodeExample}
+          </CodeExampleTabView>
+        </CodeExampleTabViewList>
+      </CodeExampleTabs>
+    );
+
+    return (
+      <div>
+        {header}
+        {this.isSingleCodeType() ? codeBody : tabsBody}
+        {this.generateFooter()}
+      </div>
+    );
+  }
+}
+
+ComponentExample.propTypes = {
+  only: React.PropTypes.oneOf([REACT, HTML, PREVIEW]),
+  maxLines: React.PropTypes.number
+};
+
+module.exports = ComponentExample;

--- a/plugins/design-system/constants/ComponentExample.js
+++ b/plugins/design-system/constants/ComponentExample.js
@@ -1,0 +1,5 @@
+module.exports = {
+  REACT: "react",
+  HTML: "html",
+  PREVIEW: "preview"
+};

--- a/plugins/design-system/styles/components/component-example/styles.less
+++ b/plugins/design-system/styles/components/component-example/styles.less
@@ -1,0 +1,89 @@
+& when (@component-example-enabled) {
+
+  .code-example-wrapper {
+    background-color: @code-example-wrapper-background-color;
+    border-left: 1px solid @code-example-border-color;
+    border-right: 1px solid @code-example-border-color;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    padding: 10px;
+    position: relative;
+
+    &.header {
+      background: @code-example-header-color;
+      border-bottom: 1px solid @code-example-border-color;
+      border-top: 1px solid @code-example-border-color;
+      padding-top: 20px;
+    }
+
+    &.footer {
+      border-bottom: 1px solid @code-example-border-color;
+
+      .code-example-footer-content {
+
+        button {
+          float: right;
+
+          .icon {
+            margin-bottom: 2px;
+            margin-left: 5px;
+          }
+        }
+      }
+    }
+  }
+
+  .code-example-heading {
+    background: @code-example-editor-color;
+    height: 35px;
+    padding-top: @code-example-heading-top-padding;
+
+    &.tabs {
+      height: @code-example-tab-height * 2;
+      padding-top: @code-example-heading-top-padding * 2;
+
+      .tooltip-wrapper {
+        margin-right: 15px;
+      }
+    }
+
+    &.single {
+
+      .tooltip-wrapper {
+        margin-right: 25px;
+        top: 15px;
+      }
+    }
+
+    .tooltip-wrapper {
+      float: right;
+      z-index: 5;
+    }
+
+    .code-example-tabbed-item {
+      background: @code-example-tab-color;
+      border: 1px solid @code-example-border-color;
+      cursor: pointer;
+      display: inline-block;
+      height: @code-example-tab-height;
+      text-align: center;
+      width: @code-example-tab-height * 2;
+
+      &:first-child {
+        margin-left: 20px;
+      }
+
+      &.active {
+        background: @code-example-tab-active-color;
+      }
+
+      .code-example-tabbed-item-label {
+        align-items: center;
+        display: inline-flex;
+        font-size: 0.9rem;
+        min-height: @code-example-tab-height;
+      }
+    }
+  }
+}

--- a/plugins/design-system/styles/components/component-example/variables.less
+++ b/plugins/design-system/styles/components/component-example/variables.less
@@ -1,0 +1,15 @@
+@component-example-enabled: true;
+
+/*
+ * Styling
+ */
+
+@code-example-border-color: #e5e5e5;
+@code-example-header-color: #fafbfc;
+@code-example-tab-color: #f3f3f4;
+@code-example-tab-active-color: #dadadb;
+@code-example-tab-active-text-color: #5b6171;
+@code-example-editor-color: hsl(220, 13%, 18%);
+@code-example-wrapper-background-color: #fff;
+@code-example-tab-height: 40px;
+@code-example-heading-top-padding: 10px;


### PR DESCRIPTION
This PR adds the `ComponentExample` component, which is made up of the `CodeExampleHeader` and `CodeExampleFooter` components. It is the primary component for the code example component.

This PR depends on: #2312, #2313

****To Test:****
- See branch `tommy/design-system/component-example-ace-editor` for the complete implementation.
- In the UI: `Design System` --> `Components` --> `Checkboxes` --> `Code Tab`
- React code is shown on one tab and HTML on the other
- Clipboard function works for both tabs
- Collapse/Expand of code

****Optional properties:****
The optional properties are:
- `only`: accepts one of `preview`, `react` and `html`
- `maxLines`: max number of lines the code block can show

****Test optional properties:****
- `preview` hides the code block
- `react` shows only react code
- `html` shows only html code
- `maxLines` should result in truncation if the number of lines in the code block exceeds it


**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
