### PR TITLE
🚨 Bump @dcos/mesos-client 0.1.6

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -25,14 +25,14 @@
       "resolved": "https://registry.npmjs.org/@dcos/http-service/-/http-service-0.1.0.tgz"
     },
     "@dcos/mesos-client": {
-      "version": "0.1.2",
-      "from": "@dcos/mesos-client@0.1.2",
-      "resolved": "https://registry.npmjs.org/@dcos/mesos-client/-/mesos-client-0.1.2.tgz"
+      "version": "0.1.6",
+      "from": "@dcos/mesos-client@0.1.6",
+      "resolved": "https://registry.npmjs.org/@dcos/mesos-client/-/mesos-client-0.1.6.tgz"
     },
     "@dcos/recordio": {
-      "version": "0.1.4",
-      "from": "@dcos/recordio@0.1.4",
-      "resolved": "https://registry.npmjs.org/@dcos/recordio/-/recordio-0.1.4.tgz"
+      "version": "0.1.5",
+      "from": "@dcos/recordio@0.1.5",
+      "resolved": "https://registry.npmjs.org/@dcos/recordio/-/recordio-0.1.5.tgz"
     },
     "abab": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "externalplugins": ""
   },
   "dependencies": {
-    "@dcos/mesos-client": "0.1.2",
+    "@dcos/mesos-client": "0.1.6",
     "@dcos/http-service": "0.1.0",
     "babel-polyfill": "6.23.0",
     "browser-info": "0.4.0",


### PR DESCRIPTION
Bumping `@dcos/mesos-client` to bump `@dcos/recordio` to 0.1.5 to make uglifyjs happy and unblock plugins repository.