### PR TITLE
fix(ServiceEditModal): show service edit instructions only in enterprise

### DIFF
--- a/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
+++ b/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from "react";
 import { injectIntl } from "react-intl";
+import { MountService } from "foundation-ui";
 import { Modal } from "reactjs-components";
 
 import ClipboardTrigger from "#SRC/js/components/ClipboardTrigger";
@@ -219,31 +220,23 @@ class ServiceActionDisabledModal extends React.Component {
   }
 
   getServiceEditMessage() {
-    const { intl } = this.props;
-    const command = this.getUpdateCommand();
+    const { intl, service } = this.props;
 
     return (
-      <div>
-        <p>
-          {intl.formatMessage({
-            id: "SERVICE_ACTIONS.SDK_SERVICE_UPDATE_PART_1"
-          })}
+      <MountService.Mount
+        type={"ServiceEditMessage:Modal"}
+        intl={intl}
+        service={service}
+      >
+        <div className="center">
+          Editing this service is only available on
           {" "}
-          <a
-            href={MetadataStore.buildDocsURI(
-              "/usage/managing-services/config-universe-service"
-            )}
-            target="_blank"
-          >
-            options.json
+          <a href="https://mesosphere.com/product/" target="_blank">
+            Mesosphere Enterprise DC/OS
           </a>
-          .{" "}
-          {intl.formatMessage({
-            id: "SERVICE_ACTIONS.SDK_SERVICE_UPDATE_PART_2"
-          })}
-        </p>
-        {this.getClipboardTrigger(command)}
-      </div>
+          .
+        </div>
+      </MountService.Mount>
     );
   }
 

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -565,9 +565,9 @@ describe("Service Actions", function() {
         .should("to.have.length", 1);
 
       cy
-        .get(".modal pre")
+        .get(".modal-body")
         .contains(
-          "dcos test --name=/services/sdk-sleep update start --options=options.json"
+          "Editing this service is only available on Mesosphere Enterprise DC/OS."
         );
 
       cy.get(".modal button").contains("Close").click();

--- a/tests/pages/services/ServiceTable-cy.js
+++ b/tests/pages/services/ServiceTable-cy.js
@@ -231,9 +231,9 @@ describe("Service Table", function() {
         .should("to.have.length", 1);
 
       cy
-        .get(".modal pre")
+        .get(".modal-body")
         .contains(
-          "dcos test --name=/services/sdk-sleep update start --options=options.json"
+          "Editing this service is only available on Mesosphere Enterprise DC/OS."
         );
 
       cy.get(".modal button").contains("Close").click();

--- a/tests/pages/services/ServiceTable-cy.js
+++ b/tests/pages/services/ServiceTable-cy.js
@@ -221,26 +221,6 @@ describe("Service Table", function() {
       cy.get(".modal").should("not.exist");
     });
 
-    it("opens the edit dialog", function() {
-      openDropdown("sdk-sleep");
-      clickDropdownAction("Edit");
-
-      cy
-        .get(".modal-header")
-        .contains("Edit Service")
-        .should("to.have.length", 1);
-
-      cy
-        .get(".modal-body")
-        .contains(
-          "Editing this service is only available on Mesosphere Enterprise DC/OS."
-        );
-
-      cy.get(".modal button").contains("Close").click();
-
-      cy.get(".modal").should("not.exist");
-    });
-
     it("opens the scale dialog", function() {
       openDropdown("sdk-sleep");
       clickDropdownAction("Scale");


### PR DESCRIPTION
**Description**:
As described in [DCOS-17205](https://jira.mesosphere.com/browse/DCOS-17205), this modal content on Open DC/OS should be as below:
![screen shot 2017-08-01 at 10 33 57 am](https://user-images.githubusercontent.com/1527504/28838357-f8cc415e-76a4-11e7-98bc-1a3dd2b0d439.png)


**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?