### PR TITLE
↩️ fix(NetworkValidatorUtil): add support for 0 vip port

### DIFF
--- a/plugins/services/src/js/validators/VipLabelsValidators.js
+++ b/plugins/services/src/js/validators/VipLabelsValidators.js
@@ -29,7 +29,7 @@ function checkServiceEndpoints(ports, pathPrefix) {
       if (!NetworkValidatorUtil.isValidPort(vipPort)) {
         return errorsMemo.concat({
           path: pathPrefix.concat([index, "labels", label]),
-          message: "Port should be an integrer less than or equal to 65535"
+          message: "Port should be an integer less than or equal to 65535"
         });
       }
 

--- a/plugins/services/src/js/validators/__tests__/VipLabelsValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/VipLabelsValidators-test.js
@@ -70,7 +70,7 @@ describe("VipLabelsValidators", function() {
         };
         expect(VipLabelsValidators.mustContainPort(spec)).toEqual([
           {
-            message: "Port should be an integrer less than or equal to 65535",
+            message: "Port should be an integer less than or equal to 65535",
             path: ["container", "docker", "portMappings", 0, "labels", "VIP_0"]
           }
         ]);

--- a/src/js/utils/NetworkValidatorUtil.js
+++ b/src/js/utils/NetworkValidatorUtil.js
@@ -4,7 +4,7 @@ const NetworkValidatorUtil = {
   isValidPort(value) {
     return (
       ValidatorUtil.isInteger(value) &&
-      ValidatorUtil.isNumberInRange(value, { min: 1, max: 65535 })
+      ValidatorUtil.isNumberInRange(value, { min: 0, max: 65535 })
     );
   }
 };

--- a/src/js/utils/__tests__/NetworkValidatorUtil-test.js
+++ b/src/js/utils/__tests__/NetworkValidatorUtil-test.js
@@ -19,17 +19,17 @@ describe("NetworkValidatorUtil", function() {
     });
 
     it("should handle number like inputs", function() {
-      expect(NetworkValidatorUtil.isValidPort(0)).toBe(false);
-      expect(NetworkValidatorUtil.isValidPort("0")).toBe(false);
+      expect(NetworkValidatorUtil.isValidPort(0)).toBe(true);
+      expect(NetworkValidatorUtil.isValidPort("0")).toBe(true);
       expect(NetworkValidatorUtil.isValidPort(80)).toBe(true);
       expect(NetworkValidatorUtil.isValidPort("80")).toBe(true);
       expect(NetworkValidatorUtil.isValidPort(8080)).toBe(true);
       expect(NetworkValidatorUtil.isValidPort("8080")).toBe(true);
     });
 
-    it("should verify that port is greater then 0", function() {
+    it("should verify that port is greater or equal to 0", function() {
       expect(NetworkValidatorUtil.isValidPort(-1)).toBe(false);
-      expect(NetworkValidatorUtil.isValidPort(0)).toBe(false);
+      expect(NetworkValidatorUtil.isValidPort(0)).toBe(true);
       expect(NetworkValidatorUtil.isValidPort(8080)).toBe(true);
     });
 
@@ -37,6 +37,10 @@ describe("NetworkValidatorUtil", function() {
       expect(NetworkValidatorUtil.isValidPort(8080)).toBe(true);
       expect(NetworkValidatorUtil.isValidPort(65535)).toBe(true);
       expect(NetworkValidatorUtil.isValidPort(65536)).toBe(false);
+    });
+
+    it("verifies that port 0 is valid", function() {
+      expect(NetworkValidatorUtil.isValidPort(0)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
---
↩️  _This PR back-ports a fix to release/1.9 introduced with #2321_

---

Allow port 0 for vip port.

Closes DCOS-17262
