### PR TITLE
DCOS-19559: Adapt placement constraints widget to the SDK form

### DIFF
--- a/src/js/components/BatchContainer.js
+++ b/src/js/components/BatchContainer.js
@@ -1,0 +1,63 @@
+import React, { Component } from "react";
+
+import Transaction from "#SRC/js/structs/Transaction";
+import TransactionTypes from "#SRC/js/constants/TransactionTypes";
+
+export default class BatchContainer extends Component {
+  constructor() {
+    super(...arguments);
+
+    this.handleChange = this.handleChange.bind(this);
+    this.handleAddItem = this.handleAddItem.bind(this);
+    this.handleRemoveItem = this.handleRemoveItem.bind(this);
+  }
+
+  handleChange(event) {
+    const fieldName = event.target.getAttribute("name");
+    if (!fieldName) {
+      return;
+    }
+
+    const value = event.target.type === "checkbox"
+      ? event.target.checked
+      : event.target.value;
+
+    const path = fieldName.split(".");
+    const batch = this.props.batch.add(new Transaction(path, value));
+
+    this.props.onChange(batch, fieldName);
+  }
+
+  handleAddItem(event) {
+    const { value, path } = event;
+
+    const batch = this.props.batch.add(
+      new Transaction(path.split("."), value, TransactionTypes.ADD_ITEM)
+    );
+
+    this.props.onChange(batch);
+  }
+
+  handleRemoveItem(event) {
+    const { value, path } = event;
+
+    const batch = this.props.batch.add(
+      new Transaction(path.split("."), value, TransactionTypes.REMOVE_ITEM)
+    );
+
+    this.props.onChange(batch);
+  }
+
+  render() {
+    const { children } = this.props;
+
+    return (
+      <div onChange={this.handleChange}>
+        {React.cloneElement(children, {
+          onAddItem: this.handleAddItem,
+          onRemoveItem: this.handleRemoveItem
+        })}
+      </div>
+    );
+  }
+}

--- a/src/js/components/PlacementConstraintsFrameworkAdapter.js
+++ b/src/js/components/PlacementConstraintsFrameworkAdapter.js
@@ -1,0 +1,94 @@
+import React, { Component } from "react";
+import Batch from "#SRC/js/structs/Batch";
+import PlacementConstraintsPartial
+  from "#SRC/js/components/PlacementConstraintsPartial";
+import BatchContainer from "#SRC/js/components/BatchContainer";
+import {
+  JSONReducer,
+  JSONParser
+} from "#PLUGINS/services/src/js/reducers/serviceForm/JSONReducers/Constraints";
+import { combineReducers } from "#SRC/js/utils/ReducerUtil";
+import {
+  FormReducer
+} from "#PLUGINS/services/src/js/reducers/serviceForm/FormReducers/Constraints";
+import CreateServiceModalFormUtil
+  from "#PLUGINS/services/src/js/utils/CreateServiceModalFormUtil";
+
+const jsonReducer = combineReducers({ constraints: JSONReducer });
+
+export default class PlacementConstraintsFrameworkAdapter extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      batch: this.generateBatchFromInput()
+    };
+
+    this.handleBatchChange = this.handleBatchChange.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.data !== this.props.data) {
+      this.setState({
+        batch: this.generateBatchFromInput(nextProps)
+      });
+    }
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    const propsChanged = nextProps.data !== this.props.data;
+    const stateChanged = nextState.batch !== this.state.batch;
+
+    return propsChanged || stateChanged;
+  }
+
+  generateBatchFromInput(props = this.props) {
+    const { data } = props;
+
+    let json;
+    try {
+      json = JSON.parse(data);
+    } catch (error) {
+      return this.state.batch || new Batch();
+    }
+
+    const parsedInput = CreateServiceModalFormUtil.stripEmptyProperties(json);
+
+    return JSONParser({ constraints: parsedInput }).reduce((batch, item) => {
+      return batch.add(item);
+    }, new Batch());
+  }
+
+  handleBatchChange(batch) {
+    const { data } = this.props;
+    const newJson = batch.reduce(jsonReducer, []);
+    const newData = JSON.stringify(newJson.constraints);
+
+    if (newData !== data) {
+      this.props.onChange(newData);
+    } else {
+      this.setState({ batch });
+    }
+  }
+
+  render() {
+    const { batch } = this.state;
+    const data = { constraints: batch.reduce(FormReducer) };
+
+    // TODO what to do about errors
+    return (
+      <BatchContainer batch={batch} onChange={this.handleBatchChange}>
+        <PlacementConstraintsPartial data={data} />
+      </BatchContainer>
+    );
+  }
+}
+
+PlacementConstraintsFrameworkAdapter.defaultProps = {
+  onChange() {}
+};
+
+PlacementConstraintsFrameworkAdapter.propTypes = {
+  onChange: React.PropTypes.func,
+  data: React.PropTypes.string
+};

--- a/src/js/components/PlacementConstraintsFrameworkAdapter.js
+++ b/src/js/components/PlacementConstraintsFrameworkAdapter.js
@@ -75,7 +75,6 @@ export default class PlacementConstraintsFrameworkAdapter extends Component {
     const { batch } = this.state;
     const data = { constraints: batch.reduce(FormReducer) };
 
-    // TODO what to do about errors
     return (
       <BatchContainer batch={batch} onChange={this.handleBatchChange}>
         <PlacementConstraintsPartial data={data} />

--- a/src/js/components/SchemaField.js
+++ b/src/js/components/SchemaField.js
@@ -16,6 +16,8 @@ import FormGroupHeading from "#SRC/js/components/form/FormGroupHeading";
 import FieldError from "#SRC/js/components/form/FieldError";
 import FieldSelect from "#SRC/js/components/form/FieldSelect";
 import FieldAutofocus from "#SRC/js/components/form/FieldAutofocus";
+import PlacementConstraintsFrameworkAdapter
+  from "#SRC/js/components/PlacementConstraintsFrameworkAdapter";
 
 class SchemaField extends Component {
   shouldComponentUpdate(nextProps) {
@@ -269,6 +271,23 @@ class SchemaField extends Component {
     );
   }
 
+  renderPlacement(errorMessage, autoFocus, props) {
+    const { required, name, formData, schema, onChange } = props;
+
+    return (
+      <div>
+        <FieldLabel>
+          {this.getFieldHeading(required, name, schema.description)}
+        </FieldLabel>
+        <PlacementConstraintsFrameworkAdapter
+          onChange={onChange}
+          data={formData}
+        />
+        <FieldError>{errorMessage}</FieldError>
+      </div>
+    );
+  }
+
   getFieldHeading(required, name = "", description) {
     let requiredSymbol = null;
     if (required) {
@@ -317,6 +336,14 @@ class SchemaField extends Component {
 
         if (schema.enum && schema.enum.length > RADIO_SELECT_THRESHOLD) {
           return this.renderSelect(errorMessage, autofocus, this.props);
+        }
+
+        if (
+          schema.media &&
+          (schema.media.type === "application/x-region-zone-constraints+json" ||
+            schema.media.type === "application/x-zone-constraints+json")
+        ) {
+          return this.renderPlacement(errorMessage, autofocus, this.props);
         }
 
         return this.renderTextInput(errorMessage, autofocus, this.props);

--- a/tests/_fixtures/cosmos/package-describe.json
+++ b/tests/_fixtures/cosmos/package-describe.json
@@ -104,6 +104,14 @@
               "media": {
                 "type": "application/x-yaml"
               }
+            },
+            "placement_constraints": {
+              "description": "Placement Constraints",
+              "media": {
+                "type": "application/x-region-zone-constraints+json"
+              },
+              "type": "string",
+              "default": "[[\"hostname\", \"UNIQUE\"]]"
             }
           },
           "required": [


### PR DESCRIPTION
✅   Depends on #2516 

1. Implement `BatchContainer` - a wrapper that takes care of the Batch even cycle
2. Implement an adapter for the `PlacementConstraintPartial`
3. Use the Adapter in the json-schema form 

Would be awesome to have a demo-universe to test this. @orlandohohmeier do you know how to put one together? We need a placement constraints with the media type `placement` and the json

Edit @nlight
This is what I did:
```
+---------------------------------------------------+          
|Adapter                    Batch               <------- String
|                              |                    |          
|  +---------------------------|----------------+   |          
|  |BatchForm                  |                |   |          
|  |                           ↓  Data |        |   |          
|  |   +-------------------------------|------+ |   |          
|  |   |Partial                        |      | |   |          
|  |   |                               |      | |   |          
|  |   |                               ↓      | |   |          
|  |   |                                      | |   |          
|  |   |                                      | |   |          
|  |   |                                      | |   |          
|  |   |                  |Events             | |   |          
|  |   +------------------|-------------------+ |   |          
|  |                      |                     |   |          
|  |                      ↓     |Batch          |   |          
|  +----------------------------|---------------+   |          
|                               ↓                 -----> String
+---------------------------------------------------+          

made with textik.com
```