### PR TITLE
fix(HashMapDisplay): if item is array, join into comma seperated string

### DIFF
--- a/src/js/components/HashMapDisplay.js
+++ b/src/js/components/HashMapDisplay.js
@@ -63,6 +63,10 @@ class HashMapDisplay extends React.Component {
         value = value.toString();
       }
 
+      if (Array.isArray(value)) {
+        value = value.join(", ");
+      }
+
       // Check if we need to render a component in the dt
       if (Object.prototype.hasOwnProperty.call(renderKeys, key)) {
         key = renderKeys[key];


### PR DESCRIPTION
Really small change, someone reported it to me a few weeks ago. The "features" hash map value was missing commas. 

Before:
![screen shot 2017-08-10 at 4 57 26 pm](https://user-images.githubusercontent.com/1527504/29196999-0554ca0a-7ded-11e7-941b-3ef4b8db7ce2.png)

After: 
![screen shot 2017-08-10 at 4 56 33 pm](https://user-images.githubusercontent.com/1527504/29196990-f963d4d4-7dec-11e7-9874-6debac773e81.png)



Closes DCOS_OSS-1372.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
