### PR TITLE
DCOS-17997: revert icon var adjustments

### DIFF
--- a/src/styles/components/icons/styles.less
+++ b/src/styles/components/icons/styles.less
@@ -109,6 +109,62 @@
       flex: 0 0 auto;
     }
   }
+
+  & when (@icon-tiny-enabled) {
+
+    .icon.icon-tiny {
+      height: @icon-tiny-height;
+      width: @icon-tiny-width;
+    }
+  }
+
+  & when (@icon-mini-enabled) {
+
+    .icon.icon-mini {
+      height: @icon-mini-height;
+      width: @icon-mini-width;
+    }
+  }
+
+  & when (@icon-small-enabled) {
+
+    .icon.icon-small {
+      height: @icon-small-height;
+      width: @icon-small-width;
+    }
+  }
+
+  & when (@icon-medium-enabled) {
+
+    .icon.icon-medium {
+      height: @icon-medium-height;
+      width: @icon-medium-width;
+    }
+  }
+
+  & when (@icon-large-enabled) {
+
+    .icon.icon-large {
+      height: @icon-large-height;
+      width: @icon-large-width;
+    }
+  }
+
+  & when (@icon-jumbo-enabled) {
+
+    .icon.icon-jumbo {
+      height: @icon-jumbo-height;
+      width: @icon-jumbo-width;
+    }
+  }
+
+  & when (@icon-huge-enabled) {
+
+    .icon.icon-huge {
+      height: @icon-huge-height;
+      width: @icon-huge-width;
+    }
+  }
 }
 
 & when (@icon-enabled) and (@layout-screen-small-enabled) {


### PR DESCRIPTION
Revert the icon variable adjustments introduced with 291ed72e as they result in rendering issues due to wrong `icon-mini` class specificity.

Closes DCOS-17997

/cc @ashenden 
