### PR TITLE
DCOS-17242: Adjust MarathonErrorUtil to handle missing detail errors

### DIFF
--- a/plugins/services/src/js/utils/MarathonErrorUtil.js
+++ b/plugins/services/src/js/utils/MarathonErrorUtil.js
@@ -99,7 +99,7 @@ const MarathonErrorUtil = {
     }
 
     // `details` can be an array of errors
-    return error.details.reduce(function(memo, { errors, path }) {
+    return error.details.reduce(function(memo, { errors = [], path }) {
       // Convert marathon path components to a dot-separated string
       // and then split it into an array
       //
@@ -119,6 +119,10 @@ const MarathonErrorUtil = {
 
           return component;
         });
+      }
+
+      if (errors.length === 0) {
+        errors = errors.concat(error.message);
       }
 
       // For every error, create the correct message

--- a/plugins/services/src/js/utils/__tests__/MarathonErrorUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/MarathonErrorUtil-test.js
@@ -112,6 +112,47 @@ describe("MarathonErrorUtil", function() {
       ]);
     });
 
+    it("translates messages with no detail errors", function() {
+      const marathonError = {
+        message: "Some error",
+        details: [
+          {
+            path: "/some/property"
+          }
+        ]
+      };
+
+      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([
+        {
+          path: ["some", "property"],
+          message: "Some error",
+          type: ServiceErrorTypes.GENERIC,
+          variables: {}
+        }
+      ]);
+    });
+
+    it("translates messages with empty detail errors", function() {
+      const marathonError = {
+        message: "Some error",
+        details: [
+          {
+            errors: [],
+            path: "/some/property"
+          }
+        ]
+      };
+
+      expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([
+        {
+          path: ["some", "property"],
+          message: "Some error",
+          type: ServiceErrorTypes.GENERIC,
+          variables: {}
+        }
+      ]);
+    });
+
     it("should properly translate marathon paths with index", function() {
       const marathonError = {
         message: "Some error",


### PR DESCRIPTION
Adjust the `parseErrors` util to translates messages with empty or missing detail errors.

DCOS-17242

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
