### PR TITLE
DCOS-18705: change cluster provisioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,10 @@ RUN set -x \
   # Install cypress
   && cypress install --cypress-version ${CYPRESS_VERSION} \
 
+  # Install dcos-launch
+  && curl 'https://downloads.dcos.io/dcos-test-utils/bin/linux/dcos-launch' > /usr/local/bin/dcos-launch \
+  && chmod +x /usr/local/bin/dcos-launch \
+
   # Ensure entrypoint is executable
   && chmod +x /usr/local/bin/dcos-ui-docker-entrypoint \
 

--- a/system-tests/_scripts/delete-cluster.sh
+++ b/system-tests/_scripts/delete-cluster.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+CLUSTER_INFO=/tmp/cluster-info.json
+
+if ! dcos-launch delete -i ${CLUSTER_INFO} 1>&2; then
+  echo "Cluster deletion failed."
+  exit 1
+fi
+
+rm ${CLUSTER_INFO};
+exit 0

--- a/system-tests/_scripts/launch-cluster.sh
+++ b/system-tests/_scripts/launch-cluster.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+
+if [ -z "${1}" ] && [ -z "${INSTALLER_URL}" ]
+then
+  echo -e "Error: Please pass the installer url or" \
+    "specify the INSTALLER_URL environment variable"
+  exit 1
+fi
+
+CLUSTER_CONFIG=/tmp/cluster-config.yaml
+CLUSTER_INFO=/tmp/cluster-info.json
+
+# Create cluster config
+cat << EOF > ${CLUSTER_CONFIG}
+---
+launch_config_version: 1
+deployment_name: dcos-ui-system-test-$(date +%s)
+installer_url: ${1:-$INSTALLER_URL}
+platform: aws
+provider: onprem
+aws_region: us-west-2
+os_name: cent-os-7
+instance_type: m4.large
+dcos_config:
+  cluster_name: DC/OS UI System Integration Tests
+  resolvers:
+    - 8.8.4.4
+    - 8.8.8.8
+  dns_search: mesos
+  master_discovery: static
+num_masters: 1
+num_private_agents: 1
+num_public_agents: 1
+ssh_user: centos
+key_helper: true
+EOF
+
+if ! dcos-launch create -c ${CLUSTER_CONFIG} -i ${CLUSTER_INFO} 1>&2
+then
+  echo "Error: Cluster launch failed."
+  exit 1
+fi
+
+if ! dcos-launch wait -i ${CLUSTER_INFO} 1>&2
+then
+  echo "Error: Cluster did not start."
+  exit 1
+fi
+
+echo "http://$(dcos-launch describe -i ${CLUSTER_INFO} | python -c \
+                'import sys, json; \
+                 contents = json.load(sys.stdin); \
+                 print(contents["masters"][0]["public_ip"], end="")')"
+exit 0

--- a/system-tests/driver-config/jenkins.sh
+++ b/system-tests/driver-config/jenkins.sh
@@ -3,13 +3,6 @@
 # This is a configuration script to the system-test-driver that runs the
 # integration tests against a newly provisioned DC/OS Open Cluster.
 #
-
-# Ensure CCM_AUTH_TOKEN is specified
-if [ -z "$CCM_AUTH_TOKEN" ]; then
-  echo "Error: Please specify the CCM_AUTH_TOKEN environment variable"
-  exit 1
-fi
-
 cat <<EOF
 criteria: []
 suites:
@@ -20,18 +13,18 @@ targets:
     title: Open Version
     features: []
 
-    type: ccm
-    config:
-      template: single-master.cloudformation.json
+    type: script
 
     env:
       PROXIED_CLUSTER_URL: http://127.0.0.1:4201
+      INSTALLER_URL: "${INSTALLER_URL}"
+      AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
+      AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
       PATH: "/usr/local/bin:$PATH"
 
     scripts:
+      create: ../_scripts/launch-cluster.sh
       proxy: http-server --proxy-secure=false -p 4201 -P \$CLUSTER_URL ../../dist
       auth: ../_scripts/auth-open.py
-
-secrets:
-  ccm_auth_token: $CCM_AUTH_TOKEN
+      teardown: ../_scripts/delete-cluster.sh
 EOF


### PR DESCRIPTION
Adjust the system-tests driver configuration to use `dcos-launch` to provision clusters. 

Please Note: That the systems for this PR will fail as the new setup required `dcos-launch` to be installed. You need to build the docker image locally and then run the `dcos-system-test-driver` after you've provided the respective environment variables. 

Closes DCOS-18705