### PR TITLE
fix(MesosStateStore): include unreachable tasks

### DIFF
--- a/plugins/services/src/js/constants/TaskStates.js
+++ b/plugins/services/src/js/constants/TaskStates.js
@@ -70,7 +70,7 @@ const TaskStates = {
   },
 
   TASK_UNREACHABLE: {
-    stateTypes: ["completed", "failure"],
+    stateTypes: ["active", "failure"],
     displayName: "Unreachable"
   },
 

--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -206,8 +206,9 @@ class TaskTable extends React.Component {
     return tasks
       .filter(function(task) {
         return (
-          TaskStates[task.state].stateTypes.includes("completed") ||
-          !task.isStartedByMarathon
+          task.state !== "TASK_UNREACHABLE" &&
+          (TaskStates[task.state].stateTypes.includes("completed") ||
+            !task.isStartedByMarathon)
         );
       })
       .reduce(function(acc, task) {


### PR DESCRIPTION
Include unreachable tasks into the task list. Also make them selectable in the Task table in the
Service detail page.

To check the issue you have to deploy an application and then shut down a agent node where one task
is currently running. This does take a couple of steps

- Find out the master IP
- find out the internal agent IP
- ssh into the master best with -A option so that you can ssh into the agent with the same keyfile
- ssh from the master to the agent node
- run `sudo systemctl stop dcos-mesos-slave.service`
- wait about 10 minutes.

Your service will be unreachable at this point and it will still be in the task table.

Also a unreachable tasks are like Schroedingers, completed and active at the same time we decieded to
rather see them as active so we can kill / restart them from the UI.

Closes DCOS_OSS-940

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
