### PR TITLE
feat(SchemaField): render yaml ace editor

### DIFF
--- a/src/js/components/SchemaField.js
+++ b/src/js/components/SchemaField.js
@@ -3,6 +3,8 @@ import deepEqual from "deep-equal";
 import { Tooltip } from "reactjs-components";
 import DefaultSchemaField
   from "react-jsonschema-form/lib/components/fields/SchemaField";
+import AceEditor from "react-ace";
+import "brace/mode/yaml";
 
 import Icon from "#SRC/js/components/Icon";
 import FieldInput from "#SRC/js/components/form/FieldInput";
@@ -231,6 +233,42 @@ class SchemaField extends Component {
     );
   }
 
+  renderYamlEditor(errorMessage, props) {
+    const { required, name, schema, formData, onChange } = props;
+
+    let decodedValue;
+    try {
+      decodedValue = atob(formData);
+    } catch (error) {
+      if (error instanceof DOMException) {
+        decodedValue = "Invalid base64 encoding detected.";
+      }
+    }
+
+    return (
+      <div>
+        <FieldLabel>
+          {this.getFieldHeading(required, name, schema.description)}
+        </FieldLabel>
+        <div>
+          <AceEditor
+            mode="yaml"
+            value={decodedValue}
+            height="300"
+            width=""
+            className="framework-form-yaml-editor"
+            highlightActiveLine={false}
+            fontSize={14}
+            showPrintMargin={false}
+            tabSize={2}
+            onChange={value => onChange(btoa(value))}
+          />
+        </div>
+        <FieldError>{errorMessage}</FieldError>
+      </div>
+    );
+  }
+
   getFieldHeading(required, name = "", description) {
     let requiredSymbol = null;
     if (required) {
@@ -269,6 +307,10 @@ class SchemaField extends Component {
       case "boolean":
         return this.renderCheckbox(errorMessage, this.props);
       case "string":
+        if (schema.media && schema.media.type === "application/x-yaml") {
+          return this.renderYamlEditor(errorMessage, this.props);
+        }
+
         if (schema.enum && schema.enum.length <= RADIO_SELECT_THRESHOLD) {
           return this.renderRadioButtons(errorMessage, this.props);
         }

--- a/src/styles/components/framework-configuration/styles.less
+++ b/src/styles/components/framework-configuration/styles.less
@@ -7,3 +7,13 @@
 .pre-install-notes.message.message-warning p {
   display: inline;
 }
+
+.framework-form-yaml-editor {
+  border: 1px solid @form-control-border-color;
+  border-radius: 4px;
+  width: 100%;
+
+  .ace_scroller.ace_scroll-left {
+    box-shadow: none;
+  }
+}

--- a/tests/_fixtures/cosmos/package-describe.json
+++ b/tests/_fixtures/cosmos/package-describe.json
@@ -96,6 +96,14 @@
                 "type": "string"
               },
               "type": "array"
+            },
+            "custom_yml": {
+              "description": "Custom YAML to be appended to config.yml on each node. This field must be base64 encoded.",
+              "default": "ZGlzY292ZXJ5Og0KICAgIHplbjoNCiAgICAgICAgcGluZzoNCiAgICAgICAgICAgIG11bHRpY2FzdDoNCiAgICAgICAgICAgICAgICBlbmFibGVkOiBmYWxzZQ==",
+              "type": "string",
+              "media": {
+                "type": "application/x-yaml"
+              }
             }
           },
           "required": [


### PR DESCRIPTION
This renders an `AceEditor` when "application/x-yaml" is encountered in the JSON schema media type. We assume the YAML is base64 encoded.

**Testing**:
1. Checkout this branch
2. Turn on fixtures
3. Navigate to catalog, and click "Review and Run" on any package, then click "Edit Config" and scroll down to the YAML in the form.

**After doing the above three steps you will see this:**
![screen shot 2017-11-22 at 2 06 19 pm](https://user-images.githubusercontent.com/1527504/33151777-5aebb508-cf8e-11e7-90bf-7f681113943a.png)

**If an invalid base64 encoded string is pasted into the JSON editor:**
![screen shot 2017-11-22 at 2 07 12 pm](https://user-images.githubusercontent.com/1527504/33151821-842f2de6-cf8e-11e7-9115-104ead817299.png)

**But since we don't do YAML validation, there are many base64 encoded strings that are not valid YAML, but will still render:**
![screen shot 2017-11-22 at 2 08 02 pm](https://user-images.githubusercontent.com/1527504/33151839-94fbef88-cf8e-11e7-822d-f0a065d93c13.png)

**If the field is required, it will show the required field error just like other form inputs:**
![screen shot 2017-11-22 at 2 00 43 pm](https://user-images.githubusercontent.com/1527504/33151679-e4464ed6-cf8d-11e7-9c96-9417b2425ade.png)

 

 



**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
