### PR TITLE
DCOS_OSS-1609: update Marathon RAML version

### DIFF
--- a/scripts/pre-install
+++ b/scripts/pre-install
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
-MARATHON_VERSION="1.4.2"
+MARATHON_VERSION="1.4.7"
 
 # Import utils
 source ${SCRIPT_PATH}/utils/git


### PR DESCRIPTION
---
ℹ️   _This PR is related to #2399 and "back-ports" the respective fix_

---

Update the Marathon RAML version to fetch the latest Marathon 1.4.7 API Spec and ensure that the UI is compatible with Marathon.
The latest spec includes `unreachableStrategy` adjustments that if not applied prevents users from creating/editings apps that are configured to expunge immediately or flag apps as inactive.

Closes DCOS_OSS-1609