### PR TITLE
fix(JobsList): add column sorting for Status and Last Run

### DIFF
--- a/src/js/constants/JobStates.js
+++ b/src/js/constants/JobStates.js
@@ -1,35 +1,47 @@
+/**
+* Sort order is ordered by most important (lowest number, top of list)
+* to least important (largest number, bottom of list)
+*/
 const JobStates = {
   INITIAL: {
     stateTypes: ["active"],
-    displayName: "Starting"
+    displayName: "Starting",
+    sortOrder: 3
   },
   STARTING: {
     stateTypes: ["active"],
-    displayName: "Starting"
+    displayName: "Starting",
+    sortOrder: 3
   },
   ACTIVE: {
     stateTypes: ["active"],
-    displayName: "Running"
+    displayName: "Running",
+    sortOrder: 4
   },
   FAILED: {
     stateTypes: ["completed", "failure"],
-    displayName: "Failed"
+    displayName: "Failed",
+    sortOrder: 0
   },
   SUCCESS: {
     stateTypes: ["success"],
-    displayName: "Success"
+    displayName: "Success",
+    sortOrder: 6
   },
   COMPLETED: {
     stateTypes: ["success"],
-    displayName: "Completed"
+    displayName: "Completed",
+    sortOrder: 5
   },
   SCHEDULED: {
     stateTypes: [],
-    displayName: "Scheduled"
+    displayName: "Scheduled",
+    sortOrder: 2
   },
   UNSCHEDULED: {
     stateTypes: [],
-    displayName: "Unscheduled"
+    displayName: "Unscheduled",
+    sortOrder: 1
   }
 };
 

--- a/src/js/constants/JobStatus.js
+++ b/src/js/constants/JobStatus.js
@@ -1,0 +1,20 @@
+/**
+* Sort order is ordered by most important (lowest number, top of list)
+* to least important (largest number, bottom of list)
+*/
+const JobStatus = {
+  "N/A": {
+    displayName: "N/A",
+    sortOrder: 1
+  },
+  Success: {
+    displayName: "Success",
+    sortOrder: 2
+  },
+  Failed: {
+    displayName: "Failed",
+    sortOrder: 0
+  }
+};
+
+module.exports = JobStatus;

--- a/src/js/pages/jobs/JobsTable.js
+++ b/src/js/pages/jobs/JobsTable.js
@@ -6,12 +6,13 @@ import { Table, Tooltip } from "reactjs-components";
 
 import Icon from "../../components/Icon";
 import JobStates from "../../constants/JobStates";
+import JobStatus from "../../constants/JobStatus";
 import JobTableHeaderLabels from "../../constants/JobTableHeaderLables";
 import ResourceTableUtil from "../../utils/ResourceTableUtil";
 import TableUtil from "../../utils/TableUtil";
 import Tree from "../../structs/Tree";
 
-const METHODS_TO_BIND = ["renderHeadline"];
+const METHODS_TO_BIND = ["renderHeadline", "jobSortFunction"];
 
 class JobsTable extends React.Component {
   constructor() {
@@ -44,7 +45,7 @@ class JobsTable extends React.Component {
         prop: "name",
         render: this.renderHeadline,
         sortable: true,
-        sortFunction: this.sortJobNames
+        sortFunction: this.jobSortFunction
       },
       {
         className,
@@ -52,14 +53,17 @@ class JobsTable extends React.Component {
         headerClassName: className,
         prop: "status",
         render: this.renderStatusColumn,
-        sortable: false
+        sortable: true,
+        sortFunction: this.jobSortFunction
       },
       {
         className,
         heading,
         headerClassName: className,
         prop: "lastRun",
-        render: this.renderLastRunStatusColumn
+        render: this.renderLastRunStatusColumn,
+        sortable: true,
+        sortFunction: this.jobSortFunction
       }
     ];
   }
@@ -96,7 +100,22 @@ class JobsTable extends React.Component {
     });
   }
 
-  sortJobNames(prop, direction) {
+  getCompareFunctionByProp(prop) {
+    switch (prop) {
+      case "name":
+        return (a, b) => a.name.localeCompare(b.name);
+      case "status":
+        return (a, b) =>
+          JobStates[a.status].sortOrder - JobStates[b.status].sortOrder;
+      case "lastRun":
+        return (a, b) =>
+          JobStatus[a.lastRun.status].sortOrder -
+          JobStatus[b.lastRun.status].sortOrder;
+    }
+  }
+
+  jobSortFunction(prop, direction) {
+    const compareFunction = this.getCompareFunctionByProp(prop);
     let score = 1;
 
     if (direction === "desc") {
@@ -111,7 +130,7 @@ class JobsTable extends React.Component {
         return score;
       }
 
-      return a.name.localeCompare(b.name);
+      return compareFunction(a, b);
     };
   }
 

--- a/src/js/structs/Job.js
+++ b/src/js/structs/Job.js
@@ -2,6 +2,7 @@ import { cleanJobJSON } from "../utils/CleanJSONUtil";
 import DateUtil from "../utils/DateUtil";
 import Item from "./Item";
 import JobRunList from "./JobRunList";
+import JobStatus from "../constants/JobStatus";
 import {
   DEFAULT_CPUS,
   DEFAULT_DISK,
@@ -72,7 +73,7 @@ module.exports = class Job extends Item {
 
   getLastRunStatus() {
     let { lastFailureAt, lastSuccessAt } = this.getLastRunsSummary();
-    let status = "N/A";
+    let status = JobStatus["N/A"].displayName;
     let time = null;
 
     if (lastFailureAt !== null) {
@@ -85,10 +86,10 @@ module.exports = class Job extends Item {
 
     if (lastFailureAt !== null || lastSuccessAt !== null) {
       if (lastFailureAt > lastSuccessAt) {
-        status = "Failed";
+        status = JobStatus["Failed"].displayName;
         time = lastFailureAt;
       } else {
-        status = "Success";
+        status = JobStatus["Success"].displayName;
         time = lastSuccessAt;
       }
     }


### PR DESCRIPTION
**Description**: 
Previously, jobs were only able to be sorted by Job Name. Nothing happened when clicking on the "Status" and "Last Run" columns.

This change adds sorting by "Status" and "Last Run". Both these columns are sorted in order of importance to the average user. For example, jobs who's last run failed are higher importance than successful jobs, and will be sorted to the top of the list.

The sort order is determined by the `sortOrder` fields in `JobStates.js` and `JobStatus.js`. This is similar to the existing [HealthSorting.js](https://github.com/dcos/dcos-ui/blob/master/plugins/services/src/js/constants/HealthSorting.js), which helps sort services.

**Testing**:
Go to the jobs page, and turn on fixtures, and click around on the column headers to see the sorting. Demo: https://cl.ly/3E1h143I160l

Here is my `jobs.json` fixture contents to make testing easier (added a few more jobs of different states): https://gist.github.com/ahoskins/7c316a86f3332b27c098be5243e2997e

Closes DCOS-16744.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
