### PR TITLE
fix(ServiceDestroyModal): fix wording on delete group

### DIFF
--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -197,16 +197,10 @@ class ServiceDestroyModal extends React.Component {
   getDestroyServiceModal() {
     const { open, service, intl } = this.props;
     const serviceName = service.getName();
+    const serviceLabel = this.getServiceLabel();
 
     let itemText = `${StringUtil.capitalize(UserActions.DELETE)}`;
-
-    if (service instanceof Pod) {
-      itemText += " Pod";
-    }
-
-    if (service instanceof ServiceTree) {
-      itemText += " Group";
-    }
+    itemText += ` ${serviceLabel}`;
 
     return (
       <Confirm
@@ -226,9 +220,14 @@ class ServiceDestroyModal extends React.Component {
             id: "SERVICE_ACTIONS.DELETE_SERVICE"
           })}
           <strong>{serviceName}</strong>
-          {intl.formatMessage({
-            id: "SERVICE_ACTIONS.DELETE_SERVICE_2"
-          })}
+          {intl.formatMessage(
+            {
+              id: "SERVICE_ACTIONS.DELETE_SERVICE_2"
+            },
+            {
+              label: serviceLabel.toLowerCase()
+            }
+          )}
         </p>
         <input
           className="form-control filter-input-text"
@@ -260,6 +259,20 @@ class ServiceDestroyModal extends React.Component {
         {this.props.subHeaderContent}
       </p>
     );
+  }
+
+  getServiceLabel() {
+    const { service } = this.props;
+
+    if (service instanceof Pod) {
+      return "Pod";
+    }
+
+    if (service instanceof ServiceTree) {
+      return "Group";
+    }
+
+    return "Service";
   }
 
   render() {

--- a/src/js/translations/en-US.json
+++ b/src/js/translations/en-US.json
@@ -74,7 +74,7 @@
   "SERVICES.DEPLOYMENT_COUNT": "{deploymentsCount} {deploymentsCount, plural, =1 {deployment} other {deployments}}",
   "SERVICES.DEPLOYMENT_MODAL_HEADING": "{deploymentsCount} Active {deploymentsCount, plural, =1 {Deployment} other {Deployments}}",
   "SERVICE_ACTIONS.DELETE_SERVICE": "In order to delete ",
-  "SERVICE_ACTIONS.DELETE_SERVICE_2": " please type service name.",
+  "SERVICE_ACTIONS.DELETE_SERVICE_2": " please type {label} name.",
   "SERVICE_ACTIONS.DELETE_SERVICE_FRAMEWORK": "In order to delete a service, you must use the DC/OS CLI to perform this command. Refer to the ",
   "SERVICE_ACTIONS.DELETE_SERVICE_FRAMEWORK_2": " for complete instructions or copy and paste this command into your CLI."
 }


### PR DESCRIPTION
Fix wording on ServiceDestroyModal when deleting a service/group/pod.

Closes DCOS-17534

**Before:**
![delete-group](https://user-images.githubusercontent.com/549394/29046148-0b7fb4cc-7b7b-11e7-9bb2-27ab310e023d.png)

**After:**
![screen shot 2017-08-07 at 2 09 25 pm](https://user-images.githubusercontent.com/549394/29046175-1f305ed6-7b7b-11e7-820c-9eb88740cac9.png)
![screen shot 2017-08-07 at 2 09 38 pm](https://user-images.githubusercontent.com/549394/29046176-1f33678e-7b7b-11e7-98eb-38ec01ea16bf.png)
![screen shot 2017-08-07 at 2 09 52 pm](https://user-images.githubusercontent.com/549394/29046174-1f3055e4-7b7b-11e7-95c5-87ef1e6ebd49.png)


**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
