### PR TITLE
fix(Pods-Test): force click container because partially covered

### DIFF
--- a/system-tests/services/test-pods.js
+++ b/system-tests/services/test-pods.js
@@ -433,7 +433,11 @@ describe("Services", function() {
       cy.root().get(".menu-tabbed-item").contains("Services").should("exist");
 
       // Select second container
-      cy.root().get(".menu-tabbed-item").contains("second-container").click();
+      cy
+        .root()
+        .get(".menu-tabbed-item")
+        .contains("second-container")
+        .click({ force: true });
 
       // Configure container
       cy


### PR DESCRIPTION
This will fix the failing system test in Open DC/OS. It is failing because the container name is partially covered by the main content body. Solution is to force click, and then the test passes.

Example failure: https://jenkins.mesosphere.com/service/jenkins/job/Frontend/job/dcos-ui-ci-master-open/165/artifact/results/results.html

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?