### PR TITLE
feat(Banner): create Banner component and mount in Page

### DIFF
--- a/src/js/components/Banner.js
+++ b/src/js/components/Banner.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+const Banner = props => {
+  return (
+    <div className="message message-warning flush-bottom">
+      {props.children}
+    </div>
+  );
+};
+
+module.exports = Banner;

--- a/src/js/components/Page.js
+++ b/src/js/components/Page.js
@@ -2,6 +2,7 @@ import classNames from "classnames/dedupe";
 import React from "react";
 import { StoreMixin } from "mesosphere-shared-reactjs";
 
+import { MountService } from "foundation-ui";
 import BasePageHeader from "../components/PageHeader";
 import FluidGeminiScrollbar from "./FluidGeminiScrollbar";
 import InternalStorageMixin from "../mixins/InternalStorageMixin";
@@ -192,6 +193,7 @@ var Page = React.createClass({
 
     return (
       <div className={classSet}>
+        <MountService.Mount type="Page:TopBanner" />
         {this.getPageHeader(title, navigation)}
         {this.getContent()}
       </div>


### PR DESCRIPTION
This adds a generic `Banner` component. This component will be used in the [licensing private plugin](https://github.com/mesosphere/dcos-ui-plugins-private/pull/636).

This PR also introduces mounting the banner in the existing `Page` component. This will cause the banner to be shown at the top of each page when enabled (when a breach or expiry).

Closes DCOS-19135.

**Testing:**

Paste the following into `componentDidMount()` of `Page.js` component:
```
    const MockBanner = () => {
      return (
        <Banner>
          You have exceeded your 60 day limit by 2 days.
          {" "}
          <a href="https://mesosphere.com/product" className="message-link">
            More Information
          </a>
        </Banner>
      );
    };

    MountService.MountService.registerComponent(MockBanner, "Page:TopBanner");
```

After pasting this, the banner will render:
![screen shot 2017-10-19 at 5 42 10 pm](https://user-images.githubusercontent.com/1527504/31800448-d2e223ca-b4f5-11e7-8c54-ae3ffe3c2bae.png)


**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
