### PR TITLE
fix(PageHeaderActions): Remove restart action when is SDK

### DIFF
--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -1,4 +1,5 @@
 import { injectIntl } from "react-intl";
+import classNames from "classnames";
 import mixin from "reactjs-mixin";
 import React, { PropTypes } from "react";
 import { routerShape } from "react-router";
@@ -161,6 +162,7 @@ class ServiceDetail extends mixin(TabsMixin) {
   getActions() {
     const { service } = this.props;
     const instanceCount = service.getInstancesCount();
+    const isSDK = isSDKService(service);
 
     const actions = [];
 
@@ -185,7 +187,10 @@ class ServiceDetail extends mixin(TabsMixin) {
     if (instanceCount > 0) {
       actions.push({
         label: "Restart",
-        onItemSelect: this.onActionsItemSelection.bind(this, RESTART)
+        onItemSelect: this.onActionsItemSelection.bind(this, RESTART),
+        className: classNames({
+          hidden: isSDK
+        })
       });
     }
     if (!service.getLabels().MARATHON_SINGLE_INSTANCE_APP) {

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -1,5 +1,4 @@
 import { injectIntl } from "react-intl";
-import classNames from "classnames";
 import mixin from "reactjs-mixin";
 import React, { PropTypes } from "react";
 import { routerShape } from "react-router";
@@ -184,13 +183,10 @@ class ServiceDetail extends mixin(TabsMixin) {
       onItemSelect: this.onActionsItemSelection.bind(this, EDIT)
     });
 
-    if (instanceCount > 0) {
+    if (instanceCount > 0 && !isSDK) {
       actions.push({
         label: "Restart",
-        onItemSelect: this.onActionsItemSelection.bind(this, RESTART),
-        className: classNames({
-          hidden: isSDK
-        })
+        onItemSelect: this.onActionsItemSelection.bind(this, RESTART)
       });
     }
     if (!service.getLabels().MARATHON_SINGLE_INSTANCE_APP) {

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -231,6 +231,7 @@ class ServicesTable extends React.Component {
   }
 
   renderServiceActions(prop, service) {
+    const isSDK = isSDKService(service);
     const isGroup = service instanceof ServiceTree;
     const isPod = service instanceof Pod;
     const isSingleInstanceApp = service.getLabels()
@@ -268,7 +269,7 @@ class ServicesTable extends React.Component {
       },
       {
         className: classNames({
-          hidden: isPod || isGroup || instancesCount === 0
+          hidden: isSDK || isPod || isGroup || instancesCount === 0
         }),
         id: RESTART,
         html: this.props.intl.formatMessage({

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -231,7 +231,6 @@ class ServicesTable extends React.Component {
   }
 
   renderServiceActions(prop, service) {
-    const isSDK = isSDKService(service);
     const isGroup = service instanceof ServiceTree;
     const isPod = service instanceof Pod;
     const isSingleInstanceApp = service.getLabels()
@@ -240,6 +239,16 @@ class ServicesTable extends React.Component {
     const scaleTextID = isGroup
       ? ServiceActionLabels.scale_by
       : ServiceActionLabels[SCALE];
+    const restartObj = {
+      className: classNames({
+        hidden: isPod || isGroup || instancesCount === 0
+      }),
+      id: RESTART,
+      html: this.props.intl.formatMessage({
+        id: ServiceActionLabels[RESTART]
+      })
+    };
+    const isSDK = isSDKService(service) ? [] : [restartObj];
 
     const dropdownItems = [
       {
@@ -266,16 +275,8 @@ class ServicesTable extends React.Component {
         }),
         id: SCALE,
         html: this.props.intl.formatMessage({ id: scaleTextID })
-      },
-      {
-        className: classNames({
-          hidden: isSDK || isPod || isGroup || instancesCount === 0
-        }),
-        id: RESTART,
-        html: this.props.intl.formatMessage({
-          id: ServiceActionLabels[RESTART]
-        })
-      },
+      }
+    ].concat(isSDK, [
       {
         className: classNames({
           hidden: instancesCount === 0
@@ -304,7 +305,7 @@ class ServicesTable extends React.Component {
           </span>
         )
       }
-    ];
+    ]);
 
     return (
       <Tooltip content="More actions">

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -239,54 +239,58 @@ class ServicesTable extends React.Component {
     const scaleTextID = isGroup
       ? ServiceActionLabels.scale_by
       : ServiceActionLabels[SCALE];
-    const restartObj = {
-      className: classNames({
-        hidden: isPod || isGroup || instancesCount === 0
-      }),
-      id: RESTART,
-      html: this.props.intl.formatMessage({
-        id: ServiceActionLabels[RESTART]
-      })
-    };
-    const isSDK = isSDKService(service) ? [] : [restartObj];
+    const isSDK = isSDKService(service);
 
-    const dropdownItems = [
-      {
-        className: "hidden",
-        id: MORE,
-        html: "",
-        selectedHtml: <Icon id="ellipsis-vertical" size="mini" />
-      },
-      {
-        className: classNames({
-          hidden: !this.hasWebUI(service)
-        }),
+    const actions = [];
+
+    actions.push({
+      className: "hidden",
+      id: MORE,
+      html: "",
+      selectedHtml: <Icon id="ellipsis-vertical" size="mini" />
+    });
+
+    if (this.hasWebUI(service)) {
+      actions.push({
         id: OPEN,
         html: this.props.intl.formatMessage({ id: ServiceActionLabels.open })
-      },
-      {
-        className: classNames({ hidden: isGroup }),
+      });
+    }
+
+    if (!isGroup) {
+      actions.push({
         id: EDIT,
         html: this.props.intl.formatMessage({ id: ServiceActionLabels.edit })
-      },
-      {
-        className: classNames({
-          hidden: (isGroup && instancesCount === 0) || isSingleInstanceApp
-        }),
+      });
+    }
+
+    if (!isGroup && instancesCount > 0 && !isSingleInstanceApp) {
+      actions.push({
         id: SCALE,
         html: this.props.intl.formatMessage({ id: scaleTextID })
-      }
-    ].concat(isSDK, [
-      {
-        className: classNames({
-          hidden: instancesCount === 0
-        }),
+      });
+    }
+
+    if (!isPod && !isGroup && instancesCount > 0 && !isSDK) {
+      actions.push({
+        id: RESTART,
+        html: this.props.intl.formatMessage({
+          id: ServiceActionLabels[RESTART]
+        })
+      });
+    }
+
+    if (instancesCount > 0) {
+      actions.push({
         id: SUSPEND,
         html: this.props.intl.formatMessage({
           id: ServiceActionLabels[SUSPEND]
         })
-      },
-      {
+      });
+    }
+
+    if (!isGroup && instancesCount === 0) {
+      actions.push({
         className: classNames({
           hidden: isGroup || instancesCount > 0
         }),
@@ -294,18 +298,19 @@ class ServicesTable extends React.Component {
         html: this.props.intl.formatMessage({
           id: ServiceActionLabels[RESUME]
         })
-      },
-      {
-        id: DELETE,
-        html: (
-          <span className="text-danger">
-            {this.props.intl.formatMessage({
-              id: ServiceActionLabels[DELETE]
-            })}
-          </span>
-        )
-      }
-    ]);
+      });
+    }
+
+    actions.push({
+      id: DELETE,
+      html: (
+        <span className="text-danger">
+          {this.props.intl.formatMessage({
+            id: ServiceActionLabels[DELETE]
+          })}
+        </span>
+      )
+    });
 
     return (
       <Tooltip content="More actions">
@@ -316,7 +321,7 @@ class ServicesTable extends React.Component {
           dropdownMenuListClassName="dropdown-menu-list"
           dropdownMenuListItemClassName="clickable"
           wrapperClassName="dropdown flush-bottom table-cell-icon"
-          items={dropdownItems}
+          items={actions}
           persistentID={MORE}
           onItemSelection={this.onActionsItemSelection.bind(this, service)}
           scrollContainer=".gm-scroll-view"

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -293,9 +293,6 @@ class ServicesTable extends React.Component {
 
     if (!isGroup && instancesCount === 0) {
       actions.push({
-        className: classNames({
-          hidden: isGroup || instancesCount > 0
-        }),
         id: RESUME,
         html: this.props.intl.formatMessage({
           id: ServiceActionLabels[RESUME]

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -264,7 +264,7 @@ class ServicesTable extends React.Component {
       });
     }
 
-    if (!isGroup && instancesCount > 0 && !isSingleInstanceApp) {
+    if ((!isGroup && instancesCount > 0) || !isSingleInstanceApp) {
       actions.push({
         id: SCALE,
         html: this.props.intl.formatMessage({ id: scaleTextID })

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -264,7 +264,9 @@ class ServicesTable extends React.Component {
       });
     }
 
-    if ((!isGroup && instancesCount > 0) || !isSingleInstanceApp) {
+    // isSingleInstanceApp = Framework main scheduler
+    // instancesCount = service instances
+    if ((isGroup && instancesCount > 0) || (!isGroup && !isSingleInstanceApp)) {
       actions.push({
         id: SCALE,
         html: this.props.intl.formatMessage({ id: scaleTextID })

--- a/src/js/components/PageHeaderActionsMenu.js
+++ b/src/js/components/PageHeaderActionsMenu.js
@@ -22,6 +22,7 @@ const handleItemSelection = item => {
 
 const getDropdownItemFromComponent = (child, index) => {
   return {
+    className: child.props.className,
     onItemSelect: child.props.onItemSelect,
     html: child,
     id: index

--- a/src/js/components/PageHeaderActionsMenu.js
+++ b/src/js/components/PageHeaderActionsMenu.js
@@ -22,7 +22,6 @@ const handleItemSelection = item => {
 
 const getDropdownItemFromComponent = (child, index) => {
   return {
-    className: child.props.className,
     onItemSelect: child.props.onItemSelect,
     html: child,
     id: index

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -637,20 +637,12 @@ describe("Service Actions", function() {
       cy.get(".modal").should("not.exist");
     });
 
-    it("opens the restart dialog", function() {
-      clickHeaderAction("Restart");
-
+    it("restart should not exist", function() {
       cy
-        .get(".modal-header")
-        .contains("Restart Service")
-        .should("have.length", 1);
-
-      cy
-        .get(".modal pre")
-        .contains("dcos marathon app restart /services/sdk-sleep");
-      cy.get(".modal button").contains("Close").click();
-
-      cy.get(".modal").should("not.exist");
+        .get(".page-header-actions .dropdown")
+        .click()
+        .contains("restart")
+        .should("not.exist");
     });
   });
 });

--- a/tests/pages/services/ServiceTable-cy.js
+++ b/tests/pages/services/ServiceTable-cy.js
@@ -309,21 +309,10 @@ describe("Service Table", function() {
       cy.get(".modal").should("not.exist");
     });
 
-    it("opens the restart dialog", function() {
+    it("restart should not exist", function() {
       openDropdown("sdk-sleep");
-      clickDropdownAction("Restart");
 
-      cy
-        .get(".modal-header")
-        .contains("Restart Service")
-        .should("have.length", 1);
-
-      cy
-        .get(".modal pre")
-        .contains("dcos marathon app restart /services/sdk-sleep");
-      cy.get(".modal button").contains("Close").click();
-
-      cy.get(".modal").should("not.exist");
+      cy.get(".dropdown-menu-items").contains("restart").should("not.exist");
     });
   });
 

--- a/tests/pages/services/ServiceTable-cy.js
+++ b/tests/pages/services/ServiceTable-cy.js
@@ -51,10 +51,7 @@ describe("Service Table", function() {
     it("hides the suspend option in the service action dropdown", function() {
       openDropdown("sleep");
 
-      cy
-        .get(".dropdown-menu-items li")
-        .contains("Suspend")
-        .should("have.class", "hidden");
+      cy.get(".dropdown-menu-items li").contains("Suspend").should("not.exist");
     });
 
     it("shows the resume option in the service action dropdown", function() {


### PR DESCRIPTION
Removes restart action button from services and service detail page when service is SDK.

A code refactoring was also done to follow `ServiceDetail` patterns for the dropdown items, meaning when testing this PR we need to do a sanity check for the other buttons besides `restart`

Closes DCOS-16564

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
