### PR TITLE
DCOS-17262: fix(NetworkValidatorUtil): add support for 0 vip port

### DIFF
--- a/src/js/utils/NetworkValidatorUtil.js
+++ b/src/js/utils/NetworkValidatorUtil.js
@@ -4,7 +4,7 @@ const NetworkValidatorUtil = {
   isValidPort(value) {
     return (
       ValidatorUtil.isInteger(value) &&
-      ValidatorUtil.isNumberInRange(value, { min: 1, max: 65535 })
+      ValidatorUtil.isNumberInRange(value, { min: 0, max: 65535 })
     );
   }
 };

--- a/src/js/utils/__tests__/NetworkValidatorUtil-test.js
+++ b/src/js/utils/__tests__/NetworkValidatorUtil-test.js
@@ -19,17 +19,17 @@ describe("NetworkValidatorUtil", function() {
     });
 
     it("should handle number like inputs", function() {
-      expect(NetworkValidatorUtil.isValidPort(0)).toBe(false);
-      expect(NetworkValidatorUtil.isValidPort("0")).toBe(false);
+      expect(NetworkValidatorUtil.isValidPort(0)).toBe(true);
+      expect(NetworkValidatorUtil.isValidPort("0")).toBe(true);
       expect(NetworkValidatorUtil.isValidPort(80)).toBe(true);
       expect(NetworkValidatorUtil.isValidPort("80")).toBe(true);
       expect(NetworkValidatorUtil.isValidPort(8080)).toBe(true);
       expect(NetworkValidatorUtil.isValidPort("8080")).toBe(true);
     });
 
-    it("should verify that port is greater then 0", function() {
+    it("should verify that port is greater or equal to 0", function() {
       expect(NetworkValidatorUtil.isValidPort(-1)).toBe(false);
-      expect(NetworkValidatorUtil.isValidPort(0)).toBe(false);
+      expect(NetworkValidatorUtil.isValidPort(0)).toBe(true);
       expect(NetworkValidatorUtil.isValidPort(8080)).toBe(true);
     });
 
@@ -37,6 +37,10 @@ describe("NetworkValidatorUtil", function() {
       expect(NetworkValidatorUtil.isValidPort(8080)).toBe(true);
       expect(NetworkValidatorUtil.isValidPort(65535)).toBe(true);
       expect(NetworkValidatorUtil.isValidPort(65536)).toBe(false);
+    });
+
+    it("verifies that port 0 is valid", function() {
+      expect(NetworkValidatorUtil.isValidPort(0)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Add support for 0 at the vip port in the network validator util.

Closes DCOS-17262

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
