### PR TITLE
feat(PackageDetailTab): [3 of 3] implement select package version

### DIFF
--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -5,7 +5,7 @@ import { Link } from "react-router";
 import React from "react";
 /* eslint-enable no-unused-vars */
 import { StoreMixin } from "mesosphere-shared-reactjs";
-import { Dropdown } from "reactjs-components";
+import { Dropdown, Tooltip } from "reactjs-components";
 
 import { replaceQueryInPathString } from "#SRC/js/utils/RouterUtil";
 import BetaOptInUtil from "../../utils/BetaOptInUtil";
@@ -78,6 +78,13 @@ class PackageDetailTab extends mixin(StoreMixin) {
     METHODS_TO_BIND.forEach(method => {
       this[method] = this[method].bind(this);
     });
+  }
+
+  isSelectedVersionLoading() {
+    const { version } = this.props.location.query;
+    const cosmosPackage = CosmosPackagesStore.getPackageDetails();
+
+    return cosmosPackage.getVersion() !== version;
   }
 
   retrievePackageInfo() {
@@ -226,6 +233,8 @@ class PackageDetailTab extends mixin(StoreMixin) {
   }
 
   getInstallButtons(cosmosPackage) {
+    const tooltipContent = "loading selected version";
+
     if (cosmosPackage.isCLIOnly()) {
       return (
         <div>
@@ -247,18 +256,34 @@ class PackageDetailTab extends mixin(StoreMixin) {
 
     return (
       <div className="button-collection">
-        <button
-          className="button button-outline"
-          onClick={this.handleConfigureInstallModalOpen}
+        <Tooltip
+          wrapperClassName="button-group"
+          wrapText={true}
+          content={tooltipContent}
+          suppress={!this.isSelectedVersionLoading()}
         >
-          Configure
-        </button>
-        <button
-          className="button button-primary"
-          onClick={this.handleInstallModalOpen}
+          <button
+            disabled={this.isSelectedVersionLoading()}
+            className="button button-outline"
+            onClick={this.handleConfigureInstallModalOpen}
+          >
+            Configure
+          </button>
+        </Tooltip>
+        <Tooltip
+          wrapperClassName="button-group"
+          wrapText={true}
+          content={tooltipContent}
+          suppress={!this.isSelectedVersionLoading()}
         >
-          Deploy
-        </button>
+          <button
+            disabled={this.isSelectedVersionLoading()}
+            className="button button-primary"
+            onClick={this.handleInstallModalOpen}
+          >
+            Deploy
+          </button>
+        </Tooltip>
       </div>
     );
   }
@@ -313,6 +338,15 @@ class PackageDetailTab extends mixin(StoreMixin) {
         transition={true}
         wrapperClassName="dropdown"
       />
+    );
+  }
+
+  getPackageDescription(definition, cosmosPackage) {
+    return (
+      <div className="pod flush-horizontal flush-bottom">
+        {this.getItems(definition, this.getItem)}
+        <ImageViewer images={cosmosPackage.getScreenshots()} />
+      </div>
     );
   }
 
@@ -406,10 +440,9 @@ class PackageDetailTab extends mixin(StoreMixin) {
               </div>
             </div>
           </div>
-          <div className="pod flush-horizontal flush-bottom">
-            {this.getItems(definition, this.getItem)}
-            <ImageViewer images={cosmosPackage.getScreenshots()} />
-          </div>
+          {this.isSelectedVersionLoading()
+            ? this.getLoadingScreen()
+            : this.getPackageDescription(definition, cosmosPackage)}
         </div>
         <InstallPackageModal
           open={state.openInstallModal}

--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -296,7 +296,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
   getPackageVersionsDropdown() {
     const cosmosPackage = CosmosPackagesStore.getPackageDetails();
     const cosmosPackageVersions = CosmosPackagesStore.getPackageVersions();
-    const selectedVersion = cosmosPackage.getCurrentVersion();
+    const selectedVersion = cosmosPackage.getVersion();
     const packageVersions = cosmosPackageVersions.getAllVersions();
     const formattedPackageVersions = formatPackageVersions(packageVersions);
 

--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -52,7 +52,12 @@ const METHODS_TO_BIND = [
   "handlePackageVersionChange"
 ];
 
-const formatPackageVersions = versions => {
+const formatPackageVersions = selectedPackage => {
+  if (selectedPackage.packageVersions == null) {
+    return [];
+  }
+  const versions = selectedPackage.packageVersions;
+
   return Object.keys(versions)
     .sort((a, b) => {
       if (+versions[a] > +versions[b]) {
@@ -103,9 +108,14 @@ class PackageDetailTab extends mixin(StoreMixin) {
   retrievePackageInfo() {
     const { packageName } = this.props.params;
     const { version } = this.props.location.query;
+    const cosmosPackages = CosmosPackagesStore.getPackages();
+    const selectedPackage = cosmosPackages.getPackageByName(packageName);
 
-    // fetch package versions available
-    CosmosPackagesStore.fetchPackageVersions(packageName);
+    // fetch package versions available only if not cached
+    if (Object.keys(selectedPackage).length < 1) {
+      CosmosPackagesStore.fetchPackageVersions(packageName);
+    }
+
     // Fetch package description
     CosmosPackagesStore.fetchPackageDescription(packageName, version);
   }
@@ -299,10 +309,11 @@ class PackageDetailTab extends mixin(StoreMixin) {
 
   getPackageVersionsDropdown() {
     const cosmosPackage = CosmosPackagesStore.getPackageDetails();
-    const cosmosPackageVersions = CosmosPackagesStore.getPackageVersions();
+    const packageName = cosmosPackage.getName();
+    const cosmosPackages = CosmosPackagesStore.getPackages();
     const selectedVersion = cosmosPackage.getVersion();
-    const packageVersions = cosmosPackageVersions.getAllVersions();
-    const formattedPackageVersions = formatPackageVersions(packageVersions);
+    const selectedPackage = cosmosPackages.getPackageByName(packageName);
+    const formattedPackageVersions = formatPackageVersions(selectedPackage);
 
     return (
       <Dropdown

--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -326,8 +326,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
     }
 
     const cosmosPackage = CosmosPackagesStore.getPackageDetails();
-    const cosmosPackageVersions = CosmosPackagesStore.getPackageVersions();
-    if (state.isLoading || !cosmosPackage || !cosmosPackageVersions) {
+    if (state.isLoading || !cosmosPackage) {
       return this.getLoadingScreen();
     }
 

--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -52,31 +52,6 @@ const METHODS_TO_BIND = [
   "handlePackageVersionChange"
 ];
 
-const formatPackageVersions = selectedPackage => {
-  if (selectedPackage.packageVersions == null) {
-    return [];
-  }
-  const versions = selectedPackage.packageVersions;
-
-  return Object.keys(versions)
-    .sort((a, b) => {
-      if (+versions[a] > +versions[b]) {
-        return 1;
-      }
-      if (+versions[a] < +versions[b]) {
-        return -1;
-      }
-
-      return 0;
-    })
-    .map(version => {
-      return {
-        html: version,
-        id: version
-      };
-    });
-};
-
 class PackageDetailTab extends mixin(StoreMixin) {
   constructor() {
     super();
@@ -108,8 +83,10 @@ class PackageDetailTab extends mixin(StoreMixin) {
   retrievePackageInfo() {
     const { packageName } = this.props.params;
     const { version } = this.props.location.query;
-    const cosmosPackages = CosmosPackagesStore.getPackages();
-    const selectedPackage = cosmosPackages.getPackageByName(packageName);
+    const cosmosPackagesVersions = CosmosPackagesStore.getPackagesVersions();
+    const selectedPackage = cosmosPackagesVersions.getPackageByName(
+      packageName
+    );
 
     // fetch package versions available only if not cached
     if (Object.keys(selectedPackage).length < 1) {
@@ -310,10 +287,20 @@ class PackageDetailTab extends mixin(StoreMixin) {
   getPackageVersionsDropdown() {
     const cosmosPackage = CosmosPackagesStore.getPackageDetails();
     const packageName = cosmosPackage.getName();
-    const cosmosPackages = CosmosPackagesStore.getPackages();
+    const cosmosPackagesVersions = CosmosPackagesStore.getPackagesVersions();
     const selectedVersion = cosmosPackage.getVersion();
-    const selectedPackage = cosmosPackages.getPackageByName(packageName);
-    const formattedPackageVersions = formatPackageVersions(selectedPackage);
+    const selectedPackageVersions = cosmosPackagesVersions
+      .getPackageByName(packageName)
+      .map(version => {
+        return {
+          html: version,
+          id: version
+        };
+      });
+
+    if (selectedPackageVersions.length === 0) {
+      return null;
+    }
 
     return (
       <Dropdown
@@ -321,7 +308,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
         dropdownMenuClassName="dropdown-menu"
         dropdownMenuListClassName="dropdown-menu-list"
         onItemSelection={this.handlePackageVersionChange}
-        items={formattedPackageVersions}
+        items={selectedPackageVersions}
         initialID={selectedVersion}
         transition={true}
         wrapperClassName="dropdown"

--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -7,6 +7,7 @@ import React from "react";
 import { StoreMixin } from "mesosphere-shared-reactjs";
 import { Dropdown } from "reactjs-components";
 
+import { replaceQueryInPathString } from "#SRC/js/utils/RouterUtil";
 import BetaOptInUtil from "../../utils/BetaOptInUtil";
 import Breadcrumb from "../../components/Breadcrumb";
 import BreadcrumbTextContent from "../../components/BreadcrumbTextContent";
@@ -287,10 +288,13 @@ class PackageDetailTab extends mixin(StoreMixin) {
 
   handlePackageVersionChange(packageOpt) {
     const packageVersion = packageOpt.id;
-    const originalPath = global.location.hash.split("?")[0];
-    const selectedVersion = `${originalPath}?version=${packageVersion}`;
+    const newPathname = replaceQueryInPathString({
+      pathname: global.location.hash,
+      query: "version",
+      value: packageVersion
+    });
 
-    global.location.replace(selectedVersion);
+    global.location.replace(newPathname);
   }
 
   getPackageVersionsDropdown() {

--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -84,7 +84,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
     const { packageName } = this.props.params;
     const { version } = this.props.location.query;
     const cosmosPackagesVersions = CosmosPackagesStore.getPackagesVersions();
-    const selectedPackage = cosmosPackagesVersions.getPackageByName(
+    const selectedPackage = cosmosPackagesVersions.getPackageVersionsByName(
       packageName
     );
 
@@ -290,7 +290,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
     const cosmosPackagesVersions = CosmosPackagesStore.getPackagesVersions();
     const selectedVersion = cosmosPackage.getVersion();
     const selectedPackageVersions = cosmosPackagesVersions
-      .getPackageByName(packageName)
+      .getPackageVersionsByName(packageName)
       .map(version => {
         return {
           html: version,

--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -5,6 +5,7 @@ import { Link } from "react-router";
 import React from "react";
 /* eslint-enable no-unused-vars */
 import { StoreMixin } from "mesosphere-shared-reactjs";
+import { Dropdown } from "reactjs-components";
 
 import BetaOptInUtil from "../../utils/BetaOptInUtil";
 import Breadcrumb from "../../components/Breadcrumb";
@@ -46,8 +47,29 @@ const PackageDetailBreadcrumbs = ({ cosmosPackage }) => {
 const METHODS_TO_BIND = [
   "handleInstallModalClose",
   "handleConfigureInstallModalOpen",
-  "handleInstallModalOpen"
+  "handleInstallModalOpen",
+  "handlePackageVersionChange"
 ];
+
+const formatPackageVersions = versions => {
+  return Object.keys(versions)
+    .sort((a, b) => {
+      if (+versions[a] > +versions[b]) {
+        return 1;
+      }
+      if (+versions[a] < +versions[b]) {
+        return -1;
+      }
+
+      return 0;
+    })
+    .map(version => {
+      return {
+        html: version,
+        id: version
+      };
+    });
+};
 
 class PackageDetailTab extends mixin(StoreMixin) {
   constructor() {
@@ -62,14 +84,13 @@ class PackageDetailTab extends mixin(StoreMixin) {
     this.store_listeners = [
       {
         name: "cosmosPackages",
-        events: ["descriptionError", "descriptionSuccess"],
-        unmountWhen(store, event) {
-          if (event === "descriptionSuccess") {
-            return !!CosmosPackagesStore.get("packageDetails");
-          }
-        },
-        listenAlways: false,
-        suppressUpdate: true
+        events: [
+          "descriptionError",
+          "descriptionSuccess",
+          "listVersionsSuccess",
+          "listVersionsError"
+        ],
+        suppressUpdate: false
       }
     ];
 
@@ -78,13 +99,29 @@ class PackageDetailTab extends mixin(StoreMixin) {
     });
   }
 
-  componentDidMount() {
-    super.componentDidMount(...arguments);
-
+  retrievePackageInfo() {
     const { packageName } = this.props.params;
     const { version } = this.props.location.query;
+
+    // fetch package versions available
+    CosmosPackagesStore.fetchPackageVersions(packageName);
     // Fetch package description
     CosmosPackagesStore.fetchPackageDescription(packageName, version);
+  }
+
+  componentDidMount() {
+    super.componentDidMount(...arguments);
+    this.retrievePackageInfo();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { version } = this.props.location.query;
+
+    if (version === prevProps.location.query.version) {
+      return false;
+    }
+
+    this.retrievePackageInfo();
   }
 
   onCosmosPackagesStoreDescriptionError() {
@@ -184,7 +221,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
     });
   }
 
-  getPackageBadge(cosmosPackage, version) {
+  getPackageBadge(cosmosPackage) {
     const isCertified = cosmosPackage.isCertified();
     const badgeCopy = isCertified ? "Certified" : "Community";
     const badgeClasses = classNames("badge badge-large badge-rounded", {
@@ -192,11 +229,10 @@ class PackageDetailTab extends mixin(StoreMixin) {
     });
 
     return (
-      <span className="badge-container selected-badge">
+      <span className="column-3 badge-container selected-badge">
         <span className={badgeClasses}>
           {badgeCopy}
         </span>
-        <small>{version}</small>
       </span>
     );
   }
@@ -249,6 +285,35 @@ class PackageDetailTab extends mixin(StoreMixin) {
     }
   }
 
+  handlePackageVersionChange(packageOpt) {
+    const packageVersion = packageOpt.id;
+    const originalPath = global.location.hash.split("?")[0];
+    const selectedVersion = `${originalPath}?version=${packageVersion}`;
+
+    global.location.replace(selectedVersion);
+  }
+
+  getPackageVersionsDropdown() {
+    const cosmosPackage = CosmosPackagesStore.getPackageDetails();
+    const cosmosPackageVersions = CosmosPackagesStore.getPackageVersions();
+    const selectedVersion = cosmosPackage.getCurrentVersion();
+    const packageVersions = cosmosPackageVersions.getAllVersions();
+    const formattedPackageVersions = formatPackageVersions(packageVersions);
+
+    return (
+      <Dropdown
+        buttonClassName="button button-link dropdown-toggle"
+        dropdownMenuClassName="dropdown-menu"
+        dropdownMenuListClassName="dropdown-menu-list"
+        onItemSelection={this.handlePackageVersionChange}
+        items={formattedPackageVersions}
+        initialID={selectedVersion}
+        transition={true}
+        wrapperClassName="dropdown"
+      />
+    );
+  }
+
   render() {
     const { props, state } = this;
 
@@ -257,12 +322,12 @@ class PackageDetailTab extends mixin(StoreMixin) {
     }
 
     const cosmosPackage = CosmosPackagesStore.getPackageDetails();
-    if (state.isLoading || !cosmosPackage) {
+    const cosmosPackageVersions = CosmosPackagesStore.getPackageVersions();
+    if (state.isLoading || !cosmosPackage || !cosmosPackageVersions) {
       return this.getLoadingScreen();
     }
 
     const name = cosmosPackage.getName();
-    const version = cosmosPackage.getVersion();
     const description = cosmosPackage.getDescription();
     const preInstallNotes = cosmosPackage.getPreInstallNotes();
 
@@ -315,10 +380,15 @@ class PackageDetailTab extends mixin(StoreMixin) {
                 </div>
               </div>
               <div className="media-object-item media-object-item-grow">
-                <h1 className="short flush-top">
-                  {name}
-                </h1>
-                <p>{this.getPackageBadge(cosmosPackage, version)}</p>
+                <div className="flex flex-direction-left-to-right">
+                  <h1 className="short flush-top">
+                    {name}
+                  </h1>
+                  {this.getPackageVersionsDropdown()}
+                </div>
+                <div className="row">
+                  {this.getPackageBadge(cosmosPackage)}
+                </div>
               </div>
               <div className="media-object-item package-action-buttons">
                 {this.getInstallButtons(cosmosPackage)}

--- a/src/js/pages/catalog/__tests__/PackageDetailTab-test.js
+++ b/src/js/pages/catalog/__tests__/PackageDetailTab-test.js
@@ -208,21 +208,6 @@ describe("PackageDetailTab", function() {
       expect(this.instance.getLoadingScreen).toHaveBeenCalled();
     });
 
-    it("should call getLoadingScreen when cosmosPackageVersions is null", function() {
-      this.instance.state.isLoading = false;
-      this.instance.getLoadingScreen = jasmine.createSpy("getLoadingScreen");
-
-      CosmosPackagesStore.getPackageDetails = jest.fn(() => {
-        return true;
-      });
-      CosmosPackagesStore.getPackageVersions = function() {
-        return null;
-      };
-
-      this.instance.render();
-      expect(this.instance.getLoadingScreen).toHaveBeenCalled();
-    });
-
     it("ignores getLoadingScreen when not loading", function() {
       this.instance.state.isLoading = false;
       this.instance.getLoadingScreen = jasmine.createSpy("getLoadingScreen");

--- a/src/js/pages/catalog/__tests__/PackageDetailTab-test.js
+++ b/src/js/pages/catalog/__tests__/PackageDetailTab-test.js
@@ -52,6 +52,26 @@ describe("PackageDetailTab", function() {
         "marathon"
       );
     });
+
+    it("do NOT call fetchPackageVersions when package versions is cached", function() {
+      CosmosPackagesStore.getPackages = jest.fn(() => {
+        return new UniversePackage({
+          marathon: {
+            packageVersions: {
+              "1": "1"
+            }
+          }
+        });
+      });
+
+      CosmosPackagesStore.fetchPackageVersions = jasmine.createSpy(
+        "fetchPackageVersions"
+      );
+
+      this.instance.retrievePackageInfo();
+      expect(CosmosPackagesStore.fetchPackageVersions).not.toHaveBeenCalled();
+    });
+
     it("call fetchPackageDescription with package name and package version", function() {
       CosmosPackagesStore.fetchPackageDescription = jasmine.createSpy(
         "fetchPackageDescription"

--- a/src/js/pages/catalog/__tests__/PackageDetailTab-test.js
+++ b/src/js/pages/catalog/__tests__/PackageDetailTab-test.js
@@ -13,9 +13,8 @@ jest.dontMock("#SRC/js/structs/UniversePackage.js");
 
 const packageDescribeFixtures = require("../../../../../tests/_fixtures/cosmos/package-describe.json")
   .package;
-const packageVersionsFixtures = require("../../../../../tests/_fixtures/cosmos/package-list-versions.json")
-  .results;
-const UniversePackage = require("#SRC/js/structs/UniversePackage.js");
+const UniversePackage = require("#SRC/js/structs/UniversePackage");
+const UniversePackagesVersions = require("#SRC/js/structs/UniversePackagesVersions");
 var CosmosPackagesStore = require("../../../stores/CosmosPackagesStore");
 
 /* eslint-disable no-unused-vars */
@@ -54,8 +53,8 @@ describe("PackageDetailTab", function() {
     });
 
     it("do NOT call fetchPackageVersions when package versions is cached", function() {
-      CosmosPackagesStore.getPackages = jest.fn(() => {
-        return new UniversePackage({
+      CosmosPackagesStore.getPackagesVersions = jest.fn(() => {
+        return new UniversePackagesVersions({
           marathon: {
             packageVersions: {
               "1": "1"
@@ -234,9 +233,6 @@ describe("PackageDetailTab", function() {
 
       CosmosPackagesStore.getPackageDetails = jest.fn(() => {
         return new UniversePackage(packageDescribeFixtures);
-      });
-      CosmosPackagesStore.getPackageVersions = jest.fn(() => {
-        return new UniversePackage(packageVersionsFixtures);
       });
 
       this.instance.render();

--- a/src/js/pages/catalog/__tests__/PackageDetailTab-test.js
+++ b/src/js/pages/catalog/__tests__/PackageDetailTab-test.js
@@ -228,6 +228,9 @@ describe("PackageDetailTab", function() {
     });
 
     it("ignores getLoadingScreen when not loading", function() {
+      this.instance.isSelectedVersionLoading = function() {
+        return false;
+      };
       this.instance.state.isLoading = false;
       this.instance.getLoadingScreen = jasmine.createSpy("getLoadingScreen");
 

--- a/src/js/pages/catalog/__tests__/PackageDetailTab-test.js
+++ b/src/js/pages/catalog/__tests__/PackageDetailTab-test.js
@@ -11,7 +11,7 @@ jest.dontMock(
 );
 jest.dontMock("#SRC/js/structs/UniversePackage.js");
 
-const packageDescribeFixtures = require("../../../../../tests/_fixtures/cosmos/package-list-versions.json")
+const packageDescribeFixtures = require("../../../../../tests/_fixtures/cosmos/package-describe.json")
   .package;
 const packageVersionsFixtures = require("../../../../../tests/_fixtures/cosmos/package-list-versions.json")
   .results;

--- a/src/js/pages/catalog/__tests__/PackageDetailTab-test.js
+++ b/src/js/pages/catalog/__tests__/PackageDetailTab-test.js
@@ -1,17 +1,27 @@
-// Setting useFixtures for when we load CosmosPackagesStore/CosmosPackageActions
-/* eslint-disable import/newline-after-import */
-const Config = require("../../../config/Config");
-var configUseFixtures = Config.useFixtures;
-Config.useFixtures = true;
-require("../../../stores/CosmosPackagesStore");
-Config.useFixtures = configUseFixtures;
-/* eslint-enable import/newline-after-import */
+jest.dontMock("../PackageDetailTab");
+jest.dontMock("../../../components/FluidGeminiScrollbar");
+jest.dontMock("../../../components/Page");
+jest.dontMock("../../../components/Panel");
+jest.dontMock("../../../mixins/InternalStorageMixin");
+jest.dontMock("../../../components/modals/InstallPackageModal");
+jest.dontMock("../../../stores/CosmosPackagesStore");
+jest.dontMock("../../../../../tests/_fixtures/cosmos/package-describe.json");
+jest.dontMock(
+  "../../../../../tests/_fixtures/cosmos/package-list-versions.json"
+);
+jest.dontMock("#SRC/js/structs/UniversePackage.js");
+
+const packageDescribeFixtures = require("../../../../../tests/_fixtures/cosmos/package-list-versions.json")
+  .package;
+const packageVersionsFixtures = require("../../../../../tests/_fixtures/cosmos/package-list-versions.json")
+  .results;
+const UniversePackage = require("#SRC/js/structs/UniversePackage.js");
+var CosmosPackagesStore = require("../../../stores/CosmosPackagesStore");
 
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */
 const ReactDOM = require("react-dom");
-const TestUtils = require("react-addons-test-utils");
 
 const PackageDetailTab = require("../PackageDetailTab");
 
@@ -31,21 +41,27 @@ describe("PackageDetailTab", function() {
     ReactDOM.unmountComponentAtNode(this.container);
   });
 
-  describe("#handleInstallModalOpen", function() {
-    beforeEach(function() {
-      this.instance.handleInstallModalOpen = jasmine.createSpy(
-        "handleInstallModalOpen"
+  describe("#retrievePackageInfo", function() {
+    it("call fetchPackageVersions with package name", function() {
+      CosmosPackagesStore.fetchPackageVersions = jasmine.createSpy(
+        "fetchPackageVersions"
       );
-      jest.runAllTimers();
+
+      this.instance.retrievePackageInfo();
+      expect(CosmosPackagesStore.fetchPackageVersions).toHaveBeenCalledWith(
+        "marathon"
+      );
     });
-
-    it("should call handler when install button is clicked", function() {
-      var installButton = ReactDOM.findDOMNode(this.instance).querySelector(
-        ".button.button-primary"
+    it("call fetchPackageDescription with package name and package version", function() {
+      CosmosPackagesStore.fetchPackageDescription = jasmine.createSpy(
+        "fetchPackageDescription"
       );
-      TestUtils.Simulate.click(installButton);
 
-      expect(this.instance.handleInstallModalOpen).toHaveBeenCalled();
+      this.instance.retrievePackageInfo();
+      expect(CosmosPackagesStore.fetchPackageDescription).toHaveBeenCalledWith(
+        "marathon",
+        1
+      );
     });
   });
 
@@ -192,9 +208,31 @@ describe("PackageDetailTab", function() {
       expect(this.instance.getLoadingScreen).toHaveBeenCalled();
     });
 
+    it("should call getLoadingScreen when cosmosPackageVersions is null", function() {
+      this.instance.state.isLoading = false;
+      this.instance.getLoadingScreen = jasmine.createSpy("getLoadingScreen");
+
+      CosmosPackagesStore.getPackageDetails = jest.fn(() => {
+        return true;
+      });
+      CosmosPackagesStore.getPackageVersions = function() {
+        return null;
+      };
+
+      this.instance.render();
+      expect(this.instance.getLoadingScreen).toHaveBeenCalled();
+    });
+
     it("ignores getLoadingScreen when not loading", function() {
       this.instance.state.isLoading = false;
       this.instance.getLoadingScreen = jasmine.createSpy("getLoadingScreen");
+
+      CosmosPackagesStore.getPackageDetails = jest.fn(() => {
+        return new UniversePackage(packageDescribeFixtures);
+      });
+      CosmosPackagesStore.getPackageVersions = jest.fn(() => {
+        return new UniversePackage(packageVersionsFixtures);
+      });
 
       this.instance.render();
       expect(this.instance.getLoadingScreen).not.toHaveBeenCalled();

--- a/src/js/structs/UniversePackage.js
+++ b/src/js/structs/UniversePackage.js
@@ -87,10 +87,6 @@ class UniversePackage extends Item {
     return this.get("version") || this.get("currentVersion");
   }
 
-  getPackageByName(packageName) {
-    return this.get()[packageName] || {};
-  }
-
   getTags() {
     return this.get("tags") || [];
   }

--- a/src/js/structs/UniversePackage.js
+++ b/src/js/structs/UniversePackage.js
@@ -84,7 +84,9 @@ class UniversePackage extends Item {
   }
 
   getVersion() {
-    return this.get("version");
+    // backport because some actions are removing
+    // version and replacing the package obj with currentVersion
+    return this.get("version") || this.get("currentVersion");
   }
 
   getTags() {

--- a/src/js/structs/UniversePackage.js
+++ b/src/js/structs/UniversePackage.js
@@ -84,9 +84,11 @@ class UniversePackage extends Item {
   }
 
   getVersion() {
-    // backport because some actions are removing
-    // version and replacing the package obj with currentVersion
     return this.get("version") || this.get("currentVersion");
+  }
+
+  getPackageByName(packageName) {
+    return this.get()[packageName] || {};
   }
 
   getTags() {

--- a/src/js/structs/UniversePackagesVersions.js
+++ b/src/js/structs/UniversePackagesVersions.js
@@ -1,0 +1,27 @@
+import Item from "./Item";
+
+const sortPackageVersions = selectedPackage => {
+  if (selectedPackage.packageVersions == null) {
+    return [];
+  }
+  const versions = selectedPackage.packageVersions;
+
+  return Object.keys(versions).sort((a, b) => {
+    if (+versions[a] > +versions[b]) {
+      return -1;
+    }
+    if (+versions[a] < +versions[b]) {
+      return 1;
+    }
+
+    return 0;
+  });
+};
+
+class UniversePackagesVersions extends Item {
+  getPackageByName(packageName) {
+    return sortPackageVersions(this.get()[packageName] || {});
+  }
+}
+
+module.exports = UniversePackagesVersions;

--- a/src/js/structs/UniversePackagesVersions.js
+++ b/src/js/structs/UniversePackagesVersions.js
@@ -19,7 +19,7 @@ const sortPackageVersions = selectedPackage => {
 };
 
 class UniversePackagesVersions extends Item {
-  getPackageByName(packageName) {
+  getPackageVersionsByName(packageName) {
     return sortPackageVersions(this.get()[packageName] || {});
   }
 }

--- a/src/js/structs/__tests__/UniversePackage-test.js
+++ b/src/js/structs/__tests__/UniversePackage-test.js
@@ -59,27 +59,4 @@ describe("UniversePackage", function() {
       expect(pkg.getMaintainer()).toEqual(undefined);
     });
   });
-
-  describe("#getAllVersions", function() {
-    it("returns package versions by package name", function() {
-      const pkg = new UniversePackage({
-        foo: {
-          packageVersions: {
-            "0.4.0": "2",
-            "0.3.0": "1",
-            "0.2.1": "0"
-          }
-        }
-      });
-      const selectedPackage = pkg.getPackageByName("foo");
-
-      expect(selectedPackage).toEqual({
-        packageVersions: {
-          "0.4.0": "2",
-          "0.3.0": "1",
-          "0.2.1": "0"
-        }
-      });
-    });
-  });
 });

--- a/src/js/structs/__tests__/UniversePackage-test.js
+++ b/src/js/structs/__tests__/UniversePackage-test.js
@@ -59,4 +59,27 @@ describe("UniversePackage", function() {
       expect(pkg.getMaintainer()).toEqual(undefined);
     });
   });
+
+  describe("#getAllVersions", function() {
+    it("returns package versions by package name", function() {
+      const pkg = new UniversePackage({
+        foo: {
+          packageVersions: {
+            "0.4.0": "2",
+            "0.3.0": "1",
+            "0.2.1": "0"
+          }
+        }
+      });
+      const selectedPackage = pkg.getPackageByName("foo");
+
+      expect(selectedPackage).toEqual({
+        packageVersions: {
+          "0.4.0": "2",
+          "0.3.0": "1",
+          "0.2.1": "0"
+        }
+      });
+    });
+  });
 });

--- a/src/js/structs/__tests__/UniversePackagesVersions-test.js
+++ b/src/js/structs/__tests__/UniversePackagesVersions-test.js
@@ -1,0 +1,38 @@
+const UniversePackagesVersions = require("../UniversePackagesVersions");
+
+describe("UniversePackagesVersions", function() {
+  describe("#getPackageByName", function() {
+    let UniversePackageVersions;
+
+    beforeEach(function() {
+      UniversePackageVersions = new UniversePackagesVersions({
+        marathon: {
+          packageVersions: {
+            "1.1.0": 1,
+            "1.4.1": 2,
+            "2.0.0": 3
+          }
+        }
+      });
+    });
+
+    it("get package by name", function() {
+      const packageVersions = UniversePackageVersions.getPackageByName(
+        "marathon"
+      );
+      const expectedResult = ["2.0.0", "1.4.1", "1.1.0"];
+
+      expect(packageVersions).toEqual(expectedResult);
+    });
+
+    it("package versions are sorted by", function() {
+      const packageVersions = UniversePackageVersions.getPackageByName(
+        "marathon"
+      );
+
+      expect(packageVersions[0]).toEqual("2.0.0");
+      expect(packageVersions[1]).toEqual("1.4.1");
+      expect(packageVersions[2]).toEqual("1.1.0");
+    });
+  });
+});

--- a/src/js/structs/__tests__/UniversePackagesVersions-test.js
+++ b/src/js/structs/__tests__/UniversePackagesVersions-test.js
@@ -1,7 +1,7 @@
 const UniversePackagesVersions = require("../UniversePackagesVersions");
 
 describe("UniversePackagesVersions", function() {
-  describe("#getPackageByName", function() {
+  describe("#getPackageVersionsByName", function() {
     let UniversePackageVersions;
 
     beforeEach(function() {
@@ -17,7 +17,7 @@ describe("UniversePackagesVersions", function() {
     });
 
     it("get package by name", function() {
-      const packageVersions = UniversePackageVersions.getPackageByName(
+      const packageVersions = UniversePackageVersions.getPackageVersionsByName(
         "marathon"
       );
       const expectedResult = ["2.0.0", "1.4.1", "1.1.0"];
@@ -26,7 +26,7 @@ describe("UniversePackagesVersions", function() {
     });
 
     it("package versions are sorted by", function() {
-      const packageVersions = UniversePackageVersions.getPackageByName(
+      const packageVersions = UniversePackageVersions.getPackageVersionsByName(
         "marathon"
       );
 

--- a/src/js/utils/RouterUtil.js
+++ b/src/js/utils/RouterUtil.js
@@ -18,6 +18,28 @@ function findRedirect(queryString) {
 
 const RouterUtil = {
   /**
+   * Replace query in url path
+   * options = {
+   *    pathname: "http://localhost:4200/#/catalog/packages/arangodb3?version=1.0.0&_k=ed535h",
+   *    query: "version",
+   *    value: "test"
+   * }
+   *
+   * Output: http://localhost:4200/#/catalog/packages/arangodb3?version=test&_k=ed535h
+   *
+   * @param {Object} options object config
+   * @returns {String} string with new query value
+   */
+  replaceQueryInPathString(options) {
+    if (!options.pathname || !options.query || !options.value) {
+      return null;
+    }
+    const regex = new RegExp(`(${options.query}=)[^&]+`);
+
+    return options.pathname.replace(regex, "$1" + options.value);
+  },
+
+  /**
    * Parse the url and find the query string (?)
    * before or after the #
    *

--- a/src/js/utils/__tests__/RouterUtil-test.js
+++ b/src/js/utils/__tests__/RouterUtil-test.js
@@ -236,5 +236,17 @@ describe("RouterUtil", function() {
         expectedResult
       );
     });
+
+    it("doesn't replace when query value is empty", function() {
+      const options = {
+        pathname: "http://localhost:4200/#/catalog/packages/arangodb3?version=&_k=ed535h",
+        query: "version",
+        value: "another-one"
+      };
+
+      expect(RouterUtil.replaceQueryInPathString(options)).toEqual(
+        "http://localhost:4200/#/catalog/packages/arangodb3?version=&_k=ed535h"
+      );
+    });
   });
 });

--- a/src/js/utils/__tests__/RouterUtil-test.js
+++ b/src/js/utils/__tests__/RouterUtil-test.js
@@ -208,4 +208,33 @@ describe("RouterUtil", function() {
       expect(RouterUtil.getQueryStringInUrl()).toEqual(expectedResult);
     });
   });
+
+  describe("#replaceQueryInPathString", function() {
+    it("replace query in pathname", function() {
+      const options = {
+        pathname: "http://localhost:4200/#/catalog/packages/arangodb3?version=1.0.0&_k=ed535h",
+        query: "version",
+        value: "another-one"
+      };
+      const expectedResult =
+        "http://localhost:4200/#/catalog/packages/arangodb3?version=another-one&_k=ed535h";
+
+      expect(RouterUtil.replaceQueryInPathString(options)).toEqual(
+        expectedResult
+      );
+    });
+
+    it("return null when options are empty, null or undefined", function() {
+      const options = {
+        pathname: "",
+        query: null,
+        value: undefined
+      };
+      const expectedResult = null;
+
+      expect(RouterUtil.replaceQueryInPathString(options)).toEqual(
+        expectedResult
+      );
+    });
+  });
 });


### PR DESCRIPTION
## ⚠️   Depends on https://github.com/dcos/dcos-ui/pull/2395 and https://github.com/dcos/dcos-ui/pull/2396

This commit includes the work for epic DCOS_OSS-1528 where as a user now you
are able to select a version in package detail page.

How to test:
- Go to catalog page click on a package
- Notice now at the top where the version used to be displayed
- You will see a dropdown with the versions available to install
- When choosing a version the description should change to the chosen version
- When deployed the version selected will be installed

Closes DCOS_OSS-1560 DCOS_OSS-1559 DCOS_OSS-1558

**before:**
<img width="1025" alt="screen shot 2017-08-21 at 2 55 25 pm" src="https://user-images.githubusercontent.com/549394/29540017-5bc3c1ce-8681-11e7-8bf1-8405fb817a50.png">

**after:**
![screen shot 2017-08-28 at 3 18 40 pm](https://user-images.githubusercontent.com/549394/29798043-6d6743ae-8c0f-11e7-80aa-55ffa74d8ce0.png)


**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
