### PR TITLE
DCOS-16705: fix(ServiceForm): allow unknown values for container images

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/Container.js
+++ b/plugins/services/src/js/reducers/serviceForm/Container.js
@@ -87,6 +87,11 @@ const containerJSONReducer = combineReducers({
     );
 
     const joinedPath = path && path.join(".");
+
+    if (type === SET && joinedPath === "container.docker") {
+      this.internalState = Object.assign({}, this.internalState, value);
+    }
+
     if (type === SET && joinedPath === "container.type") {
       this.containerType = value;
     }
@@ -312,6 +317,7 @@ module.exports = {
 
       return new Transaction(["container", "type"], value);
     },
+    simpleParser(["container", DOCKER.toLowerCase()]),
     simpleParser(["container", DOCKER.toLowerCase(), "image"]),
     simpleParser(["container", MESOS.toLowerCase(), "image"]),
     simpleParser(["container", DOCKER.toLowerCase(), "forcePullImage"]),

--- a/plugins/services/src/js/reducers/serviceForm/Docker.js
+++ b/plugins/services/src/js/reducers/serviceForm/Docker.js
@@ -11,6 +11,7 @@ function getContainerSettingsReducer(name) {
     if (joinedPath === "container.type" && Boolean(value)) {
       this.networkType = value;
     }
+
     if (type === SET && joinedPath === `container.docker.${name}`) {
       this.value = Boolean(value);
     }

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
@@ -86,6 +86,9 @@ function containersParser(state) {
       memo.push(new Transaction(["containers", index, "name"], item.name));
     }
 
+    if (item.image) {
+      memo.push(new Transaction(["containers", index, "image"], item.image));
+    }
     if (item.image && item.image.id) {
       memo.push(
         new Transaction(["containers", index, "image", "id"], item.image.id)
@@ -344,6 +347,10 @@ module.exports = {
       this.endpoints = [];
     }
 
+    if (this.image == null) {
+      this.image = {};
+    }
+
     if (this.volumeMounts == null) {
       this.volumeMounts = [];
     }
@@ -473,9 +480,14 @@ module.exports = {
       );
     }
 
+    if (type === SET && joinedPath === `containers.${index}.image`) {
+      newState[index].image = this.image = Object.assign({}, this.image, value);
+    }
+
     if (type === SET && joinedPath === `containers.${index}.image.id`) {
-      newState[index] = Object.assign({}, newState[index], {
-        image: { id: value, kind: "DOCKER" }
+      newState[index].image = this.image = Object.assign({}, this.image, {
+        id: value,
+        kind: "DOCKER"
       });
       if (value === "") {
         delete newState[index].image;

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -1130,6 +1130,39 @@ describe("Container", function() {
     });
   });
 
+  describe("#Unknown Values", function() {
+    it("keep docker unknown values", function() {
+      expect(
+        Container.JSONParser({
+          container: {
+            docker: {
+              image: "nginx",
+              pullConfig: {
+                some: "value"
+              }
+            }
+          }
+        })
+          .reduce(function(batch, transaction) {
+            return batch.add(transaction);
+          }, new Batch())
+          .reduce(Container.JSONReducer.bind({}), {})
+      ).toEqual({
+        portMappings: null,
+        docker: {
+          image: "nginx",
+          forcePullImage: null,
+          privileged: null,
+          pullConfig: {
+            some: "value"
+          }
+        },
+        type: "MESOS",
+        volumes: []
+      });
+    });
+  });
+
   describe("Volumes", function() {
     it("should return an empty array if no volumes are set", function() {
       const batch = new Batch();


### PR DESCRIPTION
This PR introduces the support for unknown values in container(s) images. They will now be saved
and not wiped with the next generation.

*How to test*

in the tests there is a good example which can be copied over. Apply it to the service form and try to wipe the custom / unknown value.

Closes DCOS-16705

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
