### PR TITLE
Adjust Health Reporting for SDK Tasks

### DIFF
--- a/plugins/services/src/js/constants/TaskHealthStates.js
+++ b/plugins/services/src/js/constants/TaskHealthStates.js
@@ -1,7 +1,7 @@
 const TaskHealthStates = {
   HEALTHY: "Healthy",
   UNHEALTHY: "Unhealthy",
-  UNKNOWN: "Unkown"
+  UNKNOWN: "Unknown"
 };
 
 module.exports = TaskHealthStates;

--- a/plugins/services/src/js/structs/Framework.js
+++ b/plugins/services/src/js/structs/Framework.js
@@ -1,4 +1,5 @@
 import { cleanServiceJSON } from "#SRC/js/utils/CleanJSONUtil";
+import { isSDKService } from "#SRC/js/utils/ServiceUtil";
 
 import {
   ROUTE_ACCESS_PREFIX,
@@ -32,6 +33,7 @@ module.exports = class Framework extends Application {
   }
 
   getTasksSummary() {
+    const isSDK = isSDKService(this);
     // TODO: Circular reference workaround DCOS_OSS-783
     const MesosStateStore = require("#SRC/js/stores/MesosStateStore");
 
@@ -47,7 +49,7 @@ module.exports = class Framework extends Application {
       }
       if (task.statuses != null) {
         return task.statuses.reduce(function(memo, status) {
-          if (status.healthy) {
+          if (status.healthy || (isSDK && status.healthy === undefined)) {
             memo.tasksHealthy++;
             memo.tasksUnknown--;
           }

--- a/plugins/services/src/js/structs/ServiceTree.js
+++ b/plugins/services/src/js/structs/ServiceTree.js
@@ -119,7 +119,10 @@ module.exports = class ServiceTree extends Tree {
    */
   findServiceByName(name) {
     return this.findItem(function(item) {
-      return item.getName() === name && item instanceof Service;
+      return (
+        (item instanceof Framework && item.getFrameworkName() === name) ||
+        (item instanceof Service && item.getName() === name)
+      );
     });
   }
 

--- a/plugins/services/src/js/structs/ServiceTree.js
+++ b/plugins/services/src/js/structs/ServiceTree.js
@@ -113,19 +113,6 @@ module.exports = class ServiceTree extends Tree {
     });
   }
 
-  /**
-   * @param {string} name
-   * @return {Service} matching Service
-   */
-  findServiceByName(name) {
-    return this.findItem(function(item) {
-      return (
-        (item instanceof Framework && item.getFrameworkName() === name) ||
-        (item instanceof Service && item.getName() === name)
-      );
-    });
-  }
-
   // TODO @pierlo-upitup MARATHON-1030: refactor for more generic usage
   filterItemsByFilter(filter) {
     let services = this.getItems();

--- a/plugins/services/src/js/utils/GraphQLTaskUtil.js
+++ b/plugins/services/src/js/utils/GraphQLTaskUtil.js
@@ -45,6 +45,7 @@ function getTaskHealthFromMarathon(task) {
 
 function mergeHealth(task) {
   let health = TaskHealthStates.UNKNOWN;
+
   let taskHealth = getTaskHealthFromMesos(task);
 
   if (taskHealth === null) {
@@ -56,6 +57,14 @@ function mergeHealth(task) {
   }
   if (taskHealth === false) {
     health = TaskHealthStates.UNHEALTHY;
+  }
+
+  if (
+    health === TaskHealthStates.UNKNOWN &&
+    task.sdkTask &&
+    task.state === "TASK_RUNNING"
+  ) {
+    health = TaskHealthStates.HEALTHY;
   }
 
   task.health = health;

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -219,10 +219,13 @@ class MesosStateStore extends GetSetBaseStore {
     frameworks.forEach(framework => {
       framework.tasks.forEach(function(task) {
         if (task.slave_id === nodeID) {
-          // Need to get service from Marathon because we need the labels
-          const service = DCOSStore.serviceTree.findServiceByName(
-            framework.name
-          );
+          // Need to get service from Marathon because we need the labels.
+          const service = DCOSStore.serviceTree.findItem(function(item) {
+            return (
+              item instanceof Framework &&
+              item.getFrameworkName() === framework.name
+            );
+          });
           task = assignSchedulerTaskField(task, schedulerTasks);
           task = flagSDKTask(task, service);
           memberTasks[task.id] = task;


### PR DESCRIPTION
All tasks for an SDK service have been changed to report "healthy" by default, if in RUNNING state and they haven't been reported as "unhealthy". Previously tasks matching this criteria reported "unknown".

This change affects the tasks associated with an SDK service (service detail page for SDK service, and node detail page, where SDK tasks are running on that node).

SDK service detail before:
![](https://cl.ly/2W1b2a1P2H0L/Image%202017-08-03%20at%202.41.16%20PM.png)

SDK service detail after:
![](https://cl.ly/020c1n0e451D/Image%202017-08-03%20at%202.41.50%20PM.png)

Node detail before:
![](https://cl.ly/1c2b351O1D3c/Image%202017-08-03%20at%202.42.21%20PM.png)

Node detail after:
![](https://cl.ly/002W2R2S2K44/Image%202017-08-03%20at%202.42.05%20PM.png)


**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
