### PR TITLE
chore(*): make compression-webpack-plugin a dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1631,6 +1631,18 @@
       "from": "compression@>=1.5.2 <1.6.0",
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz"
     },
+    "compression-webpack-plugin": {
+      "version": "0.4.0",
+      "from": "compression-webpack-plugin@0.4.0",
+      "resolved": "https://registry.npmjs.org/compression-webpack-plugin/-/compression-webpack-plugin-0.4.0.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        }
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "from": "concat-map@0.0.1",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,7 @@
     "node": "4.4.x",
     "npm": "3.9.x"
   },
-  "browserslist": [
-    "last 2 versions",
-    "ie 11"
-  ],
+  "browserslist": ["last 2 versions", "ie 11"],
   "config": {
     "port": 4200,
     "externalplugins": ""
@@ -77,6 +74,7 @@
     "babel-register": "6.24.1",
     "babel-runtime": "6.23.0",
     "colors": "1.1.2",
+    "compression-webpack-plugin": "0.4.0",
     "css-loader": "0.23.1",
     "eslint": "3.15.0",
     "eslint-config-dcos": "github:dcos/javascript#v0.2.1",
@@ -131,9 +129,8 @@
     "clean": "rm -rf dist",
     "shrinkwrap": "npm shrinkwrap --dev && ./node_modules/.bin/gulp fixShrinkwrap",
     "preinstall": "./scripts/pre-install",
-    "prebuild-assets": "./node_modules/.bin/gulp checkDependencies && npm install compression-webpack-plugin@latest",
+    "prebuild-assets": "./node_modules/.bin/gulp checkDependencies",
     "build-assets": "npm run clean && NODE_ENV=production webpack --config ./webpack/webpack.production.babel.js",
-    "postbuild-assets": "rm -rf node_modules/compression-webpack-plugin",
     "build": "npm run lint && npm test && npm run build-assets && npm run validate-build",
     "build-with-external-plugins": "npm run lint && npm run lint-plugins && npm test && npm run build-assets",
     "lint": "npm run stylelint && npm run eslint",


### PR DESCRIPTION
I discovered that our build depends on `compression-webpack-plugin` in a funny manner. And on the `@latest` version which is even funnier. So `compression-webpack-plugin@latest` hit version 1.0.0 and now it depends on `webpack` 2 or 3 Ooops 😊  