### PR TITLE
chore(react): migrate deprecated React.PropTypes

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -311,7 +311,596 @@
         "chokidar": {
           "version": "1.6.1",
           "from": "chokidar@>=1.6.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz"
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+          "dependencies": {
+            "fsevents": {
+              "version": "1.1.3",
+              "from": "fsevents@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.1.0",
+                  "from": "abbrev@1.1.0",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
+                },
+                "ajv": {
+                  "version": "4.11.8",
+                  "from": "ajv@4.11.8",
+                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
+                },
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "ansi-regex@2.1.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                },
+                "aproba": {
+                  "version": "1.1.1",
+                  "from": "aproba@1.1.1",
+                  "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz"
+                },
+                "are-we-there-yet": {
+                  "version": "1.1.4",
+                  "from": "are-we-there-yet@1.1.4",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz"
+                },
+                "asn1": {
+                  "version": "0.2.3",
+                  "from": "asn1@0.2.3",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                },
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "from": "assert-plus@0.2.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                },
+                "asynckit": {
+                  "version": "0.4.0",
+                  "from": "asynckit@0.4.0",
+                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+                },
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "from": "aws-sign2@0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                },
+                "aws4": {
+                  "version": "1.6.0",
+                  "from": "aws4@1.6.0",
+                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+                },
+                "balanced-match": {
+                  "version": "0.4.2",
+                  "from": "balanced-match@0.4.2",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                },
+                "bcrypt-pbkdf": {
+                  "version": "1.0.1",
+                  "from": "bcrypt-pbkdf@1.0.1",
+                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
+                },
+                "block-stream": {
+                  "version": "0.0.9",
+                  "from": "block-stream@0.0.9",
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+                },
+                "boom": {
+                  "version": "2.10.1",
+                  "from": "boom@2.10.1",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                },
+                "brace-expansion": {
+                  "version": "1.1.7",
+                  "from": "brace-expansion@1.1.7",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
+                },
+                "buffer-shims": {
+                  "version": "1.0.0",
+                  "from": "buffer-shims@1.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                },
+                "caseless": {
+                  "version": "0.12.0",
+                  "from": "caseless@0.12.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+                },
+                "co": {
+                  "version": "4.6.0",
+                  "from": "co@4.6.0",
+                  "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+                },
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "from": "code-point-at@1.1.0",
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "from": "combined-stream@1.0.5",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "from": "console-control-strings@1.1.0",
+                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "cryptiles@2.0.5",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                },
+                "dashdash": {
+                  "version": "1.14.1",
+                  "from": "dashdash@1.14.1",
+                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@1.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.6.8",
+                  "from": "debug@2.6.8",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
+                },
+                "deep-extend": {
+                  "version": "0.4.2",
+                  "from": "deep-extend@0.4.2",
+                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
+                },
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "from": "delayed-stream@1.0.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                },
+                "delegates": {
+                  "version": "1.0.0",
+                  "from": "delegates@1.0.0",
+                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                },
+                "detect-libc": {
+                  "version": "1.0.2",
+                  "from": "detect-libc@^1.0.2",
+                  "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz"
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "from": "ecc-jsbn@0.1.1",
+                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                },
+                "extend": {
+                  "version": "3.0.1",
+                  "from": "extend@3.0.1",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+                },
+                "extsprintf": {
+                  "version": "1.0.2",
+                  "from": "extsprintf@1.0.2",
+                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "from": "forever-agent@0.6.1",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                },
+                "form-data": {
+                  "version": "2.1.4",
+                  "from": "form-data@2.1.4",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
+                },
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "from": "fs.realpath@1.0.0",
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                },
+                "fstream": {
+                  "version": "1.0.11",
+                  "from": "fstream@1.0.11",
+                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz"
+                },
+                "fstream-ignore": {
+                  "version": "1.0.5",
+                  "from": "fstream-ignore@1.0.5",
+                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
+                },
+                "gauge": {
+                  "version": "2.7.4",
+                  "from": "gauge@2.7.4",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz"
+                },
+                "getpass": {
+                  "version": "0.1.7",
+                  "from": "getpass@0.1.7",
+                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@1.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "7.1.2",
+                  "from": "glob@7.1.2",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+                },
+                "graceful-fs": {
+                  "version": "4.1.11",
+                  "from": "graceful-fs@4.1.11",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                },
+                "har-schema": {
+                  "version": "1.0.5",
+                  "from": "har-schema@1.0.5",
+                  "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+                },
+                "har-validator": {
+                  "version": "4.2.1",
+                  "from": "har-validator@4.2.1",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
+                },
+                "has-unicode": {
+                  "version": "2.0.1",
+                  "from": "has-unicode@2.0.1",
+                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "from": "hawk@3.1.3",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "hoek@2.16.3",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "from": "http-signature@1.1.1",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "from": "inflight@1.0.6",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@2.0.3",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "ini@1.3.4",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "from": "is-fullwidth-code-point@1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "from": "is-typedarray@1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "isarray@1.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@0.1.2",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "jodid25519": {
+                  "version": "1.0.2",
+                  "from": "jodid25519@1.0.2",
+                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                },
+                "jsbn": {
+                  "version": "0.1.1",
+                  "from": "jsbn@0.1.1",
+                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+                },
+                "json-schema": {
+                  "version": "0.2.3",
+                  "from": "json-schema@0.2.3",
+                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                },
+                "json-stable-stringify": {
+                  "version": "1.0.1",
+                  "from": "json-stable-stringify@1.0.1",
+                  "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@5.0.1",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "jsonify": {
+                  "version": "0.0.0",
+                  "from": "jsonify@0.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                },
+                "jsprim": {
+                  "version": "1.4.0",
+                  "from": "jsprim@1.4.0",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@1.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    }
+                  }
+                },
+                "mime-db": {
+                  "version": "1.27.0",
+                  "from": "mime-db@1.27.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.15",
+                  "from": "mime-types@2.1.15",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "from": "minimatch@3.0.4",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@0.5.1",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+                },
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "ms@2.0.0",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                },
+                "node-pre-gyp": {
+                  "version": "0.6.39",
+                  "from": "node-pre-gyp@^0.6.39",
+                  "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz"
+                },
+                "nopt": {
+                  "version": "4.0.1",
+                  "from": "nopt@4.0.1",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz"
+                },
+                "npmlog": {
+                  "version": "4.1.0",
+                  "from": "npmlog@4.1.0",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz"
+                },
+                "number-is-nan": {
+                  "version": "1.0.1",
+                  "from": "number-is-nan@1.0.1",
+                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                },
+                "oauth-sign": {
+                  "version": "0.8.2",
+                  "from": "oauth-sign@0.8.2",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "from": "object-assign@4.1.1",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "from": "once@1.4.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+                },
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "from": "os-homedir@1.0.2",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "from": "os-tmpdir@1.0.2",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+                },
+                "osenv": {
+                  "version": "0.1.4",
+                  "from": "osenv@0.1.4",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "from": "path-is-absolute@1.0.1",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                },
+                "performance-now": {
+                  "version": "0.2.0",
+                  "from": "performance-now@0.2.0",
+                  "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "from": "process-nextick-args@1.0.7",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                },
+                "punycode": {
+                  "version": "1.4.1",
+                  "from": "punycode@1.4.1",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                },
+                "qs": {
+                  "version": "6.4.0",
+                  "from": "qs@6.4.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+                },
+                "rc": {
+                  "version": "1.2.1",
+                  "from": "rc@1.2.1",
+                  "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.2.0",
+                      "from": "minimist@1.2.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.2.9",
+                  "from": "readable-stream@2.2.9",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
+                },
+                "request": {
+                  "version": "2.81.0",
+                  "from": "request@2.81.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
+                },
+                "rimraf": {
+                  "version": "2.6.1",
+                  "from": "rimraf@2.6.1",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+                },
+                "safe-buffer": {
+                  "version": "5.0.1",
+                  "from": "safe-buffer@5.0.1",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                },
+                "semver": {
+                  "version": "5.3.0",
+                  "from": "semver@5.3.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "from": "set-blocking@2.0.0",
+                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+                },
+                "signal-exit": {
+                  "version": "3.0.2",
+                  "from": "signal-exit@3.0.2",
+                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "sntp@1.0.9",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                },
+                "sshpk": {
+                  "version": "1.13.0",
+                  "from": "sshpk@1.13.0",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@1.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    }
+                  }
+                },
+                "string_decoder": {
+                  "version": "1.0.1",
+                  "from": "string_decoder@1.0.1",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz"
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "from": "string-width@1.0.2",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "from": "stringstream@0.0.5",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "strip-ansi@3.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                },
+                "strip-json-comments": {
+                  "version": "2.0.1",
+                  "from": "strip-json-comments@2.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+                },
+                "tar": {
+                  "version": "2.2.1",
+                  "from": "tar@2.2.1",
+                  "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+                },
+                "tar-pack": {
+                  "version": "3.4.0",
+                  "from": "tar-pack@3.4.0",
+                  "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "2.3.2",
+                  "from": "tough-cookie@2.3.2",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.6.0",
+                  "from": "tunnel-agent@0.6.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+                },
+                "tweetnacl": {
+                  "version": "0.14.5",
+                  "from": "tweetnacl@0.14.5",
+                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                },
+                "uid-number": {
+                  "version": "0.0.6",
+                  "from": "uid-number@0.0.6",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@1.0.2",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                },
+                "uuid": {
+                  "version": "3.0.1",
+                  "from": "uuid@3.0.1",
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+                },
+                "verror": {
+                  "version": "1.3.6",
+                  "from": "verror@1.3.6",
+                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                },
+                "wide-align": {
+                  "version": "1.1.2",
+                  "from": "wide-align@1.1.2",
+                  "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
+                },
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@1.0.2",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            }
+          }
         },
         "core-js": {
           "version": "2.4.1",
@@ -2563,7 +3152,7 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "from": "decamelize@>=1.1.2 <2.0.0",
+      "from": "decamelize@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
     "decompress": {
@@ -3307,7 +3896,7 @@
     },
     "eslint-config-airbnb": {
       "version": "10.0.1",
-      "from": "eslint-config-airbnb@>=10.0.1 <11.0.0",
+      "from": "eslint-config-airbnb@10.0.1",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-10.0.1.tgz"
     },
     "eslint-config-airbnb-base": {
@@ -3809,7 +4398,7 @@
     },
     "find-up": {
       "version": "1.1.2",
-      "from": "find-up@>=1.0.0 <2.0.0",
+      "from": "find-up@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "dependencies": {
         "path-exists": {
@@ -5123,7 +5712,7 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "from": "isarray@>=1.0.0 <1.1.0",
+      "from": "isarray@1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
     },
     "isexe": {
@@ -6413,7 +7002,7 @@
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "from": "lodash._reinterpolate@>=3.0.0 <3.1.0",
+      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
     },
     "lodash._root": {
@@ -6704,7 +7293,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "from": "meow@3.7.0",
+      "from": "meow@>=3.5.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "dependencies": {
         "object-assign": {
@@ -6798,7 +7387,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "from": "minimist@>=1.1.3 <2.0.0",
+      "from": "minimist@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
     },
     "mkdirp": {
@@ -7840,7 +8429,7 @@
     },
     "prop-types": {
       "version": "15.6.0",
-      "from": "prop-types@>=15.5.6 <16.0.0",
+      "from": "prop-types@latest",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
       "dependencies": {
         "fbjs": {
@@ -7850,12 +8439,12 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "from": "js-tokens@^3.0.0",
+          "from": "js-tokens@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
         },
         "loose-envify": {
           "version": "1.3.1",
-          "from": "loose-envify@^1.3.1",
+          "from": "loose-envify@>=1.3.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
         },
         "object-assign": {
@@ -9019,7 +9608,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "from": "strip-ansi@>=3.0.0 <4.0.0",
+      "from": "strip-ansi@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
     },
     "strip-bom": {
@@ -9326,7 +9915,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.2.7 <3.0.0",
+      "from": "through@>=2.3.4 <2.4.0",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
@@ -10158,7 +10747,7 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.1 <4.1.0",
+      "from": "xtend@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "moment": "2.13.0",
     "objektiv": "0.3.0",
     "prettycron": "0.10.0",
+    "prop-types": "15.6.0",
     "query-string": "4.1.0",
     "react": "15.4.1",
     "react-ace": "3.7.0",

--- a/packages/foundation-ui/src/mount/Mount.js
+++ b/packages/foundation-ui/src/mount/Mount.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import { MountService } from "./index";
 import { CHANGE } from "./MountEvent";

--- a/plugins/nodes/src/js/components/HealthTab.js
+++ b/plugins/nodes/src/js/components/HealthTab.js
@@ -1,4 +1,5 @@
 import PureRender from "react-addons-pure-render-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 import { hashHistory } from "react-router";
 import { Table } from "reactjs-components";
@@ -173,9 +174,9 @@ class HealthTab extends React.Component {
 }
 
 HealthTab.propTypes = {
-  node: React.PropTypes.object.isRequired,
-  units: React.PropTypes.object.isRequired,
-  params: React.PropTypes.object.isRequired
+  node: PropTypes.object.isRequired,
+  units: PropTypes.object.isRequired,
+  params: PropTypes.object.isRequired
 };
 
 module.exports = HealthTab;

--- a/plugins/nodes/src/js/components/NodesGridDials.js
+++ b/plugins/nodes/src/js/components/NodesGridDials.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { routerShape } from "react-router";
 import { Tooltip } from "reactjs-components";
@@ -16,11 +17,11 @@ var NodesGridDials = React.createClass({
   displayName: "NodesGridDials",
 
   propTypes: {
-    hosts: React.PropTypes.array.isRequired,
-    selectedResource: React.PropTypes.string.isRequired,
-    serviceColors: React.PropTypes.object.isRequired,
-    showServices: React.PropTypes.bool.isRequired,
-    resourcesByFramework: React.PropTypes.object.isRequired
+    hosts: PropTypes.array.isRequired,
+    selectedResource: PropTypes.string.isRequired,
+    serviceColors: PropTypes.object.isRequired,
+    showServices: PropTypes.bool.isRequired,
+    resourcesByFramework: PropTypes.object.isRequired
   },
 
   contextTypes: {

--- a/plugins/nodes/src/js/components/NodesGridView.js
+++ b/plugins/nodes/src/js/components/NodesGridView.js
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import { Form } from "reactjs-components";
 import PureRender from "react-addons-pure-render-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 
 import Loader from "#SRC/js/components/Loader";
@@ -18,17 +19,17 @@ var NodesGridView = React.createClass({
   mixins: [PureRender],
 
   propTypes: {
-    hasLoadingError: React.PropTypes.bool,
-    hiddenServices: React.PropTypes.array,
-    hosts: React.PropTypes.instanceOf(NodesList).isRequired,
-    receivedEmptyMesosState: React.PropTypes.bool,
-    receivedNodeHealthResponse: React.PropTypes.bool,
-    onShowServices: React.PropTypes.func.isRequired,
-    resourcesByFramework: React.PropTypes.object.isRequired,
-    selectedResource: React.PropTypes.string.isRequired,
-    serviceColors: React.PropTypes.object.isRequired,
-    services: React.PropTypes.array.isRequired,
-    showServices: React.PropTypes.bool
+    hasLoadingError: PropTypes.bool,
+    hiddenServices: PropTypes.array,
+    hosts: PropTypes.instanceOf(NodesList).isRequired,
+    receivedEmptyMesosState: PropTypes.bool,
+    receivedNodeHealthResponse: PropTypes.bool,
+    onShowServices: PropTypes.func.isRequired,
+    resourcesByFramework: PropTypes.object.isRequired,
+    selectedResource: PropTypes.string.isRequired,
+    serviceColors: PropTypes.object.isRequired,
+    services: PropTypes.array.isRequired,
+    showServices: PropTypes.bool
   },
 
   defaultProps: {

--- a/plugins/nodes/src/js/components/NodesTable.js
+++ b/plugins/nodes/src/js/components/NodesTable.js
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import { Link } from "react-router";
 import PureRender from "react-addons-pure-render-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 import { Table, Tooltip } from "reactjs-components";
 
@@ -25,7 +26,7 @@ var NodesTable = React.createClass({
   mixins: [PureRender],
 
   propTypes: {
-    hosts: React.PropTypes.instanceOf(NodesList).isRequired
+    hosts: PropTypes.instanceOf(NodesList).isRequired
   },
 
   getDefaultProps() {

--- a/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
+++ b/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
@@ -1,4 +1,5 @@
 import PureRender from "react-addons-pure-render-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 
 import DSLExpression from "#SRC/js/structs/DSLExpression";
@@ -213,25 +214,25 @@ class HostsPageContent extends React.Component {
 }
 
 HostsPageContent.propTypes = {
-  byServiceFilter: React.PropTypes.string,
-  filterButtonContent: React.PropTypes.func,
-  filterInputText: React.PropTypes.node,
-  filterItemList: React.PropTypes.array.isRequired,
-  filteredNodeCount: React.PropTypes.number.isRequired,
-  handleFilterChange: React.PropTypes.func.isRequired,
-  hosts: React.PropTypes.instanceOf(NodesList).isRequired,
-  isFiltering: React.PropTypes.bool,
-  nodeCount: React.PropTypes.number.isRequired,
-  onFilterChange: React.PropTypes.func,
-  onResetFilter: React.PropTypes.func.isRequired,
-  onResourceSelectionChange: React.PropTypes.func.isRequired,
-  refreshRate: React.PropTypes.number.isRequired,
-  selectedResource: React.PropTypes.string.isRequired,
-  services: React.PropTypes.array.isRequired,
-  totalHostsResources: React.PropTypes.object.isRequired,
-  totalNodeCount: React.PropTypes.number.isRequired,
-  totalResources: React.PropTypes.object.isRequired,
-  viewTypeRadioButtons: React.PropTypes.node.isRequired
+  byServiceFilter: PropTypes.string,
+  filterButtonContent: PropTypes.func,
+  filterInputText: PropTypes.node,
+  filterItemList: PropTypes.array.isRequired,
+  filteredNodeCount: PropTypes.number.isRequired,
+  handleFilterChange: PropTypes.func.isRequired,
+  hosts: PropTypes.instanceOf(NodesList).isRequired,
+  isFiltering: PropTypes.bool,
+  nodeCount: PropTypes.number.isRequired,
+  onFilterChange: PropTypes.func,
+  onResetFilter: PropTypes.func.isRequired,
+  onResourceSelectionChange: PropTypes.func.isRequired,
+  refreshRate: PropTypes.number.isRequired,
+  selectedResource: PropTypes.string.isRequired,
+  services: PropTypes.array.isRequired,
+  totalHostsResources: PropTypes.object.isRequired,
+  totalNodeCount: PropTypes.number.isRequired,
+  totalResources: PropTypes.object.isRequired,
+  viewTypeRadioButtons: PropTypes.node.isRequired
 };
 
 module.exports = HostsPageContent;

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailHealthTab.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailHealthTab.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { routerShape } from "react-router";
 
@@ -19,7 +20,7 @@ NodeDetailHealthTab.contextTypes = {
 };
 
 NodeDetailHealthTab.propTypes = {
-  node: React.PropTypes.instanceOf(Node).isRequired
+  node: PropTypes.instanceOf(Node).isRequired
 };
 
 module.exports = NodeDetailHealthTab;

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
@@ -1,4 +1,5 @@
 import PureRender from "react-addons-pure-render-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 
 import ConfigurationMap from "#SRC/js/components/ConfigurationMap";
@@ -116,7 +117,7 @@ class NodeDetailTab extends React.Component {
 }
 
 NodeDetailTab.propTypes = {
-  node: React.PropTypes.instanceOf(Node).isRequired
+  node: PropTypes.instanceOf(Node).isRequired
 };
 
 module.exports = NodeDetailTab;

--- a/plugins/nodes/src/js/pages/nodes/NodesTaskDetailPage.js
+++ b/plugins/nodes/src/js/pages/nodes/NodesTaskDetailPage.js
@@ -1,4 +1,5 @@
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 /* eslint-disable no-unused-vars */
 import React from "react";
 /* eslint-enable no-unused-vars */
@@ -67,8 +68,8 @@ class NodesTaskDetailPage extends mixin(StoreMixin) {
 }
 
 NodesTaskDetailPage.propTypes = {
-  params: React.PropTypes.object,
-  routes: React.PropTypes.array
+  params: PropTypes.object,
+  routes: PropTypes.array
 };
 
 module.exports = NodesTaskDetailPage;

--- a/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-grid/NodesGridContainer.js
@@ -1,5 +1,6 @@
 import deepEqual from "deep-equal";
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 import { routerShape } from "react-router";
 import { StoreMixin } from "mesosphere-shared-reactjs";
@@ -172,7 +173,7 @@ class NodesGridContainer extends mixin(StoreMixin, QueryParamsMixin) {
 
 NodesGridContainer.contextTypes = {
   router: routerShape.isRequired,
-  selectedResource: React.PropTypes.string
+  selectedResource: PropTypes.string
 };
 
 module.exports = NodesGridContainer;

--- a/plugins/services/src/js/components/ConfigurationMapBooleanValue.js
+++ b/plugins/services/src/js/components/ConfigurationMapBooleanValue.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
@@ -41,15 +42,12 @@ ConfigurationMapBooleanValue.defaultProps = {
 };
 
 ConfigurationMapBooleanValue.propTypes = {
-  defaultValue: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.node
-  ]),
-  options: React.PropTypes.shape({
-    truthy: React.PropTypes.any,
-    falsy: React.PropTypes.any
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  options: PropTypes.shape({
+    truthy: PropTypes.any,
+    falsy: PropTypes.any
   }),
-  value: React.PropTypes.any
+  value: PropTypes.any
 };
 
 module.exports = ConfigurationMapBooleanValue;

--- a/plugins/services/src/js/components/ConfigurationMapDurationValue.js
+++ b/plugins/services/src/js/components/ConfigurationMapDurationValue.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
@@ -59,13 +60,10 @@ ConfigurationMapDurationValue.defaultProps = {
 };
 
 ConfigurationMapDurationValue.propTypes = {
-  defaultValue: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.node
-  ]),
-  multiplicants: React.PropTypes.object,
-  units: React.PropTypes.oneOf(Object.keys(MULTIPLICANTS)),
-  value: React.PropTypes.number
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  multiplicants: PropTypes.object,
+  units: PropTypes.oneOf(Object.keys(MULTIPLICANTS)),
+  value: PropTypes.number
 };
 
 module.exports = ConfigurationMapDurationValue;

--- a/plugins/services/src/js/components/ConfigurationMapMultilineValue.js
+++ b/plugins/services/src/js/components/ConfigurationMapMultilineValue.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
@@ -30,11 +31,8 @@ ConfigurationMapMultilineValue.defaultProps = {
 };
 
 ConfigurationMapMultilineValue.propTypes = {
-  defaultValue: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.node
-  ]),
-  value: React.PropTypes.string
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  value: PropTypes.string
 };
 
 module.exports = ConfigurationMapMultilineValue;

--- a/plugins/services/src/js/components/ConfigurationMapSizeValue.js
+++ b/plugins/services/src/js/components/ConfigurationMapSizeValue.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
@@ -47,16 +48,13 @@ ConfigurationMapSizeValue.defaultProps = {
 };
 
 ConfigurationMapSizeValue.propTypes = {
-  decimals: React.PropTypes.number,
-  defaultValue: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.node
-  ]),
-  multiplier: React.PropTypes.number,
-  scale: React.PropTypes.number,
-  threshold: React.PropTypes.number,
-  units: React.PropTypes.array,
-  value: React.PropTypes.number
+  decimals: PropTypes.number,
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  multiplier: PropTypes.number,
+  scale: PropTypes.number,
+  threshold: PropTypes.number,
+  units: PropTypes.array,
+  value: PropTypes.number
 };
 
 module.exports = ConfigurationMapSizeValue;

--- a/plugins/services/src/js/components/ConfigurationMapTable.js
+++ b/plugins/services/src/js/components/ConfigurationMapTable.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { Table } from "reactjs-components";
 
@@ -156,8 +157,8 @@ class ConfigurationMapTable extends React.Component {
 }
 
 ConfigurationMapTable.propTypes = {
-  onEditClick: React.PropTypes.func,
-  tabViewID: React.PropTypes.string
+  onEditClick: PropTypes.func,
+  tabViewID: PropTypes.string
 };
 
 module.exports = ConfigurationMapTable;

--- a/plugins/services/src/js/components/ConfigurationMapValueWithDefault.js
+++ b/plugins/services/src/js/components/ConfigurationMapValueWithDefault.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
@@ -29,11 +30,8 @@ ConfigurationMapValueWithDefault.defaultProps = {
 };
 
 ConfigurationMapValueWithDefault.propTypes = {
-  value: React.PropTypes.any,
-  defaultValue: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.node
-  ])
+  value: PropTypes.any,
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
 };
 
 module.exports = ConfigurationMapValueWithDefault;

--- a/plugins/services/src/js/components/EmptyLogScreen.js
+++ b/plugins/services/src/js/components/EmptyLogScreen.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 function EmptyLogScreen({ logName }) {
   // Append space if logName is defined

--- a/plugins/services/src/js/components/FilterByService.js
+++ b/plugins/services/src/js/components/FilterByService.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { Dropdown } from "reactjs-components";
 
@@ -9,10 +10,10 @@ var FilterByService = React.createClass({
   displayName: "FilterByService",
 
   propTypes: {
-    byServiceFilter: React.PropTypes.string,
-    services: React.PropTypes.array.isRequired,
-    totalHostsCount: React.PropTypes.number.isRequired,
-    handleFilterChange: React.PropTypes.func
+    byServiceFilter: PropTypes.string,
+    services: PropTypes.array.isRequired,
+    totalHostsCount: PropTypes.number.isRequired,
+    handleFilterChange: PropTypes.func
   },
 
   getDefaultProps() {

--- a/plugins/services/src/js/components/HighOrderServiceConfiguration.js
+++ b/plugins/services/src/js/components/HighOrderServiceConfiguration.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import Framework from "#PLUGINS/services/src/js/structs/Framework";
@@ -30,10 +31,10 @@ const HighOrderServiceConfiguration = function(props) {
 };
 
 HighOrderServiceConfiguration.propTypes = {
-  errors: React.PropTypes.array,
-  service: React.PropTypes.oneOfType([
-    React.PropTypes.instanceOf(Pod),
-    React.PropTypes.instanceOf(Service)
+  errors: PropTypes.array,
+  service: PropTypes.oneOfType([
+    PropTypes.instanceOf(Pod),
+    PropTypes.instanceOf(Service)
   ])
 };
 

--- a/plugins/services/src/js/components/HighOrderServiceDebug.js
+++ b/plugins/services/src/js/components/HighOrderServiceDebug.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import Pod from "../structs/Pod";
@@ -16,9 +17,9 @@ const HighOrderServiceDebug = function(props) {
 };
 
 HighOrderServiceDebug.propTypes = {
-  service: React.PropTypes.oneOfType([
-    React.PropTypes.instanceOf(Pod),
-    React.PropTypes.instanceOf(Service)
+  service: PropTypes.oneOfType([
+    PropTypes.instanceOf(Pod),
+    PropTypes.instanceOf(Service)
   ])
 };
 

--- a/plugins/services/src/js/components/HighOrderServiceInstances.js
+++ b/plugins/services/src/js/components/HighOrderServiceInstances.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import Pod from "../structs/Pod";
@@ -23,10 +24,10 @@ const HighOrderServiceInstances = function(props) {
 };
 
 HighOrderServiceInstances.propTypes = {
-  params: React.PropTypes.object.isRequired,
-  service: React.PropTypes.oneOfType([
-    React.PropTypes.instanceOf(Pod),
-    React.PropTypes.instanceOf(Service)
+  params: PropTypes.object.isRequired,
+  service: PropTypes.oneOfType([
+    PropTypes.instanceOf(Pod),
+    PropTypes.instanceOf(Service)
   ])
 };
 

--- a/plugins/services/src/js/components/Highlight.js
+++ b/plugins/services/src/js/components/Highlight.js
@@ -1,4 +1,5 @@
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 
 import InternalStorageMixin from "#SRC/js/mixins/InternalStorageMixin";
@@ -264,19 +265,19 @@ Highlight.defaultProps = {
 };
 
 Highlight.propTypes = {
-  search: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.number,
-    React.PropTypes.bool,
+  search: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.bool,
     regExpPropType
   ]).isRequired,
-  caseSensitive: React.PropTypes.bool,
-  matchElement: React.PropTypes.string,
-  matchClass: React.PropTypes.string,
-  searchDebounceDelay: React.PropTypes.number,
-  searchDebounceThreshold: React.PropTypes.number,
-  selectedMatchClass: React.PropTypes.string,
-  watching: React.PropTypes.number
+  caseSensitive: PropTypes.bool,
+  matchElement: PropTypes.string,
+  matchClass: PropTypes.string,
+  searchDebounceDelay: PropTypes.number,
+  searchDebounceThreshold: PropTypes.number,
+  selectedMatchClass: PropTypes.string,
+  watching: PropTypes.number
 };
 
 module.exports = Highlight;

--- a/plugins/services/src/js/components/LogView.js
+++ b/plugins/services/src/js/components/LogView.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { CSSTransitionGroup } from "react-transition-group";
 import throttle from "lodash.throttle";
@@ -332,12 +333,12 @@ LogView.defaultProps = {
 };
 
 LogView.propTypes = {
-  hasLoadedTop: React.PropTypes.bool,
-  highlightText: React.PropTypes.string,
-  fetchPreviousLogs: React.PropTypes.func,
-  onCountChange: React.PropTypes.func,
-  logName: React.PropTypes.string,
-  watching: React.PropTypes.number
+  hasLoadedTop: PropTypes.bool,
+  highlightText: PropTypes.string,
+  fetchPreviousLogs: PropTypes.func,
+  onCountChange: PropTypes.func,
+  logName: PropTypes.string,
+  watching: PropTypes.number
 };
 
 module.exports = LogView;

--- a/plugins/services/src/js/components/MarathonTaskDetailsList.js
+++ b/plugins/services/src/js/components/MarathonTaskDetailsList.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import DCOSStore from "#SRC/js/stores/DCOSStore";
@@ -190,7 +191,7 @@ class MarathonTaskDetailsList extends React.Component {
 }
 
 MarathonTaskDetailsList.propTypes = {
-  taskID: React.PropTypes.string.isRequired
+  taskID: PropTypes.string.isRequired
 };
 
 module.exports = MarathonTaskDetailsList;

--- a/plugins/services/src/js/components/MesosLogContainer.js
+++ b/plugins/services/src/js/components/MesosLogContainer.js
@@ -1,4 +1,5 @@
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 import { StoreMixin } from "mesosphere-shared-reactjs";
 
@@ -235,11 +236,11 @@ MesosLogContainer.defaultProps = {
 };
 
 MesosLogContainer.propTypes = {
-  filePath: React.PropTypes.string,
-  highlightText: React.PropTypes.string,
-  logName: React.PropTypes.string,
-  task: React.PropTypes.object.isRequired,
-  watching: React.PropTypes.number
+  filePath: PropTypes.string,
+  highlightText: PropTypes.string,
+  logName: PropTypes.string,
+  task: PropTypes.object.isRequired,
+  watching: PropTypes.number
 };
 
 module.exports = MesosLogContainer;

--- a/plugins/services/src/js/components/SearchLog.js
+++ b/plugins/services/src/js/components/SearchLog.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 import ReactDOM from "react-dom";
 
@@ -176,9 +177,9 @@ SearchLog.defaultProps = {
 };
 
 SearchLog.propTypes = {
-  logFiles: React.PropTypes.array,
-  actions: React.PropTypes.node,
-  children: React.PropTypes.node
+  logFiles: PropTypes.array,
+  actions: PropTypes.node,
+  children: PropTypes.node
 };
 
 module.exports = SearchLog;

--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -1,4 +1,5 @@
 import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
 import React from "react";
 import { Link } from "react-router";
 
@@ -257,10 +258,10 @@ ServiceBreadcrumbs.defaultProps = {
 };
 
 ServiceBreadcrumbs.propTypes = {
-  extra: React.PropTypes.arrayOf(React.PropTypes.node),
-  serviceID: React.PropTypes.string,
-  taskID: React.PropTypes.string,
-  taskName: React.PropTypes.string
+  extra: PropTypes.arrayOf(PropTypes.node),
+  serviceID: PropTypes.string,
+  taskID: PropTypes.string,
+  taskName: PropTypes.string
 };
 
 module.exports = ServiceBreadcrumbs;

--- a/plugins/services/src/js/components/ServiceConnectionContainer.js
+++ b/plugins/services/src/js/components/ServiceConnectionContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { isSDKService } from "#SRC/js/utils/ServiceUtil";
 
@@ -24,7 +25,7 @@ const ServiceConnectionContainer = function(props) {
 };
 
 ServiceConnectionContainer.propTypes = {
-  service: React.PropTypes.instanceOf(Service)
+  service: PropTypes.instanceOf(Service)
 };
 
 module.exports = ServiceConnectionContainer;

--- a/plugins/services/src/js/components/ServiceItemNotFound.js
+++ b/plugins/services/src/js/components/ServiceItemNotFound.js
@@ -1,5 +1,6 @@
 import { Link } from "react-router";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import AlertPanel from "#SRC/js/components/AlertPanel";
 import AlertPanelHeader from "#SRC/js/components/AlertPanelHeader";

--- a/plugins/services/src/js/components/ServiceList.js
+++ b/plugins/services/src/js/components/ServiceList.js
@@ -1,5 +1,6 @@
 import deepEqual from "deep-equal";
 import { List } from "reactjs-components";
+import PropTypes from "prop-types";
 import React from "react";
 import { Link, routerShape } from "react-router";
 
@@ -10,7 +11,7 @@ const ServiceList = React.createClass({
   displayName: "ServiceList",
 
   propTypes: {
-    services: React.PropTypes.array.isRequired
+    services: PropTypes.array.isRequired
   },
 
   contextTypes: {

--- a/plugins/services/src/js/components/ServiceStatusIcon.js
+++ b/plugins/services/src/js/components/ServiceStatusIcon.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { Link } from "react-router";
 import { Tooltip } from "reactjs-components";
@@ -184,12 +185,12 @@ class ServiceStatusIcon extends Component {
 }
 
 ServiceStatusIcon.propTypes = {
-  showTooltip: React.PropTypes.bool,
-  tooltipContent: React.PropTypes.string,
-  service: React.PropTypes.oneOfType([
-    React.PropTypes.instanceOf(Service),
-    React.PropTypes.instanceOf(ServiceTree),
-    React.PropTypes.instanceOf(Pod)
+  showTooltip: PropTypes.bool,
+  tooltipContent: PropTypes.string,
+  service: PropTypes.oneOfType([
+    PropTypes.instanceOf(Service),
+    PropTypes.instanceOf(ServiceTree),
+    PropTypes.instanceOf(Pod)
   ])
 };
 

--- a/plugins/services/src/js/components/ServiceStatusProgressBar.js
+++ b/plugins/services/src/js/components/ServiceStatusProgressBar.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import { Tooltip } from "reactjs-components";
 
 import StringUtil from "#SRC/js/utils/StringUtil";

--- a/plugins/services/src/js/components/TaskDirectoryTable.js
+++ b/plugins/services/src/js/components/TaskDirectoryTable.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 import { Table } from "reactjs-components";
 
@@ -218,9 +219,9 @@ TaskDirectoryTable.defaultProps = {
 };
 
 TaskDirectoryTable.propTypes = {
-  directoryPath: React.PropTypes.string,
-  onOpenLogClick: React.PropTypes.func,
-  files: React.PropTypes.array
+  directoryPath: PropTypes.string,
+  onOpenLogClick: PropTypes.func,
+  files: PropTypes.array
 };
 
 module.exports = TaskDirectoryTable;

--- a/plugins/services/src/js/components/TaskEndpointsList.js
+++ b/plugins/services/src/js/components/TaskEndpointsList.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import deepEqual from "deep-equal";
 
@@ -163,9 +164,9 @@ TaskEndpointsList.defaultProps = {
 };
 
 TaskEndpointsList.propTypes = {
-  portLimit: React.PropTypes.number,
-  task: React.PropTypes.object,
-  node: React.PropTypes.object
+  portLimit: PropTypes.number,
+  task: PropTypes.object,
+  node: PropTypes.object
 };
 
 module.exports = TaskEndpointsList;

--- a/plugins/services/src/js/components/VolumeTable.js
+++ b/plugins/services/src/js/components/VolumeTable.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import { Link } from "react-router";
+import PropTypes from "prop-types";
 import React from "react";
 import { Table } from "reactjs-components";
 
@@ -175,9 +176,9 @@ class VolumeTable extends React.Component {
 }
 
 VolumeTable.propTypes = {
-  volumes: React.PropTypes.arrayOf(React.PropTypes.instanceOf(Volume)),
-  params: React.PropTypes.object.isRequired,
-  routes: React.PropTypes.array.isRequired
+  volumes: PropTypes.arrayOf(PropTypes.instanceOf(Volume)),
+  params: PropTypes.object.isRequired,
+  routes: PropTypes.array.isRequired
 };
 
 module.exports = VolumeTable;

--- a/plugins/services/src/js/components/dsl/FuzzyTextDSLSection.js
+++ b/plugins/services/src/js/components/dsl/FuzzyTextDSLSection.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import DSLCombinerTypes from "#SRC/js/constants/DSLCombinerTypes";
 import DSLExpression from "#SRC/js/structs/DSLExpression";

--- a/plugins/services/src/js/components/dsl/ServiceHealthDSLSection.js
+++ b/plugins/services/src/js/components/dsl/ServiceHealthDSLSection.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import DSLCombinerTypes from "#SRC/js/constants/DSLCombinerTypes";
 import DSLExpression from "#SRC/js/structs/DSLExpression";

--- a/plugins/services/src/js/components/dsl/ServiceOtherDSLSection.js
+++ b/plugins/services/src/js/components/dsl/ServiceOtherDSLSection.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import DSLCombinerTypes from "#SRC/js/constants/DSLCombinerTypes";
 import DSLExpression from "#SRC/js/structs/DSLExpression";

--- a/plugins/services/src/js/components/dsl/ServiceStatusDSLSection.js
+++ b/plugins/services/src/js/components/dsl/ServiceStatusDSLSection.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import DSLCombinerTypes from "#SRC/js/constants/DSLCombinerTypes";
 import DSLExpression from "#SRC/js/structs/DSLExpression";

--- a/plugins/services/src/js/components/forms/ArtifactsSection.js
+++ b/plugins/services/src/js/components/forms/ArtifactsSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { Tooltip } from "reactjs-components";
 
@@ -112,12 +113,12 @@ class ArtifactsSection extends Component {
 }
 
 ArtifactsSection.propTypes = {
-  data: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      uri: React.PropTypes.string
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      uri: PropTypes.string
     })
   ),
-  path: React.PropTypes.string
+  path: PropTypes.string
 };
 
 module.exports = ArtifactsSection;

--- a/plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { Tooltip } from "reactjs-components";
 
@@ -256,11 +257,11 @@ ContainerServiceFormAdvancedSection.defaultProps = {
 };
 
 ContainerServiceFormAdvancedSection.propTypes = {
-  data: React.PropTypes.object,
-  errors: React.PropTypes.object,
-  onAddItem: React.PropTypes.func,
-  onRemoveItem: React.PropTypes.func,
-  path: React.PropTypes.string
+  data: PropTypes.object,
+  errors: PropTypes.object,
+  onAddItem: PropTypes.func,
+  onRemoveItem: PropTypes.func,
+  path: PropTypes.string
 };
 
 ContainerServiceFormAdvancedSection.configReducers = {

--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { Tooltip } from "reactjs-components";
 
@@ -241,11 +242,11 @@ ContainerServiceFormSection.defaultProps = {
 };
 
 ContainerServiceFormSection.propTypes = {
-  data: React.PropTypes.object,
-  errors: React.PropTypes.object,
-  onAddItem: React.PropTypes.func,
-  onRemoveItem: React.PropTypes.func,
-  path: React.PropTypes.string
+  data: PropTypes.object,
+  errors: PropTypes.object,
+  onAddItem: PropTypes.func,
+  onRemoveItem: PropTypes.func,
+  path: PropTypes.string
 };
 
 ContainerServiceFormSection.configReducers = {

--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -1,5 +1,6 @@
 import { Tooltip } from "reactjs-components";
 import { MountService } from "foundation-ui";
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 
 import AddButton from "#SRC/js/components/form/AddButton";
@@ -287,11 +288,11 @@ EnvironmentFormSection.defaultProps = {
 };
 
 EnvironmentFormSection.propTypes = {
-  data: React.PropTypes.object,
-  errors: React.PropTypes.object,
-  onAddItem: React.PropTypes.func,
-  onRemoveItem: React.PropTypes.func,
-  mountType: React.PropTypes.string
+  data: PropTypes.object,
+  errors: PropTypes.object,
+  onAddItem: PropTypes.func,
+  onRemoveItem: PropTypes.func,
+  mountType: PropTypes.string
 };
 
 EnvironmentFormSection.configReducers = {

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { Confirm, Tooltip } from "reactjs-components";
 
@@ -420,11 +421,11 @@ GeneralServiceFormSection.defaultProps = {
 };
 
 GeneralServiceFormSection.propTypes = {
-  data: React.PropTypes.object,
-  errors: React.PropTypes.object,
-  onAddItem: React.PropTypes.func,
-  onRemoveItem: React.PropTypes.func,
-  onClickItem: React.PropTypes.func
+  data: PropTypes.object,
+  errors: PropTypes.object,
+  onAddItem: PropTypes.func,
+  onRemoveItem: PropTypes.func,
+  onClickItem: PropTypes.func
 };
 
 GeneralServiceFormSection.configReducers = General;

--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { Tooltip } from "reactjs-components";
 import Objektiv from "objektiv";
@@ -532,10 +533,10 @@ HealthChecksFormSection.defaultProps = {
 };
 
 HealthChecksFormSection.propTypes = {
-  data: React.PropTypes.object,
-  errors: React.PropTypes.object,
-  onAddItem: React.PropTypes.func,
-  onRemoveItem: React.PropTypes.func
+  data: PropTypes.object,
+  errors: PropTypes.object,
+  onAddItem: PropTypes.func,
+  onRemoveItem: PropTypes.func
 };
 
 HealthChecksFormSection.configReducers = {

--- a/plugins/services/src/js/components/forms/MultiContainerFormAdvancedSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerFormAdvancedSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
@@ -45,8 +46,8 @@ MultiContainerFormAdvancedSection.defaultProps = {
 };
 
 MultiContainerFormAdvancedSection.propTypes = {
-  data: React.PropTypes.object,
-  path: React.PropTypes.string
+  data: PropTypes.object,
+  path: PropTypes.string
 };
 
 module.exports = MultiContainerFormAdvancedSection;

--- a/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { Tooltip } from "reactjs-components";
 import Objektiv from "objektiv";
@@ -521,11 +522,11 @@ MultiContainerHealthChecksFormSection.defaultProps = {
 };
 
 MultiContainerHealthChecksFormSection.propTypes = {
-  data: React.PropTypes.object,
-  errors: React.PropTypes.object,
-  handleTabChange: React.PropTypes.func,
-  onAddItem: React.PropTypes.func,
-  onRemoveItem: React.PropTypes.func
+  data: PropTypes.object,
+  errors: PropTypes.object,
+  handleTabChange: PropTypes.func,
+  onAddItem: PropTypes.func,
+  onRemoveItem: PropTypes.func
 };
 
 module.exports = MultiContainerHealthChecksFormSection;

--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { Tooltip } from "reactjs-components";
 import mixin from "reactjs-mixin";
@@ -545,10 +546,10 @@ MultiContainerNetworkingFormSection.defaultProps = {
 };
 
 MultiContainerNetworkingFormSection.propTypes = {
-  data: React.PropTypes.object,
-  errors: React.PropTypes.object,
-  onAddItem: React.PropTypes.func,
-  onRemoveItem: React.PropTypes.func
+  data: PropTypes.object,
+  errors: PropTypes.object,
+  onAddItem: PropTypes.func,
+  onRemoveItem: PropTypes.func
 };
 
 MultiContainerNetworkingFormSection.configReducers = {

--- a/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
@@ -1,4 +1,5 @@
 import { Tooltip, Select, SelectOption } from "reactjs-components";
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import Objektiv from "objektiv";
 import { MountService } from "foundation-ui";
@@ -339,11 +340,11 @@ MultiContainerVolumesFormSection.defaultProps = {
 };
 
 MultiContainerVolumesFormSection.propTypes = {
-  data: React.PropTypes.object,
-  errors: React.PropTypes.object,
-  handleTabChange: React.PropTypes.func,
-  onAddItem: React.PropTypes.func,
-  onRemoveItem: React.PropTypes.func
+  data: PropTypes.object,
+  errors: PropTypes.object,
+  handleTabChange: PropTypes.func,
+  onAddItem: PropTypes.func,
+  onRemoveItem: PropTypes.func
 };
 
 MultiContainerVolumesFormSection.configReducers = {

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { Tooltip } from "reactjs-components";
 import mixin from "reactjs-mixin";
@@ -768,10 +769,10 @@ NetworkingFormSection.defaultProps = {
 };
 
 NetworkingFormSection.propTypes = {
-  data: React.PropTypes.object,
-  errors: React.PropTypes.object,
-  onAddItem: React.PropTypes.func,
-  onRemoveItem: React.PropTypes.func
+  data: PropTypes.object,
+  errors: PropTypes.object,
+  onAddItem: PropTypes.func,
+  onRemoveItem: PropTypes.func
 };
 
 NetworkingFormSection.configReducers = {

--- a/plugins/services/src/js/components/forms/VolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/VolumesFormSection.js
@@ -1,4 +1,5 @@
 import { Tooltip, Select, SelectOption } from "reactjs-components";
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import Objektiv from "objektiv";
 import { MountService } from "foundation-ui";
@@ -448,10 +449,10 @@ VolumesFormSection.defaultProps = {
 };
 
 VolumesFormSection.propTypes = {
-  data: React.PropTypes.object,
-  errors: React.PropTypes.object,
-  onAddItem: React.PropTypes.func,
-  onRemoveItem: React.PropTypes.func
+  data: PropTypes.object,
+  errors: PropTypes.object,
+  onAddItem: PropTypes.func,
+  onRemoveItem: PropTypes.func
 };
 
 VolumesFormSection.configReducers = {

--- a/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
+++ b/plugins/services/src/js/components/modals/CreateServiceJsonOnly.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import deepEqual from "deep-equal";
 
 import FieldHelp from "#SRC/js/components/form/FieldHelp";

--- a/plugins/services/src/js/components/modals/CreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModal.js
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import deepEqual from "deep-equal";
-import React, { Component, PropTypes } from "react";
+import PropTypes from "prop-types";
+import React, { Component } from "react";
 import { Confirm } from "reactjs-components";
 import { Hooks } from "PluginSDK";
 import { routerShape } from "react-router";

--- a/plugins/services/src/js/components/modals/CreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModalForm.js
@@ -1,7 +1,8 @@
 import classNames from "classnames";
 import deepEqual from "deep-equal";
-import React, { PropTypes, Component } from "react";
 import { MountService } from "foundation-ui";
+import PropTypes from "prop-types";
+import React, { Component } from "react";
 
 import { deepCopy, findNestedPropertyInObject } from "#SRC/js/utils/Util";
 import { pluralize } from "#SRC/js/utils/StringUtil";

--- a/plugins/services/src/js/components/modals/CreateServiceModalServicePicker.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModalServicePicker.js
@@ -1,4 +1,5 @@
 import { MountService } from "foundation-ui";
+import PropTypes from "prop-types";
 /* eslint-disable no-unused-vars */
 import React from "react";
 /* eslint-enable no-unused-vars */
@@ -98,7 +99,7 @@ class CreateServiceModalServicePicker extends React.Component {
 }
 
 CreateServiceModalServicePicker.propTypes = {
-  onServiceSelect: React.PropTypes.func
+  onServiceSelect: PropTypes.func
 };
 
 module.exports = CreateServiceModalServicePicker;

--- a/plugins/services/src/js/components/modals/DisabledGroupDestroyModal.js
+++ b/plugins/services/src/js/components/modals/DisabledGroupDestroyModal.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import { Modal } from "reactjs-components";
 import ModalHeading from "#SRC/js/components/modals/ModalHeading";
 

--- a/plugins/services/src/js/components/modals/KillPodInstanceModal.js
+++ b/plugins/services/src/js/components/modals/KillPodInstanceModal.js
@@ -1,5 +1,6 @@
 import { Confirm } from "reactjs-components";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import PureRender from "react-addons-pure-render-mixin";
 
 import ModalHeading from "#SRC/js/components/modals/ModalHeading";

--- a/plugins/services/src/js/components/modals/KillTaskModal.js
+++ b/plugins/services/src/js/components/modals/KillTaskModal.js
@@ -1,5 +1,6 @@
 import { Confirm } from "reactjs-components";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import PureRender from "react-addons-pure-render-mixin";
 
 import ModalHeading from "#SRC/js/components/modals/ModalHeading";

--- a/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
+++ b/plugins/services/src/js/components/modals/ServiceActionDisabledModal.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import { injectIntl } from "react-intl";
 import { MountService } from "foundation-ui";
 import { Modal } from "reactjs-components";

--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -1,7 +1,8 @@
 import { Confirm } from "reactjs-components";
 import { routerShape } from "react-router";
 import PureRender from "react-addons-pure-render-mixin";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import { injectIntl, intlShape } from "react-intl";
 
 import ModalHeading from "#SRC/js/components/modals/ModalHeading";

--- a/plugins/services/src/js/components/modals/ServiceGroupFormModal.js
+++ b/plugins/services/src/js/components/modals/ServiceGroupFormModal.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import PureRender from "react-addons-pure-render-mixin";
 
 import FormModal from "#SRC/js/components/FormModal";

--- a/plugins/services/src/js/components/modals/ServiceModals.js
+++ b/plugins/services/src/js/components/modals/ServiceModals.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import ActionKeys from "../../constants/ActionKeys";
 import ServiceTree from "../../structs/ServiceTree";

--- a/plugins/services/src/js/components/modals/ServiceRestartModal.js
+++ b/plugins/services/src/js/components/modals/ServiceRestartModal.js
@@ -1,5 +1,6 @@
 import { Confirm } from "reactjs-components";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import PureRender from "react-addons-pure-render-mixin";
 
 import ModalHeading from "#SRC/js/components/modals/ModalHeading";

--- a/plugins/services/src/js/components/modals/ServiceResumeModal.js
+++ b/plugins/services/src/js/components/modals/ServiceResumeModal.js
@@ -1,5 +1,6 @@
 import { Confirm } from "reactjs-components";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import PureRender from "react-addons-pure-render-mixin";
 
 import FieldInput from "#SRC/js/components/form/FieldInput";

--- a/plugins/services/src/js/components/modals/ServiceScaleFormModal.js
+++ b/plugins/services/src/js/components/modals/ServiceScaleFormModal.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import PureRender from "react-addons-pure-render-mixin";
 
 import FormModal from "#SRC/js/components/FormModal";

--- a/plugins/services/src/js/components/modals/ServiceStopModal.js
+++ b/plugins/services/src/js/components/modals/ServiceStopModal.js
@@ -1,5 +1,6 @@
 import { Confirm } from "reactjs-components";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import PureRender from "react-addons-pure-render-mixin";
 
 import ModalHeading from "#SRC/js/components/modals/ModalHeading";

--- a/plugins/services/src/js/components/modals/TaskModals.js
+++ b/plugins/services/src/js/components/modals/TaskModals.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import ActionKeys from "../../constants/ActionKeys";
 import KillPodInstanceModal from "./KillPodInstanceModal";

--- a/plugins/services/src/js/containers/pod-configuration/PodConfigurationContainer.js
+++ b/plugins/services/src/js/containers/pod-configuration/PodConfigurationContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import Pod from "../../structs/Pod";
@@ -22,7 +23,7 @@ class PodConfigurationTabView extends React.Component {
 }
 
 PodConfigurationTabView.propTypes = {
-  pod: React.PropTypes.instanceOf(Pod)
+  pod: PropTypes.instanceOf(Pod)
 };
 
 module.exports = PodConfigurationTabView;

--- a/plugins/services/src/js/containers/pod-debug/PodContainerTerminationTable.js
+++ b/plugins/services/src/js/containers/pod-debug/PodContainerTerminationTable.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 import { Table } from "reactjs-components";
 
@@ -118,8 +119,8 @@ PodContainerTerminationTable.defaultProps = {
 };
 
 PodContainerTerminationTable.propTypes = {
-  className: React.PropTypes.string,
-  containers: React.PropTypes.array.isRequired
+  className: PropTypes.string,
+  containers: PropTypes.array.isRequired
 };
 
 module.exports = PodContainerTerminationTable;

--- a/plugins/services/src/js/containers/pod-debug/PodDebugContainer.js
+++ b/plugins/services/src/js/containers/pod-debug/PodDebugContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { routerShape } from "react-router";
 
@@ -263,7 +264,7 @@ PodDebugTabView.contextTypes = {
 };
 
 PodDebugTabView.propTypes = {
-  pod: React.PropTypes.instanceOf(Pod)
+  pod: PropTypes.instanceOf(Pod)
 };
 
 module.exports = PodDebugTabView;

--- a/plugins/services/src/js/containers/pod-detail/PodDetail.js
+++ b/plugins/services/src/js/containers/pod-detail/PodDetail.js
@@ -1,5 +1,6 @@
 import mixin from "reactjs-mixin";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import { routerShape } from "react-router";
 import { Hooks } from "PluginSDK";
 
@@ -268,7 +269,7 @@ PodDetail.contextTypes = {
 
 PodDetail.propTypes = {
   children: PropTypes.node,
-  pod: React.PropTypes.instanceOf(Pod)
+  pod: PropTypes.instanceOf(Pod)
 };
 
 module.exports = PodDetail;

--- a/plugins/services/src/js/containers/pod-detail/PodHeader.js
+++ b/plugins/services/src/js/containers/pod-detail/PodHeader.js
@@ -1,5 +1,6 @@
 import classNames from "classnames/dedupe";
 import { Dropdown } from "reactjs-components";
+import PropTypes from "prop-types";
 import React from "react";
 
 import DetailViewHeader from "#SRC/js/components/DetailViewHeader";
@@ -179,12 +180,12 @@ PodHeader.defaultProps = {
 };
 
 PodHeader.propTypes = {
-  onDestroy: React.PropTypes.func,
-  onEdit: React.PropTypes.func,
-  onScale: React.PropTypes.func,
-  onStop: React.PropTypes.func,
-  pod: React.PropTypes.instanceOf(Pod).isRequired,
-  tabs: React.PropTypes.array
+  onDestroy: PropTypes.func,
+  onEdit: PropTypes.func,
+  onScale: PropTypes.func,
+  onStop: PropTypes.func,
+  pod: PropTypes.instanceOf(Pod).isRequired,
+  tabs: PropTypes.array
 };
 
 module.exports = PodHeader;

--- a/plugins/services/src/js/containers/pod-instances/PodInstancesContainer.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesContainer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import AppDispatcher from "#SRC/js/events/AppDispatcher";
 import ContainerUtil from "#SRC/js/utils/ContainerUtil";

--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import deepEqual from "deep-equal";
+import PropTypes from "prop-types";
 import React from "react";
 import { Link } from "react-router";
 import { Tooltip } from "reactjs-components";
@@ -484,11 +485,11 @@ PodInstancesTable.defaultProps = {
 };
 
 PodInstancesTable.propTypes = {
-  filterText: React.PropTypes.string,
-  instances: React.PropTypes.instanceOf(PodInstanceList),
-  inverseStyle: React.PropTypes.bool,
-  onSelectionChange: React.PropTypes.func,
-  pod: React.PropTypes.instanceOf(Pod).isRequired
+  filterText: PropTypes.string,
+  instances: PropTypes.instanceOf(PodInstanceList),
+  inverseStyle: PropTypes.bool,
+  onSelectionChange: PropTypes.func,
+  pod: PropTypes.instanceOf(Pod).isRequired
 };
 
 module.exports = PodInstancesTable;

--- a/plugins/services/src/js/containers/pod-instances/PodInstancesView.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesView.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { routerShape } from "react-router";
 
@@ -165,15 +166,15 @@ class PodInstancesView extends React.Component {
 }
 
 PodInstancesView.contextTypes = {
-  modalHandlers: React.PropTypes.shape({
-    killPodInstances: React.PropTypes.func.isRequired
+  modalHandlers: PropTypes.shape({
+    killPodInstances: PropTypes.func.isRequired
   }).isRequired,
   router: routerShape
 };
 
 PodInstancesView.propTypes = {
-  instances: React.PropTypes.instanceOf(PodInstanceList).isRequired,
-  pod: React.PropTypes.instanceOf(Pod).isRequired
+  instances: PropTypes.instanceOf(PodInstanceList).isRequired,
+  pod: PropTypes.instanceOf(Pod).isRequired
 };
 
 module.exports = PodInstancesView;

--- a/plugins/services/src/js/containers/pod-instances/PodViewFilter.js
+++ b/plugins/services/src/js/containers/pod-instances/PodViewFilter.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import FilterBar from "#SRC/js/components/FilterBar";
@@ -105,15 +106,15 @@ PodViewFilter.defaultProps = {
 };
 
 PodViewFilter.propTypes = {
-  filter: React.PropTypes.shape({
-    text: React.PropTypes.string,
-    status: React.PropTypes.string
+  filter: PropTypes.shape({
+    text: PropTypes.string,
+    status: PropTypes.string
   }),
-  items: React.PropTypes.array,
-  inverseStyle: React.PropTypes.bool,
-  onFilterChange: React.PropTypes.func,
-  statusMapper: React.PropTypes.func,
-  statusChoices: React.PropTypes.array
+  items: PropTypes.array,
+  inverseStyle: PropTypes.bool,
+  onFilterChange: PropTypes.func,
+  statusMapper: PropTypes.func,
+  statusChoices: PropTypes.array
 };
 
 module.exports = PodViewFilter;

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfiguration.js
@@ -1,5 +1,6 @@
 import { Dropdown, Tooltip } from "reactjs-components";
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 import { routerShape } from "react-router";
 import { StoreMixin } from "mesosphere-shared-reactjs";
@@ -261,9 +262,9 @@ ServiceConfiguration.defaultProps = {
 };
 
 ServiceConfiguration.propTypes = {
-  onEditClick: React.PropTypes.func.isRequired,
-  errors: React.PropTypes.array,
-  service: React.PropTypes.instanceOf(Service).isRequired
+  onEditClick: PropTypes.func.isRequired,
+  errors: PropTypes.array,
+  service: PropTypes.instanceOf(Service).isRequired
 };
 
 module.exports = ServiceConfiguration;

--- a/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
+++ b/plugins/services/src/js/containers/service-configuration/ServiceConfigurationContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import DCOSStore from "#SRC/js/stores/DCOSStore";
@@ -45,9 +46,9 @@ ServiceConfigurationContainer.defaultProps = {
 };
 
 ServiceConfigurationContainer.propTypes = {
-  onEditClick: React.PropTypes.func,
-  errors: React.PropTypes.array,
-  service: React.PropTypes.instanceOf(Service)
+  onEditClick: PropTypes.func,
+  errors: PropTypes.array,
+  service: PropTypes.instanceOf(Service)
 };
 
 module.exports = ServiceConfigurationContainer;

--- a/plugins/services/src/js/containers/service-connection/EndpointClipboardTrigger.js
+++ b/plugins/services/src/js/containers/service-connection/EndpointClipboardTrigger.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import ClipboardTrigger from "#SRC/js/components/ClipboardTrigger";
 import Icon from "#SRC/js/components/Icon";
@@ -24,7 +25,7 @@ class EndpointClipboardTrigger extends React.Component {
 }
 
 EndpointClipboardTrigger.propTypes = {
-  command: React.PropTypes.string.isRequired
+  command: PropTypes.string.isRequired
 };
 
 module.exports = EndpointClipboardTrigger;

--- a/plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.js
+++ b/plugins/services/src/js/containers/service-connection/SDKServiceConnectionEndpointList.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { routerShape } from "react-router";
 
@@ -227,7 +228,7 @@ SDKServiceConnectionEndpointList.contextTypes = {
 };
 
 SDKServiceConnectionEndpointList.propTypes = {
-  service: React.PropTypes.instanceOf(Service)
+  service: PropTypes.instanceOf(Service)
 };
 
 module.exports = SDKServiceConnectionEndpointList;

--- a/plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js
+++ b/plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { routerShape } from "react-router";
 
@@ -207,9 +208,9 @@ class ServiceConnectionEndpointList extends React.Component {
 }
 
 ServiceConnectionEndpointList.propTypes = {
-  onEditClick: React.PropTypes.func,
-  errors: React.PropTypes.array,
-  service: React.PropTypes.instanceOf(Service)
+  onEditClick: PropTypes.func,
+  errors: PropTypes.array,
+  service: PropTypes.instanceOf(Service)
 };
 
 ServiceConnectionEndpointList.contextTypes = {

--- a/plugins/services/src/js/containers/service-connection/ServiceNoEndpointsPanel.js
+++ b/plugins/services/src/js/containers/service-connection/ServiceNoEndpointsPanel.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import AlertPanel from "#SRC/js/components/AlertPanel";
 import AlertPanelHeader from "#SRC/js/components/AlertPanelHeader";
@@ -25,8 +26,8 @@ const ServiceNoEndpointPanel = props => {
 };
 
 ServiceNoEndpointPanel.propTypes = {
-  onClick: React.PropTypes.func.isRequired,
-  serviceId: React.PropTypes.string.isRequired
+  onClick: PropTypes.func.isRequired,
+  serviceId: PropTypes.string.isRequired
 };
 
 module.exports = ServiceNoEndpointPanel;

--- a/plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.js
+++ b/plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { routerShape } from "react-router";
 
@@ -138,9 +139,9 @@ class ServicePodConnectionEndpointList extends React.Component {
 }
 
 ServicePodConnectionEndpointList.propTypes = {
-  onEditClick: React.PropTypes.func,
-  errors: React.PropTypes.array,
-  service: React.PropTypes.instanceOf(Service)
+  onEditClick: PropTypes.func,
+  errors: PropTypes.array,
+  service: PropTypes.instanceOf(Service)
 };
 
 ServicePodConnectionEndpointList.contextTypes = {

--- a/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
+++ b/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { routerShape } from "react-router";
 
@@ -370,7 +371,7 @@ ServiceDebugContainer.contextTypes = {
 };
 
 ServiceDebugContainer.propTypes = {
-  service: React.PropTypes.instanceOf(Service)
+  service: PropTypes.instanceOf(Service)
 };
 
 module.exports = ServiceDebugContainer;

--- a/plugins/services/src/js/containers/service-detail/ServiceDetail.js
+++ b/plugins/services/src/js/containers/service-detail/ServiceDetail.js
@@ -1,6 +1,7 @@
 import { injectIntl } from "react-intl";
 import mixin from "reactjs-mixin";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import { routerShape } from "react-router";
 import { Hooks } from "PluginSDK";
 

--- a/plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.js
+++ b/plugins/services/src/js/containers/service-instances/ServiceInstancesContainer.js
@@ -1,5 +1,6 @@
 import mixin from "reactjs-mixin";
 import { MountService } from "foundation-ui";
+import PropTypes from "prop-types";
 import React from "react";
 import { StoreMixin } from "mesosphere-shared-reactjs";
 
@@ -79,8 +80,8 @@ class ServiceInstancesContainer extends mixin(StoreMixin) {
 }
 
 ServiceInstancesContainer.propTypes = {
-  service: React.PropTypes.instanceOf(Service),
-  params: React.PropTypes.object.isRequired
+  service: PropTypes.instanceOf(Service),
+  params: PropTypes.object.isRequired
 };
 
 module.exports = ServiceInstancesContainer;

--- a/plugins/services/src/js/containers/services/EmptyServiceTree.js
+++ b/plugins/services/src/js/containers/services/EmptyServiceTree.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import AlertPanel from "#SRC/js/components/AlertPanel";
 import AlertPanelHeader from "#SRC/js/components/AlertPanelHeader";

--- a/plugins/services/src/js/containers/services/ServiceTreeView.js
+++ b/plugins/services/src/js/containers/services/ServiceTreeView.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import { routerShape } from "react-router";
 
 import DSLExpression from "#SRC/js/structs/DSLExpression";

--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import { routerShape } from "react-router";
 
 import { DCOS_CHANGE, MESOS_STATE_CHANGE } from "#SRC/js/constants/EventTypes";

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -2,7 +2,8 @@ import classNames from "classnames";
 import { Dropdown, Table, Tooltip } from "reactjs-components";
 import { injectIntl } from "react-intl";
 import { Link, routerShape } from "react-router";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import { Hooks } from "PluginSDK";
 
 import StringUtil from "#SRC/js/utils/StringUtil";

--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import { routerShape, Link } from "react-router";
+import PropTypes from "prop-types";
 import React from "react";
 import { Tooltip } from "reactjs-components";
 
@@ -450,11 +451,11 @@ TaskTable.contextTypes = {
 };
 
 TaskTable.propTypes = {
-  checkedItemsMap: React.PropTypes.object,
-  className: React.PropTypes.string,
-  onCheckboxChange: React.PropTypes.func,
-  params: React.PropTypes.object.isRequired,
-  tasks: React.PropTypes.array.isRequired
+  checkedItemsMap: PropTypes.object,
+  className: PropTypes.string,
+  onCheckboxChange: PropTypes.func,
+  params: PropTypes.object.isRequired,
+  tasks: PropTypes.array.isRequired
 };
 
 TaskTable.defaultProps = {

--- a/plugins/services/src/js/containers/tasks/TasksContainer.js
+++ b/plugins/services/src/js/containers/tasks/TasksContainer.js
@@ -1,5 +1,6 @@
-import React, { PropTypes } from "react";
 import { routerShape } from "react-router";
+import PropTypes from "prop-types";
+import React from "react";
 
 import AppDispatcher from "#SRC/js/events/AppDispatcher";
 import ContainerUtil from "#SRC/js/utils/ContainerUtil";

--- a/plugins/services/src/js/containers/tasks/TasksView.js
+++ b/plugins/services/src/js/containers/tasks/TasksView.js
@@ -1,8 +1,9 @@
 import classNames from "classnames";
 import mixin from "reactjs-mixin";
 import { Tooltip } from "reactjs-components";
-import React, { PropTypes } from "react";
 import { routerShape } from "react-router";
+import PropTypes from "prop-types";
+import React from "react";
 
 import DCOSStore from "#SRC/js/stores/DCOSStore";
 import DSLFilterField from "#SRC/js/components/DSLFilterField";
@@ -262,8 +263,8 @@ class TasksView extends mixin(SaveStateMixin) {
 }
 
 TasksView.contextTypes = {
-  modalHandlers: React.PropTypes.shape({
-    killTasks: React.PropTypes.func.isRequired
+  modalHandlers: PropTypes.shape({
+    killTasks: PropTypes.func.isRequired
   }).isRequired
 };
 
@@ -274,10 +275,10 @@ TasksView.defaultProps = {
 };
 
 TasksView.propTypes = {
-  params: React.PropTypes.object.isRequired,
-  inverseStyle: React.PropTypes.bool,
-  itemID: React.PropTypes.string,
-  tasks: React.PropTypes.array
+  params: PropTypes.object.isRequired,
+  inverseStyle: PropTypes.bool,
+  itemID: PropTypes.string,
+  tasks: PropTypes.array
 };
 
 TasksView.contextTypes = {

--- a/plugins/services/src/js/containers/volume-detail/ServiceVolumeContainer.js
+++ b/plugins/services/src/js/containers/volume-detail/ServiceVolumeContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import { DCOS_CHANGE } from "#SRC/js/constants/EventTypes";
@@ -77,7 +78,7 @@ class ServiceVolumeContainer extends React.Component {
 }
 
 ServiceVolumeContainer.propTypes = {
-  params: React.PropTypes.object.isRequired
+  params: PropTypes.object.isRequired
 };
 
 module.exports = ServiceVolumeContainer;

--- a/plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.js
+++ b/plugins/services/src/js/containers/volume-detail/TaskVolumeContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import { DCOS_CHANGE } from "#SRC/js/constants/EventTypes";
@@ -78,7 +79,7 @@ class TaskVolumeContainer extends React.Component {
 }
 
 TaskVolumeContainer.propTypes = {
-  params: React.PropTypes.object.isRequired
+  params: PropTypes.object.isRequired
 };
 
 module.exports = TaskVolumeContainer;

--- a/plugins/services/src/js/containers/volume-detail/VolumeDetail.js
+++ b/plugins/services/src/js/containers/volume-detail/VolumeDetail.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 import { Link } from "react-router";
 
@@ -123,8 +124,8 @@ class VolumeDetail extends React.Component {
 }
 
 VolumeDetail.propTypes = {
-  service: React.PropTypes.object.isRequired,
-  volume: React.PropTypes.object.isRequired
+  service: PropTypes.object.isRequired,
+  volume: PropTypes.object.isRequired
 };
 
 module.exports = VolumeDetail;

--- a/plugins/services/src/js/pages/EditFrameworkConfiguration.js
+++ b/plugins/services/src/js/pages/EditFrameworkConfiguration.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import mixin from "reactjs-mixin";
 import { StoreMixin } from "mesosphere-shared-reactjs";
 import { routerShape } from "react-router";

--- a/plugins/services/src/js/pages/task-details/ServiceTaskDetailPage.js
+++ b/plugins/services/src/js/pages/task-details/ServiceTaskDetailPage.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import MesosStateStore from "#SRC/js/stores/MesosStateStore";
@@ -50,8 +51,8 @@ class ServiceTaskDetailPage extends React.Component {
 }
 
 ServiceTaskDetailPage.propTypes = {
-  params: React.PropTypes.object,
-  routes: React.PropTypes.array
+  params: PropTypes.object,
+  routes: PropTypes.array
 };
 
 module.exports = ServiceTaskDetailPage;

--- a/plugins/services/src/js/pages/task-details/TaskDetail.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetail.js
@@ -1,4 +1,5 @@
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 /* eslint-disable no-unused-vars */
 import React from "react";
 import { routerShape, formatPattern } from "react-router";
@@ -366,8 +367,8 @@ TaskDetail.contextTypes = {
 };
 
 TaskDetail.propTypes = {
-  params: React.PropTypes.object,
-  routes: React.PropTypes.array
+  params: PropTypes.object,
+  routes: PropTypes.array
 };
 
 module.exports = TaskDetail;

--- a/plugins/services/src/js/pages/task-details/TaskDetailsTab.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetailsTab.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import CompositeState from "#SRC/js/structs/CompositeState";
@@ -213,7 +214,7 @@ class TaskDetailsTab extends React.Component {
 }
 
 TaskDetailsTab.propTypes = {
-  task: React.PropTypes.object
+  task: PropTypes.object
 };
 
 TaskDetailsTab.defaultProps = {

--- a/plugins/services/src/js/pages/task-details/TaskFileBrowser.js
+++ b/plugins/services/src/js/pages/task-details/TaskFileBrowser.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import TaskDirectoryTable from "../../components/TaskDirectoryTable";
@@ -33,8 +34,8 @@ class TaskFileBrowser extends React.Component {
 }
 
 TaskFileBrowser.propTypes = {
-  directory: React.PropTypes.object,
-  task: React.PropTypes.object
+  directory: PropTypes.object,
+  task: PropTypes.object
 };
 
 TaskFileBrowser.defaultProps = {

--- a/plugins/services/src/js/pages/task-details/TaskFileViewer.js
+++ b/plugins/services/src/js/pages/task-details/TaskFileViewer.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import { Dropdown, Tooltip } from "reactjs-components";
+import PropTypes from "prop-types";
 import React from "react";
 import { routerShape, formatPattern } from "react-router";
 
@@ -233,10 +234,10 @@ TaskFileViewer.defaultProps = {
 };
 
 TaskFileViewer.propTypes = {
-  directory: React.PropTypes.instanceOf(TaskDirectory),
-  limitLogFiles: React.PropTypes.arrayOf(React.PropTypes.string),
-  selectedLogFile: React.PropTypes.object,
-  task: React.PropTypes.object
+  directory: PropTypes.instanceOf(TaskDirectory),
+  limitLogFiles: PropTypes.arrayOf(PropTypes.string),
+  selectedLogFile: PropTypes.object,
+  task: PropTypes.object
 };
 
 module.exports = TaskFileViewer;

--- a/plugins/services/src/js/pages/task-details/TaskFilesTab.js
+++ b/plugins/services/src/js/pages/task-details/TaskFilesTab.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 class TaskFilesTab extends React.Component {
@@ -18,9 +19,9 @@ class TaskFilesTab extends React.Component {
 }
 
 TaskFilesTab.propTypes = {
-  children: React.PropTypes.node,
-  directory: React.PropTypes.object,
-  task: React.PropTypes.object
+  children: PropTypes.node,
+  directory: PropTypes.object,
+  task: PropTypes.object
 };
 
 TaskFilesTab.defaultProps = {

--- a/plugins/services/src/js/pages/task-details/TaskLogsContainer.js
+++ b/plugins/services/src/js/pages/task-details/TaskLogsContainer.js
@@ -1,4 +1,5 @@
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 import { StoreMixin } from "mesosphere-shared-reactjs";
 
@@ -80,11 +81,11 @@ class TaskLogsContainer extends mixin(StoreMixin) {
 }
 
 TaskLogsContainer.propTypes = {
-  directory: React.PropTypes.instanceOf(TaskDirectory),
-  params: React.PropTypes.object,
-  routes: React.PropTypes.array,
-  selectedLogFile: React.PropTypes.object,
-  task: React.PropTypes.instanceOf(Task)
+  directory: PropTypes.instanceOf(TaskDirectory),
+  params: PropTypes.object,
+  routes: PropTypes.array,
+  selectedLogFile: PropTypes.object,
+  task: PropTypes.instanceOf(Task)
 };
 
 module.exports = TaskLogsContainer;

--- a/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
+++ b/plugins/services/src/js/pages/task-details/TaskSystemLogsContainer.js
@@ -2,6 +2,7 @@ import classNames from "classnames";
 import { Dropdown } from "reactjs-components";
 import deepEqual from "deep-equal";
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 import { StoreMixin } from "mesosphere-shared-reactjs";
 
@@ -361,8 +362,8 @@ class TaskSystemLogsContainer extends mixin(StoreMixin) {
 }
 
 TaskSystemLogsContainer.propTypes = {
-  task: React.PropTypes.shape({
-    slave_id: React.PropTypes.string
+  task: PropTypes.shape({
+    slave_id: PropTypes.string
   })
 };
 
@@ -371,12 +372,12 @@ TaskSystemLogsContainer.defaultProps = {
 };
 
 TaskSystemLogsContainer.propTypes = {
-  filePath: React.PropTypes.string,
-  highlightText: React.PropTypes.string,
-  logName: React.PropTypes.string,
-  onCountChange: React.PropTypes.func,
-  task: React.PropTypes.object.isRequired,
-  watching: React.PropTypes.number
+  filePath: PropTypes.string,
+  highlightText: PropTypes.string,
+  logName: PropTypes.string,
+  onCountChange: PropTypes.func,
+  task: PropTypes.object.isRequired,
+  watching: PropTypes.number
 };
 
 module.exports = TaskSystemLogsContainer;

--- a/plugins/services/src/js/service-configuration/PodContainerArtifactsConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodContainerArtifactsConfigSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { MountService } from "foundation-ui";
 
@@ -100,9 +101,9 @@ PodContainerArtifactsConfigSection.defaultProps = {
 };
 
 PodContainerArtifactsConfigSection.propTypes = {
-  artifacts: React.PropTypes.array,
-  index: React.PropTypes.number,
-  onEditClick: React.PropTypes.func
+  artifacts: PropTypes.array,
+  index: PropTypes.number,
+  onEditClick: PropTypes.func
 };
 
 module.exports = PodContainerArtifactsConfigSection;

--- a/plugins/services/src/js/service-configuration/PodContainerConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodContainerConfigSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { MountService } from "foundation-ui";
 
@@ -145,8 +146,8 @@ const PodContainerConfigSection = ({
 };
 
 PodContainerConfigSection.propTypes = {
-  index: React.PropTypes.number,
-  onEditClick: React.PropTypes.func
+  index: PropTypes.number,
+  onEditClick: PropTypes.func
 };
 
 module.exports = PodContainerConfigSection;

--- a/plugins/services/src/js/service-configuration/PodContainersConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodContainersConfigSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import Alert from "#SRC/js/components/Alert";
@@ -43,7 +44,7 @@ const PodContainersConfigSection = ({ appConfig, onEditClick }) => {
 };
 
 PodContainersConfigSection.propTypes = {
-  onEditClick: React.PropTypes.func
+  onEditClick: PropTypes.func
 };
 
 module.exports = PodContainersConfigSection;

--- a/plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodEnvironmentVariablesConfigSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { MountService } from "foundation-ui";
 
@@ -91,7 +92,7 @@ const PodEnvironmentVariablesConfigSection = ({ appConfig, onEditClick }) => {
 };
 
 PodEnvironmentVariablesConfigSection.propTypes = {
-  onEditClick: React.PropTypes.func
+  onEditClick: PropTypes.func
 };
 
 module.exports = PodEnvironmentVariablesConfigSection;

--- a/plugins/services/src/js/service-configuration/PodGeneralConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodGeneralConfigSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { MountService } from "foundation-ui";
 
@@ -195,7 +196,7 @@ const PodGeneralConfigSection = ({ appConfig, onEditClick }) => {
 };
 
 PodGeneralConfigSection.propTypes = {
-  onEditClick: React.PropTypes.func
+  onEditClick: PropTypes.func
 };
 
 module.exports = PodGeneralConfigSection;

--- a/plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodHealthChecksConfigSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { MountService } from "foundation-ui";
 
@@ -194,8 +195,8 @@ PodHealthChecksConfigSection.defaultProps = {
 };
 
 PodHealthChecksConfigSection.propTypes = {
-  appConfig: React.PropTypes.object,
-  onEditClick: React.PropTypes.func
+  appConfig: PropTypes.object,
+  onEditClick: PropTypes.func
 };
 
 module.exports = PodHealthChecksConfigSection;

--- a/plugins/services/src/js/service-configuration/PodLabelsConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodLabelsConfigSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { MountService } from "foundation-ui";
 
@@ -98,8 +99,8 @@ PodLabelsConfigSection.defaultProps = {
 };
 
 PodLabelsConfigSection.propTypes = {
-  appConfig: React.PropTypes.object,
-  onEditClick: React.PropTypes.func
+  appConfig: PropTypes.object,
+  onEditClick: PropTypes.func
 };
 
 module.exports = PodLabelsConfigSection;

--- a/plugins/services/src/js/service-configuration/PodNetworkConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodNetworkConfigSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { MountService } from "foundation-ui";
 
@@ -148,8 +149,8 @@ PodNetworkConfigSection.defaultProps = {
 };
 
 PodNetworkConfigSection.propTypes = {
-  appConfig: React.PropTypes.object,
-  onEditClick: React.PropTypes.func
+  appConfig: PropTypes.object,
+  onEditClick: PropTypes.func
 };
 
 module.exports = PodNetworkConfigSection;

--- a/plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { MountService } from "foundation-ui";
 
@@ -81,8 +82,8 @@ PodPlacementConstraintsConfigSection.defaultProps = {
 };
 
 PodPlacementConstraintsConfigSection.propTypes = {
-  appConfig: React.PropTypes.object,
-  onEditClick: React.PropTypes.func
+  appConfig: PropTypes.object,
+  onEditClick: PropTypes.func
 };
 
 module.exports = PodPlacementConstraintsConfigSection;

--- a/plugins/services/src/js/service-configuration/PodStorageConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodStorageConfigSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { MountService } from "foundation-ui";
 
@@ -141,8 +142,8 @@ PodStorageConfigSection.defaultProps = {
 };
 
 PodStorageConfigSection.propTypes = {
-  appConfig: React.PropTypes.object,
-  onEditClick: React.PropTypes.func
+  appConfig: PropTypes.object,
+  onEditClick: PropTypes.func
 };
 
 module.exports = PodStorageConfigSection;

--- a/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
+++ b/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { MountService } from "foundation-ui";
 
@@ -112,9 +113,9 @@ ServiceConfigDisplay.defaultProps = {
 };
 
 ServiceConfigDisplay.propTypes = {
-  appConfig: React.PropTypes.object.isRequired,
-  errors: React.PropTypes.array,
-  onEditClick: React.PropTypes.func
+  appConfig: PropTypes.object.isRequired,
+  errors: PropTypes.array,
+  onEditClick: PropTypes.func
 };
 
 module.exports = ServiceConfigDisplay;

--- a/plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { MountService } from "foundation-ui";
 
@@ -78,8 +79,8 @@ ServicePlacementConstraintsConfigSection.defaultProps = {
 };
 
 ServicePlacementConstraintsConfigSection.propTypes = {
-  appConfig: React.PropTypes.object,
-  onEditClick: React.PropTypes.func
+  appConfig: PropTypes.object,
+  onEditClick: PropTypes.func
 };
 
 module.exports = ServicePlacementConstraintsConfigSection;

--- a/src/js/components/Alert.js
+++ b/src/js/components/Alert.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 
 import Icon from "./Icon";
@@ -40,10 +41,10 @@ Alert.defaultProps = {
 };
 
 Alert.propTypes = {
-  children: React.PropTypes.node.isRequired,
-  flushBottom: React.PropTypes.bool,
-  showIcon: React.PropTypes.bool,
-  type: React.PropTypes.oneOf(["danger", "success"])
+  children: PropTypes.node.isRequired,
+  flushBottom: PropTypes.bool,
+  showIcon: PropTypes.bool,
+  type: PropTypes.oneOf(["danger", "success"])
 };
 
 module.exports = Alert;

--- a/src/js/components/AlertPanel.js
+++ b/src/js/components/AlertPanel.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 import Panel from "./Panel";
@@ -11,8 +12,8 @@ var AlertPanel = React.createClass({
   },
 
   propTypes: {
-    icon: React.PropTypes.node,
-    iconClassName: React.PropTypes.string
+    icon: PropTypes.node,
+    iconClassName: PropTypes.string
   },
 
   // TODO: Use iconIDs instead of icon classes.

--- a/src/js/components/AlertPanelHeader.js
+++ b/src/js/components/AlertPanelHeader.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 const AlertPanelHeader = function(props) {
@@ -9,7 +10,7 @@ const AlertPanelHeader = function(props) {
 };
 
 AlertPanelHeader.propTypes = {
-  children: React.PropTypes.node
+  children: PropTypes.node
 };
 
 module.exports = AlertPanelHeader;

--- a/src/js/components/Breadcrumb.js
+++ b/src/js/components/Breadcrumb.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 
 class Breadcrumb extends React.Component {
@@ -28,9 +29,9 @@ Breadcrumb.defaultProps = {
 };
 
 Breadcrumb.propTypes = {
-  isCaret: React.PropTypes.bool,
-  isIcon: React.PropTypes.bool,
-  title: React.PropTypes.string.isRequired
+  isCaret: PropTypes.bool,
+  isIcon: PropTypes.bool,
+  title: PropTypes.string.isRequired
 };
 
 module.exports = Breadcrumb;

--- a/src/js/components/BreadcrumbSegmentLink.js
+++ b/src/js/components/BreadcrumbSegmentLink.js
@@ -1,5 +1,6 @@
 import { Link, formatPattern } from "react-router";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 class BreadcrumbSegmentLink extends React.Component {
   render() {

--- a/src/js/components/BreadcrumbSupplementalContent.js
+++ b/src/js/components/BreadcrumbSupplementalContent.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 
 class BreadcrumbSupplementalContent extends React.Component {
@@ -27,7 +28,7 @@ BreadcrumbSupplementalContent.defaultProps = {
 };
 
 BreadcrumbSupplementalContent.propTypes = {
-  hasProgressBar: React.PropTypes.bool
+  hasProgressBar: PropTypes.bool
 };
 
 module.exports = BreadcrumbSupplementalContent;

--- a/src/js/components/BreadcrumbTextContent.js
+++ b/src/js/components/BreadcrumbTextContent.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 class BreadcrumbTextContent extends React.Component {
@@ -15,7 +16,7 @@ class BreadcrumbTextContent extends React.Component {
 }
 
 BreadcrumbTextContent.propTypes = {
-  title: React.PropTypes.string
+  title: PropTypes.string
 };
 
 module.exports = BreadcrumbTextContent;

--- a/src/js/components/CheckboxTable.js
+++ b/src/js/components/CheckboxTable.js
@@ -1,11 +1,10 @@
 import classNames from "classnames";
 import { Form, Table } from "reactjs-components";
+import PropTypes from "prop-types";
 import React from "react";
 
 import ResourceTableUtil from "../utils/ResourceTableUtil";
 import TableUtil from "../utils/TableUtil";
-
-const PropTypes = React.PropTypes;
 
 const METHODS_TO_BIND = [
   "getTableRowOptions",

--- a/src/js/components/ClickToSelect.js
+++ b/src/js/components/ClickToSelect.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 class ClickToSelect extends React.Component {
@@ -20,7 +21,7 @@ class ClickToSelect extends React.Component {
 }
 
 ClickToSelect.propTypes = {
-  children: React.PropTypes.any
+  children: PropTypes.any
 };
 
 module.exports = ClickToSelect;

--- a/src/js/components/ClipboardTrigger.js
+++ b/src/js/components/ClipboardTrigger.js
@@ -1,5 +1,6 @@
 import Clipboard from "clipboard";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import ReactDOM from "react-dom";
 import { Tooltip } from "reactjs-components";
 

--- a/src/js/components/CollapsibleErrorMessage.js
+++ b/src/js/components/CollapsibleErrorMessage.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 import Icon from "./Icon";
@@ -203,11 +204,11 @@ CollapsibleErrorMessage.defaultProps = {
 };
 
 CollapsibleErrorMessage.propTypes = {
-  className: React.PropTypes.string,
-  details: React.PropTypes.array,
-  expanded: React.PropTypes.bool,
-  message: React.PropTypes.node,
-  onToggle: React.PropTypes.func
+  className: PropTypes.string,
+  details: PropTypes.array,
+  expanded: PropTypes.bool,
+  message: PropTypes.node,
+  onToggle: PropTypes.func
 };
 
 module.exports = CollapsibleErrorMessage;

--- a/src/js/components/CollapsingString.js
+++ b/src/js/components/CollapsingString.js
@@ -1,4 +1,5 @@
 import DeepEqual from "deep-equal";
+import PropTypes from "prop-types";
 import React from "react";
 import ReactDOM from "react-dom";
 
@@ -167,16 +168,16 @@ CollapsingString.defaultProps = {
 
 CollapsingString.propTypes = {
   // The number of characters to keep visible at the end of the string.
-  endLength: React.PropTypes.number,
-  fullStringClassName: React.PropTypes.string,
+  endLength: PropTypes.number,
+  fullStringClassName: PropTypes.string,
   // The selector for the parent whose width should be referenced. By default,
   // the node's direct parent will be used.
-  parentSelector: React.PropTypes.string,
-  string: React.PropTypes.string.isRequired,
-  truncatedStringEndClassName: React.PropTypes.string,
-  truncatedStringStartClassName: React.PropTypes.string,
-  truncatedWrapperClassName: React.PropTypes.string,
-  wrapperClassName: React.PropTypes.string
+  parentSelector: PropTypes.string,
+  string: PropTypes.string.isRequired,
+  truncatedStringEndClassName: PropTypes.string,
+  truncatedStringStartClassName: PropTypes.string,
+  truncatedWrapperClassName: PropTypes.string,
+  wrapperClassName: PropTypes.string
 };
 
 module.exports = CollapsingString;

--- a/src/js/components/ComponentList.js
+++ b/src/js/components/ComponentList.js
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import { Link } from "react-router";
 import { List } from "reactjs-components";
+import PropTypes from "prop-types";
 import React from "react";
 
 class ComponentList extends React.Component {
@@ -129,9 +130,9 @@ ComponentList.defaultProps = {
 };
 
 ComponentList.propTypes = {
-  displayCount: React.PropTypes.number,
+  displayCount: PropTypes.number,
   // Required object of type HealthUnitsList.
-  units: React.PropTypes.object.isRequired
+  units: PropTypes.object.isRequired
 };
 
 module.exports = ComponentList;

--- a/src/js/components/ConfigurationMapHeading.js
+++ b/src/js/components/ConfigurationMapHeading.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 
 import DetailViewSectionHeading from "./DetailViewSectionHeading";
@@ -19,12 +20,12 @@ ConfigurationMapHeading.defaultProps = {
 };
 
 ConfigurationMapHeading.propTypes = {
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
-  level: React.PropTypes.oneOf([1, 2, 3, 4, 5, 6])
+  level: PropTypes.oneOf([1, 2, 3, 4, 5, 6])
 };
 
 module.exports = ConfigurationMapHeading;

--- a/src/js/components/ConfigurationMapLabel.js
+++ b/src/js/components/ConfigurationMapLabel.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 
 const ConfigurationMapLabel = props => {
@@ -14,7 +15,7 @@ const ConfigurationMapLabel = props => {
 };
 
 ConfigurationMapLabel.propTypes = {
-  keepTextCase: React.PropTypes.bool
+  keepTextCase: PropTypes.bool
 };
 
 module.exports = ConfigurationMapLabel;

--- a/src/js/components/CosmosErrorHeader.js
+++ b/src/js/components/CosmosErrorHeader.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 const CosmosErrorHeader = function(props) {
@@ -9,7 +10,7 @@ const CosmosErrorHeader = function(props) {
 };
 
 CosmosErrorHeader.propTypes = {
-  children: React.PropTypes.node
+  children: PropTypes.node
 };
 
 module.exports = CosmosErrorHeader;

--- a/src/js/components/CosmosErrorMessage.js
+++ b/src/js/components/CosmosErrorMessage.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import Alert from "./Alert";
@@ -118,12 +119,12 @@ CosmosErrorMessage.defaultProps = {
 };
 
 CosmosErrorMessage.propTypes = {
-  error: React.PropTypes.shape({
-    message: React.PropTypes.node,
-    type: React.PropTypes.string,
-    data: React.PropTypes.object
+  error: PropTypes.shape({
+    message: PropTypes.node,
+    type: PropTypes.string,
+    data: PropTypes.object
   }),
-  flushBottom: React.PropTypes.bool
+  flushBottom: PropTypes.bool
 };
 
 module.exports = CosmosErrorMessage;

--- a/src/js/components/CreateServiceModalCatalogPanelOption.js
+++ b/src/js/components/CreateServiceModalCatalogPanelOption.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import packageServiceImage
@@ -31,8 +32,8 @@ class CreateServicePickerCatalogOption extends React.Component {
 }
 
 CreateServicePickerCatalogOption.propTypes = {
-  columnClasses: React.PropTypes.string,
-  onOptionSelect: React.PropTypes.func
+  columnClasses: PropTypes.string,
+  onOptionSelect: PropTypes.func
 };
 
 module.exports = CreateServicePickerCatalogOption;

--- a/src/js/components/DSLFilterField.js
+++ b/src/js/components/DSLFilterField.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import DSLFilterList from "../structs/DSLFilterList";
 import DSLInputField from "./DSLInputField";

--- a/src/js/components/DSLForm.js
+++ b/src/js/components/DSLForm.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import DSLExpression from "../structs/DSLExpression";
 

--- a/src/js/components/DSLFormDropdownPanel.js
+++ b/src/js/components/DSLFormDropdownPanel.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import DSLForm from "./DSLForm";
 import DSLExpression from "../structs/DSLExpression";

--- a/src/js/components/DSLFormWithExpressionUpdates.js
+++ b/src/js/components/DSLFormWithExpressionUpdates.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import DSLCombinerTypes from "../constants/DSLCombinerTypes";
 import DSLFilterTypes from "../constants/DSLFilterTypes";

--- a/src/js/components/DSLInputField.js
+++ b/src/js/components/DSLInputField.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import Icon from "./Icon";
 import DSLExpression from "../structs/DSLExpression";

--- a/src/js/components/DetailViewHeader.js
+++ b/src/js/components/DetailViewHeader.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 import CollapsingString from "./CollapsingString";
@@ -118,10 +119,10 @@ class DetailViewHeader extends React.Component {
   }
 }
 
-const classPropType = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
+const classPropType = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
 ]);
 
 DetailViewHeader.defaultProps = {
@@ -129,11 +130,11 @@ DetailViewHeader.defaultProps = {
 };
 
 DetailViewHeader.propTypes = {
-  actionButtons: React.PropTypes.arrayOf(React.PropTypes.element),
-  icon: React.PropTypes.node,
-  navigationTabs: React.PropTypes.node,
-  subTitle: React.PropTypes.node,
-  title: React.PropTypes.string,
+  actionButtons: PropTypes.arrayOf(PropTypes.element),
+  icon: PropTypes.node,
+  navigationTabs: PropTypes.node,
+  subTitle: PropTypes.node,
+  title: PropTypes.string,
 
   className: classPropType,
   detailViewHeaderClassNames: classPropType,

--- a/src/js/components/DetailViewSectionHeading.js
+++ b/src/js/components/DetailViewSectionHeading.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 
 const DetailViewSectionHeading = props => {
@@ -20,12 +21,12 @@ DetailViewSectionHeading.defaultProps = {
 };
 
 DetailViewSectionHeading.propTypes = {
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
-  level: React.PropTypes.oneOf([1, 2, 3, 4, 5, 6])
+  level: PropTypes.oneOf([1, 2, 3, 4, 5, 6])
 };
 
 module.exports = DetailViewSectionHeading;

--- a/src/js/components/ErrorsAlert.js
+++ b/src/js/components/ErrorsAlert.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import Alert from "./Alert";
@@ -54,9 +55,9 @@ ErrorsAlert.defaultProps = {
 };
 
 ErrorsAlert.propTypes = {
-  errors: React.PropTypes.array,
-  hideTopLevelErrors: React.PropTypes.bool,
-  pathMapping: React.PropTypes.array
+  errors: PropTypes.array,
+  hideTopLevelErrors: PropTypes.bool,
+  pathMapping: PropTypes.array
 };
 
 module.exports = ErrorsAlert;

--- a/src/js/components/ExpandingTable.js
+++ b/src/js/components/ExpandingTable.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 import { Table } from "reactjs-components";
 
@@ -147,16 +148,16 @@ ExpandingTable.defaultProps = {
 };
 
 ExpandingTable.propTypes = {
-  alignCells: React.PropTypes.oneOf(["top", "middle", "bottom"]),
-  childRowClassName: React.PropTypes.string,
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  alignCells: PropTypes.oneOf(["top", "middle", "bottom"]),
+  childRowClassName: PropTypes.string,
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
-  expandAll: React.PropTypes.bool,
-  expandRowsByDefault: React.PropTypes.bool,
-  tableComponent: React.PropTypes.func
+  expandAll: PropTypes.bool,
+  expandRowsByDefault: PropTypes.bool,
+  tableComponent: PropTypes.func
 };
 
 module.exports = ExpandingTable;

--- a/src/js/components/FilterBar.js
+++ b/src/js/components/FilterBar.js
@@ -1,4 +1,5 @@
 import PureRender from "react-addons-pure-render-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 
 class FilterBar extends React.Component {
@@ -61,10 +62,10 @@ class FilterBar extends React.Component {
 }
 
 FilterBar.propTypes = {
-  className: React.PropTypes.string,
-  rightAlignLastNChildren: React.PropTypes.number,
-  leftChildrenClass: React.PropTypes.string,
-  rightChildrenClass: React.PropTypes.string
+  className: PropTypes.string,
+  rightAlignLastNChildren: PropTypes.number,
+  leftChildrenClass: PropTypes.string,
+  rightChildrenClass: PropTypes.string
 };
 
 FilterBar.defaultProps = {

--- a/src/js/components/FilterButtons.js
+++ b/src/js/components/FilterButtons.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 
 class FilterButtons extends React.Component {
@@ -76,17 +77,17 @@ FilterButtons.defaultProps = {
 };
 
 FilterButtons.propTypes = {
-  filters: React.PropTypes.array,
+  filters: PropTypes.array,
   // The key in itemList that is being filtered
-  filterByKey: React.PropTypes.string,
-  inverseStyle: React.PropTypes.bool,
-  itemList: React.PropTypes.array.isRequired,
+  filterByKey: PropTypes.string,
+  inverseStyle: PropTypes.bool,
+  itemList: PropTypes.array.isRequired,
   // A function that returns the onClick for a filter button given the filter.
-  onFilterChange: React.PropTypes.func,
+  onFilterChange: PropTypes.func,
   // Optional function to generate button text. args: (filter, count)
-  renderButtonContent: React.PropTypes.func,
+  renderButtonContent: PropTypes.func,
   // The filter in props.filters that is currently selected.
-  selectedFilter: React.PropTypes.string
+  selectedFilter: PropTypes.string
 };
 
 module.exports = FilterButtons;

--- a/src/js/components/FilterHeadline.js
+++ b/src/js/components/FilterHeadline.js
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import PureRender from "react-addons-pure-render-mixin";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import StringUtil from "../utils/StringUtil";
 

--- a/src/js/components/FilterInputText.js
+++ b/src/js/components/FilterInputText.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import Icon from "./Icon";
 import ServiceFilterTypes

--- a/src/js/components/FluidGeminiScrollbar.js
+++ b/src/js/components/FluidGeminiScrollbar.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import GeminiScrollbar from "react-gemini-scrollbar";
+import PropTypes from "prop-types";
 import React from "react";
 
 import ScrollbarUtil from "../utils/ScrollbarUtil";
@@ -112,10 +113,7 @@ class FluidGeminiScrollbar extends React.Component {
 }
 
 FluidGeminiScrollbar.propTypes = {
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.object
-  ])
+  className: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
 };
 
 module.exports = FluidGeminiScrollbar;

--- a/src/js/components/FormModal.js
+++ b/src/js/components/FormModal.js
@@ -1,5 +1,6 @@
 import classNames from "classnames/dedupe";
 import { Form, Modal } from "reactjs-components";
+import PropTypes from "prop-types";
 import React from "react";
 
 const METHODS_TO_BIND = [
@@ -166,22 +167,22 @@ FormModal.defaultProps = {
 };
 
 FormModal.propTypes = {
-  buttonDefinition: React.PropTypes.array,
-  children: React.PropTypes.node,
-  contentClasses: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  buttonDefinition: PropTypes.array,
+  children: PropTypes.node,
+  contentClasses: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
-  contentFooter: React.PropTypes.node,
-  definition: React.PropTypes.array,
-  disabled: React.PropTypes.bool,
-  extraFooterContent: React.PropTypes.node,
-  modalProps: React.PropTypes.object,
-  onChange: React.PropTypes.func,
-  onClose: React.PropTypes.func.isRequired,
-  onSubmit: React.PropTypes.func,
-  open: React.PropTypes.bool
+  contentFooter: PropTypes.node,
+  definition: PropTypes.array,
+  disabled: PropTypes.bool,
+  extraFooterContent: PropTypes.node,
+  modalProps: PropTypes.object,
+  onChange: PropTypes.func,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func,
+  open: PropTypes.bool
 };
 
 module.exports = FormModal;

--- a/src/js/components/FrameworkConfiguration.js
+++ b/src/js/components/FrameworkConfiguration.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import PropTypes from "prop-types";
+import React, { Component } from "react";
 import { Confirm } from "reactjs-components";
 
 import FullScreenModal from "#SRC/js/components/modals/FullScreenModal";

--- a/src/js/components/FrameworkConfigurationForm.js
+++ b/src/js/components/FrameworkConfigurationForm.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import PropTypes from "prop-types";
+import React, { Component } from "react";
 import classNames from "classnames";
 import SchemaForm from "react-jsonschema-form";
 import { MountService } from "foundation-ui";

--- a/src/js/components/HashMapDisplay.js
+++ b/src/js/components/HashMapDisplay.js
@@ -1,4 +1,5 @@
 import PureRender from "react-addons-pure-render-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 
 import ConfigurationMapHeading from "./ConfigurationMapHeading";
@@ -111,15 +112,15 @@ HashMapDisplay.defaultProps = {
 };
 
 HashMapDisplay.propTypes = {
-  headingLevel: React.PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
-  headlineClassName: React.PropTypes.string,
-  headline: React.PropTypes.node,
-  hash: React.PropTypes.object,
-  key: React.PropTypes.string,
+  headingLevel: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
+  headlineClassName: PropTypes.string,
+  headline: PropTypes.node,
+  hash: PropTypes.object,
+  key: PropTypes.string,
   // Optional object with keys consisting of keys in `props.hash` to be
   // replaced, and with corresponding values of the replacement to be rendered.
-  renderKeys: React.PropTypes.object,
-  emptyValue: React.PropTypes.string
+  renderKeys: PropTypes.object,
+  emptyValue: PropTypes.string
 };
 
 module.exports = HashMapDisplay;

--- a/src/js/components/Icon.js
+++ b/src/js/components/Icon.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 
 import Util from "../utils/Util";
@@ -38,22 +39,15 @@ Icon.defaultProps = {
 };
 
 Icon.propTypes = {
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
-  color: React.PropTypes.string,
-  family: React.PropTypes.oneOf(["product", "system", "tiny"]),
-  id: React.PropTypes.string.isRequired,
-  size: React.PropTypes.oneOf([
-    "tiny",
-    "mini",
-    "small",
-    "medium",
-    "large",
-    "jumbo"
-  ])
+  color: PropTypes.string,
+  family: PropTypes.oneOf(["product", "system", "tiny"]),
+  id: PropTypes.string.isRequired,
+  size: PropTypes.oneOf(["tiny", "mini", "small", "medium", "large", "jumbo"])
 };
 
 module.exports = Icon;

--- a/src/js/components/Image.js
+++ b/src/js/components/Image.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 import ReactDOM from "react-dom";
 
@@ -61,14 +62,14 @@ class Image extends React.Component {
 }
 
 Image.propTypes = {
-  src: React.PropTypes.string.isRequired,
-  fallbackSrc: React.PropTypes.string,
+  src: PropTypes.string.isRequired,
+  fallbackSrc: PropTypes.string,
 
   // Classes
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ])
 };
 

--- a/src/js/components/ImageViewer.js
+++ b/src/js/components/ImageViewer.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import ImageViewerModal from "./modals/ImageViewerModal";
 
@@ -90,7 +91,7 @@ ImageViewer.defaultProps = {
 };
 
 ImageViewer.propTypes = {
-  images: React.PropTypes.arrayOf(React.PropTypes.string)
+  images: PropTypes.arrayOf(PropTypes.string)
 };
 
 module.exports = ImageViewer;

--- a/src/js/components/JSONEditor.js
+++ b/src/js/components/JSONEditor.js
@@ -1,4 +1,5 @@
 import AceEditor from "react-ace";
+import PropTypes from "prop-types";
 import React from "react";
 import deepEqual from "deep-equal";
 import "brace/ext/searchbox";
@@ -513,22 +514,16 @@ JSONEditor.defaultProps = {
 };
 
 JSONEditor.propTypes = {
-  errors: React.PropTypes.array,
-  editorProps: React.PropTypes.object,
-  height: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.number
-  ]),
-  onBlur: React.PropTypes.func,
-  onChange: React.PropTypes.func,
-  onErrorStateChange: React.PropTypes.func,
-  onFocus: React.PropTypes.func,
-  onPropertyChange: React.PropTypes.func,
-  value: React.PropTypes.object,
-  width: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.number
-  ])
+  errors: PropTypes.array,
+  editorProps: PropTypes.object,
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onErrorStateChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  onPropertyChange: PropTypes.func,
+  value: PropTypes.object,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };
 
 module.exports = JSONEditor;

--- a/src/js/components/JobForm.js
+++ b/src/js/components/JobForm.js
@@ -1,4 +1,4 @@
-import React from "react";
+import PropTypes from "prop-types";
 
 import FormUtil from "../utils/FormUtil";
 import SchemaForm from "./SchemaForm";
@@ -153,13 +153,13 @@ JobForm.defaultProps = {
 };
 
 JobForm.propTypes = {
-  className: React.PropTypes.string,
-  defaultTab: React.PropTypes.string,
-  isEdit: React.PropTypes.bool,
-  getTriggerSubmit: React.PropTypes.func,
-  onChange: React.PropTypes.func,
-  onTabChange: React.PropTypes.func,
-  schema: React.PropTypes.object
+  className: PropTypes.string,
+  defaultTab: PropTypes.string,
+  isEdit: PropTypes.bool,
+  getTriggerSubmit: PropTypes.func,
+  onChange: PropTypes.func,
+  onTabChange: PropTypes.func,
+  schema: PropTypes.object
 };
 
 module.exports = JobForm;

--- a/src/js/components/JobSearchFilter.js
+++ b/src/js/components/JobSearchFilter.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-unused-vars */
+import PropTypes from "prop-types";
+
 import React from "react";
 /* eslint-enable no-unused-vars */
 import FilterInputText from "./FilterInputText";
@@ -17,8 +19,8 @@ class JobSearchFilter extends React.Component {
 }
 
 JobSearchFilter.propTypes = {
-  onChange: React.PropTypes.func.isRequired,
-  value: React.PropTypes.string
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.string
 };
 
 module.exports = JobSearchFilter;

--- a/src/js/components/Loader.js
+++ b/src/js/components/Loader.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 /*
@@ -83,19 +84,19 @@ Loader.defaultProps = {
   suppressHorizontalCenter: false
 };
 
-const classPropType = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
+const classPropType = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
 ]);
 
 Loader.propTypes = {
-  suppressHorizontalCenter: React.PropTypes.bool,
+  suppressHorizontalCenter: PropTypes.bool,
   className: classPropType,
-  flip: React.PropTypes.oneOf(["horizontal"]),
+  flip: PropTypes.oneOf(["horizontal"]),
   innerClassName: classPropType,
-  size: React.PropTypes.oneOf(["small", "mini"]),
-  type: React.PropTypes.oneOf([
+  size: PropTypes.oneOf(["small", "mini"]),
+  type: PropTypes.oneOf([
     "ballBeat",
     "ballScale",
     "ballSpinFadeLoader",

--- a/src/js/components/ManualBreadcrumbs.js
+++ b/src/js/components/ManualBreadcrumbs.js
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import DeepEqual from "deep-equal";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 import ReactDOM from "react-dom";
 
 import BreadcrumbSegmentLink from "./BreadcrumbSegmentLink";

--- a/src/js/components/Modals.js
+++ b/src/js/components/Modals.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { Hooks } from "PluginSDK";
 import { MountService } from "foundation-ui";
@@ -13,8 +14,8 @@ var Modals = React.createClass({
   displayName: "Modals",
 
   propTypes: {
-    showErrorModal: React.PropTypes.bool,
-    modalErrorMsg: React.PropTypes.node
+    showErrorModal: PropTypes.bool,
+    modalErrorMsg: PropTypes.node
   },
 
   getDefaultProps() {

--- a/src/js/components/NestedServiceLinks.js
+++ b/src/js/components/NestedServiceLinks.js
@@ -1,6 +1,7 @@
 import classNames from "classnames/dedupe";
 import { Link } from "react-router";
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+import React from "react";
 
 import Icon from "./Icon";
 

--- a/src/js/components/Page.js
+++ b/src/js/components/Page.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 import { StoreMixin } from "mesosphere-shared-reactjs";
 
@@ -43,15 +44,15 @@ PageHeader.defaultProps = {
 };
 
 PageHeader.propTypes = {
-  actions: React.PropTypes.array,
-  addButton: React.PropTypes.oneOfType([
-    React.PropTypes.arrayOf(React.PropTypes.object),
-    React.PropTypes.object
+  actions: PropTypes.array,
+  addButton: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.object),
+    PropTypes.object
   ]),
-  breadcrumbs: React.PropTypes.node,
-  supplementalContent: React.PropTypes.node,
-  tabs: React.PropTypes.array,
-  disabledActions: React.PropTypes.bool
+  breadcrumbs: PropTypes.node,
+  supplementalContent: PropTypes.node,
+  tabs: PropTypes.array,
+  disabledActions: PropTypes.bool
 };
 
 var Page = React.createClass({
@@ -60,20 +61,14 @@ var Page = React.createClass({
   mixins: [InternalStorageMixin, StoreMixin],
 
   propTypes: {
-    className: React.PropTypes.oneOfType([
-      React.PropTypes.array,
-      React.PropTypes.object,
-      React.PropTypes.string
+    className: PropTypes.oneOfType([
+      PropTypes.array,
+      PropTypes.object,
+      PropTypes.string
     ]),
-    dontScroll: React.PropTypes.bool,
-    navigation: React.PropTypes.oneOfType([
-      React.PropTypes.object,
-      React.PropTypes.string
-    ]),
-    title: React.PropTypes.oneOfType([
-      React.PropTypes.object,
-      React.PropTypes.string
-    ])
+    dontScroll: PropTypes.bool,
+    navigation: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+    title: PropTypes.oneOfType([PropTypes.object, PropTypes.string])
   },
 
   componentWillMount() {

--- a/src/js/components/PageHeader.js
+++ b/src/js/components/PageHeader.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 import Icon from "#SRC/js/components/Icon";
@@ -102,10 +103,10 @@ class PageHeader extends React.Component {
   }
 }
 
-const classProps = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
+const classProps = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
 ]);
 
 PageHeader.defaultProps = {
@@ -115,20 +116,20 @@ PageHeader.defaultProps = {
 };
 
 PageHeader.propTypes = {
-  addButton: React.PropTypes.oneOfType([
-    React.PropTypes.arrayOf(React.PropTypes.object),
-    React.PropTypes.object
+  addButton: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.object),
+    PropTypes.object
   ]),
-  actions: React.PropTypes.array,
-  breadcrumbs: React.PropTypes.node.isRequired,
+  actions: PropTypes.array,
+  breadcrumbs: PropTypes.node.isRequired,
   pageHeaderClassName: classProps,
   pageHeaderInnerClassName: classProps,
   pageHeaderSectionPrimaryClassName: classProps,
   pageHeaderSectionSecondaryClassName: classProps,
-  secondaryContentDetail: React.PropTypes.node,
-  supplementalContent: React.PropTypes.node,
-  tabs: React.PropTypes.array,
-  disabledActions: React.PropTypes.bool,
+  secondaryContentDetail: PropTypes.node,
+  supplementalContent: PropTypes.node,
+  tabs: PropTypes.array,
+  disabledActions: PropTypes.bool,
   pageHeaderContentClassName: classProps,
   pageHeaderActionsPrimaryClassNam: classProps
 };

--- a/src/js/components/PageHeaderActions.js
+++ b/src/js/components/PageHeaderActions.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 import { Tooltip } from "reactjs-components";
 
@@ -97,28 +98,28 @@ PageHeaderActions.defaultProps = {
   disabledActions: false
 };
 
-const classProps = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
+const classProps = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
 ]);
 
-const menuActionsProps = React.PropTypes.shape({
+const menuActionsProps = PropTypes.shape({
   className: classProps,
-  onItemSelect: React.PropTypes.func.isRequired,
-  label: React.PropTypes.node.isRequired
+  onItemSelect: PropTypes.func.isRequired,
+  label: PropTypes.node.isRequired
 });
 
 PageHeaderActions.propTypes = {
-  addButton: React.PropTypes.oneOfType([
-    React.PropTypes.arrayOf(menuActionsProps),
+  addButton: PropTypes.oneOfType([
+    PropTypes.arrayOf(menuActionsProps),
     menuActionsProps
   ]),
-  actions: React.PropTypes.arrayOf(
-    React.PropTypes.oneOfType([React.PropTypes.node, menuActionsProps])
+  actions: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.node, menuActionsProps])
   ),
-  supplementalContent: React.PropTypes.node,
-  disabledActions: React.PropTypes.bool
+  supplementalContent: PropTypes.node,
+  disabledActions: PropTypes.bool
 };
 
 module.exports = PageHeaderActions;

--- a/src/js/components/PageHeaderActionsMenu.js
+++ b/src/js/components/PageHeaderActionsMenu.js
@@ -1,4 +1,5 @@
 import { Dropdown } from "reactjs-components";
+import PropTypes from "prop-types";
 import React from "react";
 
 import Icon from "./Icon";
@@ -57,16 +58,16 @@ PageHeaderActionsMenu.defaultProps = {
 
 PageHeaderActionsMenu.propTypes = {
   // anchorRight gets passed to Dropdown. It's truthy here unlike in the Dropdown.
-  anchorRight: React.PropTypes.bool,
-  children: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      props: React.PropTypes.shape({
-        onItemSelect: React.PropTypes.func
+  anchorRight: PropTypes.bool,
+  children: PropTypes.arrayOf(
+    PropTypes.shape({
+      props: PropTypes.shape({
+        onItemSelect: PropTypes.func
       })
     })
   ),
-  iconID: React.PropTypes.string,
-  disabledActions: React.PropTypes.bool
+  iconID: PropTypes.string,
+  disabledActions: PropTypes.bool
 };
 
 module.exports = PageHeaderActionsMenu;

--- a/src/js/components/PageHeaderBreadcrumbs.js
+++ b/src/js/components/PageHeaderBreadcrumbs.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import { Link } from "react-router";
+import PropTypes from "prop-types";
 import React from "react";
 import { Tooltip } from "reactjs-components";
 
@@ -71,8 +72,8 @@ class PageHeaderBreadcrumbs extends React.Component {
 }
 
 PageHeaderBreadcrumbs.propTypes = {
-  iconID: React.PropTypes.string.isRequired,
-  breadcrumbs: React.PropTypes.arrayOf(React.PropTypes.node).isRequired
+  iconID: PropTypes.string.isRequired,
+  breadcrumbs: PropTypes.arrayOf(PropTypes.node).isRequired
 };
 
 module.exports = PageHeaderBreadcrumbs;

--- a/src/js/components/PageHeaderNavigationDropdown.js
+++ b/src/js/components/PageHeaderNavigationDropdown.js
@@ -1,4 +1,5 @@
 import { Dropdown } from "reactjs-components";
+import PropTypes from "prop-types";
 import React from "react";
 
 import Icon from "./Icon";
@@ -76,14 +77,11 @@ PageHeaderNavigationDropdown.defaultProps = {
 };
 
 PageHeaderNavigationDropdown.propTypes = {
-  items: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      id: React.PropTypes.oneOfType([
-        React.PropTypes.number,
-        React.PropTypes.string
-      ]).isRequired,
-      isActive: React.PropTypes.bool.isRequired,
-      label: React.PropTypes.node.isRequired
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+      isActive: PropTypes.bool.isRequired,
+      label: PropTypes.node.isRequired
     })
   )
 };

--- a/src/js/components/PageHeaderTabs.js
+++ b/src/js/components/PageHeaderTabs.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import { Link, routerShape } from "react-router";
+import PropTypes from "prop-types";
 import React from "react";
 
 import PageHeaderNavigationDropdown from "./PageHeaderNavigationDropdown";
@@ -119,12 +120,12 @@ PageHeaderTabs.defaultProps = {
 };
 
 PageHeaderTabs.propTypes = {
-  tabs: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      isActive: React.PropTypes.bool,
-      label: React.PropTypes.node.isRequired,
-      routePath: React.PropTypes.string,
-      callback: React.PropTypes.func
+  tabs: PropTypes.arrayOf(
+    PropTypes.shape({
+      isActive: PropTypes.bool,
+      label: PropTypes.node.isRequired,
+      routePath: PropTypes.string,
+      callback: PropTypes.func
     })
   )
 };

--- a/src/js/components/Panel.js
+++ b/src/js/components/Panel.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 const defaultClasses = {
@@ -12,26 +13,26 @@ var Panel = React.createClass({
   displayName: "Panel",
 
   propTypes: {
-    heading: React.PropTypes.node,
-    footer: React.PropTypes.node,
+    heading: PropTypes.node,
+    footer: PropTypes.node,
 
     // classes
-    contentClass: React.PropTypes.oneOfType([
-      React.PropTypes.array,
-      React.PropTypes.object,
-      React.PropTypes.string
+    contentClass: PropTypes.oneOfType([
+      PropTypes.array,
+      PropTypes.object,
+      PropTypes.string
     ]),
-    headingClass: React.PropTypes.oneOfType([
-      React.PropTypes.array,
-      React.PropTypes.object,
-      React.PropTypes.string
+    headingClass: PropTypes.oneOfType([
+      PropTypes.array,
+      PropTypes.object,
+      PropTypes.string
     ]),
-    footerClass: React.PropTypes.oneOfType([
-      React.PropTypes.array,
-      React.PropTypes.object,
-      React.PropTypes.string
+    footerClass: PropTypes.oneOfType([
+      PropTypes.array,
+      PropTypes.object,
+      PropTypes.string
     ]),
-    onClick: React.PropTypes.func
+    onClick: PropTypes.func
   },
 
   getNode(nodeName) {

--- a/src/js/components/ProgressBar.js
+++ b/src/js/components/ProgressBar.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import classNames from "classnames/dedupe";
 
@@ -116,16 +117,16 @@ ProgressBar.defaultProps = {
 };
 
 ProgressBar.propTypes = {
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
-  total: React.PropTypes.number,
-  data: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      className: React.PropTypes.string,
-      value: React.PropTypes.number.isRequired
+  total: PropTypes.number,
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      className: PropTypes.string,
+      value: PropTypes.number.isRequired
     })
   ).isRequired
 };

--- a/src/js/components/RepositoriesTable.js
+++ b/src/js/components/RepositoriesTable.js
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import { Confirm, Table } from "reactjs-components";
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 /* eslint-disable no-unused-vars */
 import React from "react";
 /* eslint-enable no-unused-vars */
@@ -247,7 +248,7 @@ RepositoriesTable.defaultProps = {
 };
 
 RepositoriesTable.propTypes = {
-  repositories: React.PropTypes.object.isRequired
+  repositories: PropTypes.object.isRequired
 };
 
 module.exports = RepositoriesTable;

--- a/src/js/components/RequestErrorMsg.js
+++ b/src/js/components/RequestErrorMsg.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 import Config from "../config/Config";
@@ -59,13 +60,13 @@ RequestErrorMsg.defaultProps = {
 };
 
 RequestErrorMsg.propTypes = {
-  columnClasses: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  columnClasses: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
-  header: React.PropTypes.node,
-  message: React.PropTypes.node
+  header: PropTypes.node,
+  message: PropTypes.node
 };
 
 module.exports = RequestErrorMsg;

--- a/src/js/components/ReviewConfig.js
+++ b/src/js/components/ReviewConfig.js
@@ -1,4 +1,5 @@
 import GeminiScrollbar from "react-gemini-scrollbar";
+import PropTypes from "prop-types";
 import React from "react";
 
 import RouterUtil from "#SRC/js/utils/RouterUtil";
@@ -103,11 +104,11 @@ ReviewConfig.defaultProps = {
 };
 
 ReviewConfig.propTypes = {
-  className: React.PropTypes.string,
-  configuration: React.PropTypes.object.isRequired,
-  packageIcon: React.PropTypes.string,
-  packageName: React.PropTypes.string,
-  packageVersion: React.PropTypes.string
+  className: PropTypes.string,
+  configuration: PropTypes.object.isRequired,
+  packageIcon: PropTypes.string,
+  packageName: PropTypes.string,
+  packageVersion: PropTypes.string
 };
 
 module.exports = ReviewConfig;

--- a/src/js/components/SchemaForm.js
+++ b/src/js/components/SchemaForm.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 import { StoreMixin } from "mesosphere-shared-reactjs";
 import { Tooltip } from "reactjs-components";
@@ -432,11 +433,11 @@ SchemaForm.defaultProps = {
 };
 
 SchemaForm.propTypes = {
-  getTriggerSubmit: React.PropTypes.func,
-  schema: React.PropTypes.object,
-  packageIcon: React.PropTypes.string,
-  packageName: React.PropTypes.string,
-  packageVersion: React.PropTypes.string
+  getTriggerSubmit: PropTypes.func,
+  schema: PropTypes.object,
+  packageIcon: PropTypes.string,
+  packageName: PropTypes.string,
+  packageVersion: PropTypes.string
 };
 
 module.exports = SchemaForm;

--- a/src/js/components/SideTabs.js
+++ b/src/js/components/SideTabs.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 
 class SideTabs extends React.Component {
@@ -110,10 +111,10 @@ SideTabs.defaultProps = {
 };
 
 SideTabs.propTypes = {
-  className: React.PropTypes.string,
-  onTabClick: React.PropTypes.func,
-  selectedTab: React.PropTypes.string,
-  tabs: React.PropTypes.array
+  className: PropTypes.string,
+  onTabClick: PropTypes.func,
+  selectedTab: PropTypes.string,
+  tabs: PropTypes.array
 };
 
 module.exports = SideTabs;

--- a/src/js/components/TabButton.js
+++ b/src/js/components/TabButton.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 import { Tooltip } from "reactjs-components";
 
@@ -92,23 +93,23 @@ class TabButton extends React.Component {
   }
 }
 
-const classProps = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
+const classProps = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
 ]);
 
 TabButton.propTypes = {
-  active: React.PropTypes.bool,
-  children: React.PropTypes.node,
+  active: PropTypes.bool,
+  children: PropTypes.node,
   className: classProps,
-  id: React.PropTypes.string.isRequired,
-  label: React.PropTypes.node,
+  id: PropTypes.string.isRequired,
+  label: PropTypes.node,
   labelClassName: classProps,
-  showErrorBadge: React.PropTypes.bool,
-  count: React.PropTypes.number,
-  description: React.PropTypes.string,
-  onClickBadge: React.PropTypes.func
+  showErrorBadge: PropTypes.bool,
+  count: PropTypes.number,
+  description: PropTypes.string,
+  onClickBadge: PropTypes.func
 };
 
 module.exports = TabButton;

--- a/src/js/components/TabButtonList.js
+++ b/src/js/components/TabButtonList.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 class TabButtonList extends React.Component {
@@ -38,15 +39,15 @@ class TabButtonList extends React.Component {
 }
 
 TabButtonList.propTypes = {
-  activeTab: React.PropTypes.string,
-  children: React.PropTypes.node,
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  activeTab: PropTypes.string,
+  children: PropTypes.node,
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
-  onChange: React.PropTypes.func,
-  vertical: React.PropTypes.bool
+  onChange: PropTypes.func,
+  vertical: PropTypes.bool
 };
 
 module.exports = TabButtonList;

--- a/src/js/components/TabForm.js
+++ b/src/js/components/TabForm.js
@@ -2,6 +2,7 @@ import classNames from "classnames/dedupe";
 import { Form, Tooltip } from "reactjs-components";
 import GeminiScrollbar from "react-gemini-scrollbar";
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 
 import Icon from "./Icon";
@@ -235,24 +236,24 @@ TabForm.defaultProps = {
   onTabClick() {}
 };
 
-const classPropType = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
+const classPropType = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
 ]);
 
 TabForm.propTypes = {
   className: classPropType,
-  defaultTab: React.PropTypes.string,
-  definition: React.PropTypes.object.isRequired,
+  defaultTab: PropTypes.string,
+  definition: PropTypes.object.isRequired,
   formContentClassNames: classPropType,
   formRowClass: classPropType,
-  getTriggerSubmit: React.PropTypes.func,
+  getTriggerSubmit: PropTypes.func,
   navigationContentClassNames: classPropType,
-  onError: React.PropTypes.func,
-  onChange: React.PropTypes.func,
-  onSubmit: React.PropTypes.func,
-  onTabClick: React.PropTypes.func
+  onError: PropTypes.func,
+  onChange: PropTypes.func,
+  onSubmit: PropTypes.func,
+  onTabClick: PropTypes.func
 };
 
 module.exports = TabForm;

--- a/src/js/components/TabView.js
+++ b/src/js/components/TabView.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 class TabView extends React.Component {
@@ -14,13 +15,13 @@ class TabView extends React.Component {
 }
 
 TabView.propTypes = {
-  children: React.PropTypes.node,
-  className: React.PropTypes.oneOf([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  children: PropTypes.node,
+  className: PropTypes.oneOf([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
-  id: React.PropTypes.string.isRequired
+  id: PropTypes.string.isRequired
 };
 
 module.exports = TabView;

--- a/src/js/components/TabViewList.js
+++ b/src/js/components/TabViewList.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 
 class TabViewList extends React.Component {
@@ -29,12 +30,12 @@ class TabViewList extends React.Component {
 }
 
 TabViewList.propTypes = {
-  activeTab: React.PropTypes.string,
-  children: React.PropTypes.node,
-  className: React.PropTypes.oneOf([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  activeTab: PropTypes.string,
+  children: PropTypes.node,
+  className: PropTypes.oneOf([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ])
 };
 

--- a/src/js/components/Tabs.js
+++ b/src/js/components/Tabs.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 import TabButtonList from "./TabButtonList";
@@ -34,15 +35,15 @@ class Tabs extends React.Component {
 
 Tabs.propTypes = {
   // Optional variable to set active tab from owner component
-  activeTab: React.PropTypes.string,
-  children: React.PropTypes.node.isRequired,
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  activeTab: PropTypes.string,
+  children: PropTypes.node.isRequired,
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
-  handleTabChange: React.PropTypes.func.isRequired,
-  vertical: React.PropTypes.bool
+  handleTabChange: PropTypes.func.isRequired,
+  vertical: PropTypes.bool
 };
 
 module.exports = Tabs;

--- a/src/js/components/TimeAgo.js
+++ b/src/js/components/TimeAgo.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import DateUtil from "../utils/DateUtil";
@@ -86,14 +87,11 @@ TimeAgo.defaultProps = {
 };
 
 TimeAgo.propTypes = {
-  autoUpdate: React.PropTypes.bool,
-  className: React.PropTypes.string,
-  prefix: React.PropTypes.node,
-  suppressSuffix: React.PropTypes.bool,
-  time: React.PropTypes.oneOfType([
-    React.PropTypes.object,
-    React.PropTypes.number
-  ])
+  autoUpdate: PropTypes.bool,
+  className: PropTypes.string,
+  prefix: PropTypes.node,
+  suppressSuffix: PropTypes.bool,
+  time: PropTypes.oneOfType([PropTypes.object, PropTypes.number])
 };
 
 module.exports = TimeAgo;

--- a/src/js/components/ToggleButton.js
+++ b/src/js/components/ToggleButton.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 
 class ToggleButton extends React.Component {
@@ -35,19 +36,19 @@ ToggleButton.defaultProps = {
 };
 
 ToggleButton.propTypes = {
-  checked: React.PropTypes.bool,
-  children: React.PropTypes.node,
-  onChange: React.PropTypes.func,
+  checked: PropTypes.bool,
+  children: PropTypes.node,
+  onChange: PropTypes.func,
 
-  checkboxClassName: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  checkboxClassName: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ])
 };
 

--- a/src/js/components/ToggleValue.js
+++ b/src/js/components/ToggleValue.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 
 class ToggleValue extends Component {
@@ -25,8 +26,8 @@ class ToggleValue extends Component {
 }
 
 ToggleValue.propTypes = {
-  primaryValue: React.PropTypes.string.isRequired,
-  secondaryValue: React.PropTypes.string.isRequired
+  primaryValue: PropTypes.string.isRequired,
+  secondaryValue: PropTypes.string.isRequired
 };
 
 module.exports = ToggleValue;

--- a/src/js/components/Typeahead.js
+++ b/src/js/components/Typeahead.js
@@ -1,7 +1,8 @@
 import classNames from "classnames";
 import InnerTypeahead from "mesosphere-react-typeahead";
+import PropTypes from "prop-types";
 /* eslint-disable no-unused-vars */
-import React, { PropTypes } from "react";
+import React from "react";
 /* eslint-enable no-unused-vars */
 
 import FilterInputText from "./FilterInputText";

--- a/src/js/components/UnitHealthDropdown.js
+++ b/src/js/components/UnitHealthDropdown.js
@@ -1,5 +1,6 @@
 import { Dropdown } from "reactjs-components";
 import PureRender from "react-addons-pure-render-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 
 import UnitHealthStatus from "../constants/UnitHealthStatus";
@@ -69,10 +70,10 @@ class UnitHealthDropdown extends React.Component {
 }
 
 UnitHealthDropdown.propTypes = {
-  className: React.PropTypes.string,
-  dropdownMenuClassName: React.PropTypes.string,
-  initialID: React.PropTypes.string,
-  onHealthSelection: React.PropTypes.func
+  className: PropTypes.string,
+  dropdownMenuClassName: PropTypes.string,
+  initialID: PropTypes.string,
+  onHealthSelection: PropTypes.func
 };
 
 UnitHealthDropdown.defaultProps = {

--- a/src/js/components/UnitHealthNodesTable.js
+++ b/src/js/components/UnitHealthNodesTable.js
@@ -1,4 +1,5 @@
 import { Link } from "react-router";
+import PropTypes from "prop-types";
 import React from "react";
 import { Table } from "reactjs-components";
 
@@ -127,8 +128,8 @@ class UnitHealthNodesTable extends React.Component {
 }
 
 UnitHealthNodesTable.propTypes = {
-  nodes: React.PropTypes.array.isRequired,
-  params: React.PropTypes.object
+  nodes: PropTypes.array.isRequired,
+  params: PropTypes.object
 };
 
 module.exports = UnitHealthNodesTable;

--- a/src/js/components/UserAccountDropdownTrigger.js
+++ b/src/js/components/UserAccountDropdownTrigger.js
@@ -1,4 +1,5 @@
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 import { StoreMixin } from "mesosphere-shared-reactjs";
 
@@ -65,9 +66,9 @@ UserAccountDropdownTrigger.defaultProps = {
 };
 
 UserAccountDropdownTrigger.propTypes = {
-  clusterName: React.PropTypes.node,
-  onUpdate: React.PropTypes.func,
-  showCaret: React.PropTypes.bool
+  clusterName: PropTypes.node,
+  onUpdate: PropTypes.func,
+  showCaret: PropTypes.bool
 };
 
 module.exports = UserAccountDropdownTrigger;

--- a/src/js/components/breadcrumbs/JobsBreadcrumbs.js
+++ b/src/js/components/breadcrumbs/JobsBreadcrumbs.js
@@ -1,5 +1,6 @@
 import { Link } from "react-router";
 import prettycron from "prettycron";
+import PropTypes from "prop-types";
 import React from "react";
 import { Tooltip } from "reactjs-components";
 
@@ -118,10 +119,10 @@ const JobsBreadcrumbs = ({ tree, item, children, details = true }) => {
 };
 
 JobsBreadcrumbs.propTypes = {
-  tree: React.PropTypes.instanceOf(JobTree).isRequired,
-  item: React.PropTypes.oneOfType([
-    React.PropTypes.instanceOf(JobTree),
-    React.PropTypes.instanceOf(Job)
+  tree: PropTypes.instanceOf(JobTree).isRequired,
+  item: PropTypes.oneOfType([
+    PropTypes.instanceOf(JobTree),
+    PropTypes.instanceOf(Job)
   ])
 };
 

--- a/src/js/components/charts/AnimationCircle.js
+++ b/src/js/components/charts/AnimationCircle.js
@@ -1,4 +1,5 @@
 import d3 from "d3";
+import PropTypes from "prop-types";
 import React from "react";
 import ReactDOM from "react-dom";
 
@@ -6,12 +7,12 @@ var AnimationCircle = React.createClass({
   displayName: "AnimationCircle",
 
   propTypes: {
-    className: React.PropTypes.string,
-    transitionTime: React.PropTypes.number.isRequired,
-    position: React.PropTypes.array.isRequired,
-    radius: React.PropTypes.number,
-    cx: React.PropTypes.number,
-    cy: React.PropTypes.number
+    className: PropTypes.string,
+    transitionTime: PropTypes.number.isRequired,
+    position: PropTypes.array.isRequired,
+    radius: PropTypes.number,
+    cx: PropTypes.number,
+    cy: PropTypes.number
   },
 
   getInitialState() {

--- a/src/js/components/charts/Bar.js
+++ b/src/js/components/charts/Bar.js
@@ -1,4 +1,5 @@
 import d3 from "d3";
+import PropTypes from "prop-types";
 import React from "react";
 import ReactDOM from "react-dom";
 
@@ -6,12 +7,12 @@ var Bar = React.createClass({
   displayName: "Bar",
 
   propTypes: {
-    posX: React.PropTypes.number.isRequired,
-    posY: React.PropTypes.number.isRequired,
-    rectHeight: React.PropTypes.number.isRequired,
-    rectWidth: React.PropTypes.number.isRequired,
-    colorClass: React.PropTypes.string.isRequired,
-    lineClass: React.PropTypes.string.isRequired
+    posX: PropTypes.number.isRequired,
+    posY: PropTypes.number.isRequired,
+    rectHeight: PropTypes.number.isRequired,
+    rectWidth: PropTypes.number.isRequired,
+    colorClass: PropTypes.string.isRequired,
+    lineClass: PropTypes.string.isRequired
   },
 
   componentDidMount() {

--- a/src/js/components/charts/BarChart.js
+++ b/src/js/components/charts/BarChart.js
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import d3 from "d3";
 import deepEqual from "deep-equal";
+import PropTypes from "prop-types";
 import React from "react";
 import ReactDOM from "react-dom";
 
@@ -15,17 +16,17 @@ var BarChart = React.createClass({
   mixins: [ChartMixin, InternalStorageMixin],
 
   propTypes: {
-    axisConfiguration: React.PropTypes.object,
-    data: React.PropTypes.array.isRequired,
+    axisConfiguration: PropTypes.object,
+    data: PropTypes.array.isRequired,
     // `height` and `width` are required if this
     // module isn't used as a child of the `Chart` component
     // Otherwise Chart will automatically calculate this.
-    height: React.PropTypes.number,
-    inverseStyle: React.PropTypes.bool,
-    peakline: React.PropTypes.bool,
-    refreshRate: React.PropTypes.number.isRequired,
-    y: React.PropTypes.string,
-    width: React.PropTypes.number
+    height: PropTypes.number,
+    inverseStyle: PropTypes.bool,
+    peakline: PropTypes.bool,
+    refreshRate: PropTypes.number.isRequired,
+    y: PropTypes.string,
+    width: PropTypes.number
   },
 
   getDefaultProps() {

--- a/src/js/components/charts/Chart.js
+++ b/src/js/components/charts/Chart.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import ReactDOM from "react-dom";
 import { StoreMixin } from "mesosphere-shared-reactjs";
@@ -11,8 +12,8 @@ var Chart = React.createClass({
   mixins: [InternalStorageMixin, StoreMixin],
 
   propTypes: {
-    calcHeight: React.PropTypes.func,
-    delayRender: React.PropTypes.bool
+    calcHeight: PropTypes.func,
+    delayRender: PropTypes.bool
   },
 
   getDefaultProps() {

--- a/src/js/components/charts/ChartStripes.js
+++ b/src/js/components/charts/ChartStripes.js
@@ -1,12 +1,13 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 var ChartStripes = React.createClass({
   displayName: "ChartStripes",
 
   propTypes: {
-    count: React.PropTypes.number.isRequired,
-    height: React.PropTypes.number.isRequired,
-    width: React.PropTypes.number.isRequired
+    count: PropTypes.number.isRequired,
+    height: PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired
   },
 
   getStripes(props) {

--- a/src/js/components/charts/DialChart.js
+++ b/src/js/components/charts/DialChart.js
@@ -1,4 +1,5 @@
 import d3 from "d3";
+import PropTypes from "prop-types";
 import React from "react";
 import ReactDOM from "react-dom";
 
@@ -17,10 +18,10 @@ var DialChart = React.createClass({
 
   propTypes: {
     // [{colorIndex: 0, name: 'Some Name', value: 4}]
-    data: React.PropTypes.array.isRequired,
-    slices: React.PropTypes.array,
-    duration: React.PropTypes.number,
-    value: React.PropTypes.string
+    data: PropTypes.array.isRequired,
+    slices: PropTypes.array,
+    duration: PropTypes.number,
+    value: PropTypes.string
   },
 
   getDefaultProps() {

--- a/src/js/components/charts/DialSlice.js
+++ b/src/js/components/charts/DialSlice.js
@@ -1,12 +1,13 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 
 var DialSlice = React.createClass({
   displayName: "DialSlice",
 
   propTypes: {
-    colorIndex: React.PropTypes.node,
-    path: React.PropTypes.string.isRequired
+    colorIndex: PropTypes.node,
+    path: PropTypes.string.isRequired
   },
 
   render() {

--- a/src/js/components/charts/HostTimeSeriesChart.js
+++ b/src/js/components/charts/HostTimeSeriesChart.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import Chart from "./Chart";
@@ -9,10 +10,10 @@ var HostTimeSeriesChart = React.createClass({
   displayName: "HostTimeSeriesChart",
 
   propTypes: {
-    data: React.PropTypes.array.isRequired,
-    refreshRate: React.PropTypes.number.isRequired,
-    roundUpValue: React.PropTypes.number,
-    minMaxY: React.PropTypes.number
+    data: PropTypes.array.isRequired,
+    refreshRate: PropTypes.number.isRequired,
+    roundUpValue: PropTypes.number,
+    minMaxY: PropTypes.number
   },
 
   getDefaultProps() {

--- a/src/js/components/charts/Rect.js
+++ b/src/js/components/charts/Rect.js
@@ -1,7 +1,6 @@
+import PropTypes from "prop-types";
 import React from "react";
 import ReactDOM from "react-dom";
-
-const PropTypes = React.PropTypes;
 
 class Rect extends React.Component {
   componentDidMount() {

--- a/src/js/components/charts/ResourceBarChart.js
+++ b/src/js/components/charts/ResourceBarChart.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 
 import BarChart from "./BarChart";
@@ -12,13 +13,13 @@ const ResourceBarChart = React.createClass({
   displayName: "ResourceBarChart",
 
   propTypes: {
-    onResourceSelectionChange: React.PropTypes.func.isRequired,
-    itemCount: React.PropTypes.number.isRequired,
-    resources: React.PropTypes.object.isRequired,
-    refreshRate: React.PropTypes.number.isRequired,
-    resourceType: React.PropTypes.string,
-    selectedResource: React.PropTypes.string.isRequired,
-    totalResources: React.PropTypes.object.isRequired
+    onResourceSelectionChange: PropTypes.func.isRequired,
+    itemCount: PropTypes.number.isRequired,
+    resources: PropTypes.object.isRequired,
+    refreshRate: PropTypes.number.isRequired,
+    resourceType: PropTypes.string,
+    selectedResource: PropTypes.string.isRequired,
+    totalResources: PropTypes.object.isRequired
   },
 
   getDefaultProps() {

--- a/src/js/components/charts/ResourceChart.js
+++ b/src/js/components/charts/ResourceChart.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import BarChart from "../../components/charts/BarChart";
@@ -95,9 +96,9 @@ ResourceChart.defaultProps = {
 };
 
 ResourceChart.propTypes = {
-  className: React.PropTypes.string,
-  resourceName: React.PropTypes.string,
-  resources: React.PropTypes.object
+  className: PropTypes.string,
+  resourceName: PropTypes.string,
+  resources: PropTypes.object
 };
 
 module.exports = ResourceChart;

--- a/src/js/components/charts/ResourceTimeSeriesChart.js
+++ b/src/js/components/charts/ResourceTimeSeriesChart.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import Chart from "./Chart";
@@ -9,12 +10,12 @@ var ResourceTimeSeriesChart = React.createClass({
   displayName: "ResourceTimeSeriesChart",
 
   propTypes: {
-    colorIndex: React.PropTypes.number.isRequired,
-    usedResources: React.PropTypes.object.isRequired,
-    totalResources: React.PropTypes.object.isRequired,
-    usedResourcesStates: React.PropTypes.object.isRequired,
-    mode: React.PropTypes.string,
-    refreshRate: React.PropTypes.number.isRequired
+    colorIndex: PropTypes.number.isRequired,
+    usedResources: PropTypes.object.isRequired,
+    totalResources: PropTypes.object.isRequired,
+    usedResourcesStates: PropTypes.object.isRequired,
+    mode: PropTypes.string,
+    refreshRate: PropTypes.number.isRequired
   },
 
   getDefaultProps() {

--- a/src/js/components/charts/TasksChart.js
+++ b/src/js/components/charts/TasksChart.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import deepEqual from "deep-equal";
+import PropTypes from "prop-types";
 import React from "react";
 
 import Chart from "./Chart";
@@ -27,7 +28,7 @@ var TasksChart = React.createClass({
 
   propTypes: {
     // {TASK_RUNNING: 0, TASK_STAGING: 4}
-    tasks: React.PropTypes.object.isRequired
+    tasks: PropTypes.object.isRequired
   },
 
   shouldComponentUpdate(nextProps) {

--- a/src/js/components/charts/TimeSeriesArea.js
+++ b/src/js/components/charts/TimeSeriesArea.js
@@ -1,4 +1,5 @@
 import d3 from "d3";
+import PropTypes from "prop-types";
 import React from "react";
 import ReactDOM from "react-dom";
 
@@ -6,11 +7,11 @@ var TimeSeriesArea = React.createClass({
   displayName: "TimeSeriesArea",
 
   propTypes: {
-    className: React.PropTypes.string,
-    line: React.PropTypes.string.isRequired,
-    path: React.PropTypes.string.isRequired,
-    position: React.PropTypes.array.isRequired,
-    transitionTime: React.PropTypes.number.isRequired
+    className: PropTypes.string,
+    line: PropTypes.string.isRequired,
+    path: PropTypes.string.isRequired,
+    position: PropTypes.array.isRequired,
+    transitionTime: PropTypes.number.isRequired
   },
 
   componentDidMount() {

--- a/src/js/components/charts/TimeSeriesChart.js
+++ b/src/js/components/charts/TimeSeriesChart.js
@@ -1,5 +1,6 @@
 import d3 from "d3";
 import deepEqual from "deep-equal";
+import PropTypes from "prop-types";
 import React from "react";
 import ReactDOM from "react-dom";
 
@@ -18,20 +19,20 @@ var TimeSeriesChart = React.createClass({
   displayName: "TimeSeriesChart",
 
   propTypes: {
-    axisConfiguration: React.PropTypes.object,
+    axisConfiguration: PropTypes.object,
     // [{name: 'Area Name', values: [{date: some time, y: 0}]}]
-    data: React.PropTypes.array.isRequired,
+    data: PropTypes.array.isRequired,
     // `height` and `width` are required if this
     // module isn't used as a child of the `Chart` component
     // Otherwise Chart will automatically calculate this.
-    height: React.PropTypes.number,
-    margin: React.PropTypes.object.isRequired,
-    maxY: React.PropTypes.number,
-    refreshRate: React.PropTypes.number.isRequired,
-    ticksY: React.PropTypes.number,
-    y: React.PropTypes.string,
-    yFormat: React.PropTypes.string,
-    width: React.PropTypes.number
+    height: PropTypes.number,
+    margin: PropTypes.object.isRequired,
+    maxY: PropTypes.number,
+    refreshRate: PropTypes.number.isRequired,
+    ticksY: PropTypes.number,
+    y: PropTypes.string,
+    yFormat: PropTypes.string,
+    width: PropTypes.number
   },
 
   mixins: [ChartMixin, InternalStorageMixin],

--- a/src/js/components/charts/TimeSeriesLabel.js
+++ b/src/js/components/charts/TimeSeriesLabel.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import deepEqual from "deep-equal";
+import PropTypes from "prop-types";
 import React from "react";
 
 import ValueTypes from "../../constants/ValueTypes";
@@ -8,16 +9,12 @@ var TimeSeriesLabel = React.createClass({
   displayName: "TimeSeriesLabel",
 
   propTypes: {
-    colorIndex: React.PropTypes.number,
-    currentValue: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number
-    ]).isRequired,
-    subHeading: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number
-    ]).isRequired,
-    y: React.PropTypes.string
+    colorIndex: PropTypes.number,
+    currentValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+      .isRequired,
+    subHeading: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+      .isRequired,
+    y: PropTypes.string
   },
 
   getDefaultProps() {

--- a/src/js/components/charts/TimeSeriesMouseOver.js
+++ b/src/js/components/charts/TimeSeriesMouseOver.js
@@ -1,4 +1,5 @@
 import d3 from "d3";
+import PropTypes from "prop-types";
 import React from "react";
 
 import Maths from "../../utils/Maths";
@@ -7,16 +8,16 @@ var TimeSeriesMouseOver = React.createClass({
   displayName: "TimeSeriesMouseOver",
 
   propTypes: {
-    addMouseHandler: React.PropTypes.func.isRequired,
-    data: React.PropTypes.array.isRequired,
-    getBoundingBox: React.PropTypes.func.isRequired,
-    height: React.PropTypes.number.isRequired,
-    removeMouseHandler: React.PropTypes.func.isRequired,
-    width: React.PropTypes.number.isRequired,
-    xScale: React.PropTypes.func.isRequired,
-    y: React.PropTypes.string.isRequired,
-    yScale: React.PropTypes.func.isRequired,
-    yCaption: React.PropTypes.string.isRequired
+    addMouseHandler: PropTypes.func.isRequired,
+    data: PropTypes.array.isRequired,
+    getBoundingBox: PropTypes.func.isRequired,
+    height: PropTypes.number.isRequired,
+    removeMouseHandler: PropTypes.func.isRequired,
+    width: PropTypes.number.isRequired,
+    xScale: PropTypes.func.isRequired,
+    y: PropTypes.string.isRequired,
+    yScale: PropTypes.func.isRequired,
+    yCaption: PropTypes.string.isRequired
   },
 
   componentDidMount() {

--- a/src/js/components/form/AddButton.js
+++ b/src/js/components/form/AddButton.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 import Icon from "../Icon";
@@ -24,14 +25,14 @@ AddButton.defaultProps = {
 };
 
 AddButton.propTypes = {
-  children: React.PropTypes.node,
-  onClick: React.PropTypes.func,
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  children: PropTypes.node,
+  onClick: PropTypes.func,
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
-  icon: React.PropTypes.node
+  icon: PropTypes.node
 };
 
 module.exports = AddButton;

--- a/src/js/components/form/AdvancedSection.js
+++ b/src/js/components/form/AdvancedSection.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 import AdvancedSectionContent from "./AdvancedSectionContent";
@@ -50,12 +51,12 @@ class AdvancedSection extends React.Component {
 }
 
 AdvancedSection.propTypes = {
-  initialIsExpanded: React.PropTypes.bool,
-  children: React.PropTypes.node,
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  initialIsExpanded: PropTypes.bool,
+  children: PropTypes.node,
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ])
 };
 

--- a/src/js/components/form/AdvancedSectionContent.js
+++ b/src/js/components/form/AdvancedSectionContent.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 const AdvancedSectionContent = ({ className, children }) => {
@@ -12,11 +13,11 @@ const AdvancedSectionContent = ({ className, children }) => {
 };
 
 AdvancedSectionContent.propTypes = {
-  children: React.PropTypes.node,
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  children: PropTypes.node,
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ])
 };
 

--- a/src/js/components/form/AdvancedSectionLabel.js
+++ b/src/js/components/form/AdvancedSectionLabel.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 import Icon from "../Icon";
@@ -30,14 +31,14 @@ const AdvancedSectionLabel = ({ className, children, isExpanded, onClick }) => {
 };
 
 AdvancedSectionLabel.propTypes = {
-  children: React.PropTypes.node,
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  children: PropTypes.node,
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
-  isExpanded: React.PropTypes.bool,
-  onClick: React.PropTypes.func
+  isExpanded: PropTypes.bool,
+  onClick: PropTypes.func
 };
 
 module.exports = AdvancedSectionLabel;

--- a/src/js/components/form/FieldError.js
+++ b/src/js/components/form/FieldError.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 import { omit } from "../../utils/Util";
@@ -17,10 +18,10 @@ const FieldError = props => {
 
 FieldError.propTypes = {
   // Classes
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ])
 };
 

--- a/src/js/components/form/FieldHelp.js
+++ b/src/js/components/form/FieldHelp.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 import { omit } from "../../utils/Util";
@@ -21,12 +22,12 @@ FieldHelp.defaultProps = {
 
 FieldHelp.propTypes = {
   // Classes
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
-  textTransform: React.PropTypes.oneOf(["none", "uppercase"])
+  textTransform: PropTypes.oneOf(["none", "uppercase"])
 };
 
 module.exports = FieldHelp;

--- a/src/js/components/form/FieldInput.js
+++ b/src/js/components/form/FieldInput.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 import { omit } from "../../utils/Util";
@@ -26,19 +27,16 @@ FieldInput.defaultProps = {
 };
 
 FieldInput.propTypes = {
-  type: React.PropTypes.string,
-  onChange: React.PropTypes.func,
-  checked: React.PropTypes.bool,
-  value: React.PropTypes.oneOfType([
-    React.PropTypes.number,
-    React.PropTypes.string
-  ]),
+  type: PropTypes.string,
+  onChange: PropTypes.func,
+  checked: PropTypes.bool,
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
   // Classes
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ])
 };
 

--- a/src/js/components/form/FieldLabel.js
+++ b/src/js/components/form/FieldLabel.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 import { findNestedPropertyInObject, omit } from "../../utils/Util";
@@ -44,17 +45,17 @@ const FieldLabel = props => {
 };
 
 FieldLabel.propTypes = {
-  children: React.PropTypes.node,
+  children: PropTypes.node,
   // Vertically center the element based on the height of input fields
-  matchInputHeight: React.PropTypes.bool,
+  matchInputHeight: PropTypes.bool,
   // Optional boolean to show a required indicator
-  required: React.PropTypes.bool,
+  required: PropTypes.bool,
 
   // Classes
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ])
 };
 

--- a/src/js/components/form/FieldSelect.js
+++ b/src/js/components/form/FieldSelect.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import classNames from "classnames/dedupe";
 import { omit } from "#SRC/js/utils/Util";
@@ -21,16 +22,13 @@ FieldSelect.defaultProps = {
 };
 
 FieldSelect.propTypes = {
-  name: React.PropTypes.string,
-  onChange: React.PropTypes.func,
-  value: React.PropTypes.oneOfType([
-    React.PropTypes.number,
-    React.PropTypes.string
-  ]),
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  name: PropTypes.string,
+  onChange: PropTypes.func,
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ])
 };
 

--- a/src/js/components/form/FieldTextarea.js
+++ b/src/js/components/form/FieldTextarea.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 import { omit } from "../../utils/Util";
@@ -16,17 +17,14 @@ FieldTextarea.defaultProps = {
 };
 
 FieldTextarea.propTypes = {
-  onChange: React.PropTypes.func,
-  value: React.PropTypes.oneOfType([
-    React.PropTypes.number,
-    React.PropTypes.string
-  ]),
+  onChange: PropTypes.func,
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
   // Classes
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ])
 };
 

--- a/src/js/components/form/FormGroup.js
+++ b/src/js/components/form/FormGroup.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 import FieldError from "./FieldError";
@@ -45,27 +46,27 @@ FormGroup.defaultProps = {
   hasNarrowMargins: false
 };
 
-const classPropType = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
+const classPropType = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
 ]);
 
 FormGroup.propTypes = {
-  children: React.PropTypes.node,
+  children: PropTypes.node,
   // Optional boolean to display error
-  showError: React.PropTypes.bool,
+  showError: PropTypes.bool,
 
   // Classes
   className: classPropType,
   // Class to be toggled, can be overridden by className
-  errorClassName: React.PropTypes.string,
+  errorClassName: PropTypes.string,
   // When true, will add padding to the top of the form group to vertically
   // align it with its siblings that have labels.
-  applyLabelOffset: React.PropTypes.bool,
+  applyLabelOffset: PropTypes.bool,
   // When true, the component will apply specific styles for use with the delete
   // row button
-  hasNarrowMargins: React.PropTypes.bool
+  hasNarrowMargins: PropTypes.bool
 };
 
 module.exports = FormGroup;

--- a/src/js/components/form/FormGroupContainer.js
+++ b/src/js/components/form/FormGroupContainer.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { Tooltip } from "reactjs-components";
 import classNames from "classnames";
@@ -43,9 +44,9 @@ FormGroupContainer.defaultProps = {
 };
 
 FormGroupContainer.propTypes = {
-  children: React.PropTypes.node,
-  onRemove: React.PropTypes.func,
-  onClick: React.PropTypes.func
+  children: PropTypes.node,
+  onRemove: PropTypes.func,
+  onClick: PropTypes.func
 };
 
 module.exports = FormGroupContainer;

--- a/src/js/components/form/FormGroupHeading.js
+++ b/src/js/components/form/FormGroupHeading.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 
 import FormGroupHeadingContent from "./FormGroupHeadingContent";
@@ -31,13 +32,13 @@ FormGroupHeading.defaultProps = {
 };
 
 FormGroupHeading.propTypes = {
-  children: React.PropTypes.node.isRequired,
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  children: PropTypes.node.isRequired,
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
-  required: React.PropTypes.bool
+  required: PropTypes.bool
 };
 
 module.exports = FormGroupHeading;

--- a/src/js/components/form/FormGroupHeadingContent.js
+++ b/src/js/components/form/FormGroupHeadingContent.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 
 import Config from "../../config/Config";
@@ -43,14 +44,14 @@ FormGroupHeadingContent.defaultProps = {
 };
 
 FormGroupHeadingContent.propTypes = {
-  children: React.PropTypes.node,
-  className: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.object,
-    React.PropTypes.string
+  children: PropTypes.node,
+  className: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object,
+    PropTypes.string
   ]),
-  primary: React.PropTypes.bool,
-  title: React.PropTypes.string
+  primary: PropTypes.bool,
+  title: PropTypes.string
 };
 
 module.exports = FormGroupHeadingContent;

--- a/src/js/components/modals/ActionsModal.js
+++ b/src/js/components/modals/ActionsModal.js
@@ -1,5 +1,6 @@
 import { Confirm, Dropdown } from "reactjs-components";
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 import { StoreMixin } from "mesosphere-shared-reactjs";
 
@@ -264,12 +265,12 @@ class ActionsModal extends mixin(StoreMixin) {
 }
 
 ActionsModal.propTypes = {
-  action: React.PropTypes.string.isRequired,
-  actionText: React.PropTypes.object.isRequired,
-  itemID: React.PropTypes.string.isRequired,
-  itemType: React.PropTypes.string.isRequired,
-  onClose: React.PropTypes.func.isRequired,
-  selectedItems: React.PropTypes.array.isRequired
+  action: PropTypes.string.isRequired,
+  actionText: PropTypes.object.isRequired,
+  itemID: PropTypes.string.isRequired,
+  itemType: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+  selectedItems: PropTypes.array.isRequired
 };
 
 module.exports = ActionsModal;

--- a/src/js/components/modals/AddRepositoryFormModal.js
+++ b/src/js/components/modals/AddRepositoryFormModal.js
@@ -1,4 +1,5 @@
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 /* eslint-disable no-unused-vars */
 import React from "react";
 /* eslint-enable no-unused-vars */
@@ -163,8 +164,8 @@ class AddRepositoryFormModal extends mixin(StoreMixin) {
 }
 
 AddRepositoryFormModal.propTypes = {
-  numberOfRepositories: React.PropTypes.number.isRequired,
-  open: React.PropTypes.bool
+  numberOfRepositories: PropTypes.number.isRequired,
+  open: PropTypes.bool
 };
 
 module.exports = AddRepositoryFormModal;

--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -1,6 +1,7 @@
 import browserInfo from "browser-info";
 import classNames from "classnames";
 import { Modal } from "reactjs-components";
+import PropTypes from "prop-types";
 import React from "react";
 
 import ClickToSelect from "../ClickToSelect";
@@ -204,11 +205,11 @@ class CliInstallModal extends React.Component {
 }
 
 CliInstallModal.propTypes = {
-  title: React.PropTypes.string.isRequired,
-  subHeaderContent: React.PropTypes.string,
-  showFooter: React.PropTypes.bool.isRequired,
-  footer: React.PropTypes.node,
-  onClose: React.PropTypes.func.isRequired
+  title: PropTypes.string.isRequired,
+  subHeaderContent: PropTypes.string,
+  showFooter: PropTypes.bool.isRequired,
+  footer: PropTypes.node,
+  onClose: PropTypes.func.isRequired
 };
 
 module.exports = CliInstallModal;

--- a/src/js/components/modals/ErrorModal.js
+++ b/src/js/components/modals/ErrorModal.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import { Modal } from "reactjs-components";
@@ -8,8 +9,8 @@ var ErrorModal = React.createClass({
   displayName: "ErrorModal",
 
   propTypes: {
-    onClose: React.PropTypes.func.isRequired,
-    errorMsg: React.PropTypes.element
+    onClose: PropTypes.func.isRequired,
+    errorMsg: PropTypes.element
   },
 
   onClose() {

--- a/src/js/components/modals/FullScreenModal.js
+++ b/src/js/components/modals/FullScreenModal.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import { Modal } from "reactjs-components";
+import PropTypes from "prop-types";
 import React from "react";
 
 import Util from "../../utils/Util";
@@ -39,8 +40,8 @@ FullScreenModal.defaultProps = {
 };
 
 FullScreenModal.propTypes = {
-  children: React.PropTypes.node,
-  useGemini: React.PropTypes.bool
+  children: PropTypes.node,
+  useGemini: PropTypes.bool
 };
 
 module.exports = FullScreenModal;

--- a/src/js/components/modals/FullScreenModalHeader.js
+++ b/src/js/components/modals/FullScreenModalHeader.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 class FullScreenModalHeader extends React.Component {
@@ -14,14 +15,14 @@ class FullScreenModalHeader extends React.Component {
   }
 }
 
-const classProps = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
+const classProps = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
 ]);
 
 FullScreenModalHeader.propTypes = {
-  children: React.PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
   className: classProps
 };
 

--- a/src/js/components/modals/FullScreenModalHeaderActions.js
+++ b/src/js/components/modals/FullScreenModalHeaderActions.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 class FullScreenModalHeaderActions extends React.Component {
@@ -47,22 +48,22 @@ class FullScreenModalHeaderActions extends React.Component {
   }
 }
 
-const classProps = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
+const classProps = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
 ]);
 
 FullScreenModalHeaderActions.propTypes = {
-  actions: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
+  actions: PropTypes.arrayOf(
+    PropTypes.shape({
       className: classProps,
-      clickHandler: React.PropTypes.func,
-      label: React.PropTypes.node
+      clickHandler: PropTypes.func,
+      label: PropTypes.node
     })
   ),
   className: classProps,
-  type: React.PropTypes.oneOf(["primary", "secondary"]).isRequired
+  type: PropTypes.oneOf(["primary", "secondary"]).isRequired
 };
 
 module.exports = FullScreenModalHeaderActions;

--- a/src/js/components/modals/FullScreenModalHeaderSubTitle.js
+++ b/src/js/components/modals/FullScreenModalHeaderSubTitle.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 class FullScreenModalHeaderSubTitle extends React.Component {
@@ -14,14 +15,14 @@ class FullScreenModalHeaderSubTitle extends React.Component {
   }
 }
 
-const classProps = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
+const classProps = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
 ]);
 
 FullScreenModalHeaderSubTitle.propTypes = {
-  children: React.PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
   className: classProps
 };
 

--- a/src/js/components/modals/FullScreenModalHeaderTitle.js
+++ b/src/js/components/modals/FullScreenModalHeaderTitle.js
@@ -1,4 +1,5 @@
 import classNames from "classnames/dedupe";
+import PropTypes from "prop-types";
 import React from "react";
 
 class FullScreenModalHeaderTitle extends React.Component {
@@ -14,14 +15,14 @@ class FullScreenModalHeaderTitle extends React.Component {
   }
 }
 
-const classProps = React.PropTypes.oneOfType([
-  React.PropTypes.array,
-  React.PropTypes.object,
-  React.PropTypes.string
+const classProps = PropTypes.oneOfType([
+  PropTypes.array,
+  PropTypes.object,
+  PropTypes.string
 ]);
 
 FullScreenModalHeaderTitle.propTypes = {
-  children: React.PropTypes.node.isRequired,
+  children: PropTypes.node.isRequired,
   className: classProps
 };
 

--- a/src/js/components/modals/ImageViewerModal.js
+++ b/src/js/components/modals/ImageViewerModal.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import { Modal } from "reactjs-components";
+import PropTypes from "prop-types";
 import React from "react";
 
 import Icon from "../Icon";
@@ -135,10 +136,10 @@ ImageViewerModal.defaultProps = {
 };
 
 ImageViewerModal.propTypes = {
-  images: React.PropTypes.arrayOf(React.PropTypes.string),
-  onLeftClick: React.PropTypes.func.isRequired,
-  onRightClick: React.PropTypes.func.isRequired,
-  onClose: React.PropTypes.func.isRequired
+  images: PropTypes.arrayOf(PropTypes.string),
+  onLeftClick: PropTypes.func.isRequired,
+  onRightClick: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired
 };
 
 module.exports = ImageViewerModal;

--- a/src/js/components/modals/JobFormModal.js
+++ b/src/js/components/modals/JobFormModal.js
@@ -1,6 +1,7 @@
 import Ace from "react-ace";
 import mixin from "reactjs-mixin";
 import { Modal } from "reactjs-components";
+import PropTypes from "prop-types";
 import React from "react";
 import { StoreMixin } from "mesosphere-shared-reactjs";
 
@@ -475,10 +476,10 @@ JobFormModal.defaultProps = {
 };
 
 JobFormModal.propTypes = {
-  isEdit: React.PropTypes.bool,
-  job: React.PropTypes.instanceOf(Job),
-  open: React.PropTypes.bool,
-  onClose: React.PropTypes.func
+  isEdit: PropTypes.bool,
+  job: PropTypes.instanceOf(Job),
+  open: PropTypes.bool,
+  onClose: PropTypes.func
 };
 
 module.exports = JobFormModal;

--- a/src/js/components/modals/JobStopRunModal.js
+++ b/src/js/components/modals/JobStopRunModal.js
@@ -1,5 +1,6 @@
 import { Confirm } from "reactjs-components";
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 import { StoreMixin } from "mesosphere-shared-reactjs";
 
@@ -124,11 +125,11 @@ JobStopRunModal.defaultProps = {
 };
 
 JobStopRunModal.propTypes = {
-  jobID: React.PropTypes.string.isRequired,
-  onClose: React.PropTypes.func.isRequired,
-  onSuccess: React.PropTypes.func,
-  open: React.PropTypes.bool.isRequired,
-  selectedItems: React.PropTypes.array.isRequired
+  jobID: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSuccess: PropTypes.func,
+  open: PropTypes.bool.isRequired,
+  selectedItems: PropTypes.array.isRequired
 };
 
 module.exports = JobStopRunModal;

--- a/src/js/components/modals/ModalHeading.js
+++ b/src/js/components/modals/ModalHeading.js
@@ -1,4 +1,5 @@
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import React from "react";
 
 const ModalHeading = props => {
@@ -19,8 +20,8 @@ ModalHeading.defaultProps = {
 };
 
 ModalHeading.propTypes = {
-  children: React.PropTypes.node.isRequired,
-  level: React.PropTypes.oneOf([1, 2, 3, 4, 5, 6])
+  children: PropTypes.node.isRequired,
+  level: PropTypes.oneOf([1, 2, 3, 4, 5, 6])
 };
 
 module.exports = ModalHeading;

--- a/src/js/components/modals/UsersActionsModal.js
+++ b/src/js/components/modals/UsersActionsModal.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-unused-vars */
+import PropTypes from "prop-types";
+
 import React from "react";
 /* eslint-enable no-unused-vars */
 
@@ -41,11 +43,11 @@ class UsersActionsModal extends ActionsModal {
 }
 
 UsersActionsModal.propTypes = {
-  action: React.PropTypes.string.isRequired,
-  actionText: React.PropTypes.object.isRequired,
-  itemID: React.PropTypes.string.isRequired,
-  onClose: React.PropTypes.func.isRequired,
-  selectedItems: React.PropTypes.array.isRequired
+  action: PropTypes.string.isRequired,
+  actionText: PropTypes.object.isRequired,
+  itemID: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+  selectedItems: PropTypes.array.isRequired
 };
 
 module.exports = UsersActionsModal;

--- a/src/js/components/modals/VersionsModal.js
+++ b/src/js/components/modals/VersionsModal.js
@@ -1,4 +1,5 @@
 import { Modal } from "reactjs-components";
+import PropTypes from "prop-types";
 import React from "react";
 
 import ClickToSelect from "../ClickToSelect";
@@ -9,8 +10,8 @@ var VersionsModal = React.createClass({
   displayName: "VersionsModal",
 
   propTypes: {
-    onClose: React.PropTypes.func.isRequired,
-    versionDump: React.PropTypes.object.isRequired
+    onClose: PropTypes.func.isRequired,
+    versionDump: PropTypes.object.isRequired
   },
 
   onClose() {

--- a/src/js/pages/catalog/DeployFrameworkConfiguration.js
+++ b/src/js/pages/catalog/DeployFrameworkConfiguration.js
@@ -1,5 +1,6 @@
-import React, { PropTypes } from "react";
+import React from "react";
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 import qs from "query-string";
 import deepEqual from "deep-equal";
 import { StoreMixin } from "mesosphere-shared-reactjs";

--- a/src/js/pages/jobs/JobConfiguration.js
+++ b/src/js/pages/jobs/JobConfiguration.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import ConfigurationMap from "../../components/ConfigurationMap";
@@ -179,7 +180,7 @@ class JobConfiguration extends React.Component {
 }
 
 JobConfiguration.propTypes = {
-  job: React.PropTypes.instanceOf(Job).isRequired
+  job: PropTypes.instanceOf(Job).isRequired
 };
 
 module.exports = JobConfiguration;

--- a/src/js/pages/jobs/JobRunHistoryTable.js
+++ b/src/js/pages/jobs/JobRunHistoryTable.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import { Link } from "react-router";
+import PropTypes from "prop-types";
 import React from "react";
 
 import moment from "moment";
@@ -398,7 +399,7 @@ class JobRunHistoryTable extends React.Component {
 }
 
 JobRunHistoryTable.propTypes = {
-  params: React.PropTypes.object
+  params: PropTypes.object
 };
 
 module.exports = JobRunHistoryTable;

--- a/src/js/pages/jobs/JobTaskDetailPage.js
+++ b/src/js/pages/jobs/JobTaskDetailPage.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { Link } from "react-router";
 
@@ -63,8 +64,8 @@ class JobTaskDetailPage extends React.Component {
 }
 
 JobTaskDetailPage.propTypes = {
-  params: React.PropTypes.object,
-  routes: React.PropTypes.array
+  params: PropTypes.object,
+  routes: PropTypes.array
 };
 
 module.exports = JobTaskDetailPage;

--- a/src/js/pages/jobs/JobsTab.js
+++ b/src/js/pages/jobs/JobsTab.js
@@ -1,4 +1,5 @@
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 import { routerShape } from "react-router";
 
@@ -249,7 +250,7 @@ class JobsTab extends mixin(StoreMixin) {
 
 JobsTab.contextTypes = {
   router: routerShape,
-  location: React.PropTypes.object.isRequired
+  location: PropTypes.object.isRequired
 };
 
 module.exports = JobsTab;

--- a/src/js/pages/jobs/JobsTable.js
+++ b/src/js/pages/jobs/JobsTable.js
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import { Link } from "react-router";
 import prettycron from "prettycron";
+import PropTypes from "prop-types";
 import React from "react";
 import { Table, Tooltip } from "reactjs-components";
 
@@ -265,7 +266,7 @@ class JobsTable extends React.Component {
 }
 
 JobsTable.propTypes = {
-  jobs: React.PropTypes.array.isRequired
+  jobs: PropTypes.array.isRequired
 };
 
 module.exports = JobsTable;

--- a/src/js/pages/network/VirtualNetworksTable.js
+++ b/src/js/pages/network/VirtualNetworksTable.js
@@ -1,5 +1,6 @@
 import classNames from "classnames";
 import { routerShape, Link } from "react-router";
+import PropTypes from "prop-types";
 import React from "react";
 import { Table } from "reactjs-components";
 
@@ -118,7 +119,7 @@ VirtualNetworksTable.contextTypes = {
 };
 
 VirtualNetworksTable.propTypes = {
-  overlays: React.PropTypes.instanceOf(OverlayList)
+  overlays: PropTypes.instanceOf(OverlayList)
 };
 
 module.exports = VirtualNetworksTable;

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 
 import ConfigurationMap from "../../../components/ConfigurationMap";
@@ -40,7 +41,7 @@ class VirtualNetworkDetailsTab extends React.Component {
 }
 
 VirtualNetworkDetailsTab.propTypes = {
-  overlay: React.PropTypes.instanceOf(Overlay)
+  overlay: PropTypes.instanceOf(Overlay)
 };
 
 module.exports = VirtualNetworkDetailsTab;

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskPage.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskPage.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React from "react";
 import { Link } from "react-router";
 
@@ -123,8 +124,8 @@ class VirtualNetworkTaskPage extends React.Component {
 }
 
 VirtualNetworkTaskPage.propTypes = {
-  params: React.PropTypes.object,
-  routes: React.PropTypes.array
+  params: PropTypes.object,
+  routes: PropTypes.array
 };
 
 module.exports = VirtualNetworkTaskPage;

--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import { routerShape, Link } from "react-router";
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 /* eslint-disable no-unused-vars */
 import React from "react";
 /* eslint-enable no-unused-vars */
@@ -314,7 +315,7 @@ VirtualNetworkTaskTab.contextTypes = {
 };
 
 VirtualNetworkTaskTab.propTypes = {
-  overlay: React.PropTypes.instanceOf(Overlay)
+  overlay: PropTypes.instanceOf(Overlay)
 };
 
 module.exports = VirtualNetworkTaskTab;

--- a/src/js/pages/system/OrganizationTab.js
+++ b/src/js/pages/system/OrganizationTab.js
@@ -3,6 +3,7 @@ import { Dropdown, Form, Table } from "reactjs-components";
 import { Hooks } from "PluginSDK";
 import { Link } from "react-router";
 import mixin from "reactjs-mixin";
+import PropTypes from "prop-types";
 /* eslint-disable no-unused-vars */
 import React from "react";
 /* eslint-enable no-unused-vars */
@@ -518,9 +519,9 @@ class OrganizationTab extends mixin(StoreMixin, InternalStorageMixin) {
 }
 
 OrganizationTab.propTypes = {
-  items: React.PropTypes.array.isRequired,
-  itemID: React.PropTypes.string.isRequired,
-  itemName: React.PropTypes.string.isRequired
+  items: PropTypes.array.isRequired,
+  itemID: PropTypes.string.isRequired,
+  itemName: PropTypes.string.isRequired
 };
 
 module.exports = OrganizationTab;

--- a/src/js/pages/system/UsersPage.js
+++ b/src/js/pages/system/UsersPage.js
@@ -1,6 +1,7 @@
 import { Hooks } from "PluginSDK";
 import mixin from "reactjs-mixin";
 import { Link } from "react-router";
+import PropTypes from "prop-types";
 /* eslint-disable no-unused-vars */
 import React from "react";
 /* eslint-enable no-unused-vars */
@@ -113,7 +114,7 @@ class UsersPage extends mixin(StoreMixin) {
 }
 
 UsersPage.propTypes = {
-  params: React.PropTypes.object
+  params: PropTypes.object
 };
 
 UsersPage.routeConfig = {

--- a/src/js/pages/system/units-health-node-detail/NodeInfoPanel.js
+++ b/src/js/pages/system/units-health-node-detail/NodeInfoPanel.js
@@ -1,4 +1,5 @@
 import PureRender from "react-addons-pure-render-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 
 import ConfigurationMap from "../../../components/ConfigurationMap";
@@ -50,9 +51,9 @@ class NodeInfoPanel extends React.Component {
 }
 
 NodeInfoPanel.propTypes = {
-  docsURL: React.PropTypes.string,
-  output: React.PropTypes.string,
-  summary: React.PropTypes.string
+  docsURL: PropTypes.string,
+  output: PropTypes.string,
+  summary: PropTypes.string
 };
 
 NodeInfoPanel.defaultProps = {

--- a/src/js/pages/system/units-health-node-detail/UnitsHealthNodeDetailPanel.js
+++ b/src/js/pages/system/units-health-node-detail/UnitsHealthNodeDetailPanel.js
@@ -1,4 +1,5 @@
 import PureRender from "react-addons-pure-render-mixin";
+import PropTypes from "prop-types";
 import React from "react";
 
 import NodeInfoPanel from "./NodeInfoPanel";
@@ -23,10 +24,10 @@ class UnitsHealthNodeDetailPanel extends React.Component {
 }
 
 UnitsHealthNodeDetailPanel.propTypes = {
-  docsURL: React.PropTypes.string,
-  hostIP: React.PropTypes.string,
-  output: React.PropTypes.string,
-  summary: React.PropTypes.string
+  docsURL: PropTypes.string,
+  hostIP: PropTypes.string,
+  output: PropTypes.string,
+  summary: PropTypes.string
 };
 
 module.exports = UnitsHealthNodeDetailPanel;

--- a/src/js/routes/factories/network.js
+++ b/src/js/routes/factories/network.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-unused-vars */
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+
+import React from "react";
 /* eslint-enable no-unused-vars */
 import { IndexRoute, Route, Redirect } from "react-router";
 

--- a/src/js/routes/factories/organization.js
+++ b/src/js/routes/factories/organization.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-unused-vars */
-import React, { PropTypes } from "react";
+import PropTypes from "prop-types";
+
+import React from "react";
 /* eslint-enable no-unused-vars */
 import { Route, Redirect } from "react-router";
 

--- a/src/js/utils/JestUtil.js
+++ b/src/js/utils/JestUtil.js
@@ -1,4 +1,5 @@
 import TestUtils from "react-addons-test-utils";
+import PropTypes from "prop-types";
 import React from "react";
 import ReactDOM from "react-dom";
 import { routerShape } from "react-router";
@@ -146,7 +147,7 @@ const JestUtil = {
         return Object.assign(
           {
             router: routerShape,
-            routeDepth: React.PropTypes.number
+            routeDepth: PropTypes.number
           },
           contextTypes
         );


### PR DESCRIPTION
Enabling react@16

PropTypes have been extracted in a separate package `prop-types`. It still works with both, can be merged before changing the plugins.