### PR TITLE
chore(TasksTable-cy): remove only to run all tests

### DIFF
--- a/tests/pages/catalog/packages/package/PackageTab-cy.js
+++ b/tests/pages/catalog/packages/package/PackageTab-cy.js
@@ -132,13 +132,15 @@ describe("Package Detail Tab", function() {
         .should("to.have.length", 1);
     });
 
-    it("closes the framework config when cancel button clicked", function() {
-      cy.get(".modal .modal-header button").contains("Cancel").click();
+    it("goes to form when back button is clicked", function() {
+      cy.get(".modal .modal-header button").contains("Back").click();
 
-      cy.get(".page-body-content h1").should("contain", "marathon");
+      cy
+        .get('.modal .menu-tabbed-container input[name="group"]')
+        .type(`{selectall}group-1`);
     });
 
-    it("changes cancel button to back when form edited", function() {
+    it("changes cancel button to back when on review screen", function() {
       cy.get(".modal button").contains("Edit Config").click();
 
       cy

--- a/tests/pages/services/TasksTable-cy.js
+++ b/tests/pages/services/TasksTable-cy.js
@@ -148,7 +148,7 @@ describe("Tasks Table", function() {
       });
     });
 
-    it.only("Shows the correct region", function() {
+    it("Shows the correct region", function() {
       cy.visitUrl({ url: "/services/detail/%2Fcassandra/tasks?_k=rh67gf" });
       cy.get("td.task-table-column-zone-address").eq(1).contains("(Local)");
     });


### PR DESCRIPTION
Remove overlooked `only` function to run all the integration tests