### PR TITLE
fix(serviceForm): Remove docker object if no image is provided

### DIFF
--- a/plugins/services/src/js/reducers/JSONMultiContainerParser.js
+++ b/plugins/services/src/js/reducers/JSONMultiContainerParser.js
@@ -1,6 +1,5 @@
 import { simpleParser } from "#SRC/js/utils/ParserUtil";
 
-import { JSONParser as container } from "./serviceForm/Container";
 import {
   JSONParser as constraints
 } from "./serviceForm/MultiContainerConstraints";
@@ -42,7 +41,6 @@ module.exports = [
   simpleParser(["gpus"]),
   simpleParser(["cmd"]),
   constraints,
-  container,
   containers,
   environmentVariables,
   externalVolumes,

--- a/plugins/services/src/js/reducers/serviceForm/Container.js
+++ b/plugins/services/src/js/reducers/serviceForm/Container.js
@@ -261,6 +261,13 @@ module.exports = {
       delete newState.docker;
     }
 
+    if (
+      ValidatorUtil.isEmpty(newState.docker.image) &&
+      newState.type !== DOCKER
+    ) {
+      delete newState.docker;
+    }
+
     if (ValidatorUtil.isEmpty(newState.type)) {
       newState.type = null;
     }

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -13,15 +13,10 @@ const Container = require("../Container");
 
 describe("Container", function() {
   describe("#JSONReducer", function() {
-    it("should return a null container as default object", function() {
+    it("returns a null container as default object without docker object", function() {
       const batch = new Batch();
 
       expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-        docker: {
-          forcePullImage: null,
-          image: "",
-          privileged: null
-        },
         portMappings: null,
         type: null,
         volumes: []
@@ -203,11 +198,6 @@ describe("Container", function() {
       );
 
       expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-        docker: {
-          forcePullImage: null,
-          image: "",
-          privileged: null
-        },
         portMappings: null,
         type: null,
         volumes: []
@@ -306,11 +296,6 @@ describe("Container", function() {
       );
 
       expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-        docker: {
-          forcePullImage: null,
-          image: "",
-          privileged: null
-        },
         portMappings: null,
         type: null,
         volumes: []
@@ -479,11 +464,6 @@ describe("Container", function() {
         batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-          docker: {
-            forcePullImage: null,
-            image: "",
-            privileged: null
-          },
           portMappings: null,
           type: null,
           volumes: []
@@ -994,11 +974,6 @@ describe("Container", function() {
         );
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-          docker: {
-            forcePullImage: null,
-            image: "",
-            privileged: null
-          },
           portMappings: null,
           type: "MESOS",
           volumes: []
@@ -1022,11 +997,6 @@ describe("Container", function() {
           );
 
           expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-            docker: {
-              forcePullImage: null,
-              image: "",
-              privileged: null
-            },
             portMappings: [
               {
                 containerPort: 0,
@@ -1071,11 +1041,6 @@ describe("Container", function() {
           );
 
           expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-            docker: {
-              forcePullImage: null,
-              image: "",
-              privileged: null
-            },
             portMappings: [
               {
                 containerPort: 0,
@@ -1107,11 +1072,6 @@ describe("Container", function() {
           );
 
           expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-            docker: {
-              forcePullImage: null,
-              image: "",
-              privileged: null
-            },
             portMappings: [
               {
                 containerPort: 0,
@@ -1126,6 +1086,39 @@ describe("Container", function() {
             volumes: []
           });
         });
+      });
+    });
+
+    it("removes docker if no image is present", function() {
+      let batch = Container.JSONParser({
+        container: {
+          docker: {
+            image: "nginx",
+            pullConfig: {
+              some: "value"
+            }
+          }
+        }
+      }).reduce(function(batch, transaction) {
+        return batch.add(transaction);
+      }, new Batch());
+
+      batch = batch.add(
+        new Transaction(["container", "docker", "image"], "", SET)
+      );
+
+      expect(
+        batch.reduce(Container.JSONReducer.bind({}), {
+          docker: {
+            image: "alpine",
+            forcePull: true
+          },
+          type: "DOCKER"
+        })
+      ).toEqual({
+        type: "MESOS",
+        portMappings: null,
+        volumes: []
       });
     });
   });
@@ -1168,11 +1161,6 @@ describe("Container", function() {
       const batch = new Batch();
 
       expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-        docker: {
-          forcePullImage: null,
-          image: "",
-          privileged: null
-        },
         portMappings: null,
         type: null,
         volumes: []
@@ -1188,11 +1176,6 @@ describe("Container", function() {
       );
 
       expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-        docker: {
-          forcePullImage: null,
-          image: "",
-          privileged: null
-        },
         portMappings: null,
         type: "MESOS",
         volumes: [
@@ -1213,11 +1196,6 @@ describe("Container", function() {
       batch = batch.add(new Transaction(["externalVolumes"], null, ADD_ITEM));
 
       expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-        docker: {
-          forcePullImage: null,
-          image: "",
-          privileged: null
-        },
         portMappings: null,
         type: "MESOS",
         volumes: [
@@ -1246,11 +1224,6 @@ describe("Container", function() {
       );
 
       expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-        docker: {
-          forcePullImage: null,
-          image: "",
-          privileged: null
-        },
         portMappings: null,
         type: "MESOS",
         volumes: [
@@ -1288,11 +1261,6 @@ describe("Container", function() {
       batch = batch.add(new Transaction(["localVolumes"], 0, REMOVE_ITEM));
 
       expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-        docker: {
-          forcePullImage: null,
-          image: "",
-          privileged: null
-        },
         portMappings: null,
         type: null,
         volumes: []


### PR DESCRIPTION
Remove docker object if no image is provided and the container type is unequal to `"DOCKER"`

For testing create:
```
{
  "id": "/sleeper",
  "instances": 1,
  "portDefinitions": [],
  "container": {
    "type": "DOCKER",
    "volumes": [],
    "docker": {
      "image": "alpine"
    }
  },
  "cpus": 0.1,
  "mem": 128,
  "requirePorts": false,
  "networks": [],
  "healthChecks": [],
  "fetch": [],
  "constraints": [],
  "cmd": "sleep 1000;"
}
```

Wait till the app is deployed then go in remove the `alpine` image and set the container runtime to
MESOS. The Result is positive if in the JSON the docker object is not present anymore. And you
should be able to deploy the new version.

Closes DCOS-17284

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
