### PR TITLE
feat(HighOrderServiceConfiguration): Config tab using cosmos for frameworks

### DIFF
--- a/plugins/services/src/js/components/HighOrderServiceConfiguration.js
+++ b/plugins/services/src/js/components/HighOrderServiceConfiguration.js
@@ -1,16 +1,23 @@
 import React from "react";
 
+import Framework from "#PLUGINS/services/src/js/structs/Framework";
 import Pod from "../structs/Pod";
 import PodConfigurationContainer
   from "../containers/pod-configuration/PodConfigurationContainer";
 import Service from "../structs/Service";
 import ServiceConfigurationContainer
   from "../containers/service-configuration/ServiceConfigurationContainer";
+import FrameworkConfigurationContainer
+  from "../containers/framework-configuration/FrameworkConfigurationContainer";
 
 const HighOrderServiceConfiguration = function(props) {
   const { errors, onEditClick, service } = props;
   if (service instanceof Pod) {
     return <PodConfigurationContainer pod={service} />;
+  }
+
+  if (service instanceof Framework) {
+    return <FrameworkConfigurationContainer service={service} />;
   }
 
   return (

--- a/plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.js
+++ b/plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.js
@@ -1,0 +1,106 @@
+import React from "react";
+
+import UniversePackage from "#SRC/js/structs/UniversePackage";
+
+import Framework from "#PLUGINS/services/src/js/structs/Framework";
+import { routerShape } from "react-router";
+import FrameworkConfigurationReviewScreen
+  from "#SRC/js/components/FrameworkConfigurationReviewScreen";
+import Loader from "src/js/components/Loader";
+import CosmosPackagesStore from "#SRC/js/stores/CosmosPackagesStore";
+import { COSMOS_SERVICE_DESCRIBE_CHANGE } from "#SRC/js/constants/EventTypes";
+
+const METHODS_TO_BIND = [
+  "reorderResolvedOptions",
+  "handleEditClick",
+  "onCosmosPackagesStoreServiceDescriptionSuccess"
+];
+
+class FrameworkConfigurationContainer extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const { service } = this.props;
+
+    this.state = {
+      frameworkData: null
+    };
+
+    METHODS_TO_BIND.forEach(method => {
+      this[method] = this[method].bind(this);
+    });
+
+    CosmosPackagesStore.fetchServiceDescription(service.getId());
+  }
+
+  componentDidMount() {
+    CosmosPackagesStore.addChangeListener(
+      COSMOS_SERVICE_DESCRIBE_CHANGE,
+      this.onCosmosPackagesStoreServiceDescriptionSuccess
+    );
+  }
+
+  componentWillUnmount() {
+    CosmosPackagesStore.removeChangeListener(
+      COSMOS_SERVICE_DESCRIBE_CHANGE,
+      this.onCosmosPackagesStoreServiceDescriptionSuccess
+    );
+  }
+
+  onCosmosPackagesStoreServiceDescriptionSuccess() {
+    const fullPackage = CosmosPackagesStore.getServiceDetails();
+    const packageDetails = new UniversePackage(fullPackage.package);
+
+    // necessary to have review screen same order of tabs as the form
+    const frameworkData = this.reorderResolvedOptions(
+      fullPackage.resolvedOptions,
+      packageDetails.getConfig()
+    );
+
+    this.setState({ frameworkData });
+  }
+
+  reorderResolvedOptions(resolvedOptions, config) {
+    const order = Object.keys(config.properties);
+    const orderedResolvedOptions = {};
+    order.forEach(tab => {
+      orderedResolvedOptions[tab] = resolvedOptions[tab];
+    });
+
+    return orderedResolvedOptions;
+  }
+
+  handleEditClick() {
+    const { router } = this.context;
+    const { service } = this.props;
+
+    router.push(
+      `/services/detail/${encodeURIComponent(service.getId())}/edit/`
+    );
+  }
+
+  render() {
+    const { frameworkData } = this.state;
+
+    if (!frameworkData) {
+      return <Loader />;
+    }
+
+    return (
+      <FrameworkConfigurationReviewScreen
+        frameworkData={frameworkData}
+        onEditClick={this.handleEditClick}
+      />
+    );
+  }
+}
+
+FrameworkConfigurationContainer.propTypes = {
+  service: React.PropTypes.instanceOf(Framework).isRequired
+};
+
+FrameworkConfigurationContainer.contextTypes = {
+  router: routerShape
+};
+
+module.exports = FrameworkConfigurationContainer;

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -8,6 +8,7 @@ import DCOSStore from "#SRC/js/stores/DCOSStore";
 import Icon from "#SRC/js/components/Icon";
 import Loader from "#SRC/js/components/Loader";
 import { isSDKService } from "#SRC/js/utils/ServiceUtil";
+import RouterUtil from "#SRC/js/utils/RouterUtil";
 
 import ApplicationSpec from "../../structs/ApplicationSpec";
 import ServiceConfigDisplay
@@ -118,17 +119,7 @@ class ServiceConfiguration extends mixin(StoreMixin) {
       );
     }
 
-    return [
-      <button
-        className="button button-primary-link"
-        disabled={isSDKService(service)}
-        key="version-button-edit"
-        onClick={() => this.handleEditButtonClick()}
-      >
-        Edit
-      </button>,
-      applyButton
-    ];
+    return [applyButton];
   }
 
   getVersionsDropdown() {
@@ -215,9 +206,46 @@ class ServiceConfiguration extends mixin(StoreMixin) {
       );
     }
 
+    const fileName = "config.json";
+    const configString = JSON.stringify(config, null, 2);
+
     return (
       <div className="container">
-        {this.getVersionsActions()}
+        <div className="row">
+          <div className="column-6">
+            {this.getVersionsActions()}
+          </div>
+          <div className="column-6 text-align-right">
+            <button
+              className="button button-primary-link button-inline-flex"
+              onClick={this.handleEditButtonClick}
+            >
+              <Icon id="pencil" size="mini" family="system" />
+              <span className="form-group-heading-content">
+                {"Edit Config"}
+              </span>
+            </button>
+            <a
+              className="button button-primary-link flush-right"
+              download={fileName}
+              onClick={RouterUtil.triggerIEDownload.bind(
+                null,
+                fileName,
+                configString
+              )}
+              href={RouterUtil.getResourceDownloadPath(
+                "attachment/json",
+                fileName,
+                configString
+              )}
+            >
+              <Icon id="download" size="mini" family="system" />
+              <span className="form-group-heading-content">
+                {"Download Config"}
+              </span>
+            </a>
+          </div>
+        </div>
         <ServiceConfigDisplay appConfig={config} errors={errors} />
       </div>
     );

--- a/src/js/components/FrameworkConfiguration.js
+++ b/src/js/components/FrameworkConfiguration.js
@@ -11,16 +11,15 @@ import FullScreenModalHeaderTitle
 import FullScreenModalHeaderSubTitle
   from "#SRC/js/components/modals/FullScreenModalHeaderSubTitle";
 import ToggleButton from "#SRC/js/components/ToggleButton";
-import HashMapDisplay from "#SRC/js/components/HashMapDisplay";
 import ModalHeading from "#SRC/js/components/modals/ModalHeading";
 import UniversePackage from "#SRC/js/structs/UniversePackage";
-import Icon from "#SRC/js/components/Icon";
 import Util from "#SRC/js/utils/Util";
 import StringUtil from "#SRC/js/utils/StringUtil";
 import CosmosErrorMessage from "#SRC/js/components/CosmosErrorMessage";
-import RouterUtil from "#SRC/js/utils/RouterUtil";
 import FrameworkConfigurationForm
   from "#SRC/js/components/FrameworkConfigurationForm";
+import FrameworkConfigurationReviewScreen
+  from "#SRC/js/components/FrameworkConfigurationReviewScreen";
 
 const METHODS_TO_BIND = [
   "handleJSONToggle",
@@ -74,23 +73,6 @@ class FrameworkConfiguration extends Component {
     const { activeTab, focusField } = this.getFirstTabAndField();
 
     this.setState({ reviewActive: false, activeTab, focusField });
-  }
-
-  getHashMapRenderKeys(formData) {
-    if (!Util.isObject(formData)) {
-      return {};
-    }
-
-    let renderKeys = {};
-    Object.keys(formData).forEach(key => {
-      renderKeys[key] = StringUtil.capitalizeEveryWord(key);
-      renderKeys = Object.assign(
-        renderKeys,
-        this.getHashMapRenderKeys(formData[key])
-      );
-    });
-
-    return renderKeys;
   }
 
   getFirstTabAndField() {
@@ -237,11 +219,6 @@ class FrameworkConfiguration extends Component {
   getReviewScreen() {
     const { deployErrors, isInitialDeploy, formData } = this.props;
 
-    const fileName = "config.json";
-    const configString = JSON.stringify(formData, null, 2);
-
-    const renderKeys = this.getHashMapRenderKeys(formData);
-
     let warningMessage = null;
     if (isInitialDeploy) {
       warningMessage = this.getWarningMessage();
@@ -257,46 +234,10 @@ class FrameworkConfiguration extends Component {
         <div className="container container-wide">
           {errorsAlert}
           {warningMessage}
-          <div className="row">
-            <div className="column-4">
-              <h1 className="flush-top">Configuration</h1>
-            </div>
-            <div className="column-8 text-align-right">
-              <button
-                className="button button-primary-link button-inline-flex"
-                onClick={this.handleEditConfigurationButtonClick}
-              >
-                <Icon id="pencil" size="mini" family="system" />
-                <span className="form-group-heading-content">
-                  {"Edit Config"}
-                </span>
-              </button>
-              <a
-                className="button button-primary-link flush-right"
-                download={fileName}
-                onClick={RouterUtil.triggerIEDownload.bind(
-                  null,
-                  fileName,
-                  configString
-                )}
-                href={RouterUtil.getResourceDownloadPath(
-                  "attachment/json",
-                  fileName,
-                  configString
-                )}
-              >
-                <Icon id="download" size="mini" family="system" />
-                <span className="form-group-heading-content">
-                  {"Download Config"}
-                </span>
-              </a>
-            </div>
-          </div>
-          <HashMapDisplay
-            hash={formData}
-            renderKeys={renderKeys}
-            headlineClassName={"text-capitalize"}
-            emptyValue={"\u2014"}
+          <FrameworkConfigurationReviewScreen
+            frameworkData={formData}
+            title={"Configuration"}
+            onEditClick={this.handleEditConfigurationButtonClick}
           />
         </div>
       </div>

--- a/src/js/components/FrameworkConfigurationReviewScreen.js
+++ b/src/js/components/FrameworkConfigurationReviewScreen.js
@@ -1,0 +1,111 @@
+import React from "react";
+
+import HashMapDisplay from "#SRC/js/components/HashMapDisplay";
+import Util from "#SRC/js/utils/Util";
+import StringUtil from "#SRC/js/utils/StringUtil";
+import Icon from "#SRC/js/components/Icon";
+import RouterUtil from "#SRC/js/utils/RouterUtil";
+
+const METHODS_TO_BIND = ["reorderResolvedOptions", "getHashMapRenderKeys"];
+
+class FrameworkConfigurationReviewScreen extends React.Component {
+  constructor(props) {
+    super(props);
+
+    METHODS_TO_BIND.forEach(method => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  reorderResolvedOptions(resolvedOptions, config) {
+    const order = Object.keys(config.properties);
+    const orderedResolvedOptions = {};
+    order.forEach(tab => {
+      orderedResolvedOptions[tab] = resolvedOptions[tab];
+    });
+
+    return orderedResolvedOptions;
+  }
+
+  getHashMapRenderKeys(formData) {
+    if (!Util.isObject(formData)) {
+      return {};
+    }
+
+    let renderKeys = {};
+    Object.keys(formData).forEach(key => {
+      renderKeys[key] = StringUtil.capitalizeEveryWord(key);
+      renderKeys = Object.assign(
+        renderKeys,
+        this.getHashMapRenderKeys(formData[key])
+      );
+    });
+
+    return renderKeys;
+  }
+
+  render() {
+    const { frameworkData, title, onEditClick } = this.props;
+
+    const fileName = "config.json";
+    const configString = JSON.stringify(frameworkData, null, 2);
+
+    return (
+      <div className="container">
+        <div className="row">
+          <div className="column-4">
+            <h1 className="flush-top">{title}</h1>
+          </div>
+          <div className="column-8 text-align-right">
+            <button
+              className="button button-primary-link button-inline-flex"
+              onClick={onEditClick}
+            >
+              <Icon id="pencil" size="mini" family="system" />
+              <span className="form-group-heading-content">
+                {"Edit Config"}
+              </span>
+            </button>
+            <a
+              className="button button-primary-link flush-right"
+              download={fileName}
+              onClick={RouterUtil.triggerIEDownload.bind(
+                null,
+                fileName,
+                configString
+              )}
+              href={RouterUtil.getResourceDownloadPath(
+                "attachment/json",
+                fileName,
+                configString
+              )}
+            >
+              <Icon id="download" size="mini" family="system" />
+              <span className="form-group-heading-content">
+                {"Download Config"}
+              </span>
+            </a>
+          </div>
+        </div>
+        <HashMapDisplay
+          hash={frameworkData}
+          renderKeys={this.getHashMapRenderKeys(frameworkData)}
+          headlineClassName={"text-capitalize"}
+          emptyValue={"\u2014"}
+        />
+      </div>
+    );
+  }
+}
+
+FrameworkConfigurationReviewScreen.defaultProps = {
+  title: ""
+};
+
+FrameworkConfigurationReviewScreen.propTypes = {
+  onEditClick: React.PropTypes.func.isRequired,
+  frameworkData: React.PropTypes.object.isRequired,
+  title: React.PropTypes.string
+};
+
+module.exports = FrameworkConfigurationReviewScreen;

--- a/tests/pages/services/ServiceDetail-cy.js
+++ b/tests/pages/services/ServiceDetail-cy.js
@@ -1,89 +1,120 @@
 describe("Service Detail Page", function() {
-  beforeEach(function() {
-    cy.configureCluster({
-      mesos: "1-task-healthy",
-      nodeHealth: true
+  context("Services", function() {
+    beforeEach(function() {
+      cy.configureCluster({
+        mesos: "1-task-healthy",
+        nodeHealth: true
+      });
+    });
+
+    context("Navigate to service page", function() {
+      it("should show the Page Not Found alert panel", function() {
+        cy.visitUrl({
+          url: "/services/non-existing-service"
+        });
+        cy.get(".page-body-content").contains("Page not found");
+      });
+    });
+
+    context("Navigate to service detail page", function() {
+      it("shows the Service Not Found alert panel in page contents", function() {
+        cy.visitUrl({
+          url: "/services/detail/non-existing-service"
+        });
+        cy.get(".page-body-content").contains("Service not found");
+      });
+
+      it("shows instances tab per default", function() {
+        cy.visitUrl({
+          url: "/services/detail/%2Fsleep"
+        });
+
+        cy
+          .get(".menu-tabbed-item .active")
+          .contains("Tasks")
+          .get(".table")
+          .contains("sleep");
+
+        cy.hash().should("match", /services\/detail\/%2Fsleep\/tasks.*/);
+      });
+
+      it("shows configuration tab when clicked", function() {
+        cy.visitUrl({
+          url: "/services/detail/%2Fsleep"
+        });
+
+        cy.get(".menu-tabbed-item").contains("Configuration").click();
+
+        cy
+          .get(".menu-tabbed-item .active")
+          .contains("Configuration")
+          .get(".configuration-map");
+
+        cy
+          .hash()
+          .should("match", /services\/detail\/%2Fsleep\/configuration.*/);
+      });
+
+      it("shows debug tab when clicked", function() {
+        cy.visitUrl({
+          url: "/services/detail/%2Fsleep"
+        });
+
+        cy.get(".menu-tabbed-item").contains("Debug").click();
+
+        cy
+          .get(".menu-tabbed-item .active")
+          .contains("Debug")
+          .get(".page-body-content")
+          .contains("Last Changes");
+
+        cy.hash().should("match", /services\/detail\/%2Fsleep\/debug.*/);
+      });
+
+      it("shows volumes tab when clicked", function() {
+        cy.visitUrl({
+          url: "/services/detail/%2Fsleep"
+        });
+
+        cy.get(".menu-tabbed-item").contains("Volumes").click();
+
+        cy.get(".menu-tabbed-item .active").contains("Volumes");
+
+        cy
+          .get(".table")
+          .contains("tr", "volume-1")
+          .parents(".table")
+          .contains("tr", "volume-2");
+
+        cy.hash().should("match", /services\/detail\/%2Fsleep\/volumes.*/);
+      });
     });
   });
 
-  context("Navigate to service page", function() {
-    it("should show the Page Not Found alert panel", function() {
-      cy.visitUrl({
-        url: "/services/non-existing-service"
+  context("SDK Services", function() {
+    beforeEach(function() {
+      cy.configureCluster({
+        mesos: "1-for-each-health",
+        nodeHealth: true,
+        universePackages: true
       });
-      cy.get(".page-body-content").contains("Page not found");
-    });
-  });
 
-  context("Navigate to service detail page", function() {
-    it("shows the Service Not Found alert panel in page contents", function() {
       cy.visitUrl({
-        url: "/services/detail/non-existing-service"
+        url: "/services/detail/%2Fcassandra-healthy/configuration"
       });
-      cy.get(".page-body-content").contains("Service not found");
     });
 
-    it("shows instances tab per default", function() {
-      cy.visitUrl({
-        url: "/services/detail/%2Fsleep"
-      });
+    it("edit config button opens the edit flow", function() {
+      cy.get(".container").contains("Edit Config").click();
 
       cy
-        .get(".menu-tabbed-item .active")
-        .contains("Tasks")
-        .get(".table")
-        .contains("sleep");
-
-      cy.hash().should("match", /services\/detail\/%2Fsleep\/tasks.*/);
+        .location()
+        .its("hash")
+        .should("include", "#/services/detail/%2Fcassandra-healthy/edit");
     });
 
-    it("shows configuration tab when clicked", function() {
-      cy.visitUrl({
-        url: "/services/detail/%2Fsleep"
-      });
-
-      cy.get(".menu-tabbed-item").contains("Configuration").click();
-
-      cy
-        .get(".menu-tabbed-item .active")
-        .contains("Configuration")
-        .get(".configuration-map");
-
-      cy.hash().should("match", /services\/detail\/%2Fsleep\/configuration.*/);
-    });
-
-    it("shows debug tab when clicked", function() {
-      cy.visitUrl({
-        url: "/services/detail/%2Fsleep"
-      });
-
-      cy.get(".menu-tabbed-item").contains("Debug").click();
-
-      cy
-        .get(".menu-tabbed-item .active")
-        .contains("Debug")
-        .get(".page-body-content")
-        .contains("Last Changes");
-
-      cy.hash().should("match", /services\/detail\/%2Fsleep\/debug.*/);
-    });
-
-    it("shows volumes tab when clicked", function() {
-      cy.visitUrl({
-        url: "/services/detail/%2Fsleep"
-      });
-
-      cy.get(".menu-tabbed-item").contains("Volumes").click();
-
-      cy.get(".menu-tabbed-item .active").contains("Volumes");
-
-      cy
-        .get(".table")
-        .contains("tr", "volume-1")
-        .parents(".table")
-        .contains("tr", "volume-2");
-
-      cy.hash().should("match", /services\/detail\/%2Fsleep\/volumes.*/);
+    it("download button exists", function() {
+      cy.get(".container").contains("Download Config");
     });
   });
 });

--- a/tests/pages/services/ServiceVersions-cy.js
+++ b/tests/pages/services/ServiceVersions-cy.js
@@ -108,33 +108,10 @@ describe("Service Versions", function() {
         cy.visitUrl({
           url: "/services/detail/%2Fservices%2Fsdk-sleep/configuration"
         });
-
-        cy.get(".services-version-select button").as("dropdown");
       });
 
-      it("disables edit and apply buttons for sdk service", function() {
-        cy
-          .get("@dropdown")
-          .get(".button span")
-          .contains(new Date("2015-08-28T01:26:14.620Z").toLocaleString())
-          .parent()
-          .click();
-
-        cy
-          .get("@dropdown")
-          .get(".dropdown-menu-list ul li")
-          .contains(new Date("2015-02-28T05:12:12.221Z").toLocaleString())
-          .click();
-
-        cy
-          .get(".page-body-content .button")
-          .contains("Edit")
-          .should("have.attr", "disabled");
-
-        cy
-          .get(".page-body-content .button")
-          .contains("Apply")
-          .should("have.attr", "disabled");
+      it("does not show version selection for sdk service", function() {
+        cy.get(".services-version-select button").should("not.exist");
       });
     });
   });


### PR DESCRIPTION
**Description:**
1) Use the `/cosmos/service/describe` data to render the configuration tab on service detail when the service is Framework.
2) Also, change the configuration tab for non-framework services: adding a "Download config" button and "Edit config" button (to make it visually the same as frameworks config tab).
3) Use the new configuration tab partial to render the review screen for framework forms

**Implementation**:
We extract the review screen and edit / download buttons into their own partial called `FrameworkConfigurationReviewScreen`. The component is the area within the red ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) box below.

**1) New config tab for framework:**
![image 2017-12-04 at 1 34 03 pm](https://user-images.githubusercontent.com/1527504/33577610-6fad34da-d8f8-11e7-9b54-9b14d9c8415a.png)

**2) Changes to config tab for non-frameworks:**
![image 2017-12-05 at 1 59 45 pm](https://user-images.githubusercontent.com/1527504/33633157-b1b7e484-d9c4-11e7-9dd0-cf8eabbfd3b1.png)

**3) Review screen for frameworks form now also uses the partial:**
![image 2017-12-04 at 1 34 13 pm](https://user-images.githubusercontent.com/1527504/33577624-7fb453cc-d8f8-11e7-87c1-911fdc648f2a.png)

Closes DCOS_OSS-1789.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
