### PR TITLE
DCOS_OSS-1569: adjust SDK action handling

### DIFF
--- a/plugins/services/src/js/containers/pod-detail/PodDetail.js
+++ b/plugins/services/src/js/containers/pod-detail/PodDetail.js
@@ -1,6 +1,7 @@
 import mixin from "reactjs-mixin";
 import React, { PropTypes } from "react";
 import { routerShape } from "react-router";
+import { Hooks } from "PluginSDK";
 
 import Page from "#SRC/js/components/Page";
 import RouterUtil from "#SRC/js/utils/RouterUtil";
@@ -85,7 +86,14 @@ class PodDetail extends mixin(TabsMixin) {
     }
 
     // We still want to support the `open` action to display the web view
-    if (actionID !== OPEN && (containsSDKService || isSDKService(pod))) {
+    if (
+      (containsSDKService || isSDKService(pod)) &&
+      !Hooks.applyFilter(
+        "isEnabledSDKAction",
+        actionID === EDIT || actionID === OPEN,
+        actionID
+      )
+    ) {
       this.handleActionDisabledModalOpen(actionID);
     } else {
       this.handleServiceAction(actionID);

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -2,6 +2,7 @@ import { injectIntl } from "react-intl";
 import mixin from "reactjs-mixin";
 import React, { PropTypes } from "react";
 import { routerShape } from "react-router";
+import { Hooks } from "PluginSDK";
 
 import Page from "#SRC/js/components/Page";
 import RouterUtil from "#SRC/js/utils/RouterUtil";
@@ -92,8 +93,14 @@ class ServiceDetail extends mixin(TabsMixin) {
         }) != null;
     }
 
-    // We still want to support the `open` action to display the web view
-    if (actionID !== OPEN && (containsSDKService || isSDKService(service))) {
+    if (
+      (containsSDKService || isSDKService(service)) &&
+      !Hooks.applyFilter(
+        "isEnabledSDKAction",
+        actionID === EDIT || actionID === OPEN,
+        actionID
+      )
+    ) {
       this.handleActionDisabledModalOpen(actionID);
     } else {
       this.handleServiceAction(actionID);

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -3,6 +3,7 @@ import { Dropdown, Table, Tooltip } from "reactjs-components";
 import { injectIntl } from "react-intl";
 import { Link, routerShape } from "react-router";
 import React, { PropTypes } from "react";
+import { Hooks } from "PluginSDK";
 
 import Icon from "#SRC/js/components/Icon";
 import Links from "#SRC/js/constants/Links";
@@ -82,10 +83,14 @@ class ServicesTable extends React.Component {
         }) != null;
     }
 
+    // We still want to support the `open` action to display the web view
     if (
-      // We still want to support the `open` action to display the web view
-      actionItem.id !== OPEN &&
-      (containsSDKService || isSDKService(service))
+      (containsSDKService || isSDKService(service)) &&
+      !Hooks.applyFilter(
+        "isEnabledSDKAction",
+        actionItem.id === EDIT || actionItem.id === OPEN,
+        actionItem.id
+      )
     ) {
       this.handleActionDisabledModalOpen(service, actionItem.id);
     } else {

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -573,25 +573,6 @@ describe("Service Actions", function() {
       cy.get(".modal").should("not.exist");
     });
 
-    it("opens the edit dialog", function() {
-      clickHeaderAction("Edit");
-
-      cy
-        .get(".modal-header")
-        .contains("Edit Service")
-        .should("to.have.length", 1);
-
-      cy
-        .get(".modal-body")
-        .contains(
-          "Editing this service is only available on Mesosphere Enterprise DC/OS."
-        );
-
-      cy.get(".modal button").contains("Close").click();
-
-      cy.get(".modal").should("not.exist");
-    });
-
     it("opens the scale dialog", function() {
       clickHeaderAction("Scale");
 


### PR DESCRIPTION
Add a `isEnabledSDKAction` filter to dynamically enable/disable SDK actions and enable `OPEN` and `EDTI` by default.

Closes DCOS_OSS-1569