### PR TITLE
Introduce DI/IoC container

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4804,6 +4804,11 @@
       "from": "invariant@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz"
     },
+    "inversify": {
+      "version": "4.3.0",
+      "from": "inversify@latest",
+      "resolved": "https://registry.npmjs.org/inversify/-/inversify-4.3.0.tgz"
+    },
     "invert-kv": {
       "version": "1.0.0",
       "from": "invert-kv@>=1.0.0 <2.0.0",
@@ -8271,6 +8276,11 @@
       "version": "3.3.1",
       "from": "redux@3.3.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.3.1.tgz"
+    },
+    "reflect-metadata": {
+      "version": "0.1.10",
+      "from": "reflect-metadata@latest",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.10.tgz"
     },
     "regenerate": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "deep-equal": "1.0.1",
     "flux": "2.1.1",
     "intl": "1.2.5",
+    "inversify": "4.3.0",
     "less-color-lighten": "0.0.1",
     "lodash.throttle": "4.1.1",
     "md5": "2.1.0",
@@ -62,6 +63,7 @@
     "reactjs-components": "0.16.0-beta.27",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
+    "reflect-metadata": "0.1.10",
     "rxjs": "5.4.3",
     "tv4": "1.2.7"
   },

--- a/src/js/container.js
+++ b/src/js/container.js
@@ -1,0 +1,5 @@
+import { Container } from "inversify";
+
+const container = new Container();
+
+export default container;

--- a/webpack/webpack.dev.babel.js
+++ b/webpack/webpack.dev.babel.js
@@ -89,7 +89,12 @@ module.exports = Object.assign({}, webpackConfig, {
 
     new webpack.optimize.CommonsChunkPlugin("vendor", "vendor.js", Infinity),
 
-    new SVGCompilerPlugin({ baseDir: "src/img/components/icons" })
+    new SVGCompilerPlugin({ baseDir: "src/img/components/icons" }),
+
+    // Polyfill to make InversifyJS working
+    new webpack.ProvidePlugin({
+      Reflect: "reflect-metadata"
+    })
   ],
   module: {
     preLoaders: webpackConfig.module.preLoaders,

--- a/webpack/webpack.production.babel.js
+++ b/webpack/webpack.production.babel.js
@@ -83,6 +83,11 @@ module.exports = Object.assign({}, webpackConfig, {
       algorithm: "gzip",
       test: /\.js$|\.css|\.html$/,
       minRatio: 0.9
+    }),
+
+    // Polyfill to make InversifyJS working
+    new webpack.ProvidePlugin({
+      Reflect: "reflect-metadata"
     })
   ],
   module: {


### PR DESCRIPTION
In order to loosen coupling in the codebase and set the foundation for the modularization. DI can help with singletons as the container will be the source of truth.

On top of that it's easier to test code with DI, just binding a mock to the container instead of relying on Jest or other tooling that isn't ideal.

So currently there's only npm dependencies and an empty container.

The first citizen of the container's going to be the MesosStream.