### PR TITLE
Add host compare method in RouterUtil

### DIFF
--- a/src/js/utils/RouterUtil.js
+++ b/src/js/utils/RouterUtil.js
@@ -189,15 +189,34 @@ const RouterUtil = {
   },
 
   /**
-   * Compair two urls if they have the same host name
+   * Get URL full path. If it is a full path url return, if not attach
+   * the current local origin.
+   *
+   * @param {String} url The url
+   * @returns {String} - The url with the full path
+   */
+  getFullPath(url) {
+    if (!/http:\/\/|https:\/\//.test(url)) {
+      url = `${global.location.origin}${url.replace(/^(\/|)/g, "/")}`;
+    }
+
+    return url;
+  },
+
+  /**
+   * Compares two urls if they have the same host name
    *
    * @param {String} urlA The first url
    * @param {String} urlB The second url
    * @returns {Boolean} - True if they have the same host, false if they don't
    */
   hasSameHost(urlA, urlB) {
-    const parsedUrlA = Util.parseUrl(urlA);
-    const parsedUrlB = Util.parseUrl(urlB);
+    if (typeof urlA !== "string" || typeof urlB !== "string") {
+      return false;
+    }
+
+    const parsedUrlA = Util.parseUrl(this.getFullPath(urlA));
+    const parsedUrlB = Util.parseUrl(this.getFullPath(urlB));
 
     if (!parsedUrlA || !parsedUrlB) {
       return false;

--- a/src/js/utils/RouterUtil.js
+++ b/src/js/utils/RouterUtil.js
@@ -186,6 +186,24 @@ const RouterUtil = {
       const blob = new Blob([data], { type: "application/json" });
       global.navigator.msSaveOrOpenBlob(blob, filename);
     }
+  },
+
+  /**
+   * Compair two urls if they have the same host name
+   *
+   * @param {String} urlA The first url
+   * @param {String} urlB The second url
+   * @returns {Boolean} - True if they have the same host, false if they don't
+   */
+  hasSameHost(urlA, urlB) {
+    const parsedUrlA = Util.parseUrl(urlA);
+    const parsedUrlB = Util.parseUrl(urlB);
+
+    if (!parsedUrlA || !parsedUrlB) {
+      return false;
+    }
+
+    return parsedUrlA.host === parsedUrlB.host;
   }
 };
 

--- a/src/js/utils/RouterUtil.js
+++ b/src/js/utils/RouterUtil.js
@@ -189,21 +189,6 @@ const RouterUtil = {
   },
 
   /**
-   * Get URL full path. If it is a full path url return, if not attach
-   * the current local origin.
-   *
-   * @param {String} url The url
-   * @returns {String} - The url with the full path
-   */
-  getFullPath(url) {
-    if (!/http:\/\/|https:\/\//.test(url)) {
-      url = `${global.location.origin}${url.replace(/^(\/|)/g, "/")}`;
-    }
-
-    return url;
-  },
-
-  /**
    * Compares two urls if they have the same host name
    *
    * @param {String} urlA The first url
@@ -215,8 +200,8 @@ const RouterUtil = {
       return false;
     }
 
-    const parsedUrlA = Util.parseUrl(this.getFullPath(urlA));
-    const parsedUrlB = Util.parseUrl(this.getFullPath(urlB));
+    const parsedUrlA = Util.parseUrl(urlA);
+    const parsedUrlB = Util.parseUrl(urlB);
 
     if (!parsedUrlA || !parsedUrlB) {
       return false;

--- a/src/js/utils/__tests__/RouterUtil-test.js
+++ b/src/js/utils/__tests__/RouterUtil-test.js
@@ -226,35 +226,6 @@ describe("RouterUtil", function() {
     });
   });
 
-  describe("#getFullPath", function() {
-    beforeEach(function() {
-      const localhost = "http://localhost:4200";
-
-      // Overwrite jsdom global/window location mock
-      Object.defineProperty(global.location, "origin", {
-        writable: true,
-        value: localhost
-      });
-    });
-
-    it("attaches the local path for relative path", function() {
-      const fullPath = RouterUtil.getFullPath("/some/stuff");
-      expect(fullPath).toEqual("http://localhost:4200/some/stuff");
-    });
-
-    it("attaches the local path for relative path without leading slash", function() {
-      const fullPath = RouterUtil.getFullPath("some/stuff");
-      expect(fullPath).toEqual("http://localhost:4200/some/stuff");
-    });
-
-    it("leaves a full path in tact", function() {
-      const fullPath = RouterUtil.getFullPath(
-        "https://cluster-1.com/some/stuff"
-      );
-      expect(fullPath).toEqual("https://cluster-1.com/some/stuff");
-    });
-  });
-
   describe("#hasSameHost", function() {
     beforeEach(function() {
       const localhost = "http://localhost:4200";
@@ -296,14 +267,6 @@ describe("RouterUtil", function() {
       const hasSameHost = RouterUtil.hasSameHost(
         "/some/path",
         "some/other/path"
-      );
-      expect(hasSameHost).toEqual(true);
-    });
-
-    it("returns true for same relative and local host path", function() {
-      const hasSameHost = RouterUtil.hasSameHost(
-        "http://localhost:4200/some/path",
-        "/some/path"
       );
       expect(hasSameHost).toEqual(true);
     });

--- a/src/js/utils/__tests__/RouterUtil-test.js
+++ b/src/js/utils/__tests__/RouterUtil-test.js
@@ -225,4 +225,28 @@ describe("RouterUtil", function() {
       expect(path).toEqual("");
     });
   });
+
+  describe("#hasSameHost", function() {
+    it("returns false for different hosts", function() {
+      const hasSameHost = RouterUtil.hasSameHost(
+        "http://cluster-a.com",
+        "http://cluster-b.com"
+      );
+      expect(hasSameHost).toEqual(false);
+    });
+    it("returns true for same hosts", function() {
+      const hasSameHost = RouterUtil.hasSameHost(
+        "https://cluster-a.com/test/test2/test3",
+        "https://cluster-a.com"
+      );
+      expect(hasSameHost).toEqual(true);
+    });
+    it("returns false if wrong value types entered", function() {
+      const hasSameHost = RouterUtil.hasSameHost(
+        [1, 2, 3],
+        "https://cluster-a.com"
+      );
+      expect(hasSameHost).toEqual(false);
+    });
+  });
 });


### PR DESCRIPTION
Add host compare method in RouteUtil. This is needed for the cluster linking task.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
