### PR TITLE
DCOS-17301: not all tasks were shown under the service

### DIFF
--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -283,14 +283,18 @@ class MesosStateStore extends GetSetBaseStore {
     }
 
     const schedulerTasks = this.getSchedulerTasks();
+    const serviceIsFramework = service && service instanceof Framework;
+    const serviceFrameworkName = serviceIsFramework
+      ? service.getFrameworkName()
+      : serviceName;
 
     // Combine framework (if matching framework was found) and filtered
     // Marathon tasks. This will give you a list of framework tasks including
     // the scheduler tasks or a list of Marathon application tasks.
     return frameworks.reduce(function(serviceTasks, framework) {
       const { tasks = [], completed_tasks = {}, name } = framework;
-      // Include tasks from framework match, if service is a Framework
-      if (service instanceof Framework && name === serviceName) {
+
+      if (serviceIsFramework && serviceFrameworkName === name) {
         return serviceTasks
           .concat(tasks, completed_tasks)
           .map(task => assignSchedulerTaskField(task, schedulerTasks));


### PR DESCRIPTION
If you create a service inside a folder, it won't show all of the tasks under the service.

In the MesosStateStore we had the following check

```
const serviceName = service.getId().split("/").pop();

if(framework.name === serviceName) { ... }

```
with

```
service: { id: "/test/elastic" }
framework { name: "test/elastic" }
```

The problem is that if we have a service in a folder the service id is "/test/elastic" and with the split pop() we lose the full id.

Also the framework's name is "test/elastic". So it would compare framework.name = "test/elastic" with serviceName = "elastic" eventually.

> So you would see this on one DCOS dashboard
![image](https://user-images.githubusercontent.com/180432/28637255-c528a1f2-71f5-11e7-8352-d0cc1a4e4085.png)
> and this on the Mesos dashboard
![image](https://user-images.githubusercontent.com/180432/28637289-e3318952-71f5-11e7-9217-92888103e569.png)

I created 2 new methods one **getFullId()** to return **"test/elastic"** from the service
 and one **getServiceName()** to return **"test/elastic"** from the framework.

> Note concerning the naming for "getFullId() and getServiceName()"
> 
> I don't like the following method in the Application.js. Although it says getName() it returns part of the Id.
> But we can't change it now easily as a defect since it is used in numerous areas.

```
  getName() {
    return this.getId().split("/").pop();
  }
```

Closes DCOS-17301

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
