### PR TITLE
feat(babel): allow stage-3 syntax

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
   plugins: ['transform-runtime'],
-  presets: ['es2015', 'react']
+  presets: ['es2015', 'stage-3', 'react']
 }
 

--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -1,33 +1,39 @@
-var babel = require('babel-core');
-var jestPreset = require('babel-preset-jest');
-var jison = require('jison');
-var webpackAlias = require('jest-webpack-alias');
+var babel = require("babel-core");
+var jestPreset = require("babel-preset-jest");
+var jison = require("jison");
+var webpackAlias = require("jest-webpack-alias");
 
 module.exports = {
   // Gets called by jest during test prep for every module.
   // src is the raw module content as a String.
-  process: function (src, filename) {
+  process: function(src, filename) {
     var isJISON = filename.match(/\.jison$/i);
     // Don't bother doing anything to node_modules
-    if (filename.indexOf('node_modules') === -1 || filename.indexOf('node_modules/dcos-dygraphs') > -1) {
+    if (
+      filename.indexOf("node_modules") === -1 ||
+      filename.indexOf("node_modules/dcos-dygraphs") > -1
+    ) {
       // Don't load image data - it can't be parsed by jest.
       if (filename.match(/\.(jpe?g|png|gif|bmp|svg|less|raml)$/i)) {
-        return '';
+        return "";
       }
       // Use JISON generator for JISON grammar
       if (isJISON) {
-        src = (new jison.Generator(src)).generate();
+        src = new jison.Generator(src).generate();
       }
       // Run our modules through Babel before running tests
       if (babel.util.canCompile(filename) || isJISON) {
         src = babel.transform(src, {
-          auxiliaryCommentBefore: ' istanbul ignore next ',
+          auxiliaryCommentBefore: " istanbul ignore next ",
           filename,
-          presets: [jestPreset].concat([
-            'babel-preset-es2015',
-            'babel-preset-react'
-          ].map(require.resolve)),
-          retainLines: true,
+          presets: [jestPreset].concat(
+            [
+              "babel-preset-es2015",
+              "babel-preset-stage-3",
+              "babel-preset-react"
+            ].map(require.resolve)
+          ),
+          retainLines: true
         }).code;
       }
       // Run our modules through the jest-webpack-alias plugin so we

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -372,6 +372,47 @@
         }
       }
     },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "from": "babel-helper-builder-binary-assignment-operator-visitor@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "dependencies": {
+        "babel-types": {
+          "version": "6.26.0",
+          "from": "babel-types@^6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.26.0",
+              "from": "babel-runtime@^6.26.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.5.1",
+                  "from": "core-js@^2.4.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.11.0",
+                  "from": "regenerator-runtime@^0.11.0",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "from": "lodash@^4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "from": "to-fast-properties@^1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+        }
+      }
+    },
     "babel-helper-builder-react-jsx": {
       "version": "6.8.0",
       "from": "babel-helper-builder-react-jsx@>=6.8.0 <7.0.0",
@@ -435,6 +476,121 @@
           "version": "6.24.1",
           "from": "babel-types@^6.24.1",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
+        }
+      }
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "from": "babel-helper-explode-assignable-expression@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "dependencies": {
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "from": "babel-code-frame@^6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz"
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "from": "babel-messages@^6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "from": "babel-traverse@^6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.26.0",
+              "from": "babel-runtime@^6.26.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.5.1",
+                  "from": "core-js@^2.4.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.11.0",
+                  "from": "regenerator-runtime@^0.11.0",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "from": "babel-types@^6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.26.0",
+              "from": "babel-runtime@^6.26.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.5.1",
+                  "from": "core-js@^2.4.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.11.0",
+                  "from": "regenerator-runtime@^0.11.0",
+                  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "from": "babylon@^6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz"
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "from": "chalk@^1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+        },
+        "debug": {
+          "version": "2.6.9",
+          "from": "debug@^2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+        },
+        "globals": {
+          "version": "9.18.0",
+          "from": "globals@^9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "from": "invariant@^2.2.2",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "from": "js-tokens@^3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "from": "lodash@^4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        },
+        "ms": {
+          "version": "2.0.0",
+          "from": "ms@2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "from": "supports-color@^2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "from": "to-fast-properties@^1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
         }
       }
     },
@@ -525,6 +681,107 @@
           "version": "6.24.1",
           "from": "babel-types@^6.24.1",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
+        }
+      }
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "from": "babel-helper-remap-async-to-generator@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "dependencies": {
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "from": "babel-code-frame@>=6.26.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz"
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "from": "babel-messages@>=6.23.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "from": "babel-traverse@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.26.0",
+              "from": "babel-runtime@>=6.26.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
+            }
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "from": "babel-types@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.26.0",
+              "from": "babel-runtime@^6.26.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
+            }
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "from": "babylon@>=6.18.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz"
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "from": "chalk@>=1.1.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+        },
+        "core-js": {
+          "version": "2.5.1",
+          "from": "core-js@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+        },
+        "debug": {
+          "version": "2.6.9",
+          "from": "debug@>=2.6.8 <3.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+        },
+        "globals": {
+          "version": "9.18.0",
+          "from": "globals@>=9.18.0 <10.0.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "from": "invariant@>=2.2.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "from": "js-tokens@>=3.0.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "from": "lodash@>=4.17.4 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        },
+        "ms": {
+          "version": "2.0.0",
+          "from": "ms@2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.11.0",
+          "from": "regenerator-runtime@>=0.11.0 <0.12.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "from": "to-fast-properties@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
         }
       }
     },
@@ -636,6 +893,21 @@
       "from": "babel-plugin-react-transform@>=2.0.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-transform/-/babel-plugin-react-transform-2.0.2.tgz"
     },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-async-functions@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz"
+    },
+    "babel-plugin-syntax-async-generators": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-async-generators@>=6.5.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz"
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-exponentiation-operator@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz"
+    },
     "babel-plugin-syntax-flow": {
       "version": "6.8.0",
       "from": "babel-plugin-syntax-flow@>=6.3.13 <7.0.0",
@@ -645,6 +917,26 @@
       "version": "6.8.0",
       "from": "babel-plugin-syntax-jsx@>=6.3.13 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.8.0.tgz"
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-object-rest-spread@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz"
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "from": "babel-plugin-syntax-trailing-function-commas@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz"
+    },
+    "babel-plugin-transform-async-generator-functions": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-async-generator-functions@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz"
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-async-to-generator@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz"
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
@@ -902,10 +1194,37 @@
       "from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz"
     },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-exponentiation-operator@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz"
+    },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.8.0",
       "from": "babel-plugin-transform-flow-strip-types@>=6.3.13 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.8.0.tgz"
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "from": "babel-plugin-transform-object-rest-spread@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.26.0",
+          "from": "babel-runtime@^6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
+        },
+        "core-js": {
+          "version": "2.5.1",
+          "from": "core-js@^2.4.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.11.0",
+          "from": "regenerator-runtime@^0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+        }
+      }
     },
     "babel-plugin-transform-react-display-name": {
       "version": "6.8.0",
@@ -980,6 +1299,11 @@
       "version": "1.1.1",
       "from": "babel-preset-react-hmre@1.1.1",
       "resolved": "https://registry.npmjs.org/babel-preset-react-hmre/-/babel-preset-react-hmre-1.1.1.tgz"
+    },
+    "babel-preset-stage-3": {
+      "version": "6.24.1",
+      "from": "babel-preset-stage-3@6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz"
     },
     "babel-register": {
       "version": "6.24.1",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "babel-preset-jest": "19.0.0",
     "babel-preset-react": "6.5.0",
     "babel-preset-react-hmre": "1.1.1",
+    "babel-preset-stage-3": "6.24.1",
     "babel-register": "6.24.1",
     "babel-runtime": "6.23.0",
     "colors": "1.1.2",

--- a/webpack/webpack.dev.babel.js
+++ b/webpack/webpack.dev.babel.js
@@ -103,9 +103,11 @@ module.exports = Object.assign({}, webpackConfig, {
           JSON.stringify({
             cacheDirectory: "/tmp",
             // Map through resolve to fix preset loading problem
-            presets: ["babel-preset-es2015", "babel-preset-react"].map(
-              require.resolve
-            )
+            presets: [
+              "babel-preset-es2015",
+              "babel-preset-stage-3",
+              "babel-preset-react"
+            ].map(require.resolve)
           })
       },
       {

--- a/webpack/webpack.test.js
+++ b/webpack/webpack.test.js
@@ -1,6 +1,6 @@
 // Transform our es6 webpack.dev.babel.js so we can use it in ../jest/preprocessor.js
 require("babel-register")({
-  presets: ["es2015"]
+  presets: ["es2015", "stage-3"]
 });
 
 module.exports = require("./webpack.dev.babel.js");


### PR DESCRIPTION
Stage 3 brings a lot of nice things and means those proposals at the candidate level already which means little to no changes. Full list of stage 3 proposals can be found here https://github.com/tc39/proposals I'm especially looking forward to [rest and spread properties](https://github.com/tc39/proposal-object-rest-spread)