### PR TITLE
feat(SchemaUtil): parse a partial definition

### DIFF
--- a/src/js/utils/SchemaUtil.js
+++ b/src/js/utils/SchemaUtil.js
@@ -268,7 +268,7 @@ const SchemaUtil = {
 
     Object.keys(schemaProperties).forEach(function(topLevelProp) {
       const topLevelPropertyObject = schemaProperties[topLevelProp];
-      const secondLevelProperties = topLevelPropertyObject.properties;
+      const secondLevelProperties = topLevelPropertyObject.properties || {};
       const requiredProps = topLevelPropertyObject.required;
       const definitionForm = (multipleDefinition[topLevelProp] = {});
 

--- a/src/js/utils/__tests__/SchemaUtil-test.js
+++ b/src/js/utils/__tests__/SchemaUtil-test.js
@@ -48,6 +48,29 @@ describe("SchemaUtil", function() {
       });
     });
 
+    describe("schema with no second level properties", function() {
+      const $scope = {};
+      beforeEach(function() {
+        var schema = {
+          properties: {
+            application: {
+              description: "This is a description"
+            }
+          }
+        };
+
+        $scope.subheaderRender = jasmine.createSpy();
+        $scope.result = SchemaUtil.schemaToMultipleDefinition({
+          schema,
+          renderSubheader: $scope.subheaderRender
+        });
+      });
+
+      it("creates the definition", function() {
+        expect($scope.result.application.definition).toEqual([]);
+      });
+    });
+
     describe("nested schema", function() {
       beforeEach(function() {
         var schema = {


### PR DESCRIPTION
We've fixed that in 1.10 as a part of #2411 https://github.com/dcos/dcos-ui/pull/2411/commits/552770ab47e3f849e7e3cabc870682ab0314708f and agreed not to fix on master since the form will be gone in 1.11

But people still stumble upon this bug, so let's fix it just in case.

to test try editing `spark-history` catalog package. Without the fix it throws with the fix it opens the form that looks broken but that's because the package doesn't provide anything to config.