### PR TITLE
DCOS-19114 DCOS-19108 DCOS-19109 DCOS-19111: add filter nodes by health

### DIFF
--- a/plugins/nodes/src/js/components/NodesGridView.js
+++ b/plugins/nodes/src/js/components/NodesGridView.js
@@ -5,6 +5,7 @@ import React from "react";
 
 import Loader from "#SRC/js/components/Loader";
 import RequestErrorMsg from "#SRC/js/components/RequestErrorMsg";
+import NodesList from "#SRC/js/structs/NodesList";
 
 import NodesGridDials from "./NodesGridDials";
 
@@ -19,7 +20,7 @@ var NodesGridView = React.createClass({
   propTypes: {
     hasLoadingError: React.PropTypes.bool,
     hiddenServices: React.PropTypes.array,
-    hosts: React.PropTypes.array.isRequired,
+    hosts: React.PropTypes.instanceOf(NodesList).isRequired,
     receivedEmptyMesosState: React.PropTypes.bool,
     receivedNodeHealthResponse: React.PropTypes.bool,
     onShowServices: React.PropTypes.func.isRequired,
@@ -139,7 +140,7 @@ var NodesGridView = React.createClass({
         </div>
 
         <NodesGridDials
-          hosts={props.hosts}
+          hosts={props.hosts.getItems()}
           resourcesByFramework={props.resourcesByFramework}
           selectedResource={props.selectedResource}
           serviceColors={props.serviceColors}

--- a/plugins/nodes/src/js/components/NodesTable.js
+++ b/plugins/nodes/src/js/components/NodesTable.js
@@ -4,6 +4,7 @@ import PureRender from "react-addons-pure-render-mixin";
 import React from "react";
 import { Table, Tooltip } from "reactjs-components";
 
+import NodesList from "#SRC/js/structs/NodesList";
 import Icon from "#SRC/js/components/Icon";
 import Loader from "#SRC/js/components/Loader";
 import NodesTableHeaderLabels from "#SRC/js/constants/NodesTableHeaderLabels";
@@ -24,12 +25,12 @@ var NodesTable = React.createClass({
   mixins: [PureRender],
 
   propTypes: {
-    hosts: React.PropTypes.array.isRequired
+    hosts: React.PropTypes.object.isRequired
   },
 
   getDefaultProps() {
     return {
-      hosts: []
+      hosts: new NodesList([])
     };
   },
 
@@ -239,6 +240,8 @@ var NodesTable = React.createClass({
   },
 
   render() {
+    const { hosts } = this.props;
+
     return (
       <Table
         buildRowOptions={this.getRowAttributes}
@@ -246,7 +249,7 @@ var NodesTable = React.createClass({
         colGroup={this.getColGroup()}
         columns={this.getColumns()}
         containerSelector=".gm-scroll-view"
-        data={this.props.hosts.slice()}
+        data={hosts.getItems().slice()}
         itemHeight={TableUtil.getRowHeight()}
         sortBy={{ prop: "health", order: "asc" }}
       />

--- a/plugins/nodes/src/js/components/NodesTable.js
+++ b/plugins/nodes/src/js/components/NodesTable.js
@@ -25,7 +25,7 @@ var NodesTable = React.createClass({
   mixins: [PureRender],
 
   propTypes: {
-    hosts: React.PropTypes.object.isRequired
+    hosts: React.PropTypes.instanceOf(NodesList).isRequired
   },
 
   getDefaultProps() {

--- a/plugins/nodes/src/js/components/dsl/NodesHealthDSLSection.js
+++ b/plugins/nodes/src/js/components/dsl/NodesHealthDSLSection.js
@@ -1,0 +1,73 @@
+import React, { PropTypes } from "react";
+
+import DSLCombinerTypes from "#SRC/js/constants/DSLCombinerTypes";
+import DSLExpression from "#SRC/js/structs/DSLExpression";
+import DSLExpressionPart from "#SRC/js/structs/DSLExpressionPart";
+import DSLFormWithExpressionUpdates
+  from "#SRC/js/components/DSLFormWithExpressionUpdates";
+import DSLUtil from "#SRC/js/utils/DSLUtil";
+import FieldInput from "#SRC/js/components/form/FieldInput";
+import FieldLabel from "#SRC/js/components/form/FieldLabel";
+import FormGroup from "#SRC/js/components/form/FormGroup";
+
+const EXPRESSION_PARTS = {
+  is_healthy: DSLExpressionPart.attribute("is", "healthy"),
+  is_unhealthy: DSLExpressionPart.attribute("is", "unhealthy")
+};
+
+class NodesHealthDSLSection extends React.Component {
+  render() {
+    const { expression, onChange } = this.props;
+    const enabled = DSLUtil.canProcessParts(expression, EXPRESSION_PARTS);
+    const data = DSLUtil.getPartValues(expression, EXPRESSION_PARTS);
+
+    return (
+      <DSLFormWithExpressionUpdates
+        enabled={enabled}
+        expression={expression}
+        groupCombiner={DSLCombinerTypes.AND}
+        itemCombiner={DSLCombinerTypes.OR}
+        onChange={onChange}
+        parts={EXPRESSION_PARTS}
+      >
+
+        <label>Health</label>
+        <div className="row">
+          <div className="column-6">
+            <FormGroup>
+              <FieldLabel>
+                <FieldInput
+                  checked={data.is_healthy}
+                  disabled={!enabled}
+                  name="is_healthy"
+                  type="checkbox"
+                />
+                Healthy
+              </FieldLabel>
+            </FormGroup>
+          </div>
+          <div className="column-6">
+            <FormGroup>
+              <FieldLabel>
+                <FieldInput
+                  checked={data.is_unhealthy}
+                  disabled={!enabled}
+                  name="is_unhealthy"
+                  type="checkbox"
+                />
+                Unhealthy
+              </FieldLabel>
+            </FormGroup>
+          </div>
+        </div>
+      </DSLFormWithExpressionUpdates>
+    );
+  }
+}
+
+NodesHealthDSLSection.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  expression: PropTypes.instanceOf(DSLExpression).isRequired
+};
+
+module.exports = NodesHealthDSLSection;

--- a/plugins/nodes/src/js/components/dsl/NodesHealthDSLSection.js
+++ b/plugins/nodes/src/js/components/dsl/NodesHealthDSLSection.js
@@ -33,7 +33,7 @@ class NodesHealthDSLSection extends React.Component {
 
         <label>Health</label>
         <div className="row">
-          <div className="column-6">
+          <div className="column-12">
             <FormGroup>
               <FieldLabel>
                 <FieldInput
@@ -46,7 +46,7 @@ class NodesHealthDSLSection extends React.Component {
               </FieldLabel>
             </FormGroup>
           </div>
-          <div className="column-6">
+          <div className="column-12">
             <FormGroup>
               <FieldLabel>
                 <FieldInput

--- a/plugins/nodes/src/js/filters/NodesHealthFilter.js
+++ b/plugins/nodes/src/js/filters/NodesHealthFilter.js
@@ -1,0 +1,43 @@
+import DSLFilterTypes from "#SRC/js/constants/DSLFilterTypes";
+import DSLFilter from "#SRC/js/structs/DSLFilter";
+
+const LABEL = "is";
+
+const LABEL_TO_HEALTH = {
+  healthy: "healthy",
+  unhealthy: "unhealthy"
+};
+
+/**
+ * This filter handles the `health:status` for services using `getHealth`
+ */
+class NodesHealthFilter extends DSLFilter {
+  /**
+   * Handle all `health:XXXX` attribute filters that we can handle.
+   *
+   * @override
+   */
+  filterCanHandle(filterType, filterArguments) {
+    return (
+      filterType === DSLFilterTypes.ATTRIB &&
+      filterArguments.label === LABEL &&
+      LABEL_TO_HEALTH[filterArguments.text.toLowerCase()] != null
+    );
+  }
+
+  /**
+   * Keep only services whose health status matches the value of
+   * the `health` label
+   *
+   * @override
+   */
+  filterApply(resultset, filterType, filterArguments) {
+    const testStatus = LABEL_TO_HEALTH[filterArguments.text.toLowerCase()];
+
+    return resultset.filterItems(node => {
+      return node.getHealth().key.toLowerCase() === testStatus;
+    });
+  }
+}
+
+module.exports = NodesHealthFilter;

--- a/plugins/nodes/src/js/filters/NodesHealthFilter.js
+++ b/plugins/nodes/src/js/filters/NodesHealthFilter.js
@@ -8,12 +8,9 @@ const LABEL_TO_HEALTH = {
   unhealthy: "unhealthy"
 };
 
-/**
- * This filter handles the `health:status` for services using `getHealth`
- */
 class NodesHealthFilter extends DSLFilter {
   /**
-   * Handle all `health:XXXX` attribute filters that we can handle.
+   * Handle all `is:healthy||unhealthy` attribute filters that we can handle.
    *
    * @override
    */

--- a/plugins/nodes/src/js/pages/NodesOverview.js
+++ b/plugins/nodes/src/js/pages/NodesOverview.js
@@ -25,7 +25,7 @@ import HostsPageContent from "./nodes-overview/HostsPageContent";
 import NodeBreadcrumbs from "../components/NodeBreadcrumbs";
 
 const NODES_DISPLAY_LIMIT = 300;
-const SERVICE_FILTERS = new DSLFilterList([new NodesHealthFilter()]);
+const NODES_FILTERS = new DSLFilterList([new NodesHealthFilter()]);
 
 function getMesosHosts(state) {
   const { filterExpression = new DSLExpression("") } = state;
@@ -35,7 +35,7 @@ function getMesosHosts(state) {
 
   let filteredNodes = nodes;
   if (filterExpression && filterExpression.defined) {
-    filteredNodes = filterExpression.filter(SERVICE_FILTERS, filteredNodes);
+    filteredNodes = filterExpression.filter(NODES_FILTERS, filteredNodes);
   }
   const nodeIDs = filteredNodes.getItems().map(function(node) {
     return node.id;
@@ -273,7 +273,6 @@ var NodesOverview = React.createClass({
           onResetFilter={this.resetFilter}
           onResourceSelectionChange={this.onResourceSelectionChange}
           refreshRate={data.refreshRate}
-          selectedFilter={"all"}
           selectedResource={selectedResource}
           services={data.services}
           totalHostsResources={data.totalHostsResources}

--- a/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
+++ b/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
@@ -1,15 +1,21 @@
 import PureRender from "react-addons-pure-render-mixin";
 import React from "react";
 
+import DSLExpression from "#SRC/js/structs/DSLExpression";
+import DSLFilterList from "#SRC/js/structs/DSLFilterList";
+import DSLFilterField from "#SRC/js/components/DSLFilterField";
 import FilterBar from "#SRC/js/components/FilterBar";
-import FilterButtons from "#SRC/js/components/FilterButtons";
 import FilterHeadline from "#SRC/js/components/FilterHeadline";
 import ResourceBarChart from "#SRC/js/components/charts/ResourceBarChart";
 
 import FilterByService
   from "../../../../../services/src/js/components/FilterByService";
 
-const HEALTH_FILTER_BUTTONS = ["all", "healthy", "unhealthy"];
+import NodesHealthDSLSection from "../../components/dsl/NodesHealthDSLSection";
+
+import NodesHealthFilter from "../../filters/NodesHealthFilter";
+
+const SERVICE_FILTERS = new DSLFilterList([new NodesHealthFilter()]);
 
 const METHODS_TO_BIND = ["onResetFilter"];
 
@@ -17,6 +23,11 @@ class HostsPageContent extends React.Component {
   constructor() {
     super(...arguments);
     this.shouldComponentUpdate = PureRender.shouldComponentUpdate.bind(this);
+
+    this.state = {
+      expression: "",
+      filterExpression: new DSLExpression("")
+    };
 
     METHODS_TO_BIND.forEach(method => {
       this[method] = this[method].bind(this);
@@ -31,22 +42,42 @@ class HostsPageContent extends React.Component {
     }
   }
 
+  getFilterBar() {
+    // const { filters, onFilterExpressionChange } = this.props;
+
+    const filters = SERVICE_FILTERS;
+    const filterExpression = this.state.filterExpression;
+
+    return (
+      <div className="column-12">
+        <DSLFilterField
+          filters={filters}
+          formSections={[NodesHealthDSLSection]}
+          expression={filterExpression}
+          onChange={function(event) {
+            this.props.onFilterChange(event);
+            this.setState({
+              expression: event.value,
+              filterExpression: new DSLExpression(event.value)
+            });
+          }.bind(this)}
+        />
+      </div>
+    );
+  }
+
   render() {
     const {
       byServiceFilter,
       children,
-      filterButtonContent,
       filterInputText,
-      filterItemList,
       filteredNodeCount,
       handleFilterChange,
       hosts,
       isFiltering,
       nodeCount,
-      onFilterChange,
       onResourceSelectionChange,
       refreshRate,
-      selectedFilter,
       selectedResource,
       services,
       totalHostsResources,
@@ -75,14 +106,7 @@ class HostsPageContent extends React.Component {
         />
         <FilterBar rightAlignLastNChildren={1}>
           {filterInputText}
-          <FilterButtons
-            filterByKey="title"
-            filters={HEALTH_FILTER_BUTTONS}
-            itemList={filterItemList}
-            onFilterChange={onFilterChange}
-            renderButtonContent={filterButtonContent}
-            selectedFilter={selectedFilter}
-          />
+          {this.getFilterBar()}
           <div className="form-group flush-bottom">
             <FilterByService
               byServiceFilter={byServiceFilter}
@@ -111,7 +135,7 @@ HostsPageContent.propTypes = {
   filterItemList: React.PropTypes.array.isRequired,
   filteredNodeCount: React.PropTypes.number.isRequired,
   handleFilterChange: React.PropTypes.func.isRequired,
-  hosts: React.PropTypes.array.isRequired,
+  hosts: React.PropTypes.object.isRequired,
   isFiltering: React.PropTypes.bool,
   nodeCount: React.PropTypes.number.isRequired,
   onFilterChange: React.PropTypes.func,

--- a/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
+++ b/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
@@ -6,6 +6,7 @@ import DSLFilterList from "#SRC/js/structs/DSLFilterList";
 import DSLFilterField from "#SRC/js/components/DSLFilterField";
 import FilterBar from "#SRC/js/components/FilterBar";
 import FilterHeadline from "#SRC/js/components/FilterHeadline";
+import NodesList from "#SRC/js/structs/NodesList";
 import ResourceBarChart from "#SRC/js/components/charts/ResourceBarChart";
 
 import FilterByService
@@ -15,9 +16,9 @@ import NodesHealthDSLSection from "../../components/dsl/NodesHealthDSLSection";
 
 import NodesHealthFilter from "../../filters/NodesHealthFilter";
 
-const SERVICE_FILTERS = new DSLFilterList([new NodesHealthFilter()]);
+const NODES_FILTERS = new DSLFilterList([new NodesHealthFilter()]);
 
-const METHODS_TO_BIND = ["onResetFilter"];
+const METHODS_TO_BIND = ["onResetFilter", "onFilterChangeHandler"];
 
 class HostsPageContent extends React.Component {
   constructor() {
@@ -42,10 +43,16 @@ class HostsPageContent extends React.Component {
     }
   }
 
-  getFilterBar() {
-    // const { filters, onFilterExpressionChange } = this.props;
+  onFilterChangeHandler(event) {
+    this.props.onFilterChange(event);
+    this.setState({
+      expression: event.value,
+      filterExpression: new DSLExpression(event.value)
+    });
+  }
 
-    const filters = SERVICE_FILTERS;
+  getFilterBar() {
+    const filters = NODES_FILTERS;
     const filterExpression = this.state.filterExpression;
 
     return (
@@ -54,13 +61,7 @@ class HostsPageContent extends React.Component {
           filters={filters}
           formSections={[NodesHealthDSLSection]}
           expression={filterExpression}
-          onChange={function(event) {
-            this.props.onFilterChange(event);
-            this.setState({
-              expression: event.value,
-              filterExpression: new DSLExpression(event.value)
-            });
-          }.bind(this)}
+          onChange={this.onFilterChangeHandler}
         />
       </div>
     );
@@ -135,14 +136,13 @@ HostsPageContent.propTypes = {
   filterItemList: React.PropTypes.array.isRequired,
   filteredNodeCount: React.PropTypes.number.isRequired,
   handleFilterChange: React.PropTypes.func.isRequired,
-  hosts: React.PropTypes.object.isRequired,
+  hosts: React.PropTypes.instanceOf(NodesList).isRequired,
   isFiltering: React.PropTypes.bool,
   nodeCount: React.PropTypes.number.isRequired,
   onFilterChange: React.PropTypes.func,
   onResetFilter: React.PropTypes.func.isRequired,
   onResourceSelectionChange: React.PropTypes.func.isRequired,
   refreshRate: React.PropTypes.number.isRequired,
-  selectedFilter: React.PropTypes.string,
   selectedResource: React.PropTypes.string.isRequired,
   services: React.PropTypes.array.isRequired,
   totalHostsResources: React.PropTypes.object.isRequired,

--- a/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.js
@@ -7,6 +7,7 @@ import { StoreMixin } from "mesosphere-shared-reactjs";
 import CompositeState from "#SRC/js/structs/CompositeState";
 import MesosStateStore from "#SRC/js/stores/MesosStateStore";
 import QueryParamsMixin from "#SRC/js/mixins/QueryParamsMixin";
+import NodesList from "#SRC/js/structs/NodesList";
 
 import NodesGridView from "../../../components/NodesGridView";
 
@@ -19,7 +20,7 @@ class NodesGridContainer extends mixin(StoreMixin, QueryParamsMixin) {
     super(...arguments);
 
     this.state = {
-      filteredNodes: [],
+      filteredNodes: new NodesList([]),
       filters: { health: "all", name: "", service: null },
       hasLoadingError: false,
       hiddenServices: [],
@@ -49,7 +50,7 @@ class NodesGridContainer extends mixin(StoreMixin, QueryParamsMixin) {
   }
 
   componentWillReceiveProps(props) {
-    const { services, location: { query } } = props;
+    const { services, location: { query }, hosts } = props;
     const ids = services.map(function(service) {
       return service.id;
     });
@@ -66,7 +67,7 @@ class NodesGridContainer extends mixin(StoreMixin, QueryParamsMixin) {
       name: query.searchString || "",
       service: query.filterService || null
     };
-    this.setFilters(filters);
+    this.setFilters(hosts, filters);
   }
 
   computeServiceColors(services) {
@@ -93,15 +94,16 @@ class NodesGridContainer extends mixin(StoreMixin, QueryParamsMixin) {
   }
 
   getFilteredNodes(filters = this.state.filters) {
-    return CompositeState.getNodesList().filter(filters).getItems();
+    return CompositeState.getNodesList().filter(filters);
   }
 
-  setFilters(newFilters, callback) {
+  // TODO: remove set Filters and only filter at the top level;
+  setFilters(nodes, newFilters, callback) {
     if (newFilters.service === "") {
       newFilters.service = null;
     }
     const filters = Object.assign({}, this.state.filters, newFilters);
-    const filteredNodes = this.getFilteredNodes(filters);
+    const filteredNodes = nodes.filter(filters);
 
     this.setState({ filters, filteredNodes }, callback);
   }

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -4,6 +4,7 @@ import { StoreMixin } from "mesosphere-shared-reactjs";
 
 import CompositeState from "#SRC/js/structs/CompositeState";
 import QueryParamsMixin from "#SRC/js/mixins/QueryParamsMixin";
+import NodesList from "#SRC/js/structs/NodesList";
 
 import NodesTable from "../../../components/NodesTable";
 
@@ -12,7 +13,7 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
     super(...arguments);
 
     this.state = {
-      filteredNodes: [],
+      filteredNodes: new NodesList([]),
       filters: { health: "all", name: "", service: null },
       receivedNodeHealthResponse: false
     };
@@ -26,28 +27,8 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
     ];
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { location: { query } } = nextProps;
-    const filters = {
-      health: query.filterHealth || "all",
-      name: query.searchString || "",
-      service: query.filterService || null
-    };
-    this.setFilters(filters);
-  }
-
   getFilteredNodes(filters = this.state.filters) {
-    return CompositeState.getNodesList().filter(filters).getItems();
-  }
-
-  setFilters(newFilters, callback) {
-    if (newFilters.service === "") {
-      newFilters.service = null;
-    }
-    const filters = Object.assign({}, this.state.filters, newFilters);
-    const filteredNodes = this.getFilteredNodes(filters);
-
-    this.setState({ filters, filteredNodes }, callback);
+    return CompositeState.getNodesList().filter(filters);
   }
 
   onNodeHealthStoreSuccess() {
@@ -58,11 +39,13 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
   }
 
   render() {
-    const { receivedNodeHealthResponse, filteredNodes } = this.state;
+    const { receivedNodeHealthResponse } = this.state;
+
+    const { hosts } = this.props;
 
     return (
       <NodesTable
-        hosts={filteredNodes}
+        hosts={hosts}
         receivedNodeHealthResponse={receivedNodeHealthResponse}
       />
     );

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -27,8 +27,29 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
     ];
   }
 
+  componentWillReceiveProps(nextProps) {
+    const { location: { query }, hosts } = nextProps;
+    const filters = {
+      health: query.filterHealth || "all",
+      name: query.searchString || "",
+      service: query.filterService || null
+    };
+    this.setFilters(hosts, filters);
+  }
+
   getFilteredNodes(filters = this.state.filters) {
     return CompositeState.getNodesList().filter(filters);
+  }
+
+  // TODO: remove set Filters and only filter at the top level;
+  setFilters(nodes, newFilters, callback) {
+    if (newFilters.service === "") {
+      newFilters.service = null;
+    }
+    const filters = Object.assign({}, this.state.filters, newFilters);
+    const filteredNodes = nodes.filter(filters); // this.getFilteredNodes(filters);
+
+    this.setState({ filters, filteredNodes }, callback);
   }
 
   onNodeHealthStoreSuccess() {
@@ -39,13 +60,11 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
   }
 
   render() {
-    const { receivedNodeHealthResponse } = this.state;
-
-    const { hosts } = this.props;
+    const { receivedNodeHealthResponse, filteredNodes } = this.state;
 
     return (
       <NodesTable
-        hosts={hosts}
+        hosts={filteredNodes}
         receivedNodeHealthResponse={receivedNodeHealthResponse}
       />
     );

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -47,7 +47,7 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
       newFilters.service = null;
     }
     const filters = Object.assign({}, this.state.filters, newFilters);
-    const filteredNodes = nodes.filter(filters); // this.getFilteredNodes(filters);
+    const filteredNodes = nodes.filter(filters);
 
     this.setState({ filters, filteredNodes }, callback);
   }

--- a/tests/pages/networking/Networks-cy.js
+++ b/tests/pages/networking/Networks-cy.js
@@ -73,7 +73,12 @@ describe("Networks", function() {
 
     it("allows users to filter the table", function() {
       cy
-        .get("input.form-control")
+        // Even though this is a anti pattern and almost always not needed
+        // Wait a bit so "Cannot Connect With The Server" isn't displayed
+        // 2 secs is based on the time "Cannot Connect With The Server" was displayed
+        // before the nodes table is displayed
+        .wait(2000)
+        .get(".filter-bar-item .filter-input-text")
         .type("sleep.7084272b-6b76-11e5-a953-08002719334a");
       cy.get("tbody tr").should(function($tableRows) {
         expect(getVisibleTableRows($tableRows).length).to.equal(1);

--- a/tests/pages/nodes/NodesPage-cy.js
+++ b/tests/pages/nodes/NodesPage-cy.js
@@ -19,7 +19,8 @@ describe("Nodes Page", function() {
     });
 
     it("should only show healthy node", function() {
-      cy.get("@filterBar").contains("Healthy").click();
+      cy.get(".filter-input-text").as("filterInputText");
+      cy.get("@filterInputText").type("is:healthy");
 
       cy
         .get("@hostnames")
@@ -29,7 +30,8 @@ describe("Nodes Page", function() {
     });
 
     it("should only show unhealthy node", function() {
-      cy.get("@filterBar").contains("Unhealthy").click();
+      cy.get(".filter-input-text").as("filterInputText");
+      cy.get("@filterInputText").type("is:unhealthy");
 
       cy
         .get("@hostnames")
@@ -102,7 +104,8 @@ describe("Nodes Page", function() {
       it("should only show unhealthy node", function() {
         cy.get("@filterBar").contains("Filter by Service").click();
         cy.get(".dropdown-menu").contains("cassandra-unhealthy").click();
-        cy.get("@filterBar").contains("Healthy").click();
+        cy.get(".filter-input-text").as("filterInputText");
+        cy.get("@filterInputText").type("is:unhealthy");
 
         cy
           .get(".nodes-grid-dials")

--- a/tests/pages/nodes/NodesPage-cy.js
+++ b/tests/pages/nodes/NodesPage-cy.js
@@ -105,7 +105,7 @@ describe("Nodes Page", function() {
         cy.get("@filterBar").contains("Filter by Service").click();
         cy.get(".dropdown-menu").contains("cassandra-unhealthy").click();
         cy.get(".filter-input-text").as("filterInputText");
-        cy.get("@filterInputText").type("is:unhealthy");
+        cy.get("@filterInputText").type("is:healthy");
 
         cy
           .get(".nodes-grid-dials")


### PR DESCRIPTION
This adds the DSL filter functionality from the service page to the nodes page. 

![image](https://user-images.githubusercontent.com/156010/31828384-5d1b5646-b5ba-11e7-87b4-9c3b48a483cb.png)

![image](https://user-images.githubusercontent.com/156010/31828392-63a19016-b5ba-11e7-817f-eb140b310492.png)

![image](https://user-images.githubusercontent.com/156010/31828411-6e933d30-b5ba-11e7-8681-45d193962128.png)

Yes Design wise it is not looking the best right now. But I am going to implement the Service filter as well and as  soon as this one is removed I would like to expand the bar over the whole line.

Closes DCOS-19114 DCOS-19108 DCOS-19109 DCOS-19111

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
