### PR TITLE
DCOS-18082: adjust jest to disable automocking

### DIFF
--- a/jest/gen-config.js
+++ b/jest/gen-config.js
@@ -10,7 +10,6 @@ if (process.env.npm_config_externalplugins) {
 }
 
 var config = {
-  'automock': true,
   'testPathDirs': testPaths,
   'globals': {
     '__DEV__': true
@@ -33,42 +32,6 @@ var config = {
   'coverageReporters': ["json", "lcov", "cobertura", "text"],
   // We need this to override jest's default ['/node_modules/']
   'preprocessorIgnorePatterns' : [],
-  'unmockedModulePathPatterns': [
-    'babel-polyfill',
-    'babel-runtime',
-    'browser-info',
-    'classnames',
-    'd3',
-    'deep-equal',
-    'events',
-    'flux',
-    'jasmine-reporters',
-    'localStorage',
-    'mesosphere-shared-reactjs',
-    'moment',
-    'md5',
-    'mixins/index',
-    'src/js/config/',
-    'src/js/constants',
-    'src/js/plugin-bridge/AppReducer',
-    'src/js/plugin-bridge/Hooks',
-    'src/js/plugin-bridge/Loader',
-    'src/js/plugin-bridge/middleware',
-    'src/js/plugin-bridge/PluginSDK',
-    'src/js/plugin-bridge/PluginTestUtils',
-    'src/js/stores/BaseStore',
-    'src/js/stores/GetSetBaseStore',
-    'src/js/structs',
-    'src/js/utils',
-    'plugins',
-    'react',
-    'reactjs-components',
-    'reactjs-mixin',
-    'react-router',
-    'redux',
-    'tests',
-    'underscore'
-  ],
   'testPathIgnorePatterns': [
     '/tmp/',
     '/node_modules/'

--- a/packages/foundation-ui/src/mount/__tests__/Mount-test.js
+++ b/packages/foundation-ui/src/mount/__tests__/Mount-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../Mount");
-jest.dontMock("../MountService");
-jest.dontMock("../index");
-jest.dontMock("../../utils/ReactUtil");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/packages/foundation-ui/src/mount/__tests__/MountService-test.js
+++ b/packages/foundation-ui/src/mount/__tests__/MountService-test.js
@@ -1,4 +1,3 @@
-jest.dontMock("../MountService");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/packages/foundation-ui/src/navigation/__tests__/NavigationService-test.js
+++ b/packages/foundation-ui/src/navigation/__tests__/NavigationService-test.js
@@ -1,4 +1,3 @@
-jest.dontMock("../NavigationService");
 const NavigationService = require("../NavigationService");
 
 describe("NavigationService", function() {

--- a/packages/foundation-ui/src/routing/__tests__/RoutingService-test.js
+++ b/packages/foundation-ui/src/routing/__tests__/RoutingService-test.js
@@ -1,4 +1,3 @@
-jest.dontMock("../RoutingService");
 const RoutingService = require("../RoutingService");
 const ReactRouter = require("react-router");
 

--- a/packages/foundation-ui/src/utils/__tests__/ReactUtil-test.js
+++ b/packages/foundation-ui/src/utils/__tests__/ReactUtil-test.js
@@ -1,4 +1,3 @@
-jest.dontMock("../ReactUtil");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/plugins/banner/__tests__/BannerPlugin-test.js
+++ b/plugins/banner/__tests__/BannerPlugin-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("#SRC/js/components/Icon");
-jest.dontMock("#SRC/js/utils/DOMUtils");
-jest.dontMock("../hooks");
-
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/plugins/nodes/src/js/components/__tests__/NodesGridDials-test.js
+++ b/plugins/nodes/src/js/components/__tests__/NodesGridDials-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("#SRC/js/components/CollapsingString");
-jest.dontMock("#SRC/js/utils/Util");
-jest.dontMock("#SRC/js/utils/ResourcesUtil");
-jest.dontMock("../NodesGridDials");
-
 const deepEqual = require("deep-equal");
 /* eslint-disable no-unused-vars */
 const React = require("react");

--- a/plugins/nodes/src/js/components/__tests__/NodesGridView-test.js
+++ b/plugins/nodes/src/js/components/__tests__/NodesGridView-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("#SRC/js/components/CollapsingString");
-jest.dontMock("#SRC/js/mixins/InternalStorageMixin");
-jest.dontMock("../NodesGridView");
-jest.dontMock("#SRC/js/stores/MesosStateStore");
-jest.dontMock("#SRC/js/utils/Util");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/plugins/nodes/src/js/pages/__tests__/NodeDetailPage-test.js
+++ b/plugins/nodes/src/js/pages/__tests__/NodeDetailPage-test.js
@@ -1,12 +1,3 @@
-jest.dontMock("#SRC/js/components/charts/Chart");
-jest.dontMock("#SRC/js/mixins/InternalStorageMixin");
-jest.dontMock("#SRC/js/mixins/TabsMixin");
-jest.dontMock("#SRC/js/stores/MesosSummaryStore");
-jest.dontMock("../nodes/NodeDetailPage");
-jest.dontMock("#SRC/js/components/RequestErrorMsg");
-jest.dontMock("#SRC/js/structs/CompositeState");
-jest.dontMock("#SRC/js/components/Page");
-
 const JestUtil = require("#SRC/js/utils/JestUtil");
 
 JestUtil.unMockStores(["MesosSummaryStore", "MesosStateStore"]);

--- a/plugins/nodes/src/js/stores/__tests__/NodeHealthStore-test.js
+++ b/plugins/nodes/src/js/stores/__tests__/NodeHealthStore-test.js
@@ -1,9 +1,3 @@
-jest.dontMock("../NodeHealthStore");
-jest.dontMock("#SRC/js/config/Config");
-jest.dontMock("#SRC/js/events/AppDispatcher");
-jest.dontMock("#SRC/js/events/UnitHealthActions");
-jest.dontMock("../../../../../../tests/_fixtures/unit-health/nodes.json");
-
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 
 const ActionTypes = require("#SRC/js/constants/ActionTypes");

--- a/plugins/services/src/js/components/__tests__/ConfigurationMapBooleanValue-test.js
+++ b/plugins/services/src/js/components/__tests__/ConfigurationMapBooleanValue-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../ConfigurationMapBooleanValue");
-jest.dontMock("#SRC/js/components/ConfigurationMapValue");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 const ReactDOM = require("react-dom");

--- a/plugins/services/src/js/components/__tests__/ConfigurationMapDurationValue-test.js
+++ b/plugins/services/src/js/components/__tests__/ConfigurationMapDurationValue-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../ConfigurationMapDurationValue");
-jest.dontMock("#SRC/js/components/ConfigurationMapValue");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 const ReactDOM = require("react-dom");

--- a/plugins/services/src/js/components/__tests__/ConfigurationMapMultilineValue-test.js
+++ b/plugins/services/src/js/components/__tests__/ConfigurationMapMultilineValue-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../ConfigurationMapMultilineValue");
-jest.dontMock("#SRC/js/components/ConfigurationMapValue");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 const ReactDOM = require("react-dom");

--- a/plugins/services/src/js/components/__tests__/ConfigurationMapSizeValue-test.js
+++ b/plugins/services/src/js/components/__tests__/ConfigurationMapSizeValue-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../ConfigurationMapSizeValue");
-jest.dontMock("#SRC/js/components/ConfigurationMapValue");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 const ReactDOM = require("react-dom");

--- a/plugins/services/src/js/components/__tests__/ConfigurationMapTable-test.js
+++ b/plugins/services/src/js/components/__tests__/ConfigurationMapTable-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../ConfigurationMapEditAction");
-jest.dontMock("../ConfigurationMapTable");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 const ReactDOM = require("react-dom");

--- a/plugins/services/src/js/components/__tests__/ConfigurationMapValueWithDefault-test.js
+++ b/plugins/services/src/js/components/__tests__/ConfigurationMapValueWithDefault-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../ConfigurationMapValueWithDefault");
-jest.dontMock("#SRC/js/components/ConfigurationMapValue");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 const ReactDOM = require("react-dom");

--- a/plugins/services/src/js/components/__tests__/DeploymentsModal-test.js
+++ b/plugins/services/src/js/components/__tests__/DeploymentsModal-test.js
@@ -1,12 +1,3 @@
-jest.unmock("moment");
-jest.unmock("#SRC/js/components/CollapsingString");
-jest.unmock("#SRC/js/components/FluidGeminiScrollbar");
-jest.unmock("#SRC/js/components/Page");
-jest.unmock("#SRC/js/components/TimeAgo");
-jest.unmock("#SRC/js/mixins/InternalStorageMixin");
-jest.unmock("../DeploymentsModal");
-jest.unmock("../../structs/Deployment");
-
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/plugins/services/src/js/components/__tests__/FilterByService-test.js
+++ b/plugins/services/src/js/components/__tests__/FilterByService-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("../FilterByService");
-jest.dontMock("./fixtures/MockFrameworks");
-jest.dontMock("#SRC/js/utils/Util");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/plugins/services/src/js/components/__tests__/HealthBar-test.js
+++ b/plugins/services/src/js/components/__tests__/HealthBar-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("../HealthBar");
-jest.dontMock("#SRC/js/components/StatusBar");
-
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/plugins/services/src/js/components/__tests__/Highlight-test.js
+++ b/plugins/services/src/js/components/__tests__/Highlight-test.js
@@ -1,4 +1,3 @@
-jest.dontMock("../Highlight");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/plugins/services/src/js/components/__tests__/LogView-test.js
+++ b/plugins/services/src/js/components/__tests__/LogView-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("#SRC/js/mixins/InternalStorageMixin");
-jest.dontMock("../Highlight");
-jest.dontMock("../LogView");
-
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/plugins/services/src/js/components/__tests__/MesosLogContainer-test.js
+++ b/plugins/services/src/js/components/__tests__/MesosLogContainer-test.js
@@ -1,10 +1,3 @@
-jest.dontMock("../Highlight");
-jest.dontMock("../MesosLogContainer");
-jest.dontMock("../LogView");
-jest.dontMock("#SRC/js/structs/Item");
-jest.dontMock("#SRC/js/components/Loader");
-jest.dontMock("../../structs/LogBuffer");
-
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/plugins/services/src/js/components/__tests__/ServiceBreadcrumbs-test.js
+++ b/plugins/services/src/js/components/__tests__/ServiceBreadcrumbs-test.js
@@ -1,10 +1,5 @@
-jest.dontMock("#SRC/js/components/Breadcrumb");
-jest.dontMock("#SRC/js/components/BreadcrumbCaret");
-jest.dontMock("#SRC/js/components/BreadcrumbTextContent");
-jest.dontMock("#SRC/js/components/BreadcrumbSupplementalContent");
-jest.dontMock("#SRC/js/components/PageHeaderBreadcrumbs");
-jest.dontMock("../ServiceBreadcrumbs");
-jest.dontMock("../../structs/Service");
+jest.mock("#SRC/js/stores/DCOSStore");
+
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/plugins/services/src/js/components/__tests__/ServiceList-test.js
+++ b/plugins/services/src/js/components/__tests__/ServiceList-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("../../structs/ServiceTree");
-jest.dontMock("../ServiceList");
-jest.dontMock("../../stores/MarathonStore");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/plugins/services/src/js/components/__tests__/TaskEndpointsList-test.js
+++ b/plugins/services/src/js/components/__tests__/TaskEndpointsList-test.js
@@ -1,4 +1,3 @@
-jest.dontMock("../TaskEndpointsList");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesContainer-test.js
+++ b/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesContainer-test.js
@@ -1,19 +1,3 @@
-jest.dontMock("../../../structs/Pod");
-jest.dontMock("../../../structs/PodInstanceList");
-jest.dontMock("../../../structs/PodInstance");
-jest.dontMock("../../../structs/PodContainer");
-jest.dontMock("../../../../../../../tests/_fixtures/pods/PodFixture");
-jest.dontMock("#SRC/js/components/CheckboxTable");
-jest.dontMock("#SRC/js/components/CollapsingString");
-jest.dontMock("#SRC/js/components/ExpandingTable");
-jest.dontMock("#SRC/js/components/FilterBar");
-jest.dontMock("#SRC/js/components/FilterInputText");
-jest.dontMock("#SRC/js/components/FilterButtons");
-jest.dontMock("#SRC/js/components/TimeAgo");
-jest.dontMock("../PodViewFilter");
-jest.dontMock("../PodInstancesContainer");
-jest.dontMock("../PodInstancesTable");
-
 const JestUtil = require("#SRC/js/utils/JestUtil");
 /* eslint-disable no-unused-vars */
 const React = require("react");

--- a/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.js
+++ b/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.js
@@ -1,14 +1,3 @@
-jest.dontMock("../../../structs/Pod");
-jest.dontMock("../../../structs/PodInstanceList");
-jest.dontMock("../../../structs/PodInstance");
-jest.dontMock("../../../structs/PodContainer");
-jest.dontMock("#SRC/js/components/CheckboxTable");
-jest.dontMock("#SRC/js/components/CollapsingString");
-jest.dontMock("#SRC/js/components/ExpandingTable");
-jest.dontMock("#SRC/js/components/TimeAgo");
-jest.dontMock("../PodInstancesTable");
-jest.dontMock("../../../../../../../tests/_fixtures/pods/PodFixture");
-
 const JestUtil = require("#SRC/js/utils/JestUtil");
 /* eslint-disable no-unused-vars */
 const React = require("react");

--- a/plugins/services/src/js/containers/service-configuration/__tests__/ServiceConfigurationContainer-test.js
+++ b/plugins/services/src/js/containers/service-configuration/__tests__/ServiceConfigurationContainer-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("../ServiceConfigurationContainer");
-jest.dontMock("../../../service-configuration/ServiceConfigDisplay");
-jest.dontMock("#SRC/js/components/ErrorsAlert");
-jest.dontMock("#SRC/js/components/ConfigurationMap");
-
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/plugins/services/src/js/containers/services/__tests__/ServicesContainer-test.js
+++ b/plugins/services/src/js/containers/services/__tests__/ServicesContainer-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("objektiv");
-jest.dontMock("../ServicesContainer");
-
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/plugins/services/src/js/containers/services/__tests__/ServicesTable-test.js
+++ b/plugins/services/src/js/containers/services/__tests__/ServicesTable-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("#SRC/js/components/CollapsingString");
-jest.dontMock("../../../constants/HealthStatus");
-jest.dontMock("../ServicesTable");
 // Explicitly mock for react-intl
 jest.mock("../../../components/modals/ServiceActionDisabledModal");
 

--- a/plugins/services/src/js/containers/tasks/__tests__/TaskTable-test.js
+++ b/plugins/services/src/js/containers/tasks/__tests__/TaskTable-test.js
@@ -1,11 +1,4 @@
-jest.dontMock("moment");
-
-jest.dontMock("#SRC/js/components/CollapsingString");
-jest.dontMock("#SRC/js/stores/MesosStateStore");
-
-jest.dontMock("./fixtures/MockTasks.json");
-jest.dontMock("../../../constants/TaskStates");
-jest.dontMock("../TaskTable");
+jest.mock("#SRC/js/stores/DCOSStore");
 
 /* eslint-disable no-unused-vars */
 const React = require("react");

--- a/plugins/services/src/js/events/__tests__/MarathonActions-test.js
+++ b/plugins/services/src/js/events/__tests__/MarathonActions-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("#SRC/js/events/AppDispatcher");
-jest.dontMock("#SRC/js/events/UnitHealthActions");
-jest.dontMock("#SRC/js/config/Config");
-jest.dontMock("../../constants/ActionTypes");
-
 const Hooks = require("PluginSDK").Hooks;
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 

--- a/plugins/services/src/js/events/__tests__/MesosLogActions-test.js
+++ b/plugins/services/src/js/events/__tests__/MesosLogActions-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../MesosLogActions");
-jest.dontMock("#SRC/js/events/AppDispatcher");
-jest.dontMock("../../constants/ActionTypes");
-
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 
 const MesosLogActions = require("../MesosLogActions");

--- a/plugins/services/src/js/events/__tests__/TaskDirectoryActions-test.js
+++ b/plugins/services/src/js/events/__tests__/TaskDirectoryActions-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../TaskDirectoryActions");
-jest.dontMock("#SRC/js/events/AppDispatcher");
-jest.dontMock("#SRC/js/config/Config");
-
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 
 const ActionTypes = require("../../constants/ActionTypes");

--- a/plugins/services/src/js/filters/__tests__/ServiceAttributeHasVolumesFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceAttributeHasVolumesFilter-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("#SRC/js/structs/DSLFilterList");
-jest.dontMock("#SRC/resources/grammar/SearchDSL.jison");
-jest.dontMock("../ServiceAttributeHasVolumesFilter");
-jest.dontMock("#SRC/js/structs/List");
-
 var DSLFilterList = require("#SRC/js/structs/DSLFilterList");
 var List = require("#SRC/js/structs/List");
 var SearchDSL = require("#SRC/resources/grammar/SearchDSL.jison");

--- a/plugins/services/src/js/filters/__tests__/ServiceAttributeHealthFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceAttributeHealthFilter-test.js
@@ -1,9 +1,3 @@
-jest.dontMock("#SRC/js/structs/DSLFilterList");
-jest.dontMock("#SRC/resources/grammar/SearchDSL.jison");
-jest.dontMock("../../constants/HealthStatus");
-jest.dontMock("../ServiceAttributeHealthFilter");
-jest.dontMock("#SRC/js/structs/List");
-
 var DSLFilterList = require("#SRC/js/structs/DSLFilterList");
 var SearchDSL = require("#SRC/resources/grammar/SearchDSL.jison");
 var HealthStatus = require("../../constants/HealthStatus");

--- a/plugins/services/src/js/filters/__tests__/ServiceAttributeIsCatalogFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceAttributeIsCatalogFilter-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("#SRC/js/structs/DSLFilterList");
-jest.dontMock("#SRC/resources/grammar/SearchDSL.jison");
-jest.dontMock("../ServiceAttributeIsCatalogFilter");
-jest.dontMock("#SRC/js/structs/List");
-
 var Application = require("../../structs/Application");
 var DSLFilterList = require("#SRC/js/structs/DSLFilterList");
 var Framework = require("../../structs/Framework");

--- a/plugins/services/src/js/filters/__tests__/ServiceAttributeIsFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceAttributeIsFilter-test.js
@@ -1,9 +1,3 @@
-jest.dontMock("#SRC/js/structs/DSLFilterList");
-jest.dontMock("#SRC/resources/grammar/SearchDSL.jison");
-jest.dontMock("../../constants/ServiceStatus");
-jest.dontMock("../ServiceAttributeIsFilter");
-jest.dontMock("#SRC/js/structs/List");
-
 var DSLFilterList = require("#SRC/js/structs/DSLFilterList");
 var SearchDSL = require("#SRC/resources/grammar/SearchDSL.jison");
 var ServiceStatus = require("../../constants/ServiceStatus");

--- a/plugins/services/src/js/filters/__tests__/ServiceAttributeIsPodFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceAttributeIsPodFilter-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("#SRC/js/structs/DSLFilterList");
-jest.dontMock("#SRC/resources/grammar/SearchDSL.jison");
-jest.dontMock("../ServiceAttributeIsPodFilter");
-jest.dontMock("#SRC/js/structs/List");
-
 var Application = require("../../structs/Application");
 var DSLFilterList = require("#SRC/js/structs/DSLFilterList");
 var Framework = require("../../structs/Framework");

--- a/plugins/services/src/js/filters/__tests__/ServiceAttributeNoHealthchecksFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceAttributeNoHealthchecksFilter-test.js
@@ -1,9 +1,3 @@
-jest.dontMock("#SRC/js/structs/DSLFilterList");
-jest.dontMock("#SRC/resources/grammar/SearchDSL.jison");
-jest.dontMock("../../constants/HealthStatus");
-jest.dontMock("../ServiceAttributeNoHealthchecksFilter");
-jest.dontMock("#SRC/js/structs/List");
-
 var DSLFilterList = require("#SRC/js/structs/DSLFilterList");
 var SearchDSL = require("#SRC/resources/grammar/SearchDSL.jison");
 var HealthStatus = require("../../constants/HealthStatus");

--- a/plugins/services/src/js/filters/__tests__/ServiceNameTextFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceNameTextFilter-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("#SRC/js/structs/DSLFilterList");
-jest.dontMock("#SRC/resources/grammar/SearchDSL.jison");
-jest.dontMock("../ServiceNameTextFilter");
-jest.dontMock("#SRC/js/structs/List");
-
 var DSLFilterList = require("#SRC/js/structs/DSLFilterList");
 var SearchDSL = require("#SRC/resources/grammar/SearchDSL.jison");
 var ServiceNameTextFilter = require("../ServiceNameTextFilter");

--- a/plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.js
+++ b/plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.js
@@ -1,13 +1,3 @@
-jest.dontMock("../TaskFilesTab");
-jest.dontMock("../TaskDetail");
-jest.dontMock("../../../stores/MarathonStore");
-
-jest.dontMock("#SRC/js/stores/DCOSStore");
-jest.dontMock("#SRC/js/stores/MesosStateStore");
-jest.dontMock("#SRC/js/stores/MesosSummaryStore");
-jest.dontMock("#SRC/js/components/Page");
-jest.dontMock("#SRC/js/mixins/InternalStorageMixin");
-
 const JestUtil = require("#SRC/js/utils/JestUtil");
 
 JestUtil.unMockStores([

--- a/plugins/services/src/js/pages/task-details/__tests__/TaskFileViewer-test.js
+++ b/plugins/services/src/js/pages/task-details/__tests__/TaskFileViewer-test.js
@@ -1,9 +1,3 @@
-jest.dontMock("#SRC/js/components/Icon");
-jest.dontMock("../../../components/MesosLogContainer");
-jest.dontMock("#SRC/js/components/RequestErrorMsg");
-jest.dontMock("../TaskFileViewer");
-jest.dontMock("#SRC/js/components/FilterBar");
-
 const JestUtil = require("#SRC/js/utils/JestUtil");
 
 JestUtil.unMockStores(["TaskDirectoryStore", "MesosLogStore"]);

--- a/plugins/services/src/js/stores/__tests__/MarathonStore-test.js
+++ b/plugins/services/src/js/stores/__tests__/MarathonStore-test.js
@@ -1,10 +1,3 @@
-jest.dontMock("../../constants/EventTypes");
-jest.dontMock("../../constants/HealthLabels");
-jest.dontMock("../MarathonStore");
-jest.dontMock("./fixtures/MockAppMetadata");
-jest.dontMock("./fixtures/MockMarathonResponse.json");
-jest.dontMock("../../structs/DeploymentsList");
-
 const DeploymentsList = require("../../structs/DeploymentsList");
 const EventTypes = require("../../constants/EventTypes");
 const HealthLabels = require("../../constants/HealthLabels");

--- a/plugins/services/src/js/stores/__tests__/MesosLogStore-test.js
+++ b/plugins/services/src/js/stores/__tests__/MesosLogStore-test.js
@@ -1,11 +1,3 @@
-jest.dontMock("../MesosLogStore");
-jest.dontMock("#SRC/js/config/Config");
-jest.dontMock("../../events/MesosLogActions");
-jest.dontMock("../../structs/LogBuffer");
-jest.dontMock("#SRC/js/structs/Item");
-jest.dontMock("#SRC/js/structs/List");
-jest.dontMock("#SRC/js/utils/Util");
-
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 
 const ActionTypes = require("../../constants/ActionTypes");

--- a/plugins/services/src/js/structs/__tests__/DirectoryItem-test.js
+++ b/plugins/services/src/js/structs/__tests__/DirectoryItem-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../DirectoryItem");
-
 const DirectoryItem = require("../DirectoryItem");
 
 describe("DirectoryItem", function() {

--- a/plugins/services/src/js/structs/__tests__/Framework-test.js
+++ b/plugins/services/src/js/structs/__tests__/Framework-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("#SRC/js/stores/MesosStateStore");
-
 const JestUtil = require("#SRC/js/utils/JestUtil");
 
 JestUtil.unMockStores(["MesosStateStore"]);

--- a/plugins/services/src/js/structs/__tests__/LogBuffer-test.js
+++ b/plugins/services/src/js/structs/__tests__/LogBuffer-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("#SRC/js/structs/Item");
-jest.dontMock("#SRC/js/structs/List");
-jest.dontMock("../LogBuffer");
-jest.dontMock("#SRC/js/utils/Util");
-
 const Item = require("#SRC/js/structs/Item");
 const List = require("#SRC/js/structs/List");
 const LogBuffer = require("../LogBuffer");

--- a/plugins/services/src/js/structs/__tests__/Pod-test.js
+++ b/plugins/services/src/js/structs/__tests__/Pod-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../../../../../../tests/_fixtures/pods/PodFixture");
-
 const Pod = require("../Pod");
 
 const HealthStatus = require("../../constants/HealthStatus");

--- a/plugins/services/src/js/structs/__tests__/PodContainer-test.js
+++ b/plugins/services/src/js/structs/__tests__/PodContainer-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../../../../../../tests/_fixtures/pods/PodFixture");
-
 const PodContainer = require("../PodContainer");
 const PodContainerStatus = require("../../constants/PodContainerStatus");
 

--- a/plugins/services/src/js/structs/__tests__/PodInstance-test.js
+++ b/plugins/services/src/js/structs/__tests__/PodInstance-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../../../../../../tests/_fixtures/pods/PodFixture");
-
 const PodInstance = require("../PodInstance");
 const PodInstanceStatus = require("../../constants/PodInstanceStatus");
 

--- a/plugins/services/src/js/structs/__tests__/PodSpec-test.js
+++ b/plugins/services/src/js/structs/__tests__/PodSpec-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../../../../../../tests/_fixtures/pods/PodFixture");
-
 const PodSpec = require("../PodSpec");
 
 const PodFixture = require("../../../../../../tests/_fixtures/pods/PodFixture");

--- a/plugins/services/src/js/structs/__tests__/ServicesList-test.js
+++ b/plugins/services/src/js/structs/__tests__/ServicesList-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("#SRC/js/utils/StringUtil");
-jest.dontMock("#SRC/js/utils/Util");
-
 const Framework = require("../Framework");
 const ServicesList = require("../ServicesList");
 

--- a/plugins/services/src/js/structs/__tests__/TaskDirectory-test.js
+++ b/plugins/services/src/js/structs/__tests__/TaskDirectory-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../DirectoryItem");
-jest.dontMock("../TaskDirectory");
-jest.dontMock("#SRC/js/utils/Util");
-
 const DirectoryItem = require("../DirectoryItem");
 const TaskDirectory = require("../TaskDirectory");
 

--- a/plugins/services/src/js/utils/__tests__/DeclinedOffersUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/DeclinedOffersUtil-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../DeclinedOffersUtil");
-jest.dontMock("../../structs/Application");
-jest.dontMock("../../structs/ServiceTree");
-
 const DeclinedOffersUtil = require("../DeclinedOffersUtil");
 
 describe("DeclinedOffersUtil", function() {

--- a/plugins/services/src/js/utils/__tests__/FrameworkUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/FrameworkUtil-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("../FrameworkUtil");
-jest.dontMock("../../constants/ServiceImages");
-
 const ServiceImages = require("../../constants/ServiceImages");
 const FrameworkUtil = require("../FrameworkUtil");
 

--- a/plugins/services/src/js/utils/__tests__/HostUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/HostUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../HostUtil");
-
 const HostUtil = require("../HostUtil");
 
 describe("HostUtil", function() {

--- a/plugins/services/src/js/utils/__tests__/MarathonErrorUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/MarathonErrorUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../MarathonErrorUtil");
-
 const MarathonErrorUtil = require("../MarathonErrorUtil");
 const ServiceErrorTypes = require("../../constants/ServiceErrorTypes");
 

--- a/plugins/services/src/js/utils/__tests__/MarathonUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/MarathonUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../MarathonUtil");
-
 const MarathonUtil = require("../MarathonUtil");
 
 describe("MarathonUtil", function() {

--- a/plugins/services/src/js/utils/__tests__/ServiceConfigUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceConfigUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../ServiceConfigUtil");
-
 const ServiceConfigUtil = require("../ServiceConfigUtil");
 
 describe("ServiceConfigUtil", function() {

--- a/plugins/services/src/js/utils/__tests__/ServiceSpecUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceSpecUtil-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("../ServiceSpecUtil");
-jest.dontMock("../../structs/PodSpec");
-
 const ApplicationSpec = require("../../structs/ApplicationSpec");
 const FrameworkSpec = require("../../structs/FrameworkSpec");
 const PodSpec = require("../../structs/PodSpec");

--- a/plugins/services/src/js/utils/__tests__/ServiceTableUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceTableUtil-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("../ServiceTableUtil");
-jest.dontMock("../../structs/Application");
-
 const Application = require("../../structs/Application");
 const ServiceTableUtil = require("../ServiceTableUtil");
 const ServiceTree = require("../../structs/ServiceTree");

--- a/plugins/services/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceUtil-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../ServiceUtil");
-jest.dontMock("../../structs/Service");
-jest.dontMock("../../constants/VolumeConstants");
-
 const Application = require("../../structs/Application");
 const ApplicationSpec = require("../../structs/ApplicationSpec");
 const Framework = require("../../structs/Framework");

--- a/plugins/services/src/js/utils/__tests__/ServiceValidatorUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceValidatorUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../ServiceValidatorUtil");
-
 const ServiceValidatorUtil = require("../ServiceValidatorUtil");
 
 describe("ServiceValidatorUtil", function() {

--- a/plugins/services/src/js/utils/__tests__/TaskTableUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/TaskTableUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../TaskTableUtil");
-
 const Service = require("../../structs/Service");
 const TaskTableUtil = require("../TaskTableUtil");
 

--- a/plugins/services/src/js/utils/__tests__/VipLabelUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/VipLabelUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../VipLabelUtil");
-
 const VipLabelUtil = require("../VipLabelUtil");
 
 const appID = "/some-app";

--- a/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
@@ -1,4 +1,3 @@
-jest.unmock("../MarathonAppValidators");
 const MarathonAppValidators = require("../MarathonAppValidators");
 const {
   PROP_MISSING_ONE,

--- a/plugins/services/src/js/validators/__tests__/VipLabelsValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/VipLabelsValidators-test.js
@@ -1,4 +1,3 @@
-jest.unmock("../VipLabelsValidators");
 const VipLabelsValidators = require("../VipLabelsValidators");
 
 describe("VipLabelsValidators", function() {

--- a/plugins/tracking/__tests__/TrackingPlugin-test.js
+++ b/plugins/tracking/__tests__/TrackingPlugin-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("../index");
-jest.dontMock("../hooks");
-
 jest.setMock("react-router", {
   hashHistory: {
     location: { pathname: "/foo" },

--- a/plugins/tracking/actions/__tests__/Actions-test.js
+++ b/plugins/tracking/actions/__tests__/Actions-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("#SRC/js/utils/Util");
-jest.dontMock("../Actions");
-
 jest.setMock("react-router", {
   hashHistory: {
     location: "/foo",

--- a/src/js/components/__tests__/Authenticated-test.js
+++ b/src/js/components/__tests__/Authenticated-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../Authenticated");
-jest.dontMock("../../stores/AuthStore");
-jest.dontMock("../../events/AuthActions");
-
 const React = require("react");
 const ReactDOM = require("react-dom");
 const TestUtils = require("react-addons-test-utils");

--- a/src/js/components/__tests__/BreadcrumbSegmentLink-test.js
+++ b/src/js/components/__tests__/BreadcrumbSegmentLink-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../BreadcrumbSegmentLink");
-
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/__tests__/ClickToSelect-test.js
+++ b/src/js/components/__tests__/ClickToSelect-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../ClickToSelect");
-
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/__tests__/ComponentList-test.js
+++ b/src/js/components/__tests__/ComponentList-test.js
@@ -1,4 +1,3 @@
-jest.dontMock("../ComponentList");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/__tests__/DescriptionList-test.js
+++ b/src/js/components/__tests__/DescriptionList-test.js
@@ -1,10 +1,3 @@
-jest.dontMock("../ConfigurationMapLabel");
-jest.dontMock("../ConfigurationMapRow");
-jest.dontMock("../ConfigurationMapHeading");
-jest.dontMock("../ConfigurationMapSection");
-jest.dontMock("../ConfigurationMapValue");
-jest.dontMock("../HashMapDisplay");
-jest.dontMock("../DetailViewSectionHeading");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/__tests__/DetailViewHeader-test.js
+++ b/src/js/components/__tests__/DetailViewHeader-test.js
@@ -1,4 +1,3 @@
-jest.dontMock("../DetailViewHeader");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/__tests__/ExpandingTable-test.js
+++ b/src/js/components/__tests__/ExpandingTable-test.js
@@ -1,4 +1,3 @@
-jest.dontMock("../ExpandingTable");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/__tests__/FilterBar-test.js
+++ b/src/js/components/__tests__/FilterBar-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../FilterBar");
-
 const React = require("react");
 const TestUtils = require("react-addons-test-utils");
 

--- a/src/js/components/__tests__/FilterButtons-test.js
+++ b/src/js/components/__tests__/FilterButtons-test.js
@@ -1,4 +1,3 @@
-jest.dontMock("../FilterButtons");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/__tests__/JSONEditor-test.js
+++ b/src/js/components/__tests__/JSONEditor-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../JSONEditor");
-
 const React = require("react");
 const ReactDOM = require("react-dom");
 const JSONEditor = require("../JSONEditor");

--- a/src/js/components/__tests__/Panel-test.js
+++ b/src/js/components/__tests__/Panel-test.js
@@ -1,4 +1,3 @@
-jest.dontMock("../Panel");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/__tests__/ReviewConfig-test.js
+++ b/src/js/components/__tests__/ReviewConfig-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("../ConfigurationMap");
-jest.dontMock("../ReviewConfig");
-
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/__tests__/ServerErrorModal-test.js
+++ b/src/js/components/__tests__/ServerErrorModal-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("#SRC/js/stores/MesosStateStore");
-jest.dontMock("#SRC/js/stores/MesosSummaryStore");
-jest.dontMock("../ServerErrorModal");
-jest.dontMock("../modals/ModalHeading");
-
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/__tests__/SideTabs-test.js
+++ b/src/js/components/__tests__/SideTabs-test.js
@@ -1,4 +1,3 @@
-jest.dontMock("../SideTabs");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/__tests__/StatusBar-test.js
+++ b/src/js/components/__tests__/StatusBar-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../StatusBar");
-
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/__tests__/TabButton-test.js
+++ b/src/js/components/__tests__/TabButton-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../TabButton");
-
 const React = require("react");
 const ReactDOM = require("react-dom");
 const TestUtils = require("react-addons-test-utils");

--- a/src/js/components/__tests__/TabButtonList-test.js
+++ b/src/js/components/__tests__/TabButtonList-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("../TabButton");
-jest.dontMock("../TabButtonList");
-
 const React = require("react");
 const TestUtils = require("react-addons-test-utils");
 

--- a/src/js/components/__tests__/TabViewList-test.js
+++ b/src/js/components/__tests__/TabViewList-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("../TabView");
-jest.dontMock("../TabViewList");
-
 const React = require("react");
 const ReactDOM = require("react-dom");
 const TestUtils = require("react-addons-test-utils");

--- a/src/js/components/__tests__/Tabs-test.js
+++ b/src/js/components/__tests__/Tabs-test.js
@@ -1,9 +1,3 @@
-jest.dontMock("../TabButton");
-jest.dontMock("../TabButtonList");
-jest.dontMock("../Tabs");
-jest.dontMock("../TabView");
-jest.dontMock("../TabViewList");
-
 const React = require("react");
 const ReactDOM = require("react-dom");
 const TestUtils = require("react-addons-test-utils");

--- a/src/js/components/charts/Chart.js
+++ b/src/js/components/charts/Chart.js
@@ -48,10 +48,6 @@ var Chart = React.createClass({
     global.addEventListener("resize", this.updateWidth);
   },
 
-  shouldComponentUpdate() {
-    return DOMUtils.isElementOnTop(ReactDOM.findDOMNode(this));
-  },
-
   componentWillUnmount() {
     global.removeEventListener("resize", this.updateWidth);
   },

--- a/src/js/components/charts/__tests__/ChartStripes-test.js
+++ b/src/js/components/charts/__tests__/ChartStripes-test.js
@@ -1,4 +1,3 @@
-jest.dontMock("../ChartStripes");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/charts/__tests__/DialChart-test.js
+++ b/src/js/components/charts/__tests__/DialChart-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../DialChart");
-jest.dontMock("../DialSlice");
-jest.dontMock("../../../mixins/InternalStorageMixin");
-jest.dontMock("classnames");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/charts/__tests__/TasksChart-test.js
+++ b/src/js/components/charts/__tests__/TasksChart-test.js
@@ -1,4 +1,3 @@
-jest.dontMock("../TasksChart");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/charts/__tests__/TimeSeriesArea-test.js
+++ b/src/js/components/charts/__tests__/TimeSeriesArea-test.js
@@ -5,11 +5,6 @@ const React = require("react");
 const ReactDOM = require("react-dom");
 const TestUtils = require("react-addons-test-utils");
 
-jest.dontMock("./fixtures/MockTimeSeriesData.json");
-jest.dontMock("../../../mixins/ChartMixin");
-jest.dontMock("../TimeSeriesChart");
-jest.dontMock("../TimeSeriesArea");
-
 const MockTimeSeriesData = require("./fixtures/MockTimeSeriesData.json");
 const TimeSeriesArea = require("../TimeSeriesArea");
 

--- a/src/js/components/charts/__tests__/TimeSeriesChart-test.js
+++ b/src/js/components/charts/__tests__/TimeSeriesChart-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../TimeSeriesChart");
-jest.dontMock("../../../mixins/ChartMixin");
-jest.dontMock("../../../mixins/InternalStorageMixin");
-
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/charts/__tests__/TimeSeriesLabel-test.js
+++ b/src/js/components/charts/__tests__/TimeSeriesLabel-test.js
@@ -1,4 +1,3 @@
-jest.dontMock("../TimeSeriesLabel");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/modals/__tests__/CliInstallModal-test.js
+++ b/src/js/components/modals/__tests__/CliInstallModal-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../CliInstallModal");
-jest.dontMock("../../../utils/DOMUtils");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/modals/__tests__/ErrorModal-test.js
+++ b/src/js/components/modals/__tests__/ErrorModal-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../ErrorModal");
-jest.dontMock("../../../utils/DOMUtils");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/components/modals/__tests__/VersionsModal-test.js
+++ b/src/js/components/modals/__tests__/VersionsModal-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../../../utils/DOMUtils");
-jest.dontMock("../../../utils/JestUtil");
-jest.dontMock(".././ModalHeading");
-jest.dontMock("../VersionsModal");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/events/__tests__/AuthActions-test.js
+++ b/src/js/events/__tests__/AuthActions-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("query-string");
-jest.dontMock("../AuthActions");
-
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 
 const ActionTypes = require("../../constants/ActionTypes");

--- a/src/js/events/__tests__/ConfigActions-test.js
+++ b/src/js/events/__tests__/ConfigActions-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../AppDispatcher");
-jest.dontMock("../../config/Config");
-jest.dontMock("../../constants/ActionTypes");
-
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 
 const ActionTypes = require("../../constants/ActionTypes");

--- a/src/js/events/__tests__/CosmosPackagesActions-test.js
+++ b/src/js/events/__tests__/CosmosPackagesActions-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("../CosmosPackagesActions");
-jest.dontMock("../AppDispatcher");
-jest.dontMock("../../config/Config");
-jest.dontMock("../../constants/ActionTypes");
-
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 const ActionTypes = require("../../constants/ActionTypes");
 const AppDispatcher = require("../AppDispatcher");

--- a/src/js/events/__tests__/MesosSummaryActions-test.js
+++ b/src/js/events/__tests__/MesosSummaryActions-test.js
@@ -1,9 +1,3 @@
-jest.dontMock("../../constants/ActionTypes");
-jest.dontMock("../AppDispatcher");
-jest.dontMock("../../config/Config");
-jest.dontMock("../MesosSummaryActions");
-jest.dontMock("../../constants/TimeScales");
-
 const Hooks = require("PluginSDK").Hooks;
 
 jest.setMock("react-router", {

--- a/src/js/events/__tests__/MetronomeActions-test.js
+++ b/src/js/events/__tests__/MetronomeActions-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("../AppDispatcher");
-jest.dontMock("../UnitHealthActions");
-jest.dontMock("../../config/Config");
-jest.dontMock("../../constants/ActionTypes");
-
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 
 const ActionTypes = require("../../constants/ActionTypes");

--- a/src/js/events/__tests__/NodeHealthActions-test.js
+++ b/src/js/events/__tests__/NodeHealthActions-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../AppDispatcher");
-jest.dontMock("../NodeHealthActions");
-jest.dontMock("../../config/Config");
-
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 
 const ActionTypes = require("../../constants/ActionTypes");

--- a/src/js/events/__tests__/SystemLogActions-test.js
+++ b/src/js/events/__tests__/SystemLogActions-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("../SystemLogActions");
-jest.dontMock("../../events/AppDispatcher");
-jest.dontMock("../../constants/ActionTypes");
-jest.dontMock("../../utils/SystemLogUtil");
-
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 
 const ActionTypes = require("../../constants/ActionTypes");

--- a/src/js/events/__tests__/UnitHealthActions-test.js
+++ b/src/js/events/__tests__/UnitHealthActions-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("../AppDispatcher");
-jest.dontMock("../UnitHealthActions");
-jest.dontMock("../../config/Config");
-jest.dontMock("../../constants/ActionTypes");
-
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 
 const ActionTypes = require("../../constants/ActionTypes");

--- a/src/js/events/__tests__/UsersActions-test.js
+++ b/src/js/events/__tests__/UsersActions-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("../AppDispatcher");
-jest.dontMock("../UsersActions");
-jest.dontMock("../../config/Config");
-jest.dontMock("../../constants/ActionTypes");
-
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 
 const ActionTypes = require("../../constants/ActionTypes");

--- a/src/js/mixins/__tests__/ChartMixin-test.js
+++ b/src/js/mixins/__tests__/ChartMixin-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../ChartMixin");
-
 const ChartMixin = require("../ChartMixin");
 
 describe("ChartMixin", function() {

--- a/src/js/mixins/__tests__/InternalStorageMixin-test.js
+++ b/src/js/mixins/__tests__/InternalStorageMixin-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../InternalStorageMixin");
-
 const InternalStorageMixin = require("../InternalStorageMixin");
 
 describe("InternalStorageMixin", function() {

--- a/src/js/mixins/__tests__/QueryParamsMixin-test.js
+++ b/src/js/mixins/__tests__/QueryParamsMixin-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../QueryParamsMixin");
-
 const QueryParamsMixin = require("../QueryParamsMixin");
 
 describe("QueryParamsMixin", function() {

--- a/src/js/mixins/__tests__/SaveStateMixin-test.js
+++ b/src/js/mixins/__tests__/SaveStateMixin-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("../SaveStateMixin");
-jest.dontMock("../../stores/UserSettingsStore");
-
 const SaveStateMixin = require("../SaveStateMixin");
 const UserSettingsStore = require("../../stores/UserSettingsStore");
 

--- a/src/js/mixins/__tests__/TabsMixin-test.js
+++ b/src/js/mixins/__tests__/TabsMixin-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../TabsMixin");
-jest.dontMock("../../utils/TabsUtil");
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */

--- a/src/js/pages/__tests__/JobsTab-test.js
+++ b/src/js/pages/__tests__/JobsTab-test.js
@@ -1,9 +1,4 @@
-jest.dontMock("../jobs/JobsTab");
-jest.dontMock("../../mixins/InternalStorageMixin");
-jest.dontMock("../../mixins/SaveStateMixin");
-jest.dontMock("../../components/Page");
-jest.mock("../../stores/UserSettingsStore");
-jest.mock("../../mixins/QueryParamsMixin");
+jest.mock("#SRC/js/stores/DCOSStore");
 
 /* eslint-disable no-unused-vars */
 const React = require("react");

--- a/src/js/pages/catalog/__tests__/PackageDetailTab-test.js
+++ b/src/js/pages/catalog/__tests__/PackageDetailTab-test.js
@@ -1,12 +1,3 @@
-jest.dontMock("../PackageDetailTab");
-jest.dontMock("../../../components/FluidGeminiScrollbar");
-jest.dontMock("../../../components/Page");
-jest.dontMock("../../../components/Panel");
-jest.dontMock("../../../mixins/InternalStorageMixin");
-jest.dontMock("../../../components/modals/InstallPackageModal");
-jest.dontMock("../../../stores/CosmosPackagesStore");
-jest.dontMock("../../../../../tests/_fixtures/cosmos/package-describe.json");
-
 // Setting useFixtures for when we load CosmosPackagesStore/CosmosPackageActions
 /* eslint-disable import/newline-after-import */
 const Config = require("../../../config/Config");

--- a/src/js/pages/catalog/__tests__/PackagesTab-test.js
+++ b/src/js/pages/catalog/__tests__/PackagesTab-test.js
@@ -1,15 +1,4 @@
 jest.mock("../../../utils/ScrollbarUtil");
-jest.dontMock("../PackagesTab");
-jest.dontMock("../CatalogPackageOption");
-jest.dontMock("../../../utils/Util");
-jest.dontMock("../../../components/FluidGeminiScrollbar");
-jest.dontMock("../../../components/SchemaForm");
-jest.dontMock("../../../components/Page");
-jest.dontMock("../../../components/Panel");
-jest.dontMock("../../../components/modals/InstallPackageModal");
-jest.dontMock("../../../mixins/InternalStorageMixin");
-jest.dontMock("../../../stores/CosmosPackagesStore");
-jest.dontMock("../../../../../tests/_fixtures/cosmos/packages-search.json");
 
 /* eslint-disable no-unused-vars */
 const React = require("react");

--- a/src/js/plugin-bridge/__tests__/ActionsPubSub-test.js
+++ b/src/js/plugin-bridge/__tests__/ActionsPubSub-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../middleware/ActionsPubSub");
-
 const APPLICATION = require("../../constants/PluginConstants").APPLICATION;
 const PluginSDK = require("PluginSDK");
 

--- a/src/js/plugin-bridge/__tests__/AppReducer-test.js
+++ b/src/js/plugin-bridge/__tests__/AppReducer-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../AppReducer");
-jest.dontMock("../../config/Config");
-jest.dontMock("../../stores/ConfigStore");
-
 const deepEqual = require("deep-equal");
 
 const EventTypes = require("../../constants/EventTypes");

--- a/src/js/plugin-bridge/__tests__/Hooks-test.js
+++ b/src/js/plugin-bridge/__tests__/Hooks-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../Hooks");
-
 const Hooks = require("../Hooks");
 
 describe("HooksAPI", function() {

--- a/src/js/plugin-bridge/__tests__/PluginSDK-test.js
+++ b/src/js/plugin-bridge/__tests__/PluginSDK-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("../AppReducer");
-jest.dontMock("../../config/Config");
-jest.dontMock("../../stores/ConfigStore");
-jest.dontMock("../../utils/StructUtil");
-
 const deepEqual = require("deep-equal");
 
 const PluginSDK = require("PluginSDK");

--- a/src/js/stores/__tests__/AuthStore-test.js
+++ b/src/js/stores/__tests__/AuthStore-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("../AuthStore");
-jest.dontMock("../../events/AuthActions");
-
 const cookie = require("cookie");
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 

--- a/src/js/stores/__tests__/ConfigStore-test.js
+++ b/src/js/stores/__tests__/ConfigStore-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../../constants/EventTypes");
-jest.dontMock("../ConfigStore");
-jest.dontMock("../../constants/EventTypes");
-
 const EventTypes = require("../../constants/EventTypes");
 const ConfigStore = require("../ConfigStore");
 

--- a/src/js/stores/__tests__/CosmosPackagesStore-test.js
+++ b/src/js/stores/__tests__/CosmosPackagesStore-test.js
@@ -1,11 +1,3 @@
-jest.dontMock("../CosmosPackagesStore");
-jest.dontMock("../../config/Config");
-jest.dontMock("../../events/AppDispatcher");
-jest.dontMock("../../events/CosmosPackagesActions");
-jest.dontMock("./fixtures/MockPackageDescribeResponse.json");
-jest.dontMock("./fixtures/MockPackagesListResponse.json");
-jest.dontMock("./fixtures/MockPackagesSearchResponse.json");
-
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 
 const AppDispatcher = require("../../events/AppDispatcher");

--- a/src/js/stores/__tests__/DCOSStore-test.js
+++ b/src/js/stores/__tests__/DCOSStore-test.js
@@ -1,8 +1,5 @@
 jest.mock("../../../../plugins/services/src/js/stores/MarathonStore");
 jest.mock("../MesosSummaryStore");
-jest.dontMock("../DCOSStore");
-jest.dontMock("../../structs/SummaryList");
-jest.dontMock("../../structs/StateSummary");
 
 const DCOSStore = require("../DCOSStore");
 const EventTypes = require("../../constants/EventTypes");

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../MesosStateStore");
-
 const MesosStateUtil = require("../../utils/MesosStateUtil");
 const Pod = require("../../../../plugins/services/src/js/structs/Pod");
 const Framework = require("../../../../plugins/services/src/js/structs/Framework");

--- a/src/js/stores/__tests__/MesosSummaryStore-test.js
+++ b/src/js/stores/__tests__/MesosSummaryStore-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("../MesosSummaryStore");
-jest.dontMock("../../utils/MesosSummaryUtil");
-jest.dontMock("../../utils/StringUtil");
-jest.dontMock("../../utils/Util");
-
 const MesosSummaryStore = require("../MesosSummaryStore");
 const Framework = require("../../../../plugins/services/src/js/structs/Framework");
 

--- a/src/js/stores/__tests__/MetronomeStore-test.js
+++ b/src/js/stores/__tests__/MetronomeStore-test.js
@@ -1,11 +1,3 @@
-jest.dontMock("../MetronomeStore");
-jest.dontMock("../../events/AppDispatcher");
-jest.dontMock("../../events/MetronomeActions");
-jest.dontMock("../../structs/Job");
-jest.dontMock("../../structs/JobTree");
-jest.dontMock("../../../../tests/_fixtures/metronome/jobs.json");
-jest.dontMock("../../../../tests/_fixtures/metronome/job.json");
-
 const ActionTypes = require("../../constants/ActionTypes");
 const AppDispatcher = require("../../events/AppDispatcher");
 const MetronomeActions = require("../../events/MetronomeActions");

--- a/src/js/stores/__tests__/NotificationStore-test.js
+++ b/src/js/stores/__tests__/NotificationStore-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../NotificationStore");
-
 const NOTIFICATION_CHANGE = require("../../constants/EventTypes")
   .NOTIFICATION_CHANGE;
 const NotificationStore = require("../NotificationStore");

--- a/src/js/stores/__tests__/SystemLogStore-test.js
+++ b/src/js/stores/__tests__/SystemLogStore-test.js
@@ -1,10 +1,3 @@
-jest.dontMock("../../constants/ActionTypes");
-jest.dontMock("../../constants/EventTypes");
-jest.dontMock("../../events/AppDispatcher");
-jest.dontMock("../SystemLogStore");
-jest.dontMock("../../constants/EventTypes");
-jest.dontMock("../../constants/SystemLogTypes");
-
 const ActionTypes = require("../../constants/ActionTypes");
 const AppDispatcher = require("../../events/AppDispatcher");
 const EventTypes = require("../../constants/EventTypes");

--- a/src/js/stores/__tests__/UnitHealthStore-test.js
+++ b/src/js/stores/__tests__/UnitHealthStore-test.js
@@ -1,9 +1,3 @@
-jest.dontMock("../UnitHealthStore");
-jest.dontMock("../../config/Config");
-jest.dontMock("../../events/AppDispatcher");
-jest.dontMock("../../events/UnitHealthActions");
-jest.dontMock("../../../../tests/_fixtures/unit-health/units.json");
-
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 
 const ActionTypes = require("../../constants/ActionTypes");

--- a/src/js/stores/__tests__/UserSettingsStore-test.js
+++ b/src/js/stores/__tests__/UserSettingsStore-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("../../utils/LocalStorageUtil");
-jest.dontMock("../UserSettingsStore");
-
 const LocalStorageUtil = require("../../utils/LocalStorageUtil");
 const UserSettingsStore = require("../UserSettingsStore");
 

--- a/src/js/stores/__tests__/UserStore-test.js
+++ b/src/js/stores/__tests__/UserStore-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("../UserStore");
-jest.dontMock("../../events/UsersActions");
-
 const UserStore = require("../UserStore");
 const ActionTypes = require("../../constants/ActionTypes");
 const AppDispatcher = require("../../events/AppDispatcher");

--- a/src/js/stores/__tests__/UsersStore-test.js
+++ b/src/js/stores/__tests__/UsersStore-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("../UsersStore");
-jest.dontMock("../../../../tests/_fixtures/acl/users-unicode.json");
-
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 
 const UsersStore = require("../UsersStore");

--- a/src/js/stores/__tests__/VirtualNetworksStore-test.js
+++ b/src/js/stores/__tests__/VirtualNetworksStore-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../VirtualNetworksStore");
-jest.dontMock("../../events/AppDispatcher");
-jest.dontMock("../../events/VirtualNetworksActions");
-
 const ActionTypes = require("../../constants/ActionTypes");
 const AppDispatcher = require("../../events/AppDispatcher");
 const EventTypes = require("../../constants/EventTypes");

--- a/src/js/stores/__tests__/VisibilityStore-test.js
+++ b/src/js/stores/__tests__/VisibilityStore-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../VisibilityStore");
-
 const VISIBILITY_CHANGE = require("../../constants/EventTypes")
   .VISIBILITY_CHANGE;
 const VisibilityStore = require("../VisibilityStore");

--- a/src/js/structs/__tests__/DSLExpression-test.js
+++ b/src/js/structs/__tests__/DSLExpression-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../DSLExpression");
-jest.dontMock("../DSLASTNodes");
-jest.dontMock("../../../resources/grammar/SearchDSL.jison");
-
 const DSLExpression = require("../DSLExpression");
 const DSLASTNodes = require("../DSLASTNodes");
 

--- a/src/js/structs/__tests__/DSLExpressionPart-test.js
+++ b/src/js/structs/__tests__/DSLExpressionPart-test.js
@@ -1,4 +1,3 @@
-jest.dontMock("../DSLExpressionPart");
 const DSLFilterTypes = require("../../constants/DSLFilterTypes");
 const DSLExpressionPart = require("../DSLExpressionPart");
 

--- a/src/js/structs/__tests__/DSLFilterList-test.js
+++ b/src/js/structs/__tests__/DSLFilterList-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../DSLFilter");
-jest.dontMock("../DSLFilterList");
 const DSLFilter = require("../DSLFilter");
 const DSLFilterList = require("../DSLFilterList");
 

--- a/src/js/structs/__tests__/HealthUnit-test.js
+++ b/src/js/structs/__tests__/HealthUnit-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../../constants/UnitHealthStatus");
-
 const HealthUnit = require("../HealthUnit");
 const UnitHealthStatus = require("../../constants/UnitHealthStatus");
 const UnitHealthTypes = require("../../constants/UnitHealthTypes");

--- a/src/js/structs/__tests__/HealthUnitsList-test.js
+++ b/src/js/structs/__tests__/HealthUnitsList-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("../../utils/UnitHealthUtil");
-jest.dontMock("../../utils/MesosSummaryUtil");
-jest.dontMock("../../utils/StringUtil");
-jest.dontMock("../../utils/Util");
-
 const HealthUnit = require("../HealthUnit");
 const HealthUnitsList = require("../HealthUnitsList");
 

--- a/src/js/structs/__tests__/NodesList-test.js
+++ b/src/js/structs/__tests__/NodesList-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../../utils/MesosSummaryUtil");
-jest.dontMock("../../utils/StringUtil");
-jest.dontMock("../../utils/Util");
-
 const Node = require("../Node");
 const NodesList = require("../NodesList");
 

--- a/src/js/structs/__tests__/RepositoryList-test.js
+++ b/src/js/structs/__tests__/RepositoryList-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../Item");
-jest.dontMock("../RepositoryList");
-jest.dontMock("../../utils/Util");
-
 const Item = require("../Item");
 const RepositoryList = require("../RepositoryList");
 

--- a/src/js/structs/__tests__/StateSummary-test.js
+++ b/src/js/structs/__tests__/StateSummary-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../../../../plugins/services/src/js/structs/Framework");
-jest.dontMock("../../utils/MesosSummaryUtil");
-jest.dontMock("../../utils/Util");
-
 const Framework = require("../../../../plugins/services/src/js/structs/Framework");
 const NodesList = require("../NodesList");
 const ServicesList = require("../../../../plugins/services/src/js/structs/ServicesList");

--- a/src/js/structs/__tests__/SummaryList-test.js
+++ b/src/js/structs/__tests__/SummaryList-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../../utils/MesosSummaryUtil");
-jest.dontMock("../../utils/Maths");
-jest.dontMock("../../utils/Util");
-
 const SummaryList = require("../SummaryList");
 const StateSummary = require("../StateSummary");
 

--- a/src/js/structs/__tests__/UniversePackage-test.js
+++ b/src/js/structs/__tests__/UniversePackage-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../../../../plugins/services/src/js/constants/ServiceImages");
-
 const ServiceImages = require("../../../../plugins/services/src/js/constants/ServiceImages");
 const UniversePackage = require("../UniversePackage");
 

--- a/src/js/structs/__tests__/UniversePackagesList-test.js
+++ b/src/js/structs/__tests__/UniversePackagesList-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../UniversePackage");
-jest.dontMock("../UniversePackagesList");
-jest.dontMock("../../utils/Util");
-
 const UniversePackage = require("../UniversePackage");
 const UniversePackagesList = require("../UniversePackagesList");
 

--- a/src/js/utils/DOMUtils.js
+++ b/src/js/utils/DOMUtils.js
@@ -163,26 +163,6 @@ var DOMUtils = {
     }
   },
 
-  isElementOnTop(el) {
-    const { left, top, height, width } = el.getBoundingClientRect();
-    const elAtPoint = global.document.elementFromPoint(
-      // The coords of the middle of the element.
-      left + width / 2,
-      top + height / 2
-    );
-
-    // If elAtPoint is null, then the element is off the screen. We return true
-    // here.
-    if (elAtPoint == null) {
-      return true;
-    }
-
-    // We need to also use #contains because the elAtPoint may be a child.
-    // We also need to check if elAtPoint contains el because it might select
-    // the parent even if the el is showing.
-    return el === elAtPoint || el.contains(elAtPoint) || elAtPoint.contains(el);
-  },
-
   getDistanceFromTopOfParent(el) {
     const elTop = el.getBoundingClientRect().top;
 

--- a/src/js/utils/JestUtil.js
+++ b/src/js/utils/JestUtil.js
@@ -42,13 +42,6 @@ const JestUtil = {
     });
   },
 
-  dontMockStore(storeID) {
-    if (storeID in stores) {
-      jest.dontMock(stores[storeID]);
-
-      return true;
-    }
-  },
   /**
    * Generates a callback function to a filter() call that will
    * keep only DOMElements matching the given tag name(s)

--- a/src/js/utils/__tests__/ApplicationUtil-test.js
+++ b/src/js/utils/__tests__/ApplicationUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../../stores/MesosSummaryStore");
-
 const ApplicationUtil = require("../ApplicationUtil");
 const Config = require("../../config/Config");
 const EventTypes = require("../../constants/EventTypes");

--- a/src/js/utils/__tests__/BetaOptInUtil-test.js
+++ b/src/js/utils/__tests__/BetaOptInUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../BetaOptInUtil");
-
 const BetaOptInUtil = require("../BetaOptInUtil");
 
 describe("BetaOptInUtil", function() {

--- a/src/js/utils/__tests__/ContainerUtil-test.js
+++ b/src/js/utils/__tests__/ContainerUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../ContainerUtil");
-
 const ContainerUtil = require("../ContainerUtil");
 
 describe("#adjustActionErrors", function() {

--- a/src/js/utils/__tests__/DOMUtils-test.js
+++ b/src/js/utils/__tests__/DOMUtils-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../DOMUtils");
-
 const DOMUtils = require("../DOMUtils");
 
 describe("DOMUtils", function() {

--- a/src/js/utils/__tests__/DOMUtils-test.js
+++ b/src/js/utils/__tests__/DOMUtils-test.js
@@ -204,51 +204,6 @@ describe("DOMUtils", function() {
     });
   });
 
-  describe("#isElementOnTop", function() {
-    beforeEach(function() {
-      this.element = {
-        getBoundingClientRect() {
-          return {
-            top: 100,
-            left: 200,
-            height: 20,
-            width: 40
-          };
-        },
-        contains(el) {
-          return this === el;
-        }
-      };
-      this.prevElementFromPoint = global.document.elementFromPoint;
-    });
-
-    afterEach(function() {
-      global.document.elementFromPoint = this.prevElementFromPoint;
-    });
-
-    it("should return false if element is not at coord", function() {
-      global.document.elementFromPoint = function() {
-        return {
-          contains() {
-            return false;
-          }
-        };
-      };
-
-      const result = DOMUtils.isElementOnTop(this.element);
-      expect(result).toEqual(false);
-    });
-
-    it("should return true if element is at coord", function() {
-      global.document.elementFromPoint = () => {
-        return this.element;
-      };
-
-      const result = DOMUtils.isElementOnTop(this.element);
-      expect(result).toEqual(true);
-    });
-  });
-
   describe("#getDistanceFromTopOfParent", function() {
     beforeEach(function() {
       this.element = {

--- a/src/js/utils/__tests__/DSLFormUtil-test.js
+++ b/src/js/utils/__tests__/DSLFormUtil-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../DSLFormUtil");
-jest.dontMock("../../structs/DSLExpressionPart");
-jest.dontMock("../../structs/DSLASTNodes");
-
 const DSLFilterTypes = require("../../constants/DSLFilterTypes");
 const DSLFormUtil = require("../DSLFormUtil");
 const DSLExpressionPart = require("../../structs/DSLExpressionPart");

--- a/src/js/utils/__tests__/DSLParserUtil-test.js
+++ b/src/js/utils/__tests__/DSLParserUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../DSLParserUtil");
-jest.dontMock("../../structs/List");
 const DSLASTNodes = require("../../structs/DSLASTNodes");
 const DSLCombinerTypes = require("../../constants/DSLCombinerTypes");
 const DSLFilter = require("../../structs/DSLFilter");

--- a/src/js/utils/__tests__/DSLUpdateUtil-test.js
+++ b/src/js/utils/__tests__/DSLUpdateUtil-test.js
@@ -1,9 +1,3 @@
-jest.dontMock("../DSLParserUtil");
-jest.dontMock("../DSLUpdateUtil");
-jest.dontMock("../DSLUtil");
-jest.dontMock("../../structs/DSLExpression");
-jest.dontMock("../../../resources/grammar/SearchDSL.jison");
-
 const DSLASTNodes = require("../../structs/DSLASTNodes");
 const DSLCombinerTypes = require("../../constants/DSLCombinerTypes");
 const DSLExpression = require("../../structs/DSLExpression");

--- a/src/js/utils/__tests__/DSLUtil-test.js
+++ b/src/js/utils/__tests__/DSLUtil-test.js
@@ -1,9 +1,3 @@
-jest.dontMock("../DSLParserUtil");
-jest.dontMock("../DSLUtil");
-jest.dontMock("../../structs/DSLExpression");
-jest.dontMock("../../structs/DSLExpressionPart");
-jest.dontMock("../../../resources/grammar/SearchDSL.jison");
-
 const DSLASTNodes = require("../../structs/DSLASTNodes");
 const DSLExpression = require("../../structs/DSLExpression");
 const DSLExpressionPart = require("../../structs/DSLExpressionPart");

--- a/src/js/utils/__tests__/DataValidatorUtil-test.js
+++ b/src/js/utils/__tests__/DataValidatorUtil-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("objektiv");
-jest.dontMock("../DataValidatorUtil");
-
 const DataValidatorUtil = require("../DataValidatorUtil");
 
 describe("DataValidatorUtil", function() {

--- a/src/js/utils/__tests__/DateUtil-test.js
+++ b/src/js/utils/__tests__/DateUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../DateUtil");
-
 const DateUtil = require("../DateUtil");
 
 describe("DateUtil", function() {

--- a/src/js/utils/__tests__/ErrorMessageUtil-test.js
+++ b/src/js/utils/__tests__/ErrorMessageUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../ErrorMessageUtil");
-
 const ErrorMessageUtil = require("../ErrorMessageUtil");
 
 describe("ErrorMessageUtil", function() {

--- a/src/js/utils/__tests__/FormUtil-test.js
+++ b/src/js/utils/__tests__/FormUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../FormUtil");
-
 const FormUtil = require("../FormUtil");
 
 describe("FormUtil", function() {

--- a/src/js/utils/__tests__/JSONEditorUtil-test.js
+++ b/src/js/utils/__tests__/JSONEditorUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../JSONEditorUtil");
-
 const JSONEditorUtil = require("../JSONEditorUtil");
 
 describe("JSONEditorUtil", function() {

--- a/src/js/utils/__tests__/JSONUtil-test.js
+++ b/src/js/utils/__tests__/JSONUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../JSONUtil");
-
 const JSONUtil = require("../JSONUtil");
 
 describe("JSONUtil", function() {

--- a/src/js/utils/__tests__/JobValidatorUtil-test.js
+++ b/src/js/utils/__tests__/JobValidatorUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../JobValidatorUtil");
-
 const JobValidatorUtil = require("../JobValidatorUtil");
 
 describe("JobValidatorUtil", function() {

--- a/src/js/utils/__tests__/LocalStorageUtil-test.js
+++ b/src/js/utils/__tests__/LocalStorageUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../LocalStorageUtil");
-
 const LocalStorageUtil = require("../LocalStorageUtil");
 
 describe("LocalStorageUtil", function() {

--- a/src/js/utils/__tests__/Maths-test.js
+++ b/src/js/utils/__tests__/Maths-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../Maths");
-
 const Maths = require("../Maths");
 
 describe("Maths", function() {

--- a/src/js/utils/__tests__/MesosSummaryUtil-test.js
+++ b/src/js/utils/__tests__/MesosSummaryUtil-test.js
@@ -1,8 +1,3 @@
-jest.dontMock("../../config/Config");
-jest.dontMock("../Maths");
-jest.dontMock("../MesosSummaryUtil");
-jest.dontMock("../Util");
-
 const MesosSummaryUtil = require("../MesosSummaryUtil");
 
 describe("MesosSummaryUtil", function() {

--- a/src/js/utils/__tests__/NetworkValidatorUtil-test.js
+++ b/src/js/utils/__tests__/NetworkValidatorUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../NetworkValidatorUtil");
-
 const NetworkValidatorUtil = require("../NetworkValidatorUtil");
 
 describe("NetworkValidatorUtil", function() {

--- a/src/js/utils/__tests__/RouterUtil-test.js
+++ b/src/js/utils/__tests__/RouterUtil-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("query-string");
-jest.dontMock("../RouterUtil");
-
 const ReactRouter = require("react-router");
 const ReactTestUtils = require("react-addons-test-utils");
 

--- a/src/js/utils/__tests__/SchemaFormUtil-test.js
+++ b/src/js/utils/__tests__/SchemaFormUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../SchemaFormUtil");
-
 const SchemaFormUtil = require("../SchemaFormUtil");
 
 describe("SchemaFormUtil", function() {

--- a/src/js/utils/__tests__/SchemaUtil-test.js
+++ b/src/js/utils/__tests__/SchemaUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../SchemaUtil");
-
 const SchemaUtil = require("../SchemaUtil");
 
 describe("SchemaUtil", function() {

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../ServiceUtil");
-
 const ServiceUtil = require("../ServiceUtil");
 
 describe("ServiceUtil", function() {

--- a/src/js/utils/__tests__/StringUtil-test.js
+++ b/src/js/utils/__tests__/StringUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../StringUtil");
-
 const StringUtil = require("../StringUtil");
 
 describe("StringUtil", function() {

--- a/src/js/utils/__tests__/StructUtil-test.js
+++ b/src/js/utils/__tests__/StructUtil-test.js
@@ -1,7 +1,3 @@
-jest.dontMock("../StructUtil");
-jest.dontMock("../../structs/List");
-jest.dontMock("../../structs/Item");
-
 const deepEqual = require("deep-equal");
 const Item = require("../../structs/Item");
 const List = require("../../structs/List");

--- a/src/js/utils/__tests__/SystemLogUtil-test.js
+++ b/src/js/utils/__tests__/SystemLogUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../SystemLogUtil");
-
 const SystemLogUtil = require("../SystemLogUtil");
 
 describe("SystemLogUtil", function() {

--- a/src/js/utils/__tests__/TableUtil-test.js
+++ b/src/js/utils/__tests__/TableUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../TableUtil");
-
 const MarathonStore = require("../../../../plugins/services/src/js/stores/MarathonStore");
 const TableUtil = require("../TableUtil");
 const Util = require("../Util");

--- a/src/js/utils/__tests__/TabsUtil-test.js
+++ b/src/js/utils/__tests__/TabsUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../TabsUtil");
-
 const TabsUtil = require("../TabsUtil");
 
 describe("TabsUtil", function() {

--- a/src/js/utils/__tests__/TemplateUtil-test.js
+++ b/src/js/utils/__tests__/TemplateUtil-test.js
@@ -1,4 +1,3 @@
-jest.dontMock("../TemplateUtil");
 const React = require("react");
 const TemplateUtil = require("../TemplateUtil");
 

--- a/src/js/utils/__tests__/UnitHealthUtil-test.js
+++ b/src/js/utils/__tests__/UnitHealthUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../../constants/UnitHealthStatus");
-
 const HealthUnit = require("../../structs/HealthUnit");
 const UnitHealthStatus = require("../../constants/UnitHealthStatus");
 const UnitHealthTypes = require("../../constants/UnitHealthTypes");

--- a/src/js/utils/__tests__/Units-test.js
+++ b/src/js/utils/__tests__/Units-test.js
@@ -1,6 +1,3 @@
-jest.dontMock("../Maths");
-jest.dontMock("../Units");
-
 const Units = require("../Units");
 
 describe("Units", function() {

--- a/src/js/utils/__tests__/Util-test.js
+++ b/src/js/utils/__tests__/Util-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../Util");
-
 const Util = require("../Util");
 
 describe("Util", function() {

--- a/src/js/utils/__tests__/ValidatorUtil-test.js
+++ b/src/js/utils/__tests__/ValidatorUtil-test.js
@@ -1,5 +1,3 @@
-jest.dontMock("../ValidatorUtil");
-
 describe("ValidatorUtil", function() {
   const ValidatorUtil = require("../ValidatorUtil");
 

--- a/src/resources/grammar/__tests__/SearchDSL-test.js
+++ b/src/resources/grammar/__tests__/SearchDSL-test.js
@@ -1,9 +1,3 @@
-jest.dontMock("../SearchDSL.jison");
-jest.dontMock("../../../js/utils/DSLParserUtil");
-jest.dontMock("../../../js/structs/DSLFilter");
-jest.dontMock("../../../js/structs/DSLFilterList");
-jest.dontMock("../../../js/structs/List");
-
 const DSLFilterTypes = require("../../../js/constants/DSLFilterTypes");
 const DSLCombinerTypes = require("../../../js/constants/DSLCombinerTypes");
 const DSLFilter = require("../../../js/structs/DSLFilter");

--- a/src/resources/grammar/__tests__/SearchDSL-test.js
+++ b/src/resources/grammar/__tests__/SearchDSL-test.js
@@ -1,28 +1,29 @@
-jest.dontMock('../SearchDSL.jison');
-jest.dontMock('../../../js/utils/DSLParserUtil');
-jest.dontMock('../../../js/structs/DSLFilter');
-jest.dontMock('../../../js/structs/DSLFilterList');
-jest.dontMock('../../../js/structs/List');
+jest.dontMock("../SearchDSL.jison");
+jest.dontMock("../../../js/utils/DSLParserUtil");
+jest.dontMock("../../../js/structs/DSLFilter");
+jest.dontMock("../../../js/structs/DSLFilterList");
+jest.dontMock("../../../js/structs/List");
 
-const DSLFilterTypes = require('../../../js/constants/DSLFilterTypes');
-const DSLCombinerTypes = require('../../../js/constants/DSLCombinerTypes');
-const DSLFilter = require('../../../js/structs/DSLFilter');
-const DSLFilterList = require('../../../js/structs/DSLFilterList');
-const List = require('../../../js/structs/List');
-const SearchDSL = require('../SearchDSL.jison');
+const DSLFilterTypes = require("../../../js/constants/DSLFilterTypes");
+const DSLCombinerTypes = require("../../../js/constants/DSLCombinerTypes");
+const DSLFilter = require("../../../js/structs/DSLFilter");
+const DSLFilterList = require("../../../js/structs/DSLFilterList");
+const List = require("../../../js/structs/List");
+const SearchDSL = require("../SearchDSL.jison");
 
 // Handles 'attrib:?'
 class AttribFilter extends DSLFilter {
   filterCanHandle(filterType, filterArguments) {
-    return filterType === DSLFilterTypes.ATTRIB &&
-           filterArguments.label === 'attrib';
+    return (
+      filterType === DSLFilterTypes.ATTRIB && filterArguments.label === "attrib"
+    );
   }
   filterApply(resultset, filterType, filterArguments) {
-    return resultset.filterItems((item) => {
+    return resultset.filterItems(item => {
       return item.attrib.indexOf(filterArguments.text) !== -1;
     });
   }
-};
+}
 
 // Handles 'text'
 class FuzzyTextFilter extends DSLFilter {
@@ -30,11 +31,11 @@ class FuzzyTextFilter extends DSLFilter {
     return filterType === DSLFilterTypes.FUZZY;
   }
   filterApply(resultset, filterType, filterArguments) {
-    return resultset.filterItems((item) => {
+    return resultset.filterItems(item => {
       return item.text.indexOf(filterArguments.text) !== -1;
     });
   }
-};
+}
 
 // Handles '"text"'
 class ExactTextFilter extends DSLFilter {
@@ -42,263 +43,279 @@ class ExactTextFilter extends DSLFilter {
     return filterType === DSLFilterTypes.EXACT;
   }
   filterApply(resultset, filterType, filterArguments) {
-    return resultset.filterItems((item) => {
+    return resultset.filterItems(item => {
       return item.text === filterArguments.text;
     });
   }
-};
+}
 
-describe('SearchDSL', function () {
-
-  describe('Metadata', function () {
-
-    describe('Filters (Operands)', function () {
-
-      it('should parse fuzzy text', function () {
-        const expr = SearchDSL.parse('fuzzy');
+describe("SearchDSL", function() {
+  describe("Metadata", function() {
+    describe("Filters (Operands)", function() {
+      it("should parse fuzzy text", function() {
+        const expr = SearchDSL.parse("fuzzy");
         expect(expr.ast.filterType).toEqual(DSLFilterTypes.FUZZY);
-        expect(expr.ast.filterParams.text).toEqual('fuzzy');
+        expect(expr.ast.filterParams.text).toEqual("fuzzy");
       });
 
-      it('should parse exact text', function () {
+      it("should parse exact text", function() {
         const expr = SearchDSL.parse('"exact string"');
         expect(expr.ast.filterType).toEqual(DSLFilterTypes.EXACT);
-        expect(expr.ast.filterParams.text).toEqual('exact string');
+        expect(expr.ast.filterParams.text).toEqual("exact string");
       });
 
-      it('should parse attributes', function () {
-        const expr = SearchDSL.parse('attrib:value');
+      it("should parse attributes", function() {
+        const expr = SearchDSL.parse("attrib:value");
         expect(expr.ast.filterType).toEqual(DSLFilterTypes.ATTRIB);
-        expect(expr.ast.filterParams.text).toEqual('value');
-        expect(expr.ast.filterParams.label).toEqual('attrib');
+        expect(expr.ast.filterParams.text).toEqual("value");
+        expect(expr.ast.filterParams.label).toEqual("attrib");
       });
-
     });
 
-    describe('Combiners (Operators)', function () {
-
-      it('should use AND operator by default', function () {
-        const expr = SearchDSL.parse('text1 text2');
+    describe("Combiners (Operators)", function() {
+      it("should use AND operator by default", function() {
+        const expr = SearchDSL.parse("text1 text2");
         expect(expr.ast.combinerType).toEqual(DSLCombinerTypes.AND);
       });
 
-      it('should properly use OR operator', function () {
-        const expr = SearchDSL.parse('text1, text2');
+      it("should properly use OR operator", function() {
+        const expr = SearchDSL.parse("text1, text2");
         expect(expr.ast.combinerType).toEqual(DSLCombinerTypes.OR);
       });
 
-      it('should properly use OR shorthand operator on attrib', function () {
+      it("should properly use OR shorthand operator on attrib", function() {
         // NOTE: attrib:value1,value2 becomes -> attrib:value1, attrib:value2
-        const expr = SearchDSL.parse('attrib:value1,value2');
+        const expr = SearchDSL.parse("attrib:value1,value2");
         expect(expr.ast.combinerType).toEqual(DSLCombinerTypes.OR);
         expect(expr.ast.children[0].filterType).toEqual(DSLFilterTypes.ATTRIB);
-        expect(expr.ast.children[0].filterParams.text).toEqual('value1');
-        expect(expr.ast.children[0].filterParams.label).toEqual('attrib');
+        expect(expr.ast.children[0].filterParams.text).toEqual("value1");
+        expect(expr.ast.children[0].filterParams.label).toEqual("attrib");
         expect(expr.ast.children[1].filterType).toEqual(DSLFilterTypes.ATTRIB);
-        expect(expr.ast.children[1].filterParams.text).toEqual('value2');
-        expect(expr.ast.children[1].filterParams.label).toEqual('attrib');
+        expect(expr.ast.children[1].filterParams.text).toEqual("value2");
+        expect(expr.ast.children[1].filterParams.label).toEqual("attrib");
       });
 
-      it('should properly handle OR shorthand + OR with other operands', function () {
+      it("should properly handle OR shorthand + OR with other operands", function() {
         // NOTE: attrib:value1,value2 becomes -> attrib:value1, attrib:value2
-        const expr = SearchDSL.parse('attrib:value1,value2, foo');
+        const expr = SearchDSL.parse("attrib:value1,value2, foo");
         expect(expr.ast.combinerType).toEqual(DSLCombinerTypes.OR);
 
         expect(expr.ast.children[0].combinerType).toEqual(DSLCombinerTypes.OR);
-        expect(expr.ast.children[0].children[0].filterType)
-          .toEqual(DSLFilterTypes.ATTRIB);
-        expect(expr.ast.children[0].children[0].filterParams.text)
-          .toEqual('value1');
-        expect(expr.ast.children[0].children[0].filterParams.label)
-          .toEqual('attrib');
-        expect(expr.ast.children[0].children[1].filterType)
-          .toEqual(DSLFilterTypes.ATTRIB);
-        expect(expr.ast.children[0].children[1].filterParams.text)
-          .toEqual('value2');
-        expect(expr.ast.children[0].children[1].filterParams.label)
-          .toEqual('attrib');
+        expect(expr.ast.children[0].children[0].filterType).toEqual(
+          DSLFilterTypes.ATTRIB
+        );
+        expect(expr.ast.children[0].children[0].filterParams.text).toEqual(
+          "value1"
+        );
+        expect(expr.ast.children[0].children[0].filterParams.label).toEqual(
+          "attrib"
+        );
+        expect(expr.ast.children[0].children[1].filterType).toEqual(
+          DSLFilterTypes.ATTRIB
+        );
+        expect(expr.ast.children[0].children[1].filterParams.text).toEqual(
+          "value2"
+        );
+        expect(expr.ast.children[0].children[1].filterParams.label).toEqual(
+          "attrib"
+        );
 
         expect(expr.ast.children[1].filterType).toEqual(DSLFilterTypes.FUZZY);
-        expect(expr.ast.children[1].filterParams.text).toEqual('foo');
+        expect(expr.ast.children[1].filterParams.text).toEqual("foo");
       });
 
-      it('should correctly populate children', function () {
-        const expr = SearchDSL.parse('text1 text2');
+      it("should correctly populate children", function() {
+        const expr = SearchDSL.parse("text1 text2");
         expect(expr.ast.children[0].filterType).toEqual(DSLFilterTypes.FUZZY);
-        expect(expr.ast.children[0].filterParams.text).toEqual('text1');
+        expect(expr.ast.children[0].filterParams.text).toEqual("text1");
         expect(expr.ast.children[1].filterType).toEqual(DSLFilterTypes.FUZZY);
-        expect(expr.ast.children[1].filterParams.text).toEqual('text2');
+        expect(expr.ast.children[1].filterParams.text).toEqual("text2");
       });
-
     });
 
-    describe('Complex expressions', function () {
-
-      it('should nest operations in correct order', function () {
-        const expr = SearchDSL.parse('text1 text2, (text3 (text4 text5), text6)');
+    describe("Complex expressions", function() {
+      it("should nest operations in correct order", function() {
+        const expr = SearchDSL.parse(
+          "text1 text2, (text3 (text4 text5), text6)"
+        );
 
         // .       : [text1 text2] OR [(text3 (text4 text5), text6)]
-        expect(expr.ast.combinerType)
-          .toEqual(DSLCombinerTypes.OR);
+        expect(expr.ast.combinerType).toEqual(DSLCombinerTypes.OR);
 
         // .0      : [text1] AND [text2]
-        expect(expr.ast.children[0].combinerType)
-          .toEqual(DSLCombinerTypes.AND);
+        expect(expr.ast.children[0].combinerType).toEqual(DSLCombinerTypes.AND);
 
         // .0.0    : text1
-        expect(expr.ast.children[0].children[0].filterType)
-          .toEqual(DSLFilterTypes.FUZZY);
-        expect(expr.ast.children[0].children[0].filterParams.text)
-          .toEqual('text1');
+        expect(expr.ast.children[0].children[0].filterType).toEqual(
+          DSLFilterTypes.FUZZY
+        );
+        expect(expr.ast.children[0].children[0].filterParams.text).toEqual(
+          "text1"
+        );
 
         // .0.1    : text2
-        expect(expr.ast.children[0].children[1].filterType)
-          .toEqual(DSLFilterTypes.FUZZY);
-        expect(expr.ast.children[0].children[1].filterParams.text)
-          .toEqual('text2');
+        expect(expr.ast.children[0].children[1].filterType).toEqual(
+          DSLFilterTypes.FUZZY
+        );
+        expect(expr.ast.children[0].children[1].filterParams.text).toEqual(
+          "text2"
+        );
 
         // .1      : [text3 (text4 text5)] OR [text6]
-        expect(expr.ast.children[1].combinerType)
-          .toEqual(DSLCombinerTypes.OR);
+        expect(expr.ast.children[1].combinerType).toEqual(DSLCombinerTypes.OR);
 
         // .1.0    : [text3] AND [text4 text5]
-        expect(expr.ast.children[1].children[0].combinerType)
-          .toEqual(DSLCombinerTypes.AND);
+        expect(expr.ast.children[1].children[0].combinerType).toEqual(
+          DSLCombinerTypes.AND
+        );
 
         // .1.0.0  : text3
-        expect(expr.ast.children[1].children[0].children[0].filterType)
-          .toEqual(DSLFilterTypes.FUZZY);
-        expect(expr.ast.children[1].children[0].children[0].filterParams.text)
-          .toEqual('text3');
+        expect(expr.ast.children[1].children[0].children[0].filterType).toEqual(
+          DSLFilterTypes.FUZZY
+        );
+        expect(
+          expr.ast.children[1].children[0].children[0].filterParams.text
+        ).toEqual("text3");
 
         // .1.0.1  : [text4] AND [text5]
-        expect(expr.ast.children[1].children[0].children[1].combinerType)
-          .toEqual(DSLCombinerTypes.AND);
+        expect(
+          expr.ast.children[1].children[0].children[1].combinerType
+        ).toEqual(DSLCombinerTypes.AND);
 
         // .1.0.1.0: text4
-        expect(expr.ast.children[1].children[0].children[1].children[0]
-          .filterType).toEqual(DSLFilterTypes.FUZZY);
-        expect(expr.ast.children[1].children[0].children[1].children[0]
-          .filterParams.text).toEqual('text4');
+        expect(
+          expr.ast.children[1].children[0].children[1].children[0].filterType
+        ).toEqual(DSLFilterTypes.FUZZY);
+        expect(
+          expr.ast.children[1].children[0].children[1].children[0].filterParams
+            .text
+        ).toEqual("text4");
 
         // .1.0.1.1: text5
-        expect(expr.ast.children[1].children[0].children[1].children[1]
-          .filterType).toEqual(DSLFilterTypes.FUZZY);
-        expect(expr.ast.children[1].children[0].children[1].children[1]
-          .filterParams.text).toEqual('text5');
+        expect(
+          expr.ast.children[1].children[0].children[1].children[1].filterType
+        ).toEqual(DSLFilterTypes.FUZZY);
+        expect(
+          expr.ast.children[1].children[0].children[1].children[1].filterParams
+            .text
+        ).toEqual("text5");
 
         // .1.1    : text6
-        expect(expr.ast.children[1].children[1].filterType)
-          .toEqual(DSLFilterTypes.FUZZY);
-        expect(expr.ast.children[1].children[1].filterParams.text)
-          .toEqual('text6');
-
+        expect(expr.ast.children[1].children[1].filterType).toEqual(
+          DSLFilterTypes.FUZZY
+        );
+        expect(expr.ast.children[1].children[1].filterParams.text).toEqual(
+          "text6"
+        );
       });
-
     });
 
-    describe('Token positions', function () {
-
-      it('should properly track location of fuzzy text', function () {
-        const expr = SearchDSL.parse('fuzzy');
+    describe("Token positions", function() {
+      it("should properly track location of fuzzy text", function() {
+        const expr = SearchDSL.parse("fuzzy");
         expect(expr.ast.position).toEqual([[0, 5]]);
       });
 
-      it('should properly track location of exact text', function () {
+      it("should properly track location of exact text", function() {
         const expr = SearchDSL.parse('"exact string"');
         expect(expr.ast.position).toEqual([[0, 14]]);
       });
 
-      it('should properly track location of attrib', function () {
-        const expr = SearchDSL.parse('attrib:value');
+      it("should properly track location of attrib", function() {
+        const expr = SearchDSL.parse("attrib:value");
         expect(expr.ast.position).toEqual([[0, 7], [7, 12]]);
       });
 
-      it('should properly track location of attrib with multi values', function () {
-        const expr = SearchDSL.parse('attrib:value1,value2');
+      it("should properly track location of attrib with multi values", function() {
+        const expr = SearchDSL.parse("attrib:value1,value2");
         expect(expr.ast.children[1].position).toEqual([[0, 7], [14, 20]]);
       });
-
     });
 
-    describe('Filtering', function () {
-
-      beforeEach(function () {
+    describe("Filtering", function() {
+      beforeEach(function() {
         this.filters = new DSLFilterList().add(
           new AttribFilter(),
           new FuzzyTextFilter(),
           new ExactTextFilter()
         );
 
-        this.mockResultset = new List({items: [
-          {text: 'some test string', attrib: ['a', 'b']},
-          {text: 'repeating test string', attrib: ['b', 'c']},
-          {text: 'some other string', attrib: ['c', 'd']}
-        ]});
+        this.mockResultset = new List({
+          items: [
+            { text: "some test string", attrib: ["a", "b"] },
+            { text: "repeating test string", attrib: ["b", "c"] },
+            { text: "some other string", attrib: ["c", "d"] }
+          ]
+        });
       });
 
-      it('should properly filter by fuzzy match', function () {
-        const expr = SearchDSL.parse('test');
+      it("should properly filter by fuzzy match", function() {
+        const expr = SearchDSL.parse("test");
 
-        expect(expr.filter(this.filters, this.mockResultset).getItems()).toEqual([
-          {text: 'some test string', attrib: ['a', 'b']},
-          {text: 'repeating test string', attrib: ['b', 'c']}
+        expect(
+          expr.filter(this.filters, this.mockResultset).getItems()
+        ).toEqual([
+          { text: "some test string", attrib: ["a", "b"] },
+          { text: "repeating test string", attrib: ["b", "c"] }
         ]);
       });
 
-      it('should properly filter by exact match', function () {
+      it("should properly filter by exact match", function() {
         const expr = SearchDSL.parse('"some other string"');
 
-        expect(expr.filter(this.filters, this.mockResultset).getItems()).toEqual([
-          {text: 'some other string', attrib: ['c', 'd']}
+        expect(
+          expr.filter(this.filters, this.mockResultset).getItems()
+        ).toEqual([{ text: "some other string", attrib: ["c", "d"] }]);
+      });
+
+      it("should properly filter by attribute", function() {
+        const expr = SearchDSL.parse("attrib:b");
+
+        expect(
+          expr.filter(this.filters, this.mockResultset).getItems()
+        ).toEqual([
+          { text: "some test string", attrib: ["a", "b"] },
+          { text: "repeating test string", attrib: ["b", "c"] }
         ]);
       });
 
-      it('should properly filter by attribute', function () {
-        const expr = SearchDSL.parse('attrib:b');
+      it("should combine with OR operator with multi-value attr", function() {
+        const expr = SearchDSL.parse("attrib:a,b");
 
-        expect(expr.filter(this.filters, this.mockResultset).getItems()).toEqual([
-          {text: 'some test string', attrib: ['a', 'b']},
-          {text: 'repeating test string', attrib: ['b', 'c']}
+        expect(
+          expr.filter(this.filters, this.mockResultset).getItems()
+        ).toEqual([
+          { text: "some test string", attrib: ["a", "b"] },
+          { text: "repeating test string", attrib: ["b", "c"] }
         ]);
       });
 
-      it('should combine with OR operator with multi-value attr', function () {
-        const expr = SearchDSL.parse('attrib:a,b');
+      it("should combine with OR operator multiple attr", function() {
+        const expr = SearchDSL.parse("attrib:a, attrib:b");
 
-        expect(expr.filter(this.filters, this.mockResultset).getItems()).toEqual([
-          {text: 'some test string', attrib: ['a', 'b']},
-          {text: 'repeating test string', attrib: ['b', 'c']}
+        expect(
+          expr.filter(this.filters, this.mockResultset).getItems()
+        ).toEqual([
+          { text: "some test string", attrib: ["a", "b"] },
+          { text: "repeating test string", attrib: ["b", "c"] }
         ]);
       });
 
-      it('should combine with OR operator multiple attr', function () {
-        const expr = SearchDSL.parse('attrib:a, attrib:b');
+      it("should combine with AND operator multiple attr", function() {
+        const expr = SearchDSL.parse("attrib:a attrib:b");
 
-        expect(expr.filter(this.filters, this.mockResultset).getItems()).toEqual([
-          {text: 'some test string', attrib: ['a', 'b']},
-          {text: 'repeating test string', attrib: ['b', 'c']}
-        ]);
+        expect(
+          expr.filter(this.filters, this.mockResultset).getItems()
+        ).toEqual([{ text: "some test string", attrib: ["a", "b"] }]);
       });
 
-      it('should combine with AND operator multiple attr', function () {
-        const expr = SearchDSL.parse('attrib:a attrib:b');
+      it("should combine with AND operator multiple attr", function() {
+        const expr = SearchDSL.parse("attrib:a attrib:b");
 
-        expect(expr.filter(this.filters, this.mockResultset).getItems()).toEqual([
-          {text: 'some test string', attrib: ['a', 'b']}
-        ]);
+        expect(
+          expr.filter(this.filters, this.mockResultset).getItems()
+        ).toEqual([{ text: "some test string", attrib: ["a", "b"] }]);
       });
-
-      it('should combine with AND operator multiple attr', function () {
-        const expr = SearchDSL.parse('attrib:a attrib:b');
-
-        expect(expr.filter(this.filters, this.mockResultset).getItems()).toEqual([
-          {text: 'some test string', attrib: ['a', 'b']}
-        ]);
-      });
-
     });
-
   });
-
 });


### PR DESCRIPTION
---
⚠️  _This branch depends on changes that will be introduced with #2382 and #2383. For a list of changes please see: https://github.com/dcos/dcos-ui/compare/b8ef547...9106ba7_

---

Disable `automocking` to make it easier to write and maintain tests and remove obsolete `dontMockStore` util.

Closes DCOS-18082