### PR TITLE
fix(GeneralServiceFormSection): rename Mesos runtime -> UCR

### DIFF
--- a/plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js
@@ -107,7 +107,7 @@ class ContainerServiceFormAdvancedSection extends Component {
     if (gpusDisabled) {
       inputNode = (
         <Tooltip
-          content="Docker Engine does not support GPU resources, please select Mesos Runtime if you want to use GPU resources."
+          content="Docker Engine does not support GPU resources, please select Universal Container Runtime (UCR) if you want to use GPU resources."
           interactive={true}
           maxWidth={300}
           wrapText={true}

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -50,7 +50,7 @@ const containerRuntimes = {
   },
   [MESOS]: {
     label: <span>{labelMap[MESOS]}</span>,
-    helpText: "Universal Container Runtime (UCR) using native Mesos engine. Supports Docker file format, multiple containers (Pods) and GPU resources."
+    helpText: "Universal Container Runtime using native Mesos engine. Supports Docker file format, multiple containers (Pods) and GPU resources."
   }
 };
 
@@ -429,10 +429,12 @@ class GeneralServiceFormSection extends Component {
     const runtimeTooltipContent = (
       <span>
         {
-          "You can run Docker containers with both container runtimes. The Universal Container Runtime is better supported in DC/OS. "
+          "You can run Docker containers with both container runtimes. The Universal Container Runtime (UCR) is better supported in DC/OS. "
         }
         <a
-          href={MetadataStore.buildDocsURI("/usage/containerizers/")}
+          href={MetadataStore.buildDocsURI(
+            "/deploying-services/containerizers/"
+          )}
           target="_blank"
         >
           More information
@@ -461,7 +463,7 @@ class GeneralServiceFormSection extends Component {
         </h3>
         <p>
           The container runtime is responsible for running your service. We
-          support the Mesos and Docker containerizers.
+          support the Docker Engine and Universal Container Runtime (UCR).
         </p>
         <FormGroup showError={Boolean(typeErrors)}>
           {this.getRuntimeSelections(data)}
@@ -485,7 +487,7 @@ class GeneralServiceFormSection extends Component {
     if (!isEmpty(gpus) && gpus !== 0) {
       isDisabled[DOCKER] = true;
       disabledTooltipContent =
-        "Docker Engine does not support GPU resources, please select Mesos Runtime if you want to use GPU resources.";
+        "Docker Engine does not support GPU resources, please select Universal Container Runtime (UCR) if you want to use GPU resources.";
     }
 
     return Object.keys(containerRuntimes).map((runtimeName, index) => {

--- a/plugins/services/src/js/components/forms/VolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/VolumesFormSection.js
@@ -259,7 +259,7 @@ class VolumesFormSection extends Component {
 
       let sizeField = (
         <Tooltip
-          content="Docker Runtime only supports the default size for implicit volumes, please select Mesos Runtime if you want to modify the size."
+          content="Docker Runtime only supports the default size for implicit volumes, please select Universal Container Runtime (UCR) if you want to modify the size."
           width={300}
           wrapperClassName="tooltip-wrapper tooltip-block-wrapper text-align-center"
           wrapText={true}

--- a/plugins/services/src/js/constants/ContainerConstants.js
+++ b/plugins/services/src/js/constants/ContainerConstants.js
@@ -5,6 +5,6 @@ module.exports = {
   },
   labelMap: {
     DOCKER: "Docker Engine",
-    MESOS: "Mesos Runtime"
+    MESOS: "Universal Container Runtime (UCR)"
   }
 };

--- a/system-tests/services/test-apps.js
+++ b/system-tests/services/test-apps.js
@@ -11,10 +11,6 @@ describe("Services", function() {
       cy.server().route("POST", /\/service\/marathon\/v2\/apps/).as("appsReq");
     });
 
-    function clickElementByText(text) {
-      cy.contains(text).click();
-    }
-
     afterEach(() => {
       cy.window().then(win => {
         win.location.href = "about:blank";
@@ -22,8 +18,8 @@ describe("Services", function() {
     });
 
     function selectMesosRuntime() {
-      clickElementByText("More Settings");
-      clickElementByText("Mesos Runtime");
+      cy.contains("More Settings").click();
+      cy.get("label").contains("Universal Container Runtime (UCR)").click();
     }
 
     it("should create a simple app", function() {
@@ -47,7 +43,7 @@ describe("Services", function() {
       cy.root().getFormGroupInputFor("Memory (MiB) *").type("{selectall}10");
       cy.root().getFormGroupInputFor("Command").type(cmdline);
 
-      // Select mesos runtime
+      // Select Universal Container Runtime (UCR)
       selectMesosRuntime();
 
       // Check JSON view
@@ -87,7 +83,7 @@ describe("Services", function() {
         .root()
         .configurationSection("General")
         .configurationMapValue("Container Runtime")
-        .contains("Mesos Runtime");
+        .contains("Universal Container Runtime (UCR)");
       cy
         .root()
         .configurationSection("General")
@@ -147,7 +143,7 @@ describe("Services", function() {
         .getFormGroupInputFor("Memory (MiB) *")
         .should("have.value", "10");
 
-      // Test Mesos Runtime again? should be tested before...
+      // Test Universal Container Runtime (UCR) again? should be tested before...
     });
 
     it("should fail create the same app name again", function() {
@@ -166,7 +162,7 @@ describe("Services", function() {
 
       cy.root().getFormGroupInputFor("Command").type(cmdline);
 
-      // Select mesos runtime
+      // Select Universal Container Runtime (UCR)
       selectMesosRuntime();
 
       // Check JSON view
@@ -210,7 +206,7 @@ describe("Services", function() {
       cy.root().getFormGroupInputFor("Memory (MiB) *").type("{selectall}10");
       cy.root().getFormGroupInputFor("Command").type(cmdline);
 
-      // Select mesos runtime
+      // Select Universal Container Runtime (UCR)
       selectMesosRuntime();
 
       // Use some artifacts
@@ -274,7 +270,7 @@ describe("Services", function() {
         .root()
         .configurationSection("General")
         .configurationMapValue("Container Runtime")
-        .contains("Mesos Runtime");
+        .contains("Universal Container Runtime (UCR)");
       cy
         .root()
         .configurationSection("General")
@@ -793,7 +789,7 @@ describe("Services", function() {
       cy.root().getFormGroupInputFor("Memory (MiB) *").type("{selectall}32");
       cy.root().getFormGroupInputFor("Command").type(cmdline);
 
-      // Select mesos runtime
+      // Select Universal Container Runtime (UCR)
       selectMesosRuntime();
 
       // Select Networking section
@@ -860,7 +856,7 @@ describe("Services", function() {
         .root()
         .configurationSection("General")
         .configurationMapValue("Container Runtime")
-        .contains("Mesos Runtime");
+        .contains("Universal Container Runtime (UCR)");
       cy
         .root()
         .configurationSection("General")
@@ -988,7 +984,7 @@ describe("Services", function() {
       cy.root().getFormGroupInputFor("Memory (MiB) *").type("{selectall}32");
       cy.root().getFormGroupInputFor("Command").type(cmdline);
 
-      // Select mesos runtime
+      // Select Universal Container Runtime (UCR)
       selectMesosRuntime();
 
       // Select Networking section
@@ -1052,7 +1048,7 @@ describe("Services", function() {
         .root()
         .configurationSection("General")
         .configurationMapValue("Container Runtime")
-        .contains("Mesos Runtime");
+        .contains("Universal Container Runtime (UCR)");
       cy
         .root()
         .configurationSection("General")
@@ -1180,7 +1176,7 @@ describe("Services", function() {
       cy.root().getFormGroupInputFor("Memory (MiB) *").type("{selectall}10");
       cy.root().getFormGroupInputFor("Command").type(cmdline);
 
-      // Select mesos runtime
+      // Select Universal Container Runtime (UCR)
       selectMesosRuntime();
 
       // Select Environment section
@@ -1249,7 +1245,7 @@ describe("Services", function() {
         .root()
         .configurationSection("General")
         .configurationMapValue("Container Runtime")
-        .contains("Mesos Runtime");
+        .contains("Universal Container Runtime (UCR)");
       cy
         .root()
         .configurationSection("General")
@@ -1603,7 +1599,7 @@ describe("Services", function() {
       cy.root().getFormGroupInputFor("Memory (MiB) *").type("{selectall}10");
       cy.root().getFormGroupInputFor("Command").type(cmdline);
 
-      // Select mesos runtime
+      // Select Universal Container Runtime (UCR)
       selectMesosRuntime();
 
       // Select Environment section
@@ -1672,7 +1668,7 @@ describe("Services", function() {
         .root()
         .configurationSection("General")
         .configurationMapValue("Container Runtime")
-        .contains("Mesos Runtime");
+        .contains("Universal Container Runtime (UCR)");
       cy
         .root()
         .configurationSection("General")
@@ -1796,7 +1792,7 @@ describe("Services", function() {
       cy.root().getFormGroupInputFor("Memory (MiB) *").type("{selectall}10");
       cy.root().getFormGroupInputFor("Command").type(cmdline);
 
-      // Select mesos runtime
+      // Select Universal Container Runtime (UCR)
       selectMesosRuntime();
 
       // Select Volumes section
@@ -1857,7 +1853,7 @@ describe("Services", function() {
         .root()
         .configurationSection("General")
         .configurationMapValue("Container Runtime")
-        .contains("Mesos Runtime");
+        .contains("Universal Container Runtime (UCR)");
       cy
         .root()
         .configurationSection("General")

--- a/system-tests/services/test-external-volumes.js
+++ b/system-tests/services/test-external-volumes.js
@@ -38,9 +38,9 @@ describe("Services", function() {
       cy.root().getFormGroupInputFor("Memory (MiB) *").type("{selectall}64");
       cy.root().getFormGroupInputFor("Command").type(cmdline);
 
-      // Select Mesos Runtime
+      // Select Universal Container Runtime (UCR)
       cy.contains("More Settings").click();
-      cy.contains("Mesos Runtime").click();
+      cy.get("label").contains("Universal Container Runtime (UCR)").click();
 
       // Select Volumes section
       cy.root().get(".menu-tabbed-item").contains("Volumes").click();
@@ -101,7 +101,7 @@ describe("Services", function() {
         .root()
         .configurationSection("General")
         .configurationMapValue("Container Runtime")
-        .contains("Mesos Runtime");
+        .contains("Universal Container Runtime (UCR)");
       cy
         .root()
         .configurationSection("General")

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -825,7 +825,7 @@ describe("Service Form Modal", function() {
         });
       });
 
-      context("Switching to Mesos Runtime", function() {
+      context("Switching to Universal Container Runtime (UCR)", function() {
         beforeEach(function() {
           // Set viewport so we have side-by-side JSON editor
           cy.viewport("macbook-15");
@@ -835,7 +835,7 @@ describe("Service Form Modal", function() {
             .contains("JSON Editor")
             .click();
 
-          cy.get("label").contains("Mesos Runtime").click();
+          cy.get("label").contains("Universal Container Runtime (UCR)").click();
         });
 
         it("should switch from Docker to Mesos correctly", function() {
@@ -855,7 +855,7 @@ describe("Service Form Modal", function() {
     context("Service: Networking", function() {
       /**
        * Clicks the runtime option under more settings
-       * @param {String} runtimeText one of ['Docker Engine', 'Mesos Runtime']
+       * @param {String} runtimeText one of ['Docker Engine', 'Universal Container Runtime (UCR)']
        */
       function setRuntime(runtimeText) {
         cy.get("a.clickable").contains("More Settings").click();
@@ -905,8 +905,8 @@ describe("Service Form Modal", function() {
             .should("not.have.attr", "disabled");
         });
 
-        it('should have all available types when "Mesos Runtime" selected', function() {
-          setRuntime("Mesos Runtime");
+        it('should have all available types when "Universal Container Runtime (UCR)" selected', function() {
+          setRuntime("Universal Container Runtime (UCR)");
           clickNetworkingTab();
 
           cy


### PR DESCRIPTION
In the new marathon service create form, instead of calling the checkbox Mesos Runtime, always call it Universal Container Runtime (UCR).

**Before**:
![screen shot 2017-08-31 at 3 04 43 pm](https://user-images.githubusercontent.com/1527504/29947303-c18c1072-8e5d-11e7-8db7-4709f3907f84.png)


**After**:
![screen shot 2017-08-31 at 3 03 32 pm](https://user-images.githubusercontent.com/1527504/29947265-98970f6e-8e5d-11e7-8de0-87805a5b18d4.png)


Closes DCOS-18312.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
