### PR TITLE
[easy] Correct src prop type declaration in image  component

### DIFF
--- a/src/js/components/Image.js
+++ b/src/js/components/Image.js
@@ -61,7 +61,7 @@ class Image extends React.Component {
 }
 
 Image.propTypes = {
-  src: React.PropTypes.string.required,
+  src: React.PropTypes.string.isRequired,
   fallbackSrc: React.PropTypes.string,
 
   // Classes


### PR DESCRIPTION
This PR fixes required `src` type for the `Image` component.