### PR TITLE
[Design System] DCOS-18090 (3 of 4): update UI component routes

### DIFF
--- a/plugins/design-system/routes/ui-components/badges.js
+++ b/plugins/design-system/routes/ui-components/badges.js
@@ -1,15 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab from "../../pages/ui-components/badges/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/badges/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/badges/tabs/StylesTab";
+import Badges from "../../pages/ui-components/Badges";
 
 module.exports = {
   title: "Badges",
   pathName: "badges",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -19,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      Badges,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/banners.js
+++ b/plugins/design-system/routes/ui-components/banners.js
@@ -1,15 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab from "../../pages/ui-components/banners/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/banners/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/banners/tabs/StylesTab";
+import Banners from "../../pages/ui-components/Banners";
 
 module.exports = {
   title: "Banners",
   pathName: "banners",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -19,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      Banners,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/breadcrumbs.js
+++ b/plugins/design-system/routes/ui-components/breadcrumbs.js
@@ -1,16 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab
-  from "../../pages/ui-components/breadcrumbs/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/breadcrumbs/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/breadcrumbs/tabs/StylesTab";
+import Breadcrumbs from "../../pages/ui-components/Breadcrumbs";
 
 module.exports = {
   title: "Breadcrumbs",
   pathName: "breadcrumbs",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -20,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      Breadcrumbs,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/button-groups.js
+++ b/plugins/design-system/routes/ui-components/button-groups.js
@@ -1,16 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab
-  from "../../pages/ui-components/button-groups/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/button-groups/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/button-groups/tabs/StylesTab";
+import ButtonGroups from "../../pages/ui-components/ButtonGroups";
 
 module.exports = {
   title: "Button Groups",
   pathName: "button-groups",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -20,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      ButtonGroups,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/buttons.js
+++ b/plugins/design-system/routes/ui-components/buttons.js
@@ -1,15 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab from "../../pages/ui-components/buttons/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/buttons/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/buttons/tabs/StylesTab";
+import Buttons from "../../pages/ui-components/Buttons";
 
 module.exports = {
   title: "Buttons",
   pathName: "buttons",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -19,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      Buttons,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/charts.js
+++ b/plugins/design-system/routes/ui-components/charts.js
@@ -1,15 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab from "../../pages/ui-components/charts/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/charts/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/charts/tabs/StylesTab";
+import Charts from "../../pages/ui-components/Charts";
 
 module.exports = {
   title: "Charts",
   pathName: "charts",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -19,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      Charts,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/checkboxes.js
+++ b/plugins/design-system/routes/ui-components/checkboxes.js
@@ -1,15 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab from "../../pages/ui-components/checkboxes/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/checkboxes/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/checkboxes/tabs/StylesTab";
+import Checkboxes from "../../pages/ui-components/Checkboxes";
 
 module.exports = {
   title: "Checkboxes",
   pathName: "checkboxes",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -19,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      Checkboxes,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/dropdowns.js
+++ b/plugins/design-system/routes/ui-components/dropdowns.js
@@ -1,15 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab from "../../pages/ui-components/dropdowns/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/dropdowns/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/dropdowns/tabs/StylesTab";
+import Dropdowns from "../../pages/ui-components/Dropdowns";
 
 module.exports = {
   title: "Dropdowns",
   pathName: "dropdowns",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -19,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      Dropdowns,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/loading-indicators.js
+++ b/plugins/design-system/routes/ui-components/loading-indicators.js
@@ -1,17 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab
-  from "../../pages/ui-components/loading-indicators/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/loading-indicators/tabs/CodeTab";
-import StylesTab
-  from "../../pages/ui-components/loading-indicators/tabs/StylesTab";
+import LoadingIndicators from "../../pages/ui-components/LoadingIndicators";
 
 module.exports = {
   title: "Loading Indicators",
   pathName: "loading-indicators",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -21,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      LoadingIndicators,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/messages.js
+++ b/plugins/design-system/routes/ui-components/messages.js
@@ -1,15 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab from "../../pages/ui-components/messages/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/messages/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/messages/tabs/StylesTab";
+import Messages from "../../pages/ui-components/Messages";
 
 module.exports = {
   title: "Messages",
   pathName: "messages",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -19,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      Messages,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/modals.js
+++ b/plugins/design-system/routes/ui-components/modals.js
@@ -1,15 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab from "../../pages/ui-components/modals/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/modals/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/modals/tabs/StylesTab";
+import Modals from "../../pages/ui-components/Modals";
 
 module.exports = {
   title: "Modals",
   pathName: "modals",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -19,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      Modals,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/panels.js
+++ b/plugins/design-system/routes/ui-components/panels.js
@@ -1,15 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab from "../../pages/ui-components/panels/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/panels/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/panels/tabs/StylesTab";
+import Panels from "../../pages/ui-components/Panels";
 
 module.exports = {
   title: "Panels",
   pathName: "panels",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -19,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      Panels,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/radio-buttons.js
+++ b/plugins/design-system/routes/ui-components/radio-buttons.js
@@ -1,16 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab
-  from "../../pages/ui-components/radio-buttons/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/radio-buttons/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/radio-buttons/tabs/StylesTab";
+import RadioButtons from "../../pages/ui-components/RadioButtons";
 
 module.exports = {
   title: "Radio Buttons",
   pathName: "radio-buttons",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -20,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      RadioButtons,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/segmented-bars.js
+++ b/plugins/design-system/routes/ui-components/segmented-bars.js
@@ -1,16 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab
-  from "../../pages/ui-components/segmented-bars/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/segmented-bars/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/segmented-bars/tabs/StylesTab";
+import SegmentedBars from "../../pages/ui-components/SegmentedBars";
 
 module.exports = {
   title: "Segmented Bars",
   pathName: "segmented-bars",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -20,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      SegmentedBars,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/selects.js
+++ b/plugins/design-system/routes/ui-components/selects.js
@@ -1,15 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab from "../../pages/ui-components/selects/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/selects/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/selects/tabs/StylesTab";
+import Selects from "../../pages/ui-components/Selects";
 
 module.exports = {
   title: "Selects",
   pathName: "selects",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -19,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      Selects,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/tables.js
+++ b/plugins/design-system/routes/ui-components/tables.js
@@ -1,15 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab from "../../pages/ui-components/tables/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/tables/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/tables/tabs/StylesTab";
+import Tables from "../../pages/ui-components/Tables";
 
 module.exports = {
   title: "Tables",
   pathName: "tables",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -19,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      Tables,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/tabs.js
+++ b/plugins/design-system/routes/ui-components/tabs.js
@@ -1,15 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab from "../../pages/ui-components/tabs/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/tabs/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/tabs/tabs/StylesTab";
+import Tabs from "../../pages/ui-components/Tabs";
 
 module.exports = {
   title: "Tabs",
   pathName: "tabs",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -19,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      Tabs,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/text-fields.js
+++ b/plugins/design-system/routes/ui-components/text-fields.js
@@ -1,16 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab
-  from "../../pages/ui-components/text-fields/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/text-fields/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/text-fields/tabs/StylesTab";
+import TextFields from "../../pages/ui-components/TextFields";
 
 module.exports = {
   title: "Text Fields",
   pathName: "text-fields",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -20,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      TextFields,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/toggles.js
+++ b/plugins/design-system/routes/ui-components/toggles.js
@@ -1,15 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab from "../../pages/ui-components/toggles/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/toggles/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/toggles/tabs/StylesTab";
+import Toggles from "../../pages/ui-components/Toggles";
 
 module.exports = {
   title: "Toggles",
   pathName: "toggles",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -19,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      Toggles,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/tooltips.js
+++ b/plugins/design-system/routes/ui-components/tooltips.js
@@ -1,15 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab from "../../pages/ui-components/tooltips/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/tooltips/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/tooltips/tabs/StylesTab";
+import Tooltips from "../../pages/ui-components/Tooltips";
 
 module.exports = {
   title: "Tooltips",
   pathName: "tooltips",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -19,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      Tooltips,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };

--- a/plugins/design-system/routes/ui-components/type.js
+++ b/plugins/design-system/routes/ui-components/type.js
@@ -1,15 +1,10 @@
 import { navigation, routing } from "foundation-ui";
 
-import ComponentPage from "../../pages/ui-components/ComponentPage";
-
-import OverviewTab from "../../pages/ui-components/type/tabs/OverviewTab";
-import CodeTab from "../../pages/ui-components/type/tabs/CodeTab";
-import StylesTab from "../../pages/ui-components/type/tabs/StylesTab";
+import Type from "../../pages/ui-components/Type";
 
 module.exports = {
   title: "Type",
   pathName: "type",
-  tabs: ["overview", "code", "styles"],
   addRoutes() {
     navigation.NavigationService.registerSecondary(
       "/ds-components",
@@ -19,39 +14,11 @@ module.exports = {
 
     routing.RoutingService.registerPage(
       `/ds-components/${this.pathName}`,
-      ComponentPage,
+      Type,
       {
         title: this.title,
         pathName: this.pathName
       }
-    );
-
-    // The following calls to #registerTab define child routes for each page.
-    // We provide the parent route, the child route, and the component to be
-    // rendered.
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[0],
-      OverviewTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[1],
-      CodeTab
-    );
-
-    routing.RoutingService.registerTab(
-      `/ds-components/${this.pathName}`,
-      this.tabs[2],
-      StylesTab
-    );
-
-    // Redirects should be rendered after all of the associated routes have been
-    // defined.
-    routing.RoutingService.registerRedirect(
-      `/ds-components/${this.pathName}`,
-      `/ds-components/${this.pathName}/${this.tabs[0]}`
     );
   }
 };


### PR DESCRIPTION
⚠️ This PR depends on #2389 and #2390
---
Since tabs are not being used for UI components anymore, the routes need to be updated to point to the single page.

See branch `tommy/design-system/remove-tabs` for complete implementation.

Closes DCOS-18090

<!--- Thank you for your contribution! Please provide enough information for others to best review your code. -->

<!-- Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it. -->

<!-- Description of motivation for making this change, what does it solve and steps needed to see change. -->

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
