### PR TITLE
Change key to index as portDefinition name could be null

### DIFF
--- a/plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js
+++ b/plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js
@@ -155,9 +155,9 @@ class ServiceConnectionEndpointList extends React.Component {
   }
 
   getPortDefinitions(endpoints, service) {
-    return endpoints.map(portDefinition => {
+    return endpoints.map((portDefinition, index) => {
       return (
-        <ConfigurationMapSection key={portDefinition.name}>
+        <ConfigurationMapSection key={index}>
           <ConfigurationMapHeading>
             {portDefinition.name}
           </ConfigurationMapHeading>

--- a/plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.js
+++ b/plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.js
@@ -63,9 +63,9 @@ class ServicePodConnectionEndpointList extends React.Component {
   }
 
   getPortDefinitions(endpoints) {
-    return endpoints.map(portDefinition => {
+    return endpoints.map((portDefinition, index) => {
       return (
-        <ConfigurationMapSection key={portDefinition.name}>
+        <ConfigurationMapSection key={index}>
           <ConfigurationMapHeading>
             {portDefinition.name}
           </ConfigurationMapHeading>


### PR DESCRIPTION
Some frameworks in rare cases have a portDefinition name of null. Change key to index as portDefinition name could be null.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
