### PR TITLE
fix(endpoints): open sdk edit page for sdk services and not the disabled modal

### DIFF
--- a/plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.js
+++ b/plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { routerShape } from "react-router";
 
 import Loader from "#SRC/js/components/Loader";
 import ConfigurationMap from "#SRC/js/components/ConfigurationMap";
@@ -17,24 +18,23 @@ import EndpointClipboardTrigger from "./EndpointClipboardTrigger";
 import ServiceNoEndpointsPanel from "./ServiceNoEndpointsPanel";
 import SDKEndpointActions from "../../events/SDKEndpointActions";
 import SDKEndpointStore from "../../stores/SDKEndpointStore";
-import { EDIT } from "../../constants/ServiceActionItem";
-import ServiceActionDisabledModal
-  from "../../components/modals/ServiceActionDisabledModal";
 
 class SDKServiceConnectionEndpointList extends React.Component {
   constructor() {
     super(...arguments);
 
     this.state = {
-      actionDisabledModalOpen: false,
       servicePreviousState: ""
     };
   }
 
-  handleOpenEditConfigurationModal(actionDisabledModalOpen) {
-    this.setState({
-      actionDisabledModalOpen
-    });
+  handleOpenEditConfigurationModal() {
+    const { service } = this.props;
+    const { router } = this.context;
+
+    router.push(
+      `/services/detail/${encodeURIComponent(service.getId())}/edit/`
+    );
   }
 
   componentDidMount() {
@@ -174,19 +174,7 @@ class SDKServiceConnectionEndpointList extends React.Component {
   }
 
   render() {
-    const { actionDisabledModalOpen } = this.state;
     const { service } = this.props;
-
-    if (actionDisabledModalOpen) {
-      return (
-        <ServiceActionDisabledModal
-          actionID={EDIT}
-          open={actionDisabledModalOpen}
-          onClose={this.handleOpenEditConfigurationModal.bind(this, false)}
-          service={service}
-        />
-      );
-    }
 
     const sdkServiceEndpoints = SDKEndpointStore.getServiceEndpoints(
       service.getId()
@@ -227,6 +215,10 @@ class SDKServiceConnectionEndpointList extends React.Component {
     );
   }
 }
+
+SDKServiceConnectionEndpointList.contextTypes = {
+  router: routerShape
+};
 
 SDKServiceConnectionEndpointList.propTypes = {
   service: React.PropTypes.instanceOf(Service)

--- a/plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.js
+++ b/plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.js
@@ -19,6 +19,8 @@ import ServiceNoEndpointsPanel from "./ServiceNoEndpointsPanel";
 import SDKEndpointActions from "../../events/SDKEndpointActions";
 import SDKEndpointStore from "../../stores/SDKEndpointStore";
 
+const METHODS_TO_BIND = ["handleOpenEditConfigurationModal"];
+
 class SDKServiceConnectionEndpointList extends React.Component {
   constructor() {
     super(...arguments);
@@ -26,6 +28,10 @@ class SDKServiceConnectionEndpointList extends React.Component {
     this.state = {
       servicePreviousState: ""
     };
+
+    METHODS_TO_BIND.forEach(method => {
+      this[method] = this[method].bind(this);
+    });
   }
 
   handleOpenEditConfigurationModal() {
@@ -200,7 +206,7 @@ class SDKServiceConnectionEndpointList extends React.Component {
       return (
         <ServiceNoEndpointsPanel
           serviceId={service.getId()}
-          onClick={this.handleOpenEditConfigurationModal.bind(this, true)}
+          onClick={this.handleOpenEditConfigurationModal}
         />
       );
     }


### PR DESCRIPTION
Open the new SDK edit page and not the disabled modal

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
