### PR TITLE
↩️[release/1.9] chore(jenkins): add system tests config stub

### DIFF
--- a/system-tests/driver-config/jenkins.sh
+++ b/system-tests/driver-config/jenkins.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# This is a configuration script to the system-test-driver that runs the
+# integration tests against a newly provisioned DC/OS Open Cluster.
+#
+
+# Ensure CCM_AUTH_TOKEN is specified
+if [ -z "$CCM_AUTH_TOKEN" ]; then
+  echo "Error: Please specify the CCM_AUTH_TOKEN environment variable"
+  exit 1
+fi
+
+cat <<EOF
+criteria: []
+suites:
+  - file:.
+targets:
+  - name: open
+    title: Open Version
+    features: []
+    type: ccm
+    config:
+      template: single-master.cloudformation.json
+      channel: testing/1.9.3
+    env:
+      PROXIED_CLUSTER_URL: http://127.0.0.1:4201
+      PATH: "/usr/local/bin:$PATH"
+    scripts:
+      proxy: http-server --proxy-secure=false -p 4201 -P \$CLUSTER_URL ../../dist
+      auth: ../_scripts/auth-open.py
+secrets:
+  ccm_auth_token: $CCM_AUTH_TOKEN
+EOF
+


### PR DESCRIPTION
As we'd like to run our system tests for every PR that means running them for 1.9 PRs as well. But 1.9 didn't have any system test, so we need at least the config in place otherwise Jenkins build will fail

The config is a copy/paste from master with one exception:
```
channel: testing/1.9.3
```

Hardcoded channel will ensure that we launch proper cluster in case we want to back port some of the tests.
