### PR TITLE
DCOS-17939: Blacklist historySummary

### DIFF
--- a/src/js/constants/JobConfig.js
+++ b/src/js/constants/JobConfig.js
@@ -1,5 +1,5 @@
 const ServiceConfig = {
-  BLACKLIST: ["activeRuns", "history"]
+  BLACKLIST: ["activeRuns", "history", "historySummary"]
 };
 
 module.exports = ServiceConfig;


### PR DESCRIPTION
historySummary field prevents you from saving a metronome job, so we should just blacklist it as it is a meta information. Please refer to the ticket to come up wit a testing scenario.