### PR TITLE
DCOS-17304: Introduce `CODEOWNERS` file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @MatApple @orlandohohmeier @Poltergeist @nLight


### PR DESCRIPTION
Introduce `CODEOWNERS` file to require reviews from project/area owners.

Closes DCOS-17304