### PR TITLE
feat(DeploymentStatusIndicator): replace loader with spinner

### DIFF
--- a/plugins/services/src/js/components/DeploymentStatusIndicator.js
+++ b/plugins/services/src/js/components/DeploymentStatusIndicator.js
@@ -6,7 +6,7 @@ import React from "react";
 import { StoreMixin } from "mesosphere-shared-reactjs";
 
 import DCOSStore from "#SRC/js/stores/DCOSStore";
-import Loader from "#SRC/js/components/Loader";
+import Icon from "#SRC/js/components/Icon";
 
 import DeploymentsModal from "./DeploymentsModal";
 
@@ -63,13 +63,7 @@ class DeploymentStatusIndicator extends mixin(StoreMixin) {
         className="button button-link button-primary button--deployments"
         onClick={this.handleDeploymentsButtonClick}
       >
-        <Loader
-          className="button--deployments__loader icon icon-mini"
-          flip="horizontal"
-          size="mini"
-          type="lineSpinFadeLoader"
-          suppressHorizontalCenter={true}
-        />
+        <Icon color="grey" id="spinner" size="mini" />
         <div className="button--deployments__copy">
           <FormattedMessage
             id="SERVICES.DEPLOYMENT_COUNT"


### PR DESCRIPTION
As per @leemunroe request, this PR replaces loader component with spinner icon introduced in #2475

**How to test:**
Deploy an application
In services page on top right side, you should still see a spiner icon

**now:**
![screen shot 2017-11-09 at 4 25 35 pm](https://user-images.githubusercontent.com/549394/32636687-bf89a26e-c56a-11e7-80ad-c3f5b15e56f5.png)


Closes DCOS-19372

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
