### PR TITLE
fix(system-tests): remove quote around false in CLI setup

### DIFF
--- a/system-tests/_scripts/setup.sh
+++ b/system-tests/_scripts/setup.sh
@@ -17,7 +17,7 @@ CONFIG_FILE=${CONFIG_DIR}/dcos.toml
 mkdir -p ${CONFIG_DIR}
 cat << EOF > ${CONFIG_FILE}
   [core]
-  ssl_verify = "false"
+  ssl_verify = false
   reporting = true
   timeout = 5
   dcos_url = "${CLUSTER_URL}"


### PR DESCRIPTION
I ran locally and tests still pass by changing this from string to boolean.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
