### PR TITLE
fix(PodGeneralConfigSection): fix onEditClick being undefined

### DIFF
--- a/plugins/services/src/js/service-configuration/PodContainerConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodContainerConfigSection.js
@@ -49,6 +49,18 @@ const PodContainerConfigSection = ({
     tabViewID = `container${index}`;
   }
 
+  let action;
+  if (onEditClick) {
+    action = (
+      <a
+        className="button button-link flush table-display-on-row-hover"
+        onClick={onEditClick.bind(null, { tabViewID })}
+      >
+        Edit
+      </a>
+    );
+  }
+
   return (
     <ConfigurationMapSection key="pod-general-section">
 
@@ -63,24 +75,14 @@ const PodContainerConfigSection = ({
         <ConfigurationMapValueWithDefault
           value={findNestedPropertyInObject(containerConfig, "image.id")}
         />
-        <a
-          className="button button-link flush table-display-on-row-hover"
-          onClick={onEditClick.bind(null, { tabViewID })}
-        >
-          Edit
-        </a>
+        {action}
       </ConfigurationMapRow>
       <ConfigurationMapRow>
         <ConfigurationMapLabel>Force pull on launch</ConfigurationMapLabel>
         <ConfigurationMapBooleanValue
           value={findNestedPropertyInObject(containerConfig, "image.forcePull")}
         />
-        <a
-          className="button button-link flush table-display-on-row-hover"
-          onClick={onEditClick.bind(null, { tabViewID })}
-        >
-          Edit
-        </a>
+        {action}
       </ConfigurationMapRow>
 
       {/* Resources */}
@@ -88,45 +90,25 @@ const PodContainerConfigSection = ({
         <ConfigurationMapRow>
           <ConfigurationMapLabel>CPUs</ConfigurationMapLabel>
           <ConfigurationMapValue value={fields.resources.cpus} />
-          <a
-            className="button button-link flush table-display-on-row-hover"
-            onClick={onEditClick.bind(null, { tabViewID })}
-          >
-            Edit
-          </a>
+          {action}
         </ConfigurationMapRow>}
       {Boolean(fields.resources.mem) &&
         <ConfigurationMapRow>
           <ConfigurationMapLabel>Memory</ConfigurationMapLabel>
           <ConfigurationMapSizeValue value={fields.resources.mem} />
-          <a
-            className="button button-link flush table-display-on-row-hover"
-            onClick={onEditClick.bind(null, { tabViewID })}
-          >
-            Edit
-          </a>
+          {action}
         </ConfigurationMapRow>}
       {Boolean(fields.resources.disk) &&
         <ConfigurationMapRow>
           <ConfigurationMapLabel>Disk</ConfigurationMapLabel>
           <ConfigurationMapSizeValue value={fields.resources.disk} />
-          <a
-            className="button button-link flush table-display-on-row-hover"
-            onClick={onEditClick.bind(null, { tabViewID })}
-          >
-            Edit
-          </a>
+          {action}
         </ConfigurationMapRow>}
       {Boolean(fields.resources.gpus) &&
         <ConfigurationMapRow>
           <ConfigurationMapLabel>GPUs</ConfigurationMapLabel>
           <ConfigurationMapValue value={fields.resources.gpus} />
-          <a
-            className="button button-link flush table-display-on-row-hover"
-            onClick={onEditClick.bind(null, { tabViewID })}
-          >
-            Edit
-          </a>
+          {action}
         </ConfigurationMapRow>}
 
       {/* Global Properties */}
@@ -134,23 +116,13 @@ const PodContainerConfigSection = ({
         <ConfigurationMapRow>
           <ConfigurationMapLabel>Run as User</ConfigurationMapLabel>
           <ConfigurationMapValue value={fields.user} />
-          <a
-            className="button button-link flush table-display-on-row-hover"
-            onClick={onEditClick.bind(null, { tabViewID })}
-          >
-            Edit
-          </a>
+          {action}
         </ConfigurationMapRow>}
       {Boolean(fields.command) &&
         <ConfigurationMapRow>
           <ConfigurationMapLabel>Command</ConfigurationMapLabel>
           <ConfigurationMapMultilineValue value={fields.command} />
-          <a
-            className="button button-link flush table-display-on-row-hover"
-            onClick={onEditClick.bind(null, { tabViewID })}
-          >
-            Edit
-          </a>
+          {action}
         </ConfigurationMapRow>}
 
       {/* Container artifacts */}

--- a/plugins/services/src/js/service-configuration/PodGeneralConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodGeneralConfigSection.js
@@ -92,6 +92,18 @@ const PodGeneralConfigSection = ({ appConfig, onEditClick }) => {
     )
   };
 
+  let action;
+  if (onEditClick) {
+    action = (
+      <a
+        className="button button-link flush table-display-on-row-hover"
+        onClick={onEditClick.bind(null, "services")}
+      >
+        Edit
+      </a>
+    );
+  }
+
   return (
     <div>
       <ConfigurationMapHeading level={1}>General</ConfigurationMapHeading>
@@ -99,92 +111,52 @@ const PodGeneralConfigSection = ({ appConfig, onEditClick }) => {
         <ConfigurationMapRow>
           <ConfigurationMapLabel>Service ID</ConfigurationMapLabel>
           <ConfigurationMapValue value={appConfig.id} />
-          <a
-            className="button button-link flush table-display-on-row-hover"
-            onClick={onEditClick.bind(null, "services")}
-          >
-            Edit
-          </a>
+          {action}
         </ConfigurationMapRow>
         <ConfigurationMapRow>
           <ConfigurationMapLabel>Instances</ConfigurationMapLabel>
           <ConfigurationMapValueWithDefault value={fields.instances} />
-          <a
-            className="button button-link flush table-display-on-row-hover"
-            onClick={onEditClick.bind(null, "services")}
-          >
-            Edit
-          </a>
+          {action}
         </ConfigurationMapRow>
         <ConfigurationMapRow>
           <ConfigurationMapLabel>CPU</ConfigurationMapLabel>
           <ConfigurationMapValue>
             {getContainerResourceSummary("cpus", appConfig)}
           </ConfigurationMapValue>
-          <a
-            className="button button-link flush table-display-on-row-hover"
-            onClick={onEditClick.bind(null, "services")}
-          >
-            Edit
-          </a>
+          {action}
         </ConfigurationMapRow>
         <ConfigurationMapRow>
           <ConfigurationMapLabel>Memory</ConfigurationMapLabel>
           <ConfigurationMapValue>
             {getContainerResourceSummary("mem", appConfig)}
           </ConfigurationMapValue>
-          <a
-            className="button button-link flush table-display-on-row-hover"
-            onClick={onEditClick.bind(null, "services")}
-          >
-            Edit
-          </a>
+          {action}
         </ConfigurationMapRow>
         <ConfigurationMapRow>
           <ConfigurationMapLabel>Disk</ConfigurationMapLabel>
           <ConfigurationMapValue>
             {getContainerResourceSummary("disk", appConfig)}
           </ConfigurationMapValue>
-          <a
-            className="button button-link flush table-display-on-row-hover"
-            onClick={onEditClick.bind(null, "services")}
-          >
-            Edit
-          </a>
+          {action}
         </ConfigurationMapRow>
         <ConfigurationMapRow>
           <ConfigurationMapLabel>GPU</ConfigurationMapLabel>
           <ConfigurationMapValue>
             {getContainerResourceSummary("gpu", appConfig)}
           </ConfigurationMapValue>
-          <a
-            className="button button-link flush table-display-on-row-hover"
-            onClick={onEditClick.bind(null, "services")}
-          >
-            Edit
-          </a>
+          {action}
         </ConfigurationMapRow>
         {Boolean(fields.backoff) &&
           <ConfigurationMapRow>
             <ConfigurationMapLabel>Backoff</ConfigurationMapLabel>
             <DurationValue units="sec" value={fields.backoff} />
-            <a
-              className="button button-link flush table-display-on-row-hover"
-              onClick={onEditClick.bind(null, "services")}
-            >
-              Edit
-            </a>
+            {action}
           </ConfigurationMapRow>}
         {Boolean(fields.backoffFactor) &&
           <ConfigurationMapRow>
             <ConfigurationMapLabel>Backoff Factor</ConfigurationMapLabel>
             <ConfigurationMapValue value={fields.backoffFactor} />
-            <a
-              className="button button-link flush table-display-on-row-hover"
-              onClick={onEditClick.bind(null, "services")}
-            >
-              Edit
-            </a>
+            {action}
           </ConfigurationMapRow>}
         {Boolean(fields.maxLaunchDelay) &&
           <ConfigurationMapRow>
@@ -192,12 +164,7 @@ const PodGeneralConfigSection = ({ appConfig, onEditClick }) => {
               Backoff Max Launch Delay
             </ConfigurationMapLabel>
             <DurationValue units="sec" value={fields.maxLaunchDelay} />
-            <a
-              className="button button-link flush table-display-on-row-hover"
-              onClick={onEditClick.bind(null, "services")}
-            >
-              Edit
-            </a>
+            {action}
           </ConfigurationMapRow>}
         {Boolean(fields.minimumHealthCapacity) &&
           <ConfigurationMapRow>
@@ -205,12 +172,7 @@ const PodGeneralConfigSection = ({ appConfig, onEditClick }) => {
               Upgrade Min Health Capacity
             </ConfigurationMapLabel>
             <ConfigurationMapValue value={fields.minimumHealthCapacity} />
-            <a
-              className="button button-link flush table-display-on-row-hover"
-              onClick={onEditClick.bind(null, "services")}
-            >
-              Edit
-            </a>
+            {action}
           </ConfigurationMapRow>}
         {Boolean(fields.maximumOverCapacity) &&
           <ConfigurationMapRow>
@@ -218,12 +180,7 @@ const PodGeneralConfigSection = ({ appConfig, onEditClick }) => {
               Upgrade Max Overcapacity
             </ConfigurationMapLabel>
             <ConfigurationMapValue value={fields.maximumOverCapacity} />
-            <a
-              className="button button-link flush table-display-on-row-hover"
-              onClick={onEditClick.bind(null, "services")}
-            >
-              Edit
-            </a>
+            {action}
           </ConfigurationMapRow>}
       </ConfigurationMapSection>
     </div>

--- a/plugins/services/src/js/service-configuration/PodNetworkConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodNetworkConfigSection.js
@@ -89,6 +89,18 @@ class PodNetworkConfigSection extends React.Component {
       return <noscript />;
     }
 
+    let action;
+    if (onEditClick) {
+      action = (
+        <a
+          className="button button-link flush table-display-on-row-hover"
+          onClick={onEditClick.bind(null, "networking")}
+        >
+          Edit
+        </a>
+      );
+    }
+
     return (
       <div>
         <ConfigurationMapHeading level={1}>Network</ConfigurationMapHeading>
@@ -100,12 +112,7 @@ class PodNetworkConfigSection extends React.Component {
             <ConfigurationMapValueWithDefault
               value={getNetworkTypes(appConfig.networks)}
             />
-            <a
-              className="button button-link flush table-display-on-row-hover"
-              onClick={onEditClick.bind(null, "networking")}
-            >
-              Edit
-            </a>
+            {action}
           </ConfigurationMapRow>
 
           {/* Service endpoints */}


### PR DESCRIPTION
Add conditionals to only render the actions if onEditClick is not undefined. **Now there should be nowhere with `onEditClick.bind()` without first checking that it's not an undefined reference.**

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
