### PR TITLE
fix(CosmosPackages): return entire response for service/describe

### DIFF
--- a/src/js/events/CosmosPackagesActions.js
+++ b/src/js/events/CosmosPackagesActions.js
@@ -209,11 +209,9 @@ const CosmosPackagesActions = {
       url: `${Config.rootUrl}/cosmos/service/describe`,
       data: JSON.stringify({ appId: serviceId }),
       success(response) {
-        const cosmosPackage = response.package;
-
         AppDispatcher.handleServerAction({
           type: REQUEST_COSMOS_SERVICE_DESCRIBE_SUCCESS,
-          data: cosmosPackage,
+          data: response,
           serviceId
         });
       },

--- a/src/js/events/__tests__/CosmosPackagesActions-test.js
+++ b/src/js/events/__tests__/CosmosPackagesActions-test.js
@@ -474,7 +474,7 @@ describe("CosmosPackagesActions", function() {
       var id = AppDispatcher.register(function(payload) {
         var action = payload.action;
         AppDispatcher.unregister(id);
-        expect(action.data).toEqual({ bar: "baz" });
+        expect(action.data).toEqual({ package: { bar: "baz" } });
       });
 
       this.configuration.success({ package: { bar: "baz" } });

--- a/src/js/stores/CosmosPackagesStore.js
+++ b/src/js/stores/CosmosPackagesStore.js
@@ -318,12 +318,7 @@ class CosmosPackagesStore extends GetSetBaseStore {
   }
 
   getServiceDetails() {
-    const serviceDetails = this.get("serviceDetails");
-    if (serviceDetails) {
-      return new UniversePackage(serviceDetails);
-    }
-
-    return null;
+    return this.get("serviceDetails");
   }
 
   getPackageVersions(packageName) {

--- a/src/js/stores/__tests__/CosmosPackagesStore-test.js
+++ b/src/js/stores/__tests__/CosmosPackagesStore-test.js
@@ -5,6 +5,7 @@ const Config = require("../../config/Config");
 const EventTypes = require("../../constants/EventTypes");
 const CosmosPackagesStore = require("../CosmosPackagesStore");
 const packageDescribeFixture = require("./fixtures/MockPackageDescribeResponse.json");
+const serviceDescribeFixture = require("./fixtures/MockServiceDescribeResponse.json");
 const packagesListFixture = require("./fixtures/MockPackagesListResponse.json");
 const packagesSearchFixture = require("./fixtures/MockPackagesSearchResponse.json");
 const ActionTypes = require("../../constants/ActionTypes");
@@ -306,30 +307,34 @@ describe("CosmosPackagesStore", function() {
     beforeEach(function() {
       this.requestFn = RequestUtil.json;
       RequestUtil.json = function(handlers) {
-        handlers.success(Object.assign({}, packageDescribeFixture));
+        handlers.success(Object.assign({}, serviceDescribeFixture));
       };
-      this.packageDescribeFixture = Object.assign({}, packageDescribeFixture);
+      this.serviceDescribeFixture = Object.assign({}, serviceDescribeFixture);
     });
 
     afterEach(function() {
       RequestUtil.json = this.requestFn;
     });
 
-    it("should return an instance of UniversePackage", function() {
+    it("should return the field package within response", function() {
       CosmosPackagesStore.fetchServiceDescription("foo");
-      var serviceDetails = CosmosPackagesStore.getServiceDetails();
-      expect(serviceDetails instanceof UniversePackage).toBeTruthy();
+      var response = CosmosPackagesStore.getServiceDetails();
+      var packageField = response.package;
+      expect(packageField.name).toEqual("marathon");
     });
 
-    it("should return the packageDetails it was given", function() {
+    it("should return the field resolvedOptions within the response", function() {
       CosmosPackagesStore.fetchServiceDescription("foo");
-      var serviceDetails = CosmosPackagesStore.getServiceDetails();
-      expect(serviceDetails.getName()).toEqual(
-        this.packageDescribeFixture.package.name
-      );
-      expect(serviceDetails.getVersion()).toEqual(
-        this.packageDescribeFixture.package.version
-      );
+      var response = CosmosPackagesStore.getServiceDetails();
+      var resolvedOptions = response.resolvedOptions;
+      expect(resolvedOptions.name).toEqual("marathon-1");
+    });
+
+    it("should return the field userProvidedOptions within the response", function() {
+      CosmosPackagesStore.fetchServiceDescription("foo");
+      var response = CosmosPackagesStore.getServiceDetails();
+      var userOptions = response.userProvidedOptions;
+      expect(userOptions.name).toEqual("marathon-1");
     });
 
     it("should pass though query parameters", function() {
@@ -349,8 +354,8 @@ describe("CosmosPackagesStore", function() {
         });
 
         var serviceDetails = CosmosPackagesStore.getServiceDetails();
-        expect(serviceDetails.get("gid")).toEqual("foo");
-        expect(serviceDetails.get("bar")).toEqual("baz");
+        expect(serviceDetails["gid"]).toEqual("foo");
+        expect(serviceDetails["bar"]).toEqual("baz");
       });
 
       it("dispatches the correct event upon success", function() {

--- a/src/js/stores/__tests__/fixtures/MockServiceDescribeResponse.json
+++ b/src/js/stores/__tests__/fixtures/MockServiceDescribeResponse.json
@@ -1,0 +1,15 @@
+{
+  "downgradesTo": [],
+  "package": {
+    "packagingVersion": "2.0",
+    "name": "marathon",
+    "version": "0.11.1"
+  },
+  "resolvedOptions": {
+    "name": "marathon-1"
+  },
+  "upgradesTo": [],
+  "userProvidedOptions": {
+    "name": "marathon-1"
+  }
+}


### PR DESCRIPTION
These actions and stores were recently added, and it was a mistake to only return the `package` field of the response. The `package` field is just a static description of the cosmos package. But we also need the up to data options, available in the `resolvedOptions` field of the response. 

This changes these stores/actions to return the entire response from the API. 

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
