### PR TITLE
DCOS-18993: implement new select placement

### DIFF
--- a/plugins/services/src/js/constants/OperatorTypes.js
+++ b/plugins/services/src/js/constants/OperatorTypes.js
@@ -7,49 +7,63 @@ const OperatorTypes = {
     requiresEmptyValue: true,
     stringNumberValue: false,
     tooltipContent: "The unique operator does not accept a value.",
-    helpContent: DEFAULT_HELP
+    helpContent: DEFAULT_HELP,
+    name: "Unique",
+    description: "Run each app task on a unique attribute ID"
   },
   CLUSTER: {
     requiresValue: true,
     requiresEmptyValue: false,
     stringNumberValue: false,
     tooltipContent: null,
-    helpContent: DEFAULT_HELP
+    helpContent: DEFAULT_HELP,
+    name: "Cluster",
+    description: "Run app tasks on nodes that share a certain attribute ID"
   },
   GROUP_BY: {
     requiresValue: false,
     requiresEmptyValue: false,
     stringNumberValue: true,
     tooltipContent: null,
-    helpContent: OPTIONAL_HELP
+    helpContent: OPTIONAL_HELP,
+    name: "Group By",
+    description: "Run app tasks evenly distributed across a certain attribute"
   },
   IS: {
     requiresValue: true,
     requiresEmptyValue: false,
     stringNumberValue: false,
     tooltipContent: null,
-    helpContent: DEFAULT_HELP
+    helpContent: DEFAULT_HELP,
+    name: "Is",
+    description: "Run app tasks on nodes that share a certain attribute ID"
   },
   LIKE: {
     requiresValue: true,
     requiresEmptyValue: false,
     stringNumberValue: false,
     tooltipContent: null,
-    helpContent: DEFAULT_HELP
+    helpContent: DEFAULT_HELP,
+    name: "Like",
+    description: "Run app tasks on a particular set of attribute IDs"
   },
   UNLIKE: {
     requiresValue: true,
     requiresEmptyValue: false,
     stringNumberValue: false,
     tooltipContent: null,
-    helpContent: DEFAULT_HELP
+    helpContent: DEFAULT_HELP,
+    name: "Unlike",
+    description: "Don't run app tasks on a particular set of attribute IDs"
   },
   MAX_PER: {
     requiresValue: true,
     requiresEmptyValue: false,
     stringNumberValue: true,
     tooltipContent: null,
-    helpContent: DEFAULT_HELP
+    helpContent: DEFAULT_HELP,
+    name: "Max Per",
+    description: "Run max number of app tasks on each attribute ID"
   }
 };
 

--- a/src/js/components/PlacementConstraintsPartial.js
+++ b/src/js/components/PlacementConstraintsPartial.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Tooltip } from "reactjs-components";
+import { Tooltip, Select, SelectOption } from "reactjs-components";
 
 import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
 import AddButton from "#SRC/js/components/form/AddButton";
@@ -8,7 +8,6 @@ import FieldError from "#SRC/js/components/form/FieldError";
 import FieldHelp from "#SRC/js/components/form/FieldHelp";
 import FieldInput from "#SRC/js/components/form/FieldInput";
 import FieldLabel from "#SRC/js/components/form/FieldLabel";
-import FieldSelect from "#SRC/js/components/form/FieldSelect";
 import FormGroup from "#SRC/js/components/form/FormGroup";
 import FormGroupHeading from "#SRC/js/components/form/FormGroupHeading";
 import FormGroupHeadingContent
@@ -98,20 +97,28 @@ export default class PlacementSection extends Component {
             showError={Boolean(operatorError)}
           >
             {operatorLabel}
-            <FieldSelect
+            <Select
               name={`constraints.${index}.operator`}
-              type="text"
               value={String(constraint.operator)}
+              placeholder="Select ..."
             >
-              <option value="">Select</option>
               {Object.keys(OperatorTypes).map((type, index) => {
                 return (
-                  <option key={index} value={type}>
-                    {type}
-                  </option>
+                  <SelectOption
+                    key={index}
+                    value={type}
+                    label={OperatorTypes[type].name}
+                  >
+                    <span className="dropdown-select-item-title">
+                      {OperatorTypes[type].name}
+                    </span>
+                    <span className="dropdown-select-item-description">
+                      {OperatorTypes[type].description}
+                    </span>
+                  </SelectOption>
                 );
               })}
-            </FieldSelect>
+            </Select>
             <FieldHelp>
               Specify where your app will run.
             </FieldHelp>

--- a/src/styles/components/form-elements/form-components/select/styles.less
+++ b/src/styles/components/form-elements/form-components/select/styles.less
@@ -1,0 +1,53 @@
+& when (@select-enabled) {
+  /*  Select (.dropdown-select) */
+
+  .form-group div.dropdown-select {
+    width: 100%;
+
+    .dropdown {
+      position: relative;
+      width: 100%;
+
+      .dropdown-toggle {
+
+        &:after {
+          display: block;
+          position: absolute;
+          right: 1.25rem;
+          top: 50%;
+        }
+        background: none;
+        border: 1px #d6d8dc solid;
+        box-shadow: none;
+        display: block;
+        margin: 0;
+        text-align: left;
+        width: 100%;
+        z-index: 1;
+
+        & when not (@form-control-padding-right = null) and not (@form-control-caret-padding-right-offset = null) {
+          padding-right: @form-control-padding-right + @form-control-caret-padding-right-offset;
+        }
+      }
+    }
+  }
+
+  .dropdown-select.dropdown-menu {
+
+    .dropdown-menu-list-item.is-selected {
+
+      .dropdown-select-item-title {
+        color: @purple;
+      }
+    }
+
+    .dropdown-select-item-title {
+      display: block;
+      margin-bottom: 4px;
+    }
+
+    .dropdown-select-item-description {
+      color: #a4a6a9;
+    }
+  }
+}

--- a/src/styles/components/form-elements/form-components/select/variables.less
+++ b/src/styles/components/form-elements/form-components/select/variables.less
@@ -1,0 +1,1 @@
+@select-enabled: true;

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -300,6 +300,8 @@
 @import 'components/form-elements/form-components/field-input/variables.less';
 @import 'components/form-elements/form-components/field-select/styles.less';
 @import 'components/form-elements/form-components/field-select/variables.less';
+@import 'components/form-elements/form-components/select/styles.less';
+@import 'components/form-elements/form-components/select/variables.less';
 
 // Icons
 

--- a/tests/pages/catalog/packages/package/PackageTab-cy.js
+++ b/tests/pages/catalog/packages/package/PackageTab-cy.js
@@ -227,18 +227,14 @@ describe("Package Detail Tab", function() {
         });
 
         it("Should disable the field value when Unique is selected in operator dropdown", function() {
-          cy
-            .get("@tabView")
-            .find('[name="constraints.0.operator"]')
-            .type("UNIQUE", { force: true });
+          cy.get("@tabView").find(".button.dropdown-toggle").click();
+
+          cy.contains(".dropdown-select-item-title", "Unique").click();
 
           // value
           cy
             .get("@tabView")
-            .find('[name="constraints.0.operator"]')
-            .parents(".form-group")
-            .next()
-            .next()
+            .find('[name="constraints.0.value"]')
             .should("be.disabled");
         });
       });

--- a/tests/pages/catalog/packages/package/PackageTab-cy.js
+++ b/tests/pages/catalog/packages/package/PackageTab-cy.js
@@ -191,7 +191,7 @@ describe("Package Detail Tab", function() {
           // operator
           cy
             .get("@tabView")
-            .find('select[name="constraints.0.operator"]')
+            .find('[name="constraints.0.operator"]')
             .should("exist");
 
           // value
@@ -216,7 +216,7 @@ describe("Package Detail Tab", function() {
           // operator
           cy
             .get("@tabView")
-            .find('select[name="constraints.0.operator"]')
+            .find('[name="constraints.0.operator"]')
             .should("not.exist");
 
           // value
@@ -229,13 +229,16 @@ describe("Package Detail Tab", function() {
         it("Should disable the field value when Unique is selected in operator dropdown", function() {
           cy
             .get("@tabView")
-            .find('select[name="constraints.0.operator"]')
-            .select("UNIQUE");
+            .find('[name="constraints.0.operator"]')
+            .type("UNIQUE", { force: true });
 
           // value
           cy
             .get("@tabView")
-            .find('input[name="constraints.0.value"]')
+            .find('[name="constraints.0.operator"]')
+            .parents(".form-group")
+            .next()
+            .next()
             .should("be.disabled");
         });
       });

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -817,18 +817,13 @@ describe("Service Form Modal", function() {
 
         it("Should disable the field value when Unique is selected in operator dropdown", function() {
           cy.get("@tabView").find(".button.dropdown-toggle").click();
-          cy
-            .get(".dropdown-select .dropdown-select-item-title")
-            .contains("Unique")
-            .click();
+
+          cy.contains(".dropdown-select-item-title", "Unique").click();
 
           // value
           cy
             .get("@tabView")
-            .find('[name="constraints.0.operator"]')
-            .parents(".form-group")
-            .next()
-            .next()
+            .find('[name="constraints.0.value"]')
             .should("be.disabled");
         });
       });

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -780,7 +780,7 @@ describe("Service Form Modal", function() {
           // operator
           cy
             .get("@tabView")
-            .find('select[name="constraints.0.operator"]')
+            .find('[name="constraints.0.operator"]')
             .should("exist");
 
           // value
@@ -805,7 +805,7 @@ describe("Service Form Modal", function() {
           // operator
           cy
             .get("@tabView")
-            .find('select[name="constraints.0.operator"]')
+            .find('[name="constraints.0.operator"]')
             .should("not.exist");
 
           // value
@@ -816,15 +816,19 @@ describe("Service Form Modal", function() {
         });
 
         it("Should disable the field value when Unique is selected in operator dropdown", function() {
+          cy.get("@tabView").find(".button.dropdown-toggle").click();
           cy
-            .get("@tabView")
-            .find('select[name="constraints.0.operator"]')
-            .select("UNIQUE");
+            .get(".dropdown-select .dropdown-select-item-title")
+            .contains("Unique")
+            .click();
 
           // value
           cy
             .get("@tabView")
-            .find('input[name="constraints.0.value"]')
+            .find('[name="constraints.0.operator"]')
+            .parents(".form-group")
+            .next()
+            .next()
             .should("be.disabled");
         });
       });


### PR DESCRIPTION
---

~⚠️ Depends on https://github.com/dcos/dcos-ui/pull/2577.~ merged 👍 

---

~⚠️ Since #2531 has copied tests which are affeced by this change, this PR is on hold until #2531 is merged.~ #2531 is merged

---

~I have started to implement the new `<Select>`, unfortunately I wasn't able to find the needed CSS code, maybe someone else can pair up with me tomorrow (or fix it, if it is done in 5min)~ 
~Currently the button is grey (as in `reactjs-components`), but it has to be white and fixed in width~

Button looks as expected now and the dropdown is implemented. If someone knows how to do the css part in a better way - please tell me :) 

--- 

To test this / help with:
1. checkout this branch
2. `npm start`
3. disable placement plugin
4. navigate to services -> create -> placement -> add advanced constraint