### PR TITLE
fix(NodesTable): Add Column to fix column sizing of the region column

### DIFF
--- a/plugins/nodes/src/js/components/NodesTable.js
+++ b/plugins/nodes/src/js/components/NodesTable.js
@@ -193,6 +193,7 @@ var NodesTable = React.createClass({
     return (
       <colgroup>
         <col />
+        <col />
         <col style={{ width: "100px" }} />
         <col style={{ width: "125px" }} />
         <col className="hidden-small-down" style={{ width: "135px" }} />


### PR DESCRIPTION
This adds some space to the region column to fit the region name in one row.

*Now*:
![image](https://user-images.githubusercontent.com/156010/31711069-43297cfa-b3f7-11e7-99d5-7b365a73f535.png)

*B4*:
![image](https://user-images.githubusercontent.com/156010/31712009-2d91f16c-b3fa-11e7-8180-939a647906b1.png)
