### PR TITLE
fix(PackagesTab): remove "services" word from section headings

### DIFF
--- a/src/js/pages/catalog/PackagesTab.js
+++ b/src/js/pages/catalog/PackagesTab.js
@@ -167,7 +167,7 @@ class PackagesTab extends mixin(StoreMixin) {
 
     return (
       <div className="pod flush-top flush-horizontal clearfix">
-        <h4 className="short flush-top">Certified Services</h4>
+        <h4 className="short flush-top">Certified</h4>
         <p className="tall flush-top">
           Certified packages are verified by Mesosphere for interoperability with DC/OS.
         </p>
@@ -188,7 +188,7 @@ class PackagesTab extends mixin(StoreMixin) {
         Community packages are unverified and unreviewed content from the community.
       </p>
     );
-    let title = "Community Services";
+    let title = "Community";
     const isSearchActive = this.state.searchString !== "";
     const titleClasses = classNames("flush-top", {
       short: !isSearchActive,

--- a/tests/pages/catalog/packages/PackagesTab-cy.js
+++ b/tests/pages/catalog/packages/PackagesTab-cy.js
@@ -113,15 +113,12 @@ describe("Packages Tab", function() {
     });
 
     it("should hide certified panels", function() {
-      cy
-        .get("h4")
-        .contains("Certified Services")
-        .should(function($certifiedHeading) {
-          expect($certifiedHeading.length).to.equal(0);
-        });
+      cy.get("h4").contains("Certified").should(function($certifiedHeading) {
+        expect($certifiedHeading.length).to.equal(0);
+      });
     });
 
-    it("should should only cassandra in panels", function() {
+    it("should show only cassandra in panels", function() {
       cy.get(".panel").should(function($panels) {
         expect($panels.length).to.equal(1);
       });
@@ -133,7 +130,7 @@ describe("Packages Tab", function() {
       cy.visitUrl({ url: "/catalog", logIn: true });
       cy
         .get("h4")
-        .contains("Certified Services")
+        .contains("Certified")
         .closest(".pod")
         .find(".panel")
         .as("panels");


### PR DESCRIPTION
Change "Certified Services" to "Certified", and change "Community Services" to "Community" in the catalog tab. 

Closes DCOS-17527.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
