### PR TITLE
test(ServiceFormModal): add test for redirect to catalog

### DIFF
--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -62,6 +62,15 @@ describe("Service Form Modal", function() {
         });
       });
 
+      it("redirects to the catalog page after click install package", function() {
+        openServiceModal();
+        cy
+          .get(".create-service-modal-service-picker-option")
+          .contains("Install a Package")
+          .click();
+        cy.url().should("contain", "/catalog");
+      });
+
       it("remembers the selected form tab when switching back from JSON", function() {
         openServiceModal();
         openServiceForm();


### PR DESCRIPTION
Protect against regression of [this bug](https://jira.mesosphere.com/browse/DCOS-17566).

This adds a test that clicking the "Install a Package" button will redirect the user to the `/catalog` page.

Button of interest below:
![screen shot 2017-08-09 at 5 47 35 pm](https://user-images.githubusercontent.com/1527504/29149756-13ae2c3a-7d2b-11e7-81fa-c39ad1668a76.png)


Closes DCOS-17714.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [x] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
