### PR TITLE
fix(Services): remove "open service" buttons for SDK services

### DIFF
--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -167,6 +167,7 @@ class ServiceDetail extends mixin(TabsMixin) {
 
     if (
       service instanceof Service &&
+      !isSDKService(service) &&
       service.getWebURL() != null &&
       service.getWebURL() !== ""
     ) {

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -204,6 +204,7 @@ class ServicesTable extends React.Component {
   hasWebUI(service) {
     return (
       service instanceof Service &&
+      !isSDKService(service) &&
       service.getWebURL() != null &&
       service.getWebURL() !== ""
     );

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -7,16 +7,13 @@ describe("Service Actions", function() {
   }
 
   context("Open Service Action", function() {
-    beforeEach(function() {
+    it('displays the "Open Service" option for services that have a web UI', function() {
       cy.configureCluster({
         mesos: "1-for-each-health",
         nodeHealth: true
       });
-
       cy.visitUrl({ url: "/services/detail/%2Fcassandra-healthy" });
-    });
 
-    it('displays the "Open Service" option for services that have a web UI', function() {
       cy.get(".page-header-actions .dropdown").click();
       cy
         .get(".dropdown-menu-items")
@@ -26,8 +23,28 @@ describe("Service Actions", function() {
         });
     });
 
-    it('does not display the "Open Service" option for services that have a web UI', function() {
+    it('does not display the "Open Service" option for services that do not have a web UI', function() {
+      cy.configureCluster({
+        mesos: "1-for-each-health",
+        nodeHealth: true
+      });
       cy.visitUrl({ url: "/services/detail/%2Fcassandra-unhealthy" });
+
+      cy.get(".page-header-actions .dropdown").click();
+      cy
+        .get(".dropdown-menu-items")
+        .contains("Open Service")
+        .should(function($menuItem) {
+          expect($menuItem.length).to.equal(0);
+        });
+    });
+
+    it('does not display the "Open Service" option for SDK services', function() {
+      cy.configureCluster({
+        mesos: "1-sdk-service",
+        nodeHealth: true
+      });
+      cy.visitUrl({ url: "/services/detail/%2Fservices%2Fsdk-sleep" });
 
       cy.get(".page-header-actions .dropdown").click();
       cy


### PR DESCRIPTION
This action is not supported for SDK service, so remove it from three places: two links in the service table row, and one link in the service detail header.

Closes DCOS-17979.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
