### PR TITLE
DCOS-14469: fix container duplicates for multi-container-pod

### DIFF
--- a/plugins/services/src/js/utils/PodUtil.js
+++ b/plugins/services/src/js/utils/PodUtil.js
@@ -90,7 +90,7 @@ var PodUtil = {
       // Filter combined container list to remove potential duplicates
       const containerIds = new Map();
       combinedContainers = combinedContainers.filter(function({ containerId }) {
-        if (!containerIds.has(containerId)) {
+        if (containerId != null && !containerIds.has(containerId)) {
           containerIds.set(containerId);
 
           return true;


### PR DESCRIPTION
To reproduce

1) Create a multi-container-pod with the following settings

```
{
  "id": "/test-multi",
  "version": "2017-07-20T20:29:38.654Z",
  "containers": [
    {
      "name": "container-1",
      "resources": {
        "cpus": 0.1,
        "mem": 128,
        "disk": 0
      },
      "image": {
        "kind": "DOCKER",
        "id": "nginx"
      }
    },
    {
      "name": "container-2",
      "resources": {
        "cpus": 0.1,
        "mem": 128,
        "disk": 0
      },
      "image": {
        "kind": "DOCKER",
        "id": "python"
      }
    }
  ],
  "networks": [
    {
      "mode": "host"
    }
  ],
  "scaling": {
    "instances": 1,
    "kind": "fixed"
  },
  "scheduling": {
    "placement": {
      "constraints": []
    }
  },
  "executorResources": {
    "cpus": 0.1,
    "mem": 32,
    "disk": 10
  },
  "volumes": [],
  "fetch": []
}
```

2) Once you save, you can click on the services tab, click on the service details and check the containers of the instance.
It should show container-1 and container-2 twice.

With this update it should show container-1 and container-2 once.

The PodUtil was looking for unique containers to merge them. But some containers had a containerId of null and it thought that they were different. That is why I included a check for null.

Closes DCOS-14469

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
