### PR TITLE
[Design System] DCOS-18090 (1 of 4): add single page for each UI component

### DIFF
--- a/plugins/design-system/pages/ComponentPage.js
+++ b/plugins/design-system/pages/ComponentPage.js
@@ -1,0 +1,25 @@
+import React, { Component } from "react";
+
+import DesignSystemPage from "./DesignSystemPage";
+import ComponentsBreadcrumbs from "../components/ComponentsBreadcrumbs";
+
+const SDK = require("../SDK").getSDK();
+
+const { Page } = SDK.get(["Page"]);
+
+class ComponentPage extends Component {
+  render() {
+    const { title, pathName } = this.props;
+
+    return (
+      <DesignSystemPage>
+        <Page.Header
+          breadcrumbs={<ComponentsBreadcrumbs title={title} path={pathName} />}
+        />
+        {this.props.children}
+      </DesignSystemPage>
+    );
+  }
+}
+
+module.exports = ComponentPage;

--- a/plugins/design-system/pages/ui-components/Badges.js
+++ b/plugins/design-system/pages/ui-components/Badges.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class Badges extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = Badges;

--- a/plugins/design-system/pages/ui-components/Banners.js
+++ b/plugins/design-system/pages/ui-components/Banners.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class Banners extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = Banners;

--- a/plugins/design-system/pages/ui-components/Breadcrumbs.js
+++ b/plugins/design-system/pages/ui-components/Breadcrumbs.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class Breadcrumbs extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = Breadcrumbs;

--- a/plugins/design-system/pages/ui-components/ButtonGroups.js
+++ b/plugins/design-system/pages/ui-components/ButtonGroups.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class ButtonGroups extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = ButtonGroups;

--- a/plugins/design-system/pages/ui-components/Charts.js
+++ b/plugins/design-system/pages/ui-components/Charts.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class Charts extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = Charts;

--- a/plugins/design-system/pages/ui-components/Checkboxes.js
+++ b/plugins/design-system/pages/ui-components/Checkboxes.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class Checkboxes extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = Checkboxes;

--- a/plugins/design-system/pages/ui-components/Dropdowns.js
+++ b/plugins/design-system/pages/ui-components/Dropdowns.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class Dropdowns extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = Dropdowns;

--- a/plugins/design-system/pages/ui-components/LoadingIndicators.js
+++ b/plugins/design-system/pages/ui-components/LoadingIndicators.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class LoadingIndicators extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = LoadingIndicators;

--- a/plugins/design-system/pages/ui-components/Messages.js
+++ b/plugins/design-system/pages/ui-components/Messages.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class Messages extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = Messages;

--- a/plugins/design-system/pages/ui-components/Modals.js
+++ b/plugins/design-system/pages/ui-components/Modals.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class Modals extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = Modals;

--- a/plugins/design-system/pages/ui-components/Panels.js
+++ b/plugins/design-system/pages/ui-components/Panels.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class Panels extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = Panels;

--- a/plugins/design-system/pages/ui-components/RadioButtons.js
+++ b/plugins/design-system/pages/ui-components/RadioButtons.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class RadioButtons extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = RadioButtons;

--- a/plugins/design-system/pages/ui-components/SegmentedBars.js
+++ b/plugins/design-system/pages/ui-components/SegmentedBars.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class SegmentedBars extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = SegmentedBars;

--- a/plugins/design-system/pages/ui-components/Selects.js
+++ b/plugins/design-system/pages/ui-components/Selects.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class Selects extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = Selects;

--- a/plugins/design-system/pages/ui-components/Tables.js
+++ b/plugins/design-system/pages/ui-components/Tables.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class Tables extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = Tables;

--- a/plugins/design-system/pages/ui-components/Tabs.js
+++ b/plugins/design-system/pages/ui-components/Tabs.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class Tabs extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = Tabs;

--- a/plugins/design-system/pages/ui-components/TextFields.js
+++ b/plugins/design-system/pages/ui-components/TextFields.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class TextFields extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = TextFields;

--- a/plugins/design-system/pages/ui-components/Toggles.js
+++ b/plugins/design-system/pages/ui-components/Toggles.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class Toggles extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = Toggles;

--- a/plugins/design-system/pages/ui-components/Tooltips.js
+++ b/plugins/design-system/pages/ui-components/Tooltips.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class Tooltips extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = Tooltips;

--- a/plugins/design-system/pages/ui-components/Type.js
+++ b/plugins/design-system/pages/ui-components/Type.js
@@ -1,0 +1,20 @@
+import React, { Component } from "react";
+import ComponentPage from "../ComponentPage";
+
+class Type extends Component {
+  render() {
+    const { title, pathName } = this.props.route.options;
+
+    return (
+      <ComponentPage title={title} pathName={pathName}>
+        <div>
+          <h3 className="flush-top">Primary Button</h3>
+          <p>Here's a primary button</p>
+          <button className="button button-primary">Button</button>
+        </div>
+      </ComponentPage>
+    );
+  }
+}
+
+module.exports = Type;


### PR DESCRIPTION
Move all the content from the tabs for each UI component and consolidate into a single page.

Note: All the content for the pages here are identical

See branch `tommy/design-system/remove-tabs` for complete implementation.

Closes DCOS-18090

<!--- Thank you for your contribution! Please provide enough information for others to best review your code. -->

<!-- Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it. -->

<!-- Description of motivation for making this change, what does it solve and steps needed to see change. -->

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
