### PR TITLE
chore(gitignore): add chrome directory and envrc file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ jest/test-results
 webpack/proxy.dev.js
 src/resources/raml
 .vscode/
+.chrome/
+.envrc


### PR DESCRIPTION
The `.chrome/` directory is created by the chrome debugger vs plugin.

The `.envrc` file is needed for direnv. I personally use this to set up the right node environment,
this will always execute when I enter the directory. Since this is a very personal thing I thought I
add this to the gitignore.