### PR TITLE
feat(object-utilities) introduce a new object-utilities package

### DIFF
--- a/packages/object-utilities/index.js
+++ b/packages/object-utilities/index.js
@@ -1,0 +1,1 @@
+export { default } from "./src/js/__protected.js";

--- a/packages/object-utilities/src/js/__protected.js
+++ b/packages/object-utilities/src/js/__protected.js
@@ -1,0 +1,44 @@
+/**
+ * Creates a non-enumerable, non-configurable
+ * and non-writeable property in the given object.
+ * Use this for properties you want to be considered
+ * as protected, functions are public for now.
+ *
+ * Usage:
+ * class WithProtected {
+ *   constructor() {
+ *     // set multiple properties
+ *     __protected(this, { foo: "bar", some: "thing"});
+ *     // set/change one
+ *     __protected(this).foo = "baz";
+ *     // read
+ *     alert(__protected(this).foo);
+ *   }
+ * }
+ *
+ * @param {Object} object – given object
+ * @param {Object} [value] – given value
+ * @return {Object} protected property / context
+ */
+export default function __protected(object, value) {
+  if (object === undefined || object === null) {
+    throw new Error("no object given or null");
+  }
+  if (object.__protected__ === undefined) {
+    Object.defineProperty(object, "__protected__", {
+      configurable: false,
+      enumerable: false,
+      writeable: false,
+      value: {}
+    });
+  }
+  if (value !== undefined) {
+    if (typeof value === "object") {
+      Object.assign(object.__protected__, value);
+    } else {
+      throw new Error("value must be an object");
+    }
+  }
+
+  return object.__protected__;
+}

--- a/packages/object-utilities/src/js/__tests__/__protected-test.js
+++ b/packages/object-utilities/src/js/__tests__/__protected-test.js
@@ -1,0 +1,40 @@
+jest.dontMock("../__protected");
+
+const __protected = require("../__protected").default;
+
+describe("__protected", () => {
+  it("initializes", () => {
+    const obj = {};
+    expect(__protected(obj)).toEqual({});
+  });
+
+  it("throws error without object", () => {
+    expect(() => {
+      __protected();
+    }).toThrowError();
+  });
+
+  it("throws error with invalid value", () => {
+    const obj = {};
+    expect(() => {
+      __protected(obj, "foobar");
+    }).toThrowError();
+  });
+
+  it("saves values through value parameter", () => {
+    const obj = {};
+    expect(__protected(obj, { foo: "bar" }).foo).toEqual("bar");
+  });
+
+  it("saves value through returned object", () => {
+    const obj = {};
+    __protected(obj).foo = "bar";
+    expect(__protected(obj).foo).toEqual("bar");
+  });
+
+  it("changes value through value parameter", () => {
+    const obj = {};
+    __protected(obj, { foo: "bar" });
+    expect(__protected(obj, { foo: "baz" }).foo).toEqual("baz");
+  });
+});


### PR DESCRIPTION
This Package will hold object related utilities.
Feel free to add more and to refactor/resort stuff in here.

The first utility inside this package will be `__protected`:

Using private variables is relatively straightforward with local context
variables, but protected is a bit more tricky. This Utility enables
us to use protected variables like this:

```
class Something {
  constructor() {
    __protected(this, { foo: "bar" });
  }
  func() {
    __protected(this).foo =  __protected(this).foo + "baz" // barbaz
  }
}
class SubSomething {
  constructor() {
    __protected(this).foo = "subbaz";
  }
}
```

**Under the Hood:**
After some fiddling, I came to an approach where we simply add a __protected__ property to the class/object. Its not a real protected property, but as it is freezed and "__"-prefixed we can say its "protected by definition".

**Please discuss / give feedback.**