### PR TITLE
fix(JSONReducers/Containers): delete protocol field on ADD_ITEM

### DIFF
--- a/plugins/services/src/js/reducers/__tests__/JSONMultiContainer-test.js
+++ b/plugins/services/src/js/reducers/__tests__/JSONMultiContainer-test.js
@@ -34,7 +34,7 @@ describe("JSONMultiContainer", function() {
               {
                 name: "nginx",
                 hostPort: 0,
-                protocol: [],
+                protocol: ["tcp"],
                 labels: {
                   VIP_0: "1.2.3.4:80"
                 }
@@ -50,7 +50,7 @@ describe("JSONMultiContainer", function() {
               {
                 name: "nginx",
                 hostPort: 0,
-                protocol: [],
+                protocol: ["udp", "tcp"],
                 labels: {
                   VIP_0: "1.2.3.4:80"
                 }

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
@@ -173,7 +173,14 @@ function containersParser(state) {
     if (item.endpoints != null && item.endpoints.length !== 0) {
       const networkMode = findNestedPropertyInObject(state, "networks.0.mode");
 
-      item.endpoints.forEach((endpoint, endpointIndex) => {
+      item.endpoints.forEach((_endpoint, endpointIndex) => {
+        const endpoint = Object.assign({}, _endpoint);
+        // Internal representation of protocols field differs from the JSON
+        // Thus we need to delete the field from the ADD_ITEM value so that
+        // JSONReducer isn't confused by it
+        const endpointProtocol = endpoint.protocol;
+        delete endpoint["protocol"];
+
         memo = memo.concat([
           new Transaction(
             ["containers", index, "endpoints"],
@@ -249,7 +256,7 @@ function containersParser(state) {
           }
         }
 
-        const protocols = endpoint.protocol || [];
+        const protocols = endpointProtocol || [];
         PROTOCOLS.forEach(protocol => {
           memo.push(
             new Transaction(


### PR DESCRIPTION
Since we've ditched `applyPatch` but still want to keep in stuff that we don't know about we started copying values via `ADD_ITEM`. The problem here was that the internal representation of `protocol` field was an object wheres the JSON representation is an array. 

That array threw a wrench into the parser-reducer logic, because an array _is_ an object in javascript.

To fix the issue I had to delete `protocol` field for the `ADD_ITEM` event and process it separately. I also added a missing bit to out integrity test to make sure we won't have it again.

Closes DCOS-18694