### PR TITLE
fix(ServiceActions): adjust service edit actions back button test

### DIFF
--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -184,7 +184,8 @@ describe("Service Actions", function() {
     it("back button on review screen goes back to form", function() {
       cy
         .get('.modal .menu-tabbed-container input[name="name"]')
-        .type(`{selectall}elast`);
+        .type(`{selectall}elast`)
+        .wait(500);
 
       cy.get(".modal .modal-header button").contains("Review & Run").click();
 


### PR DESCRIPTION
Add a delay after changing the name input to ensure that the "type" operation is completed before the test hits the "Review & Run" button as cypress otherwise fails to properly change the name input. This change should increase the test reliability. 