### PR TITLE
DCOS-17408: fix(serviceForm): do not set container if it is not necessary

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/Container.js
+++ b/plugins/services/src/js/reducers/serviceForm/Container.js
@@ -188,6 +188,14 @@ module.exports = {
       return null;
     }
 
+    if (
+      newState.type == null &&
+      newState.docker == null &&
+      ValidatorUtil.isEmpty(newState.volumes)
+    ) {
+      return null;
+    }
+
     return newState;
   },
 


### PR DESCRIPTION
volumes was returning an empty array which resulted in an error of undefined type for non docker
apps

Closes DCOS-17408

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
