### PR TITLE
DCOS-16636: Adjust setup and universe teardown script

### DIFF
--- a/system-tests/_scripts/setup.sh
+++ b/system-tests/_scripts/setup.sh
@@ -5,16 +5,25 @@ source .env/bin/activate
 
 # Install DC/OS CLI in the sandbox so we can setup and teardown our tests
 if [ `uname -s` == "Darwin" ]; then
-  curl https://downloads.dcos.io/binaries/cli/darwin/x86-64/dcos-1.9/dcos -o .env/bin/dcos
+  curl https://downloads.dcos.io/binaries/cli/darwin/x86-64/dcos-1.10/dcos -o .env/bin/dcos
 else
-  curl https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.9/dcos -o .env/bin/dcos
+  curl https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.10/dcos -o .env/bin/dcos
 fi
 chmod +x .env/bin/dcos
 
 # Configure DC/OS CLI
-dcos config set core.dcos_url $CLUSTER_URL
-dcos config set core.ssl_verify False
-echo dcos_acs_token = \"$CLUSTER_AUTH_TOKEN\" >> ~/.dcos/dcos.toml
+CONFIG_DIR=~/.dcos
+CONFIG_FILE=${CONFIG_DIR}/dcos.toml
+mkdir -p ${CONFIG_DIR}
+cat << EOF > ${CONFIG_FILE}
+  [core]
+  ssl_verify = "false"
+  reporting = true
+  timeout = 5
+  dcos_url = "${CLUSTER_URL}"
+  dcos_acs_token = "${CLUSTER_AUTH_TOKEN}"
+EOF
+chmod 600 ${CONFIG_FILE}
 
 # Install cypress if missing
 if ! hash cypress 2>/dev/null; then

--- a/system-tests/universe/_scripts/teardown
+++ b/system-tests/universe/_scripts/teardown
@@ -7,9 +7,9 @@ from subprocess import check_output
 packages = json.loads(check_output('dcos package list --json', shell=True).decode('utf-8'))
 for package in packages:
   for appId in package['apps']:
-    if appId.startswith("%s." % os.environ['TEST_UUID']):
+    if appId.startswith(("/%s" % os.environ['TEST_UUID'])):
       print("Removing package %s" % appId)
-      check_output('dcos package uninstall %s --app-id=%s' % (package['name'], appId), shell=True)
+      check_output('dcos package uninstall %s --app-id=%s --yes' % (package['name'], appId), shell=True)
     elif appId == '/confluent-kafka' or appId == '/bitbucket':
       print("Removing package %s" % appId)
-      check_output('dcos package uninstall %s --app-id=%s' % (package['name'], appId), shell=True)
+      check_output('dcos package uninstall %s --app-id=%s --yes' % (package['name'], appId), shell=True)


### PR DESCRIPTION
Change the system test setup script to use the dcos 1.10 cli, to maintain compatibility with the respective DC/OS version, and fix the `appId` condition in the universe teardown script. These changes are needed to uninstall all universe packages launched during a test run.

Closes  DCOS-16636