### PR TITLE
docs(translation): remove framework cleaner instructions for 1.10

### DIFF
--- a/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
+++ b/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
@@ -198,23 +198,6 @@ class ServiceActionDisabledModal extends React.Component {
           </a> for complete instructions.{" "}
         </p>
         {this.getClipboardTrigger(command)}
-        <p>
-          {intl.formatMessage({
-            id: "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_3"
-          })}
-          {" "}
-          <a
-            href={MetadataStore.buildDocsURI(
-              "/usage/managing-services/uninstall/#framework-cleaner"
-            )}
-            target="_blank"
-          >
-            {intl.formatMessage({
-              id: "SERVICE_ACTIONS.SDK_SERVICE_CLEARNER_SCRIPT"
-            })}
-          </a>
-          .
-        </p>
       </div>
     );
   }
@@ -408,22 +391,6 @@ class ServiceActionDisabledModal extends React.Component {
           </a>
         </p>
         {this.getClipboardTrigger(packageCommand)}
-        <p>
-          {intl.formatMessage({ id: "SERVICE_ACTIONS.SDK_GROUP_DELETE_2" })}
-          {" "}
-          <a
-            href={MetadataStore.buildDocsURI(
-              "/usage/managing-services/uninstall/#framework-cleaner"
-            )}
-            target="_blank"
-          >
-            {intl.formatMessage({
-              id: "SERVICE_ACTIONS.SDK_SERVICE_CLEARNER_SCRIPT"
-            })}
-          </a>
-          {" "}
-          {intl.formatMessage({ id: "SERVICE_ACTIONS.SDK_GROUP_DELETE_3" })}.
-        </p>
         <p>
           {intl.formatMessage({ id: "SERVICE_ACTIONS.SDK_GROUP_DELETE_4" })}
           {", "}

--- a/src/js/translations/en-US.json
+++ b/src/js/translations/en-US.json
@@ -39,8 +39,6 @@
   "SERVICE_ACTIONS.SUSPEND": "Suspend",
 
   "SERVICE_ACTIONS.SDK_GROUP_DELETE_1": "Copy and paste this command into the CLI",
-  "SERVICE_ACTIONS.SDK_GROUP_DELETE_2": "Then, run the",
-  "SERVICE_ACTIONS.SDK_GROUP_DELETE_3": "for each service to clean up reserved resources",
   "SERVICE_ACTIONS.SDK_GROUP_DELETE_4": "Then",
   "SERVICE_ACTIONS.SDK_GROUP_DELETE_5": "the group",
   "SERVICE_ACTIONS.SDK_GROUP_DELETE_6": "Copy the command below into the DC/OS CLI",
@@ -58,8 +56,6 @@
   "SERVICE_ACTIONS.SDK_GROUP_UPDATE_SUSPEND": "scaling each service to 0 instances",
   "SERVICE_ACTIONS.SDK_GROUP_UPDATE_SCALE": "updating the number of instances of each service",
 
-  "SERVICE_ACTIONS.SDK_SERVICE_CLEARNER_SCRIPT": "framework cleaner script",
-
   "SERVICE_ACTIONS.SDK_SERVICE_RESTART": "Restart your service from the DC/OS CLI.",
   "SERVICE_ACTIONS.SDK_SERVICE_SUSPEND": "Suspend your service by scaling to 0 instances from the DC/OS CLI using an `options.json` file.",
   "SERVICE_ACTIONS.SDK_SERVICE_RESUME": "Resume your service by scaling to 1 or more instances from the DC/OS CLI using an `options.json` file.",
@@ -67,12 +63,11 @@
   "SERVICE_ACTIONS.SDK_SERVICE_SCALE_NOTE": "Scaling to fewer instances is not supported.",
   "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_1": "You must delete",
   "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_2": "via the DC/OS CLI. Copy and paste this command into the CLI. See the",
-  "SERVICE_ACTIONS.SDK_SERVICE_DELETE_PART_3": "To clean up resources reserved by your service, run the",
   "SERVICE_ACTIONS.SDK_SERVICE_UPDATE_PART_1": "To update this service's configuration, please update",
   "SERVICE_ACTIONS.SDK_SERVICE_UPDATE_PART_2": "Run the following CLI command:",
 
   "SERVICES.DEPLOYMENT_COUNT": "{deploymentsCount} {deploymentsCount, plural, =1 {deployment} other {deployments}}",
   "SERVICES.DEPLOYMENT_MODAL_HEADING": "{deploymentsCount} Active {deploymentsCount, plural, =1 {Deployment} other {Deployments}}",
-  "SERVICE_ACTIONS.DELETE_SERVICE_FRAMEWORK": "In order to delete a service, you must use the DC/OS CLI to perform this command. Refer to the ",
+  "SERVICE_ACTIONS.DELETE_SERVICE_FRAMEWORK": "You must use the DC/OS CLI to delete this service. Refer to the ",
   "SERVICE_ACTIONS.DELETE_SERVICE_FRAMEWORK_2": " for complete instructions or copy and paste this command into your CLI."
 }


### PR DESCRIPTION
<!--- Thank you for your contribution! Please provide enough information for others to best review your code. -->

<!-- Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it. -->

The Delete an SDK message in 1.10 tells users to use the framework cleaner script to clean up persistent state. This is no longer necessary in 1.10.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
