### PR TITLE
DCOS-16280: include forcePull parameter in image object for multi-pod containers

### DIFF
--- a/plugins/services/src/js/components/forms/MultiContainerFormAdvancedSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerFormAdvancedSection.js
@@ -1,0 +1,52 @@
+import React from "react";
+
+import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
+import FieldHelp from "#SRC/js/components/form/FieldHelp";
+import FieldInput from "#SRC/js/components/form/FieldInput";
+import FieldLabel from "#SRC/js/components/form/FieldLabel";
+
+const getForcePullSection = function(data, path) {
+  const imageForcePullPath = `${path}.image.forcePull`;
+  const imageForcePull = findNestedPropertyInObject(data, imageForcePullPath);
+
+  return (
+    <FieldLabel>
+      <FieldInput
+        checked={imageForcePull}
+        name={imageForcePullPath}
+        type="checkbox"
+        value={imageForcePull}
+      />
+      Force Pull Image On Launch
+      <FieldHelp>
+        Force Docker to pull the image before launching each instance.
+      </FieldHelp>
+    </FieldLabel>
+  );
+};
+
+const MultiContainerFormAdvancedSection = ({ data, path }) => {
+  return (
+    <div>
+      <h3 className="short-top short-bottom">
+        Advanced Settings
+      </h3>
+      <p>Advanced settings of the container.</p>
+      <p>
+        {getForcePullSection(data, path)}
+      </p>
+    </div>
+  );
+};
+
+MultiContainerFormAdvancedSection.defaultProps = {
+  data: {},
+  path: "container"
+};
+
+MultiContainerFormAdvancedSection.propTypes = {
+  data: React.PropTypes.object,
+  path: React.PropTypes.string
+};
+
+module.exports = MultiContainerFormAdvancedSection;

--- a/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/NewCreateServiceModalForm.js
@@ -37,6 +37,8 @@ import MultiContainerNetworkingFormSection
   from "../forms/MultiContainerNetworkingFormSection";
 import MultiContainerVolumesFormSection
   from "../forms/MultiContainerVolumesFormSection";
+import MultiContainerFormAdvancedSection
+  from "../forms/MultiContainerFormAdvancedSection";
 import NetworkingFormSection from "../forms/NetworkingFormSection";
 import PodSpec from "../../structs/PodSpec";
 import ServiceErrorMessages from "../../constants/ServiceErrorMessages";
@@ -373,10 +375,10 @@ class NewCreateServiceModalForm extends Component {
               More Settings
             </AdvancedSectionLabel>
             <AdvancedSectionContent>
-              <h3 className="short-top short-bottom">
-                Advanced Settings
-              </h3>
-              <p>Advanced settings of the container</p>
+              <MultiContainerFormAdvancedSection
+                data={data}
+                path={`containers.${index}`}
+              />
               <ArtifactsSection
                 data={artifacts}
                 path={artifactsPath}

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/Containers.js
@@ -118,8 +118,14 @@ module.exports = {
     }
 
     if (type === SET && joinedPath === `containers.${index}.image.id`) {
-      newState[index] = Object.assign({}, newState[index], {
-        image: { id: value }
+      newState[index].image = Object.assign({}, newState[index].image, {
+        id: value
+      });
+    }
+
+    if (type === SET && joinedPath === `containers.${index}.image.forcePull`) {
+      newState[index].image = Object.assign({}, newState[index].image, {
+        forcePull: value
       });
     }
 

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
@@ -178,6 +178,65 @@ describe("Containers", function() {
           }
         ]);
       });
+
+      it("sets forcePull correctly for multiple containers", function() {
+        const batch = [
+          new Transaction(["containers"], {}, ADD_ITEM),
+          new Transaction(["containers", 0, "image", "id"], "nginx", SET),
+          new Transaction(["containers", 0, "image", "forcePull"], true, SET)
+        ].reduce(function(batch, transaction) {
+          return batch.add(transaction);
+        }, new Batch());
+
+        expect(batch.reduce(Containers.JSONReducer.bind({}))).toEqual([
+          {
+            name: "container-1",
+            resources: { cpus: 0.1, mem: 128 },
+            image: {
+              id: "nginx",
+              kind: "DOCKER",
+              forcePull: true
+            }
+          }
+        ]);
+      });
+
+      it("deletes the image object once id is set to empty and the forcePull to false", function() {
+        const batch = [
+          new Transaction(["containers"], {}, ADD_ITEM),
+          new Transaction(["containers", 0, "image", "id"], "nginx", SET),
+          new Transaction(["containers", 0, "image", "forcePull"], true, SET),
+          new Transaction(["containers", 0, "image", "id"], "", SET),
+          new Transaction(["containers", 0, "image", "forcePull"], false, SET)
+        ].reduce(function(batch, transaction) {
+          return batch.add(transaction);
+        }, new Batch());
+
+        expect(batch.reduce(Containers.JSONReducer.bind({}))).toEqual([
+          {
+            name: "container-1",
+            resources: { cpus: 0.1, mem: 128 }
+          }
+        ]);
+      });
+
+      it("removes image object if forcePull is set to true and id is set to empty", function() {
+        const batch = [
+          new Transaction(["containers"], {}, ADD_ITEM),
+          new Transaction(["containers", 0, "image", "id"], "nginx", SET),
+          new Transaction(["containers", 0, "image", "forcePull"], true, SET),
+          new Transaction(["containers", 0, "image", "id"], "", SET)
+        ].reduce(function(batch, transaction) {
+          return batch.add(transaction);
+        }, new Batch());
+
+        expect(batch.reduce(Containers.JSONReducer.bind({}))).toEqual([
+          {
+            name: "container-1",
+            resources: { cpus: 0.1, mem: 128 }
+          }
+        ]);
+      });
     });
 
     describe("endpoints", function() {


### PR DESCRIPTION
Include the forcePull parameter in the image object for the multi-container service.
You can find this option over here => https://mesosphere.github.io/marathon/docs/pods.html#containerizers

Closes DCOS-16280

To reproduce:

1) Open the multi-container create form
2) Once you open the container's options you can see a new option named "Force pull image on launch"

![multi-container-forcepull](https://user-images.githubusercontent.com/180432/29051982-8a25209e-7b9b-11e7-8823-bb20f5849e62.png)


3) There are some interesting cases you can check
     a) If the forcePull = false and the containerImageName == "" then the image object should be           
         deleted
     b) If the forcePull = true and the containerImageName == "" then the image object doesn't show in the JSON Editor but still exists, so if you set something at the container image name it should have forcePull = true.
     c) If you first create a container and add only the container image name but don't specifically set the state of the forcePull it doesn't exist which is ok. If you deliberately set it to true or false then it should keep the value you set.

![image](https://user-images.githubusercontent.com/180432/29052049-16fbe57a-7b9c-11e7-9e76-1ab095327fd0.png)


**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [x] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
