### PR TITLE
DCOS-19657: add advanced type to constraints input

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/Constraints.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/Constraints.js
@@ -13,12 +13,21 @@ function processTransaction(state, { type, path, value }) {
   let newState = state.slice();
 
   if (type === ADD_ITEM) {
-    newState.push({ fieldName: null, operator: null, value: null });
+    let defaultValue = { fieldName: null, operator: null, value: null };
+
+    if (value != null && value.type != null) {
+      defaultValue = Object.assign({}, defaultValue, value);
+    }
+
+    newState.push(defaultValue);
   }
   if (type === REMOVE_ITEM) {
     newState = newState.filter((item, index) => {
       return index !== value;
     });
+  }
+  if (type === SET && name === "type") {
+    newState[index].type = value;
   }
   if (
     type === SET &&

--- a/src/js/components/PlacementConstraintsPartial.js
+++ b/src/js/components/PlacementConstraintsPartial.js
@@ -223,7 +223,8 @@ export default class PlacementSection extends Component {
           <FormGroup className="column-12">
             <AddButton
               onClick={this.props.onAddItem.bind(this, {
-                path: "constraints"
+                path: "constraints",
+                value: { type: "default" }
               })}
             >
               Add Placement Constraint


### PR DESCRIPTION
This introduces the possibility to give constraints a type as a optional field which will be used to
prevent jumping to custom fields which will be added later.

To test this basically play around with the Placement section nothing should behave differently.

Closes DCOS-19657