### PR TITLE
Bump @dcos/mesos-client 0.1.8

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -25,9 +25,9 @@
       "resolved": "https://registry.npmjs.org/@dcos/http-service/-/http-service-0.2.0.tgz"
     },
     "@dcos/mesos-client": {
-      "version": "0.1.7",
-      "from": "@dcos/mesos-client@0.1.7",
-      "resolved": "https://registry.npmjs.org/@dcos/mesos-client/-/mesos-client-0.1.7.tgz"
+      "version": "0.1.8",
+      "from": "@dcos/mesos-client@0.1.8",
+      "resolved": "https://registry.npmjs.org/@dcos/mesos-client/-/mesos-client-0.1.8.tgz"
     },
     "@dcos/recordio": {
       "version": "0.1.5",
@@ -306,7 +306,596 @@
         "chokidar": {
           "version": "1.6.1",
           "from": "chokidar@>=1.6.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz"
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+          "dependencies": {
+            "fsevents": {
+              "version": "1.1.3",
+              "from": "fsevents@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.1.0",
+                  "from": "abbrev@1.1.0",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
+                },
+                "ajv": {
+                  "version": "4.11.8",
+                  "from": "ajv@4.11.8",
+                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
+                },
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "ansi-regex@2.1.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                },
+                "aproba": {
+                  "version": "1.1.1",
+                  "from": "aproba@1.1.1",
+                  "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz"
+                },
+                "are-we-there-yet": {
+                  "version": "1.1.4",
+                  "from": "are-we-there-yet@1.1.4",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz"
+                },
+                "asn1": {
+                  "version": "0.2.3",
+                  "from": "asn1@0.2.3",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                },
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "from": "assert-plus@0.2.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                },
+                "asynckit": {
+                  "version": "0.4.0",
+                  "from": "asynckit@0.4.0",
+                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+                },
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "from": "aws-sign2@0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                },
+                "aws4": {
+                  "version": "1.6.0",
+                  "from": "aws4@1.6.0",
+                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+                },
+                "balanced-match": {
+                  "version": "0.4.2",
+                  "from": "balanced-match@0.4.2",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                },
+                "bcrypt-pbkdf": {
+                  "version": "1.0.1",
+                  "from": "bcrypt-pbkdf@1.0.1",
+                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
+                },
+                "block-stream": {
+                  "version": "0.0.9",
+                  "from": "block-stream@0.0.9",
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+                },
+                "boom": {
+                  "version": "2.10.1",
+                  "from": "boom@2.10.1",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                },
+                "brace-expansion": {
+                  "version": "1.1.7",
+                  "from": "brace-expansion@1.1.7",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
+                },
+                "buffer-shims": {
+                  "version": "1.0.0",
+                  "from": "buffer-shims@1.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                },
+                "caseless": {
+                  "version": "0.12.0",
+                  "from": "caseless@0.12.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+                },
+                "co": {
+                  "version": "4.6.0",
+                  "from": "co@4.6.0",
+                  "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+                },
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "from": "code-point-at@1.1.0",
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "from": "combined-stream@1.0.5",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "from": "console-control-strings@1.1.0",
+                  "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "cryptiles@2.0.5",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                },
+                "dashdash": {
+                  "version": "1.14.1",
+                  "from": "dashdash@1.14.1",
+                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@1.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.6.8",
+                  "from": "debug@2.6.8",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
+                },
+                "deep-extend": {
+                  "version": "0.4.2",
+                  "from": "deep-extend@0.4.2",
+                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
+                },
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "from": "delayed-stream@1.0.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                },
+                "delegates": {
+                  "version": "1.0.0",
+                  "from": "delegates@1.0.0",
+                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                },
+                "detect-libc": {
+                  "version": "1.0.2",
+                  "from": "detect-libc@^1.0.2",
+                  "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz"
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "from": "ecc-jsbn@0.1.1",
+                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                },
+                "extend": {
+                  "version": "3.0.1",
+                  "from": "extend@3.0.1",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+                },
+                "extsprintf": {
+                  "version": "1.0.2",
+                  "from": "extsprintf@1.0.2",
+                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "from": "forever-agent@0.6.1",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                },
+                "form-data": {
+                  "version": "2.1.4",
+                  "from": "form-data@2.1.4",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
+                },
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "from": "fs.realpath@1.0.0",
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                },
+                "fstream": {
+                  "version": "1.0.11",
+                  "from": "fstream@1.0.11",
+                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz"
+                },
+                "fstream-ignore": {
+                  "version": "1.0.5",
+                  "from": "fstream-ignore@1.0.5",
+                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
+                },
+                "gauge": {
+                  "version": "2.7.4",
+                  "from": "gauge@2.7.4",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz"
+                },
+                "getpass": {
+                  "version": "0.1.7",
+                  "from": "getpass@0.1.7",
+                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@1.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "7.1.2",
+                  "from": "glob@7.1.2",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+                },
+                "graceful-fs": {
+                  "version": "4.1.11",
+                  "from": "graceful-fs@4.1.11",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                },
+                "har-schema": {
+                  "version": "1.0.5",
+                  "from": "har-schema@1.0.5",
+                  "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+                },
+                "har-validator": {
+                  "version": "4.2.1",
+                  "from": "har-validator@4.2.1",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
+                },
+                "has-unicode": {
+                  "version": "2.0.1",
+                  "from": "has-unicode@2.0.1",
+                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "from": "hawk@3.1.3",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "hoek@2.16.3",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "from": "http-signature@1.1.1",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "from": "inflight@1.0.6",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@2.0.3",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "ini@1.3.4",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "from": "is-fullwidth-code-point@1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "from": "is-typedarray@1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "isarray@1.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@0.1.2",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "jodid25519": {
+                  "version": "1.0.2",
+                  "from": "jodid25519@1.0.2",
+                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                },
+                "jsbn": {
+                  "version": "0.1.1",
+                  "from": "jsbn@0.1.1",
+                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+                },
+                "json-schema": {
+                  "version": "0.2.3",
+                  "from": "json-schema@0.2.3",
+                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                },
+                "json-stable-stringify": {
+                  "version": "1.0.1",
+                  "from": "json-stable-stringify@1.0.1",
+                  "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@5.0.1",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "jsonify": {
+                  "version": "0.0.0",
+                  "from": "jsonify@0.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                },
+                "jsprim": {
+                  "version": "1.4.0",
+                  "from": "jsprim@1.4.0",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@1.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    }
+                  }
+                },
+                "mime-db": {
+                  "version": "1.27.0",
+                  "from": "mime-db@1.27.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.15",
+                  "from": "mime-types@2.1.15",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "from": "minimatch@3.0.4",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@0.5.1",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+                },
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "ms@2.0.0",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                },
+                "node-pre-gyp": {
+                  "version": "0.6.39",
+                  "from": "node-pre-gyp@^0.6.39",
+                  "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz"
+                },
+                "nopt": {
+                  "version": "4.0.1",
+                  "from": "nopt@4.0.1",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz"
+                },
+                "npmlog": {
+                  "version": "4.1.0",
+                  "from": "npmlog@4.1.0",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz"
+                },
+                "number-is-nan": {
+                  "version": "1.0.1",
+                  "from": "number-is-nan@1.0.1",
+                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                },
+                "oauth-sign": {
+                  "version": "0.8.2",
+                  "from": "oauth-sign@0.8.2",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "from": "object-assign@4.1.1",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "from": "once@1.4.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+                },
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "from": "os-homedir@1.0.2",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "from": "os-tmpdir@1.0.2",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+                },
+                "osenv": {
+                  "version": "0.1.4",
+                  "from": "osenv@0.1.4",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "from": "path-is-absolute@1.0.1",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                },
+                "performance-now": {
+                  "version": "0.2.0",
+                  "from": "performance-now@0.2.0",
+                  "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "from": "process-nextick-args@1.0.7",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                },
+                "punycode": {
+                  "version": "1.4.1",
+                  "from": "punycode@1.4.1",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                },
+                "qs": {
+                  "version": "6.4.0",
+                  "from": "qs@6.4.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+                },
+                "rc": {
+                  "version": "1.2.1",
+                  "from": "rc@1.2.1",
+                  "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.2.0",
+                      "from": "minimist@1.2.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.2.9",
+                  "from": "readable-stream@2.2.9",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
+                },
+                "request": {
+                  "version": "2.81.0",
+                  "from": "request@2.81.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
+                },
+                "rimraf": {
+                  "version": "2.6.1",
+                  "from": "rimraf@2.6.1",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+                },
+                "safe-buffer": {
+                  "version": "5.0.1",
+                  "from": "safe-buffer@5.0.1",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                },
+                "semver": {
+                  "version": "5.3.0",
+                  "from": "semver@5.3.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "from": "set-blocking@2.0.0",
+                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+                },
+                "signal-exit": {
+                  "version": "3.0.2",
+                  "from": "signal-exit@3.0.2",
+                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "sntp@1.0.9",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                },
+                "sshpk": {
+                  "version": "1.13.0",
+                  "from": "sshpk@1.13.0",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@1.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    }
+                  }
+                },
+                "string_decoder": {
+                  "version": "1.0.1",
+                  "from": "string_decoder@1.0.1",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz"
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "from": "string-width@1.0.2",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "from": "stringstream@0.0.5",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "strip-ansi@3.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                },
+                "strip-json-comments": {
+                  "version": "2.0.1",
+                  "from": "strip-json-comments@2.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+                },
+                "tar": {
+                  "version": "2.2.1",
+                  "from": "tar@2.2.1",
+                  "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+                },
+                "tar-pack": {
+                  "version": "3.4.0",
+                  "from": "tar-pack@3.4.0",
+                  "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "2.3.2",
+                  "from": "tough-cookie@2.3.2",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.6.0",
+                  "from": "tunnel-agent@0.6.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+                },
+                "tweetnacl": {
+                  "version": "0.14.5",
+                  "from": "tweetnacl@0.14.5",
+                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                },
+                "uid-number": {
+                  "version": "0.0.6",
+                  "from": "uid-number@0.0.6",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@1.0.2",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                },
+                "uuid": {
+                  "version": "3.0.1",
+                  "from": "uuid@3.0.1",
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+                },
+                "verror": {
+                  "version": "1.3.6",
+                  "from": "verror@1.3.6",
+                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                },
+                "wide-align": {
+                  "version": "1.1.2",
+                  "from": "wide-align@1.1.2",
+                  "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
+                },
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@1.0.2",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            }
+          }
         },
         "core-js": {
           "version": "2.4.1",
@@ -3982,7 +4571,7 @@
     },
     "gemini-scrollbar": {
       "version": "1.3.2",
-      "from": "gemini-scrollbar@>=1.3.0 <1.4.0",
+      "from": "gemini-scrollbar@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/gemini-scrollbar/-/gemini-scrollbar-1.3.2.tgz"
     },
     "generate-function": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "externalplugins": ""
   },
   "dependencies": {
+    "@dcos/mesos-client": "0.1.8",
     "@dcos/http-service": "0.2.0",
-    "@dcos/mesos-client": "0.1.7",
     "babel-polyfill": "6.23.0",
     "browser-info": "0.4.0",
     "classnames": "2.2.3",


### PR DESCRIPTION
To remove the 30 seconds timeout so the browser will control timeouts. 

The rxjs timeout has a flaw that it doesn't take into account slow connections and would just close the connection