### PR TITLE
fix(PageHeaderActions): remove suspend/resume for SDK service

### DIFF
--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -196,14 +196,14 @@ class ServiceDetail extends mixin(TabsMixin) {
       });
     }
 
-    if (instanceCount > 0) {
+    if (instanceCount > 0 && !isSDK) {
       actions.push({
         label: "Suspend",
         onItemSelect: this.onActionsItemSelection.bind(this, SUSPEND)
       });
     }
 
-    if (instanceCount === 0) {
+    if (instanceCount === 0 && !isSDK) {
       actions.push({
         label: "Resume",
         onItemSelect: this.onActionsItemSelection.bind(this, RESUME)

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -282,7 +282,7 @@ class ServicesTable extends React.Component {
       });
     }
 
-    if (instancesCount > 0) {
+    if (instancesCount > 0 && !isSDK) {
       actions.push({
         id: SUSPEND,
         html: this.props.intl.formatMessage({
@@ -291,7 +291,7 @@ class ServicesTable extends React.Component {
       });
     }
 
-    if (!isGroup && instancesCount === 0) {
+    if (!isGroup && instancesCount === 0 && !isSDK) {
       actions.push({
         id: RESUME,
         html: this.props.intl.formatMessage({

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -594,54 +594,19 @@ describe("Service Actions", function() {
       cy.get(".modal").should("not.exist");
     });
 
-    it("opens the suspend dialog", function() {
-      clickHeaderAction("Suspend");
-
-      cy
-        .get(".modal-header")
-        .contains("Suspend Service")
-        .should("to.have.length", 1);
-
-      cy
-        .get(".modal pre")
-        .contains(
-          "dcos test --name=/services/sdk-sleep update start --options=options.json"
-        );
-
-      cy.get(".modal button").contains("Close").click();
-
-      cy.get(".modal").should("not.exist");
-    });
-
-    it("opens the resume dialog", function() {
-      cy.configureCluster({
-        mesos: "1-suspended-sdk-service",
-        nodeHealth: true
-      });
-
-      clickHeaderAction("Resume");
-
-      cy
-        .get(".modal-header")
-        .contains("Resume Service")
-        .should("have.length", 1);
-
-      cy
-        .get(".modal pre")
-        .contains(
-          "dcos test --name=/services/sdk-sleep update start --options=options.json"
-        );
-
-      cy.get(".modal button").contains("Close").click();
-
-      cy.get(".modal").should("not.exist");
-    });
-
     it("restart should not exist", function() {
       cy
         .get(".page-header-actions .dropdown")
         .click()
         .contains("restart")
+        .should("not.exist");
+    });
+
+    it("suspend should not exist", function() {
+      cy
+        .get(".page-header-actions .dropdown")
+        .click()
+        .contains("suspend")
         .should("not.exist");
     });
   });

--- a/tests/pages/services/ServiceTable-cy.js
+++ b/tests/pages/services/ServiceTable-cy.js
@@ -241,55 +241,16 @@ describe("Service Table", function() {
       cy.get(".modal").should("not.exist");
     });
 
-    it("opens the suspend dialog", function() {
-      openDropdown("sdk-sleep");
-      clickDropdownAction("Suspend");
-
-      cy
-        .get(".modal-header")
-        .contains("Suspend Service")
-        .should("to.have.length", 1);
-
-      cy
-        .get(".modal pre")
-        .contains(
-          "dcos test --name=/services/sdk-sleep update start --options=options.json"
-        );
-
-      cy.get(".modal button").contains("Close").click();
-
-      cy.get(".modal").should("not.exist");
-    });
-
-    it("opens the resume dialog", function() {
-      cy.configureCluster({
-        mesos: "1-suspended-sdk-service",
-        nodeHealth: true
-      });
-
-      openDropdown("sdk-sleep");
-      clickDropdownAction("Resume");
-
-      cy
-        .get(".modal-header")
-        .contains("Resume Service")
-        .should("have.length", 1);
-
-      cy
-        .get(".modal pre")
-        .contains(
-          "dcos test --name=/services/sdk-sleep update start --options=options.json"
-        );
-
-      cy.get(".modal button").contains("Close").click();
-
-      cy.get(".modal").should("not.exist");
-    });
-
     it("restart should not exist", function() {
       openDropdown("sdk-sleep");
 
       cy.get(".dropdown-menu-items").contains("restart").should("not.exist");
+    });
+
+    it("suspend should not exist", function() {
+      openDropdown("sdk-sleep");
+
+      cy.get(".dropdown-menu-items").contains("suspend").should("not.exist");
     });
   });
 
@@ -327,30 +288,6 @@ describe("Service Table", function() {
       cy
         .get(".modal-header")
         .contains("Scale Group")
-        .should("to.have.length", 1);
-
-      cy
-        .get(".modal pre")
-        .contains(
-          "dcos test --name=/services/sdk-sleep update start --options=options.json"
-        );
-
-      cy
-        .get(".modal pre")
-        .contains("dcos marathon app update /services/sleep options.json");
-
-      cy.get(".modal button").contains("Close").click();
-
-      cy.get(".modal").should("not.exist");
-    });
-
-    it("opens the suspend dialog", function() {
-      openDropdown("services");
-      clickDropdownAction("Suspend");
-
-      cy
-        .get(".modal-header")
-        .contains("Suspend Group")
         .should("to.have.length", 1);
 
       cy


### PR DESCRIPTION
Suspending a SDK service is not supported, so remove its actions from the service table and service actions.

This is very similar to @weblancaster PR from a [few weeks ago](https://github.com/dcos/dcos-ui/pull/2343).

Closes DCOS-17982.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
