### PR TITLE
refactor(*): align unit tests

### DIFF
--- a/packages/foundation-ui/src/mount/__tests__/MountService-test.js
+++ b/packages/foundation-ui/src/mount/__tests__/MountService-test.js
@@ -20,25 +20,25 @@ describe("MountService", function() {
   });
 
   describe("registerComponent", function() {
-    it("should not throw if a valid React.Component is provided", function() {
+    it("does not throw if a valid React.Component is provided", function() {
       expect(() => {
         this.instance.registerComponent(ReactComponent, "type", 0);
       }).not.toThrow();
     });
 
-    it("should not throw if a valid stateless functional component is provided", function() {
+    it("does not throw if a valid stateless functional component is provided", function() {
       expect(() => {
         this.instance.registerComponent(FunctionalComponent, "type", 0);
       }).not.toThrow();
     });
 
-    it("should not throw if a valid type was provided", function() {
+    it("does not throw if a valid type was provided", function() {
       expect(() => {
         this.instance.registerComponent(FunctionalComponent, "type", 0);
       }).not.toThrow();
     });
 
-    it("should properly register components", function() {
+    it("registers components", function() {
       this.instance.registerComponent(ReactComponent, "type", 0);
       this.instance.registerComponent(FunctionalComponent, "type", 0);
 
@@ -48,43 +48,43 @@ describe("MountService", function() {
       ]);
     });
 
-    it("should throw if an object instead of a component was provided", function() {
+    it("throws if an object instead of a component was provided", function() {
       expect(() => {
         this.instance.registerComponent({}, "type", 0);
       }).toThrowError(COMPONENT_ERROR_MESSAGE);
     });
 
-    it("should throw if null instead of a component was provided", function() {
+    it("throws if null instead of a component was provided", function() {
       expect(() => {
         this.instance.registerComponent(null, "type", 0);
       }).toThrowError(COMPONENT_ERROR_MESSAGE);
     });
 
-    it("should throw if component is undefined", function() {
+    it("throws if component is undefined", function() {
       expect(() => {
         this.instance.registerComponent(undefined, "type", 0);
       }).toThrowError(COMPONENT_ERROR_MESSAGE);
     });
 
-    it("should throw if an object instead of a valid type was provided", function() {
+    it("throws if an object instead of a valid type was provided", function() {
       expect(() => {
         this.instance.registerComponent(FunctionalComponent, {}, 0);
       }).toThrowError(TYPE_ERROR_MESSAGE);
     });
 
-    it("should throw if null instead of a valid type was provided", function() {
+    it("throws if null instead of a valid type was provided", function() {
       expect(() => {
         this.instance.registerComponent(FunctionalComponent, null, 0);
       }).toThrowError(TYPE_ERROR_MESSAGE);
     });
 
-    it("should throw if type is undefined", function() {
+    it("throws if type is undefined", function() {
       expect(() => {
         this.instance.registerComponent(FunctionalComponent, undefined, 0);
       }).toThrowError(TYPE_ERROR_MESSAGE);
     });
 
-    it("should throw if the component/type combination is already registered", function() {
+    it("throws if the component/type combination is already registered", function() {
       this.instance.registerComponent(ReactComponent, "type");
 
       expect(() => {
@@ -104,14 +104,14 @@ describe("MountService", function() {
       this.instance.unregisterComponent(FunctionalComponent, "type");
     });
 
-    it("should properly remove matching components", function() {
+    it("removes matching components", function() {
       this.instance.unregisterComponent(FunctionalComponent, "type");
       expect(this.instance.findComponentsWithType("type")).toEqual([
         ReactComponent
       ]);
     });
 
-    it("should do nothing if no matching components was found", function() {
+    it("does nothing if no matching components was found", function() {
       this.instance.unregisterComponent(FunctionalComponent, "unknown-type");
 
       expect(this.instance.findComponentsWithType("type")).toEqual([
@@ -134,7 +134,7 @@ describe("MountService", function() {
       this.instance.registerComponent(FourthComponent, "type", 0);
     });
 
-    it("should return array of matching components in proper order", function() {
+    it("returns array of matching components in proper order", function() {
       expect(this.instance.findComponentsWithType("type")).toEqual([
         FirstComponent,
         SecondComponent,
@@ -143,7 +143,7 @@ describe("MountService", function() {
       ]);
     });
 
-    it("should return empty list if no match was found ", function() {
+    it("returns empty list if no match was found ", function() {
       expect(this.instance.findComponentsWithType("unknown-type")).toEqual([]);
     });
   });

--- a/packages/foundation-ui/src/utils/__tests__/ReactUtil-test.js
+++ b/packages/foundation-ui/src/utils/__tests__/ReactUtil-test.js
@@ -6,7 +6,7 @@ const TestUtils = require("react-addons-test-utils");
 const ReactUtil = require("../ReactUtil");
 
 describe("ReactUtil", function() {
-  it("should wrap the elements if there is more than one", function() {
+  it("wraps the elements if there is more than one", function() {
     const result = ReactUtil.wrapElements([
       <span key="1">test</span>,
       <span key="2">test</span>
@@ -15,37 +15,37 @@ describe("ReactUtil", function() {
     expect(TestUtils.isElementOfType(result, "div")).toEqual(true);
   });
 
-  it("should not wrap if not necessary", function() {
+  it("does not wrap if not necessary", function() {
     const elements = ReactUtil.wrapElements(<span>test</span>);
 
     expect(TestUtils.isElementOfType(elements, "span")).toEqual(true);
   });
 
-  it("should always wrap elements if configured", function() {
+  it("always wraps elements if configured", function() {
     const elements = ReactUtil.wrapElements(<span>test</span>, "div", true);
 
     expect(TestUtils.isElementOfType(elements, "div")).toEqual(true);
   });
 
-  it("should wrap elements with provided wrapper", function() {
+  it("wraps elements with provided wrapper", function() {
     const elements = ReactUtil.wrapElements(<span>test</span>, "p", true);
 
     expect(TestUtils.isElementOfType(elements, "p")).toEqual(true);
   });
 
-  it("should properly handle undefined elements", function() {
+  it("handles undefined elements", function() {
     const elements = ReactUtil.wrapElements(undefined);
 
     expect(elements).toEqual(null);
   });
 
-  it("should not wrap elements if they are an array with a single item", function() {
+  it("does not wrap elements if they are an array with a single item", function() {
     const elements = ReactUtil.wrapElements([<span key={0}>test</span>], "p");
 
     expect(TestUtils.isElementOfType(elements, "span")).toEqual(true);
   });
 
-  it("should wrap elements if they are an array with a single item when alwaysWrap is true", function() {
+  it("wraps elements if they are an array with a single item when alwaysWrap is true", function() {
     const elements = ReactUtil.wrapElements(
       [<span key={0}>test</span>],
       "p",

--- a/plugins/banner/__tests__/BannerPlugin-test.js
+++ b/plugins/banner/__tests__/BannerPlugin-test.js
@@ -38,7 +38,7 @@ describe("BannerPlugin", function() {
       SDK.Hooks = this.Hooks;
     });
 
-    it("should add one action and two filters", function() {
+    it("adds one action and two filters", function() {
       expect(SDK.Hooks.addAction.mock.calls[0][0]).toEqual(
         "applicationRendered"
       );
@@ -60,32 +60,32 @@ describe("BannerPlugin", function() {
   });
 
   describe("#isEnabled", function() {
-    it("should return true if headerTitle is defined", function() {
+    it("returns true if headerTitle is defined", function() {
       BannerPlugin.configure({ headerTitle: "foo" });
 
       expect(BannerPlugin.isEnabled()).toBeTruthy();
     });
 
-    it("should return true if headerContent is defined", function() {
+    it("returns true if headerContent is defined", function() {
       BannerPlugin.configure({ headerContent: "bar" });
 
       expect(BannerPlugin.isEnabled()).toBeTruthy();
     });
 
-    it("should return true if footerContent is defined", function() {
+    it("returns true if footerContent is defined", function() {
       BannerPlugin.configure({ footerContent: "foo" });
 
       expect(BannerPlugin.isEnabled()).toBeTruthy();
     });
 
-    it("should return false if no content is defined", function() {
+    it("returns false if no content is defined", function() {
       // None of these are defined: headerTitle, headerContent or footerContent
       BannerPlugin.configure({ foo: "bar" });
 
       expect(BannerPlugin.isEnabled()).toBeFalsy();
     });
 
-    it("should return false if fields are initialized to null", function() {
+    it("returns false if fields are initialized to null", function() {
       BannerPlugin.configure({
         headerTitle: null,
         headerContent: null,
@@ -95,7 +95,7 @@ describe("BannerPlugin", function() {
       expect(BannerPlugin.isEnabled()).toBeFalsy();
     });
 
-    it("should return true with mixed initialization", function() {
+    it("returns true with mixed initialization", function() {
       BannerPlugin.configure({
         headerTitle: null,
         headerContent: undefined,
@@ -117,11 +117,11 @@ describe("BannerPlugin", function() {
       );
     });
 
-    it("should not call before click", function() {
+    it("does not call before click", function() {
       expect(BannerPlugin.toggleFullContent).not.toHaveBeenCalled();
     });
 
-    it("should call once with one click", function() {
+    it("calls once with one click", function() {
       var node = ReactDOM.findDOMNode(this.instance);
       var el = node.querySelector(".banner-plugin-info-icon");
 
@@ -129,7 +129,7 @@ describe("BannerPlugin", function() {
       expect(BannerPlugin.toggleFullContent.calls.count()).toEqual(1);
     });
 
-    it("should call n times with n clicks", function() {
+    it("calls n times with n clicks", function() {
       var node = ReactDOM.findDOMNode(this.instance);
       var el = node.querySelector(".banner-plugin-info-icon");
 
@@ -154,33 +154,33 @@ describe("BannerPlugin", function() {
         .and.returnValue(this.iframe);
     });
 
-    it("should add event listener to iframe when enabled", function() {
+    it("adds event listener to iframe when enabled", function() {
       BannerPlugin.configure({ headerTitle: "foo" });
       BannerPlugin.applicationRendered();
       expect(this.iframe.contentWindow.addEventListener).toHaveBeenCalled();
     });
 
-    it("should not add event listener to iframe when not enabled", function() {
+    it("does not add event listener to iframe when not enabled", function() {
       BannerPlugin.applicationRendered();
       expect(this.iframe.contentWindow.addEventListener).not.toHaveBeenCalled();
     });
   });
 
   describe("#applicationContents", function() {
-    it("should return content when enabled", function() {
+    it("returns content when enabled", function() {
       BannerPlugin.configure({ headerTitle: "foo" });
       expect(
         TestUtils.isElement(BannerPlugin.applicationContents())
       ).toBeTruthy();
     });
 
-    it("should return null when not enabled", function() {
+    it("returns null when not enabled", function() {
       expect(
         TestUtils.isElement(BannerPlugin.applicationContents())
       ).toBeFalsy();
     });
 
-    it("should render an iframe when enabled", function() {
+    it("renders an iframe when enabled", function() {
       BannerPlugin.configure({ headerTitle: "foo" });
 
       var instance = ReactDOM.render(
@@ -196,25 +196,25 @@ describe("BannerPlugin", function() {
   });
 
   describe("#overlayNewWindowButton", function() {
-    it("should return content when enabled", function() {
+    it("returns content when enabled", function() {
       BannerPlugin.configure({ headerTitle: "foo" });
       expect(BannerPlugin.overlayNewWindowButton("foo")).toBeNull();
     });
 
-    it("should return null when not enabled", function() {
+    it("returns null when not enabled", function() {
       expect(BannerPlugin.overlayNewWindowButton("foo")).toEqual("foo");
     });
   });
 
   describe("#getColorStyles", function() {
-    it("should return default colors when nothing is changed", function() {
+    it("returns default colors when nothing is changed", function() {
       expect(BannerPlugin.getColorStyles()).toEqual({
         backgroundColor: "#1E232F",
         color: "#FFFFFF"
       });
     });
 
-    it("should return an object with provided colors", function() {
+    it("returns an object with provided colors", function() {
       BannerPlugin.configure({
         backgroundColor: "foo",
         foregroundColor: "bar"
@@ -228,7 +228,7 @@ describe("BannerPlugin", function() {
   });
 
   describe("#getIcon", function() {
-    it("should return null if imagePath is null", function() {
+    it("returns null if imagePath is null", function() {
       BannerPlugin.configure({
         imagePath: null
       });
@@ -236,7 +236,7 @@ describe("BannerPlugin", function() {
       expect(BannerPlugin.getIcon()).toBeNull();
     });
 
-    it("should return null if imagePath is empty string", function() {
+    it("returns null if imagePath is empty string", function() {
       BannerPlugin.configure({
         imagePath: ""
       });
@@ -244,7 +244,7 @@ describe("BannerPlugin", function() {
       expect(BannerPlugin.getIcon()).toBeNull();
     });
 
-    it("should return an element if imagePath is set", function() {
+    it("returns an element if imagePath is set", function() {
       BannerPlugin.configure({
         imagePath: "foo"
       });
@@ -254,7 +254,7 @@ describe("BannerPlugin", function() {
   });
 
   describe("#getTitle", function() {
-    it("should return null if headerTitle is null", function() {
+    it("returns null if headerTitle is null", function() {
       BannerPlugin.configure({
         headerTitle: null
       });
@@ -262,7 +262,7 @@ describe("BannerPlugin", function() {
       expect(BannerPlugin.getTitle()).toBeNull();
     });
 
-    it("should return null if headerTitle is empty string", function() {
+    it("returns null if headerTitle is empty string", function() {
       BannerPlugin.configure({
         headerTitle: ""
       });
@@ -270,7 +270,7 @@ describe("BannerPlugin", function() {
       expect(BannerPlugin.getTitle()).toBeNull();
     });
 
-    it("should return an element if headerTitle is set", function() {
+    it("returns an element if headerTitle is set", function() {
       BannerPlugin.configure({
         headerTitle: "foo"
       });
@@ -280,7 +280,7 @@ describe("BannerPlugin", function() {
   });
 
   describe("#getHeaderContent", function() {
-    it("should return null if headerContent is null", function() {
+    it("returns null if headerContent is null", function() {
       BannerPlugin.configure({
         headerContent: null
       });
@@ -288,7 +288,7 @@ describe("BannerPlugin", function() {
       expect(BannerPlugin.getHeaderContent()).toBeNull();
     });
 
-    it("should return null if headerContent is empty string", function() {
+    it("returns null if headerContent is empty string", function() {
       BannerPlugin.configure({
         headerContent: ""
       });
@@ -296,7 +296,7 @@ describe("BannerPlugin", function() {
       expect(BannerPlugin.getHeaderContent()).toBeNull();
     });
 
-    it("should return an element if headerContent is set", function() {
+    it("returns an element if headerContent is set", function() {
       BannerPlugin.configure({
         headerContent: "foo"
       });
@@ -318,11 +318,11 @@ describe("BannerPlugin", function() {
       };
     });
 
-    it("should return null if depending functions returns null", function() {
+    it("returns null if depending functions returns null", function() {
       expect(BannerPlugin.getHeader()).toBeNull();
     });
 
-    it("should return an element if getIcon return something", function() {
+    it("returns an element if getIcon return something", function() {
       BannerPlugin.getIcon = function() {
         return "foo";
       };
@@ -330,7 +330,7 @@ describe("BannerPlugin", function() {
       expect(TestUtils.isElement(BannerPlugin.getHeader())).toBeTruthy();
     });
 
-    it("should return an element if getTitle return something", function() {
+    it("returns an element if getTitle return something", function() {
       BannerPlugin.getTitle = function() {
         return "foo";
       };
@@ -338,7 +338,7 @@ describe("BannerPlugin", function() {
       expect(TestUtils.isElement(BannerPlugin.getHeader())).toBeTruthy();
     });
 
-    it("should return element when getHeaderContent does", function() {
+    it("returns element when getHeaderContent does", function() {
       BannerPlugin.getHeaderContent = function() {
         return "foo";
       };
@@ -348,7 +348,7 @@ describe("BannerPlugin", function() {
   });
 
   describe("#getFooter", function() {
-    it("should return null if footerContent is null", function() {
+    it("returns null if footerContent is null", function() {
       BannerPlugin.configure({
         footerContent: null
       });
@@ -356,7 +356,7 @@ describe("BannerPlugin", function() {
       expect(BannerPlugin.getFooter()).toBeNull();
     });
 
-    it("should return null if footerContent is empty string", function() {
+    it("returns null if footerContent is empty string", function() {
       BannerPlugin.configure({
         footerContent: ""
       });
@@ -364,7 +364,7 @@ describe("BannerPlugin", function() {
       expect(BannerPlugin.getFooter()).toBeNull();
     });
 
-    it("should return an element if footerContent is set", function() {
+    it("returns an element if footerContent is set", function() {
       BannerPlugin.configure({
         footerContent: "foo"
       });

--- a/plugins/nodes/src/js/components/__tests__/NodesGridDials-test.js
+++ b/plugins/nodes/src/js/components/__tests__/NodesGridDials-test.js
@@ -102,12 +102,12 @@ describe("NodesGridDials", function() {
   });
 
   describe("#getInactiveSliceData", function() {
-    it("should use the correct color", function() {
+    it("uses the correct color", function() {
       var inactiveSlice = this.instance.getInactiveSliceData();
       expect(inactiveSlice[0].colorIndex).toEqual(2);
     });
 
-    it("should use 100% of the dial", function() {
+    it("uses 100% of the dial", function() {
       var inactiveSlice = this.instance.getInactiveSliceData();
       expect(inactiveSlice[0].percentage).toEqual(100);
     });

--- a/plugins/nodes/src/js/components/__tests__/NodesGridDials-test.js
+++ b/plugins/nodes/src/js/components/__tests__/NodesGridDials-test.js
@@ -65,14 +65,14 @@ describe("NodesGridDials", function() {
       expect(typeof slice).toEqual("object");
     });
 
-    it("the used slice uses the correct color", function() {
+    it("uses the correct color", function() {
       var slice = this.activeSlices.data.find(datum => {
         return datum.name === this.resourceLabel;
       });
       expect(slice.colorIndex).toEqual(this.resourceColor);
     });
 
-    it("the used slice contains the correct percentage", function() {
+    it("calculate the active percentage", function() {
       var slice = this.activeSlices.data.find(datum => {
         return datum.name === this.resourceLabel;
       });
@@ -86,14 +86,14 @@ describe("NodesGridDials", function() {
       expect(typeof slice).toEqual("object");
     });
 
-    it("the color for the unused slice should be gray", function() {
+    it("uses gray for the unused slice", function() {
       var slice = this.activeSlices.data.find(function(datum) {
         return datum.name === "Unused";
       });
       expect(slice.colorIndex).toEqual("unused");
     });
 
-    it("the percentage of the unused slice should be the remaining of the passed percentage", function() {
+    it("calculates the used percentage", function() {
       var slice = this.activeSlices.data.find(function(datum) {
         return datum.name === "Unused";
       });
@@ -132,7 +132,7 @@ describe("NodesGridDials", function() {
   });
 
   describe("#render", function() {
-    it("render one chart", function() {
+    it("renders one chart", function() {
       var elements = TestUtils.scryRenderedDOMComponentsWithClass(
         this.instance,
         "chart"
@@ -141,7 +141,7 @@ describe("NodesGridDials", function() {
       expect(elements.length).toEqual(1);
     });
 
-    it("render the correct number of charts", function() {
+    it("renders the correct number of charts", function() {
       const host = Object.assign({}, this.hosts[0]);
       host.id = "bar";
       this.hosts.push(new Node(host));

--- a/plugins/nodes/src/js/components/__tests__/NodesGridView-test.js
+++ b/plugins/nodes/src/js/components/__tests__/NodesGridView-test.js
@@ -61,7 +61,7 @@ describe("NodesGridView", function() {
       ReactDOM.unmountComponentAtNode(this.container);
     });
 
-    it("should return a list of unique framework_ids", function() {
+    it("returns a list of unique framework_ids", function() {
       var list = this.instance.getActiveServiceIds(this.hosts.getItems());
 
       expect(list).toEqual(["a", "b", "c", "d", "e", "f", "g", "z"]);

--- a/plugins/nodes/src/js/pages/__tests__/NodeDetailPage-test.js
+++ b/plugins/nodes/src/js/pages/__tests__/NodeDetailPage-test.js
@@ -115,7 +115,7 @@ describe("NodeDetailPage", function() {
   });
 
   describe("#getNode", function() {
-    it("should store an instance of Node", function() {
+    it("stores an instance of Node", function() {
       var node = this.instance.getNode({ params: { nodeID: "existingNode" } });
       expect(node instanceof Node).toEqual(true);
       this.instance = null;

--- a/plugins/nodes/src/js/stores/__tests__/NodeHealthStore-test.js
+++ b/plugins/nodes/src/js/stores/__tests__/NodeHealthStore-test.js
@@ -21,7 +21,7 @@ describe("NodeHealthStore", function() {
     RequestUtil.json = this.requestFn;
   });
 
-  it("should return an instance of NodesList", function() {
+  it("returns an instance of NodesList", function() {
     Config.useFixtures = true;
     NodeHealthStore.fetchNodes();
     var nodes = NodeHealthStore.getNodes("nodes");
@@ -29,7 +29,7 @@ describe("NodeHealthStore", function() {
     Config.useFixtures = false;
   });
 
-  it("should return all of the nodes it was given", function() {
+  it("returns all of the nodes it was given", function() {
     Config.useFixtures = true;
     NodeHealthStore.fetchNodes();
     var nodes = NodeHealthStore.getNodes().getItems();

--- a/plugins/services/src/js/components/__tests__/ConfigurationMapBooleanValue-test.js
+++ b/plugins/services/src/js/components/__tests__/ConfigurationMapBooleanValue-test.js
@@ -6,7 +6,7 @@ const TestUtils = require("react-addons-test-utils");
 const ConfigurationMapBooleanValue = require("../ConfigurationMapBooleanValue");
 
 describe("ConfigurationMapBooleanValue", function() {
-  it("should show the default value for `true`", function() {
+  it("shows the default value for `true`", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapBooleanValue value={true} />
     );
@@ -19,7 +19,7 @@ describe("ConfigurationMapBooleanValue", function() {
     expect(contentText).toEqual("Enabled");
   });
 
-  it("should show the default value for `false`", function() {
+  it("shows the default value for `false`", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapBooleanValue value={false} />
     );
@@ -32,7 +32,7 @@ describe("ConfigurationMapBooleanValue", function() {
     expect(contentText).toEqual("Disabled");
   });
 
-  it("should show the custom value for `true`", function() {
+  it("shows the custom value for `true`", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapBooleanValue
         options={{ truthy: "foo", falsy: "bar" }}
@@ -48,7 +48,7 @@ describe("ConfigurationMapBooleanValue", function() {
     expect(contentText).toEqual("foo");
   });
 
-  it("should show the custom value for `false`", function() {
+  it("shows the custom value for `false`", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapBooleanValue
         options={{ truthy: "foo", falsy: "bar" }}
@@ -64,7 +64,7 @@ describe("ConfigurationMapBooleanValue", function() {
     expect(contentText).toEqual("bar");
   });
 
-  it("should show the `defaultValue` if missing", function() {
+  it("shows the `defaultValue` if missing", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapBooleanValue value={null} defaultValue="-" />
     );

--- a/plugins/services/src/js/components/__tests__/ConfigurationMapDurationValue-test.js
+++ b/plugins/services/src/js/components/__tests__/ConfigurationMapDurationValue-test.js
@@ -6,7 +6,7 @@ const TestUtils = require("react-addons-test-utils");
 const ConfigurationMapDurationValue = require("../ConfigurationMapDurationValue");
 
 describe("ConfigurationMapDurationValue", function() {
-  it("should assume default millisecond scale", function() {
+  it("assumes default millisecond scale", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapDurationValue value={1234} />
     );
@@ -19,7 +19,7 @@ describe("ConfigurationMapDurationValue", function() {
     expect(contentText).toEqual("1234 ms (1 sec, 234 ms)");
   });
 
-  it("should be configured for second scale", function() {
+  it("is configured for second scale", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapDurationValue units="sec" value={130} />
     );
@@ -32,7 +32,7 @@ describe("ConfigurationMapDurationValue", function() {
     expect(contentText).toEqual("130 sec (2 min, 10 sec)");
   });
 
-  it("should remove redundant components", function() {
+  it("removes redundant components", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapDurationValue units="sec" value={30} />
     );
@@ -45,7 +45,7 @@ describe("ConfigurationMapDurationValue", function() {
     expect(contentText).toEqual("30 sec");
   });
 
-  it("should correctly render `defaultValue` if empty", function() {
+  it("renders `defaultValue` if empty", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapDurationValue defaultValue="-" value={null} />
     );

--- a/plugins/services/src/js/components/__tests__/ConfigurationMapMultilineValue-test.js
+++ b/plugins/services/src/js/components/__tests__/ConfigurationMapMultilineValue-test.js
@@ -6,7 +6,7 @@ const TestUtils = require("react-addons-test-utils");
 const ConfigurationMapMultilineValue = require("../ConfigurationMapMultilineValue");
 
 describe("ConfigurationMapMultilineValue", function() {
-  it("should correctly render the text in a <pre> tag", function() {
+  it("renders the text in a <pre> tag", function() {
     var text = "Some\nmulti-line\ntext";
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapMultilineValue value={text} />
@@ -20,7 +20,7 @@ describe("ConfigurationMapMultilineValue", function() {
     expect(contentText).toEqual(text);
   });
 
-  it("should render `defaultValue` if empty", function() {
+  it("renders `defaultValue` if empty", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapMultilineValue value={null} defaultValue="-" />
     );

--- a/plugins/services/src/js/components/__tests__/ConfigurationMapSizeValue-test.js
+++ b/plugins/services/src/js/components/__tests__/ConfigurationMapSizeValue-test.js
@@ -6,7 +6,7 @@ const TestUtils = require("react-addons-test-utils");
 const ConfigurationMapSizeValue = require("../ConfigurationMapSizeValue");
 
 describe("ConfigurationMapSizeValue", function() {
-  it("should assume default MB scale", function() {
+  it("assumes default MB scale", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapSizeValue value={1.234} />
     );
@@ -19,7 +19,7 @@ describe("ConfigurationMapSizeValue", function() {
     expect(contentText).toEqual("1.23 MiB");
   });
 
-  it("should correctly handle `scale` property", function() {
+  it("handles `scale` property", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapSizeValue scale={1} value={1024} />
     );
@@ -32,7 +32,7 @@ describe("ConfigurationMapSizeValue", function() {
     expect(contentText).toEqual("1 KiB");
   });
 
-  it("should correctly pass down to Units.filesize the `decimals`", function() {
+  it("passes down to Units.filesize the `decimals`", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapSizeValue decimals={0} value={1.234} />
     );
@@ -45,7 +45,7 @@ describe("ConfigurationMapSizeValue", function() {
     expect(contentText).toEqual("1 MiB");
   });
 
-  it("should correctly pass down to Units.filesize the `multiplier`", function() {
+  it("passes down to Units.filesize the `multiplier`", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapSizeValue multiplier={1000} value={1} />
     );
@@ -58,7 +58,7 @@ describe("ConfigurationMapSizeValue", function() {
     expect(contentText).toEqual("1.05 MiB");
   });
 
-  it("should correctly pass down to Units.filesize the `threshold`", function() {
+  it("passes down to Units.filesize the `threshold`", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapSizeValue threshold={1} value={12.345} />
     );
@@ -71,7 +71,7 @@ describe("ConfigurationMapSizeValue", function() {
     expect(contentText).toEqual("0.01 GiB");
   });
 
-  it("should correctly pass down to Units.filesize the `units`", function() {
+  it("passes down to Units.filesize the `units`", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapSizeValue
         units={["A", "KiA", "MiA", "GiA", "TiA", "PiA"]}
@@ -87,7 +87,7 @@ describe("ConfigurationMapSizeValue", function() {
     expect(contentText).toEqual("1 MiA");
   });
 
-  it("should correctly render `defaultValue` if empty", function() {
+  it("renders `defaultValue` if empty", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapSizeValue defaultValue="-" value={null} />
     );

--- a/plugins/services/src/js/components/__tests__/ConfigurationMapTable-test.js
+++ b/plugins/services/src/js/components/__tests__/ConfigurationMapTable-test.js
@@ -7,7 +7,7 @@ const JestUtil = require("#SRC/js/utils/JestUtil");
 const ConfigurationMapTable = require("../ConfigurationMapTable");
 
 describe("ConfigurationMapTable", function() {
-  it("should render a simple 1-row, 2-column dataset", function() {
+  it("renders a simple 1-row, 2-column dataset", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapTable
         columns={[
@@ -37,7 +37,7 @@ describe("ConfigurationMapTable", function() {
     expect(cellText).toEqual(["1", "2"]);
   });
 
-  it("should accept custom `render` functions", function() {
+  it("accepts custom `render` functions", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapTable
         columns={[
@@ -73,7 +73,7 @@ describe("ConfigurationMapTable", function() {
     expect(cellText).toEqual(["X", "Y"]);
   });
 
-  it("should remove columns with `hideIfEmpty=true` column property", function() {
+  it("removes columns with `hideIfEmpty=true` column property", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapTable
         columns={[
@@ -104,7 +104,7 @@ describe("ConfigurationMapTable", function() {
     expect(cellText).toEqual(["1"]);
   });
 
-  it("should keep columns with `hideIfEmpty=false` column property", function() {
+  it("keeps columns with `hideIfEmpty=false` column property", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapTable
         columns={[
@@ -135,7 +135,7 @@ describe("ConfigurationMapTable", function() {
     expect(cellText).toEqual(["1", "Not Configured"]);
   });
 
-  it("should respect `placeholder` column property", function() {
+  it("respects `placeholder` column property", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapTable
         columns={[
@@ -166,7 +166,7 @@ describe("ConfigurationMapTable", function() {
     expect(cellText).toEqual(["1", "(none)"]);
   });
 
-  it("should properly handle defaults", function() {
+  it("handles defaults", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapTable
         columns={[
@@ -199,7 +199,7 @@ describe("ConfigurationMapTable", function() {
     expect(cellText).toEqual(["A", "B", "1", "2"]);
   });
 
-  it("should add edit link column if onEditClick is provided", function() {
+  it("adds edit link column if onEditClick is provided", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapTable
         onEditClick={function() {}}

--- a/plugins/services/src/js/components/__tests__/ConfigurationMapValueWithDefault-test.js
+++ b/plugins/services/src/js/components/__tests__/ConfigurationMapValueWithDefault-test.js
@@ -6,7 +6,7 @@ const TestUtils = require("react-addons-test-utils");
 const ConfigurationMapValueWithDefault = require("../ConfigurationMapValueWithDefault");
 
 describe("ConfigurationMapValueWithDefault", function() {
-  it("should correctly render value if specified", function() {
+  it("renders value if specified", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapValueWithDefault value={"foo"} />
     );
@@ -19,7 +19,7 @@ describe("ConfigurationMapValueWithDefault", function() {
     expect(contentText).toEqual("foo");
   });
 
-  it("should render `defaultValue` if empty", function() {
+  it("renders `defaultValue` if empty", function() {
     var instance = TestUtils.renderIntoDocument(
       <ConfigurationMapValueWithDefault value={null} defaultValue="-" />
     );

--- a/plugins/services/src/js/components/__tests__/DeploymentsModal-test.js
+++ b/plugins/services/src/js/components/__tests__/DeploymentsModal-test.js
@@ -8,7 +8,7 @@ const Application = require("../../structs/Application");
 
 describe("DeploymentsModal", function() {
   describe("#getRollbackModalText", function() {
-    it("should return a removal message when passed a starting deployment", function() {
+    it("returns a removal message when passed a starting deployment", function() {
       const text = DeploymentsModal.WrappedComponent.prototype
         .getRollbackModalText(
           new Deployment({
@@ -22,7 +22,7 @@ describe("DeploymentsModal", function() {
       expect(text).toContain("delete the affected service");
     });
 
-    it("should return a revert message when passed a non-starting deployment", function() {
+    it("returns a revert message when passed a non-starting deployment", function() {
       const text = DeploymentsModal.WrappedComponent.prototype.getRollbackModalText(
         new Deployment({
           id: "deployment-id",

--- a/plugins/services/src/js/components/__tests__/FilterByService-test.js
+++ b/plugins/services/src/js/components/__tests__/FilterByService-test.js
@@ -32,7 +32,7 @@ describe("FilterByService", function() {
     ReactDOM.unmountComponentAtNode(this.container);
   });
 
-  it("should display 'Filter by Framework' as default item", function() {
+  it("displays 'Filter by Framework' as default item", function() {
     var node = ReactDOM.findDOMNode(this.instance);
     var buttonNode = node.querySelector(".dropdown-toggle");
 
@@ -40,7 +40,7 @@ describe("FilterByService", function() {
   });
 
   describe("#getItemHtml", function() {
-    it("should display the badge correctly", function() {
+    it("displays the badge correctly", function() {
       const framework = new Framework(MockFrameworks.frameworks[4]);
       var item = ReactDOM.render(
         this.instance.getItemHtml(framework),
@@ -57,22 +57,22 @@ describe("FilterByService", function() {
   });
 
   describe("#getDropdownItems", function() {
-    it("should return all services and the all services item", function() {
+    it("returns all services and the all services item", function() {
       var items = this.instance.getDropdownItems(MockFrameworks.frameworks);
       expect(items.length).toEqual(MockFrameworks.frameworks.length + 1);
     });
   });
 
   describe("#getSelectedId", function() {
-    it("should return the same number when given a number", function() {
+    it("returns the same number when given a number", function() {
       expect(this.instance.getSelectedId(0)).toEqual(0);
     });
 
-    it("should return the same string when given a string", function() {
+    it("returns the same string when given a string", function() {
       expect(this.instance.getSelectedId("thisIsAnID")).toEqual("thisIsAnID");
     });
 
-    it("should return the default id when given null", function() {
+    it("returns the default id when given null", function() {
       expect(this.instance.getSelectedId(null)).toEqual("default");
     });
   });

--- a/plugins/services/src/js/components/__tests__/Highlight-test.js
+++ b/plugins/services/src/js/components/__tests__/Highlight-test.js
@@ -28,7 +28,7 @@ describe("Highlight instance", function() {
     expect(match.textContent).toEqual("World");
   });
 
-  it("should have children", function() {
+  it("has children", function() {
     var instance = ReactDOM.render(
       <Highlight search="fox">
         The quick brown fox jumped over the lazy dog.
@@ -42,7 +42,7 @@ describe("Highlight instance", function() {
     expect(matches.length).toEqual(1);
   });
 
-  it("should support custom HTML tag for matching elements", function() {
+  it("supports custom HTML tag for matching elements", function() {
     var instance = ReactDOM.render(
       <Highlight matchElement="em" search="world">
         Hello World
@@ -55,7 +55,7 @@ describe("Highlight instance", function() {
     expect(matches.length).toEqual(1);
   });
 
-  it("should support custom className for matching element", function() {
+  it("supports custom className for matching element", function() {
     var instance = ReactDOM.render(
       <Highlight matchClass="fffffound" search="Seek">
         Hide and Seek
@@ -68,7 +68,7 @@ describe("Highlight instance", function() {
     expect(matches.length).toEqual(1);
   });
 
-  it("should support passing props to parent element", function() {
+  it("supports passing props to parent element", function() {
     var instance = ReactDOM.render(
       <Highlight className="myHighlighter" search="world">
         Hello World
@@ -83,7 +83,7 @@ describe("Highlight instance", function() {
     expect(match.className).toEqual("highlight");
   });
 
-  it("should support regular expressions in search", function() {
+  it("supports regular expressions in search", function() {
     var instance = ReactDOM.render(
       <Highlight className="myHighlighter" search={/[A-Za-z]+/}>
         Easy as 123, ABC...
@@ -99,7 +99,7 @@ describe("Highlight instance", function() {
     expect(matches[2].textContent).toEqual("ABC");
   });
 
-  it("should support escaping arbitrary string in search", function() {
+  it("supports escaping arbitrary string in search", function() {
     function renderInstance() {
       ReactDOM.render(
         <Highlight className="myHighlighter" search="Test (">

--- a/plugins/services/src/js/components/__tests__/LogView-test.js
+++ b/plugins/services/src/js/components/__tests__/LogView-test.js
@@ -43,14 +43,14 @@ describe("LogView", function() {
       DOMUtils.getComputedDimensions = this.previousGetComputed;
     });
 
-    it("should not call fetchPreviousLogs if past 2000 pixels", function() {
+    it("does not call fetchPreviousLogs if past 2000 pixels", function() {
       var container = { scrollTop: 4000 };
       this.instance.checkIfCloseToTop(container);
 
       expect(this.fetchPreviousLogsSpy).not.toHaveBeenCalled();
     });
 
-    it("should not call fetchPreviousLogs if below 2000 pixels", function() {
+    it("does not call fetchPreviousLogs if below 2000 pixels", function() {
       var container = { scrollTop: 1000 };
       this.instance.checkIfCloseToTop(container);
 
@@ -59,26 +59,26 @@ describe("LogView", function() {
   });
 
   describe("#getLog", function() {
-    it("should not show empty log when fullLog is populated", function() {
+    it("does not show empty log when fullLog is populated", function() {
       this.instance.state.fullLog = "foo";
       var res = this.instance.getLog();
       expect(Array.isArray(res)).toEqual(true);
     });
 
-    it("should get empty screen when log is empty", function() {
+    it("gets empty screen when log is empty", function() {
       this.instance.state.fullLog = "";
       var res = this.instance.getLog();
       expect(TestUtils.isElementOfType(res, EmptyLogScreen)).toEqual(true);
     });
 
-    it("should call getLog when log is empty", function() {
+    it("calls getLog when log is empty", function() {
       this.instance.state.fullLog = "";
       this.instance.getLog = jasmine.createSpy("getLog");
       this.instance.render();
       expect(this.instance.getLog).toHaveBeenCalled();
     });
 
-    it("should call getLog when log is populated", function() {
+    it("calls getLog when log is populated", function() {
       this.instance.state.fullLog = "foo";
       this.instance.getLog = jasmine.createSpy("getLog");
       this.instance.render();
@@ -87,13 +87,13 @@ describe("LogView", function() {
   });
 
   describe("#getGoToBottomButton", function() {
-    it("should not return a button if currently at the bottom", function() {
+    it("does not return a button if currently at the bottom", function() {
       this.instance.state.isAtBottom = true;
       var button = this.instance.getGoToBottomButton();
       expect(button).toEqual(null);
     });
 
-    it("should return a button if not at bottom", function() {
+    it("returns a button if not at bottom", function() {
       this.instance.state.isAtBottom = false;
       var button = this.instance.getGoToBottomButton();
       expect(TestUtils.isElementOfType(button, "button")).toEqual(true);

--- a/plugins/services/src/js/components/__tests__/MesosLogContainer-test.js
+++ b/plugins/services/src/js/components/__tests__/MesosLogContainer-test.js
@@ -49,13 +49,13 @@ describe("MesosLogContainer", function() {
   });
 
   describe("#componentDidMount", function() {
-    it("should call startTailing when component mounts", function() {
+    it("calls startTailing when component mounts", function() {
       expect(MesosLogStore.startTailing).toHaveBeenCalled();
     });
   });
 
   describe("#componentWillReceiveProps", function() {
-    it("should call startTailing when new path is provided", function() {
+    it("calls startTailing when new path is provided", function() {
       this.instance.componentWillReceiveProps({
         filePath: "/other/file/path",
         task: { slave_id: "foo" }
@@ -63,7 +63,7 @@ describe("MesosLogContainer", function() {
       expect(MesosLogStore.startTailing.calls.count()).toEqual(2);
     });
 
-    it("should call stopTailing when new path is provided", function() {
+    it("calls stopTailing when new path is provided", function() {
       this.instance.componentWillReceiveProps({
         filePath: "/other/file/path",
         task: { slave_id: "foo" }
@@ -71,7 +71,7 @@ describe("MesosLogContainer", function() {
       expect(MesosLogStore.stopTailing.calls.count()).toEqual(1);
     });
 
-    it("shouldn't call startTailing when same path is provided", function() {
+    it("doesn't call startTailing when same path is provided", function() {
       this.instance.componentWillReceiveProps({
         filePath: "/some/file/path",
         task: { slave_id: "foo" }
@@ -79,7 +79,7 @@ describe("MesosLogContainer", function() {
       expect(MesosLogStore.startTailing.calls.count()).toEqual(1);
     });
 
-    it("shouldn't call stopTailing when same path is provided", function() {
+    it("doesn't call stopTailing when same path is provided", function() {
       this.instance.componentWillReceiveProps({
         filePath: "/some/file/path",
         task: { slave_id: "foo" }
@@ -89,7 +89,7 @@ describe("MesosLogContainer", function() {
   });
 
   describe("#componentWillUnmount", function() {
-    it("should call stopTailing when component unmounts", function() {
+    it("calls stopTailing when component unmounts", function() {
       this.instance.componentWillUnmount();
       expect(MesosLogStore.stopTailing).toHaveBeenCalled();
     });
@@ -100,12 +100,12 @@ describe("MesosLogContainer", function() {
       this.instance.setState = jasmine.createSpy("setState");
     });
 
-    it("should setState when path matches", function() {
+    it("setStates when path matches", function() {
       this.instance.onMesosLogStoreError("/some/file/path");
       expect(this.instance.setState).toHaveBeenCalled();
     });
 
-    it("shouldn't setState when path doesn't match", function() {
+    it("doesn't setState when path doesn't match", function() {
       this.instance.onMesosLogStoreError("/other/file/path");
       expect(this.instance.setState).not.toHaveBeenCalled();
     });
@@ -116,19 +116,19 @@ describe("MesosLogContainer", function() {
       this.instance.setState = jasmine.createSpy("setState");
     });
 
-    it("should setState when path matches", function() {
+    it("setStates when path matches", function() {
       this.instance.onMesosLogStoreSuccess("/some/file/path", APPEND);
       expect(this.instance.setState).toHaveBeenCalled();
     });
 
-    it("shouldn't setState when path doesn't match", function() {
+    it("doesn't setState when path doesn't match", function() {
       this.instance.onMesosLogStoreSuccess("/other/file/path", APPEND);
       expect(this.instance.setState).not.toHaveBeenCalled();
     });
   });
 
   describe("#render", function() {
-    it("should call getErrorScreen when error occurred", function() {
+    it("calls getErrorScreen when error occurred", function() {
       this.instance.state.hasLoadingError = 3;
       this.instance.getErrorScreen = jasmine.createSpy("getErrorScreen");
 
@@ -144,7 +144,7 @@ describe("MesosLogContainer", function() {
       expect(this.instance.getErrorScreen).not.toHaveBeenCalled();
     });
 
-    it("shouldn't call getLoadingScreen when fullLog is empty", function() {
+    it("doesn't call getLoadingScreen when fullLog is empty", function() {
       var logBuffer = new LogBuffer();
       logBuffer.add(new Item({ data: "", offset: 100 }));
       MesosLogStore.getLogBuffer = jasmine

--- a/plugins/services/src/js/components/__tests__/ServiceList-test.js
+++ b/plugins/services/src/js/components/__tests__/ServiceList-test.js
@@ -23,12 +23,12 @@ describe("ServiceList", function() {
       ReactDOM.unmountComponentAtNode(this.container);
     });
 
-    it("should allow update", function() {
+    it("allows update", function() {
       var shouldUpdate = this.instance.shouldComponentUpdate({ a: 1 });
       expect(shouldUpdate).toEqual(true);
     });
 
-    it("should not allow update", function() {
+    it("does not allow update", function() {
       var shouldUpdate = this.instance.shouldComponentUpdate(
         this.instance.props
       );

--- a/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesContainer-test.js
+++ b/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesContainer-test.js
@@ -83,7 +83,7 @@ describe("PodInstancesContainer", function() {
         TestUtils.Simulate.change(searchInput);
       });
 
-      it("should properly return matching instances", function() {
+      it("returns matching instances", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-primary"
@@ -118,7 +118,7 @@ describe("PodInstancesContainer", function() {
         TestUtils.Simulate.change(searchInput);
       });
 
-      it("should properly return matching instances and containers", function() {
+      it("returns matching instances and containers", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-primary"
@@ -143,7 +143,7 @@ describe("PodInstancesContainer", function() {
         ]);
       });
 
-      it("should always show instance total resources", function() {
+      it("always shows instance total resources", function() {
         var mem = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-mem"
@@ -175,7 +175,7 @@ describe("PodInstancesContainer", function() {
         TestUtils.Simulate.click(buttons[0]);
       });
 
-      it("should properly show all instances", function() {
+      it("shows all instances", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-primary"
@@ -211,7 +211,7 @@ describe("PodInstancesContainer", function() {
         TestUtils.Simulate.click(buttons[2]);
       });
 
-      it("should properly show no instances", function() {
+      it("shows no instances", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-primary"

--- a/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.js
+++ b/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.js
@@ -86,7 +86,7 @@ describe("PodInstancesTable", function() {
         );
       });
 
-      it("should properly render the name column", function() {
+      it("renders the name column", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-primary"
@@ -100,7 +100,7 @@ describe("PodInstancesTable", function() {
         expect(names).toEqual(["instance-1", "instance-2", "instance-3"]);
       });
 
-      it("should properly render the address column", function() {
+      it("renders the address column", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-host-address"
@@ -114,7 +114,7 @@ describe("PodInstancesTable", function() {
         expect(names).toEqual(["agent-1", "agent-2", "agent-3"]);
       });
 
-      it("should properly render the status column", function() {
+      it("renders the status column", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-status"
@@ -123,7 +123,7 @@ describe("PodInstancesTable", function() {
         expect(names).toEqual(["Running", "Running", "Staging"]);
       });
 
-      it("should properly render the cpu column", function() {
+      it("renders the cpu column", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-cpus"
@@ -134,7 +134,7 @@ describe("PodInstancesTable", function() {
         expect(names).toEqual(["1", "1", "1"]);
       });
 
-      it("should properly render the mem column", function() {
+      it("renders the mem column", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-mem"
@@ -145,7 +145,7 @@ describe("PodInstancesTable", function() {
         expect(names).toEqual(["128 MiB", "128 MiB", "128 MiB"]);
       });
 
-      it("should properly render the updated column", function() {
+      it("renders the updated column", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-updated"
@@ -156,7 +156,7 @@ describe("PodInstancesTable", function() {
         expect(names).toEqual(["a day ago", "7 days ago", "13 days ago"]);
       });
 
-      it("should properly render the version column", function() {
+      it("renders the version column", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-version"
@@ -191,7 +191,7 @@ describe("PodInstancesTable", function() {
         TestUtils.Simulate.click(columnHeader);
       });
 
-      it("should properly sort the name column", function() {
+      it("sorts the name column", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-primary"
@@ -226,7 +226,7 @@ describe("PodInstancesTable", function() {
         TestUtils.Simulate.click(columnHeader);
       });
 
-      it("should properly sort the name column", function() {
+      it("sorts the name column", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-primary"
@@ -264,7 +264,7 @@ describe("PodInstancesTable", function() {
         });
       });
 
-      it("should properly render the name column", function() {
+      it("renders the name column", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-primary"
@@ -288,7 +288,7 @@ describe("PodInstancesTable", function() {
         ]);
       });
 
-      it("should properly render the address column", function() {
+      it("renders the address column", function() {
         var columns = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-host-address"
@@ -315,7 +315,7 @@ describe("PodInstancesTable", function() {
         ]);
       });
 
-      it("should properly render the status column", function() {
+      it("renders the status column", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-status"
@@ -334,7 +334,7 @@ describe("PodInstancesTable", function() {
         ]);
       });
 
-      it("should properly render the cpu column", function() {
+      it("renders the cpu column", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-cpus"
@@ -355,7 +355,7 @@ describe("PodInstancesTable", function() {
         ]);
       });
 
-      it("should properly render the mem column", function() {
+      it("renders the mem column", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-mem"
@@ -376,7 +376,7 @@ describe("PodInstancesTable", function() {
         ]);
       });
 
-      it("should properly render the updated column", function() {
+      it("renders the updated column", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-updated"
@@ -397,7 +397,7 @@ describe("PodInstancesTable", function() {
         ]);
       });
 
-      it("should properly render the version column", function() {
+      it("renders the version column", function() {
         var names = TestUtils.scryRenderedDOMComponentsWithClass(
           this.instance,
           "task-table-column-version"

--- a/plugins/services/src/js/containers/services/__tests__/ServicesTable-test.js
+++ b/plugins/services/src/js/containers/services/__tests__/ServicesTable-test.js
@@ -34,7 +34,7 @@ describe("ServicesTable", function() {
   });
 
   describe("#renderStats", function() {
-    it("should render resources/stats cpus property", function() {
+    it("renders resources/stats cpus property", function() {
       var cpusCell = ReactDOM.render(
         this.instance.renderStats("cpus", healthyService),
         this.container
@@ -43,7 +43,7 @@ describe("ServicesTable", function() {
       expect(ReactDOM.findDOMNode(cpusCell).textContent).toEqual("1");
     });
 
-    it("should render resources/stats mem property", function() {
+    it("renders resources/stats mem property", function() {
       var memCell = ReactDOM.render(
         this.instance.renderStats("mem", healthyService),
         this.container
@@ -52,7 +52,7 @@ describe("ServicesTable", function() {
       expect(ReactDOM.findDOMNode(memCell).textContent).toEqual("2 GiB");
     });
 
-    it("should render resources/stats disk property", function() {
+    it("renders resources/stats disk property", function() {
       var disksCell = ReactDOM.render(
         this.instance.renderStats("disk", healthyService),
         this.container
@@ -61,7 +61,7 @@ describe("ServicesTable", function() {
       expect(ReactDOM.findDOMNode(disksCell).textContent).toEqual("0 B");
     });
 
-    it("should render sum of resources/stats cpus property", function() {
+    it("renders sum of resources/stats cpus property", function() {
       const application = new Application({
         healthChecks: [{ path: "", protocol: "HTTP" }],
         cpus: 1,
@@ -82,7 +82,7 @@ describe("ServicesTable", function() {
       expect(ReactDOM.findDOMNode(cpusCell).textContent).toEqual("2");
     });
 
-    it("should render sum of resources/stats mem property", function() {
+    it("renders sum of resources/stats mem property", function() {
       const application = new Application({
         healthChecks: [{ path: "", protocol: "HTTP" }],
         cpus: 1,
@@ -103,7 +103,7 @@ describe("ServicesTable", function() {
       expect(ReactDOM.findDOMNode(memCell).textContent).toEqual("4 GiB");
     });
 
-    it("should render sum of resources/stats disk property", function() {
+    it("renders sum of resources/stats disk property", function() {
       const application = new Application({
         healthChecks: [{ path: "", protocol: "HTTP" }],
         cpus: 1,

--- a/plugins/services/src/js/filters/__tests__/ServiceAttributeHasVolumesFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceAttributeHasVolumesFilter-test.js
@@ -25,7 +25,7 @@ describe("ServiceAttributeHasVolumesFilter", function() {
     ];
   });
 
-  it("Should match instances with volumes", function() {
+  it("matches instances with volumes", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("has:volumes");
 
@@ -39,7 +39,7 @@ describe("ServiceAttributeHasVolumesFilter", function() {
     ]);
   });
 
-  it("Should correctly keep nothing on unknown values", function() {
+  it("keeps nothing on unknown values", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("has:foo");
 
@@ -50,7 +50,7 @@ describe("ServiceAttributeHasVolumesFilter", function() {
     expect(expr.filter(filters, services).getItems()).toEqual([]);
   });
 
-  it("Should be case-insensitive", function() {
+  it("is case-insensitive", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("has:vOLumEs");
 

--- a/plugins/services/src/js/filters/__tests__/ServiceAttributeHealthFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceAttributeHealthFilter-test.js
@@ -30,7 +30,7 @@ describe("ServiceAttributeHealthFilter", function() {
     ];
   });
 
-  it("Should correctly keep services in healthy state", function() {
+  it("keeps services in healthy state", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:healthy");
 
@@ -41,7 +41,7 @@ describe("ServiceAttributeHealthFilter", function() {
     ]);
   });
 
-  it("Should correctly keep services in unhealthy state", function() {
+  it("keeps services in unhealthy state", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:unhealthy");
 
@@ -52,7 +52,7 @@ describe("ServiceAttributeHealthFilter", function() {
     ]);
   });
 
-  it("Should correctly keep nothing on unknown states", function() {
+  it("keeps nothing on unknown states", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:foo");
 
@@ -61,7 +61,7 @@ describe("ServiceAttributeHealthFilter", function() {
     expect(expr.filter(filters, services).getItems()).toEqual([]);
   });
 
-  it("Should be case-insensitive", function() {
+  it("is case-insensitive", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:hEaLThY");
 

--- a/plugins/services/src/js/filters/__tests__/ServiceAttributeIsCatalogFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceAttributeIsCatalogFilter-test.js
@@ -11,7 +11,7 @@ describe("ServiceAttributeIsCatalogFilter", function() {
     this.mockItems = [new Framework(), new Application(), new Pod()];
   });
 
-  it("Should match Framework instances", function() {
+  it("matches Framework instances", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:catalog");
 
@@ -24,7 +24,7 @@ describe("ServiceAttributeIsCatalogFilter", function() {
     ]);
   });
 
-  it("Should correctly keep nothing on unknown values", function() {
+  it("keeps nothing on unknown values", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:foo");
 
@@ -35,7 +35,7 @@ describe("ServiceAttributeIsCatalogFilter", function() {
     expect(expr.filter(filters, services).getItems()).toEqual([]);
   });
 
-  it("Should be case-insensitive", function() {
+  it("is case-insensitive", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:CataLOg");
 

--- a/plugins/services/src/js/filters/__tests__/ServiceAttributeIsFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceAttributeIsFilter-test.js
@@ -40,7 +40,7 @@ describe("ServiceAttributeIsFilter", function() {
     ];
   });
 
-  it("Should correctly keep services in delayed state", function() {
+  it("keeps services in delayed state", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:delayed");
 
@@ -51,7 +51,7 @@ describe("ServiceAttributeIsFilter", function() {
     ]);
   });
 
-  it("Should correctly keep services in deploying state", function() {
+  it("keeps services in deploying state", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:deploying");
 
@@ -62,7 +62,7 @@ describe("ServiceAttributeIsFilter", function() {
     ]);
   });
 
-  it("Should correctly keep services in running state", function() {
+  it("keeps services in running state", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:running");
 
@@ -73,7 +73,7 @@ describe("ServiceAttributeIsFilter", function() {
     ]);
   });
 
-  it("Should correctly keep services in stopped state", function() {
+  it("keeps services in stopped state", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:stopped");
 
@@ -84,7 +84,7 @@ describe("ServiceAttributeIsFilter", function() {
     ]);
   });
 
-  it("Should correctly keep services in waiting state", function() {
+  it("keeps services in waiting state", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:waiting");
 
@@ -95,7 +95,7 @@ describe("ServiceAttributeIsFilter", function() {
     ]);
   });
 
-  it("Should correctly keep services in n/a state", function() {
+  it("keeps services in n/a state", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:na");
 
@@ -106,7 +106,7 @@ describe("ServiceAttributeIsFilter", function() {
     ]);
   });
 
-  it("Should correctly keep nothing on unknown states", function() {
+  it("keeps nothing on unknown states", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:foo");
 
@@ -115,7 +115,7 @@ describe("ServiceAttributeIsFilter", function() {
     expect(expr.filter(filters, services).getItems()).toEqual([]);
   });
 
-  it("Should be case-insensitive", function() {
+  it("is case-insensitive", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:dElAyED");
 

--- a/plugins/services/src/js/filters/__tests__/ServiceAttributeIsPodFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceAttributeIsPodFilter-test.js
@@ -11,7 +11,7 @@ describe("ServiceAttributeIsPodFilter", function() {
     this.mockItems = [new Framework(), new Application(), new Pod()];
   });
 
-  it("Should match Pod instances", function() {
+  it("matches Pod instances", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:pod");
 
@@ -22,7 +22,7 @@ describe("ServiceAttributeIsPodFilter", function() {
     ]);
   });
 
-  it("Should correctly keep nothing on unknown values", function() {
+  it("keeps nothing on unknown values", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:foo");
 
@@ -31,7 +31,7 @@ describe("ServiceAttributeIsPodFilter", function() {
     expect(expr.filter(filters, services).getItems()).toEqual([]);
   });
 
-  it("Should be case-insensitive", function() {
+  it("is case-insensitive", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("is:pOd");
 

--- a/plugins/services/src/js/filters/__tests__/ServiceAttributeNoHealthchecksFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceAttributeNoHealthchecksFilter-test.js
@@ -30,7 +30,7 @@ describe("ServiceAttributeNoHealthchecksFilter", function() {
     ];
   });
 
-  it("Should correctly keep services without health checks", function() {
+  it("keeps services without health checks", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("no:healthchecks");
 
@@ -43,7 +43,7 @@ describe("ServiceAttributeNoHealthchecksFilter", function() {
     ]);
   });
 
-  it("Should correctly keep nothing on unknown states", function() {
+  it("keeps nothing on unknown states", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("no:boo");
 
@@ -54,7 +54,7 @@ describe("ServiceAttributeNoHealthchecksFilter", function() {
     expect(expr.filter(filters, services).getItems()).toEqual([]);
   });
 
-  it("Should be case-insensitive", function() {
+  it("is case-insensitive", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("no:HeaLThchEckS");
 

--- a/plugins/services/src/js/filters/__tests__/ServiceNameTextFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/ServiceNameTextFilter-test.js
@@ -24,7 +24,7 @@ describe("ServiceNameTextFilter", function() {
     ];
   });
 
-  it("Should match parts of service name", function() {
+  it("matches parts of service name", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse("foo");
 
@@ -36,7 +36,7 @@ describe("ServiceNameTextFilter", function() {
     ]);
   });
 
-  it("Should match exact parts of service name", function() {
+  it("matches exact parts of service name", function() {
     const services = new List({ items: this.mockItems });
     const expr = SearchDSL.parse('"foo bar"');
 

--- a/plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.js
+++ b/plugins/services/src/js/pages/task-details/__tests__/TaskDetail-test.js
@@ -72,19 +72,14 @@ describe("TaskDetail", function() {
   });
 
   describe("#componentDidMount", function() {
-    it("should call fetchDirectory after onStateStoreSuccess is called", function() {
+    it("calls fetchDirectory after onStateStoreSuccess is called", function() {
       this.instance.onStateStoreSuccess();
       expect(TaskDirectoryStore.fetchDirectory).toHaveBeenCalled();
     });
   });
 
   describe("#onTaskDirectoryStoreError", function() {
-    it("should setState", function() {
-      this.instance.onTaskDirectoryStoreError();
-      expect(this.instance.setState).toHaveBeenCalled();
-    });
-
-    it("should setState increment taskDirectoryErrorCount", function() {
+    it("increments taskDirectoryErrorCount state", function() {
       this.instance.state = { taskDirectoryErrorCount: 1 };
       this.instance.onTaskDirectoryStoreError();
       expect(this.instance.setState).toHaveBeenCalledWith({
@@ -94,12 +89,7 @@ describe("TaskDetail", function() {
   });
 
   describe("#onTaskDirectoryStoreSuccess", function() {
-    it("should setState", function() {
-      this.instance.onTaskDirectoryStoreSuccess("bar");
-      expect(this.instance.setState).toHaveBeenCalled();
-    });
-
-    it("should setState increment onTaskDirectoryStoreSuccess", function() {
+    it("increments onTaskDirectoryStoreSuccess state", function() {
       const directory = new TaskDirectory({
         items: [{ nlink: 1, path: "/stdout" }]
       });
@@ -117,17 +107,12 @@ describe("TaskDetail", function() {
   });
 
   describe("#handleFetchDirectory", function() {
-    it("should setState", function() {
-      this.instance.handleFetchDirectory();
-      expect(this.instance.setState).toHaveBeenCalled();
-    });
-
-    it("should call TaskDirectoryStore.fetchDirectory", function() {
+    it("calls TaskDirectoryStore.fetchDirectory", function() {
       this.instance.handleFetchDirectory();
       expect(TaskDirectoryStore.fetchDirectory).toHaveBeenCalled();
     });
 
-    it("should not call TaskDirectoryStore.fetchDirectory", function() {
+    it("does not call TaskDirectoryStore.fetchDirectory", function() {
       MesosStateStore.getTaskFromTaskID = function() {
         return null;
       };
@@ -137,12 +122,12 @@ describe("TaskDetail", function() {
   });
 
   describe("#handleBreadcrumbClick", function() {
-    it("should call TaskDirectoryStore.setPath", function() {
+    it("calls TaskDirectoryStore.setPath", function() {
       this.instance.handleBreadcrumbClick();
       expect(TaskDirectoryStore.setPath).toHaveBeenCalled();
     });
 
-    it("should not call TaskDirectoryStore.setPath", function() {
+    it("does not call TaskDirectoryStore.setPath", function() {
       MesosStateStore.getTaskFromTaskID = function() {
         return null;
       };
@@ -166,7 +151,7 @@ describe("TaskDetail", function() {
       ReactDOM.unmountComponentAtNode(this.container);
     });
 
-    it("should call getErrorScreen when error occurred", function() {
+    it("calls getErrorScreen when error occurred", function() {
       this.instance.state = {
         directory: new TaskDirectory({
           items: [{ nlink: 1, path: "/stdout" }]
@@ -191,12 +176,12 @@ describe("TaskDetail", function() {
       expect(this.instance.getErrorScreen).not.toHaveBeenCalled();
     });
 
-    it("should return null if there are no nodes", function() {
+    it("returns null if there are no nodes", function() {
       const node = ReactDOM.findDOMNode(this.instance);
       expect(node).toEqual(null);
     });
 
-    it("should return an element if there is a node", function() {
+    it("returns an element if there is a node", function() {
       MesosStateStore.get = function() {
         return new Task({
           slaves: { fakeProp: "faked" }
@@ -219,7 +204,7 @@ describe("TaskDetail", function() {
   });
 
   describe("#getBasicInfo", function() {
-    it("should return null if task is null", function() {
+    it("returns null if task is null", function() {
       MesosStateStore.getTaskFromTaskID = function() {
         return null;
       };
@@ -227,7 +212,7 @@ describe("TaskDetail", function() {
       expect(result).toEqual(null);
     });
 
-    it("should return an element if task is not null", function() {
+    it("returns an element if task is not null", function() {
       const result = this.instance.getBasicInfo();
 
       expect(TestUtils.isElement(result)).toEqual(true);

--- a/plugins/services/src/js/pages/task-details/__tests__/TaskFileViewer-test.js
+++ b/plugins/services/src/js/pages/task-details/__tests__/TaskFileViewer-test.js
@@ -33,7 +33,7 @@ describe("TaskFileViewer", function() {
   });
 
   describe("#render", function() {
-    it("should set button disabled when file is not found", function() {
+    it("sets button disabled when file is not found", function() {
       this.instance = ReactDOM.render(
         <TaskFileViewer
           directory={new TaskDirectory({ items: [{ nlink: 1, path: "" }] })}
@@ -49,7 +49,7 @@ describe("TaskFileViewer", function() {
       expect(btn.attributes.disabled).toBeTruthy();
     });
 
-    it("should set button not disabled when file is found", function() {
+    it("sets button not disabled when file is found", function() {
       const btn = this.container.querySelector("a.button.button-primary-link");
       // If btn.props.disabled = false, then disabled attribute will be undefined
       expect(btn.attributes.disabled).toEqual(undefined);

--- a/plugins/services/src/js/reducers/__tests__/JSONMultiContainer-test.js
+++ b/plugins/services/src/js/reducers/__tests__/JSONMultiContainer-test.js
@@ -6,7 +6,7 @@ const JSONMultiContainerReducers = require("../JSONMultiContainerReducers");
 
 describe("JSONMultiContainer", function() {
   describe("integrity", function() {
-    it("should parse and reduce without changing the JSON", function() {
+    it("parses and reduce without changing the JSON", function() {
       const podDefinition = {
         id: "/podABCD",
         labels: {

--- a/plugins/services/src/js/reducers/__tests__/JSONSingleContainerReducers-test.js
+++ b/plugins/services/src/js/reducers/__tests__/JSONSingleContainerReducers-test.js
@@ -6,7 +6,7 @@ const { combineReducers } = require("#SRC/js/utils/ReducerUtil");
 
 describe("JSONSingleContainerReducers", function() {
   describe("#cmd", function() {
-    it("should return a cmd at the root level with a nested path", function() {
+    it("returns a cmd at the root level with a nested path", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["cmd"], "sleep 999", SET));
 

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Containers-test.js
@@ -7,7 +7,7 @@ describe("Containers", function() {
   describe("#FormReducer", function() {
     describe("endpoints", function() {
       describe("Host Mode", function() {
-        it("should have one endpoint", function() {
+        it("has one endpoint", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -43,7 +43,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should have one endpoint with name", function() {
+        it("has one endpoint with name", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -83,7 +83,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should have one endpoint with name and a hostport", function() {
+        it("has one endpoint with name and a hostport", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -134,7 +134,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set the protocol right", function() {
+        it("sets the protocol right", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -179,7 +179,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set protocol to unknown value", function() {
+        it("sets protocol to unknown value", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -227,7 +227,7 @@ describe("Containers", function() {
       });
 
       describe("container Mode", function() {
-        it("should have one endpoint", function() {
+        it("has one endpoint", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -265,7 +265,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should have one endpoint with name", function() {
+        it("has one endpoint with name", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -307,7 +307,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should have one endpoint with name and a hostport", function() {
+        it("has one endpoint with name and a hostport", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -360,7 +360,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set the protocol right", function() {
+        it("sets the protocol right", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -405,7 +405,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set protocol to unknown value", function() {
+        it("sets protocol to unknown value", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -451,7 +451,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set the right container Port", function() {
+        it("sets the right container Port", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -496,7 +496,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set the right vip", function() {
+        it("sets the right vip", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -549,7 +549,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set the right custom vip", function() {
+        it("sets the right custom vip", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -609,7 +609,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set the right vip after id change", function() {
+        it("sets the right vip after id change", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -664,7 +664,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set the right custom vip even after id change", function() {
+        it("sets the right custom vip even after id change", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Endpoints-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Endpoints-test.js
@@ -6,7 +6,7 @@ const Endpoints = require("../Endpoints");
 describe("Endpoints", function() {
   describe("#FormReducer", function() {
     describe("Host Mode", function() {
-      it("should have one endpoint", function() {
+      it("has one endpoint", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
@@ -33,7 +33,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should have one endpoint with name", function() {
+      it("has one endpoint with name", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
@@ -64,7 +64,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should have one endpoint with name and a hostport", function() {
+      it("has one endpoint with name and a hostport", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
@@ -106,7 +106,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set the protocol right", function() {
+      it("sets the protocol right", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
@@ -142,7 +142,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set protocol to unknown value", function() {
+      it("sets protocol to unknown value", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
@@ -181,7 +181,7 @@ describe("Endpoints", function() {
     });
 
     describe("container Mode", function() {
-      it("should have one endpoint", function() {
+      it("has one endpoint", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
@@ -210,7 +210,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should have one endpoint with name", function() {
+      it("has one endpoint with name", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
@@ -243,7 +243,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should have one endpoint with name and a hostport", function() {
+      it("has one endpoint with name and a hostport", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
@@ -287,7 +287,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set the protocol right", function() {
+      it("sets the protocol right", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
@@ -323,7 +323,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set protocol to unknown value", function() {
+      it("sets protocol to unknown value", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
@@ -360,7 +360,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set the right container Port", function() {
+      it("sets the right container Port", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
@@ -396,7 +396,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set the right vip", function() {
+      it("sets the right vip", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
@@ -440,7 +440,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set the right custom vip", function() {
+      it("sets the right custom vip", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
@@ -491,7 +491,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set the right vip after id change", function() {
+      it("sets the right vip after id change", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));
@@ -537,7 +537,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set the right custom vip even after id change", function() {
+      it("sets the right custom vip even after id change", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], 0, ADD_ITEM));

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/EnvironmentVariables-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/EnvironmentVariables-test.js
@@ -5,7 +5,7 @@ const EnvironmentVariables = require("../EnvironmentVariables");
 
 describe("Environment Variables", function() {
   describe("#FormReducer", function() {
-    it("should return a array containing key value objects", function() {
+    it("returns a array containing key value objects", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["env"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["env", 0, "key"], "key"));
@@ -16,7 +16,7 @@ describe("Environment Variables", function() {
       ).toEqual([{ key: "key", value: "value" }]);
     });
 
-    it("should return multiple items if they have the same key", function() {
+    it("returns multiple items if they have the same key", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["env"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["env", 0, "key"], "key"));
@@ -33,7 +33,7 @@ describe("Environment Variables", function() {
       ]);
     });
 
-    it("should remove the first item", function() {
+    it("removes the first item", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["env"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["env", 0, "key"], "first"));

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/HealthChecks-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/HealthChecks-test.js
@@ -5,14 +5,14 @@ const HealthChecks = require("../HealthChecks");
 
 describe("HealthChecks", function() {
   describe("#FormReducer", function() {
-    it("should return an Array", function() {
+    it("returns an Array", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
 
       expect(batch.reduce(HealthChecks.FormReducer.bind({}), [])).toEqual([{}]);
     });
 
-    it("should set the protocol", function() {
+    it("sets the protocol", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
@@ -26,7 +26,7 @@ describe("HealthChecks", function() {
       ]);
     });
 
-    it("should set the right Command", function() {
+    it("sets the right Command", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
@@ -44,7 +44,7 @@ describe("HealthChecks", function() {
       ]);
     });
 
-    it("should set the right path", function() {
+    it("sets the right path", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
@@ -60,7 +60,7 @@ describe("HealthChecks", function() {
       ]);
     });
 
-    it("should have a fully fledged health check object", function() {
+    it("has a fully fledged health check object", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
@@ -93,47 +93,43 @@ describe("HealthChecks", function() {
       ]);
     });
 
-    it(
-      "should have a fully fledged health check object with unknown" +
-        " protocol",
-      function() {
-        let batch = new Batch();
-        batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
-        batch = batch.add(
-          new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
-        );
-        batch = batch.add(
-          new Transaction(["healthChecks", 0, "path"], "/api/health")
-        );
-        batch = batch.add(new Transaction(["healthChecks", 0, "portIndex"], 0));
-        batch = batch.add(
-          new Transaction(["healthChecks", 0, "gracePeriodSeconds"], 300)
-        );
-        batch = batch.add(
-          new Transaction(["healthChecks", 0, "intervalSeconds"], 60)
-        );
-        batch = batch.add(
-          new Transaction(["healthChecks", 0, "timeoutSeconds"], 20)
-        );
-        batch = batch.add(
-          new Transaction(["healthChecks", 0, "maxConsecutiveFailures"], 3)
-        );
+    it("has a fully fledged health check object with unknown protocol", function() {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
+      );
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "path"], "/api/health")
+      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "portIndex"], 0));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "gracePeriodSeconds"], 300)
+      );
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "intervalSeconds"], 60)
+      );
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "timeoutSeconds"], 20)
+      );
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "maxConsecutiveFailures"], 3)
+      );
 
-        expect(batch.reduce(HealthChecks.FormReducer.bind({}), [])).toEqual([
-          {
-            path: "/api/health",
-            portIndex: 0,
-            protocol: "MESOS_HTTP",
-            gracePeriodSeconds: 300,
-            intervalSeconds: 60,
-            timeoutSeconds: 20,
-            maxConsecutiveFailures: 3
-          }
-        ]);
-      }
-    );
+      expect(batch.reduce(HealthChecks.FormReducer.bind({}), [])).toEqual([
+        {
+          path: "/api/health",
+          portIndex: 0,
+          protocol: "MESOS_HTTP",
+          gracePeriodSeconds: 300,
+          intervalSeconds: 60,
+          timeoutSeconds: 20,
+          maxConsecutiveFailures: 3
+        }
+      ]);
+    });
 
-    it("should keep https after switching protocol back to HTTP", function() {
+    it("keeps https after switching protocol back to HTTP", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
@@ -154,7 +150,7 @@ describe("HealthChecks", function() {
       ]);
     });
 
-    it("should set protocol to http if https was set", function() {
+    it("sets protocol to http if https was set", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Labels-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Labels-test.js
@@ -5,7 +5,7 @@ const Labels = require("../Labels");
 
 describe("Labels", function() {
   describe("#FormReducer", function() {
-    it("should return a array containing key value objects", function() {
+    it("returns an array containing key value objects", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["labels"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["labels", 0, "key"], "key"));
@@ -15,7 +15,7 @@ describe("Labels", function() {
         { key: "key", value: "value" }
       ]);
     });
-    it("should multiple items if they have the same key", function() {
+    it("returns multiple labels, even if they have the same key", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["labels"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["labels", 0, "key"], "key"));
@@ -29,7 +29,7 @@ describe("Labels", function() {
         { key: "key", value: "value2" }
       ]);
     });
-    it("should keep remove the first item", function() {
+    it("keeps remove the first item", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["labels"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["labels", 0, "key"], "first"));

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Volumes-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Volumes-test.js
@@ -5,7 +5,7 @@ const Volumes = require("../Volumes");
 
 describe("Volumes", function() {
   describe("#FormReducer", function() {
-    it("should return an Array with one item", function() {
+    it("returns an Array with one item", function() {
       const batch = new Batch()
         .add(new Transaction(["volumes"], null, ADD_ITEM))
         .add(new Transaction(["volumes", 0, "type"], "PERSISTENT"));
@@ -20,7 +20,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should contain one full local Volumes item", function() {
+    it("contains one full local Volumes item", function() {
       const batch = new Batch()
         .add(new Transaction(["volumes"], null, ADD_ITEM))
         .add(new Transaction(["volumes", 0, "type"], "PERSISTENT"))
@@ -37,7 +37,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should parse wrong typed values correctly", function() {
+    it("parses wrong typed values correctly", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["volumes", 0, "type"], 123));
@@ -57,7 +57,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should contain two full local Volumes items", function() {
+    it("contains two full local Volumes items", function() {
       const batch = new Batch()
         .add(new Transaction(["volumes"], null, ADD_ITEM))
         .add(new Transaction(["volumes"], null, ADD_ITEM))
@@ -85,7 +85,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should remove the right row.", function() {
+    it("removes the right row.", function() {
       const batch = new Batch()
         .add(new Transaction(["volumes"], null, ADD_ITEM))
         .add(new Transaction(["volumes"], null, ADD_ITEM))
@@ -108,7 +108,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should set the right mode.", function() {
+    it("sets the right mode.", function() {
       const batch = new Batch()
         .add(new Transaction(["volumes"], null, ADD_ITEM))
         .add(new Transaction(["volumes", 0, "type"], "PERSISTENT"))

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
@@ -10,7 +10,7 @@ const { DEFAULT_POD_CONTAINER } = require("../../../../constants/DefaultPod");
 
 describe("Containers", function() {
   describe("#JSONReducer", function() {
-    it("should pass through state as default", function() {
+    it("passes through state as default", function() {
       const batch = new Batch();
 
       expect(batch.reduce(Containers.JSONReducer.bind({}), [])).toEqual([]);
@@ -241,7 +241,7 @@ describe("Containers", function() {
 
     describe("endpoints", function() {
       describe("Host Mode", function() {
-        it("should have one endpoint", function() {
+        it("has one endpoint", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -269,7 +269,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should have one endpoint with name", function() {
+        it("has one endpoint with name", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -301,7 +301,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should keep custom labels", function() {
+        it("keeps custom labels", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -333,7 +333,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should have one endpoint with name and a hostport", function() {
+        it("has one endpoint with name and a hostport", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -378,7 +378,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set the protocol right", function() {
+        it("sets the protocol right", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -415,7 +415,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set protocol to unknown value", function() {
+        it("sets protocol to unknown value", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -454,7 +454,7 @@ describe("Containers", function() {
       });
 
       describe("container Mode", function() {
-        it("should have one endpoint", function() {
+        it("has one endpoint", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -485,7 +485,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should have one endpoint with name", function() {
+        it("has one endpoint with name", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -520,7 +520,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should keep custom labels", function() {
+        it("keeps custom labels", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -554,7 +554,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should have one endpoint with name and a hostport", function() {
+        it("has one endpoint with name and a hostport", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -600,7 +600,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set the protocol right", function() {
+        it("sets the protocol right", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -638,7 +638,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set protocol to unknown value", function() {
+        it("sets protocol to unknown value", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -676,7 +676,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set the right container Port", function() {
+        it("sets the right container Port", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -714,7 +714,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set the right vip", function() {
+        it("sets the right vip", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -762,7 +762,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set the right custom vip", function() {
+        it("sets the right custom vip", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -817,7 +817,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set the right vip after id change", function() {
+        it("sets the right vip after id change", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -867,7 +867,7 @@ describe("Containers", function() {
           ]);
         });
 
-        it("should set the right custom vip even after id change", function() {
+        it("sets the right custom vip even after id change", function() {
           let batch = new Batch();
 
           batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Endpoints-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Endpoints-test.js
@@ -6,7 +6,7 @@ const Endpoints = require("../Endpoints");
 describe("Endpoints", function() {
   describe("#JSONReducer", function() {
     describe("Host Mode", function() {
-      it("should have one endpoint", function() {
+      it("has one endpoint", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -35,7 +35,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should have one endpoint with name", function() {
+      it("has one endpoint with name", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -68,7 +68,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should have one endpoint with name and a hostport", function() {
+      it("has one endpoint with name and a hostport", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -112,7 +112,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set the protocol right", function() {
+      it("sets the protocol right", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -150,7 +150,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set protocol to unknown value", function() {
+      it("sets protocol to unknown value", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -191,7 +191,7 @@ describe("Endpoints", function() {
     });
 
     describe("container Mode", function() {
-      it("should have one endpoint", function() {
+      it("has one endpoint", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -222,7 +222,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should have one endpoint with name", function() {
+      it("has one endpoint with name", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -257,7 +257,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should have one endpoint with name and a hostport", function() {
+      it("has one endpoint with name and a hostport", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -303,7 +303,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set the protocol right", function() {
+      it("sets the protocol right", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -341,7 +341,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set protocol to unknown value", function() {
+      it("sets protocol to unknown value", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -380,7 +380,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set the right container Port", function() {
+      it("sets the right container Port", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -418,7 +418,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set the right vip", function() {
+      it("sets the right vip", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -464,7 +464,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set the right custom vip", function() {
+      it("sets the right custom vip", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -517,7 +517,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set the right vip after id change", function() {
+      it("sets the right vip after id change", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));
@@ -565,7 +565,7 @@ describe("Endpoints", function() {
         ]);
       });
 
-      it("should set the right custom vip even after id change", function() {
+      it("sets the right custom vip even after id change", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["containers"], null, ADD_ITEM));

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/EnvironmentVariables-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/EnvironmentVariables-test.js
@@ -9,7 +9,7 @@ const EnvironmentVariables = require("../EnvironmentVariables");
 
 describe("Environment Variables", function() {
   describe("#JSONReducer", function() {
-    it("should return a key value object", function() {
+    it("returns a key value object", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["env"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["env", 0, "key"], "key"));
@@ -20,7 +20,7 @@ describe("Environment Variables", function() {
       ).toEqual({ key: "value" });
     });
 
-    it("should keep the last value if they have the same key", function() {
+    it("keeps the last value if they have the same key", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["env"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["env", 0, "key"], "key"));
@@ -34,7 +34,7 @@ describe("Environment Variables", function() {
       ).toEqual({ key: "value2" });
     });
 
-    it("should keep remove the first item", function() {
+    it("keeps remove the first item", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["env"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["env", 0, "key"], "first"));
@@ -51,11 +51,11 @@ describe("Environment Variables", function() {
   });
 
   describe("#JSONParser", function() {
-    it("should return an empty array", function() {
+    it("returns an empty array", function() {
       expect(EnvironmentVariables.JSONParser({})).toEqual([]);
     });
 
-    it("should return an array of transactions", function() {
+    it("returns an array of transactions", function() {
       expect(
         EnvironmentVariables.JSONParser({ env: { key: "value" } })
       ).toEqual([
@@ -65,7 +65,7 @@ describe("Environment Variables", function() {
       ]);
     });
 
-    it("should skip non-string values", function() {
+    it("skips non-string values", function() {
       expect(EnvironmentVariables.JSONParser({ env: { FOO: {} } })).toEqual([]);
     });
   });

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/HealthChecks-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/HealthChecks-test.js
@@ -9,14 +9,14 @@ const HealthChecks = require("../HealthChecks");
 
 describe("HealthChecks", function() {
   describe("#JSONReducer", function() {
-    it("should return an Array", function() {
+    it("returns an Array", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
 
       expect(batch.reduce(HealthChecks.JSONReducer.bind({}), {})).toEqual([{}]);
     });
 
-    it("should set the protocol", function() {
+    it("sets the protocol", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
@@ -30,7 +30,7 @@ describe("HealthChecks", function() {
       ]);
     });
 
-    it("should set the right Command", function() {
+    it("sets the right Command", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
@@ -50,7 +50,7 @@ describe("HealthChecks", function() {
       ]);
     });
 
-    it("should set the right path", function() {
+    it("sets the right path", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
@@ -66,7 +66,7 @@ describe("HealthChecks", function() {
       ]);
     });
 
-    it("should have a fully fledged health check object", function() {
+    it("has a fully fledged health check object", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
@@ -99,7 +99,7 @@ describe("HealthChecks", function() {
       ]);
     });
 
-    it("should remove the right item", function() {
+    it("removes the right item", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
@@ -123,43 +123,37 @@ describe("HealthChecks", function() {
       ]);
     });
 
-    it(
-      "should have a fully fledged health check object with unknown" +
-        " protocol",
-      function() {
-        let batch = new Batch();
-        batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
-        batch = batch.add(
-          new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTPS")
-        );
-        batch = batch.add(
-          new Transaction(["healthChecks", 0, "path"], "/test")
-        );
-        batch = batch.add(
-          new Transaction(["healthChecks", 0, "gracePeriodSeconds"], 1)
-        );
-        batch = batch.add(
-          new Transaction(["healthChecks", 0, "intervalSeconds"], 2)
-        );
-        batch = batch.add(
-          new Transaction(["healthChecks", 0, "timeoutSeconds"], 3)
-        );
-        batch = batch.add(
-          new Transaction(["healthChecks", 0, "maxConsecutiveFailures"], 4)
-        );
+    it("has a fully fledged health check object with unknown protocol", function() {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTPS")
+      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "gracePeriodSeconds"], 1)
+      );
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "intervalSeconds"], 2)
+      );
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "timeoutSeconds"], 3)
+      );
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "maxConsecutiveFailures"], 4)
+      );
 
-        expect(batch.reduce(HealthChecks.JSONReducer.bind({}), {})).toEqual([
-          {
-            protocol: "MESOS_HTTPS",
-            path: "/test",
-            gracePeriodSeconds: 1,
-            intervalSeconds: 2,
-            timeoutSeconds: 3,
-            maxConsecutiveFailures: 4
-          }
-        ]);
-      }
-    );
+      expect(batch.reduce(HealthChecks.JSONReducer.bind({}), {})).toEqual([
+        {
+          protocol: "MESOS_HTTPS",
+          path: "/test",
+          gracePeriodSeconds: 1,
+          intervalSeconds: 2,
+          timeoutSeconds: 3,
+          maxConsecutiveFailures: 4
+        }
+      ]);
+    });
     it("sets ipProtocol to IPv6 if set", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["container", "type"], "DOCKER"));
@@ -298,7 +292,7 @@ describe("HealthChecks", function() {
   });
 
   describe("#JSONParser", function() {
-    it("should pass unknown protocol", function() {
+    it("passes unknown protocol", function() {
       expect(
         HealthChecks.JSONParser({
           healthChecks: [

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Labels-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Labels-test.js
@@ -9,7 +9,7 @@ const Labels = require("../Labels");
 
 describe("Labels", function() {
   describe("#JSONReducer", function() {
-    it("should return a key value object", function() {
+    it("returns a key value object", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["labels"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["labels", 0, "key"], "key"));
@@ -19,7 +19,7 @@ describe("Labels", function() {
         key: "value"
       });
     });
-    it("should keep the last value if they have the same key", function() {
+    it("keeps the last value if they have the same key", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["labels"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["labels", 0, "key"], "key"));
@@ -32,7 +32,7 @@ describe("Labels", function() {
         key: "value2"
       });
     });
-    it("should keep remove the first item", function() {
+    it("keeps remove the first item", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["labels"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["labels", 0, "key"], "first"));
@@ -48,10 +48,10 @@ describe("Labels", function() {
     });
   });
   describe("#JSONParser", function() {
-    it("should return an empty array", function() {
+    it("returns an empty array", function() {
       expect(Labels.JSONParser({})).toEqual([]);
     });
-    it("should return an array of transactions", function() {
+    it("returns an array of transactions", function() {
       expect(Labels.JSONParser({ labels: { key: "value" } })).toEqual([
         { type: ADD_ITEM, value: 0, path: ["labels"] },
         { type: SET, value: "key", path: ["labels", 0, "key"] },

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/MultiContainerVolumeMounts-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/MultiContainerVolumeMounts-test.js
@@ -5,7 +5,7 @@ const VolumeMounts = require("../MultiContainerVolumeMounts");
 
 describe("MultiContainerVolumeMounts", function() {
   describe("#JSONReducer", function() {
-    it("should have an array with one object", function() {
+    it("has an array with one object", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumeMounts"], 0, ADD_ITEM));
 
@@ -14,7 +14,7 @@ describe("MultiContainerVolumeMounts", function() {
       ]);
     });
 
-    it("should have an array with one object containing a name", function() {
+    it("has an array with one object containing a name", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumeMounts"], 0, ADD_ITEM));
       batch = batch.add(new Transaction(["volumeMounts", 0, "name"], "foo"));
@@ -24,7 +24,7 @@ describe("MultiContainerVolumeMounts", function() {
       ]);
     });
 
-    it("should have to items with names", function() {
+    it("has to items with names", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumeMounts"], 0, ADD_ITEM));
       batch = batch.add(new Transaction(["volumeMounts"], 1, ADD_ITEM));
@@ -37,7 +37,7 @@ describe("MultiContainerVolumeMounts", function() {
       ]);
     });
 
-    it("should remove the right item", function() {
+    it("removes the right item", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumeMounts"], 0, ADD_ITEM));
       batch = batch.add(new Transaction(["volumeMounts"], 1, ADD_ITEM));
@@ -50,7 +50,7 @@ describe("MultiContainerVolumeMounts", function() {
       ]);
     });
 
-    it("should have to items with names and mountpath", function() {
+    it("has to items with names and mountpath", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumeMounts"], 0, ADD_ITEM));
       batch = batch.add(new Transaction(["volumeMounts"], 1, ADD_ITEM));

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Networks-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Networks-test.js
@@ -3,7 +3,7 @@ const { ADD_ITEM, SET } = require("#SRC/js/constants/TransactionTypes");
 
 describe("Networks", function() {
   describe("#JSONParser", function() {
-    it("should return an empty array", function() {
+    it("returns an empty array", function() {
       expect(Networks.JSONParser({})).toEqual([]);
     });
 

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/RequirePorts-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/RequirePorts-test.js
@@ -15,7 +15,7 @@ describe("RequirePorts", function() {
   });
 
   describe("#JSONParser", function() {
-    it("it should return true as default", function() {
+    it("returns true as default", function() {
       expect(RequirePorts.JSONParser({})).toEqual(
         new Transaction(["portsAutoAssign"], true)
       );

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/RequirePorts-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/RequirePorts-test.js
@@ -5,7 +5,7 @@ const RequirePorts = require("../RequirePorts");
 
 describe("RequirePorts", function() {
   describe("#JSONReducer", function() {
-    it("should return inverted value of portsAutoAssign", function() {
+    it("returns inverted value of portsAutoAssign", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["portsAutoAssign"], true, SET));
@@ -21,7 +21,7 @@ describe("RequirePorts", function() {
       );
     });
 
-    it("should return inverted value of requirePorts", function() {
+    it("returns inverted value of requirePorts", function() {
       expect(
         RequirePorts.JSONParser({
           requirePorts: true

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Residency-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Residency-test.js
@@ -9,7 +9,7 @@ const Residency = require("../Residency");
 
 describe("Residency", function() {
   describe("#JSONReducer", function() {
-    it("it should return undefined as default", function() {
+    it("returns undefined as default", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["id"], "foo"));

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Residency-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Residency-test.js
@@ -17,7 +17,7 @@ describe("Residency", function() {
       expect(batch.reduce(Residency.JSONReducer.bind({}))).toEqual(undefined);
     });
 
-    it("should return residency if residency ist set", function() {
+    it("returns residency if residency ist set", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["residency"], { foo: "bar" }));
@@ -27,7 +27,7 @@ describe("Residency", function() {
       });
     });
 
-    it("should return undefined if a host volume is set", function() {
+    it("returns undefined if a host volume is set", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["volumes", 0, "type"], "HOST"));
@@ -35,7 +35,7 @@ describe("Residency", function() {
       expect(batch.reduce(Residency.JSONReducer.bind({}))).toEqual(undefined);
     });
 
-    it("should return residency if a persistent volume is set", function() {
+    it("returns residency if a persistent volume is set", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["volumes", 0, "type"], "PERSISTENT"));
@@ -46,7 +46,7 @@ describe("Residency", function() {
       });
     });
 
-    it("should return undefined if a persistent volume is removed", function() {
+    it("returns undefined if a persistent volume is removed", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["volumes", 0, "type"], "PERSISTENT"));
@@ -55,7 +55,7 @@ describe("Residency", function() {
       expect(batch.reduce(Residency.JSONReducer.bind({}))).toEqual(undefined);
     });
 
-    it("should respect the parsed residency", function() {
+    it("respects the parsed residency", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["residency"], { foo: "bar" }));
@@ -69,10 +69,10 @@ describe("Residency", function() {
   });
 
   describe("#JSONParser", function() {
-    it("should return empty array if residency is not present", function() {
+    it("returns empty array if residency is not present", function() {
       expect(Residency.JSONParser({ id: "test" })).toEqual([]);
     });
-    it("should return a transaction if residency is present", function() {
+    it("returns a transaction if residency is present", function() {
       expect(Residency.JSONParser({ residency: { foo: "bar" } })).toEqual({
         type: SET,
         path: ["residency"],

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Volumes-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Volumes-test.js
@@ -9,13 +9,13 @@ const Volumes = require("../Volumes");
 
 describe("Volumes", function() {
   describe("#JSONReducer", function() {
-    it("should return an empty array if no volumes are set", function() {
+    it("returns an empty array if no volumes are set", function() {
       const batch = new Batch();
 
       expect(batch.reduce(Volumes.JSONReducer.bind({}), [])).toEqual([]);
     });
 
-    it("should return a local volume", function() {
+    it("returns a local volume", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
@@ -34,7 +34,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should parse wrong values in local volume", function() {
+    it("parses wrong values in local volume", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
@@ -58,7 +58,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should parse wrong values in local volume", function() {
+    it("parses wrong values in local volume", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
@@ -79,7 +79,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should return an external volume", function() {
+    it("returns an external volume", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
@@ -100,7 +100,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should parse wrong values in external volume", function() {
+    it("parses wrong values in external volume", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
@@ -162,7 +162,7 @@ describe("Volumes", function() {
         }
       ]);
     });
-    it("should return a local and an external volume", function() {
+    it("returns a local and an external volume", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
@@ -196,7 +196,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should return a fully filled local volume", function() {
+    it("returns a fully filled local volume", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
@@ -220,7 +220,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should return a fully filled external volume", function() {
+    it("returns a fully filled external volume", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
@@ -255,7 +255,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should remove the right local volume", function() {
+    it("removes the right local volume", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
@@ -288,7 +288,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should remove the right external volume", function() {
+    it("removes the right external volume", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
@@ -330,7 +330,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should contain a mixed combination of volumes", function() {
+    it("contains a mixed combination of volumes", function() {
       let batch = new Batch();
 
       // Add the first external Volume
@@ -415,7 +415,7 @@ describe("Volumes", function() {
   });
   describe("Volumes", function() {
     describe("#JSONParser", function() {
-      it("should return an empty array", function() {
+      it("returns an empty array", function() {
         expect(Volumes.JSONParser({})).toEqual([]);
       });
 
@@ -458,7 +458,7 @@ describe("Volumes", function() {
         ]);
       });
 
-      it("should contain the transaction for one local volume", function() {
+      it("contains the transaction for one local volume", function() {
         const state = {
           container: {
             volumes: [
@@ -491,7 +491,7 @@ describe("Volumes", function() {
         ]);
       });
 
-      it("should include a unknown value for modes", function() {
+      it("includes a unknown value for modes", function() {
         const state = {
           container: {
             volumes: [
@@ -527,7 +527,7 @@ describe("Volumes", function() {
   });
   describe("External Volumes", function() {
     describe("#JSONParser", function() {
-      it("should contain the transaction for one external volume", function() {
+      it("contains the transaction for one external volume", function() {
         const state = {
           container: {
             volumes: [
@@ -580,7 +580,7 @@ describe("Volumes", function() {
         ]);
       });
 
-      it("should include a unknown value for provider", function() {
+      it("includes a unknown value for provider", function() {
         const state = {
           container: {
             volumes: [
@@ -637,7 +637,7 @@ describe("Volumes", function() {
         ]);
       });
 
-      it("should include a unknown value for options", function() {
+      it("includes a unknown value for options", function() {
         const state = {
           container: {
             volumes: [
@@ -694,7 +694,7 @@ describe("Volumes", function() {
         ]);
       });
 
-      it("should include a size value", function() {
+      it("includes a size value", function() {
         const state = {
           container: {
             volumes: [
@@ -753,7 +753,7 @@ describe("Volumes", function() {
   });
   describe("DSS Volumes", function() {
     describe("#JSONParser", function() {
-      it("should contain the transaction for one external volume", function() {
+      it("contains the transaction for one external volume", function() {
         const state = {
           container: {
             volumes: [
@@ -794,7 +794,7 @@ describe("Volumes", function() {
       });
     });
     describe("#JSONReducer", function() {
-      it("should return a DSS volume", function() {
+      it("returns a DSS volume", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
@@ -812,7 +812,7 @@ describe("Volumes", function() {
         ]);
       });
 
-      it("should return a DSS volume with profileName", function() {
+      it("returns a DSS volume with profileName", function() {
         let batch = new Batch();
 
         batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -962,7 +962,7 @@ describe("Container", function() {
         });
       });
 
-      it("should't create portMappings when container.type is MESOS", function() {
+      it("doesn't create portMappings when container.type is MESOS", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction(["container", "type"], "MESOS", SET));
         batch = batch.add(

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -204,7 +204,7 @@ describe("Container", function() {
       });
     });
 
-    it("should not remove forcePullImage when runtime is changed", function() {
+    it("does not remove forcePullImage when runtime is changed", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["container", "type"], "DOCKER", SET));
       batch = batch.add(
@@ -303,7 +303,7 @@ describe("Container", function() {
     });
 
     describe("PortMappings", function() {
-      it("should create default portDefinition configurations", function() {
+      it("creates default portDefinition configurations", function() {
         let batch = new Batch();
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
@@ -337,7 +337,7 @@ describe("Container", function() {
         });
       });
 
-      it("shouldn't include hostPort or protocol when not enabled", function() {
+      it("doesn't include hostPort or protocol when not enabled", function() {
         let batch = new Batch();
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
@@ -378,7 +378,7 @@ describe("Container", function() {
         });
       });
 
-      it("should include hostPort or protocol when not enabled for BRIDGE", function() {
+      it("includes hostPort or protocol when not enabled for BRIDGE", function() {
         let batch = new Batch();
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
@@ -425,7 +425,7 @@ describe("Container", function() {
         });
       });
 
-      it("should create default portDefinition configurations", function() {
+      it("creates default portDefinition configurations", function() {
         let batch = new Batch();
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
@@ -459,7 +459,7 @@ describe("Container", function() {
         });
       });
 
-      it("shouldn't create portMappings by default", function() {
+      it("doesn't create portMappings by default", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
 
@@ -470,7 +470,7 @@ describe("Container", function() {
         });
       });
 
-      it("shouldn't create portMappings for HOST", function() {
+      it("doesn't create portMappings for HOST", function() {
         let batch = new Batch();
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
@@ -493,7 +493,7 @@ describe("Container", function() {
         });
       });
 
-      it("should create two default portDefinition configurations", function() {
+      it("creates two default portDefinition configurations", function() {
         let batch = new Batch();
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
@@ -539,7 +539,7 @@ describe("Container", function() {
         });
       });
 
-      it("should set the name value", function() {
+      it("sets the name value", function() {
         let batch = new Batch();
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
@@ -576,7 +576,7 @@ describe("Container", function() {
         });
       });
 
-      it("should set the port value", function() {
+      it("sets the port value", function() {
         let batch = new Batch();
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
@@ -616,7 +616,7 @@ describe("Container", function() {
         });
       });
 
-      it("should default port value to 0 if automaticPort", function() {
+      it("defaults port value to 0 if automaticPort", function() {
         let batch = new Batch();
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
@@ -657,7 +657,7 @@ describe("Container", function() {
         });
       });
 
-      it("should set the protocol value", function() {
+      it("sets the protocol value", function() {
         let batch = new Batch();
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
@@ -697,7 +697,7 @@ describe("Container", function() {
         });
       });
 
-      it("should add the labels key if the portDefinition is load balanced", function() {
+      it("adds the labels key if the portDefinition is load balanced", function() {
         let batch = new Batch();
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
@@ -746,7 +746,7 @@ describe("Container", function() {
         });
       });
 
-      it("should add the index of the portDefinition to the VIP keys", function() {
+      it("adds the index of the portDefinition to the VIP keys", function() {
         let batch = new Batch();
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
@@ -798,7 +798,7 @@ describe("Container", function() {
         });
       });
 
-      it("should add the port to the VIP string", function() {
+      it("adds the port to the VIP string", function() {
         let batch = new Batch();
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
@@ -856,7 +856,7 @@ describe("Container", function() {
         });
       });
 
-      it("should add the app ID to the VIP string when it is defined", function() {
+      it("adds the app ID to the VIP string when it is defined", function() {
         let batch = new Batch();
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
@@ -909,7 +909,7 @@ describe("Container", function() {
         });
       });
 
-      it("should store portDefinitions even if network is HOST when recorded", function() {
+      it("stores portDefinitions even if network is HOST when recorded", function() {
         let batch = new Batch();
         batch = batch.add(
           new Transaction(["container", "type"], "DOCKER", SET)
@@ -981,7 +981,7 @@ describe("Container", function() {
       });
 
       describe("UCR - BRDIGE", function() {
-        it("should create portMappings when container.type is MESOS", function() {
+        it("creates portMappings when container.type is MESOS", function() {
           let batch = new Batch();
           batch = batch.add(
             new Transaction(["container", "type"], "MESOS", SET)
@@ -1012,7 +1012,7 @@ describe("Container", function() {
           });
         });
 
-        it("should include hostPort or protocol when not enabled for BRIDGE", function() {
+        it("includes hostPort or protocol when not enabled for BRIDGE", function() {
           let batch = new Batch();
           batch = batch.add(
             new Transaction(["container", "type"], "MESOS", SET)
@@ -1056,7 +1056,7 @@ describe("Container", function() {
           });
         });
 
-        it("should create default portDefinition configurations", function() {
+        it("creates default portDefinition configurations", function() {
           let batch = new Batch();
           batch = batch.add(
             new Transaction(["container", "type"], "MESOS", SET)
@@ -1157,7 +1157,7 @@ describe("Container", function() {
   });
 
   describe("Volumes", function() {
-    it("should return an empty array if no volumes are set", function() {
+    it("returns an empty array if no volumes are set", function() {
       const batch = new Batch();
 
       expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
@@ -1167,7 +1167,7 @@ describe("Container", function() {
       });
     });
 
-    it("should return a local volume", function() {
+    it("returns a local volume", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
@@ -1190,7 +1190,7 @@ describe("Container", function() {
       });
     });
 
-    it("should return an external volume", function() {
+    it("returns an external volume", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
@@ -1215,7 +1215,7 @@ describe("Container", function() {
       });
     });
 
-    it("should return a local and an external volume", function() {
+    it("returns a local and an external volume", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
@@ -1253,7 +1253,7 @@ describe("Container", function() {
       });
     });
 
-    it("should return an empty array if all volumes have been removed", function() {
+    it("returns an empty array if all volumes have been removed", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerHealthChecks-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerHealthChecks-test.js
@@ -17,7 +17,7 @@ const {
 describe("MultiContainerHealthChecks", function() {
   describe("#JSONSegmentReducer", function() {
     describe("Generic", function() {
-      it("Should not alter state when batch is empty", function() {
+      it("does not alter state when batch is empty", function() {
         const batch = new Batch();
 
         const state = {};
@@ -29,7 +29,7 @@ describe("MultiContainerHealthChecks", function() {
         ).toEqual({});
       });
 
-      it("Should define health checks on ADD_ITEM", function() {
+      it("defines health checks on ADD_ITEM", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], null, ADD_ITEM));
 
@@ -42,7 +42,7 @@ describe("MultiContainerHealthChecks", function() {
         ).toEqual({});
       });
 
-      it("Should undefine health checks on REMOVE_ITEM", function() {
+      it("undefines health checks on REMOVE_ITEM", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], null, REMOVE_ITEM));
 
@@ -55,7 +55,7 @@ describe("MultiContainerHealthChecks", function() {
         ).toEqual(null);
       });
 
-      it("Should define `gracePeriodSeconds`", function() {
+      it("defines `gracePeriodSeconds`", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], null));
         batch = batch.add(new Transaction(["gracePeriodSeconds"], 1));
@@ -71,7 +71,7 @@ describe("MultiContainerHealthChecks", function() {
         });
       });
 
-      it("Should define `intervalSeconds`", function() {
+      it("defines `intervalSeconds`", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], null));
         batch = batch.add(new Transaction(["intervalSeconds"], 1));
@@ -87,7 +87,7 @@ describe("MultiContainerHealthChecks", function() {
         });
       });
 
-      it("Should define `maxConsecutiveFailures`", function() {
+      it("defines `maxConsecutiveFailures`", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], null));
         batch = batch.add(new Transaction(["maxConsecutiveFailures"], 1));
@@ -103,7 +103,7 @@ describe("MultiContainerHealthChecks", function() {
         });
       });
 
-      it("Should define `timeoutSeconds`", function() {
+      it("defines `timeoutSeconds`", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], null));
         batch = batch.add(new Transaction(["timeoutSeconds"], 1));
@@ -119,7 +119,7 @@ describe("MultiContainerHealthChecks", function() {
         });
       });
 
-      it("Should define `delaySeconds`", function() {
+      it("defines `delaySeconds`", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], null));
         batch = batch.add(new Transaction(["delaySeconds"], 1));
@@ -137,7 +137,7 @@ describe("MultiContainerHealthChecks", function() {
     });
 
     describe("COMMAND", function() {
-      it("Should populate default string commands", function() {
+      it("populates default string commands", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], {}));
         batch = batch.add(new Transaction(["protocol"], COMMAND));
@@ -160,7 +160,7 @@ describe("MultiContainerHealthChecks", function() {
         });
       });
 
-      it("Should populate argv when type=ARGV on commands", function() {
+      it("populates argv when the last command transaction sets type accordingly", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], {}));
         batch = batch.add(new Transaction(["protocol"], COMMAND));
@@ -186,7 +186,7 @@ describe("MultiContainerHealthChecks", function() {
         });
       });
 
-      it("The order of type=ARGV should not matter on commands", function() {
+      it("populates argv when first command transaction sets type accordingly", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], {}));
         batch = batch.add(new Transaction(["protocol"], COMMAND));
@@ -214,7 +214,7 @@ describe("MultiContainerHealthChecks", function() {
     });
 
     describe("HTTP", function() {
-      it("Should populate http endpoint", function() {
+      it("populates http endpoint", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], {}));
         batch = batch.add(new Transaction(["protocol"], HTTP));
@@ -234,7 +234,7 @@ describe("MultiContainerHealthChecks", function() {
         });
       });
 
-      it("Should populate http path", function() {
+      it("populates http path", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], {}));
         batch = batch.add(new Transaction(["protocol"], HTTP));
@@ -254,7 +254,7 @@ describe("MultiContainerHealthChecks", function() {
         });
       });
 
-      it("Should populate http scheme on https", function() {
+      it("populates http scheme on https", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], {}));
         batch = batch.add(new Transaction(["protocol"], HTTP));
@@ -273,7 +273,7 @@ describe("MultiContainerHealthChecks", function() {
         });
       });
 
-      it("Should populate http scheme on http", function() {
+      it("populates http scheme on http", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], {}));
         batch = batch.add(new Transaction(["protocol"], HTTP));
@@ -294,7 +294,7 @@ describe("MultiContainerHealthChecks", function() {
     });
 
     describe("TCP", function() {
-      it("Should populate tcp endpoint", function() {
+      it("populates tcp endpoint", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], {}));
         batch = batch.add(new Transaction(["protocol"], TCP));
@@ -315,7 +315,7 @@ describe("MultiContainerHealthChecks", function() {
     });
 
     describe("Protocol Switching", function() {
-      it("Should switch from TCP to COMMAND", function() {
+      it("switches from TCP to COMMAND", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], {}));
         batch = batch.add(new Transaction(["protocol"], TCP));
@@ -340,7 +340,7 @@ describe("MultiContainerHealthChecks", function() {
         });
       });
 
-      it("Should switch from HTTP to COMMAND", function() {
+      it("switches from HTTP to COMMAND", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], {}));
         batch = batch.add(new Transaction(["protocol"], HTTP));
@@ -365,7 +365,7 @@ describe("MultiContainerHealthChecks", function() {
         });
       });
 
-      it("Should switch from COMMAND to HTTP", function() {
+      it("switches from COMMAND to HTTP", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], {}));
         batch = batch.add(new Transaction(["protocol"], COMMAND));
@@ -389,7 +389,7 @@ describe("MultiContainerHealthChecks", function() {
         });
       });
 
-      it("Should switch from COMMAND to TCP", function() {
+      it("switches from COMMAND to TCP", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction([], {}));
         batch = batch.add(new Transaction(["protocol"], COMMAND));
@@ -415,7 +415,7 @@ describe("MultiContainerHealthChecks", function() {
   });
 
   describe("#FormReducer", function() {
-    it("Should include `protocol` field", function() {
+    it("includes `protocol` field", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction([], {}));
       batch = batch.add(new Transaction(["protocol"], COMMAND));
@@ -431,7 +431,7 @@ describe("MultiContainerHealthChecks", function() {
       });
     });
 
-    it("Should include `exec.command.type` field", function() {
+    it("includes `exec.command.type` field", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction([], {}));
       batch = batch.add(new Transaction(["protocol"], COMMAND));
@@ -453,7 +453,7 @@ describe("MultiContainerHealthChecks", function() {
       });
     });
 
-    it("Should include `exec.command.string` field", function() {
+    it("includes `exec.command.string` field", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction([], {}));
       batch = batch.add(new Transaction(["protocol"], COMMAND));
@@ -473,7 +473,7 @@ describe("MultiContainerHealthChecks", function() {
       });
     });
 
-    it("Should include `http.https` field", function() {
+    it("includes `http.https` field", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction([], {}));
       batch = batch.add(new Transaction(["protocol"], HTTP));
@@ -493,7 +493,7 @@ describe("MultiContainerHealthChecks", function() {
   });
 
   describe("#JSONSegmentParser", function() {
-    it("Should correctly populate `http` transactions", function() {
+    it("populates `http` transactions", function() {
       const healthCheck = {
         http: {
           endpoint: "foo",
@@ -514,7 +514,7 @@ describe("MultiContainerHealthChecks", function() {
       ).toEqual(transactions);
     });
 
-    it("Should correctly populate `tcp` transactions", function() {
+    it("populates `tcp` transactions", function() {
       const healthCheck = {
         tcp: {
           endpoint: "foo"
@@ -531,7 +531,7 @@ describe("MultiContainerHealthChecks", function() {
       ).toEqual(transactions);
     });
 
-    it("Should correctly populate `exec` (shell) transactions", function() {
+    it("populates `exec` (shell) transactions", function() {
       const healthCheck = {
         exec: {
           command: {
@@ -555,7 +555,7 @@ describe("MultiContainerHealthChecks", function() {
       ).toEqual(transactions);
     });
 
-    it("Should correctly populate `exec` (argv) transactions", function() {
+    it("populates `exec` (argv) transactions", function() {
       const healthCheck = {
         exec: {
           command: {

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerNetwork-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerNetwork-test.js
@@ -6,7 +6,7 @@ const Transaction = require("#SRC/js/structs/Transaction");
 
 describe("MultiContainerNetwork", function() {
   describe("#JSONReducer", function() {
-    it("should be host default type", function() {
+    it("is host default type", function() {
       const batch = new Batch();
 
       expect(batch.reduce(MultiContainerNetwork.JSONReducer.bind({}))).toEqual([
@@ -14,7 +14,7 @@ describe("MultiContainerNetwork", function() {
       ]);
     });
 
-    it("should return a network with mode host by default", function() {
+    it("returns a network with mode host by default", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["networks", 0], Networking.type.HOST));
@@ -24,7 +24,7 @@ describe("MultiContainerNetwork", function() {
       ]);
     });
 
-    it("should return a network with mode container", function() {
+    it("returns a network with mode container", function() {
       let batch = new Batch();
 
       batch = batch.add(
@@ -36,7 +36,7 @@ describe("MultiContainerNetwork", function() {
       ]);
     });
 
-    it("should reset network to mode host", function() {
+    it("resets network to mode host", function() {
       let batch = new Batch();
 
       batch = batch.add(

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerScaling-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerScaling-test.js
@@ -5,7 +5,7 @@ const { SET } = require("#SRC/js/constants/TransactionTypes");
 
 describe("MultiContainerScaling", function() {
   describe("#JSONReducer", function() {
-    it("should not return anything with an empty back", function() {
+    it("does not return anything with an empty back", function() {
       const batch = new Batch();
 
       expect(batch.reduce(MultiContainerScaling.JSONReducer.bind({}))).toEqual(
@@ -13,7 +13,7 @@ describe("MultiContainerScaling", function() {
       );
     });
 
-    it("should return a fixed scaling block when instances defined", function() {
+    it("returns a fixed scaling block when instances defined", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["instances"], 1));
@@ -26,7 +26,7 @@ describe("MultiContainerScaling", function() {
       });
     });
 
-    it("should return different scaling kinds if defined", function() {
+    it("returns different scaling kinds if defined", function() {
       let batch = new Batch();
 
       batch = batch.add(new Transaction(["scaling.kind"], "wrong"));
@@ -42,13 +42,13 @@ describe("MultiContainerScaling", function() {
   });
 
   describe("#JSONParser", function() {
-    it("should not populate transactions on empty config", function() {
+    it("does not populate transactions on empty config", function() {
       const expectedObject = [];
 
       expect(MultiContainerScaling.JSONParser({})).toEqual(expectedObject);
     });
 
-    it("should properly populate instances and scaling.kind", function() {
+    it("populates instances and scaling.kind", function() {
       const expectedObject = [
         { type: SET, value: 2, path: ["instances"] },
         { type: SET, value: "random", path: ["scaling", "kind"] }

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerVolumes-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/MultiContainerVolumes-test.js
@@ -23,7 +23,7 @@ describe("Volumes", function() {
     });
 
     describe("with no initial value in ADD_ITEM transaction", function() {
-      it("should have an array with one object", function() {
+      it("has an array with one object", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction(["volumeMounts"], null, ADD_ITEM));
 
@@ -33,7 +33,7 @@ describe("Volumes", function() {
       });
     });
 
-    it("should have an array with one object containing a name", function() {
+    it("has an array with one object containing a name", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumeMounts"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["volumeMounts", 0, "name"], "foo"));
@@ -43,20 +43,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should have an array with one object containing only a name", function() {
-      let batch = new Batch();
-      batch = batch.add(new Transaction(["volumeMounts"], null, ADD_ITEM));
-      batch = batch.add(new Transaction(["volumeMounts", 0, "name"], "foo"));
-      batch = batch.add(
-        new Transaction(["volumeMounts", 0, "volumeMounts", 0], "foobar")
-      );
-
-      expect(batch.reduce(VolumeMounts.JSONReducer.bind({}), [])).toEqual([
-        { name: "foo" }
-      ]);
-    });
-
-    it("should have two items with names", function() {
+    it("has an array with one object containing only a name", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumeMounts"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["volumeMounts", 0, "name"], "foo"));
@@ -69,7 +56,20 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should have two items with names", function() {
+    it("has two items with names", function() {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(["volumeMounts"], null, ADD_ITEM));
+      batch = batch.add(new Transaction(["volumeMounts", 0, "name"], "foo"));
+      batch = batch.add(
+        new Transaction(["volumeMounts", 0, "volumeMounts", 0], "foobar")
+      );
+
+      expect(batch.reduce(VolumeMounts.JSONReducer.bind({}), [])).toEqual([
+        { name: "foo" }
+      ]);
+    });
+
+    it("has two items with names", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumeMounts"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["volumeMounts"], null, ADD_ITEM));
@@ -82,7 +82,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should remove the right item", function() {
+    it("removes the right item", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumeMounts"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["volumeMounts"], null, ADD_ITEM));
@@ -124,7 +124,7 @@ describe("Volumes", function() {
   });
 
   describe("#FormReducer", function() {
-    it("should have an array with one object", function() {
+    it("has an array with one object", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumeMounts"], null, ADD_ITEM));
 
@@ -133,7 +133,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should have an array with one object containing a name", function() {
+    it("has an array with one object containing a name", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumeMounts"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["volumeMounts", 0, "name"], "foo"));
@@ -143,7 +143,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should have two items with names", function() {
+    it("has two items with names", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumeMounts"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["volumeMounts"], null, ADD_ITEM));
@@ -156,7 +156,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should remove the right item", function() {
+    it("removes the right item", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumeMounts"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["volumeMounts"], null, ADD_ITEM));
@@ -169,7 +169,7 @@ describe("Volumes", function() {
       ]);
     });
 
-    it("should have two items with names and mountpath", function() {
+    it("has two items with names and mountpath", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumeMounts"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["volumeMounts"], null, ADD_ITEM));
@@ -209,7 +209,7 @@ describe("Volumes", function() {
   });
 
   describe("#JSONParser", function() {
-    it("should parse a simple config", function() {
+    it("parses a simple config", function() {
       const expectedObject = [
         { type: ADD_ITEM, value: { name: "foo" }, path: ["volumeMounts"] },
         { type: SET, value: "foo", path: ["volumeMounts", 0, "name"] },
@@ -228,7 +228,7 @@ describe("Volumes", function() {
       ).toEqual(expectedObject);
     });
 
-    it("should parse a normal config", function() {
+    it("parses a normal config", function() {
       const expectedObject = [
         { type: ADD_ITEM, value: { name: "foo" }, path: ["volumeMounts"] },
         { type: SET, value: "foo", path: ["volumeMounts", 0, "name"] },
@@ -257,7 +257,7 @@ describe("Volumes", function() {
       ).toEqual(expectedObject);
     });
 
-    it("should parse a advanced config", function() {
+    it("parses a advanced config", function() {
       const expectedObject = [
         { type: ADD_ITEM, value: { name: "foobar" }, path: ["volumeMounts"] },
         { type: SET, value: "foobar", path: ["volumeMounts", 0, "name"] },

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/PortDefinitions-test.js
@@ -8,7 +8,7 @@ const {
 
 describe("PortDefinitions", function() {
   describe("#JSONReducer", function() {
-    it("should return normal config if networkType is  HOST", function() {
+    it("returns normal config if networkType is  HOST", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
 
@@ -17,7 +17,7 @@ describe("PortDefinitions", function() {
       ]);
     });
 
-    it("Should return null if networkType is not HOST", function() {
+    it("returns null if networkType is not HOST", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["networks", 0, "mode"], BRIDGE));
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
@@ -27,7 +27,7 @@ describe("PortDefinitions", function() {
       );
     });
 
-    it("Should return null if networkType is not USER", function() {
+    it("returns null if networkType is not USER", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["networks", 0, "mode"], USER));
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
@@ -37,7 +37,7 @@ describe("PortDefinitions", function() {
       );
     });
 
-    it("should create default portDefinition configurations", function() {
+    it("creates default portDefinition configurations", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
 
@@ -46,7 +46,7 @@ describe("PortDefinitions", function() {
       ]);
     });
 
-    it("should create default portDefinition configurations for BRIDGE network", function() {
+    it("creates default portDefinition configurations for BRIDGE network", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["networks", 0, "mode"], BRIDGE, SET));
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
@@ -56,7 +56,7 @@ describe("PortDefinitions", function() {
       );
     });
 
-    it("shouldn't create portDefinitions for USER", function() {
+    it("doesn't create portDefinitions for USER", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["networks", 0, "mode"], USER, SET));
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
@@ -66,7 +66,7 @@ describe("PortDefinitions", function() {
       );
     });
 
-    it("should create two default portDefinition configurations", function() {
+    it("creates two default portDefinition configurations", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
@@ -77,7 +77,7 @@ describe("PortDefinitions", function() {
       ]);
     });
 
-    it("should set the name value", function() {
+    it("sets the name value", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["portDefinitions", 0, "name"], "foo"));
@@ -87,7 +87,7 @@ describe("PortDefinitions", function() {
       ]);
     });
 
-    it("should set the port value", function() {
+    it("sets the port value", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["portsAutoAssign"], false));
@@ -100,7 +100,7 @@ describe("PortDefinitions", function() {
       ]);
     });
 
-    it("should retain port value if portsAutoAssign is set to true", function() {
+    it("retains port value if portsAutoAssign is set to true", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["portsAutoAssign"], true));
@@ -113,7 +113,7 @@ describe("PortDefinitions", function() {
       ]);
     });
 
-    it("should set the protocol value", function() {
+    it("sets the protocol value", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(
@@ -173,7 +173,7 @@ describe("PortDefinitions", function() {
       ]);
     });
 
-    it("should add the labels key if the portDefinition is load balanced", function() {
+    it("adds the labels key if the portDefinition is load balanced", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
@@ -187,7 +187,7 @@ describe("PortDefinitions", function() {
       ]);
     });
 
-    it("should add the index of the portDefinition to the VIP keys", function() {
+    it("adds the index of the portDefinition to the VIP keys", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
@@ -204,7 +204,7 @@ describe("PortDefinitions", function() {
       ]);
     });
 
-    it("should add the port to the VIP string", function() {
+    it("adds the port to the VIP string", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
@@ -222,7 +222,7 @@ describe("PortDefinitions", function() {
       ]);
     });
 
-    it("should add the app ID to the VIP string when it is defined", function() {
+    it("adds the app ID to the VIP string when it is defined", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
@@ -238,7 +238,7 @@ describe("PortDefinitions", function() {
       ]);
     });
 
-    it("should store portDefinitions even if network is USER when recorded", function() {
+    it("stores portDefinitions even if network is USER when recorded", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["networks", 0, "mode"], USER, SET));
       batch = batch.add(new Transaction(["portDefinitions"], null, ADD_ITEM));
@@ -258,7 +258,7 @@ describe("PortDefinitions", function() {
   });
 
   describe("#JSONParser", function() {
-    it("should return an empty array", function() {
+    it("returns an empty array", function() {
       expect(PortDefinitions.JSONParser({})).toEqual([]);
     });
   });

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/PortMappings-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/PortMappings-test.js
@@ -5,7 +5,7 @@ const { type: { DOCKER } } = require("../../../constants/ContainerConstants");
 
 describe("#JSONParser", function() {
   describe("PortMappings", function() {
-    it("should add portDefinition with details", function() {
+    it("adds portDefinition with details", function() {
       expect(
         PortMappings.JSONParser({
           type: DOCKER,
@@ -32,7 +32,7 @@ describe("#JSONParser", function() {
       ]);
     });
 
-    it("shouldn't add existing, but update details", function() {
+    it("doesn't add existing, but update details", function() {
       expect(
         PortMappings.JSONParser({
           type: DOCKER,
@@ -65,7 +65,7 @@ describe("#JSONParser", function() {
       ]);
     });
 
-    it("should add Transaction for automaticPort and hostPort", function() {
+    it("adds Transaction for automaticPort and hostPort", function() {
       expect(
         PortMappings.JSONParser({
           type: DOCKER,
@@ -86,7 +86,7 @@ describe("#JSONParser", function() {
       ]);
     });
 
-    it("should add Transaction for loadBalanced ports", function() {
+    it("adds Transaction for loadBalanced ports", function() {
       expect(
         PortMappings.JSONParser({
           type: DOCKER,
@@ -111,7 +111,7 @@ describe("#JSONParser", function() {
       ]);
     });
 
-    it("shouldn't add loadBalanced for wrong label", function() {
+    it("doesn't add loadBalanced for wrong label", function() {
       expect(
         PortMappings.JSONParser({
           type: DOCKER,
@@ -133,7 +133,7 @@ describe("#JSONParser", function() {
       ]);
     });
 
-    it("should add Transaction for protocol", function() {
+    it("adds Transaction for protocol", function() {
       expect(
         PortMappings.JSONParser({
           type: DOCKER,
@@ -154,7 +154,7 @@ describe("#JSONParser", function() {
       ]);
     });
 
-    it("should merge info from portMappings and portDefinitions", function() {
+    it("merges info from portMappings and portDefinitions", function() {
       expect(
         PortMappings.JSONParser({
           type: DOCKER,
@@ -208,7 +208,7 @@ describe("#JSONParser", function() {
       ]);
     });
 
-    it("should not add more from portMappings when less than portDefinitions", function() {
+    it("does not add more from portMappings when less than portDefinitions", function() {
       expect(
         PortMappings.JSONParser({
           type: DOCKER,

--- a/plugins/services/src/js/stores/__tests__/MarathonStore-test.js
+++ b/plugins/services/src/js/stores/__tests__/MarathonStore-test.js
@@ -13,7 +13,7 @@ global.atob = function() {
 
 describe("MarathonStore", function() {
   describe("#getFrameworkHealth", function() {
-    it("should return NA health when app has no health check", function() {
+    it("returns NA health when app has no health check", function() {
       var health = MarathonStore.getFrameworkHealth(
         MockMarathonResponse.hasNoHealthy.items[0]
       );
@@ -22,28 +22,28 @@ describe("MarathonStore", function() {
       expect(health.value).toEqual(HealthTypes.NA);
     });
 
-    it("should return idle when app has no running tasks", function() {
+    it("returns idle when app has no running tasks", function() {
       var health = MarathonStore.getFrameworkHealth(
         MockMarathonResponse.hasNoRunningTasks.items[0]
       );
       expect(health.key).toEqual("IDLE");
     });
 
-    it("should return unhealthy when app has only unhealthy tasks", function() {
+    it("returns unhealthy when app has only unhealthy tasks", function() {
       var health = MarathonStore.getFrameworkHealth(
         MockMarathonResponse.hasOnlyUnhealth.items[0]
       );
       expect(health.key).toEqual("UNHEALTHY");
     });
 
-    it("should return unhealthy when app has both healthy and unhealthy tasks", function() {
+    it("returns unhealthy when app has both healthy and unhealthy tasks", function() {
       var health = MarathonStore.getFrameworkHealth(
         MockMarathonResponse.hasOnlyUnhealth.items[0]
       );
       expect(health.key).toEqual("UNHEALTHY");
     });
 
-    it("should return healthy when app has healthy and no unhealthy tasks", function() {
+    it("returns healthy when app has healthy and no unhealthy tasks", function() {
       var health = MarathonStore.getFrameworkHealth(
         MockMarathonResponse.hasHealth.items[0]
       );
@@ -119,19 +119,19 @@ describe("MarathonStore", function() {
   });
 
   describe("#processMarathonGroups", function() {
-    it("should set Marathon health to idle with no items", function() {
+    it("sets Marathon health to idle with no items", function() {
       MarathonStore.processMarathonGroups({ items: [] });
       var marathonApps = MarathonStore.get("apps");
       expect(marathonApps.marathon.health.key).toEqual("IDLE");
     });
 
-    it("should set Marathon health to healthy with some apps", function() {
+    it("sets Marathon health to healthy with some apps", function() {
       MarathonStore.processMarathonGroups(MockMarathonResponse.hasOnlyUnhealth);
       var marathonApps = MarathonStore.get("apps");
       expect(marathonApps.marathon.health.key).toEqual("HEALTHY");
     });
 
-    it("should have apps with NA health if apps have no health checks", function() {
+    it("has apps with NA health if apps have no health checks", function() {
       MarathonStore.processMarathonGroups(MockMarathonResponse.hasNoHealthy);
       var marathonApps = MarathonStore.get("apps");
 
@@ -156,17 +156,17 @@ describe("MarathonStore", function() {
       MarathonStore.processMarathonDeployments([{ id: "deployment-id" }]);
     });
 
-    it("should hold the supplied deployments data on the store", function() {
+    it("holds the supplied deployments data on the store", function() {
       var deployments = MarathonStore.get("deployments");
       expect(deployments).toEqual(jasmine.any(DeploymentsList));
       expect(deployments.last().getId()).toEqual("deployment-id");
     });
 
-    it("should emit a marathon deployment event", function() {
+    it("emits a marathon deployment event", function() {
       expect(this.handler).toBeCalled();
     });
 
-    it("should emit a populated DeploymentsList", function() {
+    it("emits a populated DeploymentsList", function() {
       const deployments = this.handler.mock.calls[0][0];
       expect(deployments).toEqual(jasmine.any(DeploymentsList));
       expect(deployments.last().getId()).toEqual("deployment-id");
@@ -183,11 +183,11 @@ describe("MarathonStore", function() {
       MarathonStore.processMarathonInfoRequest({ foo: "bar" });
     });
 
-    it("should emit an event", function() {
+    it("emits an event", function() {
       expect(this.handler).toBeCalled();
     });
 
-    it("should return stored info", function() {
+    it("returns stored info", function() {
       expect(MarathonStore.getInstanceInfo()).toEqual({ foo: "bar" });
     });
   });
@@ -206,11 +206,11 @@ describe("MarathonStore", function() {
       });
     });
 
-    it("should emit a marathon queue event", function() {
+    it("emits a marathon queue event", function() {
       expect(this.handler).toBeCalled();
     });
 
-    it("should emit a launch queue", function() {
+    it("emits a launch queue", function() {
       const queue = this.handler.mock.calls[0][0];
       expect(queue).toEqual(jasmine.any(Object));
       expect(queue[0].app.id).toEqual("/service-id");
@@ -218,7 +218,7 @@ describe("MarathonStore", function() {
   });
 
   describe("#processMarathonServiceVersion", function() {
-    it("should emit correct event", function() {
+    it("emits correct event", function() {
       const handler = jest.genMockFunction();
       MarathonStore.once(EventTypes.MARATHON_SERVICE_VERSION_CHANGE, handler);
       MarathonStore.processMarathonServiceVersion({
@@ -230,7 +230,7 @@ describe("MarathonStore", function() {
       expect(handler).toBeCalled();
     });
 
-    it("should pass correct service id", function() {
+    it("passes correct service id", function() {
       const handler = jest.genMockFunction();
       MarathonStore.once(EventTypes.MARATHON_SERVICE_VERSION_CHANGE, handler);
       MarathonStore.processMarathonServiceVersion({
@@ -243,7 +243,7 @@ describe("MarathonStore", function() {
       expect(serviceID).toBe("service-id");
     });
 
-    it("should pass correct version id", function() {
+    it("passes correct version id", function() {
       const handler = jest.genMockFunction();
       MarathonStore.once(EventTypes.MARATHON_SERVICE_VERSION_CHANGE, handler);
       MarathonStore.processMarathonServiceVersion({
@@ -258,7 +258,7 @@ describe("MarathonStore", function() {
   });
 
   describe("#processMarathonServiceVersions", function() {
-    it("should emit correct event", function() {
+    it("emits correct event", function() {
       const handler = jest.genMockFunction();
       MarathonStore.once(EventTypes.MARATHON_SERVICE_VERSIONS_CHANGE, handler);
       MarathonStore.processMarathonServiceVersions({
@@ -269,7 +269,7 @@ describe("MarathonStore", function() {
       expect(handler).toBeCalled();
     });
 
-    it("should convert versions list to Map", function() {
+    it("converts versions list to Map", function() {
       const handler = jest.genMockFunction();
       MarathonStore.once(EventTypes.MARATHON_SERVICE_VERSIONS_CHANGE, handler);
       MarathonStore.processMarathonServiceVersions({
@@ -282,7 +282,7 @@ describe("MarathonStore", function() {
       expect(versions.has("2016-05-02T16:07:32.583Z")).toBe(true);
     });
 
-    it("should pass correct service id", function() {
+    it("passes correct service id", function() {
       const handler = jest.genMockFunction();
       MarathonStore.once(EventTypes.MARATHON_SERVICE_VERSIONS_CHANGE, handler);
       MarathonStore.processMarathonServiceVersions({
@@ -296,7 +296,7 @@ describe("MarathonStore", function() {
   });
 
   describe("processMarathonDeploymentRollback", function() {
-    it("should delete the relevant deployment from the store", function() {
+    it("deletes the relevant deployment from the store", function() {
       MarathonStore.processMarathonDeployments([{ id: "deployment-id" }]);
       MarathonStore.processMarathonDeploymentRollback({
         originalDeploymentID: "deployment-id"
@@ -304,7 +304,7 @@ describe("MarathonStore", function() {
       expect(MarathonStore.get("deployments").getItems().length).toEqual(0);
     });
 
-    it("should emit a deployments change event", function() {
+    it("emits a deployments change event", function() {
       const handler = jest.genMockFunction();
       MarathonStore.once(EventTypes.MARATHON_DEPLOYMENTS_CHANGE, handler);
       MarathonStore.processMarathonDeploymentRollback({
@@ -313,7 +313,7 @@ describe("MarathonStore", function() {
       expect(handler).toBeCalled();
     });
 
-    it("should emit a rollback success event", function() {
+    it("emits a rollback success event", function() {
       const handler = jest.genMockFunction();
       MarathonStore.once(
         EventTypes.MARATHON_DEPLOYMENT_ROLLBACK_SUCCESS,
@@ -329,7 +329,7 @@ describe("MarathonStore", function() {
   });
 
   describe("processMarathonDeploymentRollbackError", function() {
-    it("should emit a rollback error event", function() {
+    it("emits a rollback error event", function() {
       const handler = jest.genMockFunction();
       MarathonStore.once(
         EventTypes.MARATHON_DEPLOYMENT_ROLLBACK_ERROR,
@@ -347,7 +347,7 @@ describe("MarathonStore", function() {
   });
 
   describe("#get storeID", function() {
-    it("should return marathon", function() {
+    it("returns marathon", function() {
       expect(MarathonStore.storeID).toBe("marathon");
     });
   });

--- a/plugins/services/src/js/stores/__tests__/MesosLogStore-test.js
+++ b/plugins/services/src/js/stores/__tests__/MesosLogStore-test.js
@@ -23,20 +23,20 @@ describe("MesosLogStore", function() {
   });
 
   describe("#startTailing", function() {
-    it("should return an instance of LogBuffer", function() {
+    it("returns an instance of LogBuffer", function() {
       var logBuffer = MesosLogStore.getLogBuffer("/bar");
       expect(logBuffer instanceof LogBuffer).toBeTruthy();
     });
   });
 
   describe("#stopTailing", function() {
-    it("should not clear the log buffer by default", function() {
+    it("does not clear the log buffer by default", function() {
       MesosLogStore.stopTailing("/bar");
 
       expect(MesosLogStore.getLogBuffer("/bar")).toBeInstanceOf(LogBuffer);
     });
 
-    it("should clear the log buffer if configured", function() {
+    it("clears the log buffer if configured", function() {
       MesosLogStore.stopTailing("/bar", true);
 
       expect(MesosLogStore.getLogBuffer("/bar")).toEqual(undefined);
@@ -160,18 +160,18 @@ describe("MesosLogStore", function() {
       this.logBuffer = MesosLogStore.getLogBuffer("/bar");
     });
 
-    it("should return all of the log items it was given", function() {
+    it("returns all of the log items it was given", function() {
       const items = this.logBuffer.getItems();
       jest.runAllTimers();
       expect(items.length).toEqual(2);
     });
 
-    it("should return the full log of items it was given", function() {
+    it("returns the full log of items it was given", function() {
       jest.runAllTimers();
       expect(this.logBuffer.getFullLog()).toEqual("foobar");
     });
 
-    it("should call the fetch log 4 times", function() {
+    it("calls the fetch log 4 times", function() {
       jest.runAllTimers();
       expect(RequestUtil.json.calls.count()).toEqual(4);
     });
@@ -200,21 +200,21 @@ describe("MesosLogStore", function() {
       MesosLogStore.emit = this.previousEmit;
     });
 
-    it("should return all of the log items it was given", function() {
+    it("returns all of the log items it was given", function() {
       const items = this.logBuffer.getItems();
       expect(items.length).toEqual(2);
     });
 
-    it("should return the full log of items it was given", function() {
+    it("returns the full log of items it was given", function() {
       expect(this.logBuffer.getFullLog()).toEqual("barfoo");
     });
 
-    it("should call the fetch log 2 times", function() {
+    it("calls the fetch log 2 times", function() {
       jest.runAllTimers();
       expect(RequestUtil.json.calls.count()).toEqual(2);
     });
 
-    it("should call emit with the correct event", function() {
+    it("calls emit with the correct event", function() {
       expect(MesosLogStore.emit).toHaveBeenCalledWith(
         EventTypes.MESOS_LOG_CHANGE,
         "/bar",
@@ -222,7 +222,7 @@ describe("MesosLogStore", function() {
       );
     });
 
-    it("should not call emit with an non-existent path", function() {
+    it("does not call emit with an non-existent path", function() {
       MesosLogStore.emit = jasmine.createSpy();
       MesosLogStore.processLogPrepend("foo", "wtf", { data: "", offset: 100 });
       expect(MesosLogStore.emit).not.toHaveBeenCalled();
@@ -234,7 +234,7 @@ describe("MesosLogStore", function() {
       this.logBuffer = MesosLogStore.getLogBuffer("/bar");
     });
 
-    it("should try to restart the tailing after error", function() {
+    it("tries to restart the tailing after error", function() {
       MesosLogStore.processLogError("foo", "/bar");
       jest.runAllTimers();
       expect(RequestUtil.json.calls.count()).toEqual(2);
@@ -256,20 +256,20 @@ describe("MesosLogStore", function() {
       MesosLogStore.emit = this.previousEmit;
     });
 
-    it("should try to restart the tailing after error", function() {
+    it("tries to restart the tailing after error", function() {
       MesosLogStore.processLogPrependError("foo", "/bar");
       jest.runAllTimers();
       expect(RequestUtil.json.calls.count()).toEqual(3);
     });
 
-    it("should call emit with the correct event", function() {
+    it("calls emit with the correct event", function() {
       expect(MesosLogStore.emit).toHaveBeenCalledWith(
         EventTypes.MESOS_LOG_REQUEST_ERROR,
         "/bar"
       );
     });
 
-    it("should not call emit with an non-existent path", function() {
+    it("does not call emit with an non-existent path", function() {
       MesosLogStore.emit = jasmine.createSpy();
       MesosLogStore.processLogPrepend("foo", "wtf", { data: "", offset: 100 });
       expect(MesosLogStore.emit).not.toHaveBeenCalled();
@@ -281,7 +281,7 @@ describe("MesosLogStore", function() {
       this.logBuffer = MesosLogStore.getLogBuffer("/bar");
     });
 
-    it("should not be initialized after error", function() {
+    it("does not be initialized after error", function() {
       MesosLogStore.processOffsetError("foo", "/bar");
       expect(this.logBuffer.isInitialized()).toEqual(false);
     });
@@ -292,7 +292,7 @@ describe("MesosLogStore", function() {
       this.logBuffer = MesosLogStore.getLogBuffer("/bar");
     });
 
-    it("should be initialized after initialize and before error", function() {
+    it("is initialized after initialize and before error", function() {
       // First item will be used to initialize
       MesosLogStore.processOffset("foo", "/bar", { data: "", offset: 100 });
       expect(this.logBuffer.isInitialized()).toEqual(true);

--- a/plugins/services/src/js/structs/__tests__/Application-test.js
+++ b/plugins/services/src/js/structs/__tests__/Application-test.js
@@ -7,7 +7,7 @@ const VolumeList = require("../VolumeList");
 
 describe("Application", function() {
   describe("#getDeployments", function() {
-    it("should return an empty array", function() {
+    it("returns an empty array", function() {
       const service = new Application({
         deployments: []
       });
@@ -15,7 +15,7 @@ describe("Application", function() {
       expect(service.getDeployments()).toEqual([]);
     });
 
-    it("should return an array with one deployment", function() {
+    it("returns an array with one deployment", function() {
       const service = new Application({
         deployments: [{ id: "4d08fc0d-d450-4a3e-9c85-464ffd7565f7" }]
       });
@@ -203,7 +203,7 @@ describe("Application", function() {
   });
 
   describe("#getResources", function() {
-    it("should return correct resource data", function() {
+    it("returns correct resource data", function() {
       const service = new Application({
         cpus: 1,
         mem: 2,
@@ -220,7 +220,7 @@ describe("Application", function() {
       });
     });
 
-    it("should multiply resource by the number instances", function() {
+    it("multiplies resources by the number of instances", function() {
       const service = new Application({
         cpus: 1,
         mem: 2,
@@ -568,7 +568,7 @@ describe("Application", function() {
   });
 
   describe("#getSpec", function() {
-    it("should clean-up JSON when getting the spec", function() {
+    it("cleans up JSON when getting the spec", function() {
       const item = new Application({ foo: "bar", baz: "qux", uris: [] });
       const spec = item.getSpec();
       expect(JSON.stringify(spec)).toEqual('{"foo":"bar","baz":"qux"}');

--- a/plugins/services/src/js/structs/__tests__/ApplicationSpec-test.js
+++ b/plugins/services/src/js/structs/__tests__/ApplicationSpec-test.js
@@ -205,7 +205,7 @@ describe("ApplicationSpec", function() {
   });
 
   describe("#getIpAddress", function() {
-    it("should return the right ipAddress value", function() {
+    it("returns the right ipAddress value", function() {
       const service = new ApplicationSpec({
         ipAddress: { networkName: "d-overlay-1" }
       });
@@ -257,7 +257,7 @@ describe("ApplicationSpec", function() {
   });
 
   describe("#getResidency", function() {
-    it("should return the right residency value", function() {
+    it("returns the right residency value", function() {
       const service = new ApplicationSpec({
         residency: {
           relaunchEscalationTimeoutSeconds: 10,
@@ -291,7 +291,7 @@ describe("ApplicationSpec", function() {
   });
 
   describe("#getUpdateStrategy", function() {
-    it("should return the right updateStrategy value", function() {
+    it("returns the right updateStrategy value", function() {
       const service = new ApplicationSpec({
         updateStrategy: {
           maximumOverCapacity: 0,

--- a/plugins/services/src/js/structs/__tests__/LogBuffer-test.js
+++ b/plugins/services/src/js/structs/__tests__/LogBuffer-test.js
@@ -54,7 +54,7 @@ describe("LogBuffer", function() {
   });
 
   describe("#add", function() {
-    it("should call its super function", function() {
+    it("calls its super function", function() {
       this.originalAdd = List.prototype.add;
       List.prototype.add = jasmine.createSpy();
 
@@ -65,21 +65,21 @@ describe("LogBuffer", function() {
       List.prototype.add = this.originalAdd;
     });
 
-    it("should add length to get new 'end' when beginning log", function() {
+    it("adds length to get new 'end' when beginning log", function() {
       this.logBuffer.add(new Item({ data: "foo\nbar\nquis", offset: 100 }));
       // Explanation of what is going on in the calculation:
       // 100 + 'foo\nbar\nquis'.indexOf('\n') + 1 + 'bar\nquis'.length
       expect(this.logBuffer.getEnd()).toEqual(100 + 3 + 1 + 8);
     });
 
-    it("should start log at first newline when beginning log", function() {
+    it("starts log at first newline when beginning log", function() {
       this.logBuffer.add(new Item({ data: "foo\nbar\nquis", offset: 100 }));
       // Explanation of what is going on in the calculation:
       // 100 + 'foo\nbar\nquis'.indexOf('\n') + 1
       expect(this.logBuffer.getStart()).toEqual(100 + 3 + 1);
     });
 
-    it("should start log at end - maxFileSize when beginning log", function() {
+    it("starts log at end - maxFileSize when beginning log", function() {
       const logBuffer = new LogBuffer({ maxFileSize: 10 });
       logBuffer.add(
         new Item({
@@ -93,19 +93,19 @@ describe("LogBuffer", function() {
       expect(logBuffer.getStart()).toEqual(logBuffer.getEnd() - 3);
     });
 
-    it("should add length to get new 'end' during logging", function() {
+    it("adds length to get new 'end' during logging", function() {
       this.logBuffer.add(new Item({ data: "foo", offset: 100 }));
       this.logBuffer.add(new Item({ data: "\nbar\nquis", offset: 103 }));
       expect(this.logBuffer.getEnd()).toEqual(103 + "\nbar\nquis".length);
     });
 
-    it("should start log at first offset when file < maxFileSize", function() {
+    it("starts log at first offset when file < maxFileSize", function() {
       this.logBuffer.add(new Item({ data: "foo", offset: 100 }));
       this.logBuffer.add(new Item({ data: "\nbar\nquis", offset: 103 }));
       expect(this.logBuffer.getStart()).toEqual(100);
     });
 
-    it("should start log at end - maxFileSize during logging", function() {
+    it("starts log at end - maxFileSize during logging", function() {
       const logBuffer = new LogBuffer({ maxFileSize: 10 });
       logBuffer.add(new Item({ data: "foo", offset: 100 }));
       logBuffer.add(
@@ -120,7 +120,7 @@ describe("LogBuffer", function() {
       expect(logBuffer.getStart()).toEqual(logBuffer.getEnd() - 3);
     });
 
-    it("should cut the first item when not within maxFileSize", function() {
+    it("cuts the first item when not within maxFileSize", function() {
       const logBuffer = new LogBuffer({ maxFileSize: 10 });
       logBuffer.add(new Item({ data: "foo", offset: 100 }));
       logBuffer.add(new Item({ data: "foo", offset: 103 }));
@@ -134,7 +134,7 @@ describe("LogBuffer", function() {
       expect(logBuffer.getItems().length).toEqual(1);
     });
 
-    it("should keep all items when within maxFileSize", function() {
+    it("keeps all items when within maxFileSize", function() {
       const logBuffer = new LogBuffer({ maxFileSize: 200 });
       logBuffer.add(new Item({ data: "foo", offset: 100 }));
       logBuffer.add(new Item({ data: "foo", offset: 103 }));
@@ -150,19 +150,19 @@ describe("LogBuffer", function() {
   });
 
   describe("#prepend", function() {
-    it("should subtract length from start", function() {
+    it("subtracts length from start", function() {
       this.logBuffer.prepend(new Item({ data: "foo\nbar\nquis", offset: 100 }));
       expect(this.logBuffer.getStart()).toEqual(100);
     });
 
-    it("should be able to add then prepend", function() {
+    it("is able to add then prepend", function() {
       this.logBuffer.add(new Item({ data: "foo", offset: 100 }));
       this.logBuffer.prepend(new Item({ data: "\nbar\nquis", offset: 92 }));
       expect(this.logBuffer.getEnd()).toEqual(103);
       expect(this.logBuffer.getStart()).toEqual(92);
     });
 
-    it("should handle truncate correctly", function() {
+    it("handles truncate correctly", function() {
       const logBuffer = new LogBuffer({ maxFileSize: 10 });
       logBuffer.prepend(
         new Item({
@@ -173,7 +173,7 @@ describe("LogBuffer", function() {
       expect(logBuffer.getStart()).toEqual(logBuffer.getEnd() - 3);
     });
 
-    it("should handle truncate correctly after adding", function() {
+    it("handles truncate correctly after adding", function() {
       const logBuffer = new LogBuffer({ maxFileSize: 10 });
       logBuffer.add(new Item({ data: "foo", offset: 100 }));
       logBuffer.prepend(
@@ -187,33 +187,33 @@ describe("LogBuffer", function() {
   });
 
   describe("#initialize", function() {
-    it("should set end to 0 if offset < PAGE_SIZE", function() {
+    it("sets end to 0 if offset < PAGE_SIZE", function() {
       this.logBuffer.initialize(100);
       expect(this.logBuffer.getEnd()).toEqual(0);
     });
 
-    it("should set start to 0 if offset < PAGE_SIZE", function() {
+    it("sets start to 0 if offset < PAGE_SIZE", function() {
       this.logBuffer.initialize(100);
       expect(this.logBuffer.getStart()).toEqual(0);
     });
 
-    it("should set end to offset - PAGE_SIZE when > PAGE_SIZE", function() {
+    it("sets end to offset - PAGE_SIZE when > PAGE_SIZE", function() {
       this.logBuffer.initialize(PAGE_SIZE + 100);
       expect(this.logBuffer.getEnd()).toEqual(100);
     });
 
-    it("should set start to offset - PAGE_SIZE when > PAGE_SIZE", function() {
+    it("sets start to offset - PAGE_SIZE when > PAGE_SIZE", function() {
       this.logBuffer.initialize(PAGE_SIZE + 100);
       expect(this.logBuffer.getStart()).toEqual(100);
     });
   });
 
   describe("#getFullLog", function() {
-    it("should return empty string when no items", function() {
+    it("returns empty string when no items", function() {
       expect(this.logBuffer.getFullLog()).toEqual("");
     });
 
-    it("should return data items when it holds items", function() {
+    it("returns data items when it holds items", function() {
       this.logBuffer.add(new Item({ data: "foo", offset: 100 }));
       this.logBuffer.add(new Item({ data: "bar", offset: 103 }));
       this.logBuffer.add(new Item({ data: "quis", offset: 107 }));

--- a/plugins/services/src/js/structs/__tests__/Pod-test.js
+++ b/plugins/services/src/js/structs/__tests__/Pod-test.js
@@ -7,74 +7,74 @@ const ServiceStatus = require("../../constants/ServiceStatus");
 
 describe("Pod", function() {
   describe("#constructor", function() {
-    it("should correctly create instances", function() {
+    it("creates instances", function() {
       const instance = new Pod(Object.assign({}, PodFixture));
       expect(instance.get()).toEqual(PodFixture);
     });
   });
 
   describe("#countRunningInstances", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const pod = new Pod(PodFixture);
       expect(pod.countRunningInstances()).toEqual(2);
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const pod = new Pod();
       expect(pod.countRunningInstances()).toEqual(0);
     });
   });
 
   describe("#countNonTerminalInstances", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const pod = new Pod(PodFixture);
       expect(pod.countNonTerminalInstances()).toEqual(3);
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const pod = new Pod();
       expect(pod.countNonTerminalInstances()).toEqual(0);
     });
   });
 
   describe("#countTotalInstances", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const pod = new Pod(PodFixture);
       expect(pod.countTotalInstances()).toEqual(3);
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const pod = new Pod();
       expect(pod.countTotalInstances()).toEqual(0);
     });
   });
 
   describe("#getHealth", function() {
-    it("should return the correct value when DEGRADED", function() {
+    it("returns the correct value when DEGRADED", function() {
       const pod = new Pod({ status: "degraded" });
       expect(pod.getHealth()).toEqual(HealthStatus.UNHEALTHY);
     });
 
-    it("should return the correct value when STABLE", function() {
+    it("returns the correct value when STABLE", function() {
       const pod = new Pod({ status: "stable" });
       expect(pod.getHealth()).toEqual(HealthStatus.HEALTHY);
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const pod = new Pod();
       expect(pod.getHealth()).toEqual(HealthStatus.NA);
     });
   });
 
   describe("#getImages", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const pod = new Pod();
       expect(pod.getImages()).toEqual(ServiceImages.NA_IMAGES);
     });
   });
 
   describe("#getInstancesCount", function() {
-    it("should pass-through from specs", function() {
+    it("passes through from specs", function() {
       const pod = new Pod(PodFixture);
       expect(pod.getInstancesCount()).toEqual(
         pod.getSpec().getScalingInstances()
@@ -83,7 +83,7 @@ describe("Pod", function() {
   });
 
   describe("#getLabels", function() {
-    it("should pass-through from specs", function() {
+    it("passes through from specs", function() {
       const pod = new Pod(PodFixture);
       expect(pod.getLabels()).toEqual(pod.getSpec().getLabels());
     });
@@ -100,7 +100,7 @@ describe("Pod", function() {
   });
 
   describe("#getResources", function() {
-    it("should return correct resource data", function() {
+    it("returns correct resource data", function() {
       const pod = new Pod({
         spec: {
           containers: [
@@ -128,7 +128,7 @@ describe("Pod", function() {
       });
     });
 
-    it("should multiply resource by the number instances", function() {
+    it("multiplies resources by the number of instances", function() {
       const pod = new Pod({
         spec: {
           containers: [
@@ -157,7 +157,7 @@ describe("Pod", function() {
   });
 
   describe("#getServiceStatus", function() {
-    it("should properly detect STOPPED", function() {
+    it("detects STOPPED", function() {
       const pod = new Pod({
         spec: {
           scaling: {
@@ -171,7 +171,7 @@ describe("Pod", function() {
       expect(pod.getServiceStatus()).toEqual(ServiceStatus.STOPPED);
     });
 
-    it("should properly detect DEPLOYING", function() {
+    it("detects DEPLOYING", function() {
       const pod = new Pod({
         spec: {
           scaling: {
@@ -184,7 +184,7 @@ describe("Pod", function() {
       expect(pod.getServiceStatus()).toEqual(ServiceStatus.DEPLOYING);
     });
 
-    it("should properly detect RUNNING", function() {
+    it("detects RUNNING", function() {
       const pod = new Pod({
         spec: {
           scaling: {
@@ -197,7 +197,7 @@ describe("Pod", function() {
       expect(pod.getServiceStatus()).toEqual(ServiceStatus.RUNNING);
     });
 
-    it("should properly detect NA", function() {
+    it("detects NA", function() {
       const pod = new Pod({
         spec: {
           scaling: {
@@ -212,7 +212,7 @@ describe("Pod", function() {
   });
 
   describe("#getTasksSummary", function() {
-    it("should properly count healthy instances", function() {
+    it("counts healthy instances", function() {
       const pod = new Pod({
         spec: {
           scaling: {
@@ -244,7 +244,7 @@ describe("Pod", function() {
       });
     });
 
-    it("should properly count unhealthy instances", function() {
+    it("counts unhealthy instances", function() {
       const pod = new Pod({
         spec: {
           scaling: {
@@ -276,7 +276,7 @@ describe("Pod", function() {
       });
     });
 
-    it("should properly count unknown instances", function() {
+    it("counts unknown instances", function() {
       const pod = new Pod({
         spec: {
           scaling: {
@@ -308,7 +308,7 @@ describe("Pod", function() {
       });
     });
 
-    it("should properly count staged instances", function() {
+    it("counts staged instances", function() {
       const pod = new Pod({
         spec: {
           scaling: {
@@ -340,7 +340,7 @@ describe("Pod", function() {
       });
     });
 
-    it("should properly count over-capacity instances", function() {
+    it("counts over-capacity instances", function() {
       const pod = new Pod({
         spec: {
           scaling: {

--- a/plugins/services/src/js/structs/__tests__/PodContainer-test.js
+++ b/plugins/services/src/js/structs/__tests__/PodContainer-test.js
@@ -5,7 +5,7 @@ const PodFixture = require("../../../../../../tests/_fixtures/pods/PodFixture");
 
 describe("PodContainer", function() {
   describe("#constructor", function() {
-    it("should correctly create instances", function() {
+    it("creates instances", function() {
       const containerSpec = PodFixture.instances[0].containers[0];
       const container = new PodContainer(Object.assign({}, containerSpec));
 
@@ -14,7 +14,7 @@ describe("PodContainer", function() {
   });
 
   describe("#getContainerStatus", function() {
-    it("should correctly detect container in ERROR state", function() {
+    it("detects container in ERROR state", function() {
       const podContainer = new PodContainer({
         status: "TASK_ERROR"
       });
@@ -25,7 +25,7 @@ describe("PodContainer", function() {
       );
     });
 
-    it("should correctly detect container in FAILED state", function() {
+    it("detects container in FAILED state", function() {
       const podContainer = new PodContainer({
         status: "TASK_FAILED"
       });
@@ -36,7 +36,7 @@ describe("PodContainer", function() {
       );
     });
 
-    it("should correctly detect container in FINISHED state", function() {
+    it("detects container in FINISHED state", function() {
       const podContainer = new PodContainer({
         status: "TASK_FINISHED"
       });
@@ -47,7 +47,7 @@ describe("PodContainer", function() {
       );
     });
 
-    it("should correctly detect container in KILLED state", function() {
+    it("detects container in KILLED state", function() {
       const podContainer = new PodContainer({
         status: "TASK_KILLED"
       });
@@ -58,7 +58,7 @@ describe("PodContainer", function() {
       );
     });
 
-    it("should correctly detect container in RUNNING state", function() {
+    it("detects container in RUNNING state", function() {
       const podContainer = new PodContainer({
         status: "TASK_RUNNING"
       });
@@ -69,7 +69,7 @@ describe("PodContainer", function() {
       );
     });
 
-    it("should correctly detect container in HEALTHY state", function() {
+    it("detects container in HEALTHY state", function() {
       const podContainer = new PodContainer({
         status: "TASK_RUNNING",
         endpoints: [
@@ -87,7 +87,7 @@ describe("PodContainer", function() {
       );
     });
 
-    it("should correctly detect container in UNHEALTHY state", function() {
+    it("detects container in UNHEALTHY state", function() {
       const podContainer = new PodContainer({
         status: "TASK_RUNNING",
         endpoints: [
@@ -110,7 +110,7 @@ describe("PodContainer", function() {
       );
     });
 
-    it("should properly handle  unknown states", function() {
+    it("handles unknown states", function() {
       const podContainer = new PodContainer({
         status: "totallyrandom"
       });
@@ -119,7 +119,7 @@ describe("PodContainer", function() {
       expect(podContainer.getContainerStatus().displayName).toEqual("N/A");
     });
 
-    it("should properly handle unknown states", function() {
+    it("handles unknown states", function() {
       const podContainer = new PodContainer({
         status: "TASK_TOTALLY_RANDOM"
       });
@@ -130,75 +130,75 @@ describe("PodContainer", function() {
   });
 
   describe("#getEndpoints", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const endpoints = [{ name: "nginx", allocatedHostPort: 31001 }];
       const podContainer = new PodContainer({ endpoints });
 
       expect(podContainer.getEndpoints()).toEqual(endpoints);
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podContainer = new PodContainer();
       expect(podContainer.getEndpoints()).toEqual([]);
     });
   });
 
   describe("#getId", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podContainer = new PodContainer({ containerId: "container-1234" });
 
       expect(podContainer.getId()).toEqual("container-1234");
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podContainer = new PodContainer();
       expect(podContainer.getId()).toEqual("");
     });
   });
 
   describe("#getLastChanged", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const dateString = "2016-08-31T01:01:01.001";
       const podContainer = new PodContainer({ lastChanged: dateString });
 
       expect(podContainer.getLastChanged()).toEqual(new Date(dateString));
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podContainer = new PodContainer();
       expect(podContainer.getLastChanged().getTime()).toBeNaN();
     });
   });
 
   describe("#getLastUpdated", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const dateString = "2016-08-31T01:01:01.001";
       const podContainer = new PodContainer({ lastUpdated: dateString });
 
       expect(podContainer.getLastUpdated()).toEqual(new Date(dateString));
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podContainer = new PodContainer();
       expect(podContainer.getLastUpdated().getTime()).toBeNaN();
     });
   });
 
   describe("#getName", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podContainer = new PodContainer({ name: "container-1234" });
 
       expect(podContainer.getName()).toEqual("container-1234");
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podContainer = new PodContainer();
       expect(podContainer.getName()).toEqual("");
     });
   });
 
   describe("#getResources", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podContainer = new PodContainer({
         resources: { cpus: 0.5, mem: 64 }
       });
@@ -211,7 +211,7 @@ describe("PodContainer", function() {
       });
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podContainer = new PodContainer();
       expect(podContainer.getResources()).toEqual({
         cpus: 0,
@@ -223,7 +223,7 @@ describe("PodContainer", function() {
   });
 
   describe("#hasHealthChecks", function() {
-    it("should return false if no health checks defined", function() {
+    it("returns false if no health checks defined", function() {
       const podContainer = new PodContainer({
         endpoints: [
           { name: "nginx", allocatedHostPort: 31001 },
@@ -245,7 +245,7 @@ describe("PodContainer", function() {
       expect(podContainer.hasHealthChecks()).toEqual(true);
     });
 
-    it("should return true if at least one check has failed", function() {
+    it("returns true if at least one check has failed", function() {
       const podContainer = new PodContainer({
         endpoints: [
           { name: "nginx", allocatedHostPort: 31001, healthy: false },
@@ -256,7 +256,7 @@ describe("PodContainer", function() {
       expect(podContainer.hasHealthChecks()).toBeTruthy();
     });
 
-    it("should return true if healthy is defined everywhere", function() {
+    it("returns true if healthy is defined everywhere", function() {
       const podContainer = new PodContainer({
         endpoints: [
           { name: "nginx", allocatedHostPort: 31001, healthy: true },
@@ -269,7 +269,7 @@ describe("PodContainer", function() {
   });
 
   describe("#isHealthy", function() {
-    it("should return true if no health checks defined", function() {
+    it("returns true if no health checks defined", function() {
       const podContainer = new PodContainer({
         endpoints: [
           { name: "nginx", allocatedHostPort: 31001 },
@@ -280,7 +280,7 @@ describe("PodContainer", function() {
       expect(podContainer.isHealthy()).toBeTruthy();
     });
 
-    it("should return false if at least one check fails", function() {
+    it("returns false if at least one check fails", function() {
       const podContainer = new PodContainer({
         endpoints: [
           { name: "nginx", allocatedHostPort: 31001, healthy: false },
@@ -291,7 +291,7 @@ describe("PodContainer", function() {
       expect(podContainer.isHealthy()).toBeFalsy();
     });
 
-    it("should return true if all defined tests passes", function() {
+    it("returns true if all defined tests passes", function() {
       const podContainer = new PodContainer({
         endpoints: [
           { name: "nginx", allocatedHostPort: 31001, healthy: true },

--- a/plugins/services/src/js/structs/__tests__/PodInstance-test.js
+++ b/plugins/services/src/js/structs/__tests__/PodInstance-test.js
@@ -5,7 +5,7 @@ const PodFixture = require("../../../../../../tests/_fixtures/pods/PodFixture");
 
 describe("PodInstance", function() {
   describe("#constructor", function() {
-    it("should correctly create instances", function() {
+    it("creates instances", function() {
       const instanceSpec = PodFixture.instances[0];
       const instance = new PodInstance(Object.assign({}, instanceSpec));
 
@@ -14,46 +14,46 @@ describe("PodInstance", function() {
   });
 
   describe("#getAgentAddress", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podInstance = new PodInstance({ agentHostname: "agent-1234" });
 
       expect(podInstance.getAgentAddress()).toEqual("agent-1234");
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podInstance = new PodInstance();
       expect(podInstance.getAgentAddress()).toEqual("");
     });
   });
 
   describe("#getId", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podInstance = new PodInstance({ id: "instance-id-1234" });
 
       expect(podInstance.getId()).toEqual("instance-id-1234");
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podInstance = new PodInstance();
       expect(podInstance.getId()).toEqual("");
     });
   });
 
   describe("#getName", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podInstance = new PodInstance({ id: "instance-id-1234" });
 
       expect(podInstance.getName()).toEqual(podInstance.getId());
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podInstance = new PodInstance();
       expect(podInstance.getName()).toEqual(podInstance.getId());
     });
   });
 
   describe("#getStatus", function() {
-    it("should return FINISHED when all containers are FINISHED", function() {
+    it("returns FINISHED when all containers are FINISHED", function() {
       const podInstance = new PodInstance({
         status: "terminal",
         containers: [
@@ -72,7 +72,7 @@ describe("PodInstance", function() {
   });
 
   describe("#getInstanceStatus", function() {
-    it("should correctly detect container in PENDING state", function() {
+    it("detects container in PENDING state", function() {
       const podInstance = new PodInstance({
         status: "pending"
       });
@@ -80,7 +80,7 @@ describe("PodInstance", function() {
       expect(podInstance.getInstanceStatus()).toEqual(PodInstanceStatus.STAGED);
     });
 
-    it("should correctly detect container in STAGING state", function() {
+    it("detects container in STAGING state", function() {
       const podInstance = new PodInstance({
         status: "staging"
       });
@@ -88,7 +88,7 @@ describe("PodInstance", function() {
       expect(podInstance.getInstanceStatus()).toEqual(PodInstanceStatus.STAGED);
     });
 
-    it("should correctly detect container in DEGRADED state", function() {
+    it("detects container in DEGRADED state", function() {
       const podInstance = new PodInstance({
         status: "degraded"
       });
@@ -98,7 +98,7 @@ describe("PodInstance", function() {
       );
     });
 
-    it("should correctly detect container in TERMINAL state", function() {
+    it("detects container in TERMINAL state", function() {
       const podInstance = new PodInstance({
         status: "terminal"
       });
@@ -106,7 +106,7 @@ describe("PodInstance", function() {
       expect(podInstance.getInstanceStatus()).toEqual(PodInstanceStatus.KILLED);
     });
 
-    it("should correctly detect container in STABLE state", function() {
+    it("detects container in STABLE state", function() {
       const podInstance = new PodInstance({
         status: "stable"
       });
@@ -117,7 +117,7 @@ describe("PodInstance", function() {
       );
     });
 
-    it("should correctly detect container in UNHEALTHY state", function() {
+    it("detects container in UNHEALTHY state", function() {
       const podInstance = new PodInstance({
         status: "stable",
         containers: [
@@ -133,7 +133,7 @@ describe("PodInstance", function() {
       );
     });
 
-    it("should correctly detect container in HEALTHY state", function() {
+    it("detects container in HEALTHY state", function() {
       const podInstance = new PodInstance({
         status: "stable",
         containers: [
@@ -151,35 +151,35 @@ describe("PodInstance", function() {
   });
 
   describe("#getLastChanged", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const dateString = "2016-08-31T01:01:01.001";
       const podInstance = new PodInstance({ lastChanged: dateString });
 
       expect(podInstance.getLastChanged()).toEqual(new Date(dateString));
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podInstance = new PodInstance();
       expect(podInstance.getLastChanged().getTime()).toBeNaN();
     });
   });
 
   describe("#getLastUpdated", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const dateString = "2016-08-31T01:01:01.001";
       const podInstance = new PodInstance({ lastUpdated: dateString });
 
       expect(podInstance.getLastUpdated()).toEqual(new Date(dateString));
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podInstance = new PodInstance();
       expect(podInstance.getLastUpdated().getTime()).toBeNaN();
     });
   });
 
   describe("#getResources", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podInstance = new PodInstance({
         resources: { cpus: 0.5, mem: 64 }
       });
@@ -192,7 +192,7 @@ describe("PodInstance", function() {
       });
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podInstance = new PodInstance();
       expect(podInstance.getResources()).toEqual({
         cpus: 0,
@@ -204,7 +204,7 @@ describe("PodInstance", function() {
   });
 
   describe("#hasHealthChecks", function() {
-    it("should return true if all container have health checks", function() {
+    it("returns true if all container have health checks", function() {
       const podInstance = new PodInstance({
         status: "stable",
         containers: [
@@ -245,7 +245,7 @@ describe("PodInstance", function() {
       expect(podInstance.hasHealthChecks()).toEqual(true);
     });
 
-    it("should return true if instance state is not STABLE", function() {
+    it("returns true if instance state is not STABLE", function() {
       const podInstance = new PodInstance({
         status: "degraded",
         containers: [
@@ -268,7 +268,7 @@ describe("PodInstance", function() {
       expect(podInstance.hasHealthChecks()).toBeTruthy();
     });
 
-    it("should return true if even one container is failing", function() {
+    it("returns true if even one container is failing", function() {
       const podInstance = new PodInstance({
         status: "stable",
         containers: [
@@ -284,7 +284,7 @@ describe("PodInstance", function() {
       expect(podInstance.hasHealthChecks()).toBeTruthy();
     });
 
-    it("should return false if there are no containers", function() {
+    it("returns false if there are no containers", function() {
       const podInstance = new PodInstance({
         status: "stable",
         containers: []
@@ -295,7 +295,7 @@ describe("PodInstance", function() {
   });
 
   describe("#isHealthy", function() {
-    it("should return true if all container are healthy", function() {
+    it("returns true if all container are healthy", function() {
       const podInstance = new PodInstance({
         status: "stable",
         containers: [
@@ -317,7 +317,7 @@ describe("PodInstance", function() {
       expect(podInstance.isHealthy()).toBeTruthy();
     });
 
-    it("should return true even if containers have no checks", function() {
+    it("returns true even if containers have no checks", function() {
       const podInstance = new PodInstance({
         status: "stable",
         containers: [
@@ -333,7 +333,7 @@ describe("PodInstance", function() {
       expect(podInstance.isHealthy()).toBeTruthy();
     });
 
-    it("should return false if at least 1 container is unhealthy", function() {
+    it("returns false if at least 1 container is unhealthy", function() {
       const podInstance = new PodInstance({
         status: "degraded",
         containers: [
@@ -355,7 +355,7 @@ describe("PodInstance", function() {
       expect(podInstance.isHealthy()).toBeFalsy();
     });
 
-    it("should return false on unhealthy container even on udnef", function() {
+    it("returns false on unhealthy container even on udnef", function() {
       const podInstance = new PodInstance({
         status: "stable",
         containers: [
@@ -371,7 +371,7 @@ describe("PodInstance", function() {
       expect(podInstance.isHealthy()).toBeFalsy();
     });
 
-    it("should return true if there are no containers", function() {
+    it("returns true if there are no containers", function() {
       const podInstance = new PodInstance({
         status: "stable",
         containers: []
@@ -382,46 +382,46 @@ describe("PodInstance", function() {
   });
 
   describe("#isRunning", function() {
-    it("should return true when status is STABLE", function() {
+    it("returns true when status is STABLE", function() {
       const podInstance = new PodInstance({ status: "stable" });
       expect(podInstance.isRunning()).toBeTruthy();
     });
 
-    it("should return true when status is DEGRADED", function() {
+    it("returns true when status is DEGRADED", function() {
       const podInstance = new PodInstance({ status: "degraded" });
       expect(podInstance.isRunning()).toBeTruthy();
     });
 
-    it("should return false if not DEGRADED or STABLE", function() {
+    it("returns false if not DEGRADED or STABLE", function() {
       const podInstance = new PodInstance({ status: "terminal" });
       expect(podInstance.isRunning()).toBeFalsy();
     });
   });
 
   describe("#isStaging", function() {
-    it("should return true when status is PENDING", function() {
+    it("returns true when status is PENDING", function() {
       const podInstance = new PodInstance({ status: "pending" });
       expect(podInstance.isStaging()).toBeTruthy();
     });
 
-    it("should return true when status is STAGING", function() {
+    it("returns true when status is STAGING", function() {
       const podInstance = new PodInstance({ status: "staging" });
       expect(podInstance.isStaging()).toBeTruthy();
     });
 
-    it("should return false if not STAGING or PENDING", function() {
+    it("returns false if not STAGING or PENDING", function() {
       const podInstance = new PodInstance({ status: "terminal" });
       expect(podInstance.isStaging()).toBeFalsy();
     });
   });
 
   describe("#isTerminating", function() {
-    it("should return true when status is TERMINAL", function() {
+    it("returns true when status is TERMINAL", function() {
       const podInstance = new PodInstance({ status: "terminal" });
       expect(podInstance.isTerminating()).toBeTruthy();
     });
 
-    it("should return false if not TERMINAL", function() {
+    it("returns false if not TERMINAL", function() {
       const podInstance = new PodInstance({ status: "running" });
       expect(podInstance.isTerminating()).toBeFalsy();
     });

--- a/plugins/services/src/js/structs/__tests__/PodSpec-test.js
+++ b/plugins/services/src/js/structs/__tests__/PodSpec-test.js
@@ -4,7 +4,7 @@ const PodFixture = require("../../../../../../tests/_fixtures/pods/PodFixture");
 
 describe("PodSpec", function() {
   describe("#constructor", function() {
-    it("should correctly create instances", function() {
+    it("creates instances", function() {
       const instance = new PodSpec(Object.assign({}, PodFixture.spec));
 
       expect(instance.get()).toEqual(PodFixture.spec);
@@ -12,20 +12,20 @@ describe("PodSpec", function() {
   });
 
   describe("#getContainers", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podSpec = new PodSpec(PodFixture.spec);
 
       expect(podSpec.getContainers()).toEqual(PodFixture.spec.containers);
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podSpec = new PodSpec();
       expect(podSpec.getContainers()).toEqual([]);
     });
   });
 
   describe("#getContainerSpec", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podSpec = new PodSpec(PodFixture.spec);
 
       expect(podSpec.getContainerSpec("container-1")).toEqual(
@@ -35,33 +35,33 @@ describe("PodSpec", function() {
   });
 
   describe("#getContainerCount", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podSpec = new PodSpec(PodFixture.spec);
 
       expect(podSpec.getContainerCount()).toEqual(2);
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podSpec = new PodSpec();
       expect(podSpec.getContainerCount()).toEqual(0);
     });
   });
 
   describe("#getLabels", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podSpec = new PodSpec(PodFixture.spec);
 
       expect(podSpec.getLabels()).toEqual({ POD_LABEL: "foo" });
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podSpec = new PodSpec();
       expect(podSpec.getLabels()).toEqual({});
     });
   });
 
   describe("#getResources", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podSpec = new PodSpec(PodFixture.spec);
 
       expect(podSpec.getResources()).toEqual({
@@ -72,7 +72,7 @@ describe("PodSpec", function() {
       });
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podSpec = new PodSpec();
       expect(podSpec.getResources()).toEqual({
         cpus: 0,
@@ -84,104 +84,104 @@ describe("PodSpec", function() {
   });
 
   describe("#getScalingInstances", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podSpec = new PodSpec(PodFixture.spec);
 
       expect(podSpec.getScalingInstances()).toEqual(10);
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podSpec = new PodSpec();
       expect(podSpec.getScalingInstances()).toEqual(1);
     });
   });
 
   describe("#getVersion", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podSpec = new PodSpec(PodFixture.spec);
 
       expect(podSpec.getVersion()).toEqual("2016-08-29T01:01:01.001");
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podSpec = new PodSpec();
       expect(podSpec.getVersion()).toBeFalsy();
     });
   });
 
   describe("#getEnvironment", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podSpec = new PodSpec(PodFixture.spec);
 
       expect(podSpec.getEnvironment()).toEqual(PodFixture.spec.environment);
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podSpec = new PodSpec();
       expect(podSpec.getEnvironment()).toEqual({});
     });
   });
 
   describe("#getUser", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podSpec = new PodSpec(PodFixture.spec);
 
       expect(podSpec.getUser()).toEqual("root");
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podSpec = new PodSpec();
       expect(podSpec.getUser()).toBeFalsy();
     });
   });
 
   describe("#getScaling", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podSpec = new PodSpec(PodFixture.spec);
 
       expect(podSpec.getScaling()).toEqual(PodFixture.spec.scaling);
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podSpec = new PodSpec();
       expect(podSpec.getScaling()).toEqual({});
     });
   });
 
   describe("#getSecrets", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podSpec = new PodSpec(PodFixture.spec);
 
       expect(podSpec.getSecrets()).toEqual(PodFixture.spec.secrets);
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podSpec = new PodSpec();
       expect(podSpec.getSecrets()).toEqual({});
     });
   });
 
   describe("#getVolumes", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podSpec = new PodSpec(PodFixture.spec);
 
       expect(podSpec.getVolumes()).toEqual(PodFixture.spec.volumes);
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podSpec = new PodSpec();
       expect(podSpec.getVolumes()).toEqual([]);
     });
   });
 
   describe("#getNetworks", function() {
-    it("should return the correct value", function() {
+    it("returns the correct value", function() {
       const podSpec = new PodSpec(PodFixture.spec);
 
       expect(podSpec.getNetworks()).toEqual(PodFixture.spec.networks);
     });
 
-    it("should return the correct default value", function() {
+    it("returns the correct default value", function() {
       const podSpec = new PodSpec();
       expect(podSpec.getNetworks()).toEqual([]);
     });

--- a/plugins/services/src/js/structs/__tests__/Service-test.js
+++ b/plugins/services/src/js/structs/__tests__/Service-test.js
@@ -22,7 +22,7 @@ describe("Service", function() {
   });
 
   describe("#getResources", function() {
-    it("should return default correct resource data", function() {
+    it("returns default correct resource data", function() {
       expect(new Service().getResources()).toEqual({
         cpus: 0,
         mem: 0,

--- a/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
+++ b/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
@@ -61,7 +61,7 @@ describe("ServiceTree", function() {
       expect(this.instance.getItems()[3] instanceof Application).toEqual(true);
     });
 
-    it("should not convert instances of service", function() {
+    it("does not convert instances of service", function() {
       expect(this.instance.getItems()[4].get()).toEqual({ id: "a" });
       expect(this.instance.getItems()[5].get()).toEqual({ id: "b" });
     });
@@ -142,22 +142,22 @@ describe("ServiceTree", function() {
       });
     });
 
-    it("should return an instance of ServiceTree", function() {
+    it("returns an instance of ServiceTree", function() {
       const filteredTree = this.instance.filterItemsByText("alpha");
       expect(filteredTree instanceof ServiceTree).toBeTruthy();
     });
 
-    it("should include matching trees", function() {
+    it("includes matching trees", function() {
       const filteredItems = this.instance.filterItemsByText("test").getItems();
       expect(filteredItems[0] instanceof ServiceTree).toBeTruthy();
     });
 
-    it("should not include empty trees", function() {
+    it("does not include empty trees", function() {
       const filteredItems = this.instance.filterItemsByText("beta").getItems();
       expect(filteredItems[0] instanceof Framework).toBeTruthy();
     });
 
-    it("should no include matching subtrees", function() {
+    it("does no include matching subtrees", function() {
       const filteredItems = this.instance.filterItemsByText("foo").getItems();
       expect(filteredItems[0] instanceof ServiceTree).toBeTruthy();
     });
@@ -210,7 +210,7 @@ describe("ServiceTree", function() {
       });
     });
 
-    it("should filter by name", function() {
+    it("filters by name", function() {
       const filteredServices = this.instance
         .filterItemsByFilter({
           id: "alpha"
@@ -221,7 +221,7 @@ describe("ServiceTree", function() {
       expect(filteredServices[0].getId()).toEqual("/group/alpha");
     });
 
-    it("should filter by name in groups", function() {
+    it("filters by name in groups", function() {
       const filteredServices = this.instance
         .filterItemsByFilter({
           id: "/group/test/foo"
@@ -232,7 +232,7 @@ describe("ServiceTree", function() {
       expect(filteredServices[0].getId()).toEqual("/group/test/foo");
     });
 
-    it("should filter by health", function() {
+    it("filters by health", function() {
       const filteredServices = this.instance
         .filterItemsByFilter({
           health: [HealthTypes.HEALTHY]
@@ -243,7 +243,7 @@ describe("ServiceTree", function() {
       expect(filteredServices[0].getId()).toEqual("/group/beta");
     });
 
-    it("should perform a logical AND with multiple filters", function() {
+    it("performs a logical AND with multiple filters", function() {
       const filteredServices = this.instance
         .filterItemsByFilter({
           health: [HealthTypes.NA],
@@ -276,7 +276,7 @@ describe("ServiceTree", function() {
       });
     });
 
-    it("should find matching subtree", function() {
+    it("finds matching subtree", function() {
       expect(
         this.instance
           .findItem(function(item) {
@@ -318,23 +318,23 @@ describe("ServiceTree", function() {
       });
     });
 
-    it("should find matching item", function() {
+    it("finds matching item", function() {
       expect(this.instance.findItemById("/beta").getId()).toEqual("/beta");
     });
 
-    it("should find matching subtree item", function() {
+    it("finds matching subtree item", function() {
       expect(this.instance.findItemById("/test/foo").getId()).toEqual(
         "/test/foo"
       );
     });
 
-    it("should find matching subtree", function() {
+    it("finds matching subtree", function() {
       expect(this.instance.findItemById("/test").getId()).toEqual("/test");
     });
   });
 
   describe("#getDeployments", function() {
-    it("should return an empty array", function() {
+    it("returns an empty array", function() {
       const serviceTree = new ServiceTree({
         id: "/group/id",
         items: [
@@ -378,7 +378,7 @@ describe("ServiceTree", function() {
       expect(serviceTree.getDeployments()).toEqual([]);
     });
 
-    it("should return an array with three deployments", function() {
+    it("returns an array with three deployments", function() {
       const serviceTree = new ServiceTree({
         id: "/group/id",
         items: [

--- a/plugins/services/src/js/structs/__tests__/TaskDirectory-test.js
+++ b/plugins/services/src/js/structs/__tests__/TaskDirectory-test.js
@@ -15,11 +15,11 @@ describe("TaskDirectory", function() {
   });
 
   describe("#findFile", function() {
-    it("should return undefined when item is not is list", function() {
+    it("returns undefined when item is not is list", function() {
       expect(this.directory.findFile("quis")).toEqual(undefined);
     });
 
-    it("should return the file when item is not is list", function() {
+    it("returns the file when item is not is list", function() {
       expect(this.directory.findFile("bar").get("path")).toEqual(
         "/some/path/to/bar"
       );

--- a/plugins/services/src/js/structs/__tests__/TaskStats-test.js
+++ b/plugins/services/src/js/structs/__tests__/TaskStats-test.js
@@ -98,7 +98,7 @@ describe("TaskStats", function() {
       expect(statisticsList instanceof List).toBeTruthy();
     });
 
-    it("should only return items with stats", function() {
+    it("only returns items with stats", function() {
       const statisticsList = new TaskStats({
         totalSummary: {
           stats: {

--- a/plugins/services/src/js/structs/__tests__/Volume-test.js
+++ b/plugins/services/src/js/structs/__tests__/Volume-test.js
@@ -44,7 +44,7 @@ describe("Volume", function() {
   });
 
   describe("#getStatus", function() {
-    it("should return unavailable if no  status is defined", function() {
+    it("returns unavailable if no  status is defined", function() {
       const service = new Volume({});
 
       expect(service.getStatus()).toEqual(VolumeStatus.UNAVAILABLE);

--- a/plugins/services/src/js/utils/__tests__/CreateServiceModalFormUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/CreateServiceModalFormUtil-test.js
@@ -15,13 +15,13 @@ describe("CreateServiceModalFormUtil", function() {
     EMPTY_TYPES.forEach(function(emptyType) {
       const emptyTypeStr = getTypeName(emptyType);
 
-      it(`should remove ${emptyTypeStr} object properties`, function() {
+      it(`removes ${emptyTypeStr} object properties`, function() {
         const data = { a: "foo", b: emptyType };
         const clean = CreateServiceModalFormUtil.stripEmptyProperties(data);
         expect(clean).toEqual({ a: "foo" });
       });
 
-      it(`should remove ${emptyTypeStr} array items`, function() {
+      it(`removes ${emptyTypeStr} array items`, function() {
         const data = ["foo", emptyType];
         const clean = CreateServiceModalFormUtil.stripEmptyProperties(data);
         expect(clean).toEqual(["foo"]);

--- a/plugins/services/src/js/utils/__tests__/FrameworkUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/FrameworkUtil-test.js
@@ -9,7 +9,7 @@ describe("FrameworkUtil", function() {
       };
     });
 
-    it("should find the requested size of image", function() {
+    it("finds the requested size of image", function() {
       var image = FrameworkUtil.getImageSizeFromImagesObject(
         this.images,
         "medium"
@@ -51,18 +51,18 @@ describe("FrameworkUtil", function() {
       };
     });
 
-    it("should return parsed images when all images are defined", function() {
+    it("returns parsed images when all images are defined", function() {
       var images = FrameworkUtil.getServiceImages(this.images);
       expect(images).toEqual(this.images);
     });
 
-    it("should return default images when one size is missing", function() {
+    it("returns default images when one size is missing", function() {
       delete this.images["icon-large"];
       var images = FrameworkUtil.getServiceImages(this.images);
       expect(images).toEqual(ServiceImages.NA_IMAGES);
     });
 
-    it("should return default images when images is null", function() {
+    it("returns default images when images is null", function() {
       var images = FrameworkUtil.getServiceImages(null);
       expect(images).toEqual(ServiceImages.NA_IMAGES);
     });

--- a/plugins/services/src/js/utils/__tests__/HealthCheckUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/HealthCheckUtil-test.js
@@ -3,7 +3,7 @@ const HealthCheckProtocols = require("../../constants/HealthCheckProtocols");
 
 describe("HealthCheckUtil", function() {
   describe("#IsKnowProtocol", function() {
-    it("should return true for an empty string", function() {
+    it("returns true for an empty string", function() {
       expect(HealthCheckUtil.isKnownProtocol("")).toEqual(true);
     });
 
@@ -12,7 +12,7 @@ describe("HealthCheckUtil", function() {
       HealthCheckProtocols.MESOS_HTTPS,
       HealthCheckProtocols.COMMAND
     ].forEach(protocol => {
-      it(`should return true for ${protocol}`, function() {
+      it(`returns true for ${protocol}`, function() {
         expect(HealthCheckUtil.isKnownProtocol(protocol)).toEqual(true);
       });
     });
@@ -22,12 +22,12 @@ describe("HealthCheckUtil", function() {
       HealthCheckProtocols.HTTPS,
       HealthCheckProtocols.TCP
     ].forEach(protocol => {
-      it(`should return false for deprecated ${protocol}`, function() {
+      it(`returns false for deprecated ${protocol}`, function() {
         expect(HealthCheckUtil.isKnownProtocol(protocol)).toEqual(false);
       });
     });
 
-    it("should return false for a unknown protocol", function() {
+    it("returns false for a unknown protocol", function() {
       expect(HealthCheckUtil.isKnownProtocol("MESOS_GOPHER")).toEqual(false);
     });
   });

--- a/plugins/services/src/js/utils/__tests__/HostUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/HostUtil-test.js
@@ -2,31 +2,31 @@ const HostUtil = require("../HostUtil");
 
 describe("HostUtil", function() {
   describe("#stringToHostname", function() {
-    it("should omit dots at the start", function() {
+    it("omits dots at the start", function() {
       const result = HostUtil.stringToHostname(".fdgsf.4abc123");
 
       expect(result).toEqual("fdgsf.4abc123");
     });
 
-    it("should omit dots at the end", function() {
+    it("omits dots at the end", function() {
       const result = HostUtil.stringToHostname("fdgsf.4abc123.");
 
       expect(result).toEqual("fdgsf.4abc123");
     });
 
-    it("should omit duplicated dots", function() {
+    it("omits duplicated dots", function() {
       const result = HostUtil.stringToHostname("fdgsf..4abc123");
 
       expect(result).toEqual("fdgsf.4abc123");
     });
 
-    it("should not replace dots midway", function() {
+    it("does not replace dots midway", function() {
       const result = HostUtil.stringToHostname("fdgsf.4abc123");
 
       expect(result).toEqual("fdgsf.4abc123");
     });
 
-    it("should allow 63 char labels", function() {
+    it("allows 63 char labels", function() {
       const hostname = [
         "010203040506070809010111213141516171819202122232425262728293031",
         "010203040506070809010111213141516171819202122232425262728293031"
@@ -35,7 +35,7 @@ describe("HostUtil", function() {
       expect(HostUtil.stringToHostname(hostname)).toEqual(hostname);
     });
 
-    it("should not alter valid strings", function() {
+    it("does not alter valid strings", function() {
       const result = HostUtil.stringToHostname("0-0");
 
       expect(result).toEqual("0-0");
@@ -43,43 +43,43 @@ describe("HostUtil", function() {
   });
 
   describe("#stringToLabel", function() {
-    it("should strip invalid chars", function() {
+    it("strips invalid chars", function() {
       const result = HostUtil.stringToLabel("fd%gsf---gs7-f$gs--d7fddg-123");
 
       expect(result).toEqual("fdgsf---gs7-fgs--d7fddg-123");
     });
 
-    it("should replace underscores", function() {
+    it("replaces underscores", function() {
       const result = HostUtil.stringToLabel("fdgsf_4abc123");
 
       expect(result).toEqual("fdgsf-4abc123");
     });
 
-    it("should omit slashes", function() {
+    it("omits slashes", function() {
       const result = HostUtil.stringToLabel("fdgsf/4abc123");
 
       expect(result).toEqual("fdgsf4abc123");
     });
 
-    it("should omit dots", function() {
+    it("omits dots", function() {
       const result = HostUtil.stringToLabel(".fdgsf.4abc123.");
 
       expect(result).toEqual("fdgsf4abc123");
     });
 
-    it("should strip invalid chars from the start", function() {
+    it("strips invalid chars from the start", function() {
       const result = HostUtil.stringToLabel("-@4abc123");
 
       expect(result).toEqual("4abc123");
     });
 
-    it("should strip invalid chars from the end", function() {
+    it("strips invalid chars from the end", function() {
       const result = HostUtil.stringToLabel("4abc123-");
 
       expect(result).toEqual("4abc123");
     });
 
-    it("should strip invalid chars from the start and end", function() {
+    it("strips invalid chars from the start and end", function() {
       const result = HostUtil.stringToLabel(
         "##fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789-"
       );
@@ -89,13 +89,13 @@ describe("HostUtil", function() {
       );
     });
 
-    it("should allow dashes within the hostname", function() {
+    it("allows dashes within the hostname", function() {
       const result = HostUtil.stringToLabel("89fdgsf---gs7-fgs--d7fddg-123");
 
       expect(result).toEqual("89fdgsf---gs7-fgs--d7fddg-123");
     });
 
-    it("should strip invalid chars and trim string to 63 chars", function() {
+    it("strips invalid chars and trim string to 63 chars", function() {
       const result = HostUtil.stringToLabel(
         "fd%gsf---gs7-f$gs--d7fddg123456789012345678901234567890123456789-123"
       );
@@ -105,7 +105,7 @@ describe("HostUtil", function() {
       );
     });
 
-    it("should trim string to 63 chars", function() {
+    it("trims string to 63 chars", function() {
       const result = HostUtil.stringToLabel(
         "0102030405060708090101112131415161718192021222324252627282930313233"
       );
@@ -115,7 +115,7 @@ describe("HostUtil", function() {
       );
     });
 
-    it("should strip invalid chars from start and trim string", function() {
+    it("strips invalid chars from start and trim string", function() {
       const result = HostUtil.stringToLabel(
         "%%fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789---123"
       );
@@ -125,7 +125,7 @@ describe("HostUtil", function() {
       );
     });
 
-    it("should strip dashes from the end and trim string", function() {
+    it("strips dashes from the end and trim string", function() {
       const result = HostUtil.stringToLabel(
         "%%fdgsf---gs7-fgs--d7fddg123456789012345678901234567890123456789---123"
       );
@@ -135,7 +135,7 @@ describe("HostUtil", function() {
       );
     });
 
-    it("should strip all dashes that exceed the char limit", function() {
+    it("strips all dashes that exceed the char limit", function() {
       const result = HostUtil.stringToLabel(
         "a--------------------------------------------------------------------b"
       );
@@ -143,7 +143,7 @@ describe("HostUtil", function() {
       expect(result).toEqual("ab");
     });
 
-    it("should not alter valid hostnames", function() {
+    it("does not alter valid hostnames", function() {
       const result = HostUtil.stringToLabel(
         "a-----------------------------------------------b"
       );
@@ -153,7 +153,7 @@ describe("HostUtil", function() {
       );
     });
 
-    it("should lowercase the string", function() {
+    it("returns lowercase string", function() {
       const result = HostUtil.stringToLabel("XYZ");
 
       expect(result).toEqual("xyz");

--- a/plugins/services/src/js/utils/__tests__/MarathonErrorUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/MarathonErrorUtil-test.js
@@ -3,7 +3,7 @@ const ServiceErrorTypes = require("../../constants/ServiceErrorTypes");
 
 describe("MarathonErrorUtil", function() {
   describe("#parseErrors", function() {
-    it("should properly process string-only errors", function() {
+    it("processes string-only errors", function() {
       const marathonError = "Some error";
 
       expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([
@@ -16,7 +16,7 @@ describe("MarathonErrorUtil", function() {
       ]);
     });
 
-    it("should properly handle object errors with message-only", function() {
+    it("handles object errors with message-only", function() {
       const marathonError = {
         message: "Some error"
       };
@@ -31,7 +31,7 @@ describe("MarathonErrorUtil", function() {
       ]);
     });
 
-    it("should properly handle object errors with string details", function() {
+    it("handles object errors with string details", function() {
       const marathonError = {
         message: "Some error",
         details: "Some error details"
@@ -47,7 +47,7 @@ describe("MarathonErrorUtil", function() {
       ]);
     });
 
-    it("should properly handle object errors with null message", function() {
+    it("handles object errors with null message", function() {
       const marathonError = {
         message: null
       };
@@ -62,7 +62,7 @@ describe("MarathonErrorUtil", function() {
       ]);
     });
 
-    it("should properly handle object errors with array details", function() {
+    it("handles object errors with array details", function() {
       const marathonError = {
         message: "Some error",
         details: [
@@ -89,7 +89,7 @@ describe("MarathonErrorUtil", function() {
       ]);
     });
 
-    it("should properly translate marathon paths without index", function() {
+    it("translates marathon paths without index", function() {
       const marathonError = {
         message: "Some error",
         details: [
@@ -151,7 +151,7 @@ describe("MarathonErrorUtil", function() {
       ]);
     });
 
-    it("should properly translate marathon paths with index", function() {
+    it("translates marathon paths with index", function() {
       const marathonError = {
         message: "Some error",
         details: [
@@ -172,7 +172,7 @@ describe("MarathonErrorUtil", function() {
       ]);
     });
 
-    it("should be able to translate messages with no details", function() {
+    it("is able to translate messages with no details", function() {
       const marathonError = { message: "Some error" };
 
       expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([
@@ -185,21 +185,21 @@ describe("MarathonErrorUtil", function() {
       ]);
     });
 
-    it("should handle a message value of empty object as empty", function() {
+    it("handles a message value of empty object as empty", function() {
       // TODO (JIRA DCOS_OSS-653): We should include these with a generic error
       const marathonError = { message: {} };
 
       expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([]);
     });
 
-    it("should handle a message value of empty array as empty", function() {
+    it("handles a message value of empty array as empty", function() {
       // TODO (JIRA DCOS_OSS-653): We should include these with a generic error
       const marathonError = { message: [] };
 
       expect(MarathonErrorUtil.parseErrors(marathonError)).toEqual([]);
     });
 
-    it("should handle a details value of null as empty", function() {
+    it("handles a details value of null as empty", function() {
       // TODO (JIRA DCOS_OSS-653): We should include these with a generic error
       const marathonError = { message: "Some error", details: null };
 
@@ -213,7 +213,7 @@ describe("MarathonErrorUtil", function() {
       ]);
     });
 
-    it("should handle a details value of empty object as empty", function() {
+    it("handles a details value of empty object as empty", function() {
       // TODO (JIRA DCOS_OSS-653): We should include these with a generic error
       const marathonError = { message: "Some error", details: {} };
 
@@ -227,7 +227,7 @@ describe("MarathonErrorUtil", function() {
       ]);
     });
 
-    it("should handle a details value of empty array as empty", function() {
+    it("handles a details value of empty array as empty", function() {
       // TODO (JIRA DCOS_OSS-653): We should include these with a generic error
       const marathonError = { message: "Some error", details: [] };
 
@@ -241,7 +241,7 @@ describe("MarathonErrorUtil", function() {
       ]);
     });
 
-    it("should discard details value of object", function() {
+    it("discards details value of object", function() {
       // TODO (JIRA DCOS_OSS-653): We should include these with a generic error
       const marathonError = { message: "Some error", details: { foo: "bar" } };
 

--- a/plugins/services/src/js/utils/__tests__/MarathonUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/MarathonUtil-test.js
@@ -2,37 +2,37 @@ const MarathonUtil = require("../MarathonUtil");
 
 describe("MarathonUtil", function() {
   describe("#parseGroups", function() {
-    it("should throw error if the provided id doesn't start with a slash", function() {
+    it("throws error if the provided id doesn't start with a slash", function() {
       expect(function() {
         MarathonUtil.parseGroups({ id: "malformed/id" });
       }).toThrow();
     });
 
-    it("should throw error if an app id doesn't start with a slash", function() {
+    it("throws error if an app id doesn't start with a slash", function() {
       expect(function() {
         MarathonUtil.parseGroups({ id: "/", apps: [{ id: "malformed/id" }] });
       }).toThrow();
     });
 
-    it("should throw error if the provided id ends with a slash", function() {
+    it("throws error if the provided id ends with a slash", function() {
       expect(function() {
         MarathonUtil.parseGroups({ id: "/malformed/id/" });
       }).toThrow();
     });
 
-    it("should throw error if an app id ends with a slash", function() {
+    it("throws error if an app id ends with a slash", function() {
       expect(function() {
         MarathonUtil.parseGroups({ id: "/", apps: [{ id: "/malformed/id/" }] });
       }).toThrow();
     });
 
-    it("should not throw error if the provided id is only a slash (root id)", function() {
+    it("does not throw error if the provided id is only a slash (root id)", function() {
       expect(function() {
         MarathonUtil.parseGroups({ id: "/" });
       }).not.toThrow();
     });
 
-    it("should throw error if an app id is only a slash (root id)", function() {
+    it("throws error if an app id is only a slash (root id)", function() {
       expect(function() {
         MarathonUtil.parseGroups({ id: "/", apps: [{ id: "/" }] });
       }).toThrow();

--- a/plugins/services/src/js/utils/__tests__/PodUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/PodUtil-test.js
@@ -23,14 +23,14 @@ describe("PodUtil", function() {
   });
 
   describe("#isContainerMatchingText", function() {
-    it("should match text on container name", function() {
+    it("matches text on container name", function() {
       const instance = this.pod.getInstanceList().getItems()[0];
       const container = instance.getContainers()[0];
 
       expect(PodUtil.isContainerMatchingText(container, "c1")).toBeTruthy();
     });
 
-    it("should not match wrong text on container name", function() {
+    it("does not match wrong text on container name", function() {
       const instance = this.pod.getInstanceList().getItems()[0];
       const container = instance.getContainers()[0];
 
@@ -39,7 +39,7 @@ describe("PodUtil", function() {
   });
 
   describe("#isInstanceOrChildrenMatchingText", function() {
-    it("should match text on instance id", function() {
+    it("matches text on instance id", function() {
       const instance = this.pod.getInstanceList().getItems()[0];
 
       expect(
@@ -47,7 +47,7 @@ describe("PodUtil", function() {
       ).toBeTruthy();
     });
 
-    it("should match text on container names", function() {
+    it("matches text on container names", function() {
       const instance = this.pod.getInstanceList().getItems()[0];
 
       expect(
@@ -55,7 +55,7 @@ describe("PodUtil", function() {
       ).toBeTruthy();
     });
 
-    it("should not match if text is not present anywhere", function() {
+    it("does not match if text is not present anywhere", function() {
       const instance = this.pod.getInstanceList().getItems()[0];
 
       expect(
@@ -65,7 +65,7 @@ describe("PodUtil", function() {
   });
 
   describe("#mergeHistoricalInstanceList", function() {
-    it("should properly append new instances", function() {
+    it("appends new instances", function() {
       let instances = this.pod.getInstanceList();
       const historicalInstances = [
         {
@@ -88,7 +88,7 @@ describe("PodUtil", function() {
       expect(instances.getItems()[1].get()).toEqual(historicalInstances[0]);
     });
 
-    it("should properly append new containers on existing items", function() {
+    it("appends new containers on existing items", function() {
       let instances = this.pod.getInstanceList();
       const historicalInstances = [
         {
@@ -114,7 +114,7 @@ describe("PodUtil", function() {
       );
     });
 
-    it("should not duplicate containers", function() {
+    it("does not duplicate containers", function() {
       let instances = this.pod.getInstanceList();
       const historicalInstances = [
         {

--- a/plugins/services/src/js/utils/__tests__/ServiceSpecUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceSpecUtil-test.js
@@ -6,7 +6,7 @@ const ServiceSpecUtil = require("../ServiceSpecUtil");
 describe("ServiceSpecUtil", function() {
   describe("Pods", function() {
     describe("#setPodInstances", function() {
-      it("should properly create missing sections", function() {
+      it("creates missing sections", function() {
         var spec = new PodSpec({});
         var newSpec = ServiceSpecUtil.setPodInstances(spec, 10);
 
@@ -17,7 +17,7 @@ describe("ServiceSpecUtil", function() {
         });
       });
 
-      it("should keep existing fields intact", function() {
+      it("keeps existing fields intact", function() {
         var spec = new PodSpec({
           scaling: {
             kind: "fixed",
@@ -35,7 +35,7 @@ describe("ServiceSpecUtil", function() {
         });
       });
 
-      it("should properly reset to fixed on different scale kind", function() {
+      it("resets to fixed on different scale kind", function() {
         var spec = new PodSpec({
           scaling: {
             kind: "different",
@@ -54,7 +54,7 @@ describe("ServiceSpecUtil", function() {
     });
 
     describe("#setServiceInstances", function() {
-      it("should properly operate on PodSpec", function() {
+      it("operates on PodSpec", function() {
         var spec = new PodSpec({});
         var newSpec = ServiceSpecUtil.setServiceInstances(spec, 10);
 
@@ -69,7 +69,7 @@ describe("ServiceSpecUtil", function() {
 
   describe("Application", function() {
     describe("#setApplicationInstances", function() {
-      it("should properly create missing sections", function() {
+      it("creates missing sections", function() {
         var spec = new ApplicationSpec({});
         var newSpec = ServiceSpecUtil.setApplicationInstances(spec, 10);
 
@@ -81,7 +81,7 @@ describe("ServiceSpecUtil", function() {
     });
 
     describe("#setServiceInstances", function() {
-      it("should properly operate on ApplicationSpec", function() {
+      it("operates on ApplicationSpec", function() {
         var spec = new ApplicationSpec({});
         var newSpec = ServiceSpecUtil.setServiceInstances(spec, 10);
 
@@ -95,7 +95,7 @@ describe("ServiceSpecUtil", function() {
 
   describe("Framework", function() {
     describe("#setFrameworkInstances", function() {
-      it("should properly create missing sections", function() {
+      it("creates missing sections", function() {
         var spec = new FrameworkSpec({});
         var newSpec = ServiceSpecUtil.setFrameworkInstances(spec, 10);
 
@@ -107,7 +107,7 @@ describe("ServiceSpecUtil", function() {
     });
 
     describe("#setServiceInstances", function() {
-      it("should properly operate on FrameworkSpec", function() {
+      it("operates on FrameworkSpec", function() {
         var spec = new FrameworkSpec({});
         var newSpec = ServiceSpecUtil.setServiceInstances(spec, 10);
 

--- a/plugins/services/src/js/utils/__tests__/ServiceTableUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceTableUtil-test.js
@@ -44,15 +44,15 @@ describe("ServiceTableUtil", function() {
           );
         });
 
-        it("should return -1 if type a comes beforeEach type b", function() {
+        it("returns -1 if type a comes beforeEach type b", function() {
           expect(this.compareFunction(serviceTree, healthyService)).toEqual(-1);
         });
 
-        it("should return 0 if type a is equal to type b", function() {
+        it("returns 0 if type a is equal to type b", function() {
           expect(this.compareFunction(serviceTree, serviceTree)).toEqual(0);
         });
 
-        it("should return 1 if type a comes after type b", function() {
+        it("returns 1 if type a comes after type b", function() {
           expect(this.compareFunction(healthyService, serviceTree)).toEqual(1);
         });
       });
@@ -65,15 +65,15 @@ describe("ServiceTableUtil", function() {
           );
         });
 
-        it("should return 1 if type a comes beforeEach type b", function() {
+        it("returns 1 if type a comes beforeEach type b", function() {
           expect(this.compareFunction(serviceTree, healthyService)).toEqual(1);
         });
 
-        it("should return 0 if type a is equal to type b", function() {
+        it("returns 0 if type a is equal to type b", function() {
           expect(this.compareFunction(serviceTree, serviceTree)).toEqual(0);
         });
 
-        it("should return -1 if type a comes after type b", function() {
+        it("returns -1 if type a comes after type b", function() {
           expect(this.compareFunction(healthyService, serviceTree)).toEqual(-1);
         });
       });
@@ -87,15 +87,15 @@ describe("ServiceTableUtil", function() {
         );
       });
 
-      it("should return 1 if type a comes beforeEach type b", function() {
+      it("returns 1 if type a comes beforeEach type b", function() {
         expect(this.compareFunction(serviceTree, healthyService)).toEqual(-1);
       });
 
-      it("should return 0 if type a is equal to type b", function() {
+      it("returns 0 if type a is equal to type b", function() {
         expect(this.compareFunction(serviceTree, serviceTree)).toEqual(0);
       });
 
-      it("should return -1 if type a comes after type b", function() {
+      it("returns -1 if type a comes after type b", function() {
         expect(this.compareFunction(healthyService, serviceTree)).toEqual(1);
       });
     });
@@ -108,17 +108,17 @@ describe("ServiceTableUtil", function() {
         );
       });
 
-      it("should return 1 if a has more running tasks than b", function() {
+      it("returns 1 if a has more running tasks than b", function() {
         expect(this.compareFunction(healthyService, unhealthyService)).toEqual(
           1
         );
       });
 
-      it("should return 0 if a has same number of running tasks as b", function() {
+      it("returns 0 if a has same number of running tasks as b", function() {
         expect(this.compareFunction(healthyService, healthyService)).toEqual(0);
       });
 
-      it("should return -1 if a has less running tasks than b", function() {
+      it("returns -1 if a has less running tasks than b", function() {
         expect(this.compareFunction(unhealthyService, healthyService)).toEqual(
           -1
         );
@@ -133,17 +133,17 @@ describe("ServiceTableUtil", function() {
         );
       });
 
-      it("should return 1 if a comes after b in the status sorting", function() {
+      it("returns 1 if a comes after b in the status sorting", function() {
         expect(this.compareFunction(healthyService, unhealthyService)).toEqual(
           1
         );
       });
 
-      it("should return 0 if a has the same status as b", function() {
+      it("returns 0 if a has the same status as b", function() {
         expect(this.compareFunction(healthyService, healthyService)).toEqual(0);
       });
 
-      it("should return -1 if a comes beforeEach b in the status sorting", function() {
+      it("returns -1 if a comes beforeEach b in the status sorting", function() {
         expect(this.compareFunction(unhealthyService, healthyService)).toEqual(
           -1
         );
@@ -157,17 +157,17 @@ describe("ServiceTableUtil", function() {
         );
       });
 
-      it("should return 1 if a has more cpus than b", function() {
+      it("returns 1 if a has more cpus than b", function() {
         expect(this.compareFunction(healthyService, unhealthyService)).toEqual(
           1
         );
       });
 
-      it("should return 0 if a has same number of cpus as b", function() {
+      it("returns 0 if a has same number of cpus as b", function() {
         expect(this.compareFunction(healthyService, healthyService)).toEqual(0);
       });
 
-      it("should return -1 if a has less cpus than b", function() {
+      it("returns -1 if a has less cpus than b", function() {
         expect(this.compareFunction(unhealthyService, healthyService)).toEqual(
           -1
         );
@@ -181,17 +181,17 @@ describe("ServiceTableUtil", function() {
         );
       });
 
-      it("should return 1 if a has more mem than b", function() {
+      it("returns 1 if a has more mem than b", function() {
         expect(this.compareFunction(healthyService, unhealthyService)).toEqual(
           1
         );
       });
 
-      it("should return 0 if a has same number of mem as b", function() {
+      it("returns 0 if a has same number of mem as b", function() {
         expect(this.compareFunction(healthyService, healthyService)).toEqual(0);
       });
 
-      it("should return -1 if a has less mem than b", function() {
+      it("returns -1 if a has less mem than b", function() {
         expect(this.compareFunction(unhealthyService, healthyService)).toEqual(
           -1
         );
@@ -205,17 +205,17 @@ describe("ServiceTableUtil", function() {
         );
       });
 
-      it("should return 1 if a has more disk than b", function() {
+      it("returns 1 if a has more disk than b", function() {
         expect(this.compareFunction(healthyService, unhealthyService)).toEqual(
           1
         );
       });
 
-      it("should return 0 if a has same number of disk as b", function() {
+      it("returns 0 if a has same number of disk as b", function() {
         expect(this.compareFunction(healthyService, healthyService)).toEqual(0);
       });
 
-      it("should return -1 if a has less disk than b", function() {
+      it("returns -1 if a has less disk than b", function() {
         expect(this.compareFunction(unhealthyService, healthyService)).toEqual(
           -1
         );

--- a/plugins/services/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceUtil-test.js
@@ -6,7 +6,7 @@ const ServiceUtil = require("../ServiceUtil");
 
 describe("ServiceUtil", function() {
   describe("#createServiceFromResponse", function() {
-    it("should correctly create Application instances", function() {
+    it("creates Application instances", function() {
       const instance = ServiceUtil.createServiceFromResponse({
         id: "/test",
         cmd: "sleep 1000;",
@@ -19,7 +19,7 @@ describe("ServiceUtil", function() {
       expect(instance instanceof Application).toBeTruthy();
     });
 
-    it("should correctly create Framework instances", function() {
+    it("creates Framework instances", function() {
       const instance = ServiceUtil.createServiceFromResponse({
         id: "/test",
         cmd: "sleep 1000;",
@@ -35,7 +35,7 @@ describe("ServiceUtil", function() {
       expect(instance instanceof Framework).toBeTruthy();
     });
 
-    it("should correctly create Pod instances", function() {
+    it("creates Pod instances", function() {
       const instance = ServiceUtil.createServiceFromResponse({
         id: "/test",
         spec: {
@@ -49,7 +49,7 @@ describe("ServiceUtil", function() {
   });
 
   describe("#createFormModelFromSchema", function() {
-    it("should create the correct model", function() {
+    it("creates the correct model", function() {
       const schema = {
         type: "object",
         properties: {
@@ -97,7 +97,7 @@ describe("ServiceUtil", function() {
   });
 
   describe("#getDefinitionFromSpec", function() {
-    it("should create the correct definition for ApplicationSpec", function() {
+    it("creates the correct definition for ApplicationSpec", function() {
       const service = new ApplicationSpec({
         id: "/test",
         cmd: "sleep 1000;"
@@ -111,7 +111,7 @@ describe("ServiceUtil", function() {
   });
 
   describe("#convertServiceLabelsToArray", function() {
-    it("should return an array of key-value tuples", function() {
+    it("returns an array of key-value tuples", function() {
       const service = new Application({
         id: "/test",
         cmd: "sleep 1000;",
@@ -129,7 +129,7 @@ describe("ServiceUtil", function() {
       ]);
     });
 
-    it("should return an empty array if no labels are found", function() {
+    it("returns an empty array if no labels are found", function() {
       const service = new Application({
         id: "/test",
         cmd: "sleep 1000;"
@@ -149,7 +149,7 @@ describe("ServiceUtil", function() {
   });
 
   describe("#isEqual", function() {
-    it("should return false if services have different type", function() {
+    it("returns false if services have different type", function() {
       const serviceA = new Application({
         id: "foo"
       });
@@ -160,7 +160,7 @@ describe("ServiceUtil", function() {
       expect(ServiceUtil.isEqual(serviceA, serviceB)).toBeFalsy();
     });
 
-    it("should return false if same type but different content", function() {
+    it("returns false if same type but different content", function() {
       const serviceA = new Application({
         id: "foo"
       });
@@ -171,7 +171,7 @@ describe("ServiceUtil", function() {
       expect(ServiceUtil.isEqual(serviceA, serviceB)).toBeFalsy();
     });
 
-    it("should return true if same type and same content", function() {
+    it("returns true if same type and same content", function() {
       const serviceA = new Application({
         id: "foo"
       });
@@ -184,7 +184,7 @@ describe("ServiceUtil", function() {
   });
 
   describe("#isSDKService", function() {
-    it("should return true if service does not have the proper label", function() {
+    it("returns true if service does not have the proper label", function() {
       const service = new Framework({
         id: "/foo",
         labels: {
@@ -195,7 +195,7 @@ describe("ServiceUtil", function() {
       expect(ServiceUtil.isSDKService(service)).toEqual(true);
     });
 
-    it("should return false if service does not have the proper label", function() {
+    it("returns false if service does not have the proper label", function() {
       const service = new Framework({
         id: "/foo",
         labels: {

--- a/plugins/services/src/js/utils/__tests__/ServiceValidatorUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceValidatorUtil-test.js
@@ -2,19 +2,19 @@ const ServiceValidatorUtil = require("../ServiceValidatorUtil");
 
 describe("ServiceValidatorUtil", function() {
   describe("#isValidServiceID", function() {
-    it("should properly handle empty strings", function() {
+    it("handles empty strings", function() {
       expect(ServiceValidatorUtil.isValidServiceID("")).toBe(false);
     });
 
-    it("should properly handle undefined values", function() {
+    it("handles undefined values", function() {
       expect(ServiceValidatorUtil.isValidServiceID()).toBe(false);
     });
 
-    it("should properly handle white spaces", function() {
+    it("handles white spaces", function() {
       expect(ServiceValidatorUtil.isValidServiceID("white space")).toBe(false);
     });
 
-    it("should properly handle illegal characters", function() {
+    it("handles illegal characters", function() {
       expect(ServiceValidatorUtil.isValidServiceID("Uppercase")).toBe(false);
       expect(ServiceValidatorUtil.isValidServiceID("app#1")).toBe(false);
       expect(ServiceValidatorUtil.isValidServiceID("app_1")).toBe(false);
@@ -24,25 +24,25 @@ describe("ServiceValidatorUtil", function() {
       expect(ServiceValidatorUtil.isValidServiceID("app(1)")).toBe(false);
     });
 
-    it("should properly handle multiple forward slashes", function() {
+    it("handles multiple forward slashes", function() {
       expect(ServiceValidatorUtil.isValidServiceID("/app//id////")).toBe(false);
     });
 
-    it("should verify that the IDs don't begin with or end with a dash", function() {
+    it("verifies that the IDs don't begin with or end with a dash", function() {
       expect(ServiceValidatorUtil.isValidServiceID("-a/b/c")).toBe(false);
       expect(ServiceValidatorUtil.isValidServiceID("a/b/c-")).toBe(false);
       expect(ServiceValidatorUtil.isValidServiceID("a-b/c")).toBe(true);
       expect(ServiceValidatorUtil.isValidServiceID("a/b-c")).toBe(true);
     });
 
-    it("should verify that the IDs don't begin with or end with a dot", function() {
+    it("verifies that the IDs don't begin with or end with a dot", function() {
       expect(ServiceValidatorUtil.isValidServiceID(".a/b/c")).toBe(false);
       expect(ServiceValidatorUtil.isValidServiceID("a/b/c.")).toBe(false);
       expect(ServiceValidatorUtil.isValidServiceID("a.b/c")).toBe(true);
       expect(ServiceValidatorUtil.isValidServiceID("a/b.c")).toBe(true);
     });
 
-    it("should verify that the IDs are well-formed", function() {
+    it("verifies that the IDs are well-formed", function() {
       expect(ServiceValidatorUtil.isValidServiceID("app.1")).toBe(true);
       expect(ServiceValidatorUtil.isValidServiceID("/app.1")).toBe(true);
       expect(ServiceValidatorUtil.isValidServiceID("app.1/app-2")).toBe(true);

--- a/plugins/services/src/js/utils/__tests__/TaskTableUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/TaskTableUtil-test.js
@@ -45,52 +45,52 @@ describe("TaskTableUtil", function() {
   });
 
   describe("#getSortFunction for regular items", function() {
-    it("should return a function", function() {
+    it("returns a function", function() {
       expect(typeof this.getComparator).toEqual("function");
     });
 
-    it("should compare the most recent timestamps when prop is updated", function() {
+    it("compares the most recent timestamps when prop is updated", function() {
       var compareFunction = this.getComparator("updated");
       expect(compareFunction(this.foo, this.bar)).toEqual(-1);
     });
 
-    it("should compare tieBreaker values", function() {
+    it("compares tieBreaker values", function() {
       var compareFunction = this.getComparator("name");
 
       // 'foo' > 'bar' will equal true and compareValues returns 1
       expect(compareFunction(this.foo, this.bar)).toEqual(1);
     });
 
-    it("should compare resource values", function() {
+    it("compares resource values", function() {
       var compareFunction = this.getComparator("cpus");
       expect(compareFunction(this.foo, this.bar)).toEqual(1);
     });
 
-    it("should compare last resource values", function() {
+    it("compares last resource values", function() {
       var compareFunction = this.getComparator("mem");
       expect(compareFunction(this.foo, this.bar)).toEqual(1);
     });
   });
 
   describe("#getSortFunction for structs", function() {
-    it("should compare the most recent timestamps when prop is updated", function() {
+    it("compares the most recent timestamps when prop is updated", function() {
       var compareFunction = this.getComparator("updated");
       expect(compareFunction(this.fooStruct, this.barStruct)).toEqual(-1);
     });
 
-    it("should compare tieBreaker values", function() {
+    it("compares tieBreaker values", function() {
       var compareFunction = this.getComparator("name");
 
       // 'foo' > 'bar' will equal true and compareValues returns 1
       expect(compareFunction(this.fooStruct, this.barStruct)).toEqual(1);
     });
 
-    it("should compare resource values", function() {
+    it("compares resource values", function() {
       var compareFunction = this.getComparator("cpus");
       expect(compareFunction(this.fooStruct, this.barStruct)).toEqual(1);
     });
 
-    it("should compare last resource values", function() {
+    it("compares last resource values", function() {
       var compareFunction = this.getComparator("mem");
       expect(compareFunction(this.fooStruct, this.barStruct)).toEqual(1);
     });

--- a/plugins/services/src/js/utils/__tests__/TaskUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/TaskUtil-test.js
@@ -99,27 +99,27 @@ describe("TaskUtil", function() {
       });
     });
 
-    it("should handle empty container well", function() {
+    it("handles empty container well", function() {
       expect(TaskUtil.getPortMappings({})).toEqual(null);
     });
 
-    it("should handle empty type well", function() {
+    it("handles empty type well", function() {
       expect(TaskUtil.getPortMappings({ container: {} })).toEqual(null);
     });
 
-    it("should handle empty info well", function() {
+    it("handles empty info well", function() {
       expect(TaskUtil.getPortMappings({ container: { type: "FOO" } })).toEqual(
         null
       );
     });
 
-    it("should handle empty port mappings well", function() {
+    it("handles empty port mappings well", function() {
       expect(
         TaskUtil.getPortMappings({ container: { type: "FOO", foo: {} } })
       ).toEqual(null);
     });
 
-    it("should handle if port mappings are is not an array", function() {
+    it("handles if port mappings are is not an array", function() {
       expect(
         TaskUtil.getPortMappings({
           container: { type: "FOO", foo: { port_mappings: 0 } }
@@ -127,7 +127,7 @@ describe("TaskUtil", function() {
       ).toEqual(null);
     });
 
-    it("should provide port_mappings when available", function() {
+    it("provides port_mappings when available", function() {
       expect(this.instance).toEqual(["foo", "bar", "baz"]);
     });
   });

--- a/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
@@ -92,105 +92,105 @@ const NOTBOTHCMDARGS_ERRORS = [
 
 describe("MarathonAppValidators", function() {
   describe("#containsCmdArgsOrContainer", function() {
-    it("should return no errors if `cmd` defined", function() {
+    it("returns no errors if `cmd` defined", function() {
       const spec = { cmd: "foo" };
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec)).toEqual(
         []
       );
     });
 
-    it("should return no errors if `args` defined", function() {
+    it("returns no errors if `args` defined", function() {
       const spec = { args: ["foo"] };
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec)).toEqual(
         []
       );
     });
 
-    it("should return no errors if `container.docker.image` defined", function() {
+    it("returns no errors if `container.docker.image` defined", function() {
       const spec = { container: { docker: { image: "foo" } } };
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec)).toEqual(
         []
       );
     });
 
-    it("should return no errors if `container.appc.image` defined", function() {
+    it("returns no errors if `container.appc.image` defined", function() {
       const spec = { container: { appc: { image: "foo" } } };
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec)).toEqual(
         []
       );
     });
 
-    it("should return error if both `args` and `cmd` are defined", function() {
+    it("returns error if both `args` and `cmd` are defined", function() {
       const spec = { args: ["foo"], cmd: "bar" };
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec)).toEqual(
         NOTBOTHCMDARGS_ERRORS
       );
     });
 
-    it("should return all errors if neither is defined", function() {
+    it("returns all errors if neither is defined", function() {
       const spec = {};
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec)).toEqual(
         CMDORDOCKERIMAGE_ERRORS
       );
     });
 
-    it("should return errors if `cmd` is null", function() {
+    it("returns errors if `cmd` is null", function() {
       const spec = { cmd: null };
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec)).toEqual(
         CMDORDOCKERIMAGE_ERRORS
       );
     });
 
-    it("should return errors if `cmd` is {}", function() {
+    it("returns errors if `cmd` is {}", function() {
       const spec = { cmd: {} };
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec)).toEqual(
         CMDORDOCKERIMAGE_ERRORS
       );
     });
 
-    it("should return errors if `cmd` is []", function() {
+    it("returns errors if `cmd` is []", function() {
       const spec = { cmd: [] };
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec)).toEqual(
         CMDORDOCKERIMAGE_ERRORS
       );
     });
 
-    it("should return errors if `cmd` is empty string", function() {
+    it("returns errors if `cmd` is empty string", function() {
       const spec = { cmd: "" };
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec)).toEqual(
         CMDORDOCKERIMAGE_ERRORS
       );
     });
 
-    it("should return errors if `container` is empty", function() {
+    it("returns errors if `container` is empty", function() {
       const spec = { container: {} };
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec)).toEqual(
         CMDORDOCKERIMAGE_ERRORS
       );
     });
 
-    it("should return errors if `container.docker` is empty", function() {
+    it("returns errors if `container.docker` is empty", function() {
       const spec = { container: { docker: {} } };
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec)).toEqual(
         CMDORDOCKERIMAGE_ERRORS
       );
     });
 
-    it("should return errors if `container.appc` is empty", function() {
+    it("returns errors if `container.appc` is empty", function() {
       const spec = { container: { appc: {} } };
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec)).toEqual(
         CMDORDOCKERIMAGE_ERRORS
       );
     });
 
-    it('should return errors if `container.appc.id` does not start with "sha512-"', function() {
+    it('returns errors if `container.appc.id` does not start with "sha512-"', function() {
       const spec = { container: { appc: { image: "foo", id: "sha256-test" } } };
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec)).toEqual(
         APPCONTAINERID_ERRORS
       );
     });
 
-    it("should not return errors if `container.appc` correctly defined", function() {
+    it("does not return errors if `container.appc` correctly defined", function() {
       const spec = { container: { appc: { image: "foo", id: "sha512-test" } } };
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec)).toEqual(
         []
@@ -199,31 +199,31 @@ describe("MarathonAppValidators", function() {
   });
 
   describe("#complyWithResidencyRules", function() {
-    it("should return no errors if residency and container is undefined", function() {
+    it("returns no errors if residency and container is undefined", function() {
       const spec = {};
 
       expect(MarathonAppValidators.complyWithResidencyRules(spec)).toEqual([]);
     });
 
-    it("should return no errors if residency and volumes is undefined", function() {
+    it("returns no errors if residency and volumes is undefined", function() {
       const spec = { container: {} };
 
       expect(MarathonAppValidators.complyWithResidencyRules(spec)).toEqual([]);
     });
 
-    it("should return no errors if residency is undefined and volumes empty", function() {
+    it("returns no errors if residency is undefined and volumes empty", function() {
       const spec = { container: { volumes: [] } };
 
       expect(MarathonAppValidators.complyWithResidencyRules(spec)).toEqual([]);
     });
 
-    it("should return no errors if residency and persistent is undefined", function() {
+    it("returns no errors if residency and persistent is undefined", function() {
       const spec = { container: { volumes: [{}] } };
 
       expect(MarathonAppValidators.complyWithResidencyRules(spec)).toEqual([]);
     });
 
-    it("should return no errors if both of residency and persistent is defined", function() {
+    it("returns no errors if both of residency and persistent is defined", function() {
       const spec = {
         residency: "foo",
         container: { volumes: [{ persistent: { size: "524288" } }] }
@@ -232,7 +232,7 @@ describe("MarathonAppValidators", function() {
       expect(MarathonAppValidators.complyWithResidencyRules(spec)).toEqual([]);
     });
 
-    it("should return errors if only `residency` defined", function() {
+    it("returns errors if only `residency` defined", function() {
       const spec = { residency: "foo" };
 
       expect(MarathonAppValidators.complyWithResidencyRules(spec)).toEqual(
@@ -240,7 +240,7 @@ describe("MarathonAppValidators", function() {
       );
     });
 
-    it("should return errors if only `persistentVolumes` defined", function() {
+    it("returns errors if only `persistentVolumes` defined", function() {
       const spec = {
         container: { volumes: [{ persistent: { size: "524288" } }] }
       };
@@ -252,7 +252,7 @@ describe("MarathonAppValidators", function() {
   });
 
   describe("#mustContainImageOnDocker", function() {
-    it("should return error if runtime is docker but image is missing", function() {
+    it("returns error if runtime is docker but image is missing", function() {
       const spec = {
         container: {
           type: "DOCKER"
@@ -263,7 +263,7 @@ describe("MarathonAppValidators", function() {
       );
     });
 
-    it("should not return error if runtime is not docker and image is missing", function() {
+    it("does not return error if runtime is not docker and image is missing", function() {
       const spec = {
         container: {
           type: "MESOS"
@@ -272,7 +272,7 @@ describe("MarathonAppValidators", function() {
       expect(MarathonAppValidators.mustContainImageOnDocker(spec)).toEqual([]);
     });
 
-    it("should not return error if runtime docker and image is specified", function() {
+    it("does not return error if runtime docker and image is specified", function() {
       const spec = {
         container: {
           type: "DOCKER",
@@ -365,7 +365,7 @@ describe("MarathonAppValidators", function() {
       ]);
     });
 
-    it("shouldn't return an error for empty optional fields", function() {
+    it("doesn't return an error for empty optional fields", function() {
       const spec = {
         constraints: [["hostname", "GROUP_BY"]]
       };
@@ -395,12 +395,12 @@ describe("MarathonAppValidators", function() {
   });
 
   describe("#validateLabels", function() {
-    it("should not return error if labels are not specified", function() {
+    it("does not return error if labels are not specified", function() {
       const spec = {};
       expect(MarathonAppValidators.validateLabels(spec)).toEqual([]);
     });
 
-    it("should not return error if label keys do not start or end with spaces", function() {
+    it("does not return error if label keys do not start or end with spaces", function() {
       const spec = {
         labels: {
           foo: "bar",
@@ -410,7 +410,7 @@ describe("MarathonAppValidators", function() {
       expect(MarathonAppValidators.validateLabels(spec)).toEqual([]);
     });
 
-    it("should return errors if any label key starts with a space", function() {
+    it("returns errors if any label key starts with a space", function() {
       const spec = {
         labels: {
           " foo": "bar",
@@ -429,7 +429,7 @@ describe("MarathonAppValidators", function() {
       ]);
     });
 
-    it("should return errors if any label key ends with a space", function() {
+    it("returns errors if any label key ends with a space", function() {
       const spec = {
         labels: {
           "foo ": "bar",

--- a/src/js/components/__tests__/Authenticated-test.js
+++ b/src/js/components/__tests__/Authenticated-test.js
@@ -33,7 +33,7 @@ describe("Authenticated", function() {
     ReactDOM.unmountComponentAtNode(this.container);
   });
 
-  it("should redirect to /login if user is not logged in", function() {
+  it("redirects to /login if user is not logged in", function() {
     this.callback = jasmine.createSpy();
     Hooks.addAction("redirectToLogin", function(nextState, replace) {
       replace("/login");
@@ -42,7 +42,7 @@ describe("Authenticated", function() {
     expect(this.callback).toHaveBeenCalledWith("/login");
   });
 
-  it("shouldn't call redirect when user is not logged in", function() {
+  it("doesn't call redirect when user is not logged in", function() {
     AuthStore.isLoggedIn = function() {
       return true;
     };
@@ -51,7 +51,7 @@ describe("Authenticated", function() {
     expect(this.callback).not.toHaveBeenCalled();
   });
 
-  it("should render component when user is logged in", function() {
+  it("renders component when user is logged in", function() {
     var renderedComponent = ReactDOM.render(<this.instance />, this.container);
     var component = TestUtils.findRenderedDOMComponentWithTag(
       renderedComponent,

--- a/src/js/components/__tests__/ComponentList-test.js
+++ b/src/js/components/__tests__/ComponentList-test.js
@@ -26,7 +26,7 @@ describe("#ComponentList", function() {
   });
 
   describe("#getSortedHealthValues", function() {
-    it("should sort health units by visibility importance", function() {
+    it("sorts health units by visibility importance", function() {
       /**
        * health status visibility importance order top to bottom
        * unhealthy > NA > warn/idle > healthy
@@ -90,7 +90,7 @@ describe("#ComponentList", function() {
   });
 
   describe("#getVisibleComponents", function() {
-    it("should only return the number of visible units", function() {
+    it("only returns the number of visible units", function() {
       const unitsVisible = this.component.getVisibleComponents(
         healthUnits.getItems()
       );

--- a/src/js/components/__tests__/DescriptionList-test.js
+++ b/src/js/components/__tests__/DescriptionList-test.js
@@ -15,14 +15,14 @@ describe("HashMapDisplay", function() {
     ReactDOM.unmountComponentAtNode(this.container);
   });
 
-  it("should return null if hash is not passed", function() {
+  it("returns null if hash is not passed", function() {
     var instance = ReactDOM.render(<HashMapDisplay />, this.container);
 
     var result = ReactDOM.findDOMNode(instance);
     expect(TestUtils.isDOMComponent(result)).toEqual(false);
   });
 
-  it("should return null if hash is not passed with headline", function() {
+  it("returns null if hash is not passed with headline", function() {
     var instance = ReactDOM.render(
       <HashMapDisplay headline="foo" />,
       this.container
@@ -32,7 +32,7 @@ describe("HashMapDisplay", function() {
     expect(TestUtils.isDOMComponent(result)).toEqual(false);
   });
 
-  it("should return null if undefined is passed to hash", function() {
+  it("returns null if undefined is passed to hash", function() {
     var instance = ReactDOM.render(
       <HashMapDisplay hash={undefined} />,
       this.container
@@ -42,7 +42,7 @@ describe("HashMapDisplay", function() {
     expect(TestUtils.isDOMComponent(result)).toEqual(false);
   });
 
-  it("should return null if empty object is passed to hash", function() {
+  it("returns null if empty object is passed to hash", function() {
     var instance = ReactDOM.render(
       <HashMapDisplay hash={{}} />,
       this.container
@@ -52,7 +52,7 @@ describe("HashMapDisplay", function() {
     expect(TestUtils.isCompositeComponent(result)).toEqual(false);
   });
 
-  it("should return a node of elements if node exists", function() {
+  it("returns a node of elements if node exists", function() {
     var instance = ReactDOM.render(
       <HashMapDisplay hash={{ foo: "bar" }} />,
       this.container
@@ -62,7 +62,7 @@ describe("HashMapDisplay", function() {
     expect(TestUtils.isDOMComponent(result)).toEqual(true);
   });
 
-  it("should return a headline if headline string is given", function() {
+  it("returns a headline if headline string is given", function() {
     var instance = ReactDOM.render(
       <HashMapDisplay hash={{ foo: "bar" }} headline="baz" />,
       this.container

--- a/src/js/components/__tests__/ExpandingTable-test.js
+++ b/src/js/components/__tests__/ExpandingTable-test.js
@@ -18,7 +18,7 @@ describe("ExpandingTable", function() {
 
   describe("#render", function() {
     describe("#expandRow", function() {
-      it("should add a row to state.expandedRows", function() {
+      it("adds a row to state.expandedRows", function() {
         const instance = ReactDOM.render(
           <ExpandingTable columns={this.columns} data={this.rows} />,
           this.container
@@ -41,7 +41,7 @@ describe("ExpandingTable", function() {
         expect(instance.state.expandedRows["foo"]).toBeFalsy();
       });
 
-      it("should allow multiple rows in state.expandedRows", function() {
+      it("allows multiple rows in state.expandedRows", function() {
         const instance = ReactDOM.render(
           <ExpandingTable columns={this.columns} data={this.rows} />,
           this.container
@@ -54,7 +54,7 @@ describe("ExpandingTable", function() {
         expect(instance.state.expandedRows["bar"]).toBeTruthy();
       });
 
-      it("should expand all rows on mount when expandRowsByDefault is true", function() {
+      it("expands all rows on mount when expandRowsByDefault is true", function() {
         const instance = ReactDOM.render(
           <ExpandingTable
             columns={this.columns}
@@ -76,7 +76,7 @@ describe("ExpandingTable", function() {
     });
 
     describe("#getRenderer", function() {
-      it("should proxy the render method on each column", function() {
+      it("proxies the render method on each column", function() {
         const renderSpy = jasmine.createSpy("renderSpy");
         this.columns[0].render = renderSpy;
 

--- a/src/js/components/__tests__/JSONEditor-test.js
+++ b/src/js/components/__tests__/JSONEditor-test.js
@@ -26,7 +26,7 @@ describe("JSONEditor", function() {
       cmd: "while true; do sleep 10; done"
     };
 
-    it("should prevent unnecessary component updates", function() {
+    it("prevents unnecessary component updates", function() {
       const instance = ReactDOM.render(
         <JSONEditor value={initialValue} />,
         this.container
@@ -42,7 +42,7 @@ describe("JSONEditor", function() {
       expect(instance.shouldComponentUpdate(nextProps, nextState)).toBe(false);
     });
 
-    it("should update the component if the internal data has changed", function() {
+    it("updates the component if the internal data has changed", function() {
       const instance = ReactDOM.render(
         <JSONEditor value={initialValue} />,
         this.container
@@ -74,7 +74,7 @@ describe("JSONEditor", function() {
           "cmd": "while true; do sleep 10; done"
         }`;
 
-    it("should call on change handler with new value", function() {
+    it("calls on change handler with new value", function() {
       const onChangeHandler = jest.fn();
       const instance = ReactDOM.render(
         <JSONEditor onChange={onChangeHandler} />,
@@ -86,7 +86,7 @@ describe("JSONEditor", function() {
       expect(onChangeHandler).toBeCalledWith(JSON.parse(validJSONText));
     });
 
-    it("should not call on change handler with invalid value", function() {
+    it("does not call on change handler with invalid value", function() {
       const onChangeHandler = jest.fn();
       const instance = ReactDOM.render(
         <JSONEditor onChange={onChangeHandler} />,
@@ -97,7 +97,7 @@ describe("JSONEditor", function() {
       expect(onChangeHandler).not.toBeCalled();
     });
 
-    it("should call on change handler with new value after error was resolved", function() {
+    it("calls on change handler with new value after error was resolved", function() {
       const onChangeHandler = jest.fn();
       const instance = ReactDOM.render(
         <JSONEditor onChange={onChangeHandler} />,
@@ -110,7 +110,7 @@ describe("JSONEditor", function() {
       expect(onChangeHandler).toBeCalledWith(JSON.parse(validJSONText));
     });
 
-    it("should call error state change handler if new error was detected", function() {
+    it("calls error state change handler if new error was detected", function() {
       const onErrorStateChangeHandler = jest.fn();
       const instance = ReactDOM.render(
         <JSONEditor onErrorStateChange={onErrorStateChangeHandler} />,
@@ -122,7 +122,7 @@ describe("JSONEditor", function() {
       expect(onErrorStateChangeHandler).toBeCalled();
     });
 
-    it("should call error state change handler if error was resolved", function() {
+    it("calls error state change handler if error was resolved", function() {
       const onChangeHandler = jest.fn();
       const onErrorStateChangeHandler = jest.fn();
       const instance = ReactDOM.render(
@@ -139,7 +139,7 @@ describe("JSONEditor", function() {
       expect(onErrorStateChangeHandler.mock.calls.length).toEqual(2);
     });
 
-    it("should properly handle JSON change even with interfering prop updates", function() {
+    it("handles JSON change even with interfering prop updates", function() {
       jest.useFakeTimers();
 
       let instance = null;
@@ -171,7 +171,7 @@ describe("JSONEditor", function() {
   });
 
   describe("#updateLocalJsonState", function() {
-    it("should accept `null` as an argument", function() {
+    it("accepts `null` as an argument", function() {
       const instance = ReactDOM.render(
         <JSONEditor value={{}} />,
         this.container
@@ -185,7 +185,7 @@ describe("JSONEditor", function() {
       expect(instance.jsonError).toEqual(null);
     });
 
-    it("should update all properties as given", function() {
+    it("updates all properties as given", function() {
       const instance = ReactDOM.render(
         <JSONEditor value={{}} />,
         this.container
@@ -206,7 +206,7 @@ describe("JSONEditor", function() {
   });
 
   describe("#getNewJsonState", function() {
-    it("should return `null` if the text has not changed", function() {
+    it("returns `null` if the text has not changed", function() {
       const instance = ReactDOM.render(
         <JSONEditor value={{}} />,
         this.container
@@ -215,7 +215,7 @@ describe("JSONEditor", function() {
       expect(instance.getNewJsonState("{}")).toEqual(null);
     });
 
-    it("should return errors if JSON is invalid", function() {
+    it("returns errors if JSON is invalid", function() {
       const instance = ReactDOM.render(
         <JSONEditor value={{}} />,
         this.container
@@ -229,7 +229,7 @@ describe("JSONEditor", function() {
       });
     });
 
-    it("should return the correct state on new JSON", function() {
+    it("returns the correct state on new JSON", function() {
       const instance = ReactDOM.render(
         <JSONEditor value={{}} />,
         this.container

--- a/src/js/components/__tests__/Panel-test.js
+++ b/src/js/components/__tests__/Panel-test.js
@@ -31,7 +31,7 @@ describe("Panel", function() {
   });
 
   describe("#render", function() {
-    it("should render children", function() {
+    it("renders children", function() {
       var child = TestUtils.findRenderedDOMComponentWithClass(
         this.instance,
         "quis"
@@ -39,13 +39,13 @@ describe("Panel", function() {
       expect(TestUtils.isDOMComponent(child)).toBe(true);
     });
 
-    it("should render with given className", function() {
+    it("renders with given className", function() {
       var panel = TestUtils.findRenderedComponentWithType(this.instance, Panel);
       var node = ReactDOM.findDOMNode(panel);
       expect(node.className).toContain("foo");
     });
 
-    it("should override className to content node", function() {
+    it("overrides className to content node", function() {
       var content = TestUtils.findRenderedDOMComponentWithClass(
         this.instance,
         "bar"
@@ -54,7 +54,7 @@ describe("Panel", function() {
       expect(node.className).toContain("bar");
     });
 
-    it("should use default className to content node", function() {
+    it("uses default className to content node", function() {
       var content = TestUtils.findRenderedDOMComponentWithClass(
         ReactDOM.render(<Panel />, this.container),
         "panel-content"
@@ -63,7 +63,7 @@ describe("Panel", function() {
       expect(node.className).toContain("panel-content");
     });
 
-    it("should override className to footer node", function() {
+    it("overrides className to footer node", function() {
       var footer = TestUtils.findRenderedDOMComponentWithClass(
         this.instance,
         "bar"
@@ -72,7 +72,7 @@ describe("Panel", function() {
       expect(node.className).toContain("bar");
     });
 
-    it("should use default className to footer node", function() {
+    it("uses default className to footer node", function() {
       var footer = TestUtils.findRenderedDOMComponentWithClass(
         ReactDOM.render(<Panel footer="footer" />, this.container),
         "panel-footer"
@@ -81,7 +81,7 @@ describe("Panel", function() {
       expect(node.className).toContain("panel-footer");
     });
 
-    it("should not render footer when none is given", function() {
+    it("does not render footer when none is given", function() {
       var panel = ReactDOM.render(<Panel />, this.container);
       expect(
         TestUtils.scryRenderedDOMComponentsWithClass(panel, "panel-footer")
@@ -89,7 +89,7 @@ describe("Panel", function() {
       ).toBe(0);
     });
 
-    it("should override className to heading node", function() {
+    it("overrides className to heading node", function() {
       var heading = TestUtils.findRenderedDOMComponentWithClass(
         this.instance,
         "bar"
@@ -98,7 +98,7 @@ describe("Panel", function() {
       expect(node.className).toContain("bar");
     });
 
-    it("should use default className to heading node", function() {
+    it("uses default className to heading node", function() {
       var heading = TestUtils.findRenderedDOMComponentWithClass(
         ReactDOM.render(<Panel heading="heading" />, this.container),
         "panel-header"
@@ -107,7 +107,7 @@ describe("Panel", function() {
       expect(node.className).toContain("panel-header");
     });
 
-    it("should not render heading when none is given", function() {
+    it("does not render heading when none is given", function() {
       var panel = ReactDOM.render(<Panel />, this.container);
       expect(
         TestUtils.scryRenderedDOMComponentsWithClass(panel, "panel-header")
@@ -115,7 +115,7 @@ describe("Panel", function() {
       ).toBe(0);
     });
 
-    it("should be able to add an onClick to the panel node", function() {
+    it("is able to add an onClick to the panel node", function() {
       var panel = TestUtils.findRenderedComponentWithType(this.instance, Panel);
       TestUtils.Simulate.click(ReactDOM.findDOMNode(panel));
       expect(this.onClickSpy).toHaveBeenCalled();

--- a/src/js/components/__tests__/ProgressBar-test.js
+++ b/src/js/components/__tests__/ProgressBar-test.js
@@ -32,7 +32,7 @@ describe("#ProgressBar", function() {
   });
 
   describe("PropTypes", function() {
-    it("should throw an error if no data prop is provided", function() {
+    it("throws an error if no data prop is provided", function() {
       spyOn(console, "error");
       this.instance = ReactDOM.render(<ProgressBar />, this.container);
       expect(console.error).toHaveBeenCalledWith(
@@ -43,7 +43,7 @@ describe("#ProgressBar", function() {
       );
     });
 
-    it("should throw an error if a data item is missing a value", function() {
+    it("throws an error if a data item is missing a value", function() {
       spyOn(console, "error");
       this.instance = ReactDOM.render(
         <ProgressBar
@@ -63,7 +63,7 @@ describe("#ProgressBar", function() {
       );
     });
 
-    it("should throw an error if one data item is missing a value", function() {
+    it("throws an error if one data item is missing a value", function() {
       spyOn(console, "error");
       this.instance = ReactDOM.render(
         <ProgressBar
@@ -87,7 +87,7 @@ describe("#ProgressBar", function() {
       );
     });
 
-    it("should not throw an error if data does only contain a value field", function() {
+    it("does not throw an error if data does only contain a value field", function() {
       spyOn(console, "error");
       this.instance = ReactDOM.render(
         <ProgressBar
@@ -104,13 +104,13 @@ describe("#ProgressBar", function() {
   });
 
   describe("className", function() {
-    it("should contain status-bar (default)", function() {
+    it("contains status-bar (default)", function() {
       expect(
         this.container.querySelector("div").classList.contains("status-bar")
       ).toBeTruthy();
     });
 
-    it("should contain test-bar (custom)", function() {
+    it("contains test-bar (custom)", function() {
       this.instance = ReactDOM.render(
         <ProgressBar data={testData} className="test-bar" />,
         this.container
@@ -122,14 +122,14 @@ describe("#ProgressBar", function() {
   });
 
   describe("bars", function() {
-    it("should contain 2 .bars", function() {
+    it("contains 2 .bars", function() {
       expect(this.container.querySelectorAll(".bar").length).toEqual(
         testData.length
       );
     });
 
     describe("First .bar", function() {
-      it("should contain class name status", function() {
+      it("contains class name status", function() {
         expect(
           this.container
             .querySelector(".bar:first-child")
@@ -137,7 +137,7 @@ describe("#ProgressBar", function() {
         ).toBeTruthy();
       });
 
-      it("should have the class element-{index} if no classname is provided", function() {
+      it("has the class element-{index} if no classname is provided", function() {
         this.instance = ReactDOM.render(
           <ProgressBar
             data={[
@@ -153,7 +153,7 @@ describe("#ProgressBar", function() {
         ).toBeTruthy();
       });
 
-      it("should have a width of 40%", function() {
+      it("has a width of 40%", function() {
         expect(
           this.container.querySelector(".bar:first-child").style.width
         ).toEqual("40%");
@@ -161,7 +161,7 @@ describe("#ProgressBar", function() {
     });
 
     describe("Second .bar", function() {
-      it("should contain class name failed", function() {
+      it("contains class name failed", function() {
         expect(
           this.container
             .querySelector(".bar:nth-child(2)")
@@ -169,7 +169,7 @@ describe("#ProgressBar", function() {
         ).toBeTruthy();
       });
 
-      it("should have a width of 60%", function() {
+      it("has a width of 60%", function() {
         expect(
           this.container.querySelector(".bar:nth-child(2)").style.width
         ).toEqual("60%");
@@ -177,7 +177,7 @@ describe("#ProgressBar", function() {
     });
 
     describe("Growing small .bar portions to be visible when below threshold", function() {
-      it("should not have .bar elements < 7% width", function() {
+      it("does not have .bar elements < 7% width", function() {
         ReactDOM.render(
           <ProgressBar
             data={[
@@ -202,7 +202,7 @@ describe("#ProgressBar", function() {
         expect(percentages.filter(percent => percent < 7).length).toBe(0);
       });
 
-      it("should not have .bar elements < 7% width when using scale", function() {
+      it("does not have .bar elements < 7% width when using scale", function() {
         ReactDOM.render(
           <ProgressBar
             data={[

--- a/src/js/components/__tests__/ServerErrorModal-test.js
+++ b/src/js/components/__tests__/ServerErrorModal-test.js
@@ -50,7 +50,7 @@ describe("ServerErrorModal", function() {
   });
 
   describe("#getContent", function() {
-    it("should return the same number of children as errors", function() {
+    it("returns the same number of children as errors", function() {
       this.instance.state.errors = [1, 2, 3];
       var contents = this.instance.getContent();
       var result = contents.props.children;

--- a/src/js/components/__tests__/TabButton-test.js
+++ b/src/js/components/__tests__/TabButton-test.js
@@ -9,7 +9,7 @@ describe("TabButton", function() {
     this.clickHandler = jasmine.createSpy("click handler");
   });
 
-  it("should call the onClick prop with ID when clicked", function() {
+  it("calls the onClick prop with ID when clicked", function() {
     this.instance = TestUtils.renderIntoDocument(
       <TabButton label="foo" onClick={this.clickHandler} id="foo" />
     );
@@ -24,7 +24,7 @@ describe("TabButton", function() {
     expect(this.clickHandler).toHaveBeenCalledWith("foo");
   });
 
-  it("should clone nested TabButton instances with onClick and activeTab props", function() {
+  it("clones nested TabButton instances with onClick and activeTab props", function() {
     this.instance = TestUtils.renderIntoDocument(
       <TabButton
         activeTab="foo"
@@ -45,7 +45,7 @@ describe("TabButton", function() {
     expect(nestedInstance.props.onClick).toEqual(this.clickHandler);
   });
 
-  it("should call the parent onClick when clicking a nested TabButton", function() {
+  it("calls the parent onClick when clicking a nested TabButton", function() {
     this.instance = TestUtils.renderIntoDocument(
       <TabButton
         activeTab="foo"

--- a/src/js/components/__tests__/TabButtonList-test.js
+++ b/src/js/components/__tests__/TabButtonList-test.js
@@ -9,7 +9,7 @@ describe("TabButtonList", function() {
     this.changeHandler = jasmine.createSpy("change handler");
   });
 
-  it("should pass onChange as click handler for each TabButton instance", function() {
+  it("passes onChange as click handler for each TabButton instance", function() {
     this.instance = TestUtils.renderIntoDocument(
       <TabButtonList onChange={this.changeHandler}>
         <TabButton id="foo" />
@@ -28,7 +28,7 @@ describe("TabButtonList", function() {
     });
   });
 
-  it("should set only first child to active if no active tab is defined", function() {
+  it("sets only first child to active if no active tab is defined", function() {
     this.instance = TestUtils.renderIntoDocument(
       <TabButtonList>
         <TabButton id="foo" />
@@ -51,7 +51,7 @@ describe("TabButtonList", function() {
     });
   });
 
-  it("should pass active prop to instance whose ID matches activeTab", function() {
+  it("passes active prop to instance whose ID matches activeTab", function() {
     this.instance = TestUtils.renderIntoDocument(
       <TabButtonList activeTab="bar">
         <TabButton id="foo" />

--- a/src/js/components/__tests__/TabViewList-test.js
+++ b/src/js/components/__tests__/TabViewList-test.js
@@ -6,7 +6,7 @@ const TabView = require("../TabView");
 const TabViewList = require("../TabViewList");
 
 describe("TabViewList", function() {
-  it("should return content of first child if no activeTab is defined", function() {
+  it("returns content of first child if no activeTab is defined", function() {
     this.instance = TestUtils.renderIntoDocument(
       <TabViewList>
         <TabView id="foo">foo</TabView>
@@ -19,7 +19,7 @@ describe("TabViewList", function() {
     expect(node.textContent).toEqual("foo");
   });
 
-  it("should return content of activeTab when defined", function() {
+  it("returns content of activeTab when defined", function() {
     this.instance = TestUtils.renderIntoDocument(
       <TabViewList activeTab="bar">
         <TabView id="foo">foo</TabView>

--- a/src/js/components/__tests__/Tabs-test.js
+++ b/src/js/components/__tests__/Tabs-test.js
@@ -60,7 +60,7 @@ describe("Tabs", function() {
     expect(this.handleTabChange.mock.calls[0]).toEqual(["bar"]);
   });
 
-  it("should update to the correct active tab", function() {
+  it("updates to the correct active tab", function() {
     let activeTab = ReactDOM.findDOMNode(this.instance).querySelector(
       ".menu-tabbed-item.active .menu-tabbed-item-label"
     );
@@ -104,7 +104,7 @@ describe("Tabs", function() {
     expect(activeTab.textContent).toEqual("Qux");
   });
 
-  it("should pass the activeTab prop to its children", function() {
+  it("passes the activeTab prop to its children", function() {
     const tabButtons = ReactDOM.findDOMNode(this.instance).querySelectorAll(
       ".menu-tabbed-item"
     );
@@ -127,7 +127,7 @@ describe("Tabs", function() {
     expect(tabButtonsInstance.props.activeTab).toEqual("foo");
   });
 
-  it("should pass the change handler to TabButtonList", function() {
+  it("passes the change handler to TabButtonList", function() {
     const tabButtonsInstance = TestUtils.scryRenderedComponentsWithType(
       this.instance,
       TabButtonList
@@ -135,7 +135,7 @@ describe("Tabs", function() {
     expect(tabButtonsInstance.props.onChange).toEqual(this.handleTabChange);
   });
 
-  it("should pass the vertical prop to TabButtonList", function() {
+  it("passes the vertical prop to TabButtonList", function() {
     const tabButtonsInstance = TestUtils.scryRenderedComponentsWithType(
       this.instance,
       TabButtonList

--- a/src/js/components/charts/__tests__/ChartStripes-test.js
+++ b/src/js/components/charts/__tests__/ChartStripes-test.js
@@ -19,7 +19,7 @@ describe("ChartStripes", function() {
     ReactDOM.unmountComponentAtNode(this.container);
   });
 
-  it("should display the correct number of stripes", function() {
+  it("displays the correct number of stripes", function() {
     var stripes = TestUtils.scryRenderedDOMComponentsWithClass(
       this.instance,
       "background"
@@ -27,7 +27,7 @@ describe("ChartStripes", function() {
     expect(stripes.length).toEqual(6);
   });
 
-  it("should have correct width on each stripe", function() {
+  it("has correct width on each stripe", function() {
     var stripes = TestUtils.scryRenderedDOMComponentsWithClass(
       this.instance,
       "background"
@@ -40,7 +40,7 @@ describe("ChartStripes", function() {
     });
   });
 
-  it("should have correct x value on each stripe", function() {
+  it("has correct x value on each stripe", function() {
     var stripes = TestUtils.scryRenderedDOMComponentsWithClass(
       this.instance,
       "background"
@@ -53,7 +53,7 @@ describe("ChartStripes", function() {
     });
   });
 
-  it("should update to parameter change accordingly", function() {
+  it("updates to parameter change accordingly", function() {
     var stripes = TestUtils.scryRenderedDOMComponentsWithClass(
       this.instance,
       "background"

--- a/src/js/components/charts/__tests__/TasksChart-test.js
+++ b/src/js/components/charts/__tests__/TasksChart-test.js
@@ -59,13 +59,13 @@ describe("TasksChart", function() {
       ReactDOM.unmountComponentAtNode(this.container);
     });
 
-    it("should allow update", function() {
+    it("allows update", function() {
       this.tasks.TASK_STAGING = 1;
       var shouldUpdate = this.instance.shouldComponentUpdate(this.tasks);
       expect(shouldUpdate).toEqual(true);
     });
 
-    it("should not allow update", function() {
+    it("does not allow update", function() {
       var shouldUpdate = this.instance.shouldComponentUpdate(
         this.instance.props
       );

--- a/src/js/components/charts/__tests__/TimeSeriesArea-test.js
+++ b/src/js/components/charts/__tests__/TimeSeriesArea-test.js
@@ -73,11 +73,11 @@ describe("TimeSeriesArea", function() {
     ReactDOM.unmountComponentAtNode(this.container);
   });
 
-  it("should render a path according to first data set", function() {
+  it("renders a path according to first data set", function() {
     checkPath(this.instance, this.props);
   });
 
-  it("should render a path according to second data set", function() {
+  it("renders a path according to second data set", function() {
     this.props.values = MockTimeSeriesData.secondSet;
     var area = this.areaDef(this.props.values);
     var valueLine = this.valueLineDef(this.props.values);
@@ -95,7 +95,7 @@ describe("TimeSeriesArea", function() {
     checkPath(this.instance, this.props);
   });
 
-  it("should check that the path is correctly updated", function() {
+  it("checks that the path is correctly updated", function() {
     checkPath(this.instance, this.props);
     this.props.values = MockTimeSeriesData.secondSet;
     var area = this.areaDef(this.props.values);

--- a/src/js/components/charts/__tests__/TimeSeriesChart-test.js
+++ b/src/js/components/charts/__tests__/TimeSeriesChart-test.js
@@ -22,27 +22,27 @@ describe("TimeSeriesChart", function() {
       ReactDOM.unmountComponentAtNode(this.container);
     });
 
-    it("should call #renderAxis", function() {
+    it("calls #renderAxis", function() {
       var props = Object.assign({ foo: "bar" }, this.instance.props);
       this.instance.shouldComponentUpdate(props);
 
       expect(this.instance.renderAxis).toHaveBeenCalled();
     });
 
-    it("should not call #renderAxis", function() {
+    it("does not call #renderAxis", function() {
       this.instance.shouldComponentUpdate(this.instance.props);
 
       expect(this.instance.renderAxis).not.toHaveBeenCalled();
     });
 
-    it("should return truthy", function() {
+    it("returns truthy", function() {
       var props = Object.assign({ foo: "bar" }, this.instance.props);
       var _return = this.instance.shouldComponentUpdate(props);
 
       expect(_return).toEqual(true);
     });
 
-    it("should return truthy", function() {
+    it("returns truthy", function() {
       var data = [
         {
           values: [{ date: 0, y: 0 }, { date: 1, y: 0 }, { date: 2, y: 0 }]
@@ -62,7 +62,7 @@ describe("TimeSeriesChart", function() {
       expect(_return).toEqual(true);
     });
 
-    it("should return falsy", function() {
+    it("returns falsy", function() {
       var _return = this.instance.shouldComponentUpdate(this.instance.props);
 
       expect(_return).toEqual(false);

--- a/src/js/components/charts/__tests__/TimeSeriesLabel-test.js
+++ b/src/js/components/charts/__tests__/TimeSeriesLabel-test.js
@@ -19,7 +19,7 @@ describe("TimeSeriesLabel", function() {
     ReactDOM.unmountComponentAtNode(this.container);
   });
 
-  it("should display the correct label", function() {
+  it("displays the correct label", function() {
     // Verify that percentage is set correctly
     var title = TestUtils.findRenderedDOMComponentWithClass(
       this.instance,
@@ -28,7 +28,7 @@ describe("TimeSeriesLabel", function() {
     expect(ReactDOM.findDOMNode(title).textContent).toEqual("10%");
   });
 
-  it("should display the correct sub heading", function() {
+  it("displays the correct sub heading", function() {
     // Verify that percentage is set correctly
     var label = TestUtils.findRenderedDOMComponentWithClass(
       this.instance,
@@ -37,7 +37,7 @@ describe("TimeSeriesLabel", function() {
     expect(ReactDOM.findDOMNode(label).textContent).toBe("Foo");
   });
 
-  it("should set sub heading text color", function() {
+  it("sets sub heading text color", function() {
     // Verify that percentage is set correctly
     var label = TestUtils.findRenderedDOMComponentWithClass(
       this.instance,

--- a/src/js/components/modals/__tests__/CliInstallModal-test.js
+++ b/src/js/components/modals/__tests__/CliInstallModal-test.js
@@ -36,11 +36,11 @@ describe("CliInstallModal", function() {
       ReactDOM.unmountComponentAtNode(this.container);
     });
 
-    it("shouldn't call the callback after initialization", function() {
+    it("doesn't call the callback after initialization", function() {
       expect(this.callback).not.toHaveBeenCalled();
     });
 
-    it("should call the callback when #onClose is called", function() {
+    it("calls the callback when #onClose is called", function() {
       this.instance.onClose();
       expect(this.callback).toHaveBeenCalled();
     });

--- a/src/js/components/modals/__tests__/ErrorModal-test.js
+++ b/src/js/components/modals/__tests__/ErrorModal-test.js
@@ -20,11 +20,11 @@ describe("ErrorModal", function() {
       ReactDOM.unmountComponentAtNode(this.container);
     });
 
-    it("shouldn't call the callback after initialization", function() {
+    it("doesn't call the callback after initialization", function() {
       expect(this.callback).not.toHaveBeenCalled();
     });
 
-    it("should call the callback when #onClose is called", function() {
+    it("calls the callback when #onClose is called", function() {
       this.instance.onClose();
       expect(this.callback).toHaveBeenCalled();
     });

--- a/src/js/components/modals/__tests__/VersionsModal-test.js
+++ b/src/js/components/modals/__tests__/VersionsModal-test.js
@@ -21,11 +21,11 @@ describe("VersionsModal", function() {
       ReactDOM.unmountComponentAtNode(this.container);
     });
 
-    it("shouldn't call the callback after initialization", function() {
+    it("doesn't call the callback after initialization", function() {
       expect(this.callback).not.toHaveBeenCalled();
     });
 
-    it("should call the callback when #onClose is called", function() {
+    it("calls the callback when #onClose is called", function() {
       this.instance.onClose();
       expect(this.callback).toHaveBeenCalled();
     });
@@ -49,14 +49,14 @@ describe("VersionsModal", function() {
       ReactDOM.unmountComponentAtNode(this.container);
     });
 
-    it("should return a pre element tag", function() {
+    it("returns a pre element tag", function() {
       var content = this.instance.getContent();
       var contentInstance = ReactDOM.render(content, this.container);
       var node = ReactDOM.findDOMNode(contentInstance);
       expect(node.tagName).toBe("PRE");
     });
 
-    it("should return a pre element tag", function() {
+    it("returns a pre element tag", function() {
       var content = this.instance.getContent();
       var contentInstance = ReactDOM.render(content, this.container);
       var node = ReactDOM.findDOMNode(contentInstance);

--- a/src/js/mixins/__tests__/ChartMixin-test.js
+++ b/src/js/mixins/__tests__/ChartMixin-test.js
@@ -43,38 +43,38 @@ describe("ChartMixin", function() {
       };
     });
 
-    it("should parse strings to numbers", function() {
+    it("parses strings to numbers", function() {
       const result = ChartMixin.formatXAxis.call({ props: this.props }, "0");
       expect(result).toEqual("0");
     });
 
-    it("should parse numbers", function() {
+    it("parses numbers", function() {
       const result = ChartMixin.formatXAxis.call({ props: this.props }, 3);
       expect(result).toEqual("3s");
     });
 
-    it("should not format zeros", function() {
+    it("does not format zeros", function() {
       const result = ChartMixin.formatXAxis.call({ props: this.props }, 0);
       expect(result).toEqual(0);
     });
 
-    it("should format positive numbers", function() {
+    it("formats positive numbers", function() {
       const result = ChartMixin.formatXAxis.call({ props: this.props }, 3);
       expect(result).toEqual("3s");
     });
 
-    it("should format negative numbers", function() {
+    it("formats negative numbers", function() {
       const result = ChartMixin.formatXAxis.call({ props: this.props }, -3);
       expect(result).toEqual("-3s");
     });
 
-    it("should return an empty string if it matches the value", function() {
+    it("returns an empty string if it matches the value", function() {
       this.props.axisConfiguration.x.hideMatch = /^0$/;
       const result = ChartMixin.formatXAxis.call({ props: this.props }, 0);
       expect(result).toEqual("");
     });
 
-    it("should return value if there's no match", function() {
+    it("returns value if there's no match", function() {
       this.props.axisConfiguration.x.hideMatch = /^10$/;
       const result = ChartMixin.formatXAxis.call({ props: this.props }, 0);
       expect(result).toEqual(0);
@@ -82,7 +82,7 @@ describe("ChartMixin", function() {
   });
 
   describe("#getXScale", function() {
-    it("should build the correct amount of ticks", function() {
+    it("builds the correct amount of ticks", function() {
       var props = this.props;
       var xScale = ChartMixin.getXScale(
         props.data,
@@ -92,7 +92,7 @@ describe("ChartMixin", function() {
       expect(xScale.ticks(4)).toEqual([-60, -40, -20, 0]);
     });
 
-    it("should have the correct domain range", function() {
+    it("has the correct domain range", function() {
       var props = this.props;
       var xScale = ChartMixin.getXScale(
         props.data,
@@ -104,12 +104,12 @@ describe("ChartMixin", function() {
   });
 
   describe("#getHeight", function() {
-    it("should return 0 given 0 height and 0 margin", function() {
+    it("returns 0 given 0 height and 0 margin", function() {
       var height = ChartMixin.getHeight(this.props);
       expect(height).toEqual(0);
     });
 
-    it("should return NaN when given a NaN argument", function() {
+    it("returns NaN when given a NaN argument", function() {
       var height = ChartMixin.getHeight({
         margin: {
           top: 10,
@@ -120,7 +120,7 @@ describe("ChartMixin", function() {
       expect(isNaN(height)).toEqual(true);
     });
 
-    it("should return a number when given a null argument", function() {
+    it("returns a number when given a null argument", function() {
       var height = ChartMixin.getHeight({
         margin: {
           top: null,
@@ -160,13 +160,13 @@ describe("ChartMixin", function() {
   });
 
   describe("#getWidth", function() {
-    it("should return 0 given 0 width and 0 margin", function() {
+    it("returns 0 given 0 width and 0 margin", function() {
       var width = ChartMixin.getWidth(this.props);
 
       expect(width).toEqual(0);
     });
 
-    it("should return NaN when given NaN argument", function() {
+    it("returns NaN when given NaN argument", function() {
       var width = ChartMixin.getWidth({
         margin: {
           left: 9,
@@ -177,7 +177,7 @@ describe("ChartMixin", function() {
       expect(isNaN(width)).toEqual(true);
     });
 
-    it("should return a number when given a null argument", function() {
+    it("returns a number when given a null argument", function() {
       var width = ChartMixin.getWidth({
         margin: {
           left: 9,

--- a/src/js/mixins/__tests__/InternalStorageMixin-test.js
+++ b/src/js/mixins/__tests__/InternalStorageMixin-test.js
@@ -7,13 +7,13 @@ describe("InternalStorageMixin", function() {
   });
 
   describe("#internalStorage_get", function() {
-    it("should return an empty object", function() {
+    it("returns an empty object", function() {
       var instance = this.instance;
 
       expect(instance.internalStorage_get()).toEqual({});
     });
 
-    it("should get the last set object", function() {
+    it("gets the last set object", function() {
       var instance = this.instance;
 
       instance.internalStorage_set({
@@ -33,7 +33,7 @@ describe("InternalStorageMixin", function() {
       });
     });
 
-    it("should get the last set value", function() {
+    it("gets the last set value", function() {
       var instance = this.instance;
 
       instance.internalStorage_set("teststring");
@@ -42,7 +42,7 @@ describe("InternalStorageMixin", function() {
       expect(instance.internalStorage_get()).toBe("second teststring");
     });
 
-    it("should get the updated object", function() {
+    it("gets the updated object", function() {
       var instance = this.instance;
 
       instance.internalStorage_set({
@@ -68,7 +68,7 @@ describe("InternalStorageMixin", function() {
   });
 
   describe("#internalStorage_update", function() {
-    it("should throw an error while try to update a non Object/Array", function() {
+    it("throws an error while try to update a non Object/Array", function() {
       var instance = this.instance;
 
       instance.internalStorage_set("teststring");

--- a/src/js/mixins/__tests__/QueryParamsMixin-test.js
+++ b/src/js/mixins/__tests__/QueryParamsMixin-test.js
@@ -37,7 +37,7 @@ describe("QueryParamsMixin", function() {
     );
   });
 
-  it("should transition to the right path with the given query params", function() {
+  it("transitions to the right path with the given query params", function() {
     const queryObject = {
       arrayValue: ["value1", "value2"],
       paramKey: "paramValue",
@@ -61,7 +61,7 @@ describe("QueryParamsMixin", function() {
     expect(decodedArrayString).toEqual(["a", "b", "c"]);
   });
 
-  it("should encode nested arrays in query params", function() {
+  it("encodes nested arrays in query params", function() {
     const queryObject = {
       arrayValue: ["value1", "value2"],
       nestedArray: ["1;2;3", "4;5;6", "", "7;;8", "non-array"],
@@ -87,7 +87,7 @@ describe("QueryParamsMixin", function() {
   });
 
   describe("#resetQueryParams", function() {
-    it("should reset all params by default", function() {
+    it("resets all params by default", function() {
       this.instance.resetQueryParams();
       expect(this.instance.context.router.push).toHaveBeenCalledWith({
         pathname: "/pathname",
@@ -95,7 +95,7 @@ describe("QueryParamsMixin", function() {
       });
     });
 
-    it("should reset only specified params, when present", function() {
+    it("resets only specified params, when present", function() {
       this.instance.resetQueryParams(["arrayValue"]);
       expect(this.instance.context.router.push).toHaveBeenCalledWith({
         pathname: "/pathname",
@@ -103,7 +103,7 @@ describe("QueryParamsMixin", function() {
       });
     });
 
-    it("should exit cleanly when called without a router", function() {
+    it("exits cleanly when called without a router", function() {
       expect(
         this.instance.resetQueryParams.bind({ context: {} })
       ).not.toThrow();

--- a/src/js/mixins/__tests__/SaveStateMixin-test.js
+++ b/src/js/mixins/__tests__/SaveStateMixin-test.js
@@ -30,14 +30,14 @@ describe("SaveStateMixin", function() {
       UserSettingsStore.getKey = this.prevGetKey;
     });
 
-    it("should set the previous state", function() {
+    it("sets the previous state", function() {
       this.instance.componentWillMount();
       expect(this.instance.setState).toHaveBeenCalledWith({ open: false });
     });
   });
 
   describe("#componentWillUnmount", function() {
-    it("should call #saveState_save", function() {
+    it("calls #saveState_save", function() {
       this.instance.saveState_save = jasmine.createSpy();
       this.instance.componentWillUnmount();
       expect(this.instance.saveState_save).toHaveBeenCalled();
@@ -64,13 +64,13 @@ describe("SaveStateMixin", function() {
       UserSettingsStore.setKey = this.prevSetKey;
     });
 
-    it("should not save any state", function() {
+    it("does not save any state", function() {
       this.instance.state = { open: false, errorCount: 9001 };
       this.instance.saveState_save();
       expect(UserSettingsStore.setKey).not.toHaveBeenCalled();
     });
 
-    it("should set the previous state", function() {
+    it("sets the previous state", function() {
       this.instance.saveState_properties = ["open", "errorCount"];
       this.instance.state = { open: false, errorCount: 9001 };
       this.instance.saveState_save();
@@ -79,7 +79,7 @@ describe("SaveStateMixin", function() {
       });
     });
 
-    it("should save specified keys", function() {
+    it("saves specified keys", function() {
       this.instance.saveState_properties = ["errorCount"];
       this.instance.state = { open: false, errorCount: 9001 };
       this.instance.saveState_save();

--- a/src/js/mixins/__tests__/TabsMixin-test.js
+++ b/src/js/mixins/__tests__/TabsMixin-test.js
@@ -20,21 +20,21 @@ describe("TabsMixin", function() {
       );
     });
 
-    it("should return an element", function() {
+    it("returns an element", function() {
       expect(TestUtils.isElement(this.instance)).toEqual(true);
     });
 
-    it("should return an element containing a link", function() {
+    it("returns an element containing a link", function() {
       expect(TestUtils.isElementOfType(this.instance, Link)).toEqual(true);
     });
 
-    it("should add custom props to span", function() {
+    it("adds custom props to span", function() {
       expect(
         TabsMixin.tabs_getRoutedItem({ other: true }, "foo").props.other
       ).toEqual(true);
     });
 
-    it("should remove existing className", function() {
+    it("removes existing className", function() {
       expect(
         TabsMixin.tabs_getUnroutedItem(
           { classNames: { "menu-tabbed-item-label": false } },
@@ -43,7 +43,7 @@ describe("TabsMixin", function() {
       ).toEqual("");
     });
 
-    it("should add custom class to link", function() {
+    it("adds custom class to link", function() {
       expect(this.instance.props.className).toEqual(
         "menu-tabbed-item-label foo"
       );
@@ -58,21 +58,21 @@ describe("TabsMixin", function() {
       );
     });
 
-    it("should return an element", function() {
+    it("returns an element", function() {
       expect(TestUtils.isElement(this.instance)).toEqual(true);
     });
 
-    it("should return an element containing a span", function() {
+    it("returns an element containing a span", function() {
       expect(this.instance.type).toEqual("span");
     });
 
-    it("should add custom props to span", function() {
+    it("adds custom props to span", function() {
       expect(
         TabsMixin.tabs_getUnroutedItem({ other: true }, "baz").props.other
       ).toEqual(true);
     });
 
-    it("should remove existing className", function() {
+    it("removes existing className", function() {
       expect(
         TabsMixin.tabs_getUnroutedItem(
           { classNames: { "menu-tabbed-item-label": false } },
@@ -81,7 +81,7 @@ describe("TabsMixin", function() {
       ).toEqual("");
     });
 
-    it("should add custom class to span", function() {
+    it("adds custom class to span", function() {
       expect(this.instance.props.className).toEqual(
         "menu-tabbed-item-label hux"
       );
@@ -93,7 +93,7 @@ describe("TabsMixin", function() {
       TabsMixin.state = { currentTab: "baz" };
     });
 
-    it("should call getTabs with appropriate arguments", function() {
+    it("calls getTabs with appropriate arguments", function() {
       spyOn(TabsUtil, "getTabs");
       TabsMixin.tabs_getUnroutedTabs(null);
 
@@ -105,7 +105,7 @@ describe("TabsMixin", function() {
       expect(TabsUtil.getTabs.calls.mostRecent().args[1]).toEqual("baz");
     });
 
-    it("should call tabs_getUnroutedItem with appropriate arguments", function() {
+    it("calls tabs_getUnroutedItem with appropriate arguments", function() {
       spyOn(TabsMixin, "tabs_getUnroutedItem");
       TabsMixin.tabs_getUnroutedTabs({ classNames: "quix" });
 
@@ -122,7 +122,7 @@ describe("TabsMixin", function() {
       TabsMixin.state = { currentTab: "foo" };
     });
 
-    it("should call getTabs with appropriate arguments", function() {
+    it("calls getTabs with appropriate arguments", function() {
       spyOn(TabsUtil, "getTabs");
       TabsMixin.tabs_getRoutedTabs(null);
 
@@ -134,7 +134,7 @@ describe("TabsMixin", function() {
       expect(TabsUtil.getTabs.calls.mostRecent().args[1]).toEqual("foo");
     });
 
-    it("should call tabs_getRoutedItem with appropriate arguments", function() {
+    it("calls tabs_getRoutedItem with appropriate arguments", function() {
       spyOn(TabsMixin, "tabs_getRoutedItem");
       TabsMixin.tabs_getRoutedTabs({ classNames: "quilt" });
 
@@ -154,24 +154,24 @@ describe("TabsMixin", function() {
       };
     });
 
-    it("should not call render function before called", function() {
+    it("does not call render function before called", function() {
       spyOn(TabsMixin, "renderGraultTabView");
       expect(TabsMixin.renderGraultTabView).not.toHaveBeenCalled();
     });
 
-    it("should call appropriate render function when called", function() {
+    it("calls appropriate render function when called", function() {
       spyOn(TabsMixin, "renderGraultTabView");
       TabsMixin.tabs_getTabView();
       expect(TabsMixin.renderGraultTabView).toHaveBeenCalled();
     });
 
-    it("should call appropriate render function when called", function() {
+    it("calls appropriate render function when called", function() {
       spyOn(TabsMixin, "renderGraultTabView");
       TabsMixin.tabs_getTabView("foo", "bar");
       expect(TabsMixin.renderGraultTabView).toHaveBeenCalledWith("foo", "bar");
     });
 
-    it("should remove spaces and call render function", function() {
+    it("removes spaces and call render function", function() {
       TabsMixin.tabs_tabs = { qux: "Quux Garply" };
       TabsMixin.state = { currentTab: "qux" };
       TabsMixin.renderQuuxGarplyTabView = function() {
@@ -182,18 +182,18 @@ describe("TabsMixin", function() {
       expect(TabsMixin.renderQuuxGarplyTabView).toHaveBeenCalled();
     });
 
-    it("should return result of function when called", function() {
+    it("returns result of function when called", function() {
       var result = TabsMixin.tabs_getTabView();
       expect(result).toEqual("test");
     });
 
-    it("should null if it doesn't exist", function() {
+    it("nulls if it doesn't exist", function() {
       TabsMixin.renderGraultTabView = undefined;
       var result = TabsMixin.tabs_getTabView();
       expect(result).toEqual(null);
     });
 
-    it("should not call render function if it doesn't exist", function() {
+    it("does not call render function if it doesn't exist", function() {
       TabsMixin.renderGraultTabView = undefined;
       var fn = TabsMixin.tabs_getTabView.bind(TabsMixin);
       expect(fn).not.toThrow();

--- a/src/js/pages/catalog/__tests__/PackageDetailTab-test.js
+++ b/src/js/pages/catalog/__tests__/PackageDetailTab-test.js
@@ -90,7 +90,7 @@ describe("PackageDetailTab", function() {
         ).toEqual(1);
       });
 
-      it("should render entries with keys and values", function() {
+      it("renders entries with keys and values", function() {
         var subItem = ReactDOM.render(
           this.instance.getItems(
             [{ label: "foo", value: "baz" }, { label: "bar", value: null }],
@@ -123,7 +123,7 @@ describe("PackageDetailTab", function() {
         ).toEqual(1);
       });
 
-      it("should render entries with keys and values", function() {
+      it("renders entries with keys and values", function() {
         var subItem = ReactDOM.render(
           this.instance.getItems(
             [{ label: "foo", value: "baz" }, { label: "bar", value: null }],
@@ -138,7 +138,7 @@ describe("PackageDetailTab", function() {
   });
 
   describe("#getSubItem", function() {
-    it("should render link if url is defined", function() {
+    it("renders link if url is defined", function() {
       var link = ReactDOM.render(
         this.instance.getSubItem("url", "http://foo"),
         this.container
@@ -149,7 +149,7 @@ describe("PackageDetailTab", function() {
       expect(link.querySelector("a").tagName).toEqual("A");
     });
 
-    it("should render link with prefix if defined", function() {
+    it("renders link with prefix if defined", function() {
       var link = ReactDOM.render(
         this.instance.getSubItem("email", "foo@bar.com"),
         this.container
@@ -188,7 +188,7 @@ describe("PackageDetailTab", function() {
   });
 
   describe("#render", function() {
-    it("should call getErrorScreen when error occurred", function() {
+    it("calls getErrorScreen when error occurred", function() {
       this.instance.state.hasError = true;
       this.instance.getErrorScreen = jasmine.createSpy("getErrorScreen");
 
@@ -204,7 +204,7 @@ describe("PackageDetailTab", function() {
       expect(this.instance.getErrorScreen).not.toHaveBeenCalled();
     });
 
-    it("should call getLoadingScreen when loading", function() {
+    it("calls getLoadingScreen when loading", function() {
       this.instance.state.isLoading = true;
       this.instance.getLoadingScreen = jasmine.createSpy("getLoadingScreen");
 

--- a/src/js/pages/catalog/__tests__/PackagesTab-test.js
+++ b/src/js/pages/catalog/__tests__/PackagesTab-test.js
@@ -34,7 +34,7 @@ describe("PackagesTab", function() {
       jest.runAllTimers();
     });
 
-    it("should call handler when panel is clicked", function() {
+    it("calls handler when panel is clicked", function() {
       var panel = ReactDOM.findDOMNode(this.instance).querySelector(
         ".panel.clickable"
       );
@@ -57,11 +57,11 @@ describe("PackagesTab", function() {
       CosmosPackagesStore.getAvailablePackages = this.CosmosPackagesStoreGetAvailablePackages;
     });
 
-    it("should return packages", function() {
+    it("returns packages", function() {
       expect(this.instance.getPackageGrid(this.packages).length).toEqual(97);
     });
 
-    it("shouldn't return packages", function() {
+    it("doesn't return packages", function() {
       CosmosPackagesStore.getAvailablePackages = function() {
         return new UniversePackagesList();
       };

--- a/src/js/plugin-bridge/__tests__/ActionsPubSub-test.js
+++ b/src/js/plugin-bridge/__tests__/ActionsPubSub-test.js
@@ -9,7 +9,7 @@ describe("#ActionsPubSub", function() {
     this.unsubscribe1 = PluginSDK.onDispatch(this.mockFn1);
   });
 
-  it("should receive actions after subscribing", function() {
+  it("receives actions after subscribing", function() {
     PluginSDK.dispatch({ type: "foo" });
     expect(this.mockFn.mock.calls.length).toEqual(1);
     expect(this.mockFn1.mock.calls.length).toEqual(1);
@@ -19,7 +19,7 @@ describe("#ActionsPubSub", function() {
     });
   });
 
-  it("should stop receiving actions after unsubscribing", function() {
+  it("stops receiving actions after unsubscribing", function() {
     this.unsubscribe();
     PluginSDK.dispatch({ type: "foo" });
     expect(this.mockFn.mock.calls.length).toEqual(0);

--- a/src/js/plugin-bridge/__tests__/AppReducer-test.js
+++ b/src/js/plugin-bridge/__tests__/AppReducer-test.js
@@ -16,7 +16,7 @@ describe("AppReducer", function() {
     qux: { foo: "bar" }
   };
 
-  it("should alter state correctly when no plugins loaded", function() {
+  it("alters state correctly when no plugins loaded", function() {
     PluginSDK.dispatch({
       type: EventTypes.APP_STORE_CHANGE,
       storeID: "foo",
@@ -34,7 +34,7 @@ describe("AppReducer", function() {
     expect(deepEqual(state, expectedState)).toEqual(true);
   });
 
-  it("should alter state correctly after plugins loaded", function() {
+  it("alters state correctly after plugins loaded", function() {
     PluginSDK.dispatch({
       type: EventTypes.APP_STORE_CHANGE,
       storeID: "foo",
@@ -67,7 +67,7 @@ describe("AppReducer", function() {
     expect(deepEqual(state, expectedState)).toEqual(true);
   });
 
-  it("should alter state correctly for storeID", function() {
+  it("alters state correctly for storeID", function() {
     PluginSDK.dispatch({
       type: EventTypes.APP_STORE_CHANGE,
       storeID: "foo",
@@ -85,7 +85,7 @@ describe("AppReducer", function() {
     expect(deepEqual(state, expectedState)).toEqual(true);
   });
 
-  it("should not alter state if action dispatched from plugin", function() {
+  it("does not alter state if action dispatched from plugin", function() {
     var pluginDispatch;
     // Mock a fake plugin
     var mockPlugin = jest.genMockFunction().mockImplementation(function(SDK) {
@@ -112,7 +112,7 @@ describe("AppReducer", function() {
     expect(deepEqual(state, expectedState)).toEqual(true);
   });
 
-  it("should clone state", function() {
+  it("clones state", function() {
     var nestedObj = {};
     var data = {
       foo: "bar",

--- a/src/js/plugin-bridge/__tests__/Hooks-test.js
+++ b/src/js/plugin-bridge/__tests__/Hooks-test.js
@@ -14,19 +14,19 @@ describe("HooksAPI", function() {
       this.filteredContent = this.hooks.applyFilter("foo", "foo bar", "qux");
     });
 
-    it("should receive the arguments that we defined", function() {
+    it("receives the arguments that we defined", function() {
       expect(this.fakeFilter.mock.calls[0]).toEqual(["foo bar", "qux"]);
     });
 
-    it("should call the filter once", function() {
+    it("calls the filter once", function() {
       expect(this.fakeFilter.mock.calls.length).toEqual(1);
     });
 
-    it("should return the filtered content when a filter is applied", function() {
+    it("returns the filtered content when a filter is applied", function() {
       expect(this.filteredContent).toEqual("foo baz");
     });
 
-    it("should apply the filters in the order of priority", function() {
+    it("applies the filters in the order of priority", function() {
       var lowPriorityFilter = jest.genMockFunction();
       var highPriorityFilter = jest.genMockFunction();
 
@@ -54,24 +54,24 @@ describe("HooksAPI", function() {
       this.hooks.addAction("foo", this.fakeAction);
     });
 
-    it("should be called only once when an action is performed", function() {
+    it("is called only once when an action is performed", function() {
       this.hooks.doAction("foo", "bar");
       expect(this.fakeAction.mock.calls.length).toEqual(1);
     });
 
-    it("should receive arguments when an action is performed", function() {
+    it("receives arguments when an action is performed", function() {
       this.hooks.doAction("foo", "bar");
       expect(this.fakeAction.mock.calls[0][0]).toEqual("bar");
     });
 
-    it("should not receive arguments when arguments are not passed", function() {
+    it("does not receive arguments when arguments are not passed", function() {
       this.noArgumentsAction = jest.genMockFunction();
       this.hooks.addAction("qux", this.noArgumentsAction);
       this.hooks.doAction("qux");
       expect(this.noArgumentsAction.mock.calls[0].length).toEqual(0);
     });
 
-    it("should receive two arguments when two arguments are passed", function() {
+    it("receives two arguments when two arguments are passed", function() {
       this.twoArgumentsAction = jest.genMockFunction();
       this.hooks.addAction("quux", this.twoArgumentsAction);
       this.hooks.doAction("quux", "baz", "bar");
@@ -86,13 +86,13 @@ describe("HooksAPI", function() {
       this.hooks.addAction("foo", this.fakeAction);
     });
 
-    it("shouldn't be called after action is removed", function() {
+    it("doesn't be called after action is removed", function() {
       this.hooks.removeAction("foo", this.fakeAction);
       this.hooks.doAction("foo", "bar");
       expect(this.fakeAction).not.toHaveBeenCalled();
     });
 
-    it("should be called when action has not been removed", function() {
+    it("is called when action has not been removed", function() {
       this.hooks.doAction("foo", "bar");
       this.hooks.removeAction("foo", this.fakeAction);
       this.hooks.doAction("foo", "bar");
@@ -137,13 +137,13 @@ describe("HooksAPI", function() {
       this.hooks.addFilter("foo", this.fakeFilter);
     });
 
-    it("shouldn't be called after filter is removed", function() {
+    it("doesn't be called after filter is removed", function() {
       this.hooks.removeFilter("foo", this.fakeFilter);
       this.hooks.applyFilter("foo", "bar");
       expect(this.fakeFilter).not.toHaveBeenCalled();
     });
 
-    it("should be called when filter has not been removed", function() {
+    it("is called when filter has not been removed", function() {
       this.hooks.applyFilter("foo", "bar");
       this.hooks.removeFilter("foo", this.fakeFilter);
       this.hooks.applyFilter("foo", "bar");

--- a/src/js/plugin-bridge/__tests__/PluginSDK-test.js
+++ b/src/js/plugin-bridge/__tests__/PluginSDK-test.js
@@ -8,7 +8,7 @@ const Hooks = PluginSDK.Hooks;
 describe("PluginSDK", function() {
   describe("#initialize", function() {
     describe("#reducers", function() {
-      it("should not create a namespace in Store for plugin if no reducer returned", function() {
+      it("does not create a namespace in Store for plugin if no reducer returned", function() {
         // Mock a fake plugin
         this.mockPlugin = jest.genMockFunction().mockImplementation(function() {
           // Don't return anything
@@ -26,7 +26,7 @@ describe("PluginSDK", function() {
         expect(state.fakePlugin1).toEqual(undefined);
       });
 
-      it("should create a namespace in Store for plugin if reducer returned", function() {
+      it("creates a namespace in Store for plugin if reducer returned", function() {
         // Mock a fake plugin
         this.mockPlugin = jest.genMockFunction().mockImplementation(function() {
           // Return reducer
@@ -48,7 +48,7 @@ describe("PluginSDK", function() {
         expect(deepEqual(state.fakePlugin2, { foo: "bar" })).toEqual(true);
       });
 
-      it("should throw error if reducer is not a function", function() {
+      it("throws an error if reducer is not a function", function() {
         // Mock a fake plugin
         var mockPlugin = jest.genMockFunction().mockImplementation(function() {
           // Return invalid reducer
@@ -84,27 +84,27 @@ describe("PluginSDK", function() {
       });
     });
 
-    it("should call plugin", function() {
+    it("calls plugin", function() {
       expect(this.mockPlugin.mock.calls.length).toBe(1);
     });
 
-    it("should call plugin with correct # of args", function() {
+    it("calls plugin with correct # of args", function() {
       var args = this.mockPlugin.mock.calls[0];
       expect(args.length).toBe(1);
     });
 
-    it("should call plugin with PluginSDK", function() {
+    it("calls plugin with PluginSDK", function() {
       var SDK = this.mockPlugin.mock.calls[0][0];
       expect(SDK.toString()).toEqual(PluginSDK.toString());
     });
 
-    it("should contain Store in PluginSDK", function() {
+    it("contains Store in PluginSDK", function() {
       var store = this.mockPlugin.mock.calls[0][0].Store;
       expect(typeof store.subscribe).toEqual("function");
       expect(typeof store.getState).toEqual("function");
     });
 
-    it("should contain personal dispatch in PluginSDK", function() {
+    it("contains personal dispatch in PluginSDK", function() {
       var SDK = this.mockPlugin.mock.calls[0][0];
       var store = PluginSDK.Store;
       var dispatch = SDK.dispatch;
@@ -128,12 +128,12 @@ describe("PluginSDK", function() {
       store.dispatch = storeDispatch;
     });
 
-    it("should contain pluginID in PluginSDK", function() {
+    it("contains pluginID in PluginSDK", function() {
       var pluginID = this.mockPlugin.mock.calls[0][0].pluginID;
       expect(pluginID).toEqual("fakePlugin3");
     });
 
-    it("should contain Hooks in PluginSDK", function() {
+    it("contains Hooks in PluginSDK", function() {
       var pluginHooks = this.mockPlugin.mock.calls[0][0].Hooks;
       expect(pluginHooks).toEqual(Hooks);
     });
@@ -181,18 +181,18 @@ describe("PluginSDK", function() {
       });
     });
 
-    it("should call reducer to get initial state", function() {
+    it("calls reducer to get initial state", function() {
       // Redux calls the reducer 3 times to check everything
       expect(this.mockReducer.mock.calls.length).toEqual(3);
     });
 
-    it("should call reducer with correct state", function() {
+    it("calls reducer with correct state", function() {
       this.testArgs.dispatch({ type: "foo" });
       var prevState = this.mockReducer.mock.calls[3][0];
       expect(deepEqual(prevState, { foo: 1 })).toEqual(true);
     });
 
-    it("should call reducer with correct action", function() {
+    it("calls reducer with correct action", function() {
       this.testArgs.dispatch({ type: "foo" });
       var action = this.mockReducer.mock.calls[3][1];
       expect(
@@ -200,19 +200,19 @@ describe("PluginSDK", function() {
       ).toEqual(true);
     });
 
-    it("should update Store with new state #1", function() {
+    it("updates Store with new state #1", function() {
       this.testArgs.dispatch({ type: "reset" });
       var state = PluginSDK.Store.getState().anotherFakePlugin;
       expect(deepEqual(state, { foo: 1 })).toEqual(true);
     });
 
-    it("should update Store with new state #2", function() {
+    it("updates Store with new state #2", function() {
       this.testArgs.dispatch({ type: "foo" });
       var state = PluginSDK.Store.getState().anotherFakePlugin;
       expect(deepEqual(state, { foo: 2 })).toEqual(true);
     });
 
-    it("should update Store with new state #3", function() {
+    it("updates Store with new state #3", function() {
       this.testArgs.dispatch({ type: "bar" });
       var state = PluginSDK.Store.getState().anotherFakePlugin;
       expect(deepEqual(state, { foo: 2, bar: "qux" })).toEqual(true);

--- a/src/js/stores/__tests__/AuthStore-test.js
+++ b/src/js/stores/__tests__/AuthStore-test.js
@@ -58,14 +58,14 @@ describe("AuthStore", function() {
       global.document = this.document;
     });
 
-    it("should set the cookie to an empty string", function() {
+    it("sets the cookie to an empty string", function() {
       var args = cookie.serialize.calls.mostRecent().args;
 
       expect(args[0]).toEqual(USER_COOKIE_KEY);
       expect(args[1]).toEqual("");
     });
 
-    it("should emit a logout event", function() {
+    it("emits a logout event", function() {
       var args = AuthStore.emit.calls.mostRecent().args;
 
       expect(args[0]).toEqual(EventTypes.AUTH_USER_LOGOUT_SUCCESS);
@@ -73,7 +73,7 @@ describe("AuthStore", function() {
   });
 
   describe("#login", function() {
-    it("should make a request to login", function() {
+    it("makes a request to login", function() {
       RequestUtil.json = jasmine.createSpy();
       AuthStore.login({});
 
@@ -97,7 +97,7 @@ describe("AuthStore", function() {
       AuthStore.set({ role: undefined });
     });
 
-    it("should get the user", function() {
+    it("gets the user", function() {
       expect(AuthStore.getUser()).toEqual({
         uid: "joe",
         description: "Joe Doe"

--- a/src/js/stores/__tests__/BaseStore-test.js
+++ b/src/js/stores/__tests__/BaseStore-test.js
@@ -8,11 +8,11 @@ describe("BaseStore", function() {
   });
 
   describe("#addChangeListener", function() {
-    it("should have addChangeListener function", function() {
+    it("has addChangeListener function", function() {
       expect(typeof this.instance.addChangeListener).toEqual("function");
     });
 
-    it("should call on-function", function() {
+    it("calls on-function", function() {
       var handler = function() {};
       this.instance.addChangeListener("change", handler);
       expect(this.instance.on).toHaveBeenCalledWith("change", handler);
@@ -20,11 +20,11 @@ describe("BaseStore", function() {
   });
 
   describe("#removeChangeListener", function() {
-    it("should have removeChangeListener function", function() {
+    it("has removeChangeListener function", function() {
       expect(typeof this.instance.removeChangeListener).toEqual("function");
     });
 
-    it("should call removeListener-function", function() {
+    it("calls removeListener-function", function() {
       var handler = function() {};
       this.instance.removeChangeListener("change", handler);
       expect(this.instance.removeListener).toHaveBeenCalledWith(

--- a/src/js/stores/__tests__/ConfigStore-test.js
+++ b/src/js/stores/__tests__/ConfigStore-test.js
@@ -9,11 +9,11 @@ describe("ConfigStore", function() {
       ConfigStore.processCCIDSuccess({ foo: "bar" });
     });
 
-    it("should emit an event", function() {
+    it("emits an event", function() {
       expect(this.handler).toBeCalled();
     });
 
-    it("should return stored info", function() {
+    it("returns stored info", function() {
       expect(ConfigStore.get("ccid")).toEqual({ foo: "bar" });
     });
   });

--- a/src/js/stores/__tests__/CosmosPackagesStore-test.js
+++ b/src/js/stores/__tests__/CosmosPackagesStore-test.js
@@ -37,13 +37,13 @@ describe("CosmosPackagesStore", function() {
       RequestUtil.json = this.requestFn;
     });
 
-    it("should return an instance of UniversePackagesList", function() {
+    it("returns an instance of UniversePackagesList", function() {
       CosmosPackagesStore.fetchAvailablePackages("foo");
       var availablePackages = CosmosPackagesStore.getAvailablePackages();
       expect(availablePackages instanceof UniversePackagesList).toBeTruthy();
     });
 
-    it("should return all of the availablePackages it was given", function() {
+    it("returns all of the availablePackages it was given", function() {
       CosmosPackagesStore.fetchAvailablePackages("foo");
       var availablePackages = CosmosPackagesStore.getAvailablePackages().getItems();
       expect(availablePackages.length).toEqual(
@@ -51,7 +51,7 @@ describe("CosmosPackagesStore", function() {
       );
     });
 
-    it("should pass though query parameters", function() {
+    it("passes though query parameters", function() {
       RequestUtil.json = jasmine.createSpy("RequestUtil#json");
       CosmosPackagesStore.fetchAvailablePackages("foo");
       expect(
@@ -118,13 +118,13 @@ describe("CosmosPackagesStore", function() {
       RequestUtil.json = this.requestFn;
     });
 
-    it("should return an instance of UniversePackage", function() {
+    it("returns an instance of UniversePackage", function() {
       CosmosPackagesStore.fetchPackageDescription("foo", "bar");
       var packageDetails = CosmosPackagesStore.getPackageDetails();
       expect(packageDetails instanceof UniversePackage).toBeTruthy();
     });
 
-    it("should return the packageDetails it was given", function() {
+    it("returns the packageDetails it was given", function() {
       CosmosPackagesStore.fetchPackageDescription("foo", "bar");
       var pkg = CosmosPackagesStore.getPackageDetails();
       expect(pkg.getName()).toEqual(this.packageDescribeFixture.package.name);
@@ -133,7 +133,7 @@ describe("CosmosPackagesStore", function() {
       );
     });
 
-    it("should pass though query parameters", function() {
+    it("passes though query parameters", function() {
       RequestUtil.json = jasmine.createSpy("RequestUtil#json");
       CosmosPackagesStore.fetchPackageDescription("foo", "bar");
       expect(
@@ -215,19 +215,19 @@ describe("CosmosPackagesStore", function() {
       RequestUtil.json = this.requestFn;
     });
 
-    it("should return an instance of UniversePackage", function() {
+    it("returns an instance of UniversePackage", function() {
       CosmosPackagesStore.fetchPackageVersions("foo");
       const packageVersions = CosmosPackagesStore.getPackageVersions("foo");
       expect(packageVersions instanceof UniversePackageVersions).toBeTruthy();
     });
 
-    it("should return an null if packageName not in packageVersions", function() {
+    it("returns an null if packageName not in packageVersions", function() {
       CosmosPackagesStore.fetchPackageVersions("foo");
       const packageVersions = CosmosPackagesStore.getPackageVersions("bar");
       expect(packageVersions).toEqual(null);
     });
 
-    it("should return all package versions it was given", function() {
+    it("returns all package versions it was given", function() {
       const packageName = "foo";
       CosmosPackagesStore.fetchPackageVersions(packageName);
       const versions = CosmosPackagesStore.getPackageVersions("foo");
@@ -316,28 +316,28 @@ describe("CosmosPackagesStore", function() {
       RequestUtil.json = this.requestFn;
     });
 
-    it("should return the field package within response", function() {
+    it("returns the field package within response", function() {
       CosmosPackagesStore.fetchServiceDescription("foo");
       var response = CosmosPackagesStore.getServiceDetails();
       var packageField = response.package;
       expect(packageField.name).toEqual("marathon");
     });
 
-    it("should return the field resolvedOptions within the response", function() {
+    it("returns the field resolvedOptions within the response", function() {
       CosmosPackagesStore.fetchServiceDescription("foo");
       var response = CosmosPackagesStore.getServiceDetails();
       var resolvedOptions = response.resolvedOptions;
       expect(resolvedOptions.name).toEqual("marathon-1");
     });
 
-    it("should return the field userProvidedOptions within the response", function() {
+    it("returns the field userProvidedOptions within the response", function() {
       CosmosPackagesStore.fetchServiceDescription("foo");
       var response = CosmosPackagesStore.getServiceDetails();
       var userOptions = response.userProvidedOptions;
       expect(userOptions.name).toEqual("marathon-1");
     });
 
-    it("should pass though query parameters", function() {
+    it("passes though query parameters", function() {
       RequestUtil.json = jasmine.createSpy("RequestUtil#json");
       CosmosPackagesStore.fetchServiceDescription("foo");
       expect(
@@ -404,7 +404,7 @@ describe("CosmosPackagesStore", function() {
       RequestUtil.json = this.requestFn;
     });
 
-    it("should pass though query parameters", function() {
+    it("passes though query parameters", function() {
       RequestUtil.json = jasmine.createSpy("RequestUtil#json");
       CosmosPackagesStore.updateService("foo", { cpus: 3 });
       expect(
@@ -454,7 +454,7 @@ describe("CosmosPackagesStore", function() {
       RequestUtil.json = this.requestFn;
     });
 
-    it("should return an instance of UniverseInstalledPackagesList", function() {
+    it("returns an instance of UniverseInstalledPackagesList", function() {
       CosmosPackagesStore.fetchInstalledPackages("foo", "bar");
       var installedPackages = CosmosPackagesStore.getInstalledPackages();
       expect(
@@ -462,7 +462,7 @@ describe("CosmosPackagesStore", function() {
       ).toBeTruthy();
     });
 
-    it("should return all of the installedPackages it was given", function() {
+    it("returns all of the installedPackages it was given", function() {
       CosmosPackagesStore.fetchInstalledPackages("foo", "bar");
       var installedPackages = CosmosPackagesStore.getInstalledPackages().getItems();
       expect(installedPackages.length).toEqual(2);
@@ -475,7 +475,7 @@ describe("CosmosPackagesStore", function() {
       expect(installedPackages[0].getAppId()).toEqual("/marathon-user");
     });
 
-    it("should pass though query parameters", function() {
+    it("passes though query parameters", function() {
       RequestUtil.json = jasmine.createSpy("RequestUtil#json");
       CosmosPackagesStore.fetchInstalledPackages("foo", "bar");
       expect(

--- a/src/js/stores/__tests__/DCOSStore-test.js
+++ b/src/js/stores/__tests__/DCOSStore-test.js
@@ -38,7 +38,7 @@ describe("DCOSStore", function() {
   });
 
   describe("#constructor", function() {
-    it("should expose an empty deployments list", function() {
+    it("exposes an empty deployments list", function() {
       expect(DCOSStore.deploymentsList.getItems().length).toEqual(0);
     });
   });
@@ -114,15 +114,15 @@ describe("DCOSStore", function() {
         DCOSStore.onMarathonDeploymentsChange();
       });
 
-      it("should not update the deployments list", function() {
+      it("does not update the deployments list", function() {
         expect(DCOSStore.deploymentsList.getItems().length).toEqual(0);
       });
 
-      it("should not update the notification store", function() {
+      it("does not update the notification store", function() {
         expect(NotificationStore.addNotification).not.toHaveBeenCalled();
       });
 
-      it("should be called as soon as groups endpoint data arrives", function() {
+      it("is called as soon as groups endpoint data arrives", function() {
         spyOn(DCOSStore, "onMarathonDeploymentsChange");
         DCOSStore.onMarathonGroupsChange();
         expect(DCOSStore.onMarathonDeploymentsChange).toHaveBeenCalled();
@@ -135,18 +135,18 @@ describe("DCOSStore", function() {
         DCOSStore.onMarathonDeploymentsChange();
       });
 
-      it("should update the deployments list", function() {
+      it("updates the deployments list", function() {
         expect(DCOSStore.deploymentsList.getItems().length).toEqual(1);
         expect(DCOSStore.deploymentsList.last().id).toEqual("deployment-id");
       });
 
-      it("should populate the deployments with relevant services", function() {
+      it("populates the deployments with relevant services", function() {
         const deployment = DCOSStore.deploymentsList.last();
         const services = deployment.getAffectedServices();
         expect(services.length).toEqual(2);
       });
 
-      it("should update the notification store", function() {
+      it("updates the notification store", function() {
         expect(NotificationStore.addNotification).toHaveBeenCalledWith(
           "services-deployments",
           "deployment-count",
@@ -162,7 +162,7 @@ describe("DCOSStore", function() {
         DCOSStore.onMarathonGroupsChange();
       });
 
-      it("should trim stale services", function() {
+      it("trims stale services", function() {
         const deployment = DCOSStore.deploymentsList.last();
         const services = deployment.getAffectedServices();
         expect(services.length).toEqual(0);
@@ -194,7 +194,7 @@ describe("DCOSStore", function() {
       DCOSStore.onMesosSummaryChange();
     });
 
-    it("should update the service tree", function() {
+    it("updates the service tree", function() {
       expect(DCOSStore.serviceTree.getItems().length).toEqual(0);
 
       MarathonStore.__setKeyResponse(
@@ -213,7 +213,7 @@ describe("DCOSStore", function() {
       expect(DCOSStore.serviceTree.getItems()[0].getId()).toEqual("/alpha");
     });
 
-    it("should replace old Marathon data", function() {
+    it("replaces old Marathon data", function() {
       MarathonStore.__setKeyResponse(
         "groups",
         new ServiceTree({
@@ -241,7 +241,7 @@ describe("DCOSStore", function() {
       expect(DCOSStore.serviceTree.getItems()[0].getId()).toEqual("/beta");
     });
 
-    it("should merge (matching by id) summary data", function() {
+    it("merges (matching by id) summary data", function() {
       MarathonStore.__setKeyResponse(
         "groups",
         new ServiceTree({
@@ -259,7 +259,7 @@ describe("DCOSStore", function() {
       expect(DCOSStore.serviceTree.getItems()[0].get("bar")).toEqual("baz");
     });
 
-    it("should not merge summary data if it doesn't find a matching id", function() {
+    it("does not merge summary data if it doesn't find a matching id", function() {
       MarathonStore.__setKeyResponse(
         "groups",
         new ServiceTree({
@@ -276,7 +276,7 @@ describe("DCOSStore", function() {
       expect(DCOSStore.serviceTree.getItems()[0].get("bar")).toBeUndefined();
     });
 
-    it("should not include _itemData", function() {
+    it("does not include _itemData", function() {
       MarathonStore.__setKeyResponse(
         "groups",
         new ServiceTree({
@@ -323,7 +323,7 @@ describe("DCOSStore", function() {
       ]);
     });
 
-    it("should update the service tree", function() {
+    it("updates the service tree", function() {
       expect(DCOSStore.serviceTree.getItems()[0].getStatus()).toEqual(
         "Recovering"
       );
@@ -345,7 +345,7 @@ describe("DCOSStore", function() {
       );
     });
 
-    it("should correctly convert running apps from waiting state", function() {
+    it("converts running apps from waiting state", function() {
       expect(DCOSStore.serviceTree.getItems()[0].getStatus()).toEqual(
         "Recovering"
       );
@@ -355,7 +355,7 @@ describe("DCOSStore", function() {
       );
     });
 
-    it("should not include _itemData", function() {
+    it("does not include _itemData", function() {
       DCOSStore.onMarathonQueueChange([
         {
           app: {
@@ -395,7 +395,7 @@ describe("DCOSStore", function() {
       });
     });
 
-    it("should update the service tree", function() {
+    it("updates the service tree", function() {
       expect(DCOSStore.serviceTree.getItems()[0].getVersions()).toEqual(
         new Map([[versionID]])
       );
@@ -411,7 +411,7 @@ describe("DCOSStore", function() {
       );
     });
 
-    it("should not include _itemData", function() {
+    it("does not include _itemData", function() {
       DCOSStore.onMarathonServiceVersionChange({
         serviceID: "/alpha",
         versionID,
@@ -442,7 +442,7 @@ describe("DCOSStore", function() {
       DCOSStore.onMarathonGroupsChange();
     });
 
-    it("should update the service tree", function() {
+    it("updates the service tree", function() {
       expect(DCOSStore.serviceTree.getItems()[0].getVersions()).toEqual(
         new Map()
       );
@@ -457,7 +457,7 @@ describe("DCOSStore", function() {
       );
     });
 
-    it("should merge existing version data", function() {
+    it("merges existing version data", function() {
       DCOSStore.onMarathonServiceVersionChange({
         serviceID: "/beta",
         versionID: firstVersionID,
@@ -474,7 +474,7 @@ describe("DCOSStore", function() {
       );
     });
 
-    it("should not include _itemData", function() {
+    it("does not include _itemData", function() {
       DCOSStore.onMarathonServiceVersionsChange({
         serviceID: "/beta",
         versions: new Map([[firstVersionID]])
@@ -502,7 +502,7 @@ describe("DCOSStore", function() {
       DCOSStore.onMarathonGroupsChange();
     });
 
-    it("should update the service tree", function() {
+    it("updates the service tree", function() {
       expect(DCOSStore.serviceTree.getItems()[0].get("bar")).toBeUndefined();
 
       MesosSummaryStore.__setKeyResponse(
@@ -523,7 +523,7 @@ describe("DCOSStore", function() {
       expect(DCOSStore.serviceTree.getItems()[0].get("bar")).toEqual("baz");
     });
 
-    it("should not include _itemData", function() {
+    it("does not include _itemData", function() {
       MesosSummaryStore.__setKeyResponse(
         "states",
         new SummaryList({
@@ -544,7 +544,7 @@ describe("DCOSStore", function() {
       ).not.toBeDefined();
     });
 
-    it("should replace old summary data", function() {
+    it("replaces old summary data", function() {
       MesosSummaryStore.__setKeyResponse(
         "states",
         new SummaryList({
@@ -578,7 +578,7 @@ describe("DCOSStore", function() {
       expect(DCOSStore.serviceTree.getItems()[0].get("bar")).toEqual("qux");
     });
 
-    it("should not merge Marathon data if it doesn't find a matching id", function() {
+    it("does not merge Marathon data if it doesn't find a matching id", function() {
       MesosSummaryStore.__setKeyResponse(
         "states",
         new SummaryList({
@@ -599,7 +599,7 @@ describe("DCOSStore", function() {
   });
 
   describe("#get storeID", function() {
-    it("should return 'dcos'", function() {
+    it("returns 'dcos'", function() {
       expect(DCOSStore.storeID).toEqual("dcos");
     });
   });

--- a/src/js/stores/__tests__/GetSetBaseStore-test.js
+++ b/src/js/stores/__tests__/GetSetBaseStore-test.js
@@ -6,11 +6,11 @@ describe("GetSetBaseStore", function() {
   });
 
   describe("#get", function() {
-    it("should return undefined if no key is given", function() {
+    it("returns undefined if no key is given", function() {
       expect(this.instance.get()).toEqual(null);
     });
 
-    it("should return undefined if given an object", function() {
+    it("returns undefined if given an object", function() {
       expect(this.instance.get({})).toEqual(null);
     });
 
@@ -18,13 +18,13 @@ describe("GetSetBaseStore", function() {
       expect(this.instance.get("foo")).toEqual(null);
     });
 
-    it("should return the correct value given a key", function() {
+    it("returns the correct value given a key", function() {
       var instance = this.instance;
       instance.set({ someProperty: "someValue" });
       expect(this.instance.get("someProperty")).toEqual("someValue");
     });
 
-    it("should allow for default state values", function() {
+    it("allows for default state values", function() {
       var instance = new GetSetBaseStore();
       instance.getSet_data = {
         foo: "bar"

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -28,12 +28,12 @@ describe("MesosStateStore", function() {
       MesosStateStore.get = this.get;
     });
 
-    it("should return tasks of service with name that matches", function() {
+    it("returns tasks of service with name that matches", function() {
       var result = MesosStateStore.getTasksFromServiceName("marathon");
       expect(result).toEqual([1, 2, 3]);
     });
 
-    it("should null if no service matches", function() {
+    it("nulls if no service matches", function() {
       var result = MesosStateStore.getTasksFromServiceName("nonExistent");
       expect(result).toEqual([]);
     });
@@ -78,7 +78,7 @@ describe("MesosStateStore", function() {
       MesosStateStore.get = this.get;
     });
 
-    it("should return matching framework tasks including scheduler tasks", function() {
+    it("returns matching framework tasks including scheduler tasks", function() {
       var tasks = MesosStateStore.getTasksByService(
         new Framework({
           id: "/spark",
@@ -93,7 +93,7 @@ describe("MesosStateStore", function() {
       ]);
     });
 
-    it("should return matching application tasks", function() {
+    it("returns matching application tasks", function() {
       var tasks = MesosStateStore.getTasksByService(
         new Application({ id: "/alpha" })
       );
@@ -104,7 +104,7 @@ describe("MesosStateStore", function() {
       ]);
     });
 
-    it("should empty task list if no service matches", function() {
+    it("empties task list if no service matches", function() {
       var tasks = MesosStateStore.getTasksByService(
         new Application({ id: "/non-existent" })
       );
@@ -131,12 +131,12 @@ describe("MesosStateStore", function() {
       MesosStateStore.get = this.get;
     });
 
-    it("should return the node with the correct ID", function() {
+    it("returns the node with the correct ID", function() {
       var result = MesosStateStore.getNodeFromID("amazon-thing");
       expect(result.fakeProp).toEqual("fake");
     });
 
-    it("should return null if node not found", function() {
+    it("returns null if node not found", function() {
       var result = MesosStateStore.getNodeFromID("nonExistentNode");
       expect(result).toEqual(undefined);
     });
@@ -164,22 +164,22 @@ describe("MesosStateStore", function() {
       MesosStateStore.get = this.get;
     });
 
-    it("should return null from an unknown task ID", function() {
+    it("returns null from an unknown task ID", function() {
       var result = MesosStateStore.getTaskFromTaskID("not-a-task-id");
       expect(result).toBeNull();
     });
 
-    it("should return an instance of Task", function() {
+    it("returns an instance of Task", function() {
       var result = MesosStateStore.getTaskFromTaskID(1);
       expect(result instanceof Task).toBeTruthy();
     });
 
-    it("should find a currently running task", function() {
+    it("finds a currently running task", function() {
       var result = MesosStateStore.getTaskFromTaskID(1);
       expect(result.get()).toEqual({ id: 1 });
     });
 
-    it("should find a completed task", function() {
+    it("finds a completed task", function() {
       var result = MesosStateStore.getTaskFromTaskID(2);
       expect(result.get()).toEqual({ id: 2 });
     });
@@ -194,7 +194,7 @@ describe("MesosStateStore", function() {
       MesosStateStore.get = this.get;
     });
 
-    it("should return scheduler tasks", function() {
+    it("returns scheduler tasks", function() {
       MesosStateStore.get = function() {
         return {
           frameworks: [
@@ -232,7 +232,7 @@ describe("MesosStateStore", function() {
       ]);
     });
 
-    it("should not return plain tasks", function() {
+    it("does not return plain tasks", function() {
       MesosStateStore.get = function() {
         return {
           frameworks: [
@@ -282,7 +282,7 @@ describe("MesosStateStore", function() {
       MesosStateStore.get = this.get;
     });
 
-    it("should return the matching scheduler task", function() {
+    it("returns the matching scheduler task", function() {
       const schedulerTask = MesosStateStore.getSchedulerTaskFromServiceName(
         "foo"
       );
@@ -293,7 +293,7 @@ describe("MesosStateStore", function() {
       });
     });
 
-    it("should return undefined if no matching scheduler task was found", function() {
+    it("returns undefined if no matching scheduler task was found", function() {
       const schedulerTask = MesosStateStore.getSchedulerTaskFromServiceName(
         "bar"
       );
@@ -314,7 +314,7 @@ describe("MesosStateStore", function() {
       MesosStateStore.get = this.get;
     });
 
-    it("should pass-through to MesosStateUtil.getPodHistoricalInstances", function() {
+    it("passes through to MesosStateUtil.getPodHistoricalInstances", function() {
       var pod = new Pod({ id: "/pod-p0" });
       var result = MesosStateStore.getPodHistoricalInstances(pod);
       var expected = MesosStateUtil.getPodHistoricalInstances(

--- a/src/js/stores/__tests__/MetronomeStore-test.js
+++ b/src/js/stores/__tests__/MetronomeStore-test.js
@@ -28,7 +28,7 @@ describe("MetronomeStore", function() {
   });
 
   describe("constructor", function() {
-    it("should call the fetchJobs 3 times", function() {
+    it("calls the fetchJobs 3 times", function() {
       MetronomeStore.addChangeListener(
         EventTypes.METRONOME_JOBS_CHANGE,
         function() {}
@@ -261,7 +261,7 @@ describe("MetronomeStore", function() {
   });
 
   describe("jobTree", function() {
-    it("should return an instance of JobTree", function() {
+    it("returns an instance of JobTree", function() {
       const changeHandler = jasmine.createSpy("changeHandler");
       MetronomeStore.addChangeListener(
         EventTypes.METRONOME_JOBS_CHANGE,
@@ -279,13 +279,13 @@ describe("MetronomeStore", function() {
   });
 
   describe("#monitorJobDetail", function() {
-    it("should call #fetchJobDetail with jobID in arguments", function() {
+    it("calls #fetchJobDetail with jobID in arguments", function() {
       // Begin monitoring job details
       MetronomeStore.monitorJobDetail("foo");
       expect(MetronomeActions.fetchJobDetail).toHaveBeenCalledWith("foo");
     });
 
-    it("should continuously poll for job details", function() {
+    it("continuously polls for job details", function() {
       // Begin monitoring job details
       MetronomeStore.monitorJobDetail("foo");
       // Let three intervals run
@@ -293,7 +293,7 @@ describe("MetronomeStore", function() {
       expect(MetronomeActions.fetchJobDetail.calls.count()).toEqual(4);
     });
 
-    it("should continuously poll for multiple job details", function() {
+    it("continuously polls for multiple job details", function() {
       // Begin monitoring job details
       MetronomeStore.monitorJobDetail("foo");
       MetronomeStore.monitorJobDetail("bar");
@@ -304,7 +304,7 @@ describe("MetronomeStore", function() {
   });
 
   describe("#stopJobDetailMonitor", function() {
-    it("should prevent subsequent fetchJobDetail calls for specific jobID", function() {
+    it("prevents subsequent fetchJobDetail calls for specific jobID", function() {
       // Begin monitoring job details on specific ID
       MetronomeStore.monitorJobDetail("foo");
       // Let three intervals run
@@ -316,7 +316,7 @@ describe("MetronomeStore", function() {
       expect(MetronomeActions.fetchJobDetail.calls.count()).toEqual(4);
     });
 
-    it("should prevent subsequent fetchJobDetail calls for all jobID", function() {
+    it("prevents subsequent fetchJobDetail calls for all jobID", function() {
       // Begin monitoring job details on specific IDs
       MetronomeStore.monitorJobDetail("foo");
       MetronomeStore.monitorJobDetail("bar");
@@ -332,13 +332,13 @@ describe("MetronomeStore", function() {
   });
 
   describe("storeID", function() {
-    it("should return 'metronome'", function() {
+    it("returns 'metronome'", function() {
       expect(MetronomeStore.storeID).toEqual("metronome");
     });
   });
 
   describe("#toggleSchedule", function() {
-    it("should pass the jobID to update schedule", function() {
+    it("passes the jobID to update schedule", function() {
       spyOn(MetronomeStore, "updateSchedule");
 
       AppDispatcher.handleServerAction({
@@ -354,7 +354,7 @@ describe("MetronomeStore", function() {
       );
     });
 
-    it("should grab the schedule and set enabled to false", function() {
+    it("grabs the schedule and set enabled to false", function() {
       spyOn(MetronomeStore, "updateSchedule");
 
       AppDispatcher.handleServerAction({
@@ -370,7 +370,7 @@ describe("MetronomeStore", function() {
       ).toEqual(false);
     });
 
-    it("should grab the schedule and set enabled to true by default", function() {
+    it("grabs the schedule and set enabled to true by default", function() {
       spyOn(MetronomeStore, "updateSchedule");
 
       AppDispatcher.handleServerAction({
@@ -386,7 +386,7 @@ describe("MetronomeStore", function() {
       ).toEqual(true);
     });
 
-    it("should do nothing if job unknown", function() {
+    it("does nothing if job unknown", function() {
       spyOn(MetronomeStore, "updateSchedule");
 
       MetronomeStore.toggleSchedule("unknown", false);
@@ -394,7 +394,7 @@ describe("MetronomeStore", function() {
       expect(MetronomeStore.updateSchedule).not.toHaveBeenCalled();
     });
 
-    it("should do nothing if schedule undefined", function() {
+    it("does nothing if schedule undefined", function() {
       spyOn(MetronomeStore, "updateSchedule");
 
       AppDispatcher.handleServerAction({
@@ -412,7 +412,7 @@ describe("MetronomeStore", function() {
   });
 
   describe("#updateSchedule", function() {
-    it("should pass the jobID and schedule to the action", function() {
+    it("passes the jobID and schedule to the action", function() {
       spyOn(MetronomeActions, "updateSchedule");
 
       MetronomeStore.updateSchedule("foo", { id: "bar" });

--- a/src/js/stores/__tests__/SystemLogStore-test.js
+++ b/src/js/stores/__tests__/SystemLogStore-test.js
@@ -259,7 +259,7 @@ describe("SystemLogStore", function() {
   });
 
   describe("storeID", function() {
-    it("should return 'systemLog'", function() {
+    it("returns 'systemLog'", function() {
       expect(SystemLogStore.storeID).toEqual("systemLog");
     });
   });

--- a/src/js/stores/__tests__/UnitHealthStore-test.js
+++ b/src/js/stores/__tests__/UnitHealthStore-test.js
@@ -21,7 +21,7 @@ describe("UnitHealthStore", function() {
     RequestUtil.json = this.requestFn;
   });
 
-  it("should return an instance of HealthUnitsList", function() {
+  it("returns an instance of HealthUnitsList", function() {
     Config.useFixtures = true;
     UnitHealthStore.fetchUnits();
     var units = UnitHealthStore.getUnits("units");
@@ -29,7 +29,7 @@ describe("UnitHealthStore", function() {
     Config.useFixtures = false;
   });
 
-  it("should return all of the units it was given", function() {
+  it("returns all of the units it was given", function() {
     Config.useFixtures = true;
     UnitHealthStore.fetchUnits();
     var units = UnitHealthStore.getUnits().getItems();

--- a/src/js/stores/__tests__/UsersStore-test.js
+++ b/src/js/stores/__tests__/UsersStore-test.js
@@ -25,13 +25,13 @@ describe("UsersStore", function() {
     Config.useFixtures = this.useFixtures;
   });
 
-  it("should return an instance of UsersList", function() {
+  it("returns an instance of UsersList", function() {
     UsersStore.fetchUsers();
     var users = UsersStore.getUsers();
     expect(users instanceof UsersList).toBeTruthy();
   });
 
-  it("should return all of the users it was given", function() {
+  it("returns all of the users it was given", function() {
     UsersStore.fetchUsers();
     var users = UsersStore.getUsers().getItems();
     expect(users.length).toEqual(this.usersFixture.array.length);

--- a/src/js/structs/__tests__/Batch-test.js
+++ b/src/js/structs/__tests__/Batch-test.js
@@ -7,20 +7,20 @@ describe("Batch", function() {
   });
 
   describe("#add", function() {
-    it("should not throw an error", function() {
+    it("does not throw an error", function() {
       expect(() => {
         this.batch.add(new Transaction(["foo"], "test"));
       }).not.toThrow();
     });
 
-    it("should create new batch instances", function() {
+    it("creates new batch instances", function() {
       const newBatch = this.batch.add(new Transaction(["foo"], "test"));
       expect(newBatch).not.toBe(this.batch);
     });
   });
 
   describe("#reduce", function() {
-    it("should iterate correctly over a batch with 1 item", function() {
+    it("iterates correctly over a batch with 1 item", function() {
       const batch = this.batch.add(new Transaction(["foo"], "a"));
       const values = batch.reduce(function(values, item) {
         values.push(item.value);
@@ -31,7 +31,7 @@ describe("Batch", function() {
       expect(values).toEqual(["a"]);
     });
 
-    it("should iterate correctly over a batch with 3 item", function() {
+    it("iterates correctly over a batch with 3 item", function() {
       const batch = this.batch
         .add(new Transaction(["foo"], "a"))
         .add(new Transaction(["bar"], "b"))
@@ -45,7 +45,7 @@ describe("Batch", function() {
       expect(values).toEqual(["a", "b", "c"]);
     });
 
-    it("should run reducers at least once", function() {
+    it("runs reducers at least once", function() {
       const sum = this.batch.reduce(function(sum) {
         return sum + 1;
       }, 0);
@@ -53,7 +53,7 @@ describe("Batch", function() {
       expect(sum).toEqual(1);
     });
 
-    it("should pass sane arguments for reducing on empty batch", function() {
+    it("passes sane arguments for reducing on empty batch", function() {
       const args = this.batch.reduce(function(sum, action, index) {
         return [sum, action, index];
       }, "initial");
@@ -61,7 +61,7 @@ describe("Batch", function() {
       expect(args).toEqual(["initial", { path: [], value: "INIT" }, 0]);
     });
 
-    it("should not run reducers more than number than values", function() {
+    it("does not run reducers more than number than values", function() {
       const batch = this.batch
         .add(new Transaction(["foo"], "a"))
         .add(new Transaction(["bar"], "b"))
@@ -86,7 +86,7 @@ describe("Batch", function() {
       expect(sum).toEqual(3);
     });
 
-    it("should keep all ", function() {
+    it("keeps all ", function() {
       const batch = this.batch
         .add(new Transaction(["id"], "a"))
         .add(new Transaction(["cpu"], 1))

--- a/src/js/structs/__tests__/DSLExpressionPart-test.js
+++ b/src/js/structs/__tests__/DSLExpressionPart-test.js
@@ -2,28 +2,28 @@ const DSLFilterTypes = require("../../constants/DSLFilterTypes");
 const DSLExpressionPart = require("../DSLExpressionPart");
 
 describe("DSLExpressionPart", function() {
-  it("should correct create an .attribute('label') filter", function() {
+  it("corrects create an .attribute('label') filter", function() {
     const ret = DSLExpressionPart.attribute("label");
 
     expect(ret.filterType).toEqual(DSLFilterTypes.ATTRIB);
     expect(ret.filterParams).toEqual({ label: "label" });
   });
 
-  it("should correct create an .attribute('label', 'text') filter", function() {
+  it("corrects create an .attribute('label', 'text') filter", function() {
     const ret = DSLExpressionPart.attribute("label", "text");
 
     expect(ret.filterType).toEqual(DSLFilterTypes.ATTRIB);
     expect(ret.filterParams).toEqual({ label: "label", text: "text" });
   });
 
-  it("should correct create an .exact filter", function() {
+  it("corrects create an .exact filter", function() {
     const ret = DSLExpressionPart.exact;
 
     expect(ret.filterType).toEqual(DSLFilterTypes.EXACT);
     expect(ret.filterParams).toEqual({});
   });
 
-  it("should correct create an .fuzzy filter", function() {
+  it("corrects create an .fuzzy filter", function() {
     const ret = DSLExpressionPart.fuzzy;
 
     expect(ret.filterType).toEqual(DSLFilterTypes.FUZZY);

--- a/src/js/structs/__tests__/DSLFilterList-test.js
+++ b/src/js/structs/__tests__/DSLFilterList-test.js
@@ -2,7 +2,7 @@ const DSLFilter = require("../DSLFilter");
 const DSLFilterList = require("../DSLFilterList");
 
 describe("DSLFilterList", function() {
-  it("should return only matching filters", function() {
+  it("returns only matching filters", function() {
     class MatchFilter extends DSLFilter {
       filterCanHandle() {
         return false;

--- a/src/js/structs/__tests__/Job-test.js
+++ b/src/js/structs/__tests__/Job-test.js
@@ -366,7 +366,7 @@ describe("Job", function() {
       expect(JSON.stringify(item)).toEqual('{"foo":"bar","baz":"qux"}');
     });
 
-    it("should drop blacklisted keys", function() {
+    it("drops blacklisted keys", function() {
       const item = new Job({ foo: "bar", baz: "qux", history: [] });
       expect(JSON.stringify(item)).toEqual('{"foo":"bar","baz":"qux"}');
     });

--- a/src/js/structs/__tests__/JobRun-test.js
+++ b/src/js/structs/__tests__/JobRun-test.js
@@ -3,45 +3,45 @@ const JobTaskList = require("../JobTaskList");
 
 describe("JobRun", function() {
   describe("#getDateCreated", function() {
-    it("should return null if createdAt is undefined", function() {
+    it("returns null if createdAt is undefined", function() {
       const activeRun = new JobRun({ foo: "bar" });
       expect(activeRun.getDateCreated()).toEqual(null);
     });
 
-    it("should return the correct value in milliseconds", function() {
+    it("returns the correct value in milliseconds", function() {
       const activeRun = new JobRun({ createdAt: "1990-01-03T02:00:00Z-1" });
       expect(activeRun.getDateCreated()).toEqual(631332000000);
     });
   });
 
   describe("#getDateFinished", function() {
-    it("should return null if finishedAt is undefined", function() {
+    it("returns null if finishedAt is undefined", function() {
       const activeRun = new JobRun({ foo: "bar" });
       expect(activeRun.getDateFinished()).toEqual(null);
     });
 
-    it("should return the correct value in milliseconds", function() {
+    it("returns the correct value in milliseconds", function() {
       const activeRun = new JobRun({ finishedAt: "1990-01-03T02:00:00Z-1" });
       expect(activeRun.getDateFinished()).toEqual(631332000000);
     });
   });
 
   describe("#getJobID", function() {
-    it("should return the jobId", function() {
+    it("returns the jobId", function() {
       const activeRun = new JobRun({ jobId: "foo" });
       expect(activeRun.getJobID()).toEqual("foo");
     });
   });
 
   describe("#getStatus", function() {
-    it("should return the id", function() {
+    it("returns the id", function() {
       const activeRun = new JobRun({ status: "foo" });
       expect(activeRun.getStatus()).toEqual("foo");
     });
   });
 
   describe("#getTasks", function() {
-    it("should return an instance of JobTaskList", function() {
+    it("returns an instance of JobTaskList", function() {
       const activeRun = new JobRun({ id: "foo", tasks: [] });
       expect(activeRun.getTasks() instanceof JobTaskList).toBeTruthy();
     });

--- a/src/js/structs/__tests__/JobTask-test.js
+++ b/src/js/structs/__tests__/JobTask-test.js
@@ -2,38 +2,38 @@ const JobTask = require("../JobTask");
 
 describe("Job", function() {
   describe("#getDateStarted", function() {
-    it("should return null if startedAt is undefined", function() {
+    it("returns null if startedAt is undefined", function() {
       const jobTask = new JobTask({ foo: "bar" });
       expect(jobTask.getDateStarted()).toEqual(null);
     });
 
-    it("should properly parse the time-zone format from API", function() {
+    it("parses the time-zone format from API", function() {
       const jobTask = new JobTask({ startedAt: "1990-01-03T02:00:00Z-1" });
       expect(jobTask.getDateStarted()).toEqual(631332000000);
     });
   });
 
   describe("#getDateCompleted", function() {
-    it("should return null if completedAt is undefined", function() {
+    it("returns null if completedAt is undefined", function() {
       const jobTask = new JobTask({ foo: "bar" });
       expect(jobTask.getDateCompleted()).toEqual(null);
     });
 
-    it("should properly parse the time-zone format from API", function() {
+    it("parses the time-zone format from API", function() {
       const jobTask = new JobTask({ completedAt: "1990-01-03T02:00:00Z-1" });
       expect(jobTask.getDateCompleted()).toEqual(631332000000);
     });
   });
 
   describe("#getTaskID", function() {
-    it("should return the id", function() {
+    it("returns the id", function() {
       const jobTask = new JobTask({ id: "foo" });
       expect(jobTask.getTaskID()).toEqual("foo");
     });
   });
 
   describe("#getStatus", function() {
-    it("should return the id", function() {
+    it("returns the id", function() {
       const jobTask = new JobTask({ status: "foo" });
       expect(jobTask.getStatus()).toEqual("foo");
     });

--- a/src/js/structs/__tests__/List-test.js
+++ b/src/js/structs/__tests__/List-test.js
@@ -143,14 +143,14 @@ describe("List", function() {
       this.instance = new List({ items });
     });
 
-    it("should return an instance of List", function() {
+    it("returns an instance of List", function() {
       var items = this.instance.filterItems(function() {
         return true;
       });
       expect(items instanceof List).toEqual(true);
     });
 
-    it("should filter items", function() {
+    it("filters items", function() {
       var items = this.instance.filterItems(function(item) {
         return item.name === "bar";
       });
@@ -186,12 +186,12 @@ describe("List", function() {
       this.instance = new List({ items, filterProperties });
     });
 
-    it("should return an instance of List", function() {
+    it("returns an instance of List", function() {
       var items = this.instance.filterItemsByText("bar");
       expect(items instanceof List).toEqual(true);
     });
 
-    it("should filter instances of Item", function() {
+    it("filters instances of Item", function() {
       var items = [
         new Item({
           name: "foo",
@@ -220,26 +220,26 @@ describe("List", function() {
       expect(filteredItems[0] instanceof Item).toEqual(true);
     });
 
-    it("should filter by default getter", function() {
+    it("filters by default getter", function() {
       var filteredItems = this.instance.filterItemsByText("bar").getItems();
       expect(filteredItems.length).toEqual(1);
       expect(filteredItems[0].name).toEqual("bar");
     });
 
-    it("should filter by description", function() {
+    it("filters by description", function() {
       var filteredItems = this.instance.filterItemsByText("qux").getItems();
       expect(filteredItems.length).toEqual(1);
       expect(filteredItems[0].description.value).toEqual("qux");
     });
 
-    it("should filter by subItems", function() {
+    it("filters by subItems", function() {
       var filteredItems = this.instance.filterItemsByText("two").getItems();
       expect(filteredItems.length).toEqual(2);
       expect(filteredItems[0].subItems).toEqual(["one", "two"]);
       expect(filteredItems[1].subItems).toEqual(["two", "three"]);
     });
 
-    it("should handle filter by with null elements", function() {
+    it("handles filter by with null elements", function() {
       var items = [
         { name: null, description: { value: null }, subItems: [null, "three"] },
         { description: null, subItems: null }
@@ -257,7 +257,7 @@ describe("List", function() {
       expect(list.filterItemsByText.bind(list, "foo")).not.toThrow();
     });
 
-    it("should use provided filter properties", function() {
+    it("uses provided filter properties", function() {
       var filterProperties = {
         description(item, prop) {
           return item[prop] && item[prop].label;
@@ -275,7 +275,7 @@ describe("List", function() {
       this.instance = new List({ items: [{ name: "foo" }, { name: "bar" }] });
     });
 
-    it("should return undefined if no matching item was found", function() {
+    it("returns undefined if no matching item was found", function() {
       expect(
         this.instance.findItem(function() {
           return false;
@@ -283,7 +283,7 @@ describe("List", function() {
       ).toEqual(undefined);
     });
 
-    it("should return matching item", function() {
+    it("returns matching item", function() {
       expect(
         this.instance.findItem(function(item) {
           return item.name === "foo";
@@ -297,14 +297,14 @@ describe("List", function() {
       this.instance = new List({ items: [{ name: "foo" }, { name: "bar" }] });
     });
 
-    it("should return an instance of List", function() {
+    it("returns an instance of List", function() {
       var list = this.instance.mapItems(function(item) {
         return item;
       });
       expect(list instanceof List).toEqual(true);
     });
 
-    it("should apply callback to all items", function() {
+    it("apply callbacks to all items", function() {
       var items = this.instance
         .mapItems(function(item) {
           return { name: item.name.toUpperCase() };
@@ -320,7 +320,7 @@ describe("List", function() {
       this.instance = new List({ items: [{ name: "foo" }, { name: "bar" }] });
     });
 
-    it("should reduce all items to a value", function() {
+    it("reduces all items to a value", function() {
       var expectedValue = this.instance.reduceItems(function(
         previousValue,
         currentValue

--- a/src/js/structs/__tests__/RepositoryList-test.js
+++ b/src/js/structs/__tests__/RepositoryList-test.js
@@ -15,22 +15,22 @@ describe("RepositoryList", function() {
   });
 
   describe("#getPriority", function() {
-    it("should return correct priority of existing item", function() {
+    it("returns correct priority of existing item", function() {
       var priority = this.instance.getPriority(this.instance.getItems()[1]);
       expect(priority).toEqual(1);
     });
 
-    it("should return -1 for non-existing item", function() {
+    it("returns -1 for non-existing item", function() {
       var priority = this.instance.getPriority({ not: "available" });
       expect(priority).toEqual(-1);
     });
 
-    it("should return -1 for undefined", function() {
+    it("returns -1 for undefined", function() {
       var priority = this.instance.getPriority(undefined);
       expect(priority).toEqual(-1);
     });
 
-    it("should return -1 for null", function() {
+    it("returns -1 for null", function() {
       var priority = this.instance.getPriority(null);
       expect(priority).toEqual(-1);
     });

--- a/src/js/structs/__tests__/Transaction-test.js
+++ b/src/js/structs/__tests__/Transaction-test.js
@@ -4,44 +4,44 @@ const Transaction = require("../Transaction");
 
 describe("Transaction", function() {
   describe("#constructor", function() {
-    it("should have the type SET", function() {
+    it("has the type SET", function() {
       const transaction = new Transaction(0, 0);
       expect(transaction.type).toEqual(TransactionTypes.SET);
     });
 
-    it("should throw a Error for random type", function() {
+    it("throws an Error for random type", function() {
       expect(() => new Transaction(0, 0, "DEL")).toThrowError(TypeError);
     });
 
-    it("should accept SET constant", function() {
+    it("accepts SET constant", function() {
       expect(
         () => new Transaction(0, 0, TransactionTypes.SET)
       ).not.toThrowError();
     });
 
-    it("type should not be writable", function() {
+    it("ensures that type is not be writable", function() {
       const transaction = new Transaction(0, 0);
       expect(() => (transaction.type = "EVIL DELETE")).toThrowError();
     });
 
-    it("Should have the value which has been set", function() {
+    it("has the value which has been set", function() {
       const value = "test";
       const transaction = new Transaction(0, value);
       expect(transaction.value).toEqual(value);
     });
 
-    it("value should not be writable", function() {
+    it("ensures that value is not be writable", function() {
       const transaction = new Transaction(0, 0);
       expect(() => (transaction.value = "EVIL value")).toThrowError();
     });
 
-    it("Should have the path which has been set", function() {
+    it("has the path which has been set", function() {
       const path = "path";
       const transaction = new Transaction(path, 0);
       expect(transaction.path).toEqual(path);
     });
 
-    it("path should not be writable", function() {
+    it("ensures that path is not be writable", function() {
       const transaction = new Transaction(0, 0);
       expect(() => (transaction.path = "EVIL path")).toThrowError();
     });

--- a/src/js/structs/__tests__/Tree-test.js
+++ b/src/js/structs/__tests__/Tree-test.js
@@ -126,14 +126,14 @@ describe("Tree", function() {
       this.instance = new Tree({ items });
     });
 
-    it("should return an instance of Tree", function() {
+    it("returns an instance of Tree", function() {
       var filteredTree = this.instance.filterItems(function() {
         return true;
       });
       expect(filteredTree instanceof Tree).toEqual(true);
     });
 
-    it("should filter items", function() {
+    it("filters items", function() {
       var filteredTree = this.instance.filterItems(function(item) {
         return item.name === "bar";
       });
@@ -142,7 +142,7 @@ describe("Tree", function() {
       expect(filteredTree.getItems()[0]).toEqual({ name: "bar" });
     });
 
-    it("should filter sub items", function() {
+    it("filters sub items", function() {
       var filteredTree = this.instance.filterItems(function(item) {
         return item.name === "one";
       });
@@ -194,12 +194,12 @@ describe("Tree", function() {
       this.instance = new Tree({ items, filterProperties });
     });
 
-    it("should return an instance of Tree", function() {
+    it("returns an instance of Tree", function() {
       const filteredTree = this.instance.filterItemsByText("bar");
       expect(filteredTree instanceof Tree).toEqual(true);
     });
 
-    it("should filter sub trees", function() {
+    it("filters sub trees", function() {
       const filteredSubtree = this.instance
         .filterItemsByText("alpha")
         .getItems()[0];
@@ -207,7 +207,7 @@ describe("Tree", function() {
       expect(filteredSubtree.getItems()[0].name).toEqual("alpha");
     });
 
-    it("should filter instances of Item", function() {
+    it("filters instances of Item", function() {
       var items = [
         new Item({
           name: "foo",
@@ -236,26 +236,26 @@ describe("Tree", function() {
       expect(filteredItems[0] instanceof Item).toEqual(true);
     });
 
-    it("should filter by default getter", function() {
+    it("filters by default getter", function() {
       var filteredItems = this.instance.filterItemsByText("bar").getItems();
       expect(filteredItems.length).toEqual(1);
       expect(filteredItems[0].name).toEqual("bar");
     });
 
-    it("should filter by description", function() {
+    it("filters by description", function() {
       var filteredItems = this.instance.filterItemsByText("qux").getItems();
       expect(filteredItems.length).toEqual(1);
       expect(filteredItems[0].description.value).toEqual("qux");
     });
 
-    it("should filter by tags", function() {
+    it("filters by tags", function() {
       var filteredItems = this.instance.filterItemsByText("two").getItems();
       expect(filteredItems.length).toEqual(3);
       expect(filteredItems[0].tags).toEqual(["one", "two"]);
       expect(filteredItems[1].tags).toEqual(["two", "three"]);
     });
 
-    it("should handle filter by with null elements", function() {
+    it("handles filter by with null elements", function() {
       var items = [
         { name: null, description: { value: null }, tags: [null, "three"] },
         { description: null, tags: null }
@@ -273,7 +273,7 @@ describe("Tree", function() {
       expect(list.filterItemsByText.bind(list, "foo")).not.toThrow();
     });
 
-    it("should use provided filter properties", function() {
+    it("uses provided filter properties", function() {
       var filterProperties = {
         description(item, prop) {
           return item[prop] && item[prop].label;
@@ -297,7 +297,7 @@ describe("Tree", function() {
       });
     });
 
-    it("should return undefined if no matching item was found", function() {
+    it("returns undefined if no matching item was found", function() {
       expect(
         this.instance.findItem(function() {
           return false;
@@ -305,7 +305,7 @@ describe("Tree", function() {
       ).toEqual(undefined);
     });
 
-    it("should return matching item", function() {
+    it("returns matching item", function() {
       expect(
         this.instance.findItem(function(item) {
           return item.name === "beta";
@@ -325,14 +325,14 @@ describe("Tree", function() {
       });
     });
 
-    it("should return an instance of Tree", function() {
+    it("returns an instance of Tree", function() {
       var tree = this.instance.mapItems(function(item) {
         return item;
       });
       expect(tree instanceof Tree).toBeTruthy();
     });
 
-    it("should apply callback to all items", function() {
+    it("apply callbacks to all items", function() {
       var items = this.instance
         .mapItems(function(item) {
           if (item instanceof Tree) {
@@ -396,7 +396,7 @@ describe("Tree", function() {
       });
     });
 
-    it("should reduce tree to a single number", function() {
+    it("reduces tree to a single number", function() {
       var value = this.instance.reduceItems(function(
         previousValue,
         currentValue
@@ -411,7 +411,7 @@ describe("Tree", function() {
       expect(value).toEqual(42);
     });
 
-    it("should reduce tree to an array", function() {
+    it("reduces tree to an array", function() {
       var value = this.instance.reduceItems(function(
         previousValue,
         currentValue

--- a/src/js/structs/__tests__/UniverseInstalledPackagesList-test.js
+++ b/src/js/structs/__tests__/UniverseInstalledPackagesList-test.js
@@ -10,14 +10,14 @@ describe("UniverseInstalledPackagesList", function() {
       expect(items[0] instanceof UniversePackage).toBeTruthy();
     });
 
-    it("should store appId in UniversePackage", function() {
+    it("stores appId in UniversePackage", function() {
       var items = [{ appId: "baz", foo: "bar" }];
       var list = new UniverseInstalledPackagesList({ items });
       items = list.getItems();
       expect(items[0].get("appId")).toEqual("baz");
     });
 
-    it("should store packageInformation in UniversePackage", function() {
+    it("stores packageInformation in UniversePackage", function() {
       var items = [{ appId: "baz", foo: "bar" }];
       var list = new UniverseInstalledPackagesList({ items });
       items = list.getItems();
@@ -26,7 +26,7 @@ describe("UniverseInstalledPackagesList", function() {
   });
 
   describe("#filterItemsByText", function() {
-    it("should filter by name", function() {
+    it("filters by name", function() {
       var items = [
         { appId: "baz", name: "foo" },
         { appId: "baz", name: "bar" }
@@ -37,7 +37,7 @@ describe("UniverseInstalledPackagesList", function() {
       expect(items[0].getName()).toEqual("bar");
     });
 
-    it("should filter by description", function() {
+    it("filters by description", function() {
       var items = [
         { appId: "baz", description: "foo" },
         { appId: "baz", description: "bar" }
@@ -48,7 +48,7 @@ describe("UniverseInstalledPackagesList", function() {
       expect(items[0].getDescription()).toEqual("foo");
     });
 
-    it("should filter by tags", function() {
+    it("filters by tags", function() {
       var items = [
         { appId: "baz", tags: ["foo", "bar"] },
         { appId: "baz", tags: ["foo"] },
@@ -61,7 +61,7 @@ describe("UniverseInstalledPackagesList", function() {
       expect(items[1].getTags()).toEqual(["foo"]);
     });
 
-    it("should handle filter by tags with null elements", function() {
+    it("handles filter by tags with null elements", function() {
       var items = [
         { appId: "baz", tags: ["foo", "bar"] },
         { appId: "baz", tags: ["foo"] },

--- a/src/js/structs/__tests__/UniversePackagesList-test.js
+++ b/src/js/structs/__tests__/UniversePackagesList-test.js
@@ -12,7 +12,7 @@ describe("UniversePackagesList", function() {
   });
 
   describe("#filterItemsByText", function() {
-    it("should filter by name", function() {
+    it("filters by name", function() {
       var items = [{ name: "foo" }, { name: "bar" }];
       var list = new UniversePackagesList({ items });
       items = list.filterItemsByText("bar").getItems();
@@ -20,7 +20,7 @@ describe("UniversePackagesList", function() {
       expect(items[0].get("name")).toEqual("bar");
     });
 
-    it("should filter by description", function() {
+    it("filters by description", function() {
       var items = [{ description: "foo" }, { description: "bar" }];
       var list = new UniversePackagesList({ items });
       items = list.filterItemsByText("foo").getItems();
@@ -28,7 +28,7 @@ describe("UniversePackagesList", function() {
       expect(items[0].get("description")).toEqual("foo");
     });
 
-    it("should filter by tags", function() {
+    it("filters by tags", function() {
       var items = [{ tags: ["foo", "bar"] }, { tags: ["foo"] }, { tags: [] }];
       var list = new UniversePackagesList({ items });
       items = list.filterItemsByText("foo").getItems();
@@ -37,7 +37,7 @@ describe("UniversePackagesList", function() {
       expect(items[1].get("tags")).toEqual(["foo"]);
     });
 
-    it("should handle filter by tags with null elements", function() {
+    it("handles filter by tags with null elements", function() {
       var items = [{ tags: ["foo", "bar"] }, { tags: ["foo"] }, { tags: null }];
       var list = new UniversePackagesList({ items });
       expect(list.filterItemsByText.bind(list, "foo")).not.toThrow();

--- a/src/js/utils/__tests__/ApplicationUtil-test.js
+++ b/src/js/utils/__tests__/ApplicationUtil-test.js
@@ -18,7 +18,7 @@ describe("ApplicationUtil", function() {
       jasmine.clock().uninstall();
     });
 
-    it("should call callback right away", function() {
+    it("calls callback right away", function() {
       const handler = jasmine.createSpy("handler");
       const now = Date.now();
 
@@ -32,7 +32,7 @@ describe("ApplicationUtil", function() {
       expect(handler).toHaveBeenCalled();
     });
 
-    it("should call after time has elapsed", function() {
+    it("calls after time has elapsed", function() {
       const handler = jasmine.createSpy("handler");
       const now = Date.now();
 

--- a/src/js/utils/__tests__/ContainerUtil-test.js
+++ b/src/js/utils/__tests__/ContainerUtil-test.js
@@ -3,11 +3,11 @@ const ContainerUtil = require("../ContainerUtil");
 describe("#adjustActionErrors", function() {
   let actionErrors = ContainerUtil.adjustActionErrors({}, "foo", "error");
 
-  it("should correctly set error key", function() {
+  it("sets error key", function() {
     expect(actionErrors).toEqual({ foo: "error" });
   });
 
-  it("should correctly add to error keys", function() {
+  it("adds to error keys", function() {
     actionErrors = ContainerUtil.adjustActionErrors(
       actionErrors,
       "bar",
@@ -17,7 +17,7 @@ describe("#adjustActionErrors", function() {
     expect(actionErrors).toEqual({ foo: "error", bar: "newError" });
   });
 
-  it("should correctly alter existing keys", function() {
+  it("alters existing keys", function() {
     actionErrors = ContainerUtil.adjustActionErrors(actionErrors, "foo", null);
 
     expect(actionErrors).toEqual({ foo: null, bar: "newError" });
@@ -27,11 +27,11 @@ describe("#adjustActionErrors", function() {
 describe("#adjustPendingActions", function() {
   let pendingActions = ContainerUtil.adjustPendingActions({}, "foo", true);
 
-  it("should correctly set pending action key", function() {
+  it("sets pending action key", function() {
     expect(pendingActions).toEqual({ foo: true });
   });
 
-  it("should correctly add to pending action keys", function() {
+  it("adds to pending action keys", function() {
     pendingActions = ContainerUtil.adjustPendingActions(
       pendingActions,
       "bar",
@@ -41,7 +41,7 @@ describe("#adjustPendingActions", function() {
     expect(pendingActions).toEqual({ foo: true, bar: false });
   });
 
-  it("should correctly alter existing keys", function() {
+  it("alters existing keys", function() {
     pendingActions = ContainerUtil.adjustPendingActions(
       pendingActions,
       "foo",

--- a/src/js/utils/__tests__/DOMUtils-test.js
+++ b/src/js/utils/__tests__/DOMUtils-test.js
@@ -3,7 +3,7 @@ const DOMUtils = require("../DOMUtils");
 describe("DOMUtils", function() {
   describe("#closest", function() {
     it(
-      "should return the parent element when provided a selector and " +
+      "returns the parent element when provided a selector and " +
         "element where the element is a child of the selection",
       function() {
         var el = {
@@ -24,7 +24,7 @@ describe("DOMUtils", function() {
     );
 
     it(
-      "should return null when provided a selector and element where " +
+      "returns null when provided a selector and element where " +
         "the element is not a child of the selection",
       function() {
         var el = {
@@ -40,7 +40,7 @@ describe("DOMUtils", function() {
     );
 
     it(
-      "should return the provided element when the provided element" +
+      "returns the provided element when the provided element" +
         "matches the selector AND has a parent element",
       function() {
         var el = {

--- a/src/js/utils/__tests__/DSLFormUtil-test.js
+++ b/src/js/utils/__tests__/DSLFormUtil-test.js
@@ -5,7 +5,7 @@ const FilterNode = require("../../structs/DSLASTNodes").FilterNode;
 
 describe("DSLFormUtil", function() {
   describe("#createNodeComparisionFunction", function() {
-    it("should return `true` for FUZZY nodes, for any text", function() {
+    it("returns `true` for FUZZY nodes, for any text", function() {
       const fn = DSLFormUtil.createNodeComparisionFunction({
         fuzzy: DSLExpressionPart.fuzzy
       });
@@ -18,7 +18,7 @@ describe("DSLFormUtil", function() {
       expect(fn(unusedNode, astNode)).toBeTruthy();
     });
 
-    it("should return `false` for FUZZY nodes, if missing", function() {
+    it("returns `false` for FUZZY nodes, if missing", function() {
       const fn = DSLFormUtil.createNodeComparisionFunction({
         fuzzy: DSLExpressionPart.fuzzy
       });
@@ -31,7 +31,7 @@ describe("DSLFormUtil", function() {
       expect(fn(unusedNode, astNode)).toBeFalsy();
     });
 
-    it("should return `true` for EXACT nodes, for any text", function() {
+    it("returns `true` for EXACT nodes, for any text", function() {
       const fn = DSLFormUtil.createNodeComparisionFunction({
         exact: DSLExpressionPart.exact
       });
@@ -44,7 +44,7 @@ describe("DSLFormUtil", function() {
       expect(fn(unusedNode, astNode)).toBeTruthy();
     });
 
-    it("should return `true` for EXACT nodes, if missing", function() {
+    it("returns `true` for EXACT nodes, if missing", function() {
       const fn = DSLFormUtil.createNodeComparisionFunction({
         exact: DSLExpressionPart.exact
       });
@@ -57,7 +57,7 @@ describe("DSLFormUtil", function() {
       expect(fn(unusedNode, astNode)).toBeFalsy();
     });
 
-    it("should return `true` for ATTRIB nodes that match fully", function() {
+    it("returns `true` for ATTRIB nodes that match fully", function() {
       const fn = DSLFormUtil.createNodeComparisionFunction({
         attrib: DSLExpressionPart.attribute("is", "value")
       });
@@ -71,7 +71,7 @@ describe("DSLFormUtil", function() {
       expect(fn(unusedNode, astNode)).toBeTruthy();
     });
 
-    it("should return `false` for ATTRIB nodes that match partially", function() {
+    it("returns `false` for ATTRIB nodes that match partially", function() {
       const fn = DSLFormUtil.createNodeComparisionFunction({
         attrib: DSLExpressionPart.attribute("is", "value")
       });

--- a/src/js/utils/__tests__/DSLParserUtil-test.js
+++ b/src/js/utils/__tests__/DSLParserUtil-test.js
@@ -56,7 +56,7 @@ describe("DSLParserUtil", function() {
       this.op = DSLParserUtil.Operator.attribute("label", "text", 0, 5, 10, 20);
     });
 
-    it("should create the correct ast node", function() {
+    it("creates the correct ast node", function() {
       const { ast } = this.op;
       expect(ast instanceof DSLASTNodes.FilterNode).toBeTruthy();
 
@@ -72,7 +72,7 @@ describe("DSLParserUtil", function() {
       });
     });
 
-    it("should create the correct filter function", function() {
+    it("creates the correct filter function", function() {
       const { filter } = this.op;
 
       expect(typeof filter).toEqual("function");
@@ -91,7 +91,7 @@ describe("DSLParserUtil", function() {
       this.op = DSLParserUtil.Operator.exact("text", 0, 10);
     });
 
-    it("should create the correct ast node", function() {
+    it("creates the correct ast node", function() {
       const { ast } = this.op;
       expect(ast instanceof DSLASTNodes.FilterNode).toBeTruthy();
 
@@ -106,7 +106,7 @@ describe("DSLParserUtil", function() {
       });
     });
 
-    it("should create the correct filter function", function() {
+    it("creates the correct filter function", function() {
       const { filter } = this.op;
 
       expect(typeof filter).toEqual("function");
@@ -124,7 +124,7 @@ describe("DSLParserUtil", function() {
       this.op = DSLParserUtil.Operator.fuzzy("text", 0, 10);
     });
 
-    it("should create the correct ast node", function() {
+    it("creates the correct ast node", function() {
       const { ast } = this.op;
       expect(ast instanceof DSLASTNodes.FilterNode).toBeTruthy();
 
@@ -139,7 +139,7 @@ describe("DSLParserUtil", function() {
       });
     });
 
-    it("should create the correct filter function", function() {
+    it("creates the correct filter function", function() {
       const { filter } = this.op;
 
       expect(typeof filter).toEqual("function");
@@ -167,7 +167,7 @@ describe("DSLParserUtil", function() {
       this.op = DSLParserUtil.Merge.and(this.opLeft, this.opRight);
     });
 
-    it("should create the correct ast node", function() {
+    it("creates the correct ast node", function() {
       const { ast } = this.op;
       expect(ast instanceof DSLASTNodes.CombinerNode).toBeTruthy();
 
@@ -179,7 +179,7 @@ describe("DSLParserUtil", function() {
       expect(ast.combinerType).toEqual(DSLCombinerTypes.AND);
     });
 
-    it("should create the correct filter function", function() {
+    it("creates the correct filter function", function() {
       const { filter } = this.op;
 
       expect(typeof filter).toEqual("function");
@@ -209,7 +209,7 @@ describe("DSLParserUtil", function() {
       this.op = DSLParserUtil.Merge.or(this.opLeft, this.opRight);
     });
 
-    it("should create the correct ast node", function() {
+    it("creates the correct ast node", function() {
       const { ast } = this.op;
       expect(ast instanceof DSLASTNodes.CombinerNode).toBeTruthy();
 
@@ -221,7 +221,7 @@ describe("DSLParserUtil", function() {
       expect(ast.combinerType).toEqual(DSLCombinerTypes.OR);
     });
 
-    it("should create the correct filter function", function() {
+    it("creates the correct filter function", function() {
       const { filter } = this.op;
 
       expect(typeof filter).toEqual("function");

--- a/src/js/utils/__tests__/DSLUpdateUtil-test.js
+++ b/src/js/utils/__tests__/DSLUpdateUtil-test.js
@@ -7,54 +7,54 @@ const DSLUtil = require("../DSLUtil");
 
 describe("DSLUpdateUtil", function() {
   describe("#cleanupExpressionString", function() {
-    it("should remove extraneous whitespaces", function() {
+    it("removes extraneous whitespaces", function() {
       const expr = "foo  bar   baz ";
       expect(DSLUpdateUtil.cleanupExpressionString(expr)).toBe("foo bar baz");
     });
 
-    it("should remove repeating commas", function() {
+    it("removes repeating commas", function() {
       const expr = "foo,,  bar,  , baz";
       expect(DSLUpdateUtil.cleanupExpressionString(expr)).toBe("foo, bar, baz");
     });
 
-    it("should remove orphan commas (beginning)", function() {
+    it("removes orphan commas (beginning)", function() {
       const expr = " ,foo bar";
       expect(DSLUpdateUtil.cleanupExpressionString(expr)).toBe("foo bar");
     });
 
-    it("should remove orphan commas (ending)", function() {
+    it("removes orphan commas (ending)", function() {
       const expr = "foo bar ,";
       expect(DSLUpdateUtil.cleanupExpressionString(expr)).toBe("foo bar");
     });
 
-    it("should remove orphan commas (parenthesis-left)", function() {
+    it("removes orphan commas (parenthesis-left)", function() {
       const expr = "foo (, bar baz)";
       expect(DSLUpdateUtil.cleanupExpressionString(expr)).toBe("foo (bar baz)");
     });
 
-    it("should remove orphan commas (parenthesis-right)", function() {
+    it("removes orphan commas (parenthesis-right)", function() {
       const expr = "foo (bar baz , )";
       expect(DSLUpdateUtil.cleanupExpressionString(expr)).toBe("foo (bar baz)");
     });
 
-    it("should remove orphan commas (multi-value beginning)", function() {
+    it("removes orphan commas (multi-value beginning)", function() {
       const expr = "foo:,bar";
       expect(DSLUpdateUtil.cleanupExpressionString(expr)).toBe("foo:bar");
     });
 
-    it("should remove orphan commas (multi-value middle)", function() {
+    it("removes orphan commas (multi-value middle)", function() {
       const expr = "foo:bar,,baz";
       expect(DSLUpdateUtil.cleanupExpressionString(expr)).toBe("foo:bar,baz");
     });
 
-    it("should expand single parenthesis", function() {
+    it("expands single parenthesis", function() {
       const expr = "foo (bar) baz";
       expect(DSLUpdateUtil.cleanupExpressionString(expr)).toBe("foo bar baz");
     });
   });
 
   describe("#updateNodeTextString", function() {
-    it("should correctly update attribute nodes", function() {
+    it("updates attribute nodes", function() {
       const value = "label:foo";
 
       const node = new DSLExpression(value).ast;
@@ -68,7 +68,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly update multi-value attribute nodes", function() {
+    it("updates multi-value attribute nodes", function() {
       const value = "label:foo,baz";
 
       const node = new DSLExpression(value).ast.children[0];
@@ -82,7 +82,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly update fuzzy nodes", function() {
+    it("updates fuzzy nodes", function() {
       const value = "foo";
 
       const node = new DSLExpression(value).ast;
@@ -95,7 +95,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly update exact nodes", function() {
+    it("updates exact nodes", function() {
       const value = '"foo"';
 
       const node = new DSLExpression(value).ast;
@@ -108,7 +108,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should respect offset", function() {
+    it("respects offset", function() {
       const value = "some junk label:foo";
       const parseValue = "label:foo";
 
@@ -125,7 +125,7 @@ describe("DSLUpdateUtil", function() {
   });
 
   describe("#deleteNodeString", function() {
-    it("should correctly delete attribute nodes", function() {
+    it("deletes attribute nodes", function() {
       const value = "some fuzz label:foo";
 
       const node = new DSLExpression(value).ast.children[1];
@@ -133,7 +133,7 @@ describe("DSLUpdateUtil", function() {
       expect(DSLUpdateUtil.deleteNodeString(value, node)).toEqual("some fuzz");
     });
 
-    it("should correctly delete multi-value attribute nodes", function() {
+    it("deletes multi-value attribute nodes", function() {
       const value = "some fuzz label:foo,bar";
 
       const node = new DSLExpression(value).ast.children[1].children[1];
@@ -143,7 +143,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly delete fuzzy nodes", function() {
+    it("deletes fuzzy nodes", function() {
       const value = "some fuzz foo";
 
       const node = new DSLExpression(value).ast.children[1];
@@ -151,7 +151,7 @@ describe("DSLUpdateUtil", function() {
       expect(DSLUpdateUtil.deleteNodeString(value, node)).toEqual("some fuzz");
     });
 
-    it("should correctly delete exact nodes", function() {
+    it("deletes exact nodes", function() {
       const value = 'some fuzz "foo"';
 
       const node = new DSLExpression(value).ast.children[1];
@@ -159,7 +159,7 @@ describe("DSLUpdateUtil", function() {
       expect(DSLUpdateUtil.deleteNodeString(value, node)).toEqual("some fuzz");
     });
 
-    it("should correctly trim whitespaces on intermediate nodes", function() {
+    it("trims whitespaces on intermediate nodes", function() {
       const value = "some fuzz foo";
 
       const node = new DSLExpression(value).ast.children[0].children[1];
@@ -167,7 +167,7 @@ describe("DSLUpdateUtil", function() {
       expect(DSLUpdateUtil.deleteNodeString(value, node)).toEqual("some foo");
     });
 
-    it("should respect offset", function() {
+    it("respects offset", function() {
       const value = "some fuzz foo";
       const parseValue = "foo";
 
@@ -180,7 +180,7 @@ describe("DSLUpdateUtil", function() {
   });
 
   describe("#applyAdd", function() {
-    it("should correctly add one attribute node to an expression", function() {
+    it("adds one attribute node to an expression", function() {
       const expression = new DSLExpression("foo bar");
       const node = new DSLASTNodes.FilterNode(0, 0, DSLFilterTypes.ATTRIB, {
         label: "label",
@@ -192,7 +192,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly add fuzzy node to an expression", function() {
+    it("adds fuzzy node to an expression", function() {
       const expression = new DSLExpression("foo bar");
       const node = new DSLASTNodes.FilterNode(0, 0, DSLFilterTypes.FUZZY, {
         text: "text"
@@ -203,7 +203,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly add exact node to an expression", function() {
+    it("adds exact node to an expression", function() {
       const expression = new DSLExpression("foo bar");
       const node = new DSLASTNodes.FilterNode(0, 0, DSLFilterTypes.EXACT, {
         text: "text"
@@ -214,7 +214,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly add two attribute nodes to an expression", function() {
+    it("adds two attribute nodes to an expression", function() {
       const expression = new DSLExpression("foo bar");
       const node = new DSLASTNodes.FilterNode(0, 0, DSLFilterTypes.ATTRIB, {
         label: "label",
@@ -226,7 +226,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly add one attribute node to an expression with OR", function() {
+    it("adds one attribute node to an expression with OR", function() {
       const expression = new DSLExpression("foo bar");
       const node = new DSLASTNodes.FilterNode(0, 0, DSLFilterTypes.ATTRIB, {
         label: "label",
@@ -240,7 +240,7 @@ describe("DSLUpdateUtil", function() {
       ).toEqual("foo bar, label:text");
     });
 
-    it("should correctly add fuzzy node to an expression with OR", function() {
+    it("adds fuzzy node to an expression with OR", function() {
       const expression = new DSLExpression('"not fuzzy"');
       const node = new DSLASTNodes.FilterNode(0, 0, DSLFilterTypes.FUZZY, {
         text: "text"
@@ -253,7 +253,7 @@ describe("DSLUpdateUtil", function() {
       ).toEqual('"not fuzzy", text');
     });
 
-    it("should correctly add exact node to an expression with OR", function() {
+    it("adds exact node to an expression with OR", function() {
       const expression = new DSLExpression("foo bar");
       const node = new DSLASTNodes.FilterNode(0, 0, DSLFilterTypes.EXACT, {
         text: "text"
@@ -266,7 +266,7 @@ describe("DSLUpdateUtil", function() {
       ).toEqual('foo bar, "text"');
     });
 
-    it("should correctly create multi-value attribute when adding with OR", function() {
+    it("creates multi-value attribute when adding with OR", function() {
       const expression = new DSLExpression("foo bar label:some");
       const node = new DSLASTNodes.FilterNode(0, 0, DSLFilterTypes.ATTRIB, {
         label: "label",
@@ -280,7 +280,7 @@ describe("DSLUpdateUtil", function() {
       ).toEqual("foo bar label:some,text");
     });
 
-    it("should correctly use custom nodeCompareFunction on newCombiner", function() {
+    it("uses custom nodeCompareFunction on newCombiner", function() {
       const customComparisionFunction = function(addingNode, astNode) {
         return astNode.filterParams.text === "here";
       };
@@ -309,7 +309,7 @@ describe("DSLUpdateUtil", function() {
   });
 
   describe("#applyReplace", function() {
-    it("should correctly replace one node", function() {
+    it("replaces one node", function() {
       const expression = new DSLExpression("foo bar is:working");
       const attribNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -326,7 +326,7 @@ describe("DSLUpdateUtil", function() {
       ).toEqual("foo bar is:idle");
     });
 
-    it("should correctly replace more than one nodes", function() {
+    it("replaces more than one nodes", function() {
       const expression = new DSLExpression("some fuzzy nodes");
       const fuzzyNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -346,7 +346,7 @@ describe("DSLUpdateUtil", function() {
       ).toEqual("here can be");
     });
 
-    it("should correctly delete excess nodes", function() {
+    it("deletes excess nodes", function() {
       const expression = new DSLExpression("some fuzzy nodes that are gone");
       const fuzzyNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -366,7 +366,7 @@ describe("DSLUpdateUtil", function() {
       ).toEqual("here can be");
     });
 
-    it("should correctly add missing nodes", function() {
+    it("adds missing nodes", function() {
       const expression = new DSLExpression("few");
       const fuzzyNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -386,7 +386,7 @@ describe("DSLUpdateUtil", function() {
       ).toEqual("here can be");
     });
 
-    it("should correctly replace multi-value attribute nodes", function() {
+    it("replaces multi-value attribute nodes", function() {
       const expression = new DSLExpression("some fuzzy is:a,b,c nodes");
       const attribNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -413,7 +413,7 @@ describe("DSLUpdateUtil", function() {
       ).toEqual("some fuzzy is:one,of,many nodes");
     });
 
-    it("should correctly add missing nodes using newCombiner=OR", function() {
+    it("adds missing nodes using newCombiner=OR", function() {
       const expression = new DSLExpression("previous");
       const fuzzyNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -437,7 +437,7 @@ describe("DSLUpdateUtil", function() {
       ).toEqual("here can be");
     });
 
-    it("should correctly add missing nodes using itemCombiner=OR", function() {
+    it("adds missing nodes using itemCombiner=OR", function() {
       const expression = new DSLExpression("few");
       const fuzzyNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -459,7 +459,7 @@ describe("DSLUpdateUtil", function() {
       ).toEqual("here, can, be");
     });
 
-    it("should correctly continue with OR operator if itemCombiner=OR", function() {
+    it("continues with OR operator if itemCombiner=OR", function() {
       const expression = new DSLExpression("some label:foo");
       const fuzzyNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -490,7 +490,7 @@ describe("DSLUpdateUtil", function() {
   });
 
   describe("#applyDelete", function() {
-    it("should correctly delete one attribute node", function() {
+    it("deletes one attribute node", function() {
       const expression = new DSLExpression("is:attribute");
       const deleteNodes = [expression.ast];
 
@@ -499,7 +499,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly delete first in multiple attribute nodes", function() {
+    it("deletes first in multiple attribute nodes", function() {
       const expression = new DSLExpression("is:a is:b is:c");
       const deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -514,7 +514,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly delete last in multiple attribute nodes", function() {
+    it("deletes last in multiple attribute nodes", function() {
       const expression = new DSLExpression("is:a is:b is:c");
       const deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -529,7 +529,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly delete internal in multiple attribute nodes", function() {
+    it("deletes internal in multiple attribute nodes", function() {
       const expression = new DSLExpression("is:a is:b is:c");
       const deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -544,7 +544,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly delete first in multi-value attribute nodes", function() {
+    it("deletes first in multi-value attribute nodes", function() {
       const expression = new DSLExpression("is:a,b,c");
       const deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -559,7 +559,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly delete internal in multi-value attribute nodes", function() {
+    it("deletes internal in multi-value attribute nodes", function() {
       const expression = new DSLExpression("is:a,b,c");
       const deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -574,7 +574,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly delete last in multi-value attribute nodes", function() {
+    it("deletes last in multi-value attribute nodes", function() {
       const expression = new DSLExpression("is:a,b,c");
       const deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -589,7 +589,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly delete one in multiple attribute nodes", function() {
+    it("deletes one in multiple attribute nodes", function() {
       const expression = new DSLExpression("is:a is:b, is:c");
       const deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -604,7 +604,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly delete one in multi-value attribute node", function() {
+    it("deletes one in multi-value attribute node", function() {
       const expression = new DSLExpression("is:a,b,c");
       const deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -619,7 +619,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly delete one fuzzy node", function() {
+    it("deletes one fuzzy node", function() {
       const expression = new DSLExpression("fuzz");
       const deleteNodes = [expression.ast];
 
@@ -628,7 +628,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly delete one exact node", function() {
+    it("deletes one exact node", function() {
       const expression = new DSLExpression('"exact"');
       const deleteNodes = [expression.ast];
 
@@ -637,7 +637,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly delete nodes between other nodes", function() {
+    it("deletes nodes between other nodes", function() {
       const expression = new DSLExpression(
         'some (fuzzy expression) "with" text'
       );
@@ -651,7 +651,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it("should correctly delete lingering comma operators", function() {
+    it("deletes lingering comma operators", function() {
       const expression = new DSLExpression("some, fuzz");
       const deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -663,7 +663,7 @@ describe("DSLUpdateUtil", function() {
       );
     });
 
-    it('should correctly delete is:c in "is:a,b,c is:d,c"', function() {
+    it('deletes is:c in "is:a,b,c is:d,c"', function() {
       const expression = new DSLExpression("is:a,b,c is:d,e");
       const deleteNodes = DSLUtil.findNodesByFilter(
         expression.ast,
@@ -680,7 +680,7 @@ describe("DSLUpdateUtil", function() {
   });
 
   describe("#defaultNodeCompareFunction", function() {
-    it("should return false when comparing nodes of different type", function() {
+    it("returns false when comparing nodes of different type", function() {
       const nodeA = new DSLASTNodes.FilterNode(1, 4, DSLFilterTypes.EXACT, {
         text: "text"
       });
@@ -693,7 +693,7 @@ describe("DSLUpdateUtil", function() {
       ).toBeFalsy();
     });
 
-    it("should return true when both fuzzy regardless of text", function() {
+    it("returns true when both fuzzy regardless of text", function() {
       const nodeA = new DSLASTNodes.FilterNode(1, 4, DSLFilterTypes.FUZZY, {
         text: "text1"
       });
@@ -706,7 +706,7 @@ describe("DSLUpdateUtil", function() {
       ).toBeTruthy();
     });
 
-    it("should return true when both exact regardless of text", function() {
+    it("returns true when both exact regardless of text", function() {
       const nodeA = new DSLASTNodes.FilterNode(1, 4, DSLFilterTypes.EXACT, {
         text: "text1"
       });
@@ -719,7 +719,7 @@ describe("DSLUpdateUtil", function() {
       ).toBeTruthy();
     });
 
-    it("should return false when both attrib but different label", function() {
+    it("returns false when both attrib but different label", function() {
       const nodeA = new DSLASTNodes.FilterNode(1, 4, DSLFilterTypes.ATTRIB, {
         text: "text1",
         label: "label1"
@@ -734,7 +734,7 @@ describe("DSLUpdateUtil", function() {
       ).toBeFalsy();
     });
 
-    it("should return false when both attrib and same label", function() {
+    it("returns false when both attrib and same label", function() {
       const nodeA = new DSLASTNodes.FilterNode(1, 4, DSLFilterTypes.ATTRIB, {
         text: "text1",
         label: "label"

--- a/src/js/utils/__tests__/DSLUtil-test.js
+++ b/src/js/utils/__tests__/DSLUtil-test.js
@@ -6,7 +6,7 @@ const DSLUtil = require("../DSLUtil");
 
 describe("DSLUtil", function() {
   describe("#reduceAstFilters", function() {
-    it("should be called for every filter in the tree", function() {
+    it("is called for every filter in the tree", function() {
       const ast = new DSLExpression('foo bar (is:attribute "exact")').ast;
       const handler = jest.fn();
 
@@ -19,7 +19,7 @@ describe("DSLUtil", function() {
       expect(texts).toEqual(["foo", "bar", "attribute", "exact"]);
     });
 
-    it("should correctly return and process memo", function() {
+    it("returns and process memo", function() {
       const ast = new DSLExpression('foo bar (is:attribute "exact")').ast;
       const texts = DSLUtil.reduceAstFilters(
         ast,
@@ -34,25 +34,25 @@ describe("DSLUtil", function() {
   });
 
   describe("#canFormProcessExpression", function() {
-    it("should return true if no repeating token and no groups", function() {
+    it("returns true if no repeating token and no groups", function() {
       const expr = new DSLExpression('is:foo is:bar foo bar "expr"');
 
       expect(DSLUtil.canFormProcessExpression(expr)).toBeTruthy();
     });
 
-    it("should return true if repeating token and no group", function() {
+    it("returns true if repeating token and no group", function() {
       const expr = new DSLExpression('is:foo is:bar foo bar "expr" is:foo');
 
       expect(DSLUtil.canFormProcessExpression(expr)).toBeTruthy();
     });
 
-    it("should return true if group and no repeating token", function() {
+    it("returns true if group and no repeating token", function() {
       const expr = new DSLExpression('is:foo is:bar (foo bar "expr")');
 
       expect(DSLUtil.canFormProcessExpression(expr)).toBeTruthy();
     });
 
-    it("should return false if group and repeating token", function() {
+    it("returns false if group and repeating token", function() {
       const expr = new DSLExpression('is:foo is:bar (is:foo bar "expr")');
 
       expect(DSLUtil.canFormProcessExpression(expr)).toBeFalsy();
@@ -68,43 +68,43 @@ describe("DSLUtil", function() {
       };
     });
 
-    it("should return true when expression is empty", function() {
+    it("returns true when expression is empty", function() {
       const expression = new DSLExpression();
 
       expect(DSLUtil.canProcessParts(expression, this.parts)).toBeTruthy();
     });
 
-    it("should return true when expression has a single attribute node", function() {
+    it("returns true when expression has a single attribute node", function() {
       const expression = new DSLExpression("is:foo");
 
       expect(DSLUtil.canProcessParts(expression, this.parts)).toBeTruthy();
     });
 
-    it("should return false when expression has a repeating attribute node", function() {
+    it("returns false when expression has a repeating attribute node", function() {
       const expression = new DSLExpression("is:foo is:foo");
 
       expect(DSLUtil.canProcessParts(expression, this.parts)).toBeFalsy();
     });
 
-    it("should return true when expression has a single exact node", function() {
+    it("returns true when expression has a single exact node", function() {
       const expression = new DSLExpression('"exact foo"');
 
       expect(DSLUtil.canProcessParts(expression, this.parts)).toBeTruthy();
     });
 
-    it("should return false when expression has a repeating exact node", function() {
+    it("returns false when expression has a repeating exact node", function() {
       const expression = new DSLExpression('"exact foo" "something else"');
 
       expect(DSLUtil.canProcessParts(expression, this.parts)).toBeFalsy();
     });
 
-    it("should return true when expression has a single fuzzy node", function() {
+    it("returns true when expression has a single fuzzy node", function() {
       const expression = new DSLExpression("foo");
 
       expect(DSLUtil.canProcessParts(expression, this.parts)).toBeTruthy();
     });
 
-    it("should return true when expression has a repeating fuzzy nodes", function() {
+    it("returns true when expression has a repeating fuzzy nodes", function() {
       const expression = new DSLExpression("foo foo");
 
       expect(DSLUtil.canProcessParts(expression, this.parts)).toBeTruthy();
@@ -152,7 +152,7 @@ describe("DSLUtil", function() {
       this.exact = [this.ast.children[1]];
     });
 
-    it("should return all occurrences of attribute match", function() {
+    it("returns all occurrences of attribute match", function() {
       const filter = DSLExpressionPart.attribute("is", "foo");
 
       expect(DSLUtil.findNodesByFilter(this.ast, filter)).toEqual([
@@ -161,13 +161,13 @@ describe("DSLUtil", function() {
       ]);
     });
 
-    it("should return all occurrences of fuzzy match", function() {
+    it("returns all occurrences of fuzzy match", function() {
       const filter = DSLExpressionPart.fuzzy;
 
       expect(DSLUtil.findNodesByFilter(this.ast, filter)).toEqual(this.fuzzy);
     });
 
-    it("should return all occurrences of exact match", function() {
+    it("returns all occurrences of exact match", function() {
       const filter = DSLExpressionPart.exact;
 
       expect(DSLUtil.findNodesByFilter(this.ast, filter)).toEqual(this.exact);
@@ -183,7 +183,7 @@ describe("DSLUtil", function() {
       };
     });
 
-    it("should set `true` on existing attributes", function() {
+    it("sets `true` on existing attributes", function() {
       const expression = new DSLExpression("is:foo");
 
       expect(DSLUtil.getPartValues(expression, this.parts)).toEqual({
@@ -193,7 +193,7 @@ describe("DSLUtil", function() {
       });
     });
 
-    it("should set the string value of exact matches", function() {
+    it("sets the string value of exact matches", function() {
       const expression = new DSLExpression('"this is a test"');
 
       expect(DSLUtil.getPartValues(expression, this.parts)).toEqual({
@@ -203,7 +203,7 @@ describe("DSLUtil", function() {
       });
     });
 
-    it("should set the string value of fuzzy matches", function() {
+    it("sets the string value of fuzzy matches", function() {
       const expression = new DSLExpression("foo bar token");
 
       expect(DSLUtil.getPartValues(expression, this.parts)).toEqual({
@@ -213,7 +213,7 @@ describe("DSLUtil", function() {
       });
     });
 
-    it("should properly handle more than one property in expression", function() {
+    it("handles more than one property in expression", function() {
       const expression = new DSLExpression('foo "exact" is:foo bar token');
 
       expect(DSLUtil.getPartValues(expression, this.parts)).toEqual({
@@ -225,7 +225,7 @@ describe("DSLUtil", function() {
   });
 
   describe("#getNodeString", function() {
-    it("should correctly return the string of attribute nodes", function() {
+    it("returns the string of attribute nodes", function() {
       const node = new DSLASTNodes.FilterNode(0, 0, DSLFilterTypes.ATTRIB, {
         label: "label",
         text: "text"
@@ -234,7 +234,7 @@ describe("DSLUtil", function() {
       expect(DSLUtil.getNodeString(node)).toEqual("label:text");
     });
 
-    it("should correctly return the string of fuzzy nodes", function() {
+    it("returns the string of fuzzy nodes", function() {
       const node = new DSLASTNodes.FilterNode(0, 0, DSLFilterTypes.FUZZY, {
         text: "text"
       });
@@ -242,7 +242,7 @@ describe("DSLUtil", function() {
       expect(DSLUtil.getNodeString(node)).toEqual("text");
     });
 
-    it("should correctly return the string of exact nodes", function() {
+    it("returns the string of exact nodes", function() {
       const node = new DSLASTNodes.FilterNode(0, 0, DSLFilterTypes.EXACT, {
         text: "text"
       });

--- a/src/js/utils/__tests__/DataValidatorUtil-test.js
+++ b/src/js/utils/__tests__/DataValidatorUtil-test.js
@@ -2,14 +2,14 @@ const DataValidatorUtil = require("../DataValidatorUtil");
 
 describe("DataValidatorUtil", function() {
   describe("#errorArrayToMap", function() {
-    it("should correctly return an object", function() {
+    it("returns an object", function() {
       var obj = DataValidatorUtil.errorArrayToMap([
         { path: ["a", "b"], message: "Foo" }
       ]);
       expect(obj).toEqual({ a: { b: "Foo" } });
     });
 
-    it("should correctly merge paths that share the same base", function() {
+    it("merges paths that share the same base", function() {
       var obj = DataValidatorUtil.errorArrayToMap([
         { path: ["a", "b"], message: "Foo" },
         { path: ["a", "c"], message: "Bar" }
@@ -17,7 +17,7 @@ describe("DataValidatorUtil", function() {
       expect(obj).toEqual({ a: { b: "Foo", c: "Bar" } });
     });
 
-    it("should correctly create arrays when numbers in path", function() {
+    it("creates arrays when numbers in path", function() {
       var obj = DataValidatorUtil.errorArrayToMap([
         { path: ["a", 0, "b"], message: "Foo" },
         { path: ["a", 5, "b"], message: "Bar" }
@@ -34,7 +34,7 @@ describe("DataValidatorUtil", function() {
       });
     });
 
-    it("should correctly merge errors in the same path", function() {
+    it("merges errors in the same path", function() {
       var obj = DataValidatorUtil.errorArrayToMap([
         { path: ["a", "b"], message: "Foo" },
         { path: ["a", "b"], message: "Bar" }
@@ -42,7 +42,7 @@ describe("DataValidatorUtil", function() {
       expect(obj).toEqual({ a: { b: "Foo, Bar" } });
     });
 
-    it("should correctly handle errors with empty paths", function() {
+    it("handles errors with empty paths", function() {
       var obj = DataValidatorUtil.errorArrayToMap([
         { path: [], message: "Foo" },
         { path: ["a", "b"], message: "Bar" }
@@ -52,7 +52,7 @@ describe("DataValidatorUtil", function() {
   });
 
   describe("#updateOnlyOnPath", function() {
-    it("should not touch errors on unknown paths", function() {
+    it("does not touch errors on unknown paths", function() {
       var oldErrors = [
         { path: ["a", "b"], message: "Error1" },
         { path: ["a", "c"], message: "Error2" }
@@ -71,7 +71,7 @@ describe("DataValidatorUtil", function() {
       ]);
     });
 
-    it("should correctly update only related errors", function() {
+    it("updates only related errors", function() {
       var oldErrors = [
         { path: ["a", "b"], message: "Error1" },
         { path: ["a", "c"], message: "Error2" }
@@ -90,7 +90,7 @@ describe("DataValidatorUtil", function() {
       ]);
     });
 
-    it("should remove errors if new list contains less, unrelated errors", function() {
+    it("removes errors if new list contains less, unrelated errors", function() {
       var oldErrors = [
         { path: ["a", "b"], message: "Error1" },
         { path: ["a", "c"], message: "Error3" }
@@ -105,7 +105,7 @@ describe("DataValidatorUtil", function() {
   });
 
   describe("#stripErrorsOnPath", function() {
-    it("should remove only related errors", function() {
+    it("removes only related errors", function() {
       var oldErrors = [
         { path: ["a", "b"], message: "Error1" },
         { path: ["a", "c"], message: "Error3" }

--- a/src/js/utils/__tests__/DateUtil-test.js
+++ b/src/js/utils/__tests__/DateUtil-test.js
@@ -2,55 +2,55 @@ const DateUtil = require("../DateUtil");
 
 describe("DateUtil", function() {
   describe("#msToMultiplicants", function() {
-    it("should decompose milliseconds only", function() {
+    it("decomposes milliseconds only", function() {
       var result = DateUtil.msToMultiplicants(987);
 
       expect(result).toEqual(["987 ms"]);
     });
 
-    it("should decompose seconds only", function() {
+    it("decomposes seconds only", function() {
       var result = DateUtil.msToMultiplicants(12000);
 
       expect(result).toEqual(["12 sec"]);
     });
 
-    it("should decompose minutes only", function() {
+    it("decomposes minutes only", function() {
       var result = DateUtil.msToMultiplicants(720000);
 
       expect(result).toEqual(["12 min"]);
     });
 
-    it("should decompose hours only", function() {
+    it("decomposes hours only", function() {
       var result = DateUtil.msToMultiplicants(43200000);
 
       expect(result).toEqual(["12 h"]);
     });
 
-    it("should decompose days only", function() {
+    it("decomposes days only", function() {
       var result = DateUtil.msToMultiplicants(1036800000);
 
       expect(result).toEqual(["12 d"]);
     });
 
-    it("should decompose milliseconds and seconds", function() {
+    it("decomposes milliseconds and seconds", function() {
       var result = DateUtil.msToMultiplicants(9878);
 
       expect(result).toEqual(["9 sec", "878 ms"]);
     });
 
-    it("should decompose seconds and minutes", function() {
+    it("decomposes seconds and minutes", function() {
       var result = DateUtil.msToMultiplicants(732000);
 
       expect(result).toEqual(["12 min", "12 sec"]);
     });
 
-    it("should decompose minutes and hours", function() {
+    it("decomposes minutes and hours", function() {
       var result = DateUtil.msToMultiplicants(43920000);
 
       expect(result).toEqual(["12 h", "12 min"]);
     });
 
-    it("should decompose hours and days", function() {
+    it("decomposes hours and days", function() {
       var result = DateUtil.msToMultiplicants(1080000000);
 
       expect(result).toEqual(["12 d", "12 h"]);
@@ -58,7 +58,7 @@ describe("DateUtil", function() {
   });
 
   describe("#msToDateStr", function() {
-    it("should return the correct string for AM", function() {
+    it("returns the correct string for AM", function() {
       // December is 11 due to months being 0-based index.
       var christmas = new Date(2015, 11, 25, 8, 13);
       var christmasValue = christmas.valueOf();
@@ -68,7 +68,7 @@ describe("DateUtil", function() {
       expect(result).toEqual("12-25-2015 at 8:13am");
     });
 
-    it("should return the correct string for PM", function() {
+    it("returns the correct string for PM", function() {
       var halloween = new Date(2015, 9, 31, 20, 30);
       var halloweenValue = halloween.valueOf();
 

--- a/src/js/utils/__tests__/ErrorMessageUtil-test.js
+++ b/src/js/utils/__tests__/ErrorMessageUtil-test.js
@@ -2,7 +2,7 @@ const ErrorMessageUtil = require("../ErrorMessageUtil");
 
 describe("ErrorMessageUtil", function() {
   describe("#translateErrorMessages", function() {
-    it("should pass-through if there is no translation", function() {
+    it("passes through if there is no translation", function() {
       const errorInput = [
         {
           message: "message1",
@@ -25,7 +25,7 @@ describe("ErrorMessageUtil", function() {
       ]);
     });
 
-    it("should pass-through if no path matches", function() {
+    it("passes through if no path matches", function() {
       const errorInput = [
         {
           message: "message1",
@@ -54,7 +54,7 @@ describe("ErrorMessageUtil", function() {
       ]);
     });
 
-    it("should pass-through if no type matches", function() {
+    it("passes through if no type matches", function() {
       const errorInput = [
         {
           message: "message1",
@@ -83,7 +83,7 @@ describe("ErrorMessageUtil", function() {
       ]);
     });
 
-    it("should translate if path and type matches", function() {
+    it("translates if path and type matches", function() {
       const errorInput = [
         {
           message: "message1",
@@ -112,7 +112,7 @@ describe("ErrorMessageUtil", function() {
       ]);
     });
 
-    it("should not modify path if a rule matches", function() {
+    it("does not modify path if a rule matches", function() {
       const errorInput = [
         {
           message: "message1",
@@ -141,7 +141,7 @@ describe("ErrorMessageUtil", function() {
       ]);
     });
 
-    it("should pick the first translation that passes", function() {
+    it("picks the first translation that passes", function() {
       const errorInput = [
         {
           message: "message1",
@@ -175,7 +175,7 @@ describe("ErrorMessageUtil", function() {
       ]);
     });
 
-    it("should correctly replace variables", function() {
+    it("replaces variables", function() {
       const errorInput = [
         {
           message: "message1 is 3",
@@ -208,7 +208,7 @@ describe("ErrorMessageUtil", function() {
       ]);
     });
 
-    it("should be able to handle errors with no path", function() {
+    it("is able to handle errors with no path", function() {
       const errorInput = [{ message: "message" }];
       const translationRules = [];
 
@@ -219,7 +219,7 @@ describe("ErrorMessageUtil", function() {
       expect(translatedErrors).toEqual([{ message: "message" }]);
     });
 
-    it("should be able to handle errors with null messages", function() {
+    it("is able to handle errors with null messages", function() {
       const errorInput = [{ message: null }];
       const translationRules = [];
 

--- a/src/js/utils/__tests__/FormUtil-test.js
+++ b/src/js/utils/__tests__/FormUtil-test.js
@@ -64,19 +64,19 @@ describe("FormUtil", function() {
       });
     });
 
-    it("should not modify the unrelated properties", function() {
+    it("does not modify the unrelated properties", function() {
       expect(this.result.unrelatedProp).toEqual("hellothere");
     });
 
-    it('should create a property named "uid" that is an array', function() {
+    it('creates a property named "uid" that is an array', function() {
       expect(Array.isArray(this.result.uid)).toEqual(true);
     });
 
-    it("should convert each instance into an object", function() {
+    it("converts each instance into an object", function() {
       expect(typeof this.result.uid[0]).toEqual("object");
     });
 
-    it("should convert each instance with the correct values", function() {
+    it("converts each instance with the correct values", function() {
       expect(this.result.uid[0].uid).toEqual("kenny");
       expect(this.result.uid[0].password).toEqual("secret");
       expect(this.result.uid[1].uid).toEqual("jane");
@@ -85,7 +85,7 @@ describe("FormUtil", function() {
   });
 
   describe("#isFieldInstanceOfProp", function() {
-    it("should return true if field is instance of prop", function() {
+    it("returns true if field is instance of prop", function() {
       const fields = [
         { name: "variable[2].key", value: "kenny" },
         { name: "variable[2].value", value: "tran" }
@@ -94,7 +94,7 @@ describe("FormUtil", function() {
       expect(result).toEqual(true);
     });
 
-    it("should return false if field is not instance of prop", function() {
+    it("returns false if field is not instance of prop", function() {
       const fields = [
         { name: "variable[1].key", value: "kenny" },
         { name: "variable[1].value", value: "tran" }
@@ -103,7 +103,7 @@ describe("FormUtil", function() {
       expect(result).toEqual(false);
     });
 
-    it("should work on a single definition", function() {
+    it("works on a single definition", function() {
       const field = { name: "variable[1].key", value: "kenny" };
       const result = FormUtil.isFieldInstanceOfProp("variable", field, 1);
       expect(result).toEqual(true);
@@ -111,7 +111,7 @@ describe("FormUtil", function() {
   });
 
   describe("#removePropID", function() {
-    it("should remove the fields with that property", function() {
+    it("removes the fields with that property", function() {
       const definition = [
         { name: "password", value: "secret" },
         { name: "variable[1].key", value: "kenny" },

--- a/src/js/utils/__tests__/JSONEditorUtil-test.js
+++ b/src/js/utils/__tests__/JSONEditorUtil-test.js
@@ -2,7 +2,7 @@ const JSONEditorUtil = require("../JSONEditorUtil");
 
 describe("JSONEditorUtil", function() {
   describe("#cursorFromOffset", function() {
-    it("should properly resolve beginning edge", function() {
+    it("resolves beginning edge", function() {
       const text = "some oneline text";
       expect(JSONEditorUtil.cursorFromOffset(0, text)).toEqual({
         row: 0,
@@ -10,7 +10,7 @@ describe("JSONEditorUtil", function() {
       });
     });
 
-    it("should properly resolve ending edge", function() {
+    it("resolves ending edge", function() {
       const text = "some oneline text";
       expect(JSONEditorUtil.cursorFromOffset(16, text)).toEqual({
         row: 0,
@@ -18,7 +18,7 @@ describe("JSONEditorUtil", function() {
       });
     });
 
-    it("should ignore negative offsets", function() {
+    it("ignores negative offsets", function() {
       const text = "some oneline text";
       expect(JSONEditorUtil.cursorFromOffset(-1, text)).toEqual({
         row: 0,
@@ -26,7 +26,7 @@ describe("JSONEditorUtil", function() {
       });
     });
 
-    it("should ignore offsets exceeding string length", function() {
+    it("ignores offsets exceeding string length", function() {
       const text = "some oneline text";
       expect(JSONEditorUtil.cursorFromOffset(20, text)).toEqual({
         row: 0,
@@ -34,7 +34,7 @@ describe("JSONEditorUtil", function() {
       });
     });
 
-    it("should properly resolve offset in multiline text", function() {
+    it("resolves offset in multiline text", function() {
       const text = "first line\nsecond line\nthird line";
       expect(JSONEditorUtil.cursorFromOffset(13, text)).toEqual({
         row: 1,
@@ -44,7 +44,7 @@ describe("JSONEditorUtil", function() {
   });
 
   describe("#deepObjectDiff", function() {
-    it("should detect added values", function() {
+    it("detects added values", function() {
       const a = {};
       const b = { a: "foo" };
 
@@ -54,7 +54,7 @@ describe("JSONEditorUtil", function() {
       ]);
     });
 
-    it("should detect removed values", function() {
+    it("detects removed values", function() {
       const a = { a: "foo" };
       const b = {};
 
@@ -64,7 +64,7 @@ describe("JSONEditorUtil", function() {
       ]);
     });
 
-    it("should detect modified values", function() {
+    it("detects modified values", function() {
       const a = { a: "foo" };
       const b = { a: "bar" };
 
@@ -74,7 +74,7 @@ describe("JSONEditorUtil", function() {
       ]);
     });
 
-    it("should detect added values in arrays", function() {
+    it("detects added values in arrays", function() {
       const a = { a: [] };
       const b = { a: ["foo"] };
 
@@ -85,7 +85,7 @@ describe("JSONEditorUtil", function() {
       ]);
     });
 
-    it("should detect removed values in arrays", function() {
+    it("detects removed values in arrays", function() {
       const a = { a: ["foo"] };
       const b = { a: [] };
 
@@ -96,7 +96,7 @@ describe("JSONEditorUtil", function() {
       ]);
     });
 
-    it("should detect modified values in arrays", function() {
+    it("detects modified values in arrays", function() {
       const a = { a: ["foo"] };
       const b = { a: ["bar"] };
 
@@ -107,7 +107,7 @@ describe("JSONEditorUtil", function() {
       ]);
     });
 
-    it("should detect added values in objects", function() {
+    it("detects added values in objects", function() {
       const a = { a: {} };
       const b = { a: { b: "foo" } };
 
@@ -118,7 +118,7 @@ describe("JSONEditorUtil", function() {
       ]);
     });
 
-    it("should detect removed values in objects", function() {
+    it("detects removed values in objects", function() {
       const a = { a: { b: "foo" } };
       const b = { a: {} };
 
@@ -129,7 +129,7 @@ describe("JSONEditorUtil", function() {
       ]);
     });
 
-    it("should detect modified values in objects", function() {
+    it("detects modified values in objects", function() {
       const a = { a: { b: "foo" } };
       const b = { a: { b: "bar" } };
 
@@ -140,7 +140,7 @@ describe("JSONEditorUtil", function() {
       ]);
     });
 
-    it("should handle object-to-array mutations", function() {
+    it("handles object-to-array mutations", function() {
       const a = { a: { b: "foo" } };
       const b = { a: ["foo"] };
 
@@ -152,7 +152,7 @@ describe("JSONEditorUtil", function() {
       ]);
     });
 
-    it("should handle object-to-scalar mutations", function() {
+    it("handles object-to-scalar mutations", function() {
       const a = { a: { b: "foo" } };
       const b = { a: "bar" };
 
@@ -162,7 +162,7 @@ describe("JSONEditorUtil", function() {
       ]);
     });
 
-    it("should handle array-to-object mutations", function() {
+    it("handles array-to-object mutations", function() {
       const a = { a: ["foo"] };
       const b = { a: { b: "foo" } };
 
@@ -174,7 +174,7 @@ describe("JSONEditorUtil", function() {
       ]);
     });
 
-    it("should handle scalar-to-object mutations", function() {
+    it("handles scalar-to-object mutations", function() {
       const a = { a: "bar" };
       const b = { a: { b: "foo" } };
 
@@ -184,7 +184,7 @@ describe("JSONEditorUtil", function() {
       ]);
     });
 
-    it("should handle null-to-object mutations", function() {
+    it("handles null-to-object mutations", function() {
       const a = { a: null };
       const b = { a: { b: "foo" } };
 
@@ -194,7 +194,7 @@ describe("JSONEditorUtil", function() {
       ]);
     });
 
-    it("should handle object-to-null mutations", function() {
+    it("handles object-to-null mutations", function() {
       const a = { a: { b: "foo" } };
       const b = { a: null };
 
@@ -206,7 +206,7 @@ describe("JSONEditorUtil", function() {
   });
 
   describe("#sortObjectKeys", function() {
-    it("should order keys according to old ones", function() {
+    it("orders keys according to old ones", function() {
       const a = { a: 0, b: 1, c: 2 };
       const b = { c: 3, a: 4, b: 5 };
 
@@ -215,7 +215,7 @@ describe("JSONEditorUtil", function() {
       expect(value).toEqual({ a: 4, b: 5, c: 3 });
     });
 
-    it("should order less than previous keys in the same order", function() {
+    it("orders less than previous keys in the same order", function() {
       const a = { a: 0, b: 1, c: 2 };
       const b = { c: 3, a: 4 };
 
@@ -224,7 +224,7 @@ describe("JSONEditorUtil", function() {
       expect(value).toEqual({ a: 4, c: 3 });
     });
 
-    it("should add new keys at the end of the object", function() {
+    it("adds new keys at the end of the object", function() {
       const a = { a: 0, b: 1, c: 2 };
       const b = { c: 3, a: 4, d: 5 };
 
@@ -233,7 +233,7 @@ describe("JSONEditorUtil", function() {
       expect(value).toEqual({ a: 4, c: 3, d: 5 });
     });
 
-    it("should order keys according to old ones (nested)", function() {
+    it("orders keys according to old ones (nested)", function() {
       const a = { o: { a: 0, b: 1, c: 2 } };
       const b = { o: { c: 3, a: 4, b: 5 } };
 
@@ -242,7 +242,7 @@ describe("JSONEditorUtil", function() {
       expect(value).toEqual({ o: { a: 4, b: 5, c: 3 } });
     });
 
-    it("should order less than previous keys in the same order (nested)", function() {
+    it("orders less than previous keys in the same order (nested)", function() {
       const a = { o: { a: 0, b: 1, c: 2 } };
       const b = { o: { c: 3, a: 4 } };
 
@@ -251,7 +251,7 @@ describe("JSONEditorUtil", function() {
       expect(value).toEqual({ o: { a: 4, c: 3 } });
     });
 
-    it("should add new keys at the end of the object (nested)", function() {
+    it("adds new keys at the end of the object (nested)", function() {
       const a = { o: { a: 0, b: 1, c: 2 } };
       const b = { o: { c: 3, a: 4, d: 5 } };
 
@@ -268,7 +268,7 @@ describe("JSONEditorUtil", function() {
       expect(value).toEqual({ a: ["b", "a", "c"] });
     });
 
-    it("should properly handle null-to-object comparisons", function() {
+    it("handles null-to-object comparisons", function() {
       const a = { a: { b: "foo", c: "bar" } };
       const b = { a: null };
 
@@ -276,7 +276,7 @@ describe("JSONEditorUtil", function() {
       expect(value).toEqual({ a: null });
     });
 
-    it("should place object values in keys that were null before", function() {
+    it("places object values in keys that were null before", function() {
       const a = { a: null };
       const b = { a: { b: "foo", c: "bar" } };
 

--- a/src/js/utils/__tests__/JSONUtil-test.js
+++ b/src/js/utils/__tests__/JSONUtil-test.js
@@ -3,19 +3,19 @@ const JSONUtil = require("../JSONUtil");
 describe("JSONUtil", function() {
   describe("#getObjectInformation", function() {
     describe("Empty Object", function() {
-      it("should handle empty objects", function() {
+      it("handles empty objects", function() {
         var code = "{}";
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([]);
       });
 
-      it("should tolerate whitespaces before root object", function() {
+      it("tolerates whitespaces before root object", function() {
         var code = "    \t        \n \t   \t\n\t  {}";
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([]);
       });
 
-      it("should tolerate whitespaces after root object", function() {
+      it("tolerates whitespaces after root object", function() {
         var code = "{}    \t        \n \t   \t\n\t  ";
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([]);
@@ -23,35 +23,35 @@ describe("JSONUtil", function() {
     });
 
     describe("JSON Sanity Checks", function() {
-      it("should raise exception on invalid JSON content", function() {
+      it("raises exception on invalid JSON content", function() {
         var code = "A random {text} that has [nothing to do] with JSON!";
         expect(function() {
           JSONUtil.getObjectInformation(code);
         }).toThrow();
       });
 
-      it("should raise exception on incomplete JSON objects", function() {
+      it("raises exception on incomplete JSON objects", function() {
         var code = '{\n"name": {\n\t"value": 1\n\t}';
         expect(function() {
           JSONUtil.getObjectInformation(code);
         }).toThrow();
       });
 
-      it("should raise exception on non-quoted keys", function() {
+      it("raises exception on non-quoted keys", function() {
         var code = '{\nkey: "value"\n}';
         expect(function() {
           JSONUtil.getObjectInformation(code);
         }).toThrow();
       });
 
-      it("should raise exception on wrong keys (numeric)", function() {
+      it("raises exception on wrong keys (numeric)", function() {
         var code = '{\n929: "value"\n}';
         expect(function() {
           JSONUtil.getObjectInformation(code);
         }).toThrow();
       });
 
-      it("should raise exception on wrong keys (invalid characters)", function() {
+      it("raises exception on wrong keys (invalid characters)", function() {
         var code = '{\nkf@492!2$: "value"\n}';
         expect(function() {
           JSONUtil.getObjectInformation(code);
@@ -60,7 +60,7 @@ describe("JSONUtil", function() {
     });
 
     describe("Simple Primitives", function() {
-      it("should handle string values", function() {
+      it("handles string values", function() {
         var code = '{\n"name": "value"\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
@@ -74,7 +74,7 @@ describe("JSONUtil", function() {
         ]);
       });
 
-      it("should handle numeric values", function() {
+      it("handles numeric values", function() {
         var code = '{\n"name": 1\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
@@ -88,7 +88,7 @@ describe("JSONUtil", function() {
         ]);
       });
 
-      it("should handle `null` values", function() {
+      it("handles `null` values", function() {
         var code = '{\n"name": null\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
@@ -102,7 +102,7 @@ describe("JSONUtil", function() {
         ]);
       });
 
-      it("should handle `true` values", function() {
+      it("handles `true` values", function() {
         var code = '{\n"name": true\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
@@ -116,7 +116,7 @@ describe("JSONUtil", function() {
         ]);
       });
 
-      it("should handle `false` values", function() {
+      it("handles `false` values", function() {
         var code = '{\n"name": false\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
@@ -132,7 +132,7 @@ describe("JSONUtil", function() {
     });
 
     describe("Corner Cases", function() {
-      it("should handle repeated keys", function() {
+      it("handles repeated keys", function() {
         var code = '{\n"name": 1,\n"name": 2\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
@@ -153,7 +153,7 @@ describe("JSONUtil", function() {
         ]);
       });
 
-      it("should handle more than one keys on the same line", function() {
+      it("handles more than one keys on the same line", function() {
         var code = '{\n"name": 1, "nome": 2\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
@@ -174,7 +174,7 @@ describe("JSONUtil", function() {
         ]);
       });
 
-      it("should handle repeated keys on the same line", function() {
+      it("handles repeated keys on the same line", function() {
         var code = '{\n"name": 1, "name": 2\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
@@ -197,7 +197,7 @@ describe("JSONUtil", function() {
     });
 
     describe("Objects & Nesting", function() {
-      it("should handle single level-1 object nesting", function() {
+      it("handles single level-1 object nesting", function() {
         var code = '{\n"name": {\n\t"child": 1\n\t}\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
@@ -217,7 +217,7 @@ describe("JSONUtil", function() {
         ]);
       });
 
-      it("should handle single level-2 object nesting", function() {
+      it("handles single level-2 object nesting", function() {
         var code = '{\n"name": {\n\t"child": {\n\t\t"value": 1\n\t\t}\n\t}\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
@@ -243,7 +243,7 @@ describe("JSONUtil", function() {
         ]);
       });
 
-      it("should handle objects with multiple keys", function() {
+      it("handles objects with multiple keys", function() {
         var code = '{\n"key1": 1,\n"key2": 2,\n"key3": 3}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
@@ -271,7 +271,7 @@ describe("JSONUtil", function() {
         ]);
       });
 
-      it("should handle objects with multiple value types", function() {
+      it("handles objects with multiple value types", function() {
         var code =
           '{\n"key1": "string",\n"key2": 2,\n"key3": false,\n"key4": true,\n"key5": null\n}';
         var objects = JSONUtil.getObjectInformation(code);
@@ -314,7 +314,7 @@ describe("JSONUtil", function() {
         ]);
       });
 
-      it("should handle multiple objects with multiple keys", function() {
+      it("handles multiple objects with multiple keys", function() {
         var code =
           '{\n"obj1": {\n"key1": 1,\n"key2": 2\n}, "obj2": {\n"key3": 1,\n"key4": 2\n}, "obj3": {\n"key5": 1,\n"key6": 2\n}\n}';
         var objects = JSONUtil.getObjectInformation(code);
@@ -384,7 +384,7 @@ describe("JSONUtil", function() {
     });
 
     describe("Arrays & Nesting", function() {
-      it("should handle values in arrays", function() {
+      it("handles values in arrays", function() {
         var code = '{\n"name": [\n\t"child"\n\t]\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
@@ -404,7 +404,7 @@ describe("JSONUtil", function() {
         ]);
       });
 
-      it("should handle objects in arrays", function() {
+      it("handles objects in arrays", function() {
         var code = '{\n"name": [\n\t{"child": 1}\n\t]\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
@@ -430,7 +430,7 @@ describe("JSONUtil", function() {
         ]);
       });
 
-      it("should handle values in level-1 nested arrays", function() {
+      it("handles values in level-1 nested arrays", function() {
         var code = '{\n"name": [\n\t[\n\t\t"child"\n\t\t]\n\t]\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
@@ -456,7 +456,7 @@ describe("JSONUtil", function() {
         ]);
       });
 
-      it("should handle objects in level-1 nested arrays", function() {
+      it("handles objects in level-1 nested arrays", function() {
         var code = '{\n"name": [\n\t[{"child": 1}]\n\t]\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
@@ -488,7 +488,7 @@ describe("JSONUtil", function() {
         ]);
       });
 
-      it("should handle values in level-2 nested arrays", function() {
+      it("handles values in level-2 nested arrays", function() {
         var code = '{\n"name": [\n\t[\n\t\t["child"]\n\t\t]\n\t]\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
@@ -520,7 +520,7 @@ describe("JSONUtil", function() {
         ]);
       });
 
-      it("should handle objects in level-2 nested arrays", function() {
+      it("handles objects in level-2 nested arrays", function() {
         var code = '{\n"name": [\n\t[\n\t\t[{"child": 1}]\n\t\t]\n\t]\n}';
         var objects = JSONUtil.getObjectInformation(code);
         expect(objects).toEqual([
@@ -560,7 +560,7 @@ describe("JSONUtil", function() {
     });
 
     describe("Nixed Nesting", function() {
-      it("should handle nesting objects and arrays", function() {
+      it("handles nesting objects and arrays", function() {
         var code =
           '{\n"name": [\n\t{\n\t\t"child": [\n\t\t\t{"value":1}\n\t\t]\n\t\t}\n\t]\n}';
         var objects = JSONUtil.getObjectInformation(code);

--- a/src/js/utils/__tests__/JobUtil-test.js
+++ b/src/js/utils/__tests__/JobUtil-test.js
@@ -3,7 +3,7 @@ const JobUtil = require("../JobUtil");
 
 describe("JobUtil", function() {
   describe("#createJobFromFormModel", function() {
-    it("should return instance of Job", function() {
+    it("returns instance of Job", function() {
       const job = JobUtil.createJobFromFormModel({
         general: { id: "test" }
       });
@@ -11,15 +11,15 @@ describe("JobUtil", function() {
       expect(job).toEqual(jasmine.any(Job));
     });
 
-    it("should return instance Job if null is provided", function() {
+    it("returns instance Job if null is provided", function() {
       expect(JobUtil.createJobFromFormModel(null)).toEqual(jasmine.any(Job));
     });
 
-    it("should return instance Job if empty object is provided", function() {
+    it("returns instance Job if empty object is provided", function() {
       expect(JobUtil.createJobFromFormModel({})).toEqual(jasmine.any(Job));
     });
 
-    it("should convert form model to the corresponding job", function() {
+    it("converts form model to the corresponding job", function() {
       const job = JobUtil.createJobFromFormModel({
         general: { id: "test", cmd: "sleep 1000;" }
       });
@@ -28,7 +28,7 @@ describe("JobUtil", function() {
       expect(job.getCommand()).toEqual("sleep 1000;");
     });
 
-    it("should return job with schedule if actiavted", function() {
+    it("returns job with schedule if actiavted", function() {
       const job = JobUtil.createJobFromFormModel({
         general: { id: "test", cmd: "sleep 1000;" },
         schedule: {
@@ -50,7 +50,7 @@ describe("JobUtil", function() {
       ]);
     });
 
-    it("should remove schedule if deactivated", function() {
+    it("removes schedule if deactivated", function() {
       const job = JobUtil.createJobFromFormModel({
         general: { id: "test", cmd: "sleep 1000;" },
         schedule: {
@@ -67,7 +67,7 @@ describe("JobUtil", function() {
   });
 
   describe("#createFormModelFromSchema", function() {
-    it("should create the correct model", function() {
+    it("creates the correct model", function() {
       const schema = {
         type: "object",
         properties: {
@@ -99,7 +99,7 @@ describe("JobUtil", function() {
   });
 
   describe("#createJobSpecFromJob", function() {
-    it("should create the correct job", function() {
+    it("creates the correct job", function() {
       const job = new Job({
         id: "test",
         run: {
@@ -119,7 +119,7 @@ describe("JobUtil", function() {
       });
     });
 
-    it("should add concurrencyPolicy if schedule is defined", function() {
+    it("adds concurrencyPolicy if schedule is defined", function() {
       const job = new Job({
         id: "test",
         run: {

--- a/src/js/utils/__tests__/JobValidatorUtil-test.js
+++ b/src/js/utils/__tests__/JobValidatorUtil-test.js
@@ -2,19 +2,19 @@ const JobValidatorUtil = require("../JobValidatorUtil");
 
 describe("JobValidatorUtil", function() {
   describe("#isValidJobID", function() {
-    it("should properly handle empty strings", function() {
+    it("handles empty strings", function() {
       expect(JobValidatorUtil.isValidJobID("")).toBe(false);
     });
 
-    it("should properly handle undefined values", function() {
+    it("handles undefined values", function() {
       expect(JobValidatorUtil.isValidJobID()).toBe(false);
     });
 
-    it("should properly handle white spaces", function() {
+    it("handles white spaces", function() {
       expect(JobValidatorUtil.isValidJobID("white space")).toBe(false);
     });
 
-    it("should properly handle illegal characters", function() {
+    it("handles illegal characters", function() {
       expect(JobValidatorUtil.isValidJobID("Uppercase")).toBe(false);
       expect(JobValidatorUtil.isValidJobID("job#1")).toBe(false);
       expect(JobValidatorUtil.isValidJobID("job_1")).toBe(false);
@@ -24,16 +24,16 @@ describe("JobValidatorUtil", function() {
       expect(JobValidatorUtil.isValidJobID("job(1)")).toBe(false);
     });
 
-    it("should properly handle multiple dots", function() {
+    it("handles multiple dots", function() {
       expect(JobValidatorUtil.isValidJobID("job..id")).toBe(false);
       expect(JobValidatorUtil.isValidJobID("job..id....")).toBe(false);
     });
 
-    it("should properly handle ending dots", function() {
+    it("handles ending dots", function() {
       expect(JobValidatorUtil.isValidJobID("job.")).toBe(false);
     });
 
-    it("should properly accept correct characters", function() {
+    it("accepts correct characters", function() {
       expect(JobValidatorUtil.isValidJobID("4")).toBe(true);
       expect(JobValidatorUtil.isValidJobID("a")).toBe(true);
       expect(JobValidatorUtil.isValidJobID("job")).toBe(true);
@@ -48,15 +48,15 @@ describe("JobValidatorUtil", function() {
   });
 
   describe("#isValidCronSchedule", function() {
-    it("should properly handle empty strings", function() {
+    it("handles empty strings", function() {
       expect(JobValidatorUtil.isValidCronSchedule("")).toBe(false);
     });
 
-    it("should properly handle undefined values", function() {
+    it("handles undefined values", function() {
       expect(JobValidatorUtil.isValidCronSchedule()).toBe(false);
     });
 
-    it("should properly accept only 5 components", function() {
+    it("accepts only 5 components", function() {
       expect(JobValidatorUtil.isValidCronSchedule("*")).toBe(false);
       expect(JobValidatorUtil.isValidCronSchedule("* *")).toBe(false);
       expect(JobValidatorUtil.isValidCronSchedule("* * *")).toBe(false);
@@ -65,7 +65,7 @@ describe("JobValidatorUtil", function() {
       expect(JobValidatorUtil.isValidCronSchedule("* * * * * *")).toBe(false);
     });
 
-    it("should properly handle valid characters", function() {
+    it("handles valid characters", function() {
       expect(
         JobValidatorUtil.isValidCronSchedule(
           "* 1-10 4,5,6,7 1/1 1-2/3,4,5,6-10"
@@ -73,7 +73,7 @@ describe("JobValidatorUtil", function() {
       ).toBe(true);
     });
 
-    it("should properly handle components that do not start with a number or *", function() {
+    it("handles components that do not start with a number or *", function() {
       expect(JobValidatorUtil.isValidCronSchedule("-1 * * * *")).toBe(false);
       expect(JobValidatorUtil.isValidCronSchedule("/2 * * * *")).toBe(false);
       expect(JobValidatorUtil.isValidCronSchedule(",2 * * * *")).toBe(false);

--- a/src/js/utils/__tests__/LocalStorageUtil-test.js
+++ b/src/js/utils/__tests__/LocalStorageUtil-test.js
@@ -6,7 +6,7 @@ describe("LocalStorageUtil", function() {
   });
 
   describe("#get", function() {
-    it("should get value from localStorage", function() {
+    it("gets value from localStorage", function() {
       global.localStorage.setItem("foo", "bar");
       expect(LocalStorageUtil.get("foo")).toEqual("bar");
     });
@@ -20,7 +20,7 @@ describe("LocalStorageUtil", function() {
   });
 
   describe("#set", function() {
-    it("should get value from localStorage", function() {
+    it("gets value from localStorage", function() {
       LocalStorageUtil.set("foo", "bar");
       expect(LocalStorageUtil.get("foo")).toEqual("bar");
     });

--- a/src/js/utils/__tests__/Maths-test.js
+++ b/src/js/utils/__tests__/Maths-test.js
@@ -2,17 +2,17 @@ const Maths = require("../Maths");
 
 describe("Maths", function() {
   describe("#round", function() {
-    it("should round", function() {
+    it("rounds", function() {
       var value = Maths.round(1.9);
       expect(value).toEqual(2);
     });
 
-    it("should round on given precision", function() {
+    it("rounds on given precision", function() {
       var value = Maths.round(1.989, 2);
       expect(value).toEqual(1.99);
     });
 
-    it("should return 0 with a non number", function() {
+    it("returns 0 with a non number", function() {
       var value = Maths.round(null);
       expect(value).toEqual(0);
     });
@@ -48,49 +48,49 @@ describe("Maths", function() {
   });
 
   describe("#mapValue", function() {
-    it("should return min if there is no range", function() {
+    it("returns min if there is no range", function() {
       var value = Maths.mapValue(1, { min: 1, max: 1 });
       expect(value).toEqual(1);
     });
 
-    it("should return undefined with a non number", function() {
+    it("returns undefined with a non number", function() {
       var value = Maths.mapValue(NaN, { min: 0, max: 10 });
       expect(typeof value).toEqual("undefined");
     });
 
-    it("should return a number", function() {
+    it("returns a number", function() {
       var value = Maths.mapValue(5, { min: 0, max: 10 });
       expect(typeof value).toEqual("number");
     });
 
-    it("should map correctly", function() {
+    it("maps correctly", function() {
       var value = Maths.mapValue(5, { min: 0, max: 10 });
       expect(value).toEqual(0.5);
     });
 
-    it("should map correctly", function() {
+    it("maps correctly", function() {
       var value = Maths.mapValue(2.5, { min: 0, max: 10 });
       expect(value).toEqual(0.25);
     });
   });
 
   describe("#unmapValue", function() {
-    it("should return undefined with a non number", function() {
+    it("returns undefined with a non number", function() {
       var value = Maths.unmapValue(NaN, { min: 0, max: 10 });
       expect(typeof value).toEqual("undefined");
     });
 
-    it("should return a number", function() {
+    it("returns a number", function() {
       var value = Maths.unmapValue(0.5, { min: 0, max: 10 });
       expect(typeof value).toEqual("number");
     });
 
-    it("should map correctly", function() {
+    it("maps correctly", function() {
       var value = Maths.unmapValue(0.5, { min: 0, max: 10 });
       expect(value).toEqual(5);
     });
 
-    it("should map correctly", function() {
+    it("maps correctly", function() {
       var value = Maths.unmapValue(0.25, { min: 0, max: 10 });
       expect(value).toEqual(2.5);
     });

--- a/src/js/utils/__tests__/MesosStateUtil-test.js
+++ b/src/js/utils/__tests__/MesosStateUtil-test.js
@@ -37,7 +37,7 @@ describe("MesosStateUtil", function() {
       });
     });
 
-    it("should assign a isStartedByMarathon flag to all tasks", function() {
+    it("assigns a isStartedByMarathon flag to all tasks", function() {
       const state = {
         frameworks: [
           {
@@ -110,19 +110,19 @@ describe("MesosStateUtil", function() {
       ]
     };
 
-    it("should return the matching framework", function() {
+    it("returns the matching framework", function() {
       expect(MesosStateUtil.getFramework(state, "framework-123").name).toEqual(
         "test-1"
       );
     });
 
-    it('should return the matching "completed" framework', function() {
+    it('returns the matching "completed" framework', function() {
       expect(MesosStateUtil.getFramework(state, "framework-abc").name).toEqual(
         "test-2"
       );
     });
 
-    it("should return nothing if no matching framework was found", function() {
+    it("returns nothing if no matching framework was found", function() {
       expect(MesosStateUtil.getFramework(state, "unknown")).not.toBeDefined();
     });
   });
@@ -156,29 +156,29 @@ describe("MesosStateUtil", function() {
       );
     });
 
-    it("should handle empty object well", function() {
+    it("handles empty object well", function() {
       expect(
         MesosStateUtil.getRunningTasksFromVirtualNetworkName({}, "foo")
       ).toEqual([]);
     });
 
-    it("should throw when a null state is provided", function() {
+    it("throws when a null state is provided", function() {
       expect(function() {
         MesosStateUtil.getRunningTasksFromVirtualNetworkName(null, "foo");
       }).toThrow();
     });
 
-    it("should handle empty undefined well", function() {
+    it("handles empty undefined well", function() {
       expect(
         MesosStateUtil.getRunningTasksFromVirtualNetworkName(undefined, "foo")
       ).toEqual([]);
     });
 
-    it("should filter running tasks that doesn't have the overlay name", function() {
+    it("filters running tasks that doesn't have the overlay name", function() {
       expect(this.instance.length).toEqual(1);
     });
 
-    it("should find running tasks from different frameworks", function() {
+    it("finds running tasks from different frameworks", function() {
       expect(this.instance).toEqual([
         {
           state: "TASK_RUNNING",
@@ -191,7 +191,7 @@ describe("MesosStateUtil", function() {
   describe("#getPodHistoricalInstances", function() {
     const state = MESOS_STATE_WITH_HISTORY;
 
-    it("should correctly return only pod-related tasks", function() {
+    it("returns only pod-related tasks", function() {
       const pod = new Pod({ id: "/pod-p0" });
       const instances = MesosStateUtil.getPodHistoricalInstances(state, pod);
 
@@ -200,7 +200,7 @@ describe("MesosStateUtil", function() {
       expect(instances[1].id).toEqual("pod-p0.instance-inst-a2");
     });
 
-    it("should add `containerID` property on containers", function() {
+    it("adds `containerID` property on containers", function() {
       const pod = new Pod({ id: "/pod-p1" });
       const instances = MesosStateUtil.getPodHistoricalInstances(state, pod);
 
@@ -209,28 +209,28 @@ describe("MesosStateUtil", function() {
       );
     });
 
-    it("should add `status` property on containers", function() {
+    it("adds `status` property on containers", function() {
       const pod = new Pod({ id: "/pod-p1" });
       const instances = MesosStateUtil.getPodHistoricalInstances(state, pod);
 
       expect(instances[0].containers[0].status).toEqual("TASK_FINISHED");
     });
 
-    it("should add `lastChanged` property on containers", function() {
+    it("adds `lastChanged` property on containers", function() {
       const pod = new Pod({ id: "/pod-p1" });
       const instances = MesosStateUtil.getPodHistoricalInstances(state, pod);
 
       expect(instances[0].containers[0].lastChanged).toEqual(1008 * 1000);
     });
 
-    it("should add `lastUpdated` property on containers", function() {
+    it("adds `lastUpdated` property on containers", function() {
       const pod = new Pod({ id: "/pod-p1" });
       const instances = MesosStateUtil.getPodHistoricalInstances(state, pod);
 
       expect(instances[0].containers[0].lastUpdated).toEqual(1008 * 1000);
     });
 
-    it("should correctly summarize resources", function() {
+    it("summarizes resources", function() {
       const pod = new Pod({ id: "/pod-p0" });
       const instances = MesosStateUtil.getPodHistoricalInstances(state, pod);
 
@@ -249,7 +249,7 @@ describe("MesosStateUtil", function() {
       });
     });
 
-    it("should pick the latest timestamp for lastChanged", function() {
+    it("picks the latest timestamp for lastChanged", function() {
       const pod = new Pod({ id: "/pod-p0" });
       const instances = MesosStateUtil.getPodHistoricalInstances(state, pod);
 
@@ -262,19 +262,19 @@ describe("MesosStateUtil", function() {
   });
 
   describe("#isPodTaskId", function() {
-    it("should correctly match pod (PodDefinition) task ID", function() {
+    it("matches pod (PodDefinition) task ID", function() {
       expect(
         MesosStateUtil.isPodTaskId("podname.instance-instancename.taskname")
       ).toBeTruthy();
     });
 
-    it("should not match marathon (AppDefinition) task ID", function() {
+    it("does not match marathon (AppDefinition) task ID", function() {
       expect(
         MesosStateUtil.isPodTaskId("podname.marathon-instancename.taskname")
       ).toBeFalsy();
     });
 
-    it("should not match anything else that looks close", function() {
+    it("does not match anything else that looks close", function() {
       expect(
         MesosStateUtil.isPodTaskId("podname.marathon-instancename")
       ).toBeFalsy();
@@ -295,7 +295,7 @@ describe("MesosStateUtil", function() {
   });
 
   describe("#decomposePodTaskId", function() {
-    it("should correctly de-compose", function() {
+    it("de-scompose", function() {
       expect(
         MesosStateUtil.decomposePodTaskId(
           "podname.instance-instancename.taskname"

--- a/src/js/utils/__tests__/MetronomeUtil-test.js
+++ b/src/js/utils/__tests__/MetronomeUtil-test.js
@@ -13,13 +13,13 @@ describe("MetronomeUtil", function() {
       ]);
     });
 
-    it("should throw error if the provided id  starts with a dot", function() {
+    it("throws an error if the provided id  starts with a dot", function() {
       expect(function() {
         MetronomeUtil.parseJobs({ id: ".malformed.id" });
       }).toThrow();
     });
 
-    it("should throw error if the provided id ends with a dot", function() {
+    it("throws an error if the provided id ends with a dot", function() {
       expect(function() {
         MetronomeUtil.parseJobs({ id: "malformed.id." });
       }).toThrow();
@@ -39,7 +39,7 @@ describe("MetronomeUtil", function() {
       expect(jobs.items[0].items[0].items[0].id).toEqual("name.foo.bar");
     });
 
-    it("should throw error if item is not an object with id", function() {
+    it("throws an error if item is not an object with id", function() {
       expect(function() {
         MetronomeUtil.parseJobs({});
       }).toThrow();
@@ -51,7 +51,7 @@ describe("MetronomeUtil", function() {
       }).toThrow();
     });
 
-    it("should return root namespace if empty array is passed", function() {
+    it("returns root namespace if empty array is passed", function() {
       const jobs = MetronomeUtil.parseJobs([]);
 
       expect(jobs.id).toEqual("");
@@ -181,27 +181,27 @@ describe("MetronomeUtil", function() {
       });
     });
 
-    it("should just do nothing if history is undefined", function() {
+    it("does nothing if history is undefined", function() {
       const job = MetronomeUtil.parseJob({ id: "foo" });
 
       expect(job).toEqual({ id: "foo" });
     });
 
-    it("should add the proper status to the failed finished runs", function() {
+    it("adds the proper status to the failed finished runs", function() {
       expect(this.job.history.failedFinishedRuns[0].status).toEqual("FAILED");
     });
 
-    it("should add the job id to the failed finished runs", function() {
+    it("adds the job id to the failed finished runs", function() {
       expect(this.job.history.failedFinishedRuns[0].jobId).toEqual("foo");
     });
 
-    it("should add the proper status to the successful finished runs", function() {
+    it("adds the proper status to the successful finished runs", function() {
       expect(this.job.history.successfulFinishedRuns[0].status).toEqual(
         "COMPLETED"
       );
     });
 
-    it("should add the job id to the successful finished runs", function() {
+    it("adds the job id to the successful finished runs", function() {
       expect(this.job.history.successfulFinishedRuns[0].jobId).toEqual("foo");
     });
   });

--- a/src/js/utils/__tests__/NetworkValidatorUtil-test.js
+++ b/src/js/utils/__tests__/NetworkValidatorUtil-test.js
@@ -2,21 +2,21 @@ const NetworkValidatorUtil = require("../NetworkValidatorUtil");
 
 describe("NetworkValidatorUtil", function() {
   describe("#isValidPort", function() {
-    it("should properly handle empty strings", function() {
+    it("handles empty strings", function() {
       expect(NetworkValidatorUtil.isValidPort("")).toBe(false);
     });
 
-    it("should properly handle undefined values", function() {
+    it("handles undefined values", function() {
       expect(NetworkValidatorUtil.isValidPort()).toBe(false);
     });
 
-    it("should properly handle wrong value types", function() {
+    it("handles wrong value types", function() {
       expect(NetworkValidatorUtil.isValidPort("not a number 666")).toBe(false);
       expect(NetworkValidatorUtil.isValidPort("80.80")).toBe(false);
       expect(NetworkValidatorUtil.isValidPort("1.1")).toBe(false);
     });
 
-    it("should handle number like inputs", function() {
+    it("handles number like inputs", function() {
       expect(NetworkValidatorUtil.isValidPort(0)).toBe(true);
       expect(NetworkValidatorUtil.isValidPort("0")).toBe(true);
       expect(NetworkValidatorUtil.isValidPort(80)).toBe(true);
@@ -25,13 +25,13 @@ describe("NetworkValidatorUtil", function() {
       expect(NetworkValidatorUtil.isValidPort("8080")).toBe(true);
     });
 
-    it("should verify that port is greater or equal to 0", function() {
+    it("verifies that port is greater or equal to 0", function() {
       expect(NetworkValidatorUtil.isValidPort(-1)).toBe(false);
       expect(NetworkValidatorUtil.isValidPort(0)).toBe(true);
       expect(NetworkValidatorUtil.isValidPort(8080)).toBe(true);
     });
 
-    it("should verify that port is smaller  or equal to 65535", function() {
+    it("verifies that port is smaller  or equal to 65535", function() {
       expect(NetworkValidatorUtil.isValidPort(8080)).toBe(true);
       expect(NetworkValidatorUtil.isValidPort(65535)).toBe(true);
       expect(NetworkValidatorUtil.isValidPort(65536)).toBe(false);

--- a/src/js/utils/__tests__/ObjectUtil-test.js
+++ b/src/js/utils/__tests__/ObjectUtil-test.js
@@ -2,7 +2,7 @@ const ObjectUtil = require("../ObjectUtil");
 
 describe("ObjectUtil", function() {
   describe("#markObject", function() {
-    it("should properly mark an object", function() {
+    it("marks an object", function() {
       const obj = {};
       const mark = "mark";
 
@@ -10,7 +10,7 @@ describe("ObjectUtil", function() {
       expect(obj.___object_mark___).toEqual(mark);
     });
 
-    it("should properly overwrite previous mark", function() {
+    it("overwrites previous mark", function() {
       const obj = {};
       const previousMark = "mork";
       const mark = "mark";
@@ -22,13 +22,13 @@ describe("ObjectUtil", function() {
   });
 
   describe("#objectHasMark", function() {
-    it("should return false on unmarked objects", function() {
+    it("returns false on unmarked objects", function() {
       const obj = {};
       const mark = "mark";
       expect(ObjectUtil.objectHasMark(obj, mark)).toBeFalsy();
     });
 
-    it("should return true on correctly marked objects", function() {
+    it("returns true on correctly marked objects", function() {
       const obj = {};
       const mark = "mark";
 
@@ -36,7 +36,7 @@ describe("ObjectUtil", function() {
       expect(ObjectUtil.objectHasMark(obj, mark)).toBeTruthy();
     });
 
-    it("should return false on wrongly marked objects", function() {
+    it("returns false on wrongly marked objects", function() {
       const obj = {};
       const mark = "mark";
       const wrongMark = "mork";
@@ -45,7 +45,7 @@ describe("ObjectUtil", function() {
       expect(ObjectUtil.objectHasMark(obj, mark)).toBeFalsy();
     });
 
-    it("should correctly handle objects as marks", function() {
+    it("handles objects as marks", function() {
       const obj = {};
       const mark = {};
       const wrongMark = {};

--- a/src/js/utils/__tests__/ParserUtil-test.js
+++ b/src/js/utils/__tests__/ParserUtil-test.js
@@ -12,11 +12,11 @@ describe("ParserUtil", function() {
       };
     }
 
-    it("should return a function", function() {
+    it("returns a function", function() {
       expect(typeof ParserUtil.combineParsers()).toBe("function");
     });
 
-    it("should return the right TransactionLog", function() {
+    it("returns the right TransactionLog", function() {
       const parsers = ParserUtil.combineParsers([idParser]);
       expect(parsers({ id: "test" })).toEqual([
         {
@@ -27,7 +27,7 @@ describe("ParserUtil", function() {
       ]);
     });
 
-    it("should have the right ordered TransactionLog with multiple parsers", function() {
+    it("has the right ordered TransactionLog with multiple parsers", function() {
       const parser = ParserUtil.combineParsers([
         idParser,
         function(state) {
@@ -55,7 +55,7 @@ describe("ParserUtil", function() {
         }
       ]);
     });
-    it("should have the right order for nested parsers", function() {
+    it("has the right order for nested parsers", function() {
       const containerParser = function(state) {
         if (state.container != null && state.container.docker != null) {
           return ParserUtil.combineParsers([

--- a/src/js/utils/__tests__/ReducerUtil-test.js
+++ b/src/js/utils/__tests__/ReducerUtil-test.js
@@ -23,23 +23,23 @@ describe("ReducerUtil", function() {
       });
     });
 
-    it("should return a function", function() {
+    it("returns a function", function() {
       expect(typeof ReducerUtil.combineReducers()).toBe("function");
     });
 
-    it("should work with a simple reducer object", function() {
+    it("works with a simple reducer object", function() {
       const state = this.items.reduce(this.reducers, {});
 
       expect(state).toEqual({ id: "foo" });
     });
 
-    it("should not remove existing values", function() {
+    it("does not remove existing values", function() {
       const state = this.items.reduce(this.reducers, { bar: "bar" });
 
       expect(state).toEqual({ id: "foo", bar: "bar" });
     });
 
-    it("should use context", function() {
+    it("uses context", function() {
       const reducers = ReducerUtil.combineReducers({
         id: idReducer,
         vip(state, action) {
@@ -86,7 +86,7 @@ describe("ReducerUtil", function() {
       ]);
     });
 
-    it("should use context in nested combineReducers", function() {
+    it("uses context in nested combineReducers", function() {
       const reducers = ReducerUtil.combineReducers({
         id: idReducer,
         container: ReducerUtil.combineReducers({
@@ -141,7 +141,7 @@ describe("ReducerUtil", function() {
       ]);
     });
 
-    it("should properly apply a set of user actions", function() {
+    it("properlies apply a set of user actions", function() {
       const dockerReduce = ReducerUtil.combineReducers({
         id(state, action) {
           if (
@@ -217,7 +217,7 @@ describe("ReducerUtil", function() {
       });
     });
 
-    it("should run reducers that have not been configured", function() {
+    it("runs reducers that have not been configured", function() {
       const reducers = ReducerUtil.combineReducers({ id: idReducer });
 
       const state = this.items.reduce(reducers, { bar: "bar" });
@@ -227,29 +227,29 @@ describe("ReducerUtil", function() {
   });
 
   describe("#parseIntValue", function() {
-    it("should return the integer value parsed", function() {
+    it("returns the integer value parsed", function() {
       expect(ReducerUtil.parseIntValue("10")).toEqual(10);
     });
 
-    it("should return empty string as-is", function() {
+    it("returns empty string as-is", function() {
       expect(ReducerUtil.parseIntValue("")).toEqual("");
     });
 
-    it("should return unparsable number string as-is", function() {
+    it("returns unparsable number string as-is", function() {
       expect(ReducerUtil.parseIntValue("foo")).toEqual("foo");
     });
 
-    it("should return numbers as-is", function() {
+    it("returns numbers as-is", function() {
       expect(ReducerUtil.parseIntValue(123)).toEqual(123);
     });
   });
 
   describe("#simpleReducer", function() {
-    it("should return a function", function() {
+    it("returns a function", function() {
       expect(typeof ReducerUtil.simpleReducer()).toBe("function");
     });
 
-    it("should return default state if path doesn't match", function() {
+    it("returns default state if path doesn't match", function() {
       const simpleReducer = ReducerUtil.simpleReducer("path", "default");
       const action = {
         path: ["something", "else"],
@@ -259,7 +259,7 @@ describe("ReducerUtil", function() {
       expect(simpleReducer(undefined, action)).toEqual("default");
     });
 
-    it("should return new value if path does match", function() {
+    it("returns new value if path does match", function() {
       const simpleReducer = ReducerUtil.simpleReducer("path", "default");
       const action = {
         path: ["path"],
@@ -269,7 +269,7 @@ describe("ReducerUtil", function() {
       expect(simpleReducer(undefined, action)).toEqual("something");
     });
 
-    it("should return new value of deep nested path", function() {
+    it("returns new value of deep nested path", function() {
       const simpleReducer = ReducerUtil.simpleReducer(
         "foo.bar.deep.nest",
         "default"
@@ -284,7 +284,7 @@ describe("ReducerUtil", function() {
   });
 
   describe("#simpleIntReducer", function() {
-    it("should return a function", function() {
+    it("returns a function", function() {
       expect(typeof ReducerUtil.simpleIntReducer()).toBe("function");
     });
 
@@ -326,7 +326,7 @@ describe("ReducerUtil", function() {
   });
 
   describe("#simpleFloatReducer", function() {
-    it("should return a function", function() {
+    it("returns a function", function() {
       expect(typeof ReducerUtil.simpleFloatReducer()).toBe("function");
     });
 
@@ -370,7 +370,7 @@ describe("ReducerUtil", function() {
     });
   });
 
-  it("should return the old state if action does not fit", function() {
+  it("returns the old state if action does not fit", function() {
     const simpleReducer = ReducerUtil.simpleReducer("path", "default");
     const action = {
       path: ["something", "else"],
@@ -380,7 +380,7 @@ describe("ReducerUtil", function() {
     expect(simpleReducer("old", action)).toEqual("old");
   });
 
-  it("should return the new state if action does fit", function() {
+  it("returns the new state if action does fit", function() {
     const simpleReducer = ReducerUtil.simpleReducer("path", "default");
     const action = {
       path: ["path"],

--- a/src/js/utils/__tests__/SchemaFormUtil-test.js
+++ b/src/js/utils/__tests__/SchemaFormUtil-test.js
@@ -58,7 +58,7 @@ describe("SchemaFormUtil", function() {
       SchemaFormUtil.getDefinitionFromPath = this.getDefinitionFromPath;
     });
 
-    it("should return a model with same values", function() {
+    it("returns a model with same values", function() {
       var model = {
         key: "value",
         key2: "value2"
@@ -68,7 +68,7 @@ describe("SchemaFormUtil", function() {
       expect(model).toEqual(result);
     });
 
-    it("should replace undefined with [] when valueType is array", function() {
+    it("replaces undefined with [] when valueType is array", function() {
       this.definition.valueType = "array";
       var model = {
         key: undefined,
@@ -79,7 +79,7 @@ describe("SchemaFormUtil", function() {
       expect(result.key).toEqual([]);
     });
 
-    it("should omit null values for non-required fields", function() {
+    it("omits null values for non-required fields", function() {
       var model = {
         key: null,
         key2: "value2"
@@ -89,7 +89,7 @@ describe("SchemaFormUtil", function() {
       expect(result.key).toEqual(undefined);
     });
 
-    it("shouldn't omit null values for required fields", function() {
+    it("doesn't omit null values for required fields", function() {
       this.definition.isRequired = true;
       var model = {
         key: null,
@@ -100,7 +100,7 @@ describe("SchemaFormUtil", function() {
       expect(result.key).toEqual(null);
     });
 
-    it("should replace string with a number if integer", function() {
+    it("replaces string with a number if integer", function() {
       this.definition.valueType = "integer";
       var model = {
         key: "10",
@@ -111,7 +111,7 @@ describe("SchemaFormUtil", function() {
       expect(result.key).toEqual(10);
     });
 
-    it("should split string if array", function() {
+    it("splits string if array", function() {
       this.definition.valueType = "array";
       var model = {
         key: "10, 20, 30, 40",

--- a/src/js/utils/__tests__/SchemaUtil-test.js
+++ b/src/js/utils/__tests__/SchemaUtil-test.js
@@ -194,12 +194,12 @@ describe("SchemaUtil", function() {
   });
 
   describe("#validateSchema", function() {
-    it("should return false for an invalid schema", function() {
+    it("returns false for an invalid schema", function() {
       var result = SchemaUtil.validateSchema({ random: "properties" });
       expect(result).toEqual(false);
     });
 
-    it("should return true for valid schema", function() {
+    it("returns true for valid schema", function() {
       var schema = {
         properties: {
           application: {

--- a/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/src/js/utils/__tests__/ServiceUtil-test.js
@@ -2,7 +2,7 @@ const ServiceUtil = require("../ServiceUtil");
 
 describe("ServiceUtil", function() {
   describe("#isSDKService", function() {
-    it("should return true if service does not have the proper label", function() {
+    it("returns true if service does not have the proper label", function() {
       const service = {
         id: "/foo",
         getLabels() {
@@ -13,7 +13,7 @@ describe("ServiceUtil", function() {
       expect(ServiceUtil.isSDKService(service)).toEqual(true);
     });
 
-    it("should return false if getLabels is not a function", function() {
+    it("returns false if getLabels is not a function", function() {
       const service = {
         id: "/foo",
         getLabels: "bar"
@@ -22,7 +22,7 @@ describe("ServiceUtil", function() {
       expect(ServiceUtil.isSDKService(service)).toEqual(false);
     });
 
-    it("should return false if service does not have the proper label", function() {
+    it("returns false if service does not have the proper label", function() {
       const service = {
         id: "/foo"
       };
@@ -32,7 +32,7 @@ describe("ServiceUtil", function() {
   });
 
   describe("#isPackage", function() {
-    it("should return true if service does have the proper label", function() {
+    it("returns true if service does have the proper label", function() {
       const service = {
         id: "/foo",
         getLabels() {
@@ -43,7 +43,7 @@ describe("ServiceUtil", function() {
       expect(ServiceUtil.isPackage(service)).toEqual(true);
     });
 
-    it("should return false if getLabels is not a function", function() {
+    it("returns false if getLabels is not a function", function() {
       const service = {
         id: "/foo",
         getLabels: "bar"
@@ -52,7 +52,7 @@ describe("ServiceUtil", function() {
       expect(ServiceUtil.isPackage(service)).toEqual(false);
     });
 
-    it("should return false if service does not have the proper label", function() {
+    it("returns false if service does not have the proper label", function() {
       const service = {
         id: "/foo"
       };

--- a/src/js/utils/__tests__/StringUtil-test.js
+++ b/src/js/utils/__tests__/StringUtil-test.js
@@ -2,43 +2,43 @@ const StringUtil = require("../StringUtil");
 
 describe("StringUtil", function() {
   describe("#arrayToJoinedString", function() {
-    it("should join array with default separator", function() {
+    it("joins array with default separator", function() {
       var result = StringUtil.arrayToJoinedString([1, 2]);
 
       expect(result).toEqual("1, 2");
     });
 
-    it("should join array with the given separator", function() {
+    it("joins array with the given separator", function() {
       var result = StringUtil.arrayToJoinedString([1, 2], "-");
 
       expect(result).toEqual("1-2");
     });
 
-    it("should not append separator if array has only one  element", function() {
+    it("does not append separator if array has only one  element", function() {
       var result = StringUtil.arrayToJoinedString([1]);
 
       expect(result).toEqual("1");
     });
 
-    it("should return empty string if array is null", function() {
+    it("returns empty string if array is null", function() {
       var result = StringUtil.arrayToJoinedString(null);
 
       expect(result).toEqual("");
     });
 
-    it("should return empty string if array is undefined", function() {
+    it("returns empty string if array is undefined", function() {
       var result = StringUtil.arrayToJoinedString();
 
       expect(result).toEqual("");
     });
 
-    it("should return empty string if array is and object", function() {
+    it("returns empty string if array is and object", function() {
       var result = StringUtil.arrayToJoinedString({});
 
       expect(result).toEqual("");
     });
 
-    it("should return empty string if array is empty", function() {
+    it("returns empty string if array is empty", function() {
       var result = StringUtil.arrayToJoinedString([]);
 
       expect(result).toEqual("");
@@ -115,74 +115,74 @@ describe("StringUtil", function() {
   });
 
   describe("#isUrl", function() {
-    it("should accept a string starting with http://", function() {
+    it("accepts a string starting with http://", function() {
       var str = "http://asd/";
       expect(StringUtil.isUrl(str)).toEqual(true);
     });
 
-    it("should accept a string starting with https://", function() {
+    it("accepts a string starting with https://", function() {
       var str = "https://.asf";
       expect(StringUtil.isUrl(str)).toEqual(true);
     });
 
-    it("shouldn't accept a string with something before http://", function() {
+    it("doesn't accept a string with something before http://", function() {
       var str = "ahttp://";
       expect(StringUtil.isUrl(str)).toEqual(false);
     });
 
-    it("shouldn't accept null", function() {
+    it("doesn't accept null", function() {
       var str = null;
       expect(StringUtil.isUrl(str)).toEqual(false);
     });
 
-    it("shouldn't accept a string missing a /", function() {
+    it("doesn't accept a string missing a /", function() {
       var str = "http:/asfasfd";
       expect(StringUtil.isUrl(str)).toEqual(false);
     });
 
-    it("shouldn't accept a string missing :", function() {
+    it("doesn't accept a string missing :", function() {
       var str = "http//";
       expect(StringUtil.isUrl(str)).toEqual(false);
     });
 
-    it("shouldn't accept a string that only contains protocol", function() {
+    it("doesn't accept a string that only contains protocol", function() {
       var str = "http://";
       expect(StringUtil.isUrl(str)).toEqual(false);
     });
 
-    it("shouldn't accept a string that only contains protocol", function() {
+    it("doesn't accept a string that only contains protocol", function() {
       var str = "https://";
       expect(StringUtil.isUrl(str)).toEqual(false);
     });
   });
 
   describe("#isEmail", function() {
-    it("should accept a string with @ and . longer than 3 chars", function() {
+    it("accepts a string with @ and . longer than 3 chars", function() {
       var str = "@.as";
       expect(StringUtil.isEmail(str)).toEqual(true);
     });
 
-    it("should accept a string with @ and . longer than 3 chars", function() {
+    it("accepts a string with @ and . longer than 3 chars", function() {
       var str = "a@.a";
       expect(StringUtil.isEmail(str)).toEqual(true);
     });
 
-    it("shouldn't accept a string without a .", function() {
+    it("doesn't accept a string without a .", function() {
       var str = "a@aa";
       expect(StringUtil.isEmail(str)).toEqual(false);
     });
 
-    it("shouldn't accept null", function() {
+    it("doesn't accept null", function() {
       var str = null;
       expect(StringUtil.isEmail(str)).toEqual(false);
     });
 
-    it("shouldn't accept a string without a @", function() {
+    it("doesn't accept a string without a @", function() {
       var str = "aw.a";
       expect(StringUtil.isEmail(str)).toEqual(false);
     });
 
-    it("shouldn't accept a string shorter than 4", function() {
+    it("doesn't accept a string shorter than 4", function() {
       var str = "@.a";
       expect(StringUtil.isEmail(str)).toEqual(false);
     });

--- a/src/js/utils/__tests__/StructUtil-test.js
+++ b/src/js/utils/__tests__/StructUtil-test.js
@@ -20,32 +20,32 @@ describe("StructUtil", function() {
     // Create Item struct with embedded List Struct
     var itemStruct = new Item({ qux: "foo", items: listStruct });
 
-    it("should return original data if no structs", function() {
+    it("returns original data if no structs", function() {
       var fn = function() {};
       var originalObject = [1, "string", fn, true];
       var newObj = StructUtil.copyRawObject(originalObject);
       expect(deepEqual(newObj, originalObject)).toBeTruthy();
     });
 
-    it("should return original data from List struct", function() {
+    it("returns original data from List struct", function() {
       var newObj = StructUtil.copyRawObject(listStruct);
       expect(deepEqual(newObj, expectedArrayItems)).toBeTruthy();
     });
 
-    it("should clone Objects", function() {
+    it("clones Objects", function() {
       var array = [];
       var object = {};
       expect(StructUtil.copyRawObject(array) !== array).toBeTruthy();
       expect(StructUtil.copyRawObject(object) !== object).toBeTruthy();
     });
 
-    it("should clone Objects with structs", function() {
+    it("clones Objects with structs", function() {
       var newObj = StructUtil.copyRawObject(itemStruct);
       expect(itemStruct._itemData !== newObj).toBeTruthy();
       expect(newObj.items !== expectedArrayItems).toBeTruthy();
     });
 
-    it("should return original data with nested structs", function() {
+    it("returns original data with nested structs", function() {
       var fn = function() {};
       var nestedObj = {
         foo: listStruct,

--- a/src/js/utils/__tests__/SystemLogUtil-test.js
+++ b/src/js/utils/__tests__/SystemLogUtil-test.js
@@ -2,7 +2,7 @@ const SystemLogUtil = require("../SystemLogUtil");
 
 describe("SystemLogUtil", function() {
   describe("#getUrl", function() {
-    it("should include range element first in the url", function() {
+    it("includes range element first in the url", function() {
       var result = SystemLogUtil.getUrl("foo", { cursor: "cursor" });
 
       expect(result).toEqual(
@@ -10,7 +10,7 @@ describe("SystemLogUtil", function() {
       );
     });
 
-    it("should encode value of range element", function() {
+    it("encodes value of range element", function() {
       var result = SystemLogUtil.getUrl("foo", { limit: "lim&it" });
 
       expect(result).toEqual(
@@ -18,7 +18,7 @@ describe("SystemLogUtil", function() {
       );
     });
 
-    it("should concatenate range elements nicely together", function() {
+    it("concatenates range elements nicely together", function() {
       var result = SystemLogUtil.getUrl("foo", {
         cursor: "cursor",
         limit: "lim&it"
@@ -29,7 +29,7 @@ describe("SystemLogUtil", function() {
       );
     });
 
-    it("should include filter after range element in the url", function() {
+    it("includes filter after range element in the url", function() {
       var result = SystemLogUtil.getUrl("foo", {
         cursor: "cursor",
         filter: { param1: "param1" }
@@ -40,7 +40,7 @@ describe("SystemLogUtil", function() {
       );
     });
 
-    it("should encode filter element", function() {
+    it("encodes filter element", function() {
       var result = SystemLogUtil.getUrl("foo", {
         filter: { "param/1": "param/1" }
       });
@@ -50,7 +50,7 @@ describe("SystemLogUtil", function() {
       );
     });
 
-    it("should concatenate range elements nicely together", function() {
+    it("concatenates range elements nicely together", function() {
       var result = SystemLogUtil.getUrl("foo", {
         cursor: "cursor",
         limit: "lim&it",
@@ -71,7 +71,7 @@ describe("SystemLogUtil", function() {
       expect(result.includes("bar")).toBe(false);
     });
 
-    it("should use stream by default", function() {
+    it("uses stream by default", function() {
       var result = SystemLogUtil.getUrl("foo", {
         cursor: "cursor",
         filter: { "param/1": "param/1" }
@@ -82,7 +82,7 @@ describe("SystemLogUtil", function() {
       );
     });
 
-    it("should use range", function() {
+    it("uses range", function() {
       var result = SystemLogUtil.getUrl(
         "foo",
         {
@@ -97,7 +97,7 @@ describe("SystemLogUtil", function() {
       );
     });
 
-    it("should add framework id in the URL", function() {
+    it("adds framework id in the URL", function() {
       var result = SystemLogUtil.getUrl(
         "foo",
         {
@@ -112,7 +112,7 @@ describe("SystemLogUtil", function() {
       );
     });
 
-    it("should add executor id in the URL", function() {
+    it("adds executor id in the URL", function() {
       var result = SystemLogUtil.getUrl(
         "foo",
         {
@@ -127,7 +127,7 @@ describe("SystemLogUtil", function() {
       );
     });
 
-    it("should add container id in the URL", function() {
+    it("adds container id in the URL", function() {
       var result = SystemLogUtil.getUrl(
         "foo",
         {
@@ -142,7 +142,7 @@ describe("SystemLogUtil", function() {
       );
     });
 
-    it("should add all ids in the URL", function() {
+    it("adds all ids in the URL", function() {
       var result = SystemLogUtil.getUrl(
         "foo",
         {
@@ -160,7 +160,7 @@ describe("SystemLogUtil", function() {
       );
     });
 
-    it("should add aditional endpoint to the URL", function() {
+    it("adds aditional endpoint to the URL", function() {
       var result = SystemLogUtil.getUrl(
         "foo",
         {

--- a/src/js/utils/__tests__/TableUtil-test.js
+++ b/src/js/utils/__tests__/TableUtil-test.js
@@ -36,36 +36,36 @@ describe("TableUtil", function() {
       this.sortFunction = TableUtil.getSortFunction("id", this.getProp);
     });
 
-    it("should return a function", function() {
+    it("returns a function", function() {
       expect(typeof this.sortFunction).toEqual("function");
     });
 
-    it("should compare ids values", function() {
+    it("compares ids values", function() {
       var sortPropFunction = this.sortFunction("id");
       expect(sortPropFunction(this.foo, this.bar)).toEqual(1);
     });
 
-    it("should handle null values", function() {
+    it("handles null values", function() {
       var sortPropFunction = this.sortFunction("name");
       expect(sortPropFunction(this.foo, this.bar)).toEqual(1);
     });
 
-    it("should handle undefined values", function() {
+    it("handles undefined values", function() {
       var sortPropFunction = this.sortFunction("version");
       expect(sortPropFunction(this.foo, this.bar)).toEqual(1);
     });
 
-    it("should handle nested properties through getter function", function() {
+    it("handles nested properties through getter function", function() {
       var sortPropFunction = this.sortFunction("timestamp");
       expect(sortPropFunction(this.foo, this.bar)).toEqual(-1);
     });
 
-    it("should use if values are equal tiebreaker", function() {
+    it("uses if values are equal tiebreaker", function() {
       var sortPropFunction = this.sortFunction("equal");
       expect(sortPropFunction(this.foo, this.bar)).toEqual(1);
     });
 
-    it("should handle alternative tiebreaker", function() {
+    it("handles alternative tiebreaker", function() {
       var sortFunction = TableUtil.getSortFunction("timestamp", this.getProp);
       var sortPropFunction = sortFunction("equal");
       expect(sortPropFunction(this.foo, this.bar)).toEqual(-1);
@@ -73,13 +73,13 @@ describe("TableUtil", function() {
   });
 
   describe("#getHealthSortingOrder", function() {
-    it("should return a function", function() {
+    it("returns a function", function() {
       expect(typeof TableUtil.getHealthSortingOrder()).toEqual("function");
     });
   });
 
   describe("#getHealthSortingValue", function() {
-    it("should return sorting value when receives string value", function() {
+    it("returns sorting value when receives string value", function() {
       const healthStatus = "Unhealthy";
 
       expect(TableUtil.getHealthSortingValue(healthStatus)).toEqual(
@@ -87,7 +87,7 @@ describe("TableUtil", function() {
       );
     });
 
-    it("should return sorting value when receives number value", function() {
+    it("returns sorting value when receives number value", function() {
       const expectedSortingValue = 0;
       const healthStatus = 1;
       const getHealthSortingValueResult = TableUtil.getHealthSortingValue(
@@ -97,7 +97,7 @@ describe("TableUtil", function() {
       expect(getHealthSortingValueResult).toEqual(expectedSortingValue);
     });
 
-    it("should return default sorting value", function() {
+    it("returns default sorting value", function() {
       const healthStatus = "nada";
 
       expect(TableUtil.getHealthSortingValue(healthStatus)).toEqual(
@@ -111,7 +111,7 @@ describe("TableUtil", function() {
    * unhealthy > NA > warn/idle > healthy
    */
   describe("#sortHealthValues", function() {
-    it("should return health sorted by visibility importance when health is string", function() {
+    it("returns health sorted by visibility importance when health is string", function() {
       const units = [
         { id: "aa", health: "NA" },
         { id: "bb", health: "Healthy" },
@@ -127,7 +127,7 @@ describe("TableUtil", function() {
       expect(sortingResult).toEqual(expectedResult);
     });
 
-    it("should return health sorted by visibility importance when health is number", function() {
+    it("returns health sorted by visibility importance when health is number", function() {
       const units = [
         { id: "aa", health: 3 },
         { id: "bb", health: 0 },

--- a/src/js/utils/__tests__/TabsUtil-test.js
+++ b/src/js/utils/__tests__/TabsUtil-test.js
@@ -9,21 +9,21 @@ describe("TabsUtil", function() {
       spyOn(this, "getElement");
     });
 
-    it("should return an empty array when given an empty object", function() {
+    it("returns an empty array when given an empty object", function() {
       var result = TabsUtil.getTabs({}, null, this.getElement);
 
       expect(this.getElement).not.toHaveBeenCalled();
       expect(result).toEqual([]);
     });
 
-    it("should return equal length array to what is given", function() {
+    it("returns equal length array to what is given", function() {
       var result = TabsUtil.getTabs(this.tabs, "baz", this.getElement);
 
       expect(this.getElement.calls.count()).toEqual(3);
       expect(result.length).toEqual(3);
     });
 
-    it("should return LIs", function() {
+    it("returns LIs", function() {
       var result = TabsUtil.getTabs(this.tabs, "baz", this.getElement);
 
       expect(result[0].type).toEqual("li");
@@ -31,7 +31,7 @@ describe("TabsUtil", function() {
       expect(result[2].type).toEqual("li");
     });
 
-    it("should return elements with one active class", function() {
+    it("returns elements with one active class", function() {
       var result = TabsUtil.getTabs(this.tabs, "baz", this.getElement);
 
       expect(result[0].props.className).toEqual("menu-tabbed-item");
@@ -39,7 +39,7 @@ describe("TabsUtil", function() {
       expect(result[2].props.className).toEqual("menu-tabbed-item");
     });
 
-    it("should not highlight routes contained within the class name", function() {
+    it("does not highlight routes contained within the class name", function() {
       var tabs = TabsUtil.getTabs(
         this.hierarchicalTabs,
         "-foo",
@@ -63,7 +63,7 @@ describe("TabsUtil", function() {
       expect(tabs[2].props.className).toEqual("menu-tabbed-item");
     });
 
-    it("should call getElement with appropriate arguments", function() {
+    it("calls getElement with appropriate arguments", function() {
       TabsUtil.getTabs(this.tabs, "baz", this.getElement);
 
       expect(this.getElement.calls.allArgs()).toEqual([
@@ -73,19 +73,19 @@ describe("TabsUtil", function() {
       ]);
     });
 
-    it("should throw an error when tabs is null", function() {
+    it("throws an error when tabs is null", function() {
       var fn = TabsUtil.getTabs.bind(null, null, "baz", function() {});
 
       expect(fn).toThrow();
     });
 
-    it("should throw an error when tabs is undefined", function() {
+    it("throws an error when tabs is undefined", function() {
       var fn = TabsUtil.getTabs.bind(null, undefined, "baz", function() {});
 
       expect(fn).toThrow();
     });
 
-    it("should not have an active route when it doesn't exist", function() {
+    it("does not have an active route when it doesn't exist", function() {
       TabsUtil.getTabs(this.tabs, "notHere", this.getElement);
 
       expect(this.getElement.calls.allArgs()).toEqual([
@@ -114,7 +114,7 @@ describe("TabsUtil", function() {
       };
     });
 
-    it("should arrange tabs in correct order", function() {
+    it("arranges tabs in correct order", function() {
       var sortedTabs = TabsUtil.sortTabs(this.tabs);
       var tabContent = Object.keys(sortedTabs);
       expect(tabContent).toEqual(["bar", "foo", "qux"]);

--- a/src/js/utils/__tests__/TabsUtil-test.js
+++ b/src/js/utils/__tests__/TabsUtil-test.js
@@ -51,7 +51,7 @@ describe("TabsUtil", function() {
       expect(tabs[2].props.className).toEqual("menu-tabbed-item active");
     });
 
-    it("should highlight all routes which prefix the current tab name", function() {
+    it("highlights all routes which prefix the current tab name", function() {
       var tabs = TabsUtil.getTabs(
         this.hierarchicalTabs,
         "foobar",

--- a/src/js/utils/__tests__/UnitHealthUtil-test.js
+++ b/src/js/utils/__tests__/UnitHealthUtil-test.js
@@ -11,7 +11,7 @@ describe("UnitHealthUnit", function() {
       this.healthWeight = UnitHealthUtil.getHealthSorting(unit);
     });
 
-    it("should return a number", function() {
+    it("returns a number", function() {
       expect(typeof this.healthWeight).toEqual("number");
     });
   });

--- a/src/js/utils/__tests__/Units-test.js
+++ b/src/js/utils/__tests__/Units-test.js
@@ -29,51 +29,51 @@ describe("Units", function() {
     });
 
     // Regular tests
-    it("should convert to correct unit of B", function() {
+    it("converts to correct unit of B", function() {
       expect(Units.filesize(this.baseSize)).toBe("796 B");
     });
 
-    it("should convert to correct unit of KiB", function() {
+    it("converts to correct unit of KiB", function() {
       expect(Units.filesize(this.baseSize * 1024)).toBe("796 KiB");
     });
 
-    it("should convert to correct unit of MiB", function() {
+    it("converts to correct unit of MiB", function() {
       var factorize = Math.pow(1024, 2);
       expect(Units.filesize(this.baseSize * factorize)).toBe("796 MiB");
     });
 
-    it("should convert to correct unit of GiB", function() {
+    it("converts to correct unit of GiB", function() {
       var factorize = Math.pow(1024, 3);
       expect(Units.filesize(this.baseSize * factorize)).toBe("796 GiB");
     });
 
-    it("should convert to correct unit of PiB", function() {
+    it("converts to correct unit of PiB", function() {
       var factorize = Math.pow(1024, 5);
       expect(Units.filesize(this.baseSize * factorize)).toBe("796 PiB");
     });
 
-    it("should convert to correct unit of large PiB", function() {
+    it("converts to correct unit of large PiB", function() {
       var factorize = Math.pow(1024, 6);
       expect(Units.filesize(this.baseSize * factorize)).toBe("815104 PiB");
     });
 
-    it("should convert to correct unit of MiB", function() {
+    it("converts to correct unit of MiB", function() {
       expect(Units.filesize((this.baseSize + 108) * 1024)).toBe("0.88 MiB");
     });
 
-    it("should convert to correct unit of GiB", function() {
+    it("converts to correct unit of GiB", function() {
       var factorize = Math.pow(1024, 2);
       expect(Units.filesize((this.baseSize + 128) * factorize)).toBe("0.9 GiB");
     });
 
-    it("should convert to correct unit of TiB", function() {
+    it("converts to correct unit of TiB", function() {
       var factorize = Math.pow(1024, 3);
       expect(Units.filesize((this.baseSize + 158) * factorize)).toBe(
         "0.93 TiB"
       );
     });
 
-    it("should convert to correct unit of PiB", function() {
+    it("converts to correct unit of PiB", function() {
       var factorize = Math.pow(1024, 5);
       expect(Units.filesize((this.baseSize + 230) * factorize)).toBe(
         "1026 PiB"
@@ -81,7 +81,7 @@ describe("Units", function() {
     });
 
     // Special tests
-    it("should return '0 B' for vales of zero", function() {
+    it("returns '0 B' for vales of zero", function() {
       expect(Units.filesize(0, 0)).toBe("0 B");
     });
 
@@ -122,87 +122,87 @@ describe("Units", function() {
   });
 
   describe("#contractNumber", function() {
-    it("should format 999,999,999,999,999 correctly ", function() {
+    it("formats 999,999,999,999,999 correctly ", function() {
       return expect(Units.contractNumber(999999999999999)).toEqual("> 999T");
     });
 
-    it("should format 15,000,000,000 correctly", function() {
+    it("formats 15,000,000,000 correctly", function() {
       return expect(Units.contractNumber(15000000000)).toEqual("15B");
     });
 
-    it("should format 15,555,555,555 correctly", function() {
+    it("formats 15,555,555,555 correctly", function() {
       return expect(Units.contractNumber(15555555555)).toEqual("16B");
     });
 
-    it("should format 9,700,000,000 correctly ", function() {
+    it("formats 9,700,000,000 correctly ", function() {
       return expect(Units.contractNumber(9700000000)).toEqual("10B");
     });
 
-    it("should format 1,000,000,000 correctly ", function() {
+    it("formats 1,000,000,000 correctly ", function() {
       return expect(Units.contractNumber(1000000000)).toEqual("1B");
     });
 
-    it("should format 999,999,999 correctly ", function() {
+    it("formats 999,999,999 correctly ", function() {
       return expect(Units.contractNumber(999999999)).toEqual("1B");
     });
 
-    it("should format 999,000,000 correctly ", function() {
+    it("formats 999,000,000 correctly ", function() {
       return expect(Units.contractNumber(999000000)).toEqual("999M");
     });
 
-    it("should format 700,000,000 correctly ", function() {
+    it("formats 700,000,000 correctly ", function() {
       return expect(Units.contractNumber(700000000)).toEqual("700M");
     });
 
-    it("should format 15,000,000 correctly", function() {
+    it("formats 15,000,000 correctly", function() {
       return expect(Units.contractNumber(15000000)).toEqual("15M");
     });
 
-    it("should format 15,555,555 correctly", function() {
+    it("formats 15,555,555 correctly", function() {
       return expect(Units.contractNumber(15555555)).toEqual("16M");
     });
 
-    it("should format 1,500,000 correctly", function() {
+    it("formats 1,500,000 correctly", function() {
       return expect(Units.contractNumber(1500000)).toEqual("1.5M");
     });
 
-    it("should format 1,555,555 correctly", function() {
+    it("formats 1,555,555 correctly", function() {
       return expect(Units.contractNumber(1555555)).toEqual("1.6M");
     });
 
-    it("should format 998,000 correctly ", function() {
+    it("formats 998,000 correctly ", function() {
       return expect(Units.contractNumber(998000)).toEqual("998K");
     });
 
-    it("should format 15,000 correctly", function() {
+    it("formats 15,000 correctly", function() {
       return expect(Units.contractNumber(15000)).toEqual("15K");
     });
 
-    it("should format 15,555 correctly", function() {
+    it("formats 15,555 correctly", function() {
       return expect(Units.contractNumber(15555)).toEqual("16K");
     });
 
-    it("should format 5,500 correctly", function() {
+    it("formats 5,500 correctly", function() {
       return expect(Units.contractNumber(5500)).toEqual("5.5K");
     });
 
-    it("should format 5,555 correctly", function() {
+    it("formats 5,555 correctly", function() {
       return expect(Units.contractNumber(5555)).toEqual("5.6K");
     });
 
-    it("should format 1,900 correctly ", function() {
+    it("formats 1,900 correctly ", function() {
       return expect(Units.contractNumber(1900)).toEqual("1900");
     });
 
-    it("should format 999 correctly ", function() {
+    it("formats 999 correctly ", function() {
       return expect(Units.contractNumber(999)).toEqual("999");
     });
 
-    it("should format 10 correctly ", function() {
+    it("formats 10 correctly ", function() {
       return expect(Units.contractNumber(10)).toEqual("10");
     });
 
-    it("should format small 1.123456 correctly ", function() {
+    it("formats small 1.123456 correctly ", function() {
       expect(Units.contractNumber(1.123456)).toEqual("1.12");
 
       return expect(
@@ -247,11 +247,11 @@ describe("Units", function() {
       ).toEqual("0.123");
     });
 
-    it("should return a string given an input string", function() {
+    it("returns a string given an input string", function() {
       return expect(Units.contractNumber("foobar")).toEqual("foobar");
     });
 
-    return it('should return "undefined" given no input', function() {
+    return it('returns "undefined" given no input', function() {
       return expect(Units.contractNumber()).toEqual(undefined);
     });
   });

--- a/src/js/utils/__tests__/Util-test.js
+++ b/src/js/utils/__tests__/Util-test.js
@@ -2,7 +2,7 @@ const Util = require("../Util");
 
 describe("Util", function() {
   describe("#uniqueID", function() {
-    it("should return a unique ID each time it is called", function() {
+    it("returns a unique ID each time it is called", function() {
       const ids = Array(100).fill(null);
       ids.forEach(function(value, index) {
         ids[index] = Util.uniqueID("100");
@@ -15,13 +15,13 @@ describe("Util", function() {
       expect(result).toBeTruthy();
     });
 
-    it("should provide an integer", function() {
+    it("provides an integer", function() {
       const id = Util.uniqueID("integerID");
 
       expect(typeof id === "number" && id % 1 === 0).toBeTruthy();
     });
 
-    it("should start over from 0 for each namespace", function() {
+    it("starts over from 0 for each namespace", function() {
       Util.uniqueID("firstNamespace");
       Util.uniqueID("firstNamespace");
       const id1 = Util.uniqueID("firstNamespace");
@@ -33,7 +33,7 @@ describe("Util", function() {
   });
 
   describe("#omit", function() {
-    it("should return a copy of the object", function() {
+    it("returns a copy of the object", function() {
       var obj = { foo: "bar" };
       var newObject = Util.omit(obj, []);
 
@@ -42,7 +42,7 @@ describe("Util", function() {
       expect(obj.foo).toEqual("bar");
     });
 
-    it("should omit key given", function() {
+    it("omits key given", function() {
       var obj = {
         foo: "bar",
         qq: "zzz"
@@ -54,7 +54,7 @@ describe("Util", function() {
       expect(newObject.qq).toEqual(undefined);
     });
 
-    it("should omit multiple keys", function() {
+    it("omits multiple keys", function() {
       var obj = {
         foo: "bar",
         qq: "zzz",
@@ -96,21 +96,21 @@ describe("Util", function() {
     });
 
     describe("with correct input", function() {
-      it("should return the last element in an array", function() {
+      it("returns the last element in an array", function() {
         var array = [0, 1, 2, 3];
         var last = Util.last(array);
 
         expect(last).toEqual(3);
       });
 
-      it("should return the last element for an array of size 1", function() {
+      it("returns the last element for an array of size 1", function() {
         var array = [0];
         var last = Util.last(array);
 
         expect(last).toEqual(0);
       });
 
-      it("should return null when given empty array", function() {
+      it("returns null when given empty array", function() {
         var array = [];
         var last = Util.last(array);
 
@@ -120,28 +120,28 @@ describe("Util", function() {
   });
 
   describe("#findLastIndex", function() {
-    it("should return -1 if empty array", function() {
+    it("returns -1 if empty array", function() {
       var array = [];
       var index = Util.findLastIndex(array, function(obj) {
         return obj === 1;
       });
       expect(index).toEqual(-1);
     });
-    it("should return -1 if not found", function() {
+    it("returns -1 if not found", function() {
       var array = [1, 2, 3, 4, 5];
       var index = Util.findLastIndex(array, function(obj) {
         return obj === 6;
       });
       expect(index).toEqual(-1);
     });
-    it("should return 4", function() {
+    it("returns 4", function() {
       var array = [3, 3, 2, 3, 3, 5];
       var index = Util.findLastIndex(array, function(obj) {
         return obj === 3;
       });
       expect(index).toEqual(4);
     });
-    it("should return 1", function() {
+    it("returns 1", function() {
       var array = [
         { a: "a", b: "bbb" },
         { a: "a", b: "bbb" },
@@ -164,49 +164,49 @@ describe("Util", function() {
       this.searchString = "hello.is.it.me.you.are.looking.for";
     });
 
-    it("should find a nested defined property", function() {
+    it("finds a nested defined property", function() {
       expect(
         Util.findNestedPropertyInObject(this.searchObject, this.searchString)
       ).toEqual("?");
     });
 
-    it("should handle nested empty string definitions gracefully", function() {
+    it("handles nested empty string definitions gracefully", function() {
       expect(
         Util.findNestedPropertyInObject(this.searchObject, "hello.")
       ).toEqual(undefined);
     });
 
-    it("should handle null search object gracefully", function() {
+    it("handles null search object gracefully", function() {
       expect(Util.findNestedPropertyInObject(null, this.searchString)).toEqual(
         null
       );
     });
 
-    it("should handle undefined gracefully", function() {
+    it("handles undefined gracefully", function() {
       expect(
         Util.findNestedPropertyInObject(undefined, this.searchString)
       ).toEqual(null);
     });
 
-    it("should handle nested empty strings gracefully", function() {
+    it("handles nested empty strings gracefully", function() {
       expect(Util.findNestedPropertyInObject(this.searchObject, ".")).toEqual(
         undefined
       );
     });
 
-    it("should handle nested empty string definition gracefully", function() {
+    it("handles nested empty string definition gracefully", function() {
       expect(Util.findNestedPropertyInObject(this.searchObject, "")).toEqual(
         undefined
       );
     });
 
-    it("should handle null definition gracefully", function() {
+    it("handles null definition gracefully", function() {
       expect(Util.findNestedPropertyInObject(this.searchObject, null)).toEqual(
         null
       );
     });
 
-    it("should handle undefined definition gracefully", function() {
+    it("handles undefined definition gracefully", function() {
       expect(
         Util.findNestedPropertyInObject(this.searchObject, undefined)
       ).toEqual(null);
@@ -418,11 +418,11 @@ describe("Util", function() {
   });
 
   describe("#toLowerCaseIfString", function() {
-    it("should lower case string", function() {
+    it("lowers case string", function() {
       expect(Util.toLowerCaseIfString("Name")).toEqual("name");
     });
 
-    it("should return original param", function() {
+    it("returns original param", function() {
       const value = 10;
 
       expect(Util.toLowerCaseIfString(value)).toEqual(value);
@@ -430,11 +430,11 @@ describe("Util", function() {
   });
 
   describe("#toUpperCaseIfString", function() {
-    it("should upper case string", function() {
+    it("uppers case string", function() {
       expect(Util.toUpperCaseIfString("Name")).toEqual("NAME");
     });
 
-    it("should return original param", function() {
+    it("returns original param", function() {
       const value = 10;
 
       expect(Util.toUpperCaseIfString(value)).toEqual(value);
@@ -442,17 +442,17 @@ describe("Util", function() {
   });
 
   describe("#isString", function() {
-    it("should return true when argument is type string", function() {
+    it("returns true when argument is type string", function() {
       expect(Util.isString("Name")).toEqual(true);
     });
 
-    it("should return false when argument is NOT type string", function() {
+    it("returns false when argument is NOT type string", function() {
       expect(Util.isString(1)).toEqual(false);
     });
   });
 
   describe("#parseUrl", function() {
-    it("should return url object representation", function() {
+    it("returns url object representation", function() {
       const expectedResult = {
         hash: "",
         host: "google.com",
@@ -471,11 +471,11 @@ describe("Util", function() {
       expect(Util.parseUrl(url)).toEqual(expectedResult);
     });
 
-    it("should return null", function() {
+    it("returns null", function() {
       expect(Util.parseUrl(1)).toEqual(null);
     });
 
-    it("should return absolute url if doesn't have protocol", function() {
+    it("returns absolute url if doesn't have protocol", function() {
       const parsedUrl = Util.parseUrl("www.google.com");
       const expectedResult = "https://www.google.com/";
 

--- a/src/js/utils/__tests__/ValidatorUtil-test.js
+++ b/src/js/utils/__tests__/ValidatorUtil-test.js
@@ -42,19 +42,19 @@ describe("ValidatorUtil", function() {
   });
 
   describe("#isDefined", function() {
-    it("should properly handle empty strings", function() {
+    it("handles empty strings", function() {
       expect(ValidatorUtil.isDefined("")).toBe(false);
     });
 
-    it("should properly handle undefined values", function() {
+    it("handles undefined values", function() {
       expect(ValidatorUtil.isDefined()).toBe(false);
     });
 
-    it("should properly handle null values", function() {
+    it("handles null values", function() {
       expect(ValidatorUtil.isDefined(null)).toBe(false);
     });
 
-    it("should verify that the value is defined", function() {
+    it("verifies that the value is defined", function() {
       expect(ValidatorUtil.isDefined("a")).toBe(true);
       expect(ValidatorUtil.isDefined("#")).toBe(true);
       expect(ValidatorUtil.isDefined(0)).toBe(true);
@@ -68,7 +68,7 @@ describe("ValidatorUtil", function() {
     // RFC822 email address validator
     // http://sphinx.mythic-beasts.com/~pdw/cgi-bin/emailvalidate?address=
 
-    it("should have at least an username, an @ and one period", function() {
+    it("has at least an username, an @ and one period", function() {
       expect(ValidatorUtil.isEmail("user@foo.bar")).toBe(true);
       expect(ValidatorUtil.isEmail("Abc.123@example.com")).toBe(true);
       expect(ValidatorUtil.isEmail("!#$%&'*+-/=?^_`.{|}~@example.com")).toBe(
@@ -81,24 +81,24 @@ describe("ValidatorUtil", function() {
       expect(ValidatorUtil.isEmail('"Joe.\\Blow"@example.com')).toBe(true);
     });
 
-    it("should have an @", function() {
+    it("has an @", function() {
       expect(ValidatorUtil.isEmail("foobar")).toBe(false);
       expect(ValidatorUtil.isEmail("userfoo.bar")).toBe(false);
     });
 
-    it("should have an username", function() {
+    it("has an username", function() {
       expect(ValidatorUtil.isEmail("@foo.bar")).toBe(false);
       expect(ValidatorUtil.isEmail("user@foo.bar")).toBe(true);
     });
 
-    it("should have at least one period after @", function() {
+    it("has at least one period after @", function() {
       expect(ValidatorUtil.isEmail("user@foobar")).toBe(false);
       expect(ValidatorUtil.isEmail("Abc.123@examplecom")).toBe(false);
       expect(ValidatorUtil.isEmail("user@foo.bar")).toBe(true);
       expect(ValidatorUtil.isEmail("user@baz.foo.bar")).toBe(true);
     });
 
-    it("should treat IDN emails as valid", function() {
+    it("treats IDN emails as valid", function() {
       expect(ValidatorUtil.isEmail("伊昭傑@郵件.商務")).toBe(true);
       expect(ValidatorUtil.isEmail("θσερ@εχαμπλε.ψομ")).toBe(true);
       expect(ValidatorUtil.isEmail("test@könig.de")).toBe(true);
@@ -107,7 +107,7 @@ describe("ValidatorUtil", function() {
       expect(ValidatorUtil.isEmail("@könig.de")).toBe(false);
     });
 
-    it("should treat long unknown TLDs as valid", function() {
+    it("treats long unknown TLDs as valid", function() {
       expect(ValidatorUtil.isEmail("user@foobar.hamburg")).toBe(true);
       expect(ValidatorUtil.isEmail("user@foobar.københavn")).toBe(true);
       expect(
@@ -117,7 +117,7 @@ describe("ValidatorUtil", function() {
       ).toBe(true);
     });
 
-    it("shouldn't have whitespaces", function() {
+    it("doesn't have whitespaces", function() {
       expect(ValidatorUtil.isEmail('"Fred Bloggs"@example.com')).toBe(false);
       expect(ValidatorUtil.isEmail("user@f o o.om")).toBe(false);
       expect(ValidatorUtil.isEmail("  user  @foo.com")).toBe(false);
@@ -125,68 +125,68 @@ describe("ValidatorUtil", function() {
   });
 
   describe("#isEmpty", function() {
-    it("should return false if it receives a number", function() {
+    it("returns false if it receives a number", function() {
       expect(ValidatorUtil.isEmpty(0)).toBe(false);
       expect(ValidatorUtil.isEmpty(-100)).toBe(false);
       expect(ValidatorUtil.isEmpty(20)).toBe(false);
     });
 
-    it("should return false if it receives a boolean", function() {
+    it("returns false if it receives a boolean", function() {
       expect(ValidatorUtil.isEmpty(false)).toBe(false);
       expect(ValidatorUtil.isEmpty(true)).toBe(false);
     });
 
-    it("should return true if it receives undefined or null", function() {
+    it("returns true if it receives undefined or null", function() {
       expect(ValidatorUtil.isEmpty()).toBe(true);
       expect(ValidatorUtil.isEmpty(undefined)).toBe(true);
       expect(ValidatorUtil.isEmpty(null)).toBe(true);
     });
 
-    it("should return true if it receives an empty array", function() {
+    it("returns true if it receives an empty array", function() {
       expect(ValidatorUtil.isEmpty([])).toBe(true);
     });
 
-    it("should return false if it receives array with items", function() {
+    it("returns false if it receives array with items", function() {
       expect(ValidatorUtil.isEmpty([0])).toBe(false);
       expect(ValidatorUtil.isEmpty([{}])).toBe(false);
     });
 
-    it("should return true if it receives an empty object", function() {
+    it("returns true if it receives an empty object", function() {
       expect(ValidatorUtil.isEmpty({})).toBe(true);
     });
 
-    it("should return false if it receives an object with keys", function() {
+    it("returns false if it receives an object with keys", function() {
       expect(ValidatorUtil.isEmpty({ foo: "bar", baz: "qux" })).toBe(false);
     });
 
-    it("should return false if it receives a string", function() {
+    it("returns false if it receives a string", function() {
       expect(ValidatorUtil.isEmpty("foo")).toBe(false);
     });
   });
 
   describe("#isInteger", function() {
-    it("should properly handle empty strings", function() {
+    it("handles empty strings", function() {
       expect(ValidatorUtil.isInteger("")).toBe(false);
     });
 
-    it("should properly handle undefined values", function() {
+    it("handles undefined values", function() {
       expect(ValidatorUtil.isInteger()).toBe(false);
     });
 
-    it("should properly handle null values", function() {
+    it("handles null values", function() {
       expect(ValidatorUtil.isInteger(null)).toBe(false);
     });
 
-    it("should properly handle wrong value types", function() {
+    it("handles wrong value types", function() {
       expect(ValidatorUtil.isInteger("not a number 666")).toBe(false);
     });
 
-    it("should handle number like inputs", function() {
+    it("handles number like inputs", function() {
       expect(ValidatorUtil.isInteger(2)).toBe(true);
       expect(ValidatorUtil.isInteger("2")).toBe(true);
     });
 
-    it("should verify that the value is in an integer", function() {
+    it("verifies that the value is in an integer", function() {
       expect(ValidatorUtil.isInteger(0.1)).toBe(false);
       expect(ValidatorUtil.isInteger(2.2)).toBe(false);
       expect(ValidatorUtil.isInteger(-0.3)).toBe(false);
@@ -197,25 +197,25 @@ describe("ValidatorUtil", function() {
   });
 
   describe("#isNumber", function() {
-    it("should properly handle empty strings", function() {
+    it("handles empty strings", function() {
       expect(ValidatorUtil.isNumber("")).toBe(false);
     });
 
-    it("should properly handle undefined values", function() {
+    it("handles undefined values", function() {
       expect(ValidatorUtil.isNumber()).toBe(false);
     });
 
-    it("should properly handle null values", function() {
+    it("handles null values", function() {
       expect(ValidatorUtil.isNumber(null)).toBe(false);
     });
 
-    it("should properly handle wrong value types", function() {
+    it("handles wrong value types", function() {
       expect(ValidatorUtil.isNumber("not a number 666")).toBe(false);
       expect(ValidatorUtil.isNumber("2a+1")).toBe(false);
       expect(ValidatorUtil.isNumber("2a1")).toBe(false);
     });
 
-    it("should handle number like inputs", function() {
+    it("handles number like inputs", function() {
       expect(ValidatorUtil.isNumber("0.0001")).toBe(true);
       expect(ValidatorUtil.isNumber(-0.1)).toBe(true);
       expect(ValidatorUtil.isNumber("-.1")).toBe(true);
@@ -224,7 +224,7 @@ describe("ValidatorUtil", function() {
       expect(ValidatorUtil.isNumber("2e1")).toBe(true);
     });
 
-    it("should verify that the value is in a number", function() {
+    it("verifies that the value is in a number", function() {
       expect(ValidatorUtil.isNumber(0.1)).toBe(true);
       expect(ValidatorUtil.isNumber(2.2)).toBe(true);
       expect(ValidatorUtil.isNumber(-0.3)).toBe(true);
@@ -237,19 +237,19 @@ describe("ValidatorUtil", function() {
   });
 
   describe("#isNumberInRange", function() {
-    it("should properly handle empty strings", function() {
+    it("handles empty strings", function() {
       expect(ValidatorUtil.isNumberInRange("")).toBe(false);
     });
 
-    it("should properly handle  undefined values", function() {
+    it("handles  undefined values", function() {
       expect(ValidatorUtil.isNumberInRange()).toBe(false);
     });
 
-    it("should properly handle wrong value types", function() {
+    it("handles wrong value types", function() {
       expect(ValidatorUtil.isNumberInRange("not a number 666")).toBe(false);
     });
 
-    it("should handle number like inputs", function() {
+    it("handles number like inputs", function() {
       expect(ValidatorUtil.isNumberInRange(0.001)).toBe(true);
       expect(ValidatorUtil.isNumberInRange("0.0001")).toBe(true);
       expect(ValidatorUtil.isNumberInRange(-0.1)).toBe(false);
@@ -258,12 +258,12 @@ describe("ValidatorUtil", function() {
       expect(ValidatorUtil.isNumberInRange("2")).toBe(true);
     });
 
-    it("should verify that the value is in the default range (0 - infinity)", function() {
+    it("verifies that the value is in the default range (0 - infinity)", function() {
       expect(ValidatorUtil.isNumberInRange(-1)).toBe(false);
       expect(ValidatorUtil.isNumberInRange(1)).toBe(true);
     });
 
-    it("should verify that the value is in the range (0 - `max`)", function() {
+    it("verifies that the value is in the range (0 - `max`)", function() {
       const range = { max: 4 };
 
       expect(ValidatorUtil.isNumberInRange(-1, range)).toBe(false);
@@ -271,7 +271,7 @@ describe("ValidatorUtil", function() {
       expect(ValidatorUtil.isNumberInRange(4, range)).toBe(true);
     });
 
-    it("should verify that the value is in the range (`min` - infinity)", function() {
+    it("verifies that the value is in the range (`min` - infinity)", function() {
       const range = { min: 2 };
 
       expect(ValidatorUtil.isNumberInRange(0, range)).toBe(false);
@@ -279,7 +279,7 @@ describe("ValidatorUtil", function() {
       expect(ValidatorUtil.isNumberInRange(2, range)).toBe(true);
     });
 
-    it("should verify that the value is in the range (`min` - `max`)", function() {
+    it("verifies that the value is in the range (`min` - `max`)", function() {
       const range = { min: 3, max: 5 };
 
       expect(ValidatorUtil.isNumberInRange(0, range)).toBe(false);
@@ -292,19 +292,19 @@ describe("ValidatorUtil", function() {
   });
 
   describe("#isStringInteger", function() {
-    it("should properly handle empty strings", function() {
+    it("handles empty strings", function() {
       expect(ValidatorUtil.isStringInteger("")).toBe(false);
     });
 
-    it("should properly handle undefined values", function() {
+    it("handles undefined values", function() {
       expect(ValidatorUtil.isStringInteger()).toBe(false);
     });
 
-    it("should properly handle null values", function() {
+    it("handles null values", function() {
       expect(ValidatorUtil.isStringInteger(null)).toBe(false);
     });
 
-    it("should properly handle wrong value types", function() {
+    it("handles wrong value types", function() {
       expect(ValidatorUtil.isStringInteger("not a number 666")).toBe(false);
       expect(ValidatorUtil.isStringInteger("2a+1")).toBe(false);
       expect(ValidatorUtil.isStringInteger("2a1")).toBe(false);
@@ -316,12 +316,12 @@ describe("ValidatorUtil", function() {
       expect(ValidatorUtil.isStringInteger("1.23")).toBe(false);
     });
 
-    it("should handle integer string inputs", function() {
+    it("handles integer string inputs", function() {
       expect(ValidatorUtil.isStringInteger("2")).toBe(true);
       expect(ValidatorUtil.isStringInteger("123")).toBe(true);
     });
 
-    it("should disregard any value is in a number", function() {
+    it("disregards any value is in a number", function() {
       expect(ValidatorUtil.isStringInteger(0.1)).toBe(false);
       expect(ValidatorUtil.isStringInteger(2.2)).toBe(false);
       expect(ValidatorUtil.isStringInteger(-0.3)).toBe(false);

--- a/src/resources/grammar/__tests__/SearchDSL-test.js
+++ b/src/resources/grammar/__tests__/SearchDSL-test.js
@@ -46,19 +46,19 @@ class ExactTextFilter extends DSLFilter {
 describe("SearchDSL", function() {
   describe("Metadata", function() {
     describe("Filters (Operands)", function() {
-      it("should parse fuzzy text", function() {
+      it("parses fuzzy text", function() {
         const expr = SearchDSL.parse("fuzzy");
         expect(expr.ast.filterType).toEqual(DSLFilterTypes.FUZZY);
         expect(expr.ast.filterParams.text).toEqual("fuzzy");
       });
 
-      it("should parse exact text", function() {
+      it("parses exact text", function() {
         const expr = SearchDSL.parse('"exact string"');
         expect(expr.ast.filterType).toEqual(DSLFilterTypes.EXACT);
         expect(expr.ast.filterParams.text).toEqual("exact string");
       });
 
-      it("should parse attributes", function() {
+      it("parses attributes", function() {
         const expr = SearchDSL.parse("attrib:value");
         expect(expr.ast.filterType).toEqual(DSLFilterTypes.ATTRIB);
         expect(expr.ast.filterParams.text).toEqual("value");
@@ -67,17 +67,17 @@ describe("SearchDSL", function() {
     });
 
     describe("Combiners (Operators)", function() {
-      it("should use AND operator by default", function() {
+      it("uses AND operator by default", function() {
         const expr = SearchDSL.parse("text1 text2");
         expect(expr.ast.combinerType).toEqual(DSLCombinerTypes.AND);
       });
 
-      it("should properly use OR operator", function() {
+      it("uses OR operator", function() {
         const expr = SearchDSL.parse("text1, text2");
         expect(expr.ast.combinerType).toEqual(DSLCombinerTypes.OR);
       });
 
-      it("should properly use OR shorthand operator on attrib", function() {
+      it("uses OR shorthand operator on attrib", function() {
         // NOTE: attrib:value1,value2 becomes -> attrib:value1, attrib:value2
         const expr = SearchDSL.parse("attrib:value1,value2");
         expect(expr.ast.combinerType).toEqual(DSLCombinerTypes.OR);
@@ -89,7 +89,7 @@ describe("SearchDSL", function() {
         expect(expr.ast.children[1].filterParams.label).toEqual("attrib");
       });
 
-      it("should properly handle OR shorthand + OR with other operands", function() {
+      it("handles OR shorthand + OR with other operands", function() {
         // NOTE: attrib:value1,value2 becomes -> attrib:value1, attrib:value2
         const expr = SearchDSL.parse("attrib:value1,value2, foo");
         expect(expr.ast.combinerType).toEqual(DSLCombinerTypes.OR);
@@ -118,7 +118,7 @@ describe("SearchDSL", function() {
         expect(expr.ast.children[1].filterParams.text).toEqual("foo");
       });
 
-      it("should correctly populate children", function() {
+      it("populates children", function() {
         const expr = SearchDSL.parse("text1 text2");
         expect(expr.ast.children[0].filterType).toEqual(DSLFilterTypes.FUZZY);
         expect(expr.ast.children[0].filterParams.text).toEqual("text1");
@@ -128,7 +128,7 @@ describe("SearchDSL", function() {
     });
 
     describe("Complex expressions", function() {
-      it("should nest operations in correct order", function() {
+      it("nests operations in correct order", function() {
         const expr = SearchDSL.parse(
           "text1 text2, (text3 (text4 text5), text6)"
         );
@@ -205,22 +205,22 @@ describe("SearchDSL", function() {
     });
 
     describe("Token positions", function() {
-      it("should properly track location of fuzzy text", function() {
+      it("tracks location of fuzzy text", function() {
         const expr = SearchDSL.parse("fuzzy");
         expect(expr.ast.position).toEqual([[0, 5]]);
       });
 
-      it("should properly track location of exact text", function() {
+      it("tracks location of exact text", function() {
         const expr = SearchDSL.parse('"exact string"');
         expect(expr.ast.position).toEqual([[0, 14]]);
       });
 
-      it("should properly track location of attrib", function() {
+      it("tracks location of attrib", function() {
         const expr = SearchDSL.parse("attrib:value");
         expect(expr.ast.position).toEqual([[0, 7], [7, 12]]);
       });
 
-      it("should properly track location of attrib with multi values", function() {
+      it("tracks location of attrib with multi values", function() {
         const expr = SearchDSL.parse("attrib:value1,value2");
         expect(expr.ast.children[1].position).toEqual([[0, 7], [14, 20]]);
       });
@@ -243,7 +243,7 @@ describe("SearchDSL", function() {
         });
       });
 
-      it("should properly filter by fuzzy match", function() {
+      it("filters by fuzzy match", function() {
         const expr = SearchDSL.parse("test");
 
         expect(
@@ -254,7 +254,7 @@ describe("SearchDSL", function() {
         ]);
       });
 
-      it("should properly filter by exact match", function() {
+      it("filters by exact match", function() {
         const expr = SearchDSL.parse('"some other string"');
 
         expect(
@@ -262,7 +262,7 @@ describe("SearchDSL", function() {
         ).toEqual([{ text: "some other string", attrib: ["c", "d"] }]);
       });
 
-      it("should properly filter by attribute", function() {
+      it("filters by attribute", function() {
         const expr = SearchDSL.parse("attrib:b");
 
         expect(
@@ -273,7 +273,7 @@ describe("SearchDSL", function() {
         ]);
       });
 
-      it("should combine with OR operator with multi-value attr", function() {
+      it("combines with OR operator with multi-value attr", function() {
         const expr = SearchDSL.parse("attrib:a,b");
 
         expect(
@@ -284,7 +284,7 @@ describe("SearchDSL", function() {
         ]);
       });
 
-      it("should combine with OR operator multiple attr", function() {
+      it("combines with OR operator multiple attr", function() {
         const expr = SearchDSL.parse("attrib:a, attrib:b");
 
         expect(
@@ -295,7 +295,7 @@ describe("SearchDSL", function() {
         ]);
       });
 
-      it("should combine with AND operator multiple attr", function() {
+      it("combines with AND operator multiple attr", function() {
         const expr = SearchDSL.parse("attrib:a attrib:b");
 
         expect(
@@ -303,7 +303,7 @@ describe("SearchDSL", function() {
         ).toEqual([{ text: "some test string", attrib: ["a", "b"] }]);
       });
 
-      it("should combine with AND operator multiple attr", function() {
+      it("combines with AND operator multiple attr", function() {
         const expr = SearchDSL.parse("attrib:a attrib:b");
 
         expect(

--- a/tests/_support/utils/tests/router-test.js
+++ b/tests/_support/utils/tests/router-test.js
@@ -19,7 +19,7 @@ describe("router", function() {
   });
 
   describe("#clearRoutes", function() {
-    it("should clear previously defined routes", function(done) {
+    it("clears previously defined routes", function(done) {
       router.route(/foo/, "fx:bar");
       router.clearRoutes();
       router.getAPIResponse("foo", function(foundFixture) {
@@ -40,19 +40,19 @@ describe("router", function() {
       delete this.returnValue;
     });
 
-    it("should call #route on the global cy object with all arguments", function() {
+    it("calls #route on the global cy object with all arguments", function() {
       expect(global.cy.route.calledWith(this.fooRegEx, "fx:bar")).to.equal(
         true
       );
     });
 
-    it("should return an instance of the router util", function() {
+    it("returns an instance of the router util", function() {
       expect(this.returnValue).to.equal(router);
     });
   });
 
   describe("#getAPIResponse", function() {
-    it("should call the callback with the fixture when found", function(done) {
+    it("calls the callback with the fixture when found", function(done) {
       router.route(/foo/, "fx:bar");
       router.getAPIResponse("foo", function(foundFixture) {
         expect(foundFixture).to.equal("bar");
@@ -60,7 +60,7 @@ describe("router", function() {
       });
     });
 
-    it("should call the callback with null when the fixture is not found", function(
+    it("calls the callback with null when the fixture is not found", function(
       done
     ) {
       router.getAPIResponse("baz", function(foundFixture) {

--- a/tests/_support/utils/tests/testUtil-test.js
+++ b/tests/_support/utils/tests/testUtil-test.js
@@ -2,12 +2,12 @@ const testUtil = require("../testUtil");
 
 describe("testUtil", function() {
   describe("#getSearchParameter", function() {
-    it("should get first search parameter", function() {
+    it("gets first search parameter", function() {
       const uri = "something?q=something&q=somethingelse";
       expect(testUtil.getSearchParameter(uri)).to.equal("q=something");
     });
 
-    it("should return undefined if no query is found", function() {
+    it("returns undefined if no query is found", function() {
       const uri = "something?t=0m";
       expect(testUtil.getSearchParameter(uri)).to.equal(undefined);
     });


### PR DESCRIPTION

This PR adjusts the unit test descriptions to use the third person in the present tense instead of "should" as document on http://betterspecs.org

I wrote the follwing script to transform the descriptions and used `find` to apply the script to all `*-test.js` files.

```python
#!/usr/bin/env python

import fileinput
import re

for line in fileinput.input(inplace=1):
  line = re.sub(
    r'("|\'|`)should\shave',
    r'\1has',
    line.rstrip(),
    flags=re.IGNORECASE)
  line = re.sub(
    r'("|\'|`)should(n\'t|\snot|\sdo)',
    r'\1does\2',
    line.rstrip(),
    flags=re.IGNORECASE)
  line = re.sub(
    r'("|\'|`)should\sbe',
    r'\1is', line.rstrip(),
    flags=re.IGNORECASE)
  line = re.sub(
    r'("|\'|`)should\s(?:\w+ly\s)?(\w+([^syh\s]{2}|[aeiou]y|se|st)\b)',
    r'\1\2s',
    line.rstrip(),
    flags=re.IGNORECASE)
  line = re.sub(
    r'("|\'|`)should\s(?:\w+ly\s)?(\w+(ss|x|sh|ch)\b)',
    r'\1\2es',
    line.rstrip(),
    flags=re.IGNORECASE)
  line = re.sub(
    r'("|\'|`)should\s(?:\w+ly\s)?(\w+[^aeiou])y\b',
    r'\1\2ies',
    line.rstrip(),
    flags=re.IGNORECASE)
  line = re.sub(
    r'("|\'|`)should\s(\w+s\b)',
    r'\1\2',
    line.rstrip(),
    flags=re.IGNORECASE)

  print(line)
```

Please note that there were a few cases that I had to manually address and there were cases that I couldn't adjust as they require a thorough rewrite.

I ran the following command to find any remaining shoulds.

```bash
find . -name "*-test.js" -not -path "*/node_modules/*"  -not -path "./dist/*"  -exec grep -i --color=always "should" {} \; -exec echo {} \;
```
  