### PR TITLE
DCOS 19054: Update Buttons to match UI kit

### DIFF
--- a/plugins/nodes/src/js/pages/NodesOverview.js
+++ b/plugins/nodes/src/js/pages/NodesOverview.js
@@ -221,11 +221,11 @@ var NodesOverview = React.createClass({
   getViewTypeRadioButtons(resetFilter) {
     const isGridActive = /\/nodes\/grid\/?/i.test(this.props.location.pathname);
 
-    var listClassSet = classNames("button button-stroke", {
+    var listClassSet = classNames("button button-outline", {
       active: !isGridActive
     });
 
-    var gridClassSet = classNames("button button-stroke", {
+    var gridClassSet = classNames("button button-outline", {
       active: isGridActive
     });
 

--- a/plugins/services/src/js/components/ConfigurationMapEditAction.js
+++ b/plugins/services/src/js/components/ConfigurationMapEditAction.js
@@ -7,7 +7,7 @@ const ConfigurationMapEditAction = ({ tabViewID, onEditClick }) => {
 
   return (
     <a
-      className="button button-link flush table-display-on-row-hover"
+      className="button button-primary-link flush table-display-on-row-hover"
       onClick={onEditClick.bind(null, { tabViewID })}
     >
       Edit

--- a/plugins/services/src/js/components/DeploymentStatusIndicator.js
+++ b/plugins/services/src/js/components/DeploymentStatusIndicator.js
@@ -60,7 +60,7 @@ class DeploymentStatusIndicator extends mixin(StoreMixin) {
 
     return (
       <button
-        className="button button-link button-primary button--deployments"
+        className="button button-primary-link button--deployments"
         onClick={this.handleDeploymentsButtonClick}
       >
         <Loader

--- a/plugins/services/src/js/components/DeploymentsModal.js
+++ b/plugins/services/src/js/components/DeploymentsModal.js
@@ -395,6 +395,7 @@ class DeploymentsModal extends mixin(StoreMixin) {
           onClose={this.handleRollbackCancel}
           leftButtonCallback={this.handleRollbackCancel}
           leftButtonText="Cancel"
+          leftButtonClassName="button button-link"
           rightButtonClassName="button button-danger"
           rightButtonCallback={this.handleRollbackConfirm}
           rightButtonText="Continue Rollback"

--- a/plugins/services/src/js/components/DeploymentsModal.js
+++ b/plugins/services/src/js/components/DeploymentsModal.js
@@ -395,7 +395,7 @@ class DeploymentsModal extends mixin(StoreMixin) {
           onClose={this.handleRollbackCancel}
           leftButtonCallback={this.handleRollbackCancel}
           leftButtonText="Cancel"
-          leftButtonClassName="button button-link"
+          leftButtonClassName="button button-primary-link"
           rightButtonClassName="button button-danger"
           rightButtonCallback={this.handleRollbackConfirm}
           rightButtonText="Continue Rollback"
@@ -507,7 +507,9 @@ class DeploymentsModal extends mixin(StoreMixin) {
 
     const footer = (
       <div className="text-align-center">
-        <button className="button" onClick={onClose}>Close</button>
+        <button className="button button-primary-link" onClick={onClose}>
+          Close
+        </button>
       </div>
     );
     const heading = (

--- a/plugins/services/src/js/components/SearchLog.js
+++ b/plugins/services/src/js/components/SearchLog.js
@@ -121,11 +121,11 @@ class SearchLog extends React.Component {
       <div className="button-group button-group-directions">
         <div
           onClick={this.changeWatching.bind(this, "previous")}
-          className="button button-default button-up-arrow button-stroke"
+          className="button button-up-arrow button-outline"
         />
         <div
           onClick={this.changeWatching.bind(this, "next")}
-          className="button button-default button-down-arrow button-stroke"
+          className="button button-down-arrow button-outline"
         />
       </div>
     );

--- a/plugins/services/src/js/components/ServiceItemNotFound.js
+++ b/plugins/services/src/js/components/ServiceItemNotFound.js
@@ -7,7 +7,7 @@ import AlertPanelHeader from "#SRC/js/components/AlertPanelHeader";
 const ServiceItemNotFound = function({ message }) {
   const footer = (
     <div className="button-collection flush-bottom">
-      <Link to="/services" className="button button-stroke">
+      <Link to="/services" className="button button-primary">
         View Services
       </Link>
     </div>

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -639,7 +639,7 @@ class GeneralServiceFormSection extends Component {
           open={this.state.convertToPodModalOpen}
           onClose={this.handleCloseConvertToPodModal}
           leftButtonText="Cancel"
-          leftButtonClassName="button button-link"
+          leftButtonClassName="button button-primary-link"
           leftButtonCallback={this.handleCloseConvertToPodModal}
           rightButtonText="Switch to Pod"
           rightButtonClassName="button button-primary"

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -641,7 +641,7 @@ class GeneralServiceFormSection extends Component {
           leftButtonText="Close"
           leftButtonCallback={this.handleCloseConvertToPodModal}
           rightButtonText="Continue"
-          rightButtonClassName="button button-success"
+          rightButtonClassName="button button-primary"
           rightButtonCallback={this.handleConvertToPod}
           showHeader={true}
         >

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -638,9 +638,10 @@ class GeneralServiceFormSection extends Component {
           header={<ModalHeading>Switching to a pod service</ModalHeading>}
           open={this.state.convertToPodModalOpen}
           onClose={this.handleCloseConvertToPodModal}
-          leftButtonText="Close"
+          leftButtonText="Cancel"
+          leftButtonClassName="button button-link"
           leftButtonCallback={this.handleCloseConvertToPodModal}
-          rightButtonText="Continue"
+          rightButtonText="Switch to Pod"
           rightButtonClassName="button button-primary"
           rightButtonCallback={this.handleConvertToPod}
           showHeader={true}

--- a/plugins/services/src/js/components/modals/CreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModal.js
@@ -856,7 +856,7 @@ class CreateServiceModal extends Component {
 
     return [
       {
-        className: "button-stroke",
+        className: "button-link",
         clickHandler: this.handleGoBack,
         label
       }

--- a/plugins/services/src/js/components/modals/CreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModal.js
@@ -896,6 +896,7 @@ class CreateServiceModal extends Component {
           open={this.state.isConfirmOpen}
           onClose={this.handleCloseConfirmModal}
           leftButtonText="Cancel"
+          leftButtonClassName="button button-link"
           leftButtonCallback={this.handleCloseConfirmModal}
           rightButtonText="Discard"
           rightButtonClassName="button button-danger"

--- a/plugins/services/src/js/components/modals/CreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModal.js
@@ -856,7 +856,7 @@ class CreateServiceModal extends Component {
 
     return [
       {
-        className: "button-link",
+        className: "button-primary-link",
         clickHandler: this.handleGoBack,
         label
       }
@@ -896,7 +896,7 @@ class CreateServiceModal extends Component {
           open={this.state.isConfirmOpen}
           onClose={this.handleCloseConfirmModal}
           leftButtonText="Cancel"
-          leftButtonClassName="button button-link"
+          leftButtonClassName="button button-primary-link"
           leftButtonCallback={this.handleCloseConfirmModal}
           rightButtonText="Discard"
           rightButtonClassName="button button-danger"

--- a/plugins/services/src/js/components/modals/KillPodInstanceModal.js
+++ b/plugins/services/src/js/components/modals/KillPodInstanceModal.js
@@ -141,7 +141,7 @@ class KillPodInstanceModal extends React.Component {
         open={open}
         onClose={onClose}
         leftButtonText="Cancel"
-        leftButtonClassName="button button-link"
+        leftButtonClassName="button button-primary-link"
         leftButtonCallback={onClose}
         rightButtonText={buttonText}
         rightButtonClassName="button button-danger"

--- a/plugins/services/src/js/components/modals/KillPodInstanceModal.js
+++ b/plugins/services/src/js/components/modals/KillPodInstanceModal.js
@@ -140,7 +140,8 @@ class KillPodInstanceModal extends React.Component {
         header={header}
         open={open}
         onClose={onClose}
-        leftButtonText="Close"
+        leftButtonText="Cancel"
+        leftButtonClassName="button button-link"
         leftButtonCallback={onClose}
         rightButtonText={buttonText}
         rightButtonClassName="button button-danger"

--- a/plugins/services/src/js/components/modals/KillTaskModal.js
+++ b/plugins/services/src/js/components/modals/KillTaskModal.js
@@ -132,7 +132,8 @@ class KillTaskModal extends React.Component {
         header={header}
         open={open}
         onClose={onClose}
-        leftButtonText="Close"
+        leftButtonText="Cancel"
+        leftButtonClassName="button button-link"
         leftButtonCallback={onClose}
         rightButtonText={buttonText}
         rightButtonClassName="button button-danger"

--- a/plugins/services/src/js/components/modals/KillTaskModal.js
+++ b/plugins/services/src/js/components/modals/KillTaskModal.js
@@ -133,7 +133,7 @@ class KillTaskModal extends React.Component {
         open={open}
         onClose={onClose}
         leftButtonText="Cancel"
-        leftButtonClassName="button button-link"
+        leftButtonClassName="button button-primary-link"
         leftButtonCallback={onClose}
         rightButtonText={buttonText}
         rightButtonClassName="button button-danger"

--- a/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
+++ b/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
@@ -519,7 +519,7 @@ class ServiceActionDisabledModal extends React.Component {
 
     return (
       <div className="button-collection text-align-center flush-bottom">
-        <button className="button" onClick={onClose}>
+        <button className="button button-primary-link" onClick={onClose}>
           {intl.formatMessage({ id: "BUTTON.CLOSE" })}
         </button>
       </div>

--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -250,6 +250,7 @@ class ServiceDestroyModal extends React.Component {
         open={open}
         onClose={this.handleModalClose}
         leftButtonText="Cancel"
+        leftButtonClassName="button button-primary-link"
         leftButtonCallback={this.handleModalClose}
         rightButtonText={itemText}
         rightButtonClassName="button button-danger"

--- a/plugins/services/src/js/components/modals/ServiceGroupFormModal.js
+++ b/plugins/services/src/js/components/modals/ServiceGroupFormModal.js
@@ -71,7 +71,7 @@ class ServiceGroupFormModal extends React.Component {
     const buttonDefinition = [
       {
         text: "Cancel",
-        className: "button button-link",
+        className: "button button-primary-link",
         isClose: true
       },
       {

--- a/plugins/services/src/js/components/modals/ServiceGroupFormModal.js
+++ b/plugins/services/src/js/components/modals/ServiceGroupFormModal.js
@@ -71,12 +71,12 @@ class ServiceGroupFormModal extends React.Component {
     const buttonDefinition = [
       {
         text: "Cancel",
-        className: "button button-medium",
+        className: "button button-link",
         isClose: true
       },
       {
         text: "Create Group",
-        className: "button button-success button-medium",
+        className: "button button-primary",
         isSubmit: true
       }
     ];

--- a/plugins/services/src/js/components/modals/ServiceRestartModal.js
+++ b/plugins/services/src/js/components/modals/ServiceRestartModal.js
@@ -116,6 +116,7 @@ class ServiceRestartModal extends React.Component {
         open={open}
         onClose={onClose}
         leftButtonCallback={onClose}
+        leftButtonClassName="button button-link"
         rightButtonText={`Restart ${serviceLabel}`}
         rightButtonClassName="button button-danger"
         rightButtonCallback={() =>

--- a/plugins/services/src/js/components/modals/ServiceRestartModal.js
+++ b/plugins/services/src/js/components/modals/ServiceRestartModal.js
@@ -116,7 +116,7 @@ class ServiceRestartModal extends React.Component {
         open={open}
         onClose={onClose}
         leftButtonCallback={onClose}
-        leftButtonClassName="button button-link"
+        leftButtonClassName="button button-primary-link"
         rightButtonText={`Restart ${serviceLabel}`}
         rightButtonClassName="button button-danger"
         rightButtonCallback={() =>

--- a/plugins/services/src/js/components/modals/ServiceResumeModal.js
+++ b/plugins/services/src/js/components/modals/ServiceResumeModal.js
@@ -148,7 +148,7 @@ class ServiceResumeModal extends React.Component {
         open={open}
         onClose={onClose}
         leftButtonCallback={onClose}
-        leftButtonClassName="button button-link"
+        leftButtonClassName="button button-primary-link"
         rightButtonText="Resume Service"
         rightButtonClassName="button button-primary"
         rightButtonCallback={this.handleConfirmation}

--- a/plugins/services/src/js/components/modals/ServiceResumeModal.js
+++ b/plugins/services/src/js/components/modals/ServiceResumeModal.js
@@ -148,6 +148,7 @@ class ServiceResumeModal extends React.Component {
         open={open}
         onClose={onClose}
         leftButtonCallback={onClose}
+        leftButtonClassName="button button-link"
         rightButtonText="Resume Service"
         rightButtonClassName="button button-primary"
         rightButtonCallback={this.handleConfirmation}

--- a/plugins/services/src/js/components/modals/ServiceScaleFormModal.js
+++ b/plugins/services/src/js/components/modals/ServiceScaleFormModal.js
@@ -138,12 +138,12 @@ class ServiceScaleFormModal extends React.Component {
     const buttonDefinition = [
       {
         text: "Cancel",
-        className: "button button-medium",
+        className: "button button-primary-link",
         isClose: true
       },
       {
         text: "Scale Service",
-        className: "button button-primary button-medium",
+        className: "button button-primary",
         isSubmit: true
       }
     ];

--- a/plugins/services/src/js/components/modals/ServiceSuspendModal.js
+++ b/plugins/services/src/js/components/modals/ServiceSuspendModal.js
@@ -116,6 +116,7 @@ class ServiceSuspendModal extends React.Component {
         open={open}
         onClose={onClose}
         leftButtonCallback={onClose}
+        leftButtonClassName="button button-link"
         rightButtonText={`Suspend ${serviceLabel}`}
         rightButtonCallback={() => suspendItem(this.shouldForceUpdate())}
         showHeader={true}

--- a/plugins/services/src/js/components/modals/ServiceSuspendModal.js
+++ b/plugins/services/src/js/components/modals/ServiceSuspendModal.js
@@ -116,7 +116,7 @@ class ServiceSuspendModal extends React.Component {
         open={open}
         onClose={onClose}
         leftButtonCallback={onClose}
-        leftButtonClassName="button button-link"
+        leftButtonClassName="button button-primary-link"
         rightButtonText={`Suspend ${serviceLabel}`}
         rightButtonCallback={() => suspendItem(this.shouldForceUpdate())}
         showHeader={true}

--- a/plugins/services/src/js/containers/pod-detail/PodHeader.js
+++ b/plugins/services/src/js/containers/pod-detail/PodHeader.js
@@ -60,7 +60,7 @@ class PodHeader extends React.Component {
         Scale
       </button>,
       <button
-        className="button flush-bottom button-stroke"
+        className="button flush-bottom button-outline"
         key="action-button-edit"
         onClick={this.props.onEdit}
       >
@@ -69,7 +69,7 @@ class PodHeader extends React.Component {
       <Dropdown
         key="actions-dropdown"
         anchorRight={true}
-        buttonClassName="button button-stroke dropdown-toggle"
+        buttonClassName="button button-outline dropdown-toggle"
         dropdownMenuClassName="dropdown-menu"
         dropdownMenuListClassName="dropdown-menu-list"
         dropdownMenuListItemClassName="clickable"

--- a/plugins/services/src/js/containers/pod-instances/PodInstancesView.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesView.js
@@ -61,7 +61,10 @@ class PodInstancesView extends React.Component {
 
     return (
       <div className="button-collection flush-bottom">
-        <div className="button button-link" onClick={this.handleKillClick}>
+        <div
+          className="button button-primary-link"
+          onClick={this.handleKillClick}
+        >
           <Icon id="repeat" size="mini" />
           <span>Restart</span>
         </div>

--- a/plugins/services/src/js/containers/services/EmptyServiceTree.js
+++ b/plugins/services/src/js/containers/services/EmptyServiceTree.js
@@ -6,10 +6,10 @@ import AlertPanelHeader from "#SRC/js/components/AlertPanelHeader";
 const EmptyServiceTree = function({ onCreateGroup, onCreateService }) {
   const footer = (
     <div className="button-collection flush-bottom">
-      <button className="button button-stroke" onClick={onCreateGroup}>
-        Create Group
+      <button className="button button-primary-link" onClick={onCreateGroup}>
+        Create a Group
       </button>
-      <button className="button button-success" onClick={onCreateService}>
+      <button className="button button-primary" onClick={onCreateService}>
         Run a Service
       </button>
     </div>

--- a/plugins/services/src/js/containers/tasks/TasksView.js
+++ b/plugins/services/src/js/containers/tasks/TasksView.js
@@ -188,10 +188,10 @@ class TasksView extends mixin(SaveStateMixin) {
       handleStopClick = this.handleActionClick.bind(this, "stop");
     }
 
-    const restartButtonClasses = classNames("button button-link", {
+    const restartButtonClasses = classNames("button button-primary-link", {
       disabled: isDeploying || isSDK
     });
-    const stopButtonClasses = classNames("button button-link", {
+    const stopButtonClasses = classNames("button button-primary-link", {
       disabled: hasSchedulerTask
     });
 

--- a/plugins/services/src/js/pages/task-details/TaskFileViewer.js
+++ b/plugins/services/src/js/pages/task-details/TaskFileViewer.js
@@ -97,7 +97,7 @@ class TaskFileViewer extends React.Component {
       const name = item.getName();
 
       const classes = classNames({
-        "button button-stroke": true,
+        "button button-outline": true,
         active: name === selectedName
       });
 
@@ -193,7 +193,7 @@ class TaskFileViewer extends React.Component {
       this.getSelectionComponent(selectedLogFile),
       <Tooltip key="tooltip" anchor="end" content={"Download log file"}>
         <a
-          className="button button-stroke"
+          className="button button-primary-link"
           disabled={!filePath}
           href={TaskDirectoryActions.getDownloadURL(task.slave_id, filePath)}
         >

--- a/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
+++ b/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
@@ -225,7 +225,7 @@ class TaskSystemLogsContainer extends mixin(StoreMixin) {
     const { streams, selectedStream } = this.state;
     const buttons = streams.map((name, index) => {
       const classes = classNames({
-        "button button-stroke": true,
+        "button button-outline": true,
         active: name === selectedStream
       });
 
@@ -306,7 +306,7 @@ class TaskSystemLogsContainer extends mixin(StoreMixin) {
     // logs with a POST request
     return (
       <a
-        className="button button-stroke"
+        className="button button-outline"
         disabled={!task}
         href={SystemLogUtil.getUrl(task.slave_id, params, false, "/download")}
         key="download"

--- a/plugins/services/src/js/pages/task-details/__tests__/TaskFileViewer-test.js
+++ b/plugins/services/src/js/pages/task-details/__tests__/TaskFileViewer-test.js
@@ -42,7 +42,7 @@ describe("TaskFileViewer", function() {
         />,
         this.container
       );
-      const btn = this.container.querySelector("a.button.button-stroke");
+      const btn = this.container.querySelector("a.button.button-primary-link");
       // If btn.props.disabled = true, then disabled attribute will return an object.
       // If btn.props.disabled = false, then disabled attribute will be undefined.
       // So here we just test to see if attribute exists
@@ -50,7 +50,7 @@ describe("TaskFileViewer", function() {
     });
 
     it("should set button not disabled when file is found", function() {
-      const btn = this.container.querySelector("a.button.button-stroke");
+      const btn = this.container.querySelector("a.button.button-primary-link");
       // If btn.props.disabled = false, then disabled attribute will be undefined
       expect(btn.attributes.disabled).toEqual(undefined);
     });

--- a/src/js/components/FilterButtons.js
+++ b/src/js/components/FilterButtons.js
@@ -41,7 +41,7 @@ class FilterButtons extends React.Component {
     const filterCount = this.getCount(itemList);
 
     return filters.map(filter => {
-      const classSet = classNames("button button-stroke", {
+      const classSet = classNames("button button-outline", {
         "button-inverse": inverseStyle,
         active: filter.toLowerCase() === selectedFilter.toLowerCase()
       });

--- a/src/js/components/FormModal.js
+++ b/src/js/components/FormModal.js
@@ -149,7 +149,7 @@ FormModal.defaultProps = {
   buttonDefinition: [
     {
       text: "Cancel",
-      className: "button button-link",
+      className: "button button-primary-link",
       isClose: true
     },
     {

--- a/src/js/components/FormModal.js
+++ b/src/js/components/FormModal.js
@@ -149,12 +149,12 @@ FormModal.defaultProps = {
   buttonDefinition: [
     {
       text: "Cancel",
-      className: "button button-medium",
+      className: "button button-link",
       isClose: true
     },
     {
       text: "Create",
-      className: "button button-success button-medium",
+      className: "button button-primary",
       isSubmit: true
     }
   ],

--- a/src/js/components/PageHeaderActions.js
+++ b/src/js/components/PageHeaderActions.js
@@ -51,7 +51,7 @@ class PageHeaderActions extends React.Component {
     if (addButton != null) {
       const { label, onItemSelect, className } = addButton;
       const buttonClasses = classNames(
-        "button button-link button-narrow",
+        "button button-primary-link button-narrow",
         className
       );
 

--- a/src/js/components/PageHeaderActionsMenu.js
+++ b/src/js/components/PageHeaderActionsMenu.js
@@ -32,7 +32,7 @@ const PageHeaderActionsMenu = ({ anchorRight, children, iconID }) => {
   return (
     <Dropdown
       anchorRight={anchorRight}
-      buttonClassName="button button-link button-narrow"
+      buttonClassName="button button-primary-link button-narrow"
       items={getMenuItems(children, iconID)}
       onItemSelection={handleItemSelection}
       persistentID="trigger"

--- a/src/js/components/RepositoriesTable.js
+++ b/src/js/components/RepositoriesTable.js
@@ -229,6 +229,7 @@ class RepositoriesTable extends mixin(StoreMixin) {
           open={!!state.repositoryToRemove}
           onClose={this.handleDeleteCancel}
           leftButtonCallback={this.handleDeleteCancel}
+          leftButtonClassName="button button-link"
           rightButtonCallback={this.handleDeleteRepository}
           rightButtonClassName="button button-danger"
           rightButtonText={`${StringUtil.capitalize(UserActions.DELETE)} Repository`}

--- a/src/js/components/RepositoriesTable.js
+++ b/src/js/components/RepositoriesTable.js
@@ -173,7 +173,7 @@ class RepositoriesTable extends mixin(StoreMixin) {
     return (
       <div className="flex-align-right">
         <a
-          className="button button-link button-danger table-display-on-row-hover"
+          className="button button-danger-link table-display-on-row-hover"
           onClick={this.handleOpenConfirm.bind(this, repositoryToRemove)}
         >
           {StringUtil.capitalize(UserActions.DELETE)}
@@ -229,7 +229,7 @@ class RepositoriesTable extends mixin(StoreMixin) {
           open={!!state.repositoryToRemove}
           onClose={this.handleDeleteCancel}
           leftButtonCallback={this.handleDeleteCancel}
-          leftButtonClassName="button button-link"
+          leftButtonClassName="button button-primary-link"
           rightButtonCallback={this.handleDeleteRepository}
           rightButtonClassName="button button-danger"
           rightButtonText={`${StringUtil.capitalize(UserActions.DELETE)} Repository`}

--- a/src/js/components/ReviewConfig.js
+++ b/src/js/components/ReviewConfig.js
@@ -61,7 +61,7 @@ class ReviewConfig extends React.Component {
           </div>
           <div className="column-8 text-align-right">
             <a
-              className="button button-small button-stroke button-rounded"
+              className="button button-primary-link"
               onClick={ieDownloadConfig}
               download={fileName}
               href={`data:attachment/json;content-disposition=attachment;filename=${fileName};charset=utf-8,${encodeURIComponent(configString)}`}

--- a/src/js/components/SchemaForm.js
+++ b/src/js/components/SchemaForm.js
@@ -202,7 +202,7 @@ class SchemaForm extends mixin(StoreMixin, InternalStorageMixin) {
         className="form-row-element form-row-remove-button form-row-element-mixed-label-presence"
       >
         <button
-          className="button button-narrow button-link"
+          className="button button-narrow button-primary-link"
           onClick={this.handleRemoveRow.bind(this, generalDefinition, prop, id)}
         >
           <Icon id="close" size="mini" />

--- a/src/js/components/charts/ResourceBarChart.js
+++ b/src/js/components/charts/ResourceBarChart.js
@@ -69,7 +69,7 @@ const ResourceBarChart = React.createClass({
     const resourceLabels = ResourcesUtil.getResourceLabels();
 
     return ResourcesUtil.getDefaultResources().map(resource => {
-      const classSet = classNames("button button-stroke", {
+      const classSet = classNames("button button-outline", {
         active: selectedResource === resource
       });
 

--- a/src/js/components/modals/ActionsModal.js
+++ b/src/js/components/modals/ActionsModal.js
@@ -250,7 +250,7 @@ class ActionsModal extends mixin(StoreMixin) {
         open={!!action}
         onClose={this.handleButtonCancel}
         leftButtonCallback={this.handleButtonCancel}
-        leftButtonClassName="button button-link"
+        leftButtonClassName="button button-primary-link"
         rightButtonCallback={this.handleButtonConfirm}
         rightButtonText={StringUtil.capitalize(action)}
         showHeader={true}

--- a/src/js/components/modals/ActionsModal.js
+++ b/src/js/components/modals/ActionsModal.js
@@ -250,6 +250,7 @@ class ActionsModal extends mixin(StoreMixin) {
         open={!!action}
         onClose={this.handleButtonCancel}
         leftButtonCallback={this.handleButtonCancel}
+        leftButtonClassName="button button-link"
         rightButtonCallback={this.handleButtonConfirm}
         rightButtonText={StringUtil.capitalize(action)}
         showHeader={true}

--- a/src/js/components/modals/AddRepositoryFormModal.js
+++ b/src/js/components/modals/AddRepositoryFormModal.js
@@ -113,12 +113,12 @@ class AddRepositoryFormModal extends mixin(StoreMixin) {
     return [
       {
         text: "Close",
-        className: "button button-medium",
+        className: "button button-link",
         isClose: true
       },
       {
         text: "Add",
-        className: "button button-success button-medium",
+        className: "button button-primary",
         isSubmit: true
       }
     ];

--- a/src/js/components/modals/AddRepositoryFormModal.js
+++ b/src/js/components/modals/AddRepositoryFormModal.js
@@ -113,7 +113,7 @@ class AddRepositoryFormModal extends mixin(StoreMixin) {
     return [
       {
         text: "Cancel",
-        className: "button button-link",
+        className: "button button-primary-link",
         isClose: true
       },
       {

--- a/src/js/components/modals/AddRepositoryFormModal.js
+++ b/src/js/components/modals/AddRepositoryFormModal.js
@@ -112,12 +112,12 @@ class AddRepositoryFormModal extends mixin(StoreMixin) {
   getButtonDefinition() {
     return [
       {
-        text: "Close",
+        text: "Cancel",
         className: "button button-link",
         isClose: true
       },
       {
-        text: "Add",
+        text: "Add Repository",
         className: "button button-primary",
         isSubmit: true
       }

--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -144,7 +144,7 @@ class CliInstallModal extends React.Component {
 
     return Object.keys(osTypes).map((name, index) => {
       const classSet = classNames({
-        "button button-stroke": true,
+        "button button-outline": true,
         active: name === selectedOS
       });
 

--- a/src/js/components/modals/InstallPackageModal.js
+++ b/src/js/components/modals/InstallPackageModal.js
@@ -371,7 +371,7 @@ class InstallPackageModal
       <div className="modal-footer">
         <div className="button-collection flush-bottom">
           <button
-            className="button button-link"
+            className="button button-primary-link"
             onClick={this.handleModalClose}
           >
             Cancel
@@ -410,7 +410,7 @@ class InstallPackageModal
         <div className="modal-footer">
           <div className="button-collection flush-bottom">
             <button
-              className="button button-link"
+              className="button button-primary-link"
               onClick={this.handleChangeTab.bind(this, "advancedInstall")}
             >
               Back

--- a/src/js/components/modals/InstallPackageModal.js
+++ b/src/js/components/modals/InstallPackageModal.js
@@ -351,7 +351,7 @@ class InstallPackageModal
         <div className="modal-footer">
           <div className="button-collection button-collection-stacked horizontal-center">
             <button
-              className="button button-success button-block"
+              className="button button-primary button-block"
               onClick={this.props.onClose}
             >
               OK
@@ -370,12 +370,15 @@ class InstallPackageModal
     return (
       <div className="modal-footer">
         <div className="button-collection flush-bottom">
-          <button className="button" onClick={this.handleModalClose}>
+          <button
+            className="button button-link"
+            onClick={this.handleModalClose}
+          >
             Cancel
           </button>
           <button
             disabled={pendingRequest || hasFormErrors}
-            className="button button-success"
+            className="button button-primary"
             onClick={this.handleChangeTab.bind(this, "reviewAdvancedConfig")}
           >
             Review and Deploy
@@ -407,14 +410,14 @@ class InstallPackageModal
         <div className="modal-footer">
           <div className="button-collection flush-bottom">
             <button
-              className="button"
+              className="button button-link"
               onClick={this.handleChangeTab.bind(this, "advancedInstall")}
             >
               Back
             </button>
             <button
               disabled={pendingRequest}
-              className="button button-success"
+              className="button button-primary"
               onClick={this.handleInstallPackage}
             >
               {buttonText}
@@ -450,7 +453,7 @@ class InstallPackageModal
         <div className="modal-footer">
           <div className="button-collection button-collection-stacked horizontal-center">
             <a
-              className="button button-success button-block"
+              className="button button-primary button-block"
               href={`#/services/detail/${encodeURIComponent(appId)}`}
             >
               Go To Service

--- a/src/js/components/modals/JobFormModal.js
+++ b/src/js/components/modals/JobFormModal.js
@@ -403,7 +403,10 @@ class JobFormModal extends mixin(StoreMixin) {
 
     return (
       <div className="button-collection flush-bottom">
-        <button className="button button-link" onClick={this.handleCancel}>
+        <button
+          className="button button-primary-link"
+          onClick={this.handleCancel}
+        >
           Cancel
         </button>
         <button className="button button-primary" onClick={this.handleSubmit}>

--- a/src/js/components/modals/JobFormModal.js
+++ b/src/js/components/modals/JobFormModal.js
@@ -403,10 +403,10 @@ class JobFormModal extends mixin(StoreMixin) {
 
     return (
       <div className="button-collection flush-bottom">
-        <button className="button" onClick={this.handleCancel}>
+        <button className="button button-link" onClick={this.handleCancel}>
           Cancel
         </button>
-        <button className="button button-success" onClick={this.handleSubmit}>
+        <button className="button button-primary" onClick={this.handleSubmit}>
           {submitLabel}
         </button>
       </div>

--- a/src/js/components/modals/JobStopRunModal.js
+++ b/src/js/components/modals/JobStopRunModal.js
@@ -107,7 +107,7 @@ class JobStopRunModal extends mixin(StoreMixin) {
         onClose={onClose}
         leftButtonText="Cancel"
         leftButtonCallback={onClose}
-        leftButtonClassName="button button-link"
+        leftButtonClassName="button button-primary-link"
         rightButtonText={rightButtonText}
         rightButtonClassName="button button-danger"
         rightButtonCallback={this.handleButtonConfirm}

--- a/src/js/components/modals/JobStopRunModal.js
+++ b/src/js/components/modals/JobStopRunModal.js
@@ -105,8 +105,9 @@ class JobStopRunModal extends mixin(StoreMixin) {
         header={this.getContentHeader(selectedItems, selectedItemsLength)}
         open={open}
         onClose={onClose}
-        leftButtonText="Close"
+        leftButtonText="Cancel"
         leftButtonCallback={onClose}
+        leftButtonClassName="button button-link"
         rightButtonText={rightButtonText}
         rightButtonClassName="button button-danger"
         rightButtonCallback={this.handleButtonConfirm}

--- a/src/js/components/modals/UserFormModal.js
+++ b/src/js/components/modals/UserFormModal.js
@@ -72,12 +72,12 @@ class UserFormModal extends mixin(StoreMixin) {
     return Hooks.applyFilter("userFormModalButtonDefinition", [
       {
         text: "Cancel",
-        className: "button button-medium",
+        className: "button button-link",
         isClose: true
       },
       {
         text: "Add User",
-        className: "button button-success button-medium",
+        className: "button button-primary",
         isSubmit: true
       }
     ]);

--- a/src/js/components/modals/UserFormModal.js
+++ b/src/js/components/modals/UserFormModal.js
@@ -72,7 +72,7 @@ class UserFormModal extends mixin(StoreMixin) {
     return Hooks.applyFilter("userFormModalButtonDefinition", [
       {
         text: "Cancel",
-        className: "button button-link",
+        className: "button button-primary-link",
         isClose: true
       },
       {

--- a/src/js/pages/DashboardPage.js
+++ b/src/js/pages/DashboardPage.js
@@ -136,7 +136,7 @@ var DashboardPage = React.createClass({
     var componentCountWord = StringUtil.pluralize("Component", componentCount);
 
     return (
-      <Link to="/components" className="button button-rounded button-stroke">
+      <Link to="/components" className="button">
         {`View all ${componentCount} ${componentCountWord}`}
       </Link>
     );
@@ -153,7 +153,7 @@ var DashboardPage = React.createClass({
     }
 
     return (
-      <Link to="/services" className="button button-rounded button-stroke">
+      <Link to="/services" className="button">
         <FormattedMessage
           id="DASHBOARD.VIEW_ALL"
           values={{

--- a/src/js/pages/DashboardPage.js
+++ b/src/js/pages/DashboardPage.js
@@ -136,7 +136,7 @@ var DashboardPage = React.createClass({
     var componentCountWord = StringUtil.pluralize("Component", componentCount);
 
     return (
-      <Link to="/components" className="button">
+      <Link to="/components" className="button button-primary-link">
         {`View all ${componentCount} ${componentCountWord}`}
       </Link>
     );
@@ -153,7 +153,7 @@ var DashboardPage = React.createClass({
     }
 
     return (
-      <Link to="/services" className="button">
+      <Link to="/services" className="button button-primary-link">
         <FormattedMessage
           id="DASHBOARD.VIEW_ALL"
           values={{

--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -306,7 +306,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
         >
           <button
             disabled={isLoadingSelectedVersion}
-            className="button button-outline"
+            className="button button-primary-link"
             onClick={this.handleConfigureInstallModalOpen}
           >
             Configure

--- a/src/js/pages/jobs/JobDetailPage.js
+++ b/src/js/pages/jobs/JobDetailPage.js
@@ -188,6 +188,7 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
         onClose={this.closeDialog}
         leftButtonText="Cancel"
         leftButtonCallback={this.closeDialog}
+        leftButtonClassName="button button-link"
         rightButtonText={actionButtonLabel}
         rightButtonClassName="button button-danger"
         rightButtonCallback={this.handleAcceptDestroyDialog.bind(

--- a/src/js/pages/jobs/JobDetailPage.js
+++ b/src/js/pages/jobs/JobDetailPage.js
@@ -188,7 +188,7 @@ class JobDetailPage extends mixin(StoreMixin, TabsMixin) {
         onClose={this.closeDialog}
         leftButtonText="Cancel"
         leftButtonCallback={this.closeDialog}
-        leftButtonClassName="button button-link"
+        leftButtonClassName="button button-primary-link"
         rightButtonText={actionButtonLabel}
         rightButtonClassName="button button-danger"
         rightButtonCallback={this.handleAcceptDestroyDialog.bind(

--- a/src/js/pages/jobs/JobRunHistoryTable.js
+++ b/src/js/pages/jobs/JobRunHistoryTable.js
@@ -211,7 +211,7 @@ class JobRunHistoryTable extends React.Component {
     return (
       <div className="button-collection flush-bottom">
         <div
-          className="button button-stroke button-danger"
+          className="button button-outline button-danger"
           onClick={this.handleStopClick}
         >
           Stop

--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -185,7 +185,7 @@ class JobsTab extends mixin(StoreMixin) {
     return (
       <div className="button-collection flush-bottom">
         <button
-          className="button button-success"
+          className="button button-primary"
           onClick={this.handleOpenJobFormModal}
         >
           Create a Job

--- a/src/styles/components/buttons/styles.less
+++ b/src/styles/components/buttons/styles.less
@@ -8,65 +8,7 @@
     transform: translateX(-50%);
   }
 
-  // We need to override CNVS display properies for button elements, as flex is
-  // invalid in Safari and other browsers.
-  button {
-
-    &,
-    &.button {
-      display: inline-block;
-
-      &.button-block {
-        display: block;
-      }
-    }
-  }
-
-  // TODO: Name this animation specifically.
   .button {
-
-    &-leave,
-    &-enter,
-    &-appear {
-      opacity: 0.01;
-      transform: translate(-50%, -100%);
-      transition: transform 350ms ease-in, opacity 350ms ease-in;
-
-      &.button {
-
-        &-enter-active,
-        &-appear-active {
-          opacity: 1;
-          transform: translate(-50%, 0);
-        }
-
-        &-leave-active {
-          opacity: 0.01;
-          transform: translate(-50%, -100%);
-          transition: transform 350ms ease-in, opacity 350ms ease-in;
-        }
-      }
-    }
-
-    &-leave {
-      opacity: 1;
-      transform: translate(-50%, 0);
-    }
-
-    // TODO: https://github.com/dcos/dcos-ui/pull/741#discussion_r71219594
-    &.button-short {
-      height: auto;
-      padding-bottom: 4px;
-      padding-top: 4px;
-    }
-
-    // TODO: https://github.com/dcos/dcos-ui/pull/741#discussion_r71219660
-    &.button-fixed-width {
-
-      &.button-fixed-width-small {
-        width: @base-spacing-unit * 3;
-      }
-    }
 
     &-up-arrow,
     &-down-arrow {
@@ -175,13 +117,6 @@
     }
   }
 
-  // TODO: Audit the need for this.
-  .button-align-content {
-    align-items: center;
-    display: flex;
-    flex-flow: row nowrap;
-  }
-
   // TODO: https://github.com/dcos/dcos-ui/pull/741#discussion-diff-71220632
   .button-split-content {
     text-align: left;
@@ -207,11 +142,6 @@
       align-self: center;
       flex: 0 0 auto;
     }
-  }
-
-  // TODO: Audit the need for this.
-  .button-inverse .badge {
-    background-color: @white;
   }
 }
 

--- a/system-tests/jobs/test-jobs.js
+++ b/system-tests/jobs/test-jobs.js
@@ -94,7 +94,7 @@ describe("Jobs", function() {
 
     // Click 'Create a job'
     // Note: The current group contains the previous job
-    cy.get(".button.button-link.button-narrow").click();
+    cy.get(".button.button-primary-link.button-narrow").click();
 
     // Wait for the 'New Job' dialog to appear
     cy.get(".modal-header").contains("New Job").should("exist");
@@ -199,7 +199,7 @@ describe("Jobs", function() {
 
     // Click 'Create a job'
     // Note: The current group contains the previous jobs
-    cy.get(".button.button-link.button-narrow").click();
+    cy.get(".button.button-primary-link.button-narrow").click();
 
     // Wait for the 'New Job' dialog to appear
     // Note: The current group contains the previous two jobs
@@ -368,7 +368,7 @@ describe("Jobs", function() {
 
     // Click 'Create a job'
     // Note: The current group contains the previous jobs
-    cy.get(".button.button-link.button-narrow").click();
+    cy.get(".button.button-primary-link.button-narrow").click();
 
     // Wait for the 'New Job' dialog to appear
     cy.get(".modal-header").contains("New Job").should("exist");

--- a/system-tests/services/test-environment.js
+++ b/system-tests/services/test-environment.js
@@ -19,7 +19,7 @@ describe("Services", function() {
 
       // That should contain a 'Run a Service' button
       cy
-        .get(".page-body-content .button-success")
+        .get(".page-body-content .button-primary")
         .contains("Run a Service")
         .should("exist");
     });

--- a/tests/pages/jobs/JobActions-cy.js
+++ b/tests/pages/jobs/JobActions-cy.js
@@ -26,7 +26,7 @@ describe("Job Actions", function() {
         delay: 0
       });
       cy
-        .get(".modal .button-collection .button-success")
+        .get(".modal .button-collection .button-primary")
         .contains("Save Job")
         .click();
       cy.get(".modal").should("to.have.length", 0);

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1728,7 +1728,7 @@ describe("Service Form Modal", function() {
         .contains("button", "Review & Run")
         .click();
       // Click edit to view form
-      cy.get("a.button.button-link").eq(-1).click({ force: true });
+      cy.get("a.button.button-primary-link").eq(-1).click({ force: true });
       cy.get(".menu-tabbed-view").contains("Networking");
     });
   });

--- a/tests/pages/services/TasksTable-cy.js
+++ b/tests/pages/services/TasksTable-cy.js
@@ -103,10 +103,13 @@ describe("Tasks Table", function() {
 
     function assertActionButtons() {
       cy
-        .get(".filter-bar .button-collection .button-link > span")
+        .get(".filter-bar .button-collection .button-primary-link > span")
         .eq(0)
         .contains("Restart");
-      cy.get(".button-collection .button-link > span").eq(1).contains("Stop");
+      cy
+        .get(".button-collection .button-primary-link > span")
+        .eq(1)
+        .contains("Stop");
     }
 
     it("Select all tasks available and confirm action buttons exist", function() {

--- a/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
+++ b/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
@@ -20,7 +20,7 @@ describe("Add Repository Form Modal", function() {
 
   it("should display error if both fields aren't filled out", function() {
     cy
-      .get(".modal .modal-footer .button.button-success")
+      .get(".modal .modal-footer .button.button-primary")
       .contains("Add")
       .click();
 
@@ -37,7 +37,7 @@ describe("Add Repository Form Modal", function() {
 
   it("should display error if not a valid url", function() {
     cy
-      .get(".modal .modal-footer .button.button-success")
+      .get(".modal .modal-footer .button.button-primary")
       .contains("Add")
       .click();
 
@@ -57,7 +57,7 @@ describe("Add Repository Form Modal", function() {
       .get(".modal input")
       .eq(2)
       .type("0")
-      .get(".modal .modal-footer .button.button-success")
+      .get(".modal .modal-footer .button.button-primary")
       .contains("Add")
       .click();
 
@@ -100,7 +100,7 @@ describe("Add Repository Form Modal", function() {
       .eq(2)
       .type("0");
     cy
-      .get(".modal .modal-footer .button.button-success")
+      .get(".modal .modal-footer .button.button-primary")
       .contains("Add")
       .click();
 
@@ -127,7 +127,7 @@ describe("Add Repository Form Modal", function() {
       .eq(2)
       .type("0");
     cy
-      .get(".modal .modal-footer .button.button-success")
+      .get(".modal .modal-footer .button.button-primary")
       .contains("Add")
       .click();
 

--- a/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
+++ b/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
@@ -68,7 +68,7 @@ describe("Add Repository Form Modal", function() {
       cy
         .get(".page-body-content")
         .contains("tr", "Here we go!")
-        .find(".button.button-link.button-danger")
+        .find(".button.button-primary-link.button-danger")
         .invoke("show")
         .click({ force: true });
       cy

--- a/tests/pages/system/overview/repositories/RepositoriesTab-cy.js
+++ b/tests/pages/system/overview/repositories/RepositoriesTab-cy.js
@@ -48,7 +48,7 @@ describe("Installed Packages Tab", function() {
 
   it("displays uninstall modal when uninstall is clicked", function() {
     cy
-      .get(".button.button-link.button-danger")
+      .get(".button.button-danger-link")
       .eq(0)
       .invoke("show")
       .click({ force: true });


### PR DESCRIPTION
Brings all of our buttons up to date with the latest UI kit design direction. Primary buttons are purple solid buttons. Secondary buttons are purple link buttons. This PR purposely doesn't touch the style of button group filter toggles or the layout of buttons in modals.

Examples
![image](https://user-images.githubusercontent.com/15963/31473092-37bc84de-aea7-11e7-8ab3-d55e23209ae4.png)
![image](https://user-images.githubusercontent.com/15963/31473100-409197a2-aea7-11e7-8b31-2ce690d9689e.png)
![image](https://user-images.githubusercontent.com/15963/31473110-4e2af5e8-aea7-11e7-8284-7e99f7c012b9.png)
![image](https://user-images.githubusercontent.com/15963/31473122-58412570-aea7-11e7-8ed2-c7cd59e7ff14.png)
