### PR TITLE
DCOS_OSS-1582: adjust Marathon RAML install the version

### DIFF
--- a/scripts/pre-install
+++ b/scripts/pre-install
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
-MARATHON_VERSION="1.5.0-SNAPSHOT-557-gab275cc"
+MARATHON_VERSION="1.5.0-SNAPSHOT-713-g14280a6"
 
 # Import utils
 source ${SCRIPT_PATH}/utils/git

--- a/scripts/utils/marathon
+++ b/scripts/utils/marathon
@@ -29,8 +29,7 @@ function install_marathon_raml() {
 
   # Download and expand on-the-fly the marathon tarball into a temporary folder
   header "Downloading marathon ${VERSION} archive"
-
-  local URL="https://downloads.mesosphere.io/marathon/snapshots/marathon-docs-${VERSION}.tgz"
+  local URL="https://downloads.mesosphere.com/marathon/snapshots/marathon-raml-${VERSION}.tgz"
   local TMP_DIR=`mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'`
   curl -L ${URL} | tar -zx -C $TMP_DIR
 


### PR DESCRIPTION
Adjust the Marathon RAML URL pattern and update the version to fetch the latest Marathon 1.5 API Spec and ensure that the UI is compatible with
Marathon.

The latest spec includes `unreachableStrategy` adjustments that if not applied prevents users from creating/editings apps that are configured to expunge immediately or flag apps as inactive.

Closes DCOS_OSS-1582
