### PR TITLE
fix(FormGroupContainer): only apply hover styles if onClick provided

### DIFF
--- a/src/js/components/form/FormGroupContainer.js
+++ b/src/js/components/form/FormGroupContainer.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Tooltip } from "reactjs-components";
+import classNames from "classnames";
 
 import Icon from "../Icon";
 import StringUtil from "../../utils/StringUtil";
@@ -23,11 +24,12 @@ const FormGroupContainer = props => {
     );
   }
 
+  const classes = classNames("panel pod-short", {
+    "panel-interactive clickable": props.onClick
+  });
+
   return (
-    <div
-      className="panel panel-interactive pod-short clickable"
-      onClick={props.onClick}
-    >
+    <div className={classes} onClick={props.onClick}>
       <div className="pod-narrow pod-short">
         {removeButton}
         {props.children}


### PR DESCRIPTION
This is fixing a regression from 5e2d832 which caused hover on all `FormGroupContainers`. This PR changes it to only apply the outline and cursor pointer when an `onClick` prop is provided.

Currently, the only time an `onClick` prop is provided to `FormGroupContainer` is in the container pods when creating a service. See below the hover classes on the container, but not networking or volumes pods.
![screen recording 2017-10-31 at 02 47 pm](https://user-images.githubusercontent.com/1527504/32250614-7b156f36-be4a-11e7-94fa-6d9637a02cd8.gif)

@leemunroe can finally stop bugging me about this one now 💯 😄 

Closes DCOS-18317.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
