### PR TITLE
fix(ServiceDestroyModal): improve wording on delete/restart/suspend

### DIFF
--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -198,9 +198,7 @@ class ServiceDestroyModal extends React.Component {
     const { open, service } = this.props;
     const serviceName = service.getName();
     const serviceLabel = this.getServiceLabel();
-
-    let itemText = `${StringUtil.capitalize(UserActions.DELETE)}`;
-    itemText += ` ${serviceLabel}`;
+    const itemText = `${StringUtil.capitalize(UserActions.DELETE)} ${serviceLabel}`;
 
     return (
       <Confirm

--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -223,7 +223,7 @@ class ServiceDestroyModal extends React.Component {
           <strong>{serviceName}</strong>
           {" "}
           {serviceLabel.toLowerCase()}.
-          Please type ("
+          Type ("
           <strong>{serviceName}</strong>
           ") below to confirm you want to delete the
           {" "}

--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -195,18 +195,12 @@ class ServiceDestroyModal extends React.Component {
   }
 
   getDestroyServiceModal() {
-    const { open, service, intl } = this.props;
+    const { open, service } = this.props;
     const serviceName = service.getName();
+    const serviceLabel = this.getServiceLabel();
 
     let itemText = `${StringUtil.capitalize(UserActions.DELETE)}`;
-
-    if (service instanceof Pod) {
-      itemText += " Pod";
-    }
-
-    if (service instanceof ServiceTree) {
-      itemText += " Group";
-    }
+    itemText += ` ${serviceLabel}`;
 
     return (
       <Confirm
@@ -222,13 +216,18 @@ class ServiceDestroyModal extends React.Component {
         showHeader={true}
       >
         <p>
-          {intl.formatMessage({
-            id: "SERVICE_ACTIONS.DELETE_SERVICE"
-          })}
+          This action
+          {" "}
+          <strong>CANNOT</strong> be undone. This will permanently delete the
+          {" "}
           <strong>{serviceName}</strong>
-          {intl.formatMessage({
-            id: "SERVICE_ACTIONS.DELETE_SERVICE_2"
-          })}
+          {" "}
+          {serviceLabel.toLowerCase()}.
+          Please type ("
+          <strong>{serviceName}</strong>
+          ") below to confirm you want to delete the
+          {" "}
+          {serviceLabel.toLowerCase()}.
         </p>
         <input
           className="form-control filter-input-text"
@@ -243,9 +242,11 @@ class ServiceDestroyModal extends React.Component {
   }
 
   getModalHeading() {
+    const serviceLabel = this.getServiceLabel();
+
     return (
       <ModalHeading className="text-danger">
-        {StringUtil.capitalize(UserActions.DELETE)}
+        {StringUtil.capitalize(UserActions.DELETE)} {serviceLabel}
       </ModalHeading>
     );
   }
@@ -260,6 +261,20 @@ class ServiceDestroyModal extends React.Component {
         {this.props.subHeaderContent}
       </p>
     );
+  }
+
+  getServiceLabel() {
+    const { service } = this.props;
+
+    if (service instanceof Pod) {
+      return "Pod";
+    }
+
+    if (service instanceof ServiceTree) {
+      return "Group";
+    }
+
+    return "Service";
   }
 
   render() {

--- a/plugins/services/src/js/components/modals/ServiceRestartModal.js
+++ b/plugins/services/src/js/components/modals/ServiceRestartModal.js
@@ -5,6 +5,7 @@ import PureRender from "react-addons-pure-render-mixin";
 import ModalHeading from "#SRC/js/components/modals/ModalHeading";
 
 import AppLockedMessage from "./AppLockedMessage";
+import Pod from "../../structs/Pod";
 import Service from "../../structs/Service";
 import ServiceTree from "../../structs/ServiceTree";
 
@@ -79,38 +80,64 @@ class ServiceRestartModal extends React.Component {
     );
   }
 
-  render() {
-    const { isPending, onClose, open, service, restartService } = this.props;
+  getServiceLabel() {
+    const { service } = this.props;
 
-    const heading = (
+    if (service instanceof Pod) {
+      return "Pod";
+    }
+
+    if (service instanceof ServiceTree) {
+      return "Group";
+    }
+
+    return "Service";
+  }
+
+  getModalHeading() {
+    const serviceLabel = this.getServiceLabel();
+
+    return (
       <ModalHeading>
-        Restart Service
+        Restart {serviceLabel}
       </ModalHeading>
     );
+  }
+
+  render() {
+    const { isPending, onClose, open, service, restartService } = this.props;
     let serviceName = "";
+    const serviceLabel = this.getServiceLabel();
 
     if (service) {
-      serviceName = service.getId();
+      serviceName = service.getName();
     }
 
     return (
       <Confirm
         disabled={isPending}
-        header={heading}
+        header={this.getModalHeading()}
         open={open}
         onClose={onClose}
         leftButtonCallback={onClose}
-        rightButtonText="Restart Service"
+        rightButtonText={`Restart ${serviceLabel}`}
         rightButtonClassName="button button-danger"
         rightButtonCallback={() =>
           restartService(service, this.shouldForceUpdate())}
         showHeader={true}
       >
         <p>
-          Are you sure you want to restart
+          Restarting the
           {" "}
-          <span className="emphasize">{serviceName}</span>
-          ?
+          <strong>{serviceName}</strong>
+          {" "}
+          {serviceLabel.toLowerCase()}
+          {" "}
+          will remove all currently running instances of the
+          {" "}
+          {serviceLabel.toLowerCase()}
+          {" "}
+          and then attempt to create new instances identical to those removed.
         </p>
         {this.getErrorMessage()}
       </Confirm>

--- a/plugins/services/src/js/components/modals/ServiceRestartModal.js
+++ b/plugins/services/src/js/components/modals/ServiceRestartModal.js
@@ -106,12 +106,8 @@ class ServiceRestartModal extends React.Component {
 
   render() {
     const { isPending, onClose, open, service, restartService } = this.props;
-    let serviceName = "";
+    const serviceName = service.getName();
     const serviceLabel = this.getServiceLabel();
-
-    if (service) {
-      serviceName = service.getName();
-    }
 
     return (
       <Confirm

--- a/plugins/services/src/js/components/modals/ServiceSuspendModal.js
+++ b/plugins/services/src/js/components/modals/ServiceSuspendModal.js
@@ -107,11 +107,7 @@ class ServiceSuspendModal extends React.Component {
   render() {
     const { isPending, onClose, open, service, suspendItem } = this.props;
     const serviceLabel = this.getServiceLabel();
-    let serviceName = "";
-
-    if (service) {
-      serviceName = service.getName();
-    }
+    const serviceName = service.getName();
 
     return (
       <Confirm

--- a/plugins/services/src/js/components/modals/ServiceSuspendModal.js
+++ b/plugins/services/src/js/components/modals/ServiceSuspendModal.js
@@ -106,11 +106,8 @@ class ServiceSuspendModal extends React.Component {
 
   render() {
     const { isPending, onClose, open, service, suspendItem } = this.props;
-
-    let itemText = "";
-    let serviceName = "";
     const serviceLabel = this.getServiceLabel();
-    itemText += ` ${serviceLabel}`;
+    let serviceName = "";
 
     if (service) {
       serviceName = service.getName();
@@ -123,7 +120,7 @@ class ServiceSuspendModal extends React.Component {
         open={open}
         onClose={onClose}
         leftButtonCallback={onClose}
-        rightButtonText={`Suspend ${itemText}`}
+        rightButtonText={`Suspend ${serviceLabel}`}
         rightButtonCallback={() => suspendItem(this.shouldForceUpdate())}
         showHeader={true}
       >

--- a/plugins/services/src/js/components/modals/ServiceSuspendModal.js
+++ b/plugins/services/src/js/components/modals/ServiceSuspendModal.js
@@ -80,34 +80,46 @@ class ServiceSuspendModal extends React.Component {
     );
   }
 
-  render() {
-    const { isPending, onClose, open, service, suspendItem } = this.props;
-
-    let itemText = "Service";
-    let serviceName = "";
+  getServiceLabel() {
+    const { service } = this.props;
 
     if (service instanceof Pod) {
-      itemText = "Pod";
+      return "Pod";
     }
 
     if (service instanceof ServiceTree) {
-      itemText = "Group";
+      return "Group";
     }
 
-    if (service) {
-      serviceName = service.getId();
-    }
+    return "Service";
+  }
 
-    const heading = (
+  getModalHeading() {
+    const serviceLabel = this.getServiceLabel();
+
+    return (
       <ModalHeading>
-        Suspend {itemText}
+        Suspend {serviceLabel}
       </ModalHeading>
     );
+  }
+
+  render() {
+    const { isPending, onClose, open, service, suspendItem } = this.props;
+
+    let itemText = "";
+    let serviceName = "";
+    const serviceLabel = this.getServiceLabel();
+    itemText += ` ${serviceLabel}`;
+
+    if (service) {
+      serviceName = service.getName();
+    }
 
     return (
       <Confirm
         disabled={isPending}
-        header={heading}
+        header={this.getModalHeading()}
         open={open}
         onClose={onClose}
         leftButtonCallback={onClose}
@@ -116,11 +128,17 @@ class ServiceSuspendModal extends React.Component {
         showHeader={true}
       >
         <p>
-          Are you sure you want to suspend
+          Suspending the
           {" "}
-          <span className="emphasize">{serviceName}</span>
+          <strong>{serviceName}</strong>
           {" "}
-          by scaling to 0 instances?
+          {serviceLabel.toLowerCase()}
+          {" "}
+          will remove all currently running instances of the
+          {" "}
+          {serviceLabel.toLowerCase()}.
+          {" "}
+          The {serviceLabel.toLowerCase()} will not be deleted.
         </p>
         {this.getErrorMessage()}
       </Confirm>

--- a/src/js/translations/en-US.json
+++ b/src/js/translations/en-US.json
@@ -73,8 +73,6 @@
 
   "SERVICES.DEPLOYMENT_COUNT": "{deploymentsCount} {deploymentsCount, plural, =1 {deployment} other {deployments}}",
   "SERVICES.DEPLOYMENT_MODAL_HEADING": "{deploymentsCount} Active {deploymentsCount, plural, =1 {Deployment} other {Deployments}}",
-  "SERVICE_ACTIONS.DELETE_SERVICE": "In order to delete ",
-  "SERVICE_ACTIONS.DELETE_SERVICE_2": " please type service name.",
   "SERVICE_ACTIONS.DELETE_SERVICE_FRAMEWORK": "In order to delete a service, you must use the DC/OS CLI to perform this command. Refer to the ",
   "SERVICE_ACTIONS.DELETE_SERVICE_FRAMEWORK_2": " for complete instructions or copy and paste this command into your CLI."
 }

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -304,8 +304,8 @@ describe("Service Actions", function() {
 
     it("opens the correct service suspend dialog", function() {
       cy
-        .get(".confirm-modal p .emphasize")
-        .contains("/cassandra-healthy")
+        .get(".confirm-modal p strong")
+        .contains("cassandra-healthy")
         .should("to.have.length", 1);
     });
 


### PR DESCRIPTION
Improve wording/sentence when deleting/suspending/restarting a service/pod/group

Closes DCOS-17296 and DCOS-17534

Be aware that the wording was updated here in comparison to the Jira comment after I discussed "offline" with @ashenden 

**Now:**
![screen shot 2017-08-08 at 3 35 43 pm](https://user-images.githubusercontent.com/549394/29097832-dd0fa882-7c50-11e7-8743-ae84827fb839.png)
![screen shot 2017-08-08 at 3 36 03 pm](https://user-images.githubusercontent.com/549394/29097833-dd126356-7c50-11e7-9860-83255653b4ae.png)
![screen shot 2017-08-08 at 3 36 15 pm](https://user-images.githubusercontent.com/549394/29097834-dd12fe24-7c50-11e7-844a-83764b67eae5.png)


**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
