### PR TITLE
refactor(DOMUtils): remove isElementOnTop util

### DIFF
--- a/src/js/components/charts/Chart.js
+++ b/src/js/components/charts/Chart.js
@@ -48,10 +48,6 @@ var Chart = React.createClass({
     global.addEventListener("resize", this.updateWidth);
   },
 
-  shouldComponentUpdate() {
-    return DOMUtils.isElementOnTop(ReactDOM.findDOMNode(this));
-  },
-
   componentWillUnmount() {
     global.removeEventListener("resize", this.updateWidth);
   },

--- a/src/js/utils/DOMUtils.js
+++ b/src/js/utils/DOMUtils.js
@@ -163,26 +163,6 @@ var DOMUtils = {
     }
   },
 
-  isElementOnTop(el) {
-    const { left, top, height, width } = el.getBoundingClientRect();
-    const elAtPoint = global.document.elementFromPoint(
-      // The coords of the middle of the element.
-      left + width / 2,
-      top + height / 2
-    );
-
-    // If elAtPoint is null, then the element is off the screen. We return true
-    // here.
-    if (elAtPoint == null) {
-      return true;
-    }
-
-    // We need to also use #contains because the elAtPoint may be a child.
-    // We also need to check if elAtPoint contains el because it might select
-    // the parent even if the el is showing.
-    return el === elAtPoint || el.contains(elAtPoint) || elAtPoint.contains(el);
-  },
-
   getDistanceFromTopOfParent(el) {
     const elTop = el.getBoundingClientRect().top;
 

--- a/src/js/utils/__tests__/DOMUtils-test.js
+++ b/src/js/utils/__tests__/DOMUtils-test.js
@@ -204,51 +204,6 @@ describe("DOMUtils", function() {
     });
   });
 
-  describe("#isElementOnTop", function() {
-    beforeEach(function() {
-      this.element = {
-        getBoundingClientRect() {
-          return {
-            top: 100,
-            left: 200,
-            height: 20,
-            width: 40
-          };
-        },
-        contains(el) {
-          return this === el;
-        }
-      };
-      this.prevElementFromPoint = global.document.elementFromPoint;
-    });
-
-    afterEach(function() {
-      global.document.elementFromPoint = this.prevElementFromPoint;
-    });
-
-    it("should return false if element is not at coord", function() {
-      global.document.elementFromPoint = function() {
-        return {
-          contains() {
-            return false;
-          }
-        };
-      };
-
-      const result = DOMUtils.isElementOnTop(this.element);
-      expect(result).toEqual(false);
-    });
-
-    it("should return true if element is at coord", function() {
-      global.document.elementFromPoint = () => {
-        return this.element;
-      };
-
-      const result = DOMUtils.isElementOnTop(this.element);
-      expect(result).toEqual(true);
-    });
-  });
-
   describe("#getDistanceFromTopOfParent", function() {
     beforeEach(function() {
       this.element = {


### PR DESCRIPTION
Remove the `isElementOnTop` DOM util as the util is only used to check whether the `Chart` component should be updated. The checks performed by the utility force layout/reflow (for a
comprehensive list of properties or methods that force layout/reflow see:  https://gist.github.com/paulirish/5d52fb081b3570c81e3a) and as such shouldn't be used to check whether a component should be updated. The util also always returns true if an element is off the screen which completely renders the utility useless if used as a should component
update condition.
