### PR TITLE
fix(CreateServiceModalCatalogPanelOption): fix redirect to catalog

### DIFF
--- a/src/js/components/CreateServiceModalCatalogPanelOption.js
+++ b/src/js/components/CreateServiceModalCatalogPanelOption.js
@@ -17,7 +17,7 @@ class CreateServicePickerCatalogOption extends React.Component {
       <CreateServiceModalServicePickerOption
         columnClasses={columnClasses}
         onOptionSelect={onOptionSelect.bind(null, {
-          route: "catalog",
+          route: "/catalog",
           type: "redirect"
         })}
       >


### PR DESCRIPTION
**Problem**:
Clicking the "install a package" options redirects to an improper location and hence directs to the dashboard page. Demo:

https://cl.ly/0K0m0f2g0O2i

**Fix**:
Adding a slash before the "catalog" name fixes the problem. Now clicking the "install a package" will direct to the catalog page.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
