### PR TITLE
DCOS-17705: fix(JSONSingleContianerParser): remove duplicated fetch parser

### DIFF
--- a/plugins/services/src/js/reducers/JSONSingleContainerParser.js
+++ b/plugins/services/src/js/reducers/JSONSingleContainerParser.js
@@ -49,6 +49,5 @@ module.exports = [
   portMappings, // Note: must come after portDefinitions, as it uses its information!
   requirePorts,
   residency,
-  fetch,
   unknownVolumes
 ];


### PR DESCRIPTION
Remove duplicated fetch parser in the JSONSingleContainerParser.

As it happens the fetch parser was duplicated in the Parser and it was creating duplicated transactions for artifacts.

Closes DCOS-17705