### PR TITLE
fix(Licensing): split mount-point into one for each row

### DIFF
--- a/src/js/pages/system/OverviewDetailTab.js
+++ b/src/js/pages/system/OverviewDetailTab.js
@@ -145,11 +145,11 @@ class OverviewDetailTab extends mixin(StoreMixin) {
           </ConfigurationMapValue>
         </ConfigurationMapRow>
         <MountService.Mount
-          type="OverviewDetailTab:AdditionalGeneralDetails:Licensing:NodeCapacity"
+          type="OverviewDetailTab:AdditionalGeneralDetails:Nodes"
           limit={1}
         />
         <MountService.Mount
-          type="OverviewDetailTab:AdditionalGeneralDetails:Licensing:Expiration"
+          type="OverviewDetailTab:AdditionalGeneralDetails:Date"
           limit={1}
         />
       </ConfigurationMapSection>

--- a/src/js/pages/system/OverviewDetailTab.js
+++ b/src/js/pages/system/OverviewDetailTab.js
@@ -145,8 +145,12 @@ class OverviewDetailTab extends mixin(StoreMixin) {
           </ConfigurationMapValue>
         </ConfigurationMapRow>
         <MountService.Mount
-          type="OverviewDetailTab:AdditionalGeneralDetails"
-          limit={2}
+          type="OverviewDetailTab:AdditionalGeneralDetails:Licensing:NodeCapacity"
+          limit={1}
+        />
+        <MountService.Mount
+          type="OverviewDetailTab:AdditionalGeneralDetails:Licensing:Expiration"
+          limit={1}
         />
       </ConfigurationMapSection>
     );


### PR DESCRIPTION
This fixup splits up the mount point into two to prevent ReactUtil from creating
an additional wrapper - which breaks the styling.

Closes DCOS-19398
