### PR TITLE
DCOS-19481 | fix(placement): swap placement form fields

### DIFF
--- a/plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js
@@ -14,12 +14,12 @@ class PodPlacementConstraintsConfigSection extends React.Component {
   getColumns() {
     return [
       {
-        heading: "Field Name",
-        prop: "fieldName"
-      },
-      {
         heading: "Operator",
         prop: "operator"
+      },
+      {
+        heading: "Field Name",
+        prop: "fieldName"
       },
       {
         heading: "Value",

--- a/plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.js
@@ -13,12 +13,12 @@ class ServicePlacementConstraintsConfigSection extends React.Component {
   getColumns() {
     return [
       {
-        heading: "Field Name",
-        prop: "fieldName"
-      },
-      {
         heading: "Operator",
         prop: "operator"
+      },
+      {
+        heading: "Field Name",
+        prop: "fieldName"
       },
       {
         heading: "Value",

--- a/src/js/components/PlacementConstraintsPartial.js
+++ b/src/js/components/PlacementConstraintsPartial.js
@@ -4,7 +4,6 @@ import { Tooltip } from "reactjs-components";
 import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
 import AddButton from "#SRC/js/components/form/AddButton";
 import DeleteRowButton from "#SRC/js/components/form/DeleteRowButton";
-import FieldAutofocus from "#SRC/js/components/form/FieldAutofocus";
 import FieldError from "#SRC/js/components/form/FieldError";
 import FieldHelp from "#SRC/js/components/form/FieldHelp";
 import FieldInput from "#SRC/js/components/form/FieldInput";
@@ -128,22 +127,6 @@ export default class PlacementSection extends Component {
           <FormGroup
             className={commonFieldsClassNames}
             required={true}
-            showError={Boolean(fieldNameError)}
-          >
-            {fieldLabel}
-            <FieldAutofocus>
-              <FieldInput
-                name={`constraints.${index}.fieldName`}
-                type="text"
-                placeholder="hostname"
-                value={constraint.fieldName}
-              />
-            </FieldAutofocus>
-            <FieldError>{fieldNameError}</FieldError>
-          </FormGroup>
-          <FormGroup
-            className={commonFieldsClassNames}
-            required={true}
             showError={Boolean(operatorError)}
           >
             {operatorLabel}
@@ -156,6 +139,20 @@ export default class PlacementSection extends Component {
               {this.getOperatorTypes()}
             </FieldSelect>
             <FieldError>{operatorError}</FieldError>
+          </FormGroup>
+          <FormGroup
+            className={commonFieldsClassNames}
+            required={true}
+            showError={Boolean(fieldNameError)}
+          >
+            {fieldLabel}
+            <FieldInput
+              name={`constraints.${index}.fieldName`}
+              type="text"
+              placeholder="hostname"
+              value={constraint.fieldName}
+            />
+            <FieldError>{fieldNameError}</FieldError>
           </FormGroup>
           <FormGroup
             className={{

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -729,11 +729,6 @@ describe("Service Form Modal", function() {
           .click();
 
         cy
-          .focused()
-          .should("have.attr", "name")
-          .and("eq", "constraints.0.fieldName");
-
-        cy
           .get('.menu-tabbed-view input[name="constraints.0.fieldName"')
           .should(function($inputElement) {
             const $wrappingLabel = $inputElement.closest(".form-group");
@@ -827,6 +822,7 @@ describe("Service Form Modal", function() {
             .get("@tabView")
             .find('select[name="constraints.0.operator"]')
             .parents(".form-group")
+            .next()
             .next()
             .should("have.class", "hidden");
         });


### PR DESCRIPTION
This commit swaps the `operator` and `fieldname`
fields for better usability.

Closes DCOS-19481