### PR TITLE
feat(PackagesTab): add field autofocus

### DIFF
--- a/src/js/pages/catalog/PackagesTab.js
+++ b/src/js/pages/catalog/PackagesTab.js
@@ -8,6 +8,7 @@ import React from "react";
 /* eslint-enable no-unused-vars */
 import { StoreMixin } from "mesosphere-shared-reactjs";
 
+import FieldAutofocus from "#SRC/js/components/form/FieldAutofocus";
 import AlertPanel from "../../components/AlertPanel";
 import AlertPanelHeader from "../../components/AlertPanelHeader";
 import Breadcrumb from "../../components/Breadcrumb";
@@ -236,12 +237,14 @@ class PackagesTab extends mixin(StoreMixin) {
       content = (
         <div className="container">
           <div className="pod flush-horizontal flush-top">
-            <FilterInputText
-              className="flex-grow"
-              placeholder="Search catalog"
-              searchString={state.searchString}
-              handleFilterChange={this.handleSearchStringChange}
-            />
+            <FieldAutofocus>
+              <FilterInputText
+                className="flex-grow"
+                placeholder="Search catalog"
+                searchString={state.searchString}
+                handleFilterChange={this.handleSearchStringChange}
+              />
+            </FieldAutofocus>
           </div>
           {this.getCertifiedPackagesGrid(selectedPackages)}
           {this.getCommunityPackagesGrid(communityPackages)}


### PR DESCRIPTION
This is a minor UX improvement whenever we navigate to catalog we have to click on the search field before start typing.

I was tired of having to click on the search field.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
