### PR TITLE
fix(FrameworkConfiguration): move legal t&c text when installing

### DIFF
--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -309,16 +309,6 @@ class PackageDetailTab extends mixin(StoreMixin) {
     );
   }
 
-  getTermsConditionUrl() {
-    const cosmosPackage = CosmosPackagesStore.getPackageDetails();
-
-    if (cosmosPackage.isCertified()) {
-      return "https://mesosphere.com/catalog-terms-conditions/#certified-services";
-    } else {
-      return "https://mesosphere.com/catalog-terms-conditions/#community-services";
-    }
-  }
-
   getPackageVersionsDropdown() {
     const cosmosPackage = CosmosPackagesStore.getPackageDetails();
     const packageName = cosmosPackage.getName();
@@ -493,16 +483,6 @@ class PackageDetailTab extends mixin(StoreMixin) {
               </div>
               <div className="media-object-item package-action-buttons">
                 {this.getInstallButtons(cosmosPackage)}
-                <small>
-                  By deploying you agree to the {" "}
-                  <a
-                    href={this.getTermsConditionUrl()}
-                    target="_blank"
-                    title="Terms and Conditions"
-                  >
-                    terms and conditions
-                  </a>
-                </small>
               </div>
             </div>
           </div>

--- a/src/js/structs/UniversePackage.js
+++ b/src/js/structs/UniversePackage.js
@@ -2,6 +2,7 @@ import Item from "./Item";
 import FrameworkUtil
   from "../../../plugins/services/src/js/utils/FrameworkUtil";
 import Util from "../utils/Util";
+import StringUtil from "../utils/StringUtil";
 
 class UniversePackage extends Item {
   getActiveBlock() {
@@ -68,13 +69,7 @@ class UniversePackage extends Item {
   }
 
   getPreInstallNotes() {
-    // punctuate the end if not present
-    const notes = this.get("preInstallNotes");
-    if (notes.trim().slice(-1) !== ".") {
-      return `${notes.trim()}.`;
-    }
-
-    return notes;
+    return StringUtil.punctuate(this.get("preInstallNotes"));
   }
 
   getPostInstallNotes() {

--- a/src/js/structs/UniversePackage.js
+++ b/src/js/structs/UniversePackage.js
@@ -68,7 +68,13 @@ class UniversePackage extends Item {
   }
 
   getPreInstallNotes() {
-    return this.get("preInstallNotes");
+    // punctuate the end if not present
+    const notes = this.get("preInstallNotes");
+    if (notes.trim().slice(-1) !== ".") {
+      return `${notes.trim()}.`;
+    }
+
+    return notes;
   }
 
   getPostInstallNotes() {

--- a/src/js/utils/StringUtil.js
+++ b/src/js/utils/StringUtil.js
@@ -84,6 +84,18 @@ const StringUtil = {
     return string;
   },
 
+  punctuate(string) {
+    if (typeof string !== "string") {
+      return "";
+    }
+
+    if (string.trim().slice(-1) !== ".") {
+      return `${string.trim()}.`;
+    }
+
+    return string;
+  },
+
   capitalize(string) {
     if (typeof string !== "string") {
       return null;

--- a/src/js/utils/__tests__/StringUtil-test.js
+++ b/src/js/utils/__tests__/StringUtil-test.js
@@ -206,6 +206,38 @@ describe("StringUtil", function() {
     });
   });
 
+  describe("#punctuate", function() {
+    it("punctuates a sentence without a period", function() {
+      expect(StringUtil.punctuate("butterfly is nice")).toEqual(
+        "butterfly is nice."
+      );
+    });
+
+    it("punctuates a single word without a period", function() {
+      expect(StringUtil.punctuate("butterfly")).toEqual("butterfly.");
+    });
+
+    it("punctuates a whitespace padded sentence without a period", function() {
+      expect(StringUtil.punctuate("butterfly is nice ")).toEqual(
+        "butterfly is nice."
+      );
+    });
+
+    it("does not further punctuate a sentence with a period", function() {
+      expect(StringUtil.punctuate("butterfly is nice.")).toEqual(
+        "butterfly is nice."
+      );
+    });
+
+    it("returns empty string when parameter type not a string", function() {
+      expect(StringUtil.punctuate(1)).toEqual("");
+    });
+
+    it("punctuates empty string", function() {
+      expect(StringUtil.punctuate("")).toEqual(".");
+    });
+  });
+
   describe("#capitalize", function() {
     it("capitalizes the string correctly", function() {
       expect(StringUtil.capitalize("kenny")).toEqual("Kenny");

--- a/src/styles/components/framework-configuration/styles.less
+++ b/src/styles/components/framework-configuration/styles.less
@@ -4,6 +4,13 @@
   padding: 0;
 }
 
-.pre-install-notes.message.message-warning p {
-  display: inline;
+.pre-install-notes.message.message-warning {
+
+  p {
+    display: inline;
+  }
+
+  a {
+    color: inherit;
+  }
 }


### PR DESCRIPTION
It is a legal requirement to show the terms and conditions notice on the same page as the action that deploys the service. This change does this by moving the T&C link to the new framework review screen. This will only show when deploying from catalog, not when editing the framework. This change also removes the T&C link from the package detail page.

**Most frameworks have preinstall notes, so we append the T&C to the end:**
![image 2017-11-28 at 1 50 09 pm](https://user-images.githubusercontent.com/1527504/33346374-62cbd680-d444-11e7-8630-ba6384af7163.png)


**If it doesn't have preinstall notes, we just show the T&C (faked example, couldn't find a service without preinstall notes):**
![image 2017-11-28 at 1 56 01 pm](https://user-images.githubusercontent.com/1527504/33346428-8a469330-d444-11e7-9e55-b6b54aaf41bc.png)

**The T&C link is now removed from package detail:**
![image 2017-11-28 at 2 19 17 pm](https://user-images.githubusercontent.com/1527504/33347302-42e94d2c-d447-11e7-8f8d-b983d9497100.png)


Closes DCOS-19359.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
