### PR TITLE
Introduce Mesos Stream connection

### DIFF
--- a/src/js/container.js
+++ b/src/js/container.js
@@ -1,5 +1,9 @@
 import { Container } from "inversify";
 
+import mesosStream, { MesosStreamType } from "./core/MesosStream";
+
 const container = new Container();
+
+container.bind(MesosStreamType).toConstantValue(mesosStream);
 
 export default container;

--- a/src/js/core/MesosStream.js
+++ b/src/js/core/MesosStream.js
@@ -1,0 +1,4 @@
+import { stream } from "mesos-client";
+
+export const MesosStreamType = Symbol("MesosStreamType");
+export default stream({ type: "SUBSCRIBE" }).publishReplay().refCount();


### PR DESCRIPTION
This PR adds a ready to use `MesosStream` observable one can subscribe to to get the data. 

Opened against `drozhkov/introduce-ioc-container` for your convenience.

The observable is a `ReplaySubject` that will keep all previous values[<sup>1</sup>](#limit) and replay them to every new subscriber ensuring there's no data loss. 

`toConstantValue` IoC container will ensure you're getting the very same instance of the observable. 

`refCount` means that `rxjs` will take care counting subscribers and once there's no subscribers left it will terminate the observable. Once someone subscribes again it will open a new connection.

## Testing
a bit of manual work need s to be done. `src/js/index.js` could be a good place to add this snippet.

```javascript
import container from "./container";
import {MesosStreamType} from "./core/MesosStream";

// Hey container, give me what you have for this type
const mesosStream = container.get(MesosStreamType);

const subscription = mesosStream.subscribe(
  (value) => console.log(value),
  (err) => console.log(err)
);
```

## Dependencies
✅  #2463

## Footnotes
<a name="limit"></a> 1. Limited to `Number.MAX_SAFE_INTEGER`