### PR TITLE
↩️  DCOS-17304: Introduce `CODEOWNERS` file 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @MatApple @orlandohohmeier @Poltergeist @nLight


### PR DESCRIPTION
---
↩️  _This PR back-ports a the CODEOWNERS file that was introduces with  #2323 to release/1.8 ._

---

Introduce `CODEOWNERS` file to require reviews from project/area owners.

Closes DCOS-17304