### PR TITLE
↩️  DCOS-18788: adjust port definition protocol handling

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/SingleContainerPortDefinitionsReducer.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/SingleContainerPortDefinitionsReducer.js
@@ -28,21 +28,22 @@ function SingleContainerPortDefinitionsReducer(state = [], action) {
     if (joinedPath === "portDefinitions") {
       switch (type) {
         case ADD_ITEM:
-          state.push(
-            value || {
-              hostPort: null,
-              labels: null,
-              loadBalanced: false,
-              name: null,
-              protocol: {
-                tcp: true,
-                udp: false
-              },
-              servicePort: null,
-              vip: null,
-              vipPort: null
-            }
-          );
+          const definition = {
+            hostPort: null,
+            labels: null,
+            loadBalanced: false,
+            name: null,
+            protocol: {
+              tcp: false,
+              udp: false
+            },
+            servicePort: null,
+            vip: null,
+            vipPort: null
+          };
+          const defaults = { protocol: { tcp: true } };
+
+          state.push(Object.assign(definition, value || defaults));
           break;
         case REMOVE_ITEM:
           state = state.filter(function(item, index) {
@@ -58,6 +59,10 @@ function SingleContainerPortDefinitionsReducer(state = [], action) {
       }
 
       if (field === "protocol" && PROTOCOLS.includes(subfield)) {
+        if (state[index].protocol == null) {
+          state[index].protocol = {};
+        }
+
         state[index].protocol[subfield] = value;
       }
     }

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/PortDefinitionsReducer.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/PortDefinitionsReducer.js
@@ -43,20 +43,26 @@ function PortDefinitionsReducer(state = [], action) {
     if (joinedPath === "portDefinitions") {
       switch (type) {
         case ADD_ITEM:
+          const definition = {
+            hostPort: null,
+            labels: null,
+            loadBalanced: false,
+            name: null,
+            protocol: {
+              tcp: false,
+              udp: false
+            },
+            servicePort: null,
+            vip: null,
+            vipPort: null
+          };
+          const defaults = { protocol: { tcp: true } };
+
           state.push(
-            transformPortDefinition(value) || {
-              hostPort: null,
-              labels: null,
-              loadBalanced: false,
-              name: null,
-              protocol: {
-                tcp: true,
-                udp: false
-              },
-              servicePort: null,
-              vip: null,
-              vipPort: null
-            }
+            Object.assign(
+              definition,
+              transformPortDefinition(value) || defaults
+            )
           );
           break;
         case REMOVE_ITEM:
@@ -73,6 +79,10 @@ function PortDefinitionsReducer(state = [], action) {
       }
 
       if (field === "protocol" && PROTOCOLS.includes(subfield)) {
+        if (state[index].protocol == null) {
+          state[index].protocol = {};
+        }
+
         state[index].protocol[subfield] = value;
       }
     }

--- a/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
+++ b/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
@@ -63,14 +63,18 @@ module.exports = {
     return this.portDefinitions.map((portDefinition, index) => {
       const { name } = portDefinition;
       const vipLabel = `VIP_${index}`;
-      const hostPort = portDefinition && portDefinition.hostPort
+      const hostPort = portDefinition.hostPort
         ? Number(portDefinition.hostPort)
         : 0;
       const defaultVipPort = hostPort !== 0 ? hostPort : null;
       const vipPort = portDefinition.vipPort || defaultVipPort;
-      const protocol = PROTOCOLS.filter(function(protocol) {
-        return portDefinition.protocol[protocol];
-      }).join(",");
+
+      let protocol = null;
+      if (portDefinition.protocol) {
+        protocol = PROTOCOLS.filter(function(protocol) {
+          return portDefinition.protocol[protocol];
+        }).join(",");
+      }
 
       const labels = VipLabelUtil.generateVipLabel(
         this.appState.id,

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
@@ -128,18 +128,48 @@ describe("PortDefinitions", function() {
       ]);
     });
 
-    it("should set the complex protocol value", function() {
+    it("applies protocol changes to _incomplete_ port definition", function() {
       let batch = new Batch();
-      batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(
-        new Transaction(["portDefinitions", 0, "protocol", "udp"], true)
+        new Transaction(
+          ["portDefinitions"],
+          {
+            name: "http",
+            port: 0
+          },
+          ADD_ITEM
+        )
       );
       batch = batch.add(
         new Transaction(["portDefinitions", 0, "protocol", "tcp"], true)
       );
 
       expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual([
-        { name: null, port: 0, protocol: "udp,tcp", labels: null }
+        { name: "http", port: 0, protocol: "tcp", labels: null }
+      ]);
+    });
+
+    it("applies protocol changes to provided port definition", function() {
+      let batch = new Batch();
+      batch = batch.add(
+        new Transaction(
+          ["portDefinitions"],
+          {
+            name: "http",
+            port: 0,
+            protocol: {
+              udp: true
+            }
+          },
+          ADD_ITEM
+        )
+      );
+      batch = batch.add(
+        new Transaction(["portDefinitions", 0, "protocol", "tcp"], true)
+      );
+
+      expect(batch.reduce(PortDefinitions.JSONReducer.bind({}), {})).toEqual([
+        { name: "http", port: 0, protocol: "udp,tcp", labels: null }
       ]);
     });
 


### PR DESCRIPTION
---
↩️  _This PR back-ports the fix introduced with #2432 to release/1.10._

---

> Change the reducers to properly handle missing protocols as they otherwise throw type errors which results in duplicated JSON definitions and a broken editor experience.
>
> Closes DCOS-18788