### PR TITLE
DCOS_OSS 1783 Update modals to match UI Kit

### DIFF
--- a/plugins/services/src/js/components/modals/DisabledGroupDestroyModal.js
+++ b/plugins/services/src/js/components/modals/DisabledGroupDestroyModal.js
@@ -27,7 +27,7 @@ const DisabledGroupDestroyModal = props => {
       showFooter={true}
       showHeader={true}
     >
-      <div className="modal-service-delete-center">
+      <div>
         This group needs to be empty to delete it. Please delete any services in the group first.
       </div>
     </Modal>

--- a/plugins/services/src/js/components/modals/KillPodInstanceModal.js
+++ b/plugins/services/src/js/components/modals/KillPodInstanceModal.js
@@ -88,10 +88,9 @@ class KillPodInstanceModal extends React.Component {
     const instanceCountContent = `${selectedItemsLength} ${StringUtil.pluralize("Instance", selectedItemsLength)}`;
 
     return (
-      <div className="text-align-center">
+      <div>
         <p>
           You are about to {action.toLowerCase()} {instanceCountContent}.
-          <br />
           Are you sure you want to continue?
         </p>
         {this.getErrorMessage()}
@@ -141,7 +140,7 @@ class KillPodInstanceModal extends React.Component {
         open={open}
         onClose={onClose}
         leftButtonText="Cancel"
-        leftButtonClassName="button button-primary-link"
+        leftButtonClassName="button button-primary-link flush-left"
         leftButtonCallback={onClose}
         rightButtonText={buttonText}
         rightButtonClassName="button button-danger"

--- a/plugins/services/src/js/components/modals/KillTaskModal.js
+++ b/plugins/services/src/js/components/modals/KillTaskModal.js
@@ -87,10 +87,9 @@ class KillTaskModal extends React.Component {
     const taskCountContent = `${selectedItemsLength} ${StringUtil.pluralize("task", selectedItemsLength)}`;
 
     return (
-      <div className="text-align-center">
+      <div>
         <p>
           You are about to {action.toLowerCase()} {taskCountContent}.
-          <br />
           Are you sure you want to continue?
         </p>
         {this.getErrorMessage()}
@@ -108,7 +107,7 @@ class KillTaskModal extends React.Component {
       selectedItems
     } = this.props;
 
-    let buttonText = ACTION_DISPLAY_NAMES[action];
+    let buttonText = `${ACTION_DISPLAY_NAMES[action]} ${StringUtil.pluralize("Task", selectedItems.length)}`;
 
     if (this.shouldForceUpdate()) {
       buttonText = "Force " + buttonText;
@@ -121,7 +120,7 @@ class KillTaskModal extends React.Component {
       <ModalHeading className="text-danger">
         {ACTION_DISPLAY_NAMES[action]}
         {" "}
-        {StringUtil.pluralize("task", selectedItems.length)}
+        {StringUtil.pluralize("Task", selectedItems.length)}
       </ModalHeading>
     );
 
@@ -133,7 +132,7 @@ class KillTaskModal extends React.Component {
         open={open}
         onClose={onClose}
         leftButtonText="Cancel"
-        leftButtonClassName="button button-primary-link"
+        leftButtonClassName="button button-primary-link flush-left"
         leftButtonCallback={onClose}
         rightButtonText={buttonText}
         rightButtonClassName="button button-danger"

--- a/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
+++ b/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
@@ -388,7 +388,7 @@ class ServiceActionDisabledModal extends React.Component {
     const { intl, onClose } = this.props;
 
     return (
-      <div className="button-collection text-align-center flush-bottom">
+      <div className="flush-bottom flex flex-direction-top-to-bottom flex-align-items-stretch-screen-small flex-direction-left-to-right-screen-small flex-justify-items-space-between-screen-medium">
         <button className="button button-primary-link" onClick={onClose}>
           {intl.formatMessage({ id: "BUTTON.CLOSE" })}
         </button>

--- a/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
+++ b/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
@@ -388,7 +388,7 @@ class ServiceActionDisabledModal extends React.Component {
     const { intl, onClose } = this.props;
 
     return (
-      <div className="flush-bottom flex flex-direction-top-to-bottom flex-align-items-stretch-screen-small flex-direction-left-to-right-screen-small flex-justify-items-space-between-screen-medium">
+      <div className="flush-bottom flex flex-direction-top-to-bottom flex-align-items-stretch-screen-small flex-direction-left-to-right-screen-small flex-justify-items-space-between-screen-small">
         <button className="button button-primary-link" onClick={onClose}>
           {intl.formatMessage({ id: "BUTTON.CLOSE" })}
         </button>

--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -144,7 +144,7 @@ class ServiceDestroyModal extends React.Component {
     const serviceLabel = this.getServiceLabel();
 
     return (
-      <div className="modal-service-delete-center">
+      <div>
         <p>
           This action
           {" "}
@@ -157,20 +157,19 @@ class ServiceDestroyModal extends React.Component {
           {serviceLabel.toLowerCase()}
           .
         </p>
-        <p>
-          Type ("
-          <strong>{serviceName}</strong>
-          ") below to confirm you want to delete the
-          {" "}
-          {serviceLabel.toLowerCase()}.
-        </p>
-        <input
-          className="form-control filter-input-text"
-          onChange={this.handleChangeInputFieldDestroy}
-          type="text"
-          value={this.state.serviceNameConfirmationValue}
-          autoFocus
-        />
+        <div className="form-group flush-bottom">
+          <label for="">
+            Type "{serviceName}
+            " to confirm
+          </label>
+          <input
+            className="form-control filter-input-text"
+            onChange={this.handleChangeInputFieldDestroy}
+            type="text"
+            value={this.state.serviceNameConfirmationValue}
+            autoFocus
+          />
+        </div>
       </div>
     );
   }
@@ -187,7 +186,7 @@ class ServiceDestroyModal extends React.Component {
         open={open}
         onClose={this.handleModalClose}
         leftButtonText="Cancel"
-        leftButtonClassName="button button-primary-link"
+        leftButtonClassName="button button-primary-link flush-left"
         leftButtonCallback={this.handleModalClose}
         rightButtonText={itemText}
         rightButtonClassName="button button-danger"

--- a/plugins/services/src/js/components/modals/ServiceGroupFormModal.js
+++ b/plugins/services/src/js/components/modals/ServiceGroupFormModal.js
@@ -71,7 +71,7 @@ class ServiceGroupFormModal extends React.Component {
     const buttonDefinition = [
       {
         text: "Cancel",
-        className: "button button-primary-link",
+        className: "button button-primary-link flush-left",
         isClose: true
       },
       {
@@ -96,9 +96,9 @@ class ServiceGroupFormModal extends React.Component {
         open={open}
         definition={this.getNewGroupFormDefinition()}
       >
-        <p className="text-align-center flush-top">
-          {"Enter a path for the new group under "}
-          <span className="emphasize">{parentGroupId}</span>
+        <p>
+          {"Enter a name for the new group under "}
+          <strong>{parentGroupId}</strong>
         </p>
         {this.getErrorMessage()}
       </FormModal>

--- a/plugins/services/src/js/components/modals/ServiceRestartModal.js
+++ b/plugins/services/src/js/components/modals/ServiceRestartModal.js
@@ -116,7 +116,7 @@ class ServiceRestartModal extends React.Component {
         open={open}
         onClose={onClose}
         leftButtonCallback={onClose}
-        leftButtonClassName="button button-primary-link"
+        leftButtonClassName="button button-primary-link flush-left"
         rightButtonText={`Restart ${serviceLabel}`}
         rightButtonClassName="button button-danger"
         rightButtonCallback={() =>

--- a/plugins/services/src/js/components/modals/ServiceResumeModal.js
+++ b/plugins/services/src/js/components/modals/ServiceResumeModal.js
@@ -115,7 +115,7 @@ class ServiceResumeModal extends React.Component {
           This service is currently stopped. Do you want to resume this service? You can change the number of instances to resume by using the field below.
         </p>
         <FormRow>
-          <FormGroup className="column-12 column-small-6 column-small-offset-3 flush-bottom">
+          <FormGroup className="form-row-element column-12 form-row-input">
             <FieldInput
               name="instances"
               onChange={this.handleInstancesFieldChange}
@@ -148,7 +148,7 @@ class ServiceResumeModal extends React.Component {
         open={open}
         onClose={onClose}
         leftButtonCallback={onClose}
-        leftButtonClassName="button button-primary-link"
+        leftButtonClassName="button button-primary-link flush-left"
         rightButtonText="Resume Service"
         rightButtonClassName="button button-primary"
         rightButtonCallback={this.handleConfirmation}

--- a/plugins/services/src/js/components/modals/ServiceScaleFormModal.js
+++ b/plugins/services/src/js/components/modals/ServiceScaleFormModal.js
@@ -91,7 +91,6 @@ class ServiceScaleFormModal extends React.Component {
     return [
       {
         fieldType: "number",
-        formElementClass: "horizontal-center",
         min: 0,
         name: "instances",
         placeholder: instancesCount,
@@ -118,7 +117,7 @@ class ServiceScaleFormModal extends React.Component {
   }
 
   getBodyText() {
-    let bodyText = "How many instances would you like to scale to?";
+    let bodyText = "How many instances?";
 
     if (this.props.service instanceof ServiceTree) {
       bodyText =
@@ -126,7 +125,7 @@ class ServiceScaleFormModal extends React.Component {
     }
 
     return (
-      <p className="text-align-center flush-top">
+      <p>
         {bodyText}
       </p>
     );
@@ -138,7 +137,7 @@ class ServiceScaleFormModal extends React.Component {
     const buttonDefinition = [
       {
         text: "Cancel",
-        className: "button button-primary-link",
+        className: "button button-primary-link flush-left",
         isClose: true
       },
       {

--- a/plugins/services/src/js/components/modals/ServiceStopModal.js
+++ b/plugins/services/src/js/components/modals/ServiceStopModal.js
@@ -116,9 +116,10 @@ class ServiceStopModal extends React.Component {
         open={open}
         onClose={onClose}
         leftButtonCallback={onClose}
-        leftButtonClassName="button button-primary-link"
+        leftButtonClassName="button button-primary-link flush-left"
         rightButtonText={`Stop ${serviceLabel}`}
         rightButtonCallback={() => stopItem(this.shouldForceUpdate())}
+        rightButtonClassName="button button-danger"
         showHeader={true}
       >
         <p>

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -221,7 +221,7 @@ class ServiceConfiguration extends mixin(StoreMixin) {
               onClick={this.handleEditButtonClick}
             >
               <Icon id="pencil" size="mini" family="system" />
-              <span className="form-group-heading-content">
+              <span>
                 {"Edit Config"}
               </span>
             </button>
@@ -240,7 +240,7 @@ class ServiceConfiguration extends mixin(StoreMixin) {
               )}
             >
               <Icon id="download" size="mini" family="system" />
-              <span className="form-group-heading-content">
+              <span>
                 {"Download Config"}
               </span>
             </a>

--- a/plugins/services/src/js/containers/service-connection/ServiceNoEndpointsPanel.js
+++ b/plugins/services/src/js/containers/service-connection/ServiceNoEndpointsPanel.js
@@ -16,7 +16,7 @@ const ServiceNoEndpointPanel = props => {
         You can edit the configuration to add service endpoints.
       </p>
       <div className="button-collection flush-bottom">
-        <button className="button" onClick={onClick}>
+        <button className="button-primary-link" onClick={onClick}>
           Edit Configuration
         </button>
       </div>

--- a/src/js/components/FormModal.js
+++ b/src/js/components/FormModal.js
@@ -94,7 +94,7 @@ class FormModal extends React.Component {
 
   getFooter() {
     return (
-      <div className="button-collection text-align-center flush">
+      <div className="flush-bottom flex flex-direction-top-to-bottom flex-align-items-stretch-screen-small flex-direction-left-to-right-screen-small flex-justify-items-space-between-screen-medium">
         {this.getButtons()}
         {this.props.extraFooterContent}
       </div>
@@ -130,13 +130,12 @@ class FormModal extends React.Component {
     return (
       <Modal
         closeByBackdropClick={!this.props.disabled}
-        modalClass="modal form-modal"
+        modalClass="modal modal-small"
         onClose={this.props.onClose}
         open={this.props.open}
         showHeader={false}
         showFooter={true}
         footer={this.getFooter()}
-        titleClass="text-align-center flush"
         {...this.props.modalProps}
       >
         {this.getContent()}
@@ -149,7 +148,7 @@ FormModal.defaultProps = {
   buttonDefinition: [
     {
       text: "Cancel",
-      className: "button button-primary-link",
+      className: "button button-primary-link flush-left",
       isClose: true
     },
     {

--- a/src/js/components/FormModal.js
+++ b/src/js/components/FormModal.js
@@ -94,7 +94,7 @@ class FormModal extends React.Component {
 
   getFooter() {
     return (
-      <div className="flush-bottom flex flex-direction-top-to-bottom flex-align-items-stretch-screen-small flex-direction-left-to-right-screen-small flex-justify-items-space-between-screen-medium">
+      <div className="flush-bottom flex flex-direction-top-to-bottom flex-align-items-stretch-screen-small flex-direction-left-to-right-screen-small flex-justify-items-space-between-screen-small">
         {this.getButtons()}
         {this.props.extraFooterContent}
       </div>

--- a/src/js/components/FrameworkConfiguration.js
+++ b/src/js/components/FrameworkConfiguration.js
@@ -141,7 +141,7 @@ class FrameworkConfiguration extends Component {
 
     return [
       {
-        className: "button-stroke",
+        className: "button-primary-link",
         clickHandler: this.handleGoBack,
         label: reviewActive ? " Back" : "Cancel"
       }

--- a/src/js/components/FrameworkConfigurationReviewScreen.js
+++ b/src/js/components/FrameworkConfigurationReviewScreen.js
@@ -52,7 +52,7 @@ class FrameworkConfigurationReviewScreen extends React.Component {
               onClick={onEditClick}
             >
               <Icon id="pencil" size="mini" family="system" />
-              <span className="form-group-heading-content">
+              <span>
                 {"Edit Config"}
               </span>
             </button>
@@ -71,7 +71,7 @@ class FrameworkConfigurationReviewScreen extends React.Component {
               )}
             >
               <Icon id="download" size="mini" family="system" />
-              <span className="form-group-heading-content">
+              <span>
                 {"Download Config"}
               </span>
             </a>

--- a/src/js/components/Modals.js
+++ b/src/js/components/Modals.js
@@ -125,11 +125,8 @@ var Modals = React.createClass({
       showFooter: true,
       footer: (
         <div>
-          <div className="row text-align-center">
-            <button
-              className="button button-primary button-medium"
-              onClick={onClose}
-            >
+          <div className="text-align-center">
+            <button className="button button-primary-link" onClick={onClose}>
               Close
             </button>
           </div>

--- a/src/js/components/RepositoriesTable.js
+++ b/src/js/components/RepositoriesTable.js
@@ -196,7 +196,7 @@ class RepositoriesTable extends mixin(StoreMixin) {
     }
 
     return (
-      <div className="text-align-center">
+      <div>
         <p>
           {`Repository (${repositoryLabel}) will be ${UserActions.DELETED} from ${Config.productName}. You will not be able to install any packages belonging to that repository anymore.`}
         </p>
@@ -209,7 +209,7 @@ class RepositoriesTable extends mixin(StoreMixin) {
     const { props, state } = this;
     const heading = (
       <ModalHeading>
-        Are you sure?
+        Delete Repository
       </ModalHeading>
     );
 
@@ -229,7 +229,7 @@ class RepositoriesTable extends mixin(StoreMixin) {
           open={!!state.repositoryToRemove}
           onClose={this.handleDeleteCancel}
           leftButtonCallback={this.handleDeleteCancel}
-          leftButtonClassName="button button-primary-link"
+          leftButtonClassName="button button-primary-link flush-left"
           rightButtonCallback={this.handleDeleteRepository}
           rightButtonClassName="button button-danger"
           rightButtonText={`${StringUtil.capitalize(UserActions.DELETE)} Repository`}

--- a/src/js/components/modals/ActionsModal.js
+++ b/src/js/components/modals/ActionsModal.js
@@ -101,7 +101,7 @@ class ActionsModal extends mixin(StoreMixin) {
     const { requestErrors, validationError } = this.state;
 
     return (
-      <div className="text-align-center">
+      <div>
         {this.getActionsModalContentsText()}
         {this.getDropdown(itemType)}
         {this.getErrorMessage(validationError)}
@@ -250,7 +250,7 @@ class ActionsModal extends mixin(StoreMixin) {
         open={!!action}
         onClose={this.handleButtonCancel}
         leftButtonCallback={this.handleButtonCancel}
-        leftButtonClassName="button button-primary-link"
+        leftButtonClassName="button button-primary-link flush-left"
         rightButtonCallback={this.handleButtonConfirm}
         rightButtonText={StringUtil.capitalize(action)}
         showHeader={true}

--- a/src/js/components/modals/AddRepositoryFormModal.js
+++ b/src/js/components/modals/AddRepositoryFormModal.js
@@ -113,7 +113,7 @@ class AddRepositoryFormModal extends mixin(StoreMixin) {
     return [
       {
         text: "Cancel",
-        className: "button button-primary-link",
+        className: "button button-primary-link flush-left",
         isClose: true
       },
       {

--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -163,7 +163,6 @@ class CliInstallModal extends React.Component {
   getContent() {
     return (
       <div className="install-cli-modal-content">
-        <h4 className="flush-top">Installation</h4>
         <p>
           {
             "Choose your operating system and follow the instructions. For any issues or questions, please refer to our "
@@ -185,7 +184,7 @@ class CliInstallModal extends React.Component {
 
   render() {
     const { footer, open, showFooter, title } = this.props;
-    const header = <ModalHeading align="left" level={5}>{title}</ModalHeading>;
+    const header = <ModalHeading>{title}</ModalHeading>;
 
     return (
       <Modal

--- a/src/js/components/modals/JobFormModal.js
+++ b/src/js/components/modals/JobFormModal.js
@@ -402,7 +402,7 @@ class JobFormModal extends mixin(StoreMixin) {
     }
 
     return (
-      <div className="flush-bottom flex flex-direction-top-to-bottom flex-align-items-stretch-screen-small flex-direction-left-to-right-screen-small flex-justify-items-space-between-screen-medium">
+      <div className="flush-bottom flex flex-direction-top-to-bottom flex-align-items-stretch-screen-small flex-direction-left-to-right-screen-small flex-justify-items-space-between-screen-small">
         <button
           className="button button-primary-link flush-left"
           onClick={this.handleCancel}

--- a/src/js/components/modals/JobFormModal.js
+++ b/src/js/components/modals/JobFormModal.js
@@ -402,9 +402,9 @@ class JobFormModal extends mixin(StoreMixin) {
     }
 
     return (
-      <div className="button-collection flush-bottom">
+      <div className="flush-bottom flex flex-direction-top-to-bottom flex-align-items-stretch-screen-small flex-direction-left-to-right-screen-small flex-justify-items-space-between-screen-medium">
         <button
-          className="button button-primary-link"
+          className="button button-primary-link flush-left"
           onClick={this.handleCancel}
         >
           Cancel

--- a/src/js/components/modals/ModalHeading.js
+++ b/src/js/components/modals/ModalHeading.js
@@ -2,25 +2,19 @@ import classNames from "classnames";
 import React from "react";
 
 const ModalHeading = props => {
-  const { align, children, className, flush, level } = props;
+  const { children, level } = props;
 
   return React.createElement(
     `h${level}`,
     {
-      className: classNames(
-        `text-align-${align}`,
-        {
-          flush
-        },
-        className
-      )
+      className: classNames(`modal-header-title`)
     },
     children
   );
 };
 
 ModalHeading.defaultProps = {
-  align: "center",
+  align: "left",
   flush: true,
   level: 2
 };

--- a/src/js/components/modals/ModalHeading.js
+++ b/src/js/components/modals/ModalHeading.js
@@ -14,20 +14,12 @@ const ModalHeading = props => {
 };
 
 ModalHeading.defaultProps = {
-  align: "left",
   flush: true,
   level: 2
 };
 
 ModalHeading.propTypes = {
-  align: React.PropTypes.oneOf(["left", "right", "center"]),
   children: React.PropTypes.node.isRequired,
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
-  ]),
-  flush: React.PropTypes.bool,
   level: React.PropTypes.oneOf([1, 2, 3, 4, 5, 6])
 };
 

--- a/src/styles/components/modal/styles.less
+++ b/src/styles/components/modal/styles.less
@@ -12,6 +12,17 @@
     flex: 1 1 auto;
   }
 
+  // Remove margins from modal titles
+  .modal-header-title {
+    margin-bottom: 0;
+    margin-top: 0;
+  }
+
+  // Remove border from footer
+  .modal .modal-footer {
+    border-top: none;
+  }
+
   .modal-body {
 
     & > p {

--- a/src/styles/views/services/styles.less
+++ b/src/styles/views/services/styles.less
@@ -1,9 +1,5 @@
 & when (@services-view-enabled) {
 
-  .modal-service-delete-center {
-    text-align: center;
-  }
-
   .modal-service-delete-force {
     cursor: pointer;
 

--- a/system-tests/universe/test-universe.js
+++ b/system-tests/universe/test-universe.js
@@ -191,8 +191,8 @@ describe("Universe", function() {
       .click();
 
     // Confirm the deletion
-    cy.get(".modal.confirm-modal input").type(serviceName);
-    cy.get(".modal.confirm-modal").contains("Delete").click();
+    cy.get(".modal.modal-small input").type(serviceName);
+    cy.get(".modal.modal-small").contains("Delete").click();
 
     cy
       .get(".page-body-content table")

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -403,7 +403,7 @@ describe("Service Actions", function() {
         response: []
       });
       cy
-        .get(".modal-small .button-primary")
+        .get(".modal-small .button-danger")
         .click()
         .should("have.class", "disabled");
     });
@@ -414,7 +414,7 @@ describe("Service Actions", function() {
         url: /marathon\/v2\/apps\/\/cassandra-healthy/,
         response: []
       });
-      cy.get(".modal-small .button-primary").click();
+      cy.get(".modal-small .button-danger").click();
       cy.get(".modal-small").should("to.have.length", 0);
     });
 
@@ -427,7 +427,7 @@ describe("Service Actions", function() {
           message: "App is locked by one or more deployments."
         }
       });
-      cy.get(".modal-small .button-primary").click();
+      cy.get(".modal-small .button-danger").click();
       cy
         .get(".modal-small .text-danger")
         .should("to.have.text", "App is locked by one or more deployments.");
@@ -442,7 +442,7 @@ describe("Service Actions", function() {
           message: "Not Authorized to perform this action!"
         }
       });
-      cy.get(".modal-small .button-primary").click();
+      cy.get(".modal-small .button-danger").click();
       cy
         .get(".modal-small .text-danger")
         .should("to.have.text", "Not Authorized to perform this action!");
@@ -455,7 +455,7 @@ describe("Service Actions", function() {
         response: [],
         delay: SERVER_RESPONSE_DELAY
       });
-      cy.get(".modal-small .button-primary").as("primaryButton").click();
+      cy.get(".modal-small .button-danger").as("primaryButton").click();
       cy.get("@primaryButton").should("have.class", "disabled");
       cy.get("@primaryButton").should("not.have.class", "disabled");
     });

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -403,7 +403,7 @@ describe("Service Actions", function() {
         response: []
       });
       cy
-        .get(".modal-small .button-collection .button-primary")
+        .get(".modal-small .button-primary")
         .click()
         .should("have.class", "disabled");
     });
@@ -414,7 +414,7 @@ describe("Service Actions", function() {
         url: /marathon\/v2\/apps\/\/cassandra-healthy/,
         response: []
       });
-      cy.get(".modal-small .button-collection .button-primary").click();
+      cy.get(".modal-small .button-primary").click();
       cy.get(".modal-small").should("to.have.length", 0);
     });
 
@@ -427,7 +427,7 @@ describe("Service Actions", function() {
           message: "App is locked by one or more deployments."
         }
       });
-      cy.get(".modal-small .button-collection .button-primary").click();
+      cy.get(".modal-small .button-primary").click();
       cy
         .get(".modal-small .text-danger")
         .should("to.have.text", "App is locked by one or more deployments.");
@@ -442,7 +442,7 @@ describe("Service Actions", function() {
           message: "Not Authorized to perform this action!"
         }
       });
-      cy.get(".modal-small .button-collection .button-primary").click();
+      cy.get(".modal-small .button-primary").click();
       cy
         .get(".modal-small .text-danger")
         .should("to.have.text", "Not Authorized to perform this action!");
@@ -455,19 +455,13 @@ describe("Service Actions", function() {
         response: [],
         delay: SERVER_RESPONSE_DELAY
       });
-      cy
-        .get(".modal-small .button-collection .button-primary")
-        .as("primaryButton")
-        .click();
+      cy.get(".modal-small .button-primary").as("primaryButton").click();
       cy.get("@primaryButton").should("have.class", "disabled");
       cy.get("@primaryButton").should("not.have.class", "disabled");
     });
 
     it("closes dialog on secondary button click", function() {
-      cy
-        .get(".modal-small .button-collection .button")
-        .contains("Cancel")
-        .click();
+      cy.get(".modal-small .button").contains("Cancel").click();
       cy.get(".modal-small").should("to.have.length", 0);
     });
   });

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -226,9 +226,7 @@ describe("Service Actions", function() {
       });
 
       it("disable danger button while service name isn't correct", function() {
-        cy
-          .get(".modal-small .flush-bottom .button-danger")
-          .should("have.class", "disabled");
+        cy.get(".modal-small .button-danger").should("have.class", "disabled");
       });
 
       it("closes dialog when user type correct service name", function() {
@@ -238,7 +236,7 @@ describe("Service Actions", function() {
           response: []
         });
         cy.get(".modal-body .filter-input-text").type("sleep");
-        cy.get(".modal-small .flush-bottom .button-danger").click();
+        cy.get(".modal-small .button-danger").click();
         cy.get(".modal-small").should("to.have.length", 0);
       });
 
@@ -250,7 +248,7 @@ describe("Service Actions", function() {
           response: { message: "App is locked by one or more deployments." }
         });
         cy.get(".modal-body .filter-input-text").type("sleep");
-        cy.get(".modal-small .flush-bottom .button-danger").click();
+        cy.get(".modal-small .button-danger").click();
         cy
           .get(".modal-body .text-danger")
           .should("to.have.text", "App is locked by one or more deployments.");
@@ -264,7 +262,7 @@ describe("Service Actions", function() {
           response: { message: "Not Authorized to perform this action!" }
         });
         cy.get(".modal-body .filter-input-text").type("sleep");
-        cy.get(".modal-small .flush-bottom .button-danger").click();
+        cy.get(".modal-small .button-danger").click();
         cy
           .get(".modal-body .text-danger")
           .should("to.have.text", "Not Authorized to perform this action!");
@@ -280,13 +278,13 @@ describe("Service Actions", function() {
           },
           delay: SERVER_RESPONSE_DELAY
         });
-        cy.get(".modal-small .flush-bottom .button-danger").as("dangerButton");
+        cy.get(".modal-small .button-danger").as("dangerButton");
         cy.get(".modal-body .filter-input-text").type("sleep");
         cy.get("@dangerButton").should("not.have.class", "disabled");
       });
 
       it("closes dialog on secondary button click", function() {
-        cy.get(".modal-small .flush-bottom .button").contains("Cancel").click();
+        cy.get(".modal-small .button").contains("Cancel").click();
         cy.get(".modal-small").should("to.have.length", 0);
       });
     });
@@ -405,7 +403,7 @@ describe("Service Actions", function() {
         response: []
       });
       cy
-        .get(".modal-small .flush-bottom .button-primary")
+        .get(".modal-small .button-collection .button-primary")
         .click()
         .should("have.class", "disabled");
     });
@@ -416,7 +414,7 @@ describe("Service Actions", function() {
         url: /marathon\/v2\/apps\/\/cassandra-healthy/,
         response: []
       });
-      cy.get(".modal-small .flush-bottom .button-primary").click();
+      cy.get(".modal-small .button-collection .button-primary").click();
       cy.get(".modal-small").should("to.have.length", 0);
     });
 
@@ -429,7 +427,7 @@ describe("Service Actions", function() {
           message: "App is locked by one or more deployments."
         }
       });
-      cy.get(".modal-small .flush-bottom .button-primary").click();
+      cy.get(".modal-small .button-collection .button-primary").click();
       cy
         .get(".modal-small .text-danger")
         .should("to.have.text", "App is locked by one or more deployments.");
@@ -444,7 +442,7 @@ describe("Service Actions", function() {
           message: "Not Authorized to perform this action!"
         }
       });
-      cy.get(".modal-small .flush-bottom .button-primary").click();
+      cy.get(".modal-small .button-collection .button-primary").click();
       cy
         .get(".modal-small .text-danger")
         .should("to.have.text", "Not Authorized to perform this action!");
@@ -458,7 +456,7 @@ describe("Service Actions", function() {
         delay: SERVER_RESPONSE_DELAY
       });
       cy
-        .get(".modal-small .flush-bottom .button-primary")
+        .get(".modal-small .button-collection .button-primary")
         .as("primaryButton")
         .click();
       cy.get("@primaryButton").should("have.class", "disabled");
@@ -466,7 +464,10 @@ describe("Service Actions", function() {
     });
 
     it("closes dialog on secondary button click", function() {
-      cy.get(".modal-small .flush-bottom .button").contains("Cancel").click();
+      cy
+        .get(".modal-small .button-collection .button")
+        .contains("Cancel")
+        .click();
       cy.get(".modal-small").should("to.have.length", 0);
     });
   });

--- a/tests/pages/services/ServiceTable-cy.js
+++ b/tests/pages/services/ServiceTable-cy.js
@@ -32,9 +32,7 @@ describe("Service Table", function() {
         url: /marathon\/v2\/apps\/\/sleep/,
         response: []
       });
-      cy
-        .get(".modal-small .flush-bottom .button-danger")
-        .should("have.class", "disabled");
+      cy.get(".modal-small .button-danger").should("have.class", "disabled");
     });
   });
 


### PR DESCRIPTION
The goal of this PR is to align all modal designs with our UI Kit. In particular:

* Size of modals
* Layout (header, body, footer)
* Heading alignment and size
* Button alignment
* Wording used for headings and actions

This **does not address**:

* Adding a close icon button to each modal (separate feature request)
* Modals that could be full screen (e.g. Jobs)
* Modals that could have tabs instead of sidebars (e.g. LDAP directory)
* Form components or validation within the modals

In order to make this sweeping change, there are updates required in this repo, the private enterprise plugin repo and the reactjs-components repo.

## Examples

### Before
<img src=https://user-images.githubusercontent.com/15963/33930199-6c32a02e-dfec-11e7-928e-842b601a27d4.png width=300><img src=https://user-images.githubusercontent.com/15963/33930213-73229740-dfec-11e7-8327-53ce01a753d1.png width=300><img src=https://user-images.githubusercontent.com/15963/33930228-7b515a78-dfec-11e7-9896-13457e4b5cb8.png width=300><img src=https://user-images.githubusercontent.com/15963/33930241-830abfde-dfec-11e7-96c0-34d3e1e239e9.png width=300><img src=https://user-images.githubusercontent.com/15963/33930270-9dda1a9e-dfec-11e7-9866-4579f63a7dff.png width=300>


### After
<img src=https://user-images.githubusercontent.com/15963/33892712-c7552f96-df59-11e7-9f0a-940eb9b392b2.png width=300><img src=https://user-images.githubusercontent.com/15963/33892739-d7c2f9da-df59-11e7-9ab6-6043d003ea97.png width=300><img src=https://user-images.githubusercontent.com/15963/33892745-ddf136f0-df59-11e7-9925-9a08d868c240.png width=300><img src=https://user-images.githubusercontent.com/15963/33892757-ecf5e164-df59-11e7-9b2f-789a25b3c69c.png width=300><img src=https://user-images.githubusercontent.com/15963/33892776-f8ef6de6-df59-11e7-90ac-ed431e2f27c7.png width=300><img src=https://user-images.githubusercontent.com/15963/33893061-cd32ffd2-df5a-11e7-9799-0f12853d0ecb.png width=300><img src=https://user-images.githubusercontent.com/15963/33893074-d9f0ad1e-df5a-11e7-8250-3d75e5c4f2a7.png width=300><img src=https://user-images.githubusercontent.com/15963/33893101-ea2e33f4-df5a-11e7-9cc9-75356a0d98ee.png width=300><img src=https://user-images.githubusercontent.com/15963/33893127-ffdda158-df5a-11e7-9cd8-805e80126344.png width=300><img src=https://user-images.githubusercontent.com/15963/33893152-0cab26c6-df5b-11e7-8ee7-f4f832a343b7.png width=300><img src=https://user-images.githubusercontent.com/15963/33893171-15dafcda-df5b-11e7-882b-495be9638489.png width=300><img src=https://user-images.githubusercontent.com/15963/33893227-38e9f582-df5b-11e7-8ba6-40fcffa513f0.png width=300>


