### PR TITLE
fix(validate-tests): throw error and exit 1 when regex match

### DIFF
--- a/scripts/validate-tests
+++ b/scripts/validate-tests
@@ -7,7 +7,7 @@ source ${SCRIPT_PATH}/utils/git
 
 header "Validating tests..."
 
-! egrep --quiet -R "fdescribe\\(|fit\(" ./src && \
-! egrep --quiet -R "context\.only\(|it\.only\(" ./tests
+! egrep -R "fdescribe\\(|fit\(" ./src || exit 1 && \
+! egrep -R "context\.only\(|it\.only\(" ./tests || exit 1
 
 exit 0


### PR DESCRIPTION
This will ensure that ".only" for integration tests, or "fit" for unit tests don't make it into our codebase.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
