### PR TITLE
[WIP] DCOS-18197: Delete status while framework is being deleted

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1755,6 +1755,11 @@
       "from": "center-align@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
     },
+    "chain-function": {
+      "version": "1.0.0",
+      "from": "chain-function@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz"
+    },
     "chalk": {
       "version": "1.1.1",
       "from": "chalk@1.1.1",
@@ -2845,6 +2850,11 @@
           "resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz"
         }
       }
+    },
+    "dom-helpers": {
+      "version": "3.2.1",
+      "from": "dom-helpers@>=3.2.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz"
     },
     "dom-serializer": {
       "version": "0.1.0",
@@ -7776,6 +7786,33 @@
       "from": "promise-polyfill@>=5.1.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-5.2.1.tgz"
     },
+    "prop-types": {
+      "version": "15.6.0",
+      "from": "prop-types@>=15.5.6 <16.0.0",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+      "dependencies": {
+        "fbjs": {
+          "version": "0.8.16",
+          "from": "fbjs@>=0.8.16 <0.9.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz"
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "from": "js-tokens@^3.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "from": "loose-envify@^1.3.1",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "object-assign@>=4.1.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        }
+      }
+    },
     "proxy-addr": {
       "version": "1.0.10",
       "from": "proxy-addr@>=1.0.10 <1.1.0",
@@ -7958,11 +7995,6 @@
       "from": "react-ace@3.7.0",
       "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-3.7.0.tgz"
     },
-    "react-addons-css-transition-group": {
-      "version": "15.4.1",
-      "from": "react-addons-css-transition-group@15.4.1",
-      "resolved": "https://registry.npmjs.org/react-addons-css-transition-group/-/react-addons-css-transition-group-15.4.1.tgz"
-    },
     "react-addons-pure-render-mixin": {
       "version": "15.4.1",
       "from": "react-addons-pure-render-mixin@15.4.1",
@@ -8069,10 +8101,27 @@
       "from": "react-transform-hmr@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz"
     },
+    "react-transition-group": {
+      "version": "1.2.1",
+      "from": "react-transition-group@1.2.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
+      "dependencies": {
+        "js-tokens": {
+          "version": "3.0.2",
+          "from": "js-tokens@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "from": "loose-envify@>=1.3.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+        }
+      }
+    },
     "reactjs-components": {
-      "version": "0.16.0-beta.23",
-      "from": "reactjs-components@0.16.0-beta.23",
-      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.16.0-beta.23.tgz"
+      "version": "0.16.0-beta.26",
+      "from": "reactjs-components@0.16.0-beta.26",
+      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.16.0-beta.26.tgz"
     },
     "reactjs-mixin": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,7 @@
     "node": "4.4.x",
     "npm": "3.9.x"
   },
-  "browserslist": [
-    "last 2 versions",
-    "ie 11"
-  ],
+  "browserslist": ["last 2 versions", "ie 11"],
   "config": {
     "port": 4200,
     "externalplugins": ""
@@ -51,7 +48,6 @@
     "query-string": "4.1.0",
     "react": "15.4.1",
     "react-ace": "3.7.0",
-    "react-addons-css-transition-group": "15.4.1",
     "react-addons-pure-render-mixin": "15.4.1",
     "react-addons-test-utils": "15.4.1",
     "react-dom": "15.4.1",
@@ -59,7 +55,8 @@
     "react-intl": "2.2.3",
     "react-redux": "4.4.6",
     "react-router": "2.8.1",
-    "reactjs-components": "0.16.0-beta.23",
+    "react-transition-group": "^1.2.1",
+    "reactjs-components": "0.16.0-beta.26",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
     "rxjs": "5.4.3",
@@ -135,25 +132,36 @@
   "scripts": {
     "check-env": "./scripts/validate-engine-versions",
     "clean": "rm -rf dist",
-    "shrinkwrap": "npm shrinkwrap --dev && ./node_modules/.bin/gulp fixShrinkwrap",
+    "shrinkwrap":
+      "npm shrinkwrap --dev && ./node_modules/.bin/gulp fixShrinkwrap",
     "preinstall": "./scripts/pre-install",
     "prebuild-assets": "./node_modules/.bin/gulp checkDependencies",
-    "build-assets": "npm run clean && NODE_ENV=production webpack --config ./webpack/webpack.production.babel.js",
-    "build": "npm run lint && npm test && npm run build-assets && npm run validate-build",
-    "build-with-external-plugins": "npm run lint && npm run lint-plugins && npm test && npm run build-assets",
+    "build-assets":
+      "npm run clean && NODE_ENV=production webpack --config ./webpack/webpack.production.babel.js",
+    "build":
+      "npm run lint && npm test && npm run build-assets && npm run validate-build",
+    "build-with-external-plugins":
+      "npm run lint && npm run lint-plugins && npm test && npm run build-assets",
     "lint": "npm run stylelint && npm run eslint",
-    "eslint": "bash -c 'opts=$@ ; set -f; if [[ $# -lt 1 ]]; then opts=\"{src/js,plugins,packages}/**/*.js\"; fi ; eslint --quiet ${opts}' 0",
-    "stylelint": "bash -c 'opts=$@ ; set -f; if [[ $# -lt 1 ]]; then opts=\"{src/styles,plugins,packages}/**/*.less\"; fi ; stylelint ${opts}' 0",
+    "eslint":
+      "bash -c 'opts=$@ ; set -f; if [[ $# -lt 1 ]]; then opts=\"{src/js,plugins,packages}/**/*.js\"; fi ; eslint --quiet ${opts}' 0",
+    "stylelint":
+      "bash -c 'opts=$@ ; set -f; if [[ $# -lt 1 ]]; then opts=\"{src/styles,plugins,packages}/**/*.less\"; fi ; stylelint ${opts}' 0",
     "conventional-changelog-lint": "conventional-changelog-lint",
-    "lint-plugins": "PLUGINS=$npm_config_externalplugins; npm run eslint -- \"$PLUGINS/**/*.js\" && npm run stylelint -- \"$PLUGINS/**/*.less\"",
+    "lint-plugins":
+      "PLUGINS=$npm_config_externalplugins; npm run eslint -- \"$PLUGINS/**/*.js\" && npm run stylelint -- \"$PLUGINS/**/*.less\"",
     "prebuild": "./scripts/validate-tests",
     "serve": "npm run build-assets && ./node_modules/.bin/gulp serve",
     "serve-notify": "export NOTIFY=true && npm run serve",
-    "scaffold": "./node_modules/.bin/gulp ensureConfig && ./node_modules/.bin/gulp ensureDevProxy",
-    "start": "npm run check-env && NODE_ENV=development webpack-dev-server --config ./webpack/webpack.dev.babel.js --hot --progress --colors --content-base ./build --host 0.0.0.0 --port $npm_package_config_port",
-    "test": "node jest/gen-config.js && NODE_PATH=node_modules jest --config=jest/config.json --no-cache",
+    "scaffold":
+      "./node_modules/.bin/gulp ensureConfig && ./node_modules/.bin/gulp ensureDevProxy",
+    "start":
+      "npm run check-env && NODE_ENV=development webpack-dev-server --config ./webpack/webpack.dev.babel.js --hot --progress --colors --content-base ./build --host 0.0.0.0 --port $npm_package_config_port",
+    "test":
+      "node jest/gen-config.js && NODE_PATH=node_modules jest --config=jest/config.json --no-cache",
     "test:watch": "npm test -- --watch",
-    "testing": "NODE_ENV=testing webpack-dev-server --config ./webpack/webpack.dev.babel.js --progress --colors --content-base ./build --port $npm_package_config_port",
+    "testing":
+      "NODE_ENV=testing webpack-dev-server --config ./webpack/webpack.dev.babel.js --progress --colors --content-base ./build --port $npm_package_config_port",
     "validate-build": "scripts/validate-build dist/*.js"
   },
   "jest-webpack-alias": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-intl": "2.2.3",
     "react-redux": "4.4.6",
     "react-router": "2.8.1",
-    "react-transition-group": "^1.2.1",
+    "react-transition-group": "1.2.1",
     "reactjs-components": "0.16.0-beta.26",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",

--- a/plugins/services/src/js/components/LogView.js
+++ b/plugins/services/src/js/components/LogView.js
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactCSSTransitionGroup from "react-addons-css-transition-group";
+import { CSSTransitionGroup } from "react-transition-group";
 import throttle from "lodash.throttle";
 
 import { PREPEND } from "#SRC/js/constants/SystemLogTypes";
@@ -264,7 +264,7 @@ class LogView extends React.Component {
           {fullLog}
         </Highlight>
       </pre>,
-      <ReactCSSTransitionGroup
+      <CSSTransitionGroup
         key="log-go-down-button"
         transitionAppear={true}
         transitionName="button"
@@ -274,7 +274,7 @@ class LogView extends React.Component {
         component="div"
       >
         {this.getGoToBottomButton()}
-      </ReactCSSTransitionGroup>
+      </CSSTransitionGroup>
     ];
   }
 

--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -119,7 +119,8 @@ class ServiceBreadcrumbs extends React.Component {
       return null;
     }
 
-    const serviceStatus = service.getStatus();
+    const isDeleting = service.isDeleting();
+    const serviceStatus = isDeleting ? "Deleting" : service.getStatus();
     const tasksSummary = service.getTasksSummary();
     const runningTasksCount = service.getTaskCount();
     const instancesCount = service.getInstancesCount();

--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -119,8 +119,9 @@ class ServiceBreadcrumbs extends React.Component {
       return null;
     }
 
-    const isDeleting = service.isDeleting();
-    const serviceStatus = isDeleting ? "Deleting" : service.getStatus();
+    const serviceIsDeleting =
+      !(service instanceof ServiceTree) && service.isDeleting();
+    const serviceStatus = serviceIsDeleting ? "Deleting" : service.getStatus();
     const tasksSummary = service.getTasksSummary();
     const runningTasksCount = service.getTaskCount();
     const instancesCount = service.getInstancesCount();

--- a/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
+++ b/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
@@ -13,7 +13,6 @@ import Service from "../../structs/Service";
 import ServiceActionLabels from "../../constants/ServiceActionLabels";
 import ServiceTree from "../../structs/ServiceTree";
 import {
-  DELETE,
   EDIT,
   RESTART,
   RESUME,
@@ -60,18 +59,6 @@ class ServiceActionDisabledModal extends React.Component {
     const serviceID = service ? service.getId() : "";
 
     return `dcos marathon app restart ${serviceID}`;
-  }
-
-  getDeleteCommand(service = this.props.service) {
-    const serviceID = service ? service.getId() : "";
-    const packageName = service.getLabels().DCOS_PACKAGE_NAME;
-
-    // For groups, not services
-    if (service instanceof ServiceTree) {
-      return `dcos marathon group remove ${serviceID}`;
-    }
-
-    return `dcos package uninstall ${packageName} --app-id=${serviceID}`;
   }
 
   getServiceRestartMessage() {
@@ -172,53 +159,6 @@ class ServiceActionDisabledModal extends React.Component {
     );
   }
 
-  getServiceDeleteMessage() {
-    const { intl, service } = this.props;
-    const serviceID = service ? service.getId() : "";
-    const command = this.getDeleteCommand();
-
-    return (
-      <div>
-        <p>
-          {intl.formatMessage({
-            id: "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_1"
-          })}
-          {" "}
-          <span className="emphasis">{serviceID}</span>
-          {" "}
-          {intl.formatMessage({
-            id: "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_2"
-          })}
-          {" "}
-          <a
-            href={MetadataStore.buildDocsURI("/deploying-services/uninstall/")}
-            target="_blank"
-          >
-            {intl.formatMessage({ id: "DOCS.DOCUMENTATION" })}
-          </a> for complete instructions.{" "}
-        </p>
-        {this.getClipboardTrigger(command)}
-        <p>
-          {intl.formatMessage({
-            id: "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_3"
-          })}
-          {" "}
-          <a
-            href={MetadataStore.buildDocsURI(
-              "/usage/managing-services/uninstall/#framework-cleaner"
-            )}
-            target="_blank"
-          >
-            {intl.formatMessage({
-              id: "SERVICE_ACTIONS.SDK_SERVICE_CLEARNER_SCRIPT"
-            })}
-          </a>
-          .
-        </p>
-      </div>
-    );
-  }
-
   getServiceEditMessage() {
     const { intl, service } = this.props;
 
@@ -252,8 +192,6 @@ class ServiceActionDisabledModal extends React.Component {
         return this.getServiceResumeMessage();
       case SCALE:
         return this.getServiceScaleMessage();
-      case DELETE:
-        return this.getServiceDeleteMessage();
       case EDIT:
         return this.getServiceEditMessage();
       default:
@@ -385,72 +323,6 @@ class ServiceActionDisabledModal extends React.Component {
     );
   }
 
-  getGroupDeleteMessage() {
-    const { actionID, service, intl } = this.props;
-    const serviceID = service ? service.getId() : "";
-    const { selectedServices } = this.getServiceTypes(isSDKService);
-    const packageCommand = this.getServiceListCommand(
-      selectedServices,
-      this.getDeleteCommand
-    );
-    const groupCommand = this.getDeleteCommand();
-
-    return (
-      <div>
-        <p>
-          {intl.formatMessage({ id: "SERVICE_ACTIONS.SDK_GROUP_DELETE_1" })}
-          {". "}
-          <a
-            href={MetadataStore.buildDocsURI("/deploying-services/uninstall/")}
-            target="_blank"
-          >
-            {intl.formatMessage({ id: "DOCS.MORE_INFORMATION" })}
-          </a>
-        </p>
-        {this.getClipboardTrigger(packageCommand)}
-        <p>
-          {intl.formatMessage({ id: "SERVICE_ACTIONS.SDK_GROUP_DELETE_2" })}
-          {" "}
-          <a
-            href={MetadataStore.buildDocsURI(
-              "/usage/managing-services/uninstall/#framework-cleaner"
-            )}
-            target="_blank"
-          >
-            {intl.formatMessage({
-              id: "SERVICE_ACTIONS.SDK_SERVICE_CLEARNER_SCRIPT"
-            })}
-          </a>
-          {" "}
-          {intl.formatMessage({ id: "SERVICE_ACTIONS.SDK_GROUP_DELETE_3" })}.
-        </p>
-        <p>
-          {intl.formatMessage({ id: "SERVICE_ACTIONS.SDK_GROUP_DELETE_4" })}
-          {", "}
-          {intl
-            .formatMessage({ id: ServiceActionLabels[actionID] })
-            .toLowerCase()}
-          {" "}
-          {intl.formatMessage({ id: "SERVICE_ACTIONS.SDK_GROUP_DELETE_5" })}
-          {" "}
-          <span className="emphasis">{serviceID}</span>
-          {": "}
-          {intl.formatMessage({ id: "SERVICE_ACTIONS.SDK_GROUP_DELETE_6" })}.
-          {" "}
-          <a
-            href={MetadataStore.buildDocsURI(
-              "/cli/command-reference/dcos-marathon/dcos-marathon-group-remove/"
-            )}
-            target="_blank"
-          >
-            {intl.formatMessage({ id: "DOCS.MORE_INFORMATION" })}
-          </a>
-        </p>
-        {this.getClipboardTrigger(groupCommand)}
-      </div>
-    );
-  }
-
   getGroupMessage() {
     const { actionID, intl } = this.props;
 
@@ -463,8 +335,6 @@ class ServiceActionDisabledModal extends React.Component {
         return this.getGroupUpdateMessage(
           intl.formatMessage({ id: "SERVICE_ACTIONS.SDK_GROUP_UPDATE_SCALE" })
         );
-      case DELETE:
-        return this.getGroupDeleteMessage();
       default:
         return <noscript />;
     }

--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -20,7 +20,8 @@ const METHODS_TO_BIND = [
   "handleChangeInputFieldDestroy",
   "handleModalClose",
   "handleRightButtonClick",
-  "handleChangeInputGroupDestroy"
+  "handleChangeInputGroupDestroy",
+  "handleFormSubmit"
 ];
 
 class ServiceDestroyModal extends React.Component {
@@ -107,6 +108,11 @@ class ServiceDestroyModal extends React.Component {
     this.setState({
       serviceNameConfirmationValue: event.target.value
     });
+  }
+
+  handleFormSubmit(event) {
+    event.preventDefault();
+    this.handleRightButtonClick();
   }
 
   handleChangeInputGroupDestroy(event) {
@@ -250,9 +256,11 @@ class ServiceDestroyModal extends React.Component {
         rightButtonCallback={this.handleRightButtonClick}
         showHeader={true}
       >
-        {this.getGroupHeader()}
-        {this.getServiceDeleteForm()}
-        {this.getErrorMessage()}
+        <form onSubmit={this.handleFormSubmit}>
+          {this.getGroupHeader()}
+          {this.getServiceDeleteForm()}
+          {this.getErrorMessage()}
+        </form>
       </Confirm>
     );
   }

--- a/plugins/services/src/js/containers/pod-detail/PodDetail.js
+++ b/plugins/services/src/js/containers/pod-detail/PodDetail.js
@@ -234,6 +234,7 @@ class PodDetail extends mixin(TabsMixin) {
           actions={this.getActions()}
           breadcrumbs={breadcrumbs}
           tabs={this.getTabs()}
+          disabledActions={pod.isDeleting()}
         >
           <PodHeader
             onDestroy={this.handleActionDestroy}

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -279,6 +279,7 @@ class ServiceDetail extends mixin(TabsMixin) {
           tabs={this.getTabs()}
           breadcrumbs={breadcrumbs}
           iconID="services"
+          disabledActions={service.isDeleting()}
         />
         {clonedChildren}
         <ServiceActionDisabledModal

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -334,6 +334,7 @@ class ServicesTable extends React.Component {
           title="More actions"
           transition={true}
           transitionName="dropdown-menu"
+          disabled={service.isDeleting()}
         />
       </Tooltip>
     );
@@ -342,7 +343,10 @@ class ServicesTable extends React.Component {
   renderStatus(prop, service) {
     const instancesCount = service.getInstancesCount();
     const serviceId = service.getId();
-    const serviceStatusText = service.getStatus();
+    const serviceStatusText = !(service instanceof ServiceTree) &&
+      service.isDeleting()
+      ? "Deleting"
+      : service.getStatus();
     const serviceStatusClassSet = StatusMapping[serviceStatusText] || "";
     const { key: serviceStatusKey } = service.getServiceStatus();
     const tasksSummary = service.getTasksSummary();

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -317,6 +317,9 @@ class ServicesTable extends React.Component {
       )
     });
 
+    const serviceIsDeleting =
+      !(service instanceof ServiceTree) && service.isDeleting();
+
     return (
       <Tooltip content="More actions">
         <Dropdown
@@ -334,7 +337,7 @@ class ServicesTable extends React.Component {
           title="More actions"
           transition={true}
           transitionName="dropdown-menu"
-          disabled={service.isDeleting()}
+          disabled={serviceIsDeleting}
         />
       </Tooltip>
     );
@@ -343,8 +346,9 @@ class ServicesTable extends React.Component {
   renderStatus(prop, service) {
     const instancesCount = service.getInstancesCount();
     const serviceId = service.getId();
-    const serviceStatusText = !(service instanceof ServiceTree) &&
-      service.isDeleting()
+    const serviceIsDeleting =
+      !(service instanceof ServiceTree) && service.isDeleting();
+    const serviceStatusText = serviceIsDeleting
       ? "Deleting"
       : service.getStatus();
     const serviceStatusClassSet = StatusMapping[serviceStatusText] || "";

--- a/plugins/services/src/js/structs/PodInstance.js
+++ b/plugins/services/src/js/structs/PodInstance.js
@@ -149,4 +149,10 @@ module.exports = class PodInstance extends Item {
   isTerminating() {
     return this.getStatus() === PodInstanceState.TERMINAL;
   }
+
+  isDeleting() {
+    const env = this.get("env");
+
+    return env && env.SDK_UNINSTALL;
+  }
 };

--- a/plugins/services/src/js/structs/Service.js
+++ b/plugins/services/src/js/structs/Service.js
@@ -96,6 +96,12 @@ module.exports = class Service extends Item {
     };
   }
 
+  isDeleting() {
+    const env = this.get("env");
+
+    return env && env.SDK_UNINSTALL;
+  }
+
   toJSON() {
     return this.get();
   }

--- a/plugins/services/src/js/structs/ServiceTree.js
+++ b/plugins/services/src/js/structs/ServiceTree.js
@@ -429,4 +429,15 @@ module.exports = class ServiceTree extends Tree {
       return serviceTreeLabels;
     }, []);
   }
+<<<<<<< HEAD
+=======
+
+  getListCount() {
+    if (!this.list || !Array.isArray(this.list)) {
+      return 0;
+    }
+
+    return this.list.length;
+  }
+>>>>>>> feat(ServiceDeleteActions): remove delete status for groups
 };

--- a/plugins/services/src/js/structs/ServiceTree.js
+++ b/plugins/services/src/js/structs/ServiceTree.js
@@ -429,15 +429,4 @@ module.exports = class ServiceTree extends Tree {
       return serviceTreeLabels;
     }, []);
   }
-<<<<<<< HEAD
-=======
-
-  getListCount() {
-    if (!this.list || !Array.isArray(this.list)) {
-      return 0;
-    }
-
-    return this.list.length;
-  }
->>>>>>> feat(ServiceDeleteActions): remove delete status for groups
 };

--- a/src/js/components/Page.js
+++ b/src/js/components/Page.js
@@ -14,7 +14,8 @@ const PageHeader = ({
   addButton,
   breadcrumbs,
   supplementalContent,
-  tabs
+  tabs,
+  disabledActions
 }) => {
   return (
     <BasePageHeader
@@ -23,6 +24,7 @@ const PageHeader = ({
       breadcrumbs={breadcrumbs}
       supplementalContent={supplementalContent}
       tabs={tabs}
+      disabledActions={disabledActions}
     />
   );
 };
@@ -35,7 +37,8 @@ TemplateUtil.defineChildren(PageHeader, {
 
 PageHeader.defaultProps = {
   actions: [],
-  tabs: []
+  tabs: [],
+  disabledActions: false
 };
 
 PageHeader.propTypes = {
@@ -46,7 +49,8 @@ PageHeader.propTypes = {
   ]),
   breadcrumbs: React.PropTypes.node,
   supplementalContent: React.PropTypes.node,
-  tabs: React.PropTypes.array
+  tabs: React.PropTypes.array,
+  disabledActions: React.PropTypes.bool
 };
 
 var Page = React.createClass({

--- a/src/js/components/PageHeader.js
+++ b/src/js/components/PageHeader.js
@@ -19,7 +19,8 @@ class PageHeader extends React.Component {
         secondaryContentDetail,
         secondaryContentClassName,
         supplementalContent,
-        tabs
+        tabs,
+        disabledActions
       }
     } = this;
 
@@ -53,6 +54,7 @@ class PageHeader extends React.Component {
               actions={actions}
               addButton={addButton}
               supplementalContent={supplementalContent}
+              disabledActions={disabledActions}
             />
           </div>
           <div className={secondaryContentClasses}>
@@ -73,7 +75,8 @@ const classProps = React.PropTypes.oneOfType([
 
 PageHeader.defaultProps = {
   actions: [],
-  tabs: []
+  tabs: [],
+  disabledActions: false
 };
 
 PageHeader.propTypes = {
@@ -89,7 +92,8 @@ PageHeader.propTypes = {
   secondaryContentClassName: classProps,
   secondaryContentDetail: React.PropTypes.node,
   supplementalContent: React.PropTypes.node,
-  tabs: React.PropTypes.array
+  tabs: React.PropTypes.array,
+  disabledActions: React.PropTypes.bool
 };
 
 PageHeader.Breadcrumbs = PageHeaderBreadcrumbs;

--- a/src/js/components/PageHeaderActions.js
+++ b/src/js/components/PageHeaderActions.js
@@ -22,10 +22,18 @@ const getDropdownAction = (action, index) => {
 
 class PageHeaderActions extends React.Component {
   renderActionsMenu() {
-    const { actions } = this.props;
+    const { actions, disabledActions } = this.props;
 
     if (actions.length > 0) {
       const dropdownElements = actions.map(getDropdownAction);
+
+      if (disabledActions) {
+        return (
+          <PageHeaderActionsMenu disabledActions="true">
+            {dropdownElements}
+          </PageHeaderActionsMenu>
+        );
+      }
 
       return (
         <PageHeaderActionsMenu>
@@ -36,10 +44,18 @@ class PageHeaderActions extends React.Component {
   }
 
   renderAddButton() {
-    const { addButton } = this.props;
+    const { addButton, disabledActions } = this.props;
 
     if (Array.isArray(addButton) && addButton.length > 0) {
       const dropdownElements = addButton.map(getDropdownAction);
+
+      if (disabledActions) {
+        return (
+          <PageHeaderActionsMenu iconID="plus" disabledActions="true">
+            {dropdownElements}
+          </PageHeaderActionsMenu>
+        );
+      }
 
       return (
         <PageHeaderActionsMenu iconID="plus">
@@ -93,7 +109,8 @@ class PageHeaderActions extends React.Component {
 }
 
 PageHeaderActions.defaultProps = {
-  actions: []
+  actions: [],
+  disabledActions: false
 };
 
 const classProps = React.PropTypes.oneOfType([
@@ -116,7 +133,8 @@ PageHeaderActions.propTypes = {
   actions: React.PropTypes.arrayOf(
     React.PropTypes.oneOfType([React.PropTypes.node, menuActionsProps])
   ),
-  supplementalContent: React.PropTypes.node
+  supplementalContent: React.PropTypes.node,
+  disabledActions: React.PropTypes.bool
 };
 
 module.exports = PageHeaderActions;

--- a/src/js/components/PageHeaderActionsMenu.js
+++ b/src/js/components/PageHeaderActionsMenu.js
@@ -28,7 +28,12 @@ const getDropdownItemFromComponent = (child, index) => {
   };
 };
 
-const PageHeaderActionsMenu = ({ anchorRight, children, iconID }) => {
+const PageHeaderActionsMenu = ({
+  anchorRight,
+  children,
+  iconID,
+  disabledActions
+}) => {
   return (
     <Dropdown
       anchorRight={anchorRight}
@@ -40,13 +45,15 @@ const PageHeaderActionsMenu = ({ anchorRight, children, iconID }) => {
       dropdownMenuClassName="dropdown-menu"
       dropdownMenuListClassName="dropdown-menu-list"
       wrapperClassName="dropdown"
+      disabled={disabledActions}
     />
   );
 };
 
 PageHeaderActionsMenu.defaultProps = {
   anchorRight: true,
-  iconID: "ellipsis-vertical"
+  iconID: "ellipsis-vertical",
+  disabled: false
 };
 
 PageHeaderActionsMenu.propTypes = {
@@ -59,7 +66,8 @@ PageHeaderActionsMenu.propTypes = {
       })
     })
   ),
-  iconID: React.PropTypes.string
+  iconID: React.PropTypes.string,
+  disabledActions: React.PropTypes.bool
 };
 
 module.exports = PageHeaderActionsMenu;

--- a/src/js/components/Sidebar.js
+++ b/src/js/components/Sidebar.js
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import CSSTransitionGroup from "react-addons-css-transition-group";
+import { CSSTransitionGroup } from "react-transition-group";
 import GeminiScrollbar from "react-gemini-scrollbar";
 import { Link, routerShape } from "react-router";
 import React from "react";

--- a/src/js/translations/en-US.json
+++ b/src/js/translations/en-US.json
@@ -38,16 +38,6 @@
   "SERVICE_ACTIONS.SCALE_BY": "Scale By",
   "SERVICE_ACTIONS.SUSPEND": "Suspend",
 
-  "SERVICE_ACTIONS.SDK_GROUP_DELETE_1":
-    "Copy and paste this command into the CLI",
-  "SERVICE_ACTIONS.SDK_GROUP_DELETE_2": "Then, run the",
-  "SERVICE_ACTIONS.SDK_GROUP_DELETE_3":
-    "for each service to clean up reserved resources",
-  "SERVICE_ACTIONS.SDK_GROUP_DELETE_4": "Then",
-  "SERVICE_ACTIONS.SDK_GROUP_DELETE_5": "the group",
-  "SERVICE_ACTIONS.SDK_GROUP_DELETE_6":
-    "Copy the command below into the DC/OS CLI",
-
   "SERVICE_ACTIONS.SDK_GROUP_UPDATE_1": "your group by",
   "SERVICE_ACTIONS.SDK_GROUP_UPDATE_2": "from the DC/OS CLI",
   "SERVICE_ACTIONS.SDK_GROUP_UPDATE_3": "For",
@@ -67,8 +57,6 @@
   "SERVICE_ACTIONS.SDK_GROUP_UPDATE_SCALE":
     "updating the number of instances of each service",
 
-  "SERVICE_ACTIONS.SDK_SERVICE_CLEARNER_SCRIPT": "framework cleaner script",
-
   "SERVICE_ACTIONS.SDK_SERVICE_RESTART":
     "Restart your service from the DC/OS CLI.",
   "SERVICE_ACTIONS.SDK_SERVICE_SUSPEND":
@@ -79,11 +67,6 @@
     "Update the number of instances in your service's target configuration using an `options.json` file.",
   "SERVICE_ACTIONS.SDK_SERVICE_SCALE_NOTE":
     "Scaling to fewer instances is not supported.",
-  "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_1": "You must delete",
-  "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_2":
-    "via the DC/OS CLI. Copy and paste this command into the CLI. See the",
-  "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_3":
-    "To clean up resources reserved by your service, run the",
   "SERVICE_ACTIONS.SDK_SERVICE_UPDATE_PART_1":
     "To update this service's configuration, please update",
   "SERVICE_ACTIONS.SDK_SERVICE_UPDATE_PART_2": "Run the following CLI command:",

--- a/tests/pages/jobs/JobActions-cy.js
+++ b/tests/pages/jobs/JobActions-cy.js
@@ -13,9 +13,7 @@ describe("Job Actions", function() {
     });
 
     it("opens the correct jobs edit modal", function() {
-      cy
-        .get('.modal .form-panel input[name="id"]')
-        .should("to.have.value", "foo");
+      cy.get(".modal .form-panel form input").should("to.have.value", "foo");
     });
 
     it("closes modal on successful API request", function() {

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -572,6 +572,21 @@ describe("Service Actions", function() {
       cy.get(".modal").should("not.exist");
     });
 
+    it("submits destroy with enter", function() {
+      clickHeaderAction("Delete");
+
+      cy
+        .get(".modal-header")
+        .contains("Delete Service")
+        .should("to.have.length", 1);
+
+      cy.get(".modal-body p").contains("sdk-sleep");
+      cy.get(".modal .filter-input-text").should("exist");
+
+      cy.get(".modal .filter-input-text").type("sdk-sleep{enter}");
+      cy.get(".modal .filter-input-text").should("be.empty");
+    });
+
     it("opens the scale dialog", function() {
       clickHeaderAction("Scale");
 


### PR DESCRIPTION
When you trigger to delete a framework we'll have to show the "deleting" status and disable the dropdowns.

## So If you delete elastic:
![image](https://user-images.githubusercontent.com/180432/31156258-363ca4d0-a868-11e7-9219-be06c464fbe6.png)

## Deleting Status and disabled dropdown 1:
![image](https://user-images.githubusercontent.com/180432/31156273-5752edd2-a868-11e7-8a82-ec1f938d95bf.png)


## Deleting Status and disabled dropdown 2:
![image](https://user-images.githubusercontent.com/180432/31156276-5c75c712-a868-11e7-8e46-f5b7190bc2dd.png)


**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
