### PR TITLE
DCOS-18992: Extract placement tab

### DIFF
--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -9,13 +9,11 @@ import AdvancedSection from "#SRC/js/components/form/AdvancedSection";
 import AdvancedSectionContent
   from "#SRC/js/components/form/AdvancedSectionContent";
 import AdvancedSectionLabel from "#SRC/js/components/form/AdvancedSectionLabel";
-import DeleteRowButton from "#SRC/js/components/form/DeleteRowButton";
 import FieldAutofocus from "#SRC/js/components/form/FieldAutofocus";
 import FieldError from "#SRC/js/components/form/FieldError";
 import FieldHelp from "#SRC/js/components/form/FieldHelp";
 import FieldInput from "#SRC/js/components/form/FieldInput";
 import FieldLabel from "#SRC/js/components/form/FieldLabel";
-import FieldSelect from "#SRC/js/components/form/FieldSelect";
 import FormGroup from "#SRC/js/components/form/FormGroup";
 import FormGroupContainer from "#SRC/js/components/form/FormGroupContainer";
 import FormGroupHeading from "#SRC/js/components/form/FormGroupHeading";
@@ -31,8 +29,6 @@ import ContainerServiceFormSection from "./ContainerServiceFormSection";
 import ContainerServiceFormAdvancedSection
   from "./ContainerServiceFormAdvancedSection";
 import General from "../../reducers/serviceForm/General";
-import OperatorTypes from "../../constants/OperatorTypes";
-import PlacementConstraintsUtil from "../../utils/PlacementConstraintsUtil";
 import PodSpec from "../../structs/PodSpec";
 
 const { type: { MESOS, DOCKER }, labelMap } = ContainerConstants;
@@ -53,42 +49,6 @@ const containerRuntimes = {
     helpText: "Universal Container Runtime using native Mesos engine. Supports Docker file format, multiple containers (Pods) and GPU resources."
   }
 };
-
-function placementConstraintLabel(name, tooltipText, options = {}) {
-  const { isRequired = false, linkText = "More information" } = options;
-
-  const tooltipContent = (
-    <span>
-      {`${tooltipText} `}
-      <a
-        href="https://mesosphere.github.io/marathon/docs/constraints.html"
-        target="_blank"
-      >
-        {linkText}
-      </a>.
-    </span>
-  );
-
-  return (
-    <FieldLabel>
-      <FormGroupHeading required={isRequired}>
-        <FormGroupHeadingContent primary={true}>
-          {name}
-        </FormGroupHeadingContent>
-        <FormGroupHeadingContent>
-          <Tooltip
-            content={tooltipContent}
-            interactive={true}
-            maxWidth={300}
-            wrapText={true}
-          >
-            <Icon color="grey" id="circle-question" size="mini" />
-          </Tooltip>
-        </FormGroupHeadingContent>
-      </FormGroupHeading>
-    </FieldLabel>
-  );
-}
 
 class GeneralServiceFormSection extends Component {
   constructor() {
@@ -114,22 +74,32 @@ class GeneralServiceFormSection extends Component {
     this.setState({ convertToPodModalOpen: true });
   }
 
-  getAdvancedContainerSection() {
+  getAdvancedSettingsSection() {
     const { data = {}, errors, service } = this.props;
 
     if (service instanceof PodSpec) {
       return null;
     }
 
+    const initialIsExpanded = this.shouldShowAdvancedOptions();
+
     return (
-      <ContainerServiceFormAdvancedSection
-        data={data}
-        errors={errors}
-        onAddItem={this.props.onAddItem}
-        onRemoveItem={this.props.onRemoveItem}
-        path="container"
-        service={service}
-      />
+      <AdvancedSection initialIsExpanded={initialIsExpanded}>
+        <AdvancedSectionLabel>
+          More Settings
+        </AdvancedSectionLabel>
+        <AdvancedSectionContent>
+          {this.getRuntimeSection()}
+          <ContainerServiceFormAdvancedSection
+            data={data}
+            errors={errors}
+            onAddItem={this.props.onAddItem}
+            onRemoveItem={this.props.onRemoveItem}
+            path="container"
+            service={service}
+          />
+        </AdvancedSectionContent>
+      </AdvancedSection>
     );
   }
 
@@ -210,220 +180,8 @@ class GeneralServiceFormSection extends Component {
     );
   }
 
-  getOperatorTypes() {
-    return Object.keys(OperatorTypes).map((type, index) => {
-      return <option key={index} value={type}>{type}</option>;
-    });
-  }
-
-  getPlacementconstraints() {
-    const { data = {} } = this.props;
-    const constraintsErrors = findNestedPropertyInObject(
-      this.props.errors,
-      "constraints"
-    );
-    let errorNode = null;
-    const placementTooltipContent = (
-      <span>
-        {
-          "Constraints have three parts: a field name, an operator, and an optional parameter. The field can be the hostname of the agent node or any attribute of the agent node. "
-        }
-        <a
-          href="https://mesosphere.github.io/marathon/docs/constraints.html"
-          target="_blank"
-        >
-          More information
-        </a>.
-      </span>
-    );
-    const hasErrors =
-      constraintsErrors != null && !Array.isArray(constraintsErrors);
-
-    if (hasErrors) {
-      errorNode = (
-        <FormGroup showError={hasErrors}>
-          <FieldError>
-            {constraintsErrors}
-          </FieldError>
-        </FormGroup>
-      );
-    }
-
-    return (
-      <div>
-        <h3 className="short-bottom">
-          <FormGroupHeading>
-            <FormGroupHeadingContent primary={true}>
-              Placement Constraints
-            </FormGroupHeadingContent>
-            <FormGroupHeadingContent>
-              <Tooltip
-                content={placementTooltipContent}
-                interactive={true}
-                maxWidth={300}
-                wrapText={true}
-              >
-                <Icon color="grey" id="circle-question" size="mini" />
-              </Tooltip>
-            </FormGroupHeadingContent>
-          </FormGroupHeading>
-        </h3>
-        <p>
-          Constraints control where apps run to allow optimization for either fault tolerance or locality.
-        </p>
-        {this.getPlacementConstraintsFields(data.constraints)}
-        {errorNode}
-        <FormRow>
-          <FormGroup className="column-12">
-            <AddButton
-              onClick={this.props.onAddItem.bind(this, {
-                path: "constraints"
-              })}
-            >
-              Add Placement Constraint
-            </AddButton>
-          </FormGroup>
-        </FormRow>
-      </div>
-    );
-  }
-
-  getPlacementConstraintsFields(data = []) {
-    const constraintsErrors = findNestedPropertyInObject(
-      this.props.errors,
-      "constraints"
-    );
-    const hasOneRequiredValue = data.some(function(constraint) {
-      return PlacementConstraintsUtil.requiresValue(constraint.operator);
-    });
-    const hideValueColumn = data.every(function(constraint) {
-      return PlacementConstraintsUtil.requiresEmptyValue(constraint.operator);
-    });
-
-    return data.map((constraint, index) => {
-      let fieldLabel = null;
-      let operatorLabel = null;
-      let valueLabel = null;
-      const valueIsRequired = PlacementConstraintsUtil.requiresValue(
-        constraint.operator
-      );
-      const valueIsRequiredEmpty = PlacementConstraintsUtil.requiresEmptyValue(
-        constraint.operator
-      );
-      const fieldNameError = findNestedPropertyInObject(
-        constraintsErrors,
-        `${index}.fieldName`
-      );
-      const operatorError = findNestedPropertyInObject(
-        constraintsErrors,
-        `${index}.operator`
-      );
-      const valueError = findNestedPropertyInObject(
-        constraintsErrors,
-        `${index}.value`
-      );
-      const commonFieldsClassNames = {
-        "column-4": !hideValueColumn,
-        "column-6": hideValueColumn
-      };
-
-      if (index === 0) {
-        fieldLabel = placementConstraintLabel(
-          "Field",
-          "If you enter `hostname`, the constraint will map to the agent node hostname. If you do not enter an agent node hostname, the field will be treated as a Mesos agent node attribute, which allows you to tag an agent node.",
-          { isRequired: true }
-        );
-        operatorLabel = placementConstraintLabel(
-          "Operator",
-          "Operators specify where your app will run.",
-          { isRequired: true }
-        );
-      }
-      if (index === 0 && !hideValueColumn) {
-        valueLabel = placementConstraintLabel(
-          "Value",
-          "Values allow you to further specify your constraint.",
-          { linkText: "Learn more", isRequired: hasOneRequiredValue }
-        );
-      }
-
-      return (
-        <FormRow key={index}>
-          <FormGroup
-            className={commonFieldsClassNames}
-            required={true}
-            showError={Boolean(fieldNameError)}
-          >
-            {fieldLabel}
-            <FieldAutofocus>
-              <FieldInput
-                name={`constraints.${index}.fieldName`}
-                type="text"
-                placeholder="hostname"
-                value={constraint.fieldName}
-              />
-            </FieldAutofocus>
-            <FieldError>{fieldNameError}</FieldError>
-          </FormGroup>
-          <FormGroup
-            className={commonFieldsClassNames}
-            required={true}
-            showError={Boolean(operatorError)}
-          >
-            {operatorLabel}
-            <FieldSelect
-              name={`constraints.${index}.operator`}
-              type="text"
-              value={String(constraint.operator)}
-            >
-              <option value="">Select</option>
-              {this.getOperatorTypes()}
-            </FieldSelect>
-            <FieldError>{operatorError}</FieldError>
-          </FormGroup>
-          <FormGroup
-            className={{
-              "column-4": !hideValueColumn,
-              hidden: hideValueColumn
-            }}
-            required={valueIsRequired}
-            showError={Boolean(valueError)}
-          >
-            {valueLabel}
-            <FieldInput
-              className={{ hidden: valueIsRequiredEmpty }}
-              name={`constraints.${index}.value`}
-              type="text"
-              value={constraint.value}
-            />
-            <FieldHelp
-              className={{ hidden: valueIsRequired || valueIsRequiredEmpty }}
-            >
-              This field is optional
-            </FieldHelp>
-            <FieldError className={{ hidden: hideValueColumn }}>
-              {valueError}
-            </FieldError>
-          </FormGroup>
-
-          <FormGroup applyLabelOffset={index === 0} hasNarrowMargins={true}>
-            <DeleteRowButton
-              onClick={this.props.onRemoveItem.bind(this, {
-                value: index,
-                path: "constraints"
-              })}
-            />
-          </FormGroup>
-        </FormRow>
-      );
-    });
-  }
-
   getRuntimeSection() {
-    const { errors, service, data } = this.props;
-    if (service instanceof PodSpec) {
-      return null;
-    }
+    const { errors, data } = this.props;
 
     const typeErrors = findNestedPropertyInObject(errors, "container.type");
     const runtimeTooltipContent = (
@@ -542,7 +300,6 @@ class GeneralServiceFormSection extends Component {
 
   render() {
     const { data, errors } = this.props;
-    const initialIsExpanded = this.shouldShowAdvancedOptions();
     const title = pluralize(
       "Service",
       findNestedPropertyInObject(data, "containers.length") || 1
@@ -618,18 +375,7 @@ class GeneralServiceFormSection extends Component {
         </FormRow>
 
         {this.getContainerSection()}
-
-        <AdvancedSection initialIsExpanded={initialIsExpanded}>
-          <AdvancedSectionLabel>
-            More Settings
-          </AdvancedSectionLabel>
-          <AdvancedSectionContent>
-            {this.getRuntimeSection()}
-            {this.getPlacementconstraints()}
-            {this.getAdvancedContainerSection()}
-          </AdvancedSectionContent>
-        </AdvancedSection>
-
+        {this.getAdvancedSettingsSection()}
         {this.getMultiContainerSection()}
         {this.getConvertToPodAction()}
 

--- a/plugins/services/src/js/components/forms/PlacementSection.js
+++ b/plugins/services/src/js/components/forms/PlacementSection.js
@@ -1,0 +1,270 @@
+import React, { Component } from "react";
+import { Tooltip } from "reactjs-components";
+
+import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
+import AddButton from "#SRC/js/components/form/AddButton";
+import DeleteRowButton from "#SRC/js/components/form/DeleteRowButton";
+import FieldAutofocus from "#SRC/js/components/form/FieldAutofocus";
+import FieldError from "#SRC/js/components/form/FieldError";
+import FieldHelp from "#SRC/js/components/form/FieldHelp";
+import FieldInput from "#SRC/js/components/form/FieldInput";
+import FieldLabel from "#SRC/js/components/form/FieldLabel";
+import FieldSelect from "#SRC/js/components/form/FieldSelect";
+import FormGroup from "#SRC/js/components/form/FormGroup";
+import FormGroupHeading from "#SRC/js/components/form/FormGroupHeading";
+import FormGroupHeadingContent
+  from "#SRC/js/components/form/FormGroupHeadingContent";
+import FormRow from "#SRC/js/components/form/FormRow";
+import Icon from "#SRC/js/components/Icon";
+
+import OperatorTypes from "../../constants/OperatorTypes";
+import PlacementConstraintsUtil from "../../utils/PlacementConstraintsUtil";
+
+function placementConstraintLabel(name, tooltipText, options = {}) {
+  const { isRequired = false, linkText = "More information" } = options;
+
+  const tooltipContent = (
+    <span>
+      {`${tooltipText} `}
+      <a
+        href="https://mesosphere.github.io/marathon/docs/constraints.html"
+        target="_blank"
+      >
+        {linkText}
+      </a>.
+    </span>
+  );
+
+  return (
+    <FieldLabel>
+      <FormGroupHeading required={isRequired}>
+        <FormGroupHeadingContent primary={true}>
+          {name}
+        </FormGroupHeadingContent>
+        <FormGroupHeadingContent>
+          <Tooltip
+            content={tooltipContent}
+            interactive={true}
+            maxWidth={300}
+            wrapText={true}
+          >
+            <Icon color="grey" id="circle-question" size="mini" />
+          </Tooltip>
+        </FormGroupHeadingContent>
+      </FormGroupHeading>
+    </FieldLabel>
+  );
+}
+
+class PlacementSection extends Component {
+  getOperatorTypes() {
+    return Object.keys(OperatorTypes).map((type, index) => {
+      return <option key={index} value={type}>{type}</option>;
+    });
+  }
+
+  getPlacementConstraintsFields(data = []) {
+    const constraintsErrors = findNestedPropertyInObject(
+      this.props.errors,
+      "constraints"
+    );
+    const hasOneRequiredValue = data.some(function(constraint) {
+      return PlacementConstraintsUtil.requiresValue(constraint.operator);
+    });
+    const hideValueColumn = data.every(function(constraint) {
+      return PlacementConstraintsUtil.requiresEmptyValue(constraint.operator);
+    });
+
+    return data.map((constraint, index) => {
+      let fieldLabel = null;
+      let operatorLabel = null;
+      let valueLabel = null;
+      const valueIsRequired = PlacementConstraintsUtil.requiresValue(
+        constraint.operator
+      );
+      const valueIsRequiredEmpty = PlacementConstraintsUtil.requiresEmptyValue(
+        constraint.operator
+      );
+      const fieldNameError = findNestedPropertyInObject(
+        constraintsErrors,
+        `${index}.fieldName`
+      );
+      const operatorError = findNestedPropertyInObject(
+        constraintsErrors,
+        `${index}.operator`
+      );
+      const valueError = findNestedPropertyInObject(
+        constraintsErrors,
+        `${index}.value`
+      );
+      const commonFieldsClassNames = {
+        "column-4": !hideValueColumn,
+        "column-6": hideValueColumn
+      };
+
+      if (index === 0) {
+        fieldLabel = placementConstraintLabel(
+          "Field",
+          "If you enter `hostname`, the constraint will map to the agent node hostname. If you do not enter an agent node hostname, the field will be treated as a Mesos agent node attribute, which allows you to tag an agent node.",
+          { isRequired: true }
+        );
+        operatorLabel = placementConstraintLabel(
+          "Operator",
+          "Operators specify where your app will run.",
+          { isRequired: true }
+        );
+      }
+      if (index === 0 && !hideValueColumn) {
+        valueLabel = placementConstraintLabel(
+          "Value",
+          "Values allow you to further specify your constraint.",
+          { linkText: "Learn more", isRequired: hasOneRequiredValue }
+        );
+      }
+
+      return (
+        <FormRow key={index}>
+          <FormGroup
+            className={commonFieldsClassNames}
+            required={true}
+            showError={Boolean(fieldNameError)}
+          >
+            {fieldLabel}
+            <FieldAutofocus>
+              <FieldInput
+                name={`constraints.${index}.fieldName`}
+                type="text"
+                placeholder="hostname"
+                value={constraint.fieldName}
+              />
+            </FieldAutofocus>
+            <FieldError>{fieldNameError}</FieldError>
+          </FormGroup>
+          <FormGroup
+            className={commonFieldsClassNames}
+            required={true}
+            showError={Boolean(operatorError)}
+          >
+            {operatorLabel}
+            <FieldSelect
+              name={`constraints.${index}.operator`}
+              type="text"
+              value={String(constraint.operator)}
+            >
+              <option value="">Select</option>
+              {this.getOperatorTypes()}
+            </FieldSelect>
+            <FieldError>{operatorError}</FieldError>
+          </FormGroup>
+          <FormGroup
+            className={{
+              "column-4": !hideValueColumn,
+              hidden: hideValueColumn
+            }}
+            required={valueIsRequired}
+            showError={Boolean(valueError)}
+          >
+            {valueLabel}
+            <FieldInput
+              className={{ hidden: valueIsRequiredEmpty }}
+              name={`constraints.${index}.value`}
+              type="text"
+              value={constraint.value}
+            />
+            <FieldHelp
+              className={{ hidden: valueIsRequired || valueIsRequiredEmpty }}
+            >
+              This field is optional
+            </FieldHelp>
+            <FieldError className={{ hidden: hideValueColumn }}>
+              {valueError}
+            </FieldError>
+          </FormGroup>
+
+          <FormGroup applyLabelOffset={index === 0} hasNarrowMargins={true}>
+            <DeleteRowButton
+              onClick={this.props.onRemoveItem.bind(this, {
+                value: index,
+                path: "constraints"
+              })}
+            />
+          </FormGroup>
+        </FormRow>
+      );
+    });
+  }
+
+  render() {
+    const { data = {} } = this.props;
+    const constraintsErrors = findNestedPropertyInObject(
+      this.props.errors,
+      "constraints"
+    );
+    let errorNode = null;
+    const placementTooltipContent = (
+      <span>
+        {
+          "Constraints have three parts: a field name, an operator, and an optional parameter. The field can be the hostname of the agent node or any attribute of the agent node. "
+        }
+        <a
+          href="https://mesosphere.github.io/marathon/docs/constraints.html"
+          target="_blank"
+        >
+          More information
+        </a>.
+      </span>
+    );
+    const hasErrors =
+      constraintsErrors != null && !Array.isArray(constraintsErrors);
+
+    if (hasErrors) {
+      errorNode = (
+        <FormGroup showError={hasErrors}>
+          <FieldError>
+            {constraintsErrors}
+          </FieldError>
+        </FormGroup>
+      );
+    }
+
+    return (
+      <div>
+        <h2 className="flush-top short-bottom">
+          <FormGroupHeading>
+            <FormGroupHeadingContent primary={true}>
+              Placement Constraints
+            </FormGroupHeadingContent>
+            <FormGroupHeadingContent>
+              <Tooltip
+                content={placementTooltipContent}
+                interactive={true}
+                maxWidth={300}
+                wrapText={true}
+              >
+                <Icon color="grey" id="circle-question" size="mini" />
+              </Tooltip>
+            </FormGroupHeadingContent>
+          </FormGroupHeading>
+        </h2>
+        <p>
+          Constraints control where apps run to allow optimization for either fault tolerance or locality.
+        </p>
+        {this.getPlacementConstraintsFields(data.constraints)}
+        {errorNode}
+        <FormRow>
+          <FormGroup className="column-12">
+            <AddButton
+              onClick={this.props.onAddItem.bind(this, {
+                path: "constraints"
+              })}
+            >
+              Add Placement Constraint
+            </AddButton>
+          </FormGroup>
+        </FormRow>
+      </div>
+    );
+  }
+}
+
+export default PlacementSection;

--- a/plugins/services/src/js/components/modals/CreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModalForm.js
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import deepEqual from "deep-equal";
 import React, { PropTypes, Component } from "react";
+import { MountService } from "foundation-ui";
 
 import { deepCopy, findNestedPropertyInObject } from "#SRC/js/utils/Util";
 import { pluralize } from "#SRC/js/utils/StringUtil";
@@ -39,6 +40,7 @@ import MultiContainerVolumesFormSection
   from "../forms/MultiContainerVolumesFormSection";
 import MultiContainerFormAdvancedSection
   from "../forms/MultiContainerFormAdvancedSection";
+import PlacementSection from "../forms/PlacementSection";
 import NetworkingFormSection from "../forms/NetworkingFormSection";
 import PodSpec from "../../structs/PodSpec";
 import ServiceErrorMessages from "../../constants/ServiceErrorMessages";
@@ -430,6 +432,7 @@ class CreateServiceModalForm extends Component {
 
     if (this.state.isPod) {
       tabList.push(
+        { id: "placement", key: "placement", label: "Placement" },
         { id: "networking", key: "multinetworking", label: "Networking" },
         { id: "volumes", key: "multivolumes", label: "Volumes" },
         {
@@ -441,6 +444,7 @@ class CreateServiceModalForm extends Component {
       );
     } else {
       tabList.push(
+        { id: "placement", key: "placement", label: "Placement" },
         { id: "networking", key: "networking", label: "Networking" },
         { id: "volumes", key: "volumes", label: "Volumes" },
         { id: "healthChecks", key: "healthChecks", label: "Health Checks" },
@@ -476,6 +480,21 @@ class CreateServiceModalForm extends Component {
 
     if (this.state.isPod) {
       return [
+        <TabView id="placement" key="placement">
+          <ErrorsAlert
+            errors={errors}
+            pathMapping={ServiceErrorPathMapping}
+            hideTopLevelErrors={!showAllErrors}
+          />
+          <MountService.Mount type="CreateService:MultiContainerPlacementSection">
+            <PlacementSection
+              data={data}
+              errors={errorMap}
+              onRemoveItem={this.handleRemoveItem}
+              onAddItem={this.handleAddItem}
+            />
+          </MountService.Mount>
+        </TabView>,
         <TabView id="networking" key="multinetworking">
           <ErrorsAlert
             errors={errors}
@@ -535,6 +554,21 @@ class CreateServiceModalForm extends Component {
     }
 
     return [
+      <TabView id="placement" key="placement">
+        <ErrorsAlert
+          errors={errors}
+          pathMapping={ServiceErrorPathMapping}
+          hideTopLevelErrors={!showAllErrors}
+        />
+        <MountService.Mount type="CreateService:PlacementSection">
+          <PlacementSection
+            data={data}
+            errors={errorMap}
+            onRemoveItem={this.handleRemoveItem}
+            onAddItem={this.handleAddItem}
+          />
+        </MountService.Mount>
+      </TabView>,
       <TabView id="networking" key="networking">
         <ErrorsAlert
           errors={errors}

--- a/plugins/services/src/js/components/modals/CreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModalForm.js
@@ -486,7 +486,13 @@ class CreateServiceModalForm extends Component {
             pathMapping={ServiceErrorPathMapping}
             hideTopLevelErrors={!showAllErrors}
           />
-          <MountService.Mount type="CreateService:MultiContainerPlacementSection">
+          <MountService.Mount
+            type="CreateService:MultiContainerPlacementSection"
+            data={data}
+            errors={errorMap}
+            onRemoveItem={this.handleRemoveItem}
+            onAddItem={this.handleAddItem}
+          >
             <PlacementSection
               data={data}
               errors={errorMap}
@@ -560,7 +566,13 @@ class CreateServiceModalForm extends Component {
           pathMapping={ServiceErrorPathMapping}
           hideTopLevelErrors={!showAllErrors}
         />
-        <MountService.Mount type="CreateService:PlacementSection">
+        <MountService.Mount
+          type="CreateService:PlacementSection"
+          data={data}
+          errors={errorMap}
+          onRemoveItem={this.handleRemoveItem}
+          onAddItem={this.handleAddItem}
+        >
           <PlacementSection
             data={data}
             errors={errorMap}

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -575,20 +575,6 @@ describe("Service Form Modal", function() {
           .should("to.have.length", 0);
       });
 
-      it('Should not have a "Placement Constraints" section', function() {
-        cy
-          .get(".menu-tabbed-view")
-          .contains("Placement Constraints")
-          .should("to.have.length", 0);
-      });
-
-      it('Should not have a "Add Placement Constraint" link', function() {
-        cy
-          .get(".menu-tabbed-view .button.button-primary-link")
-          .contains("Add Placement Constraint")
-          .should("to.have.length", 0);
-      });
-
       it('Should not have a "Advanced Settings" section', function() {
         cy
           .get(".menu-tabbed-view")
@@ -638,56 +624,6 @@ describe("Service Form Modal", function() {
         cy.get(".menu-tabbed-view").contains("Container Runtime");
       });
 
-      it('Should have a "Placement Constraints" section', function() {
-        cy.get(".menu-tabbed-view").contains("Placement Constraints");
-      });
-
-      it('Should have a "Add Placement Constraint" link', function() {
-        cy
-          .get(".menu-tabbed-view .button.button-primary-link")
-          .contains("Add Placement Constraint");
-      });
-
-      it("Should vertically align the placement constraint delete row button", function() {
-        cy
-          .get(".menu-tabbed-view .button.button-primary-link")
-          .contains("Add Placement Constraint")
-          .click();
-
-        cy
-          .focused()
-          .should("have.attr", "name")
-          .and("eq", "constraints.0.fieldName");
-
-        cy
-          .get('.menu-tabbed-view input[name="constraints.0.fieldName"')
-          .should(function($inputElement) {
-            const $wrappingLabel = $inputElement.closest(".form-group");
-            const $deleteButtonFormGroup = $wrappingLabel.siblings(
-              ".form-group-without-top-label"
-            );
-
-            const inputClientRect = $inputElement
-              .get(0)
-              .getBoundingClientRect();
-            const inputMidpoint =
-              inputClientRect.top + inputClientRect.height / 2;
-
-            const deleteButtonClientRect = $deleteButtonFormGroup
-              .find(".button")
-              .get(0)
-              .getBoundingClientRect();
-            const deleteButtonMidpoint =
-              deleteButtonClientRect.top + deleteButtonClientRect.height / 2;
-
-            const midpointDifference = Math.abs(
-              inputMidpoint - deleteButtonMidpoint
-            );
-
-            expect(midpointDifference <= alignmentThreshold).to.equal(true);
-          });
-      });
-
       it('Should have a "Advanced Settings" section', function() {
         cy.get(".menu-tabbed-view").contains("Advanced Settings");
       });
@@ -712,77 +648,6 @@ describe("Service Form Modal", function() {
         cy
           .get(".menu-tabbed-view .button.button-primary-link")
           .contains("Add Artifact");
-      });
-
-      context("Add Placement Constraint", function() {
-        beforeEach(function() {
-          cy
-            .get(".menu-tabbed-view .button.button-primary-link")
-            .contains("Add Placement Constraint")
-            .click();
-
-          cy.get(".menu-tabbed-view").as("tabView");
-        });
-
-        it('Should add rows when "Add Placement Constraint" link clicked', function() {
-          // Field
-          cy
-            .get("@tabView")
-            .find('.form-control[name="constraints.0.fieldName"]')
-            .should("exist");
-
-          // operator
-          cy
-            .get("@tabView")
-            .find('select[name="constraints.0.operator"]')
-            .should("exist");
-
-          // value
-          cy
-            .get("@tabView")
-            .find('.form-control[name="constraints.0.value"]')
-            .should("exist");
-        });
-
-        it("Should remove rows when remove button clicked", function() {
-          cy.contains(".form-row", "Operator").within(function() {
-            // Click delete button
-            cy.get("a.button").click();
-          });
-
-          // Field
-          cy
-            .get("@tabView")
-            .find('.form-control[name="constraints.0.fieldName"]')
-            .should("not.exist");
-
-          // operator
-          cy
-            .get("@tabView")
-            .find('select[name="constraints.0.operator"]')
-            .should("not.exist");
-
-          // value
-          cy
-            .get("@tabView")
-            .find('.form-control[name="constraints.0.value"]')
-            .should("not.exist");
-        });
-
-        it('Should hide the "value" when "Unique" is selected in operator dropdown', function() {
-          cy
-            .get("@tabView")
-            .find('select[name="constraints.0.operator"]')
-            .select("UNIQUE");
-
-          // value
-          cy
-            .get("@tabView")
-            .find('select[name="constraints.0.operator"]')
-            .parents(".form-group")
-            .next()
-            .should("have.class", "hidden");
-        });
       });
 
       context("Add Artifact", function() {
@@ -848,6 +713,122 @@ describe("Service Form Modal", function() {
           cy
             .contains("Grant Runtime Privileges")
             .should("have.class", "disabled");
+        });
+      });
+    });
+
+    context("Service: Placement", function() {
+      beforeEach(function() {
+        cy.get(".menu-tabbed-item").contains("Placement").click();
+      });
+
+      it("Should vertically align the placement constraint delete row button", function() {
+        cy
+          .get(".menu-tabbed-view .button.button-primary-link")
+          .contains("Add Placement Constraint")
+          .click();
+
+        cy
+          .focused()
+          .should("have.attr", "name")
+          .and("eq", "constraints.0.fieldName");
+
+        cy
+          .get('.menu-tabbed-view input[name="constraints.0.fieldName"')
+          .should(function($inputElement) {
+            const $wrappingLabel = $inputElement.closest(".form-group");
+            const $deleteButtonFormGroup = $wrappingLabel.siblings(
+              ".form-group-without-top-label"
+            );
+
+            const inputClientRect = $inputElement
+              .get(0)
+              .getBoundingClientRect();
+            const inputMidpoint =
+              inputClientRect.top + inputClientRect.height / 2;
+
+            const deleteButtonClientRect = $deleteButtonFormGroup
+              .find(".button")
+              .get(0)
+              .getBoundingClientRect();
+            const deleteButtonMidpoint =
+              deleteButtonClientRect.top + deleteButtonClientRect.height / 2;
+
+            const midpointDifference = Math.abs(
+              inputMidpoint - deleteButtonMidpoint
+            );
+
+            expect(midpointDifference <= alignmentThreshold).to.equal(true);
+          });
+      });
+
+      context("Add Placement Constraint", function() {
+        beforeEach(function() {
+          cy.get(".menu-tabbed-view").as("tabView");
+          cy
+            .get(".menu-tabbed-view .button.button-primary-link")
+            .contains("Add Placement Constraint")
+            .click();
+        });
+
+        it('Should add rows when "Add Placement Constraint" link clicked', function() {
+          // Field
+          cy
+            .get("@tabView")
+            .find('.form-control[name="constraints.0.fieldName"]')
+            .should("exist");
+
+          // operator
+          cy
+            .get("@tabView")
+            .find('select[name="constraints.0.operator"]')
+            .should("exist");
+
+          // value
+          cy
+            .get("@tabView")
+            .find('.form-control[name="constraints.0.value"]')
+            .should("exist");
+        });
+
+        it("Should remove rows when remove button clicked", function() {
+          cy.contains(".form-row", "Operator").within(function() {
+            // Click delete button
+            cy.get("a.button").click();
+          });
+
+          // Field
+          cy
+            .get("@tabView")
+            .find('.form-control[name="constraints.0.fieldName"]')
+            .should("not.exist");
+
+          // operator
+          cy
+            .get("@tabView")
+            .find('select[name="constraints.0.operator"]')
+            .should("not.exist");
+
+          // value
+          cy
+            .get("@tabView")
+            .find('.form-control[name="constraints.0.value"]')
+            .should("not.exist");
+        });
+
+        it('Should hide the "value" when "Unique" is selected in operator dropdown', function() {
+          cy
+            .get("@tabView")
+            .find('select[name="constraints.0.operator"]')
+            .select("UNIQUE");
+
+          // value
+          cy
+            .get("@tabView")
+            .find('select[name="constraints.0.operator"]')
+            .parents(".form-group")
+            .next()
+            .should("have.class", "hidden");
         });
       });
     });
@@ -1625,7 +1606,10 @@ describe("Service Form Modal", function() {
 
       it("Should add new container", function() {
         cy.get(".pod-narrow.pod-short").should("to.have.length", 1);
-        cy.get(".menu-tabbed-view .button.button-primary-link").eq(3).click();
+        cy
+          .get(".menu-tabbed-view .button.button-primary-link")
+          .contains("Add Container")
+          .click();
         cy.get(".pod-narrow.pod-short").should("to.have.length", 2);
       });
 
@@ -1652,7 +1636,10 @@ describe("Service Form Modal", function() {
           .siblings()
           .should("to.have.length", 1);
 
-        cy.get(".menu-tabbed-view .button.button-primary-link").eq(3).click();
+        cy
+          .get(".menu-tabbed-view .button.button-primary-link")
+          .contains("Add Container")
+          .click();
 
         cy
           .get(".menu-tabbed-item-label")
@@ -1662,7 +1649,10 @@ describe("Service Form Modal", function() {
       });
 
       it("Should be right aligned of the parent", function() {
-        cy.get(".menu-tabbed-view .button.button-primary-link").eq(3).click();
+        cy
+          .get(".menu-tabbed-view .button.button-primary-link")
+          .contains("Add Container")
+          .click();
 
         cy
           .get(".menu-tabbed-item-label")
@@ -1701,7 +1691,10 @@ describe("Service Form Modal", function() {
 
     it("Should contain two containers at review and run modal", function() {
       // Add a second container
-      cy.get(".menu-tabbed-view .button.button-primary-link").eq(3).click();
+      cy
+        .get(".menu-tabbed-view .button.button-primary-link")
+        .contains("Add Container")
+        .click();
 
       // Click review and run
       cy


### PR DESCRIPTION
Just moving the section from under `More Settings` to the separate tab and wrapping the component with the `<Mount />` so that we could override the partial.

Before:
<img width="784" alt="screen shot 2017-11-13 at 16 33 03" src="https://user-images.githubusercontent.com/186223/32734310-f8318652-c891-11e7-9c1e-594b06352a18.png">


After:
![screen shot 2017-11-13 at 15 17 19](https://user-images.githubusercontent.com/186223/32729947-c55403e2-c885-11e7-961f-dbef60924922.png)


Closes DCOS-18992