### PR TITLE
feat(OverviewDetailTab): add licensing rows mount point

### DIFF
--- a/src/js/pages/system/OverviewDetailTab.js
+++ b/src/js/pages/system/OverviewDetailTab.js
@@ -144,6 +144,10 @@ class OverviewDetailTab extends mixin(StoreMixin) {
             {publicIP}
           </ConfigurationMapValue>
         </ConfigurationMapRow>
+        <MountService.Mount
+          type="OverviewDetailTab:AdditionalGeneralDetails"
+          limit={2}
+        />
       </ConfigurationMapSection>
     );
   }


### PR DESCRIPTION
This will mount the two licensing rows to the cluster overview. The row content will come from the licensing plugin.

Closes DCOS-19133.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
