### PR TITLE
fix(ServiceNetworkingConfigSection): fix system-tests for auto-assign port

### DIFF
--- a/system-tests/services/test-apps.js
+++ b/system-tests/services/test-apps.js
@@ -1679,7 +1679,7 @@ describe("Services", function() {
         .children("table")
         .getTableColumn("Host Port")
         .contents()
-        .should("deep.equal", ["0"]);
+        .should("deep.equal", ["Auto Assigned"]);
 
       // Run service
       cy.get("button.button-primary").contains("Run Service").click();
@@ -2314,7 +2314,7 @@ describe("Services", function() {
         .children("table")
         .getTableColumn("Host Port")
         .contents()
-        .should("deep.equal", ["Not Configured"]);
+        .should("deep.equal", ["Auto Assigned"]);
 
       cy
         .root()
@@ -2515,7 +2515,7 @@ describe("Services", function() {
         .children("table")
         .getTableColumn("Host Port")
         .contents()
-        .should("deep.equal", ["Not Configured", "4200"]);
+        .should("deep.equal", ["Auto Assigned", "Auto Assigned"]);
 
       cy
         .root()


### PR DESCRIPTION
In the ServiceNetworkingConfigSection set the port to "Auto Assign" if requiredPorts is false.
If the requirePorts: true then show the selected port.

This PR will fix the system test errors that appear due to this change.

Closes DCOS_OSS-1272

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
