### PR TITLE
fix(jest-config) changed that every package/plugin has own root

### DIFF
--- a/jest/gen-config.js
+++ b/jest/gen-config.js
@@ -3,14 +3,48 @@
  */
 var fs = require('fs');
 var path = require('path');
-var testPaths = ['src', 'plugins', 'tests', 'packages'];
 
+/**
+ * List of root (test path) directories
+ *
+ * @description Jest will only search for tests and
+ * load manual mocks (e.g. `src/__mocks__/fs.js`) within these directories.
+ *
+ * @type {Array.<string>}
+ */
+const roots = ['src', 'tests'];
+
+/**
+ * List of package directories
+ *
+ * @description Packages (subdirectories)  within these directories are
+ * going to be added as a "root" directory; this allows packages to roll
+ * their own "manual" mocks (e.g., `my-package/__mocks__/fs.js`),
+ * as Jest only loads them from root directories.
+ *
+ * @type {Array.<string>}
+ */
+const packages = ["plugins", "packages"];
+
+// Add `npm_config_externalplugins` and strip trailing slash
+// to make sure the paths are compatible.
 if (process.env.npm_config_externalplugins) {
-  testPaths.push(process.env.npm_config_externalplugins);
+  packages.push(process.env.npm_config_externalplugins.replace(/\/$/, ""));
 }
 
+// Traverse the subdirectories for every package directory and add the
+// directories to the list root directories.
+packages.forEach(function(packageDir) {
+  fs.readdirSync(packageDir).forEach(function(rootDir) {
+    const relativePath = packageDir + "/" + rootDir;
+    if (fs.statSync(relativePath).isDirectory()) {
+      roots.push(relativePath);
+    }
+  });
+});
+
 var config = {
-  'testPathDirs': testPaths,
+  'testPathDirs': roots,
   'globals': {
     '__DEV__': true
   },


### PR DESCRIPTION
…s its own root

when using manual mocks for global packages or node modules, you have to place them into
"your root folder", sadly `testPathDir` is poorly named as it actually is defining root folders,
not only folders to search for tests.

this commit adds one root folder per package and plugin instead of just defining
"packages" and "plugins" as roots.

jest also renamed `testPathDir` to `roots` in newer versions which better explains
what this option is doing.
