### PR TITLE
Improve test validation

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -5,12 +5,33 @@ SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
 # Import utils
 source ${SCRIPT_PATH}/utils/git
 source ${SCRIPT_PATH}/utils/message
+source ${SCRIPT_PATH}/utils/test
 
 title "Run pre-commit hook..."
 
 # Get a list of staged JavaScript and Less files
 staged_javascript_files=$(get_staged_files_with_name '*.js');
 staged_less_files=$(get_staged_files_with_name '*.less');
+
+# Validate staged tests
+if [ -n "${staged_javascript_files}" ]
+then
+  header "Validate staged JavaScript tests..."
+  debug_directives=$(find_debug_directives ${staged_javascript_files})
+
+  if [ -n "${debug_directives}" ]
+  then
+    warning "Debug directives found"
+
+    echo -e "Please remove all found debug directives" \
+     "before committing your changes. \n" \
+     "${debug_directives}"
+
+    exit 1
+  fi
+
+  info "Staged JavaScript tests looks good"
+fi
 
 # Lint staged JavaScript and Less files
 if [ -n "${staged_javascript_files}" ]
@@ -19,6 +40,7 @@ then
   npm run eslint --silent -- ${staged_javascript_files} || exit $?
   info "Staged JavaScript looks good"
 fi
+
 if [ -n "${staged_less_files}" ]
 then
   header "Lint staged Less files..."

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -5,12 +5,30 @@ SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
 # Import utils
 source ${SCRIPT_PATH}/utils/git
 source ${SCRIPT_PATH}/utils/message
+source ${SCRIPT_PATH}/utils/test
 
-${SCRIPT_PATH}/validate-tests
-
-title "Lint commit messages..."
+title "Run pre-push hook..."
 
 fork_point=$(get_fork_point)
+
+header "Validate staged JavaScript tests..."
+debug_directives=$(
+  find_debug_directives $(git diff --name-only ${fork_point} HEAD  -- "*.js")
+)
+
+if [ -n "${debug_directives}" ]
+then
+  warning "Debug directives found"
+
+  echo -e "Please remove all found debug directives" \
+   "before committing your changes. \n" \
+   "${debug_directives}"
+
+  exit 1
+fi
+info "Staged JavaScript tests looks good"
+
+header "Lint commit messages..."
 linting_errors="$(
   npm run conventional-changelog-lint --silent -- -f ${fork_point} -t HEAD;
   echo x$?

--- a/scripts/utils/test
+++ b/scripts/utils/test
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+DEBUG_DIRECTIVE_PATTERN="(f(it|describe)|(it|describe|test|context)\.only)\("
+
+# Example: find_debug_directives ./test src/js/components/__tests__/Component-test.js
+find_debug_directives(){
+  if [[ ! -n $* ]]
+  then
+   exit 0
+  fi
+
+ local matches=$(
+    grep -E -R -s --color=always ${DEBUG_DIRECTIVE_PATTERN} $*
+  )
+
+ echo -e "${matches}"
+}

--- a/scripts/validate-tests
+++ b/scripts/validate-tests
@@ -4,10 +4,26 @@ SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
 
 # Import utils
 source ${SCRIPT_PATH}/utils/message
+source ${SCRIPT_PATH}/utils/test
 
-header "Validating tests..."
+title "Validating tests..."
 
-! egrep -R "fdescribe\\(|fit\(" ./src || exit 1 && \
-! egrep -R "context\.only\(|it\.only\(" ./tests || exit 1
+debug_directives=$(
+ find_debug_directives ./src ./plugins ./packages ./tests ./system-tests
+)
+
+
+if [ -n "${debug_directives}" ]
+then
+  warning "Debug directives found"
+
+  echo -e "Please remove all found debug directives" \
+   "to ensure that all test run properly. \n"
+   "${debug_directives}"
+
+  exit 1
+fi
+
+info "Tests look good."
 
 exit 0

--- a/scripts/validate-tests
+++ b/scripts/validate-tests
@@ -3,7 +3,7 @@
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
 
 # Import utils
-source ${SCRIPT_PATH}/utils/git
+source ${SCRIPT_PATH}/utils/message
 
 header "Validating tests..."
 


### PR DESCRIPTION
Improve test validation by adding a new test util and adjusting the `validate-tests` script as well as the git hooks.

* Add a `find_debug_directives` test util to validate tests and make sure they don't include any debug directives preventing proper test execution.
* Adjust `pre-push` hook using the `find_debug_directives` test utility to bail if tests are invalid.
* Change the `validate-tests` script to validate all test using the `find_debug_directives` test utility. This change also removes the dependency on `egrep` which should no longer be used as it's deprecated binary.
* Introduce a test validation step to make sure that we don't commit any debug directives (e.g., `only`) which could render our test useless.