### PR TITLE
DCOS-19354: add IPv6 healthcheck support

### DIFF
--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -20,6 +20,7 @@ import FormGroupHeadingContent
   from "#SRC/js/components/form/FormGroupHeadingContent";
 import FormRow from "#SRC/js/components/form/FormRow";
 import Icon from "#SRC/js/components/Icon";
+import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
 
 import {
   MESOS_HTTP,
@@ -222,7 +223,7 @@ class HealthChecksFormSection extends Component {
 
     return (
       <FormRow>
-        <FormGroup className="column-12" showError={Boolean(errors.value)}>
+        <FormGroup className="column-6" showError={Boolean(errors.value)}>
           <FieldLabel>
             <FormGroupHeading>
               <FormGroupHeadingContent primary={true}>
@@ -249,6 +250,34 @@ class HealthChecksFormSection extends Component {
     return data.portDefinitions.map((port, index) => {
       return <option key={index} value={index}>{port.name || index}</option>;
     });
+  }
+
+  getIpProtocol(data) {
+    const { healthCheck, key, errors } = data;
+    const runtime = findNestedPropertyInObject(
+      this.props.data,
+      "container.type"
+    );
+    // IPv6 Healthchecks is currently only supported in DOCKER runtime.
+    if (runtime !== "DOCKER") {
+      return null;
+    }
+
+    return (
+      <FormGroup showError={false} className="column-12">
+        <FieldLabel>
+          <FieldInput
+            checked={healthCheck.ipProtocol === "IPv6"}
+            name={`healthChecks.${key}.ipProtocol`}
+            type="checkbox"
+            value="IPv6"
+          />
+          {"Make "}
+          <span className="truecase">IPv6</span>
+        </FieldLabel>
+        <FieldError>{errors.ipProtocol}</FieldError>
+      </FormGroup>
+    );
   }
 
   getHTTPFields(healthCheck, key) {
@@ -341,6 +370,9 @@ class HealthChecksFormSection extends Component {
           </FieldLabel>
           <FieldError>{errors.protocol}</FieldError>
         </FormGroup>
+      </FormRow>,
+      <FormRow key="IPv6">
+        {this.getIpProtocol({ healthCheck, key, errors })}
       </FormRow>
     ];
   }

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/HealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/HealthChecks.js
@@ -64,6 +64,9 @@ module.exports = {
         if (`healthChecks.${index}.command` === joinedPath) {
           state[index].command = value;
         }
+        if (`healthChecks.${index}.ipProtocol` === joinedPath) {
+          state[index].ipProtocol = value === true ? "IPv6" : "IPv4";
+        }
         if (`healthChecks.${index}.path` === joinedPath) {
           state[index].path = value;
         }

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/HealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/HealthChecks.js
@@ -65,7 +65,9 @@ module.exports = {
           state[index].command = value;
         }
         if (`healthChecks.${index}.ipProtocol` === joinedPath) {
-          state[index].ipProtocol = value === true ? "IPv6" : "IPv4";
+          state[index].ipProtocol = value === true || value === "IPv6"
+            ? "IPv6"
+            : "IPv4";
         }
         if (`healthChecks.${index}.path` === joinedPath) {
           state[index].path = value;

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/HealthChecks-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/HealthChecks-test.js
@@ -175,5 +175,42 @@ describe("HealthChecks", function() {
         }
       ]);
     });
+
+    it("sets ipProtocol to IPv6 if set", function() {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
+      );
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "ipProtocol"], true)
+      );
+
+      expect(batch.reduce(HealthChecks.FormReducer.bind({}), [])).toEqual([
+        {
+          protocol: "MESOS_HTTP",
+          ipProtocol: "IPv6"
+        }
+      ]);
+    });
+
+    it("sets https ipProtocol to IPv6 if set", function() {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
+      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "https"], true));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "ipProtocol"], true)
+      );
+
+      expect(batch.reduce(HealthChecks.FormReducer.bind({}), [])).toEqual([
+        {
+          protocol: "MESOS_HTTPS",
+          ipProtocol: "IPv6"
+        }
+      ]);
+    });
   });
 });

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/HealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/HealthChecks.js
@@ -28,11 +28,7 @@ function getMapHealthChecks(docker) {
 
       if (item.protocol.toUpperCase() !== COMMAND) {
         newItem.path = item.path ? item.path : null;
-        if (
-          item.ipProtocol &&
-          docker.type === "DOCKER" &&
-          docker.image !== ""
-        ) {
+        if (item.ipProtocol && docker.type === "DOCKER") {
           newItem.ipProtocol = item.ipProtocol ? item.ipProtocol : null;
         }
       }
@@ -51,9 +47,8 @@ module.exports = {
     if (this.docker == null) {
       // `this` is a context which is given to every reducer so it could
       // cache information.
-      // In this case we are caching the values for `container.type` and
-      // `container.docker.image` as we will need this information to render ipProtocol
-      this.docker = { type: "DOCKER", image: "" };
+      // In this case we are caching the values for `container.type`
+      this.docker = { type: "DOCKER" };
     }
 
     if (this.healthChecks == null) {
@@ -69,9 +64,6 @@ module.exports = {
 
     if (joinedPath === "container.type") {
       this.docker.type = value;
-    }
-    if (joinedPath === "container.docker.image") {
-      this.docker.image = value;
     }
     if (type === REMOVE_ITEM && joinedPath === "portDefinitions") {
       this.healthChecks = this.healthChecks
@@ -122,7 +114,8 @@ module.exports = {
           this.healthChecks[index].command = value;
         }
         if (`healthChecks.${index}.ipProtocol` === joinedPath) {
-          this.healthChecks[index].ipProtocol = value === true
+          this.healthChecks[index].ipProtocol = value === true ||
+            value === "IPv6"
             ? "IPv6"
             : "IPv4";
         }

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/HealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/HealthChecks.js
@@ -8,7 +8,7 @@ import {
   MESOS_HTTPS
 } from "../../../constants/HealthCheckProtocols";
 
-function getMapHealthChecks(docker) {
+function getMapHealthChecks(runtime) {
   return function mapHealthChecks(item) {
     const newItem = Util.omit(item, [
       "path",
@@ -28,7 +28,7 @@ function getMapHealthChecks(docker) {
 
       if (item.protocol.toUpperCase() !== COMMAND) {
         newItem.path = item.path ? item.path : null;
-        if (item.ipProtocol && docker.type === "DOCKER") {
+        if (item.ipProtocol && runtime === "DOCKER") {
           newItem.ipProtocol = item.ipProtocol ? item.ipProtocol : null;
         }
       }
@@ -44,11 +44,11 @@ module.exports = {
       return state;
     }
 
-    if (this.docker == null) {
+    if (this.runtime == null) {
       // `this` is a context which is given to every reducer so it could
       // cache information.
       // In this case we are caching the values for `container.type`
-      this.docker = { type: "DOCKER" };
+      this.runtime = "DOCKER";
     }
 
     if (this.healthChecks == null) {
@@ -63,7 +63,7 @@ module.exports = {
     const joinedPath = path.join(".");
 
     if (joinedPath === "container.type") {
-      this.docker.type = value;
+      this.runtime = value;
     }
     if (type === REMOVE_ITEM && joinedPath === "portDefinitions") {
       this.healthChecks = this.healthChecks
@@ -96,7 +96,7 @@ module.exports = {
             break;
         }
 
-        return this.healthChecks.map(getMapHealthChecks(this.docker));
+        return this.healthChecks.map(getMapHealthChecks(this.runtime));
       }
 
       const index = joinedPath.match(/\d+/)[0];
@@ -147,7 +147,7 @@ module.exports = {
       }
     }
 
-    return this.healthChecks.map(getMapHealthChecks(this.docker));
+    return this.healthChecks.map(getMapHealthChecks(this.runtime));
   },
   JSONParser(state) {
     if (state.healthChecks == null) {

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/HealthChecks-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/HealthChecks-test.js
@@ -160,6 +160,155 @@ describe("HealthChecks", function() {
         ]);
       }
     );
+    it("sets ipProtocol to IPv6 if set", function() {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(["container", "type"], "DOCKER"));
+      batch = batch.add(
+        new Transaction(["container", "docker", "image"], "alpine")
+      );
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
+      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "ipProtocol"], true)
+      );
+
+      expect(batch.reduce(HealthChecks.JSONReducer.bind({}), [])).toEqual([
+        {
+          protocol: "MESOS_HTTP",
+          ipProtocol: "IPv6",
+          path: "/test"
+        }
+      ]);
+    });
+
+    it("sets https ipProtocol to IPv6 if set", function() {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(["container", "type"], "DOCKER"));
+      batch = batch.add(
+        new Transaction(["container", "docker", "image"], "alpine")
+      );
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
+      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
+      batch = batch.add(new Transaction(["healthChecks", 0, "https"], true));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "ipProtocol"], true)
+      );
+
+      expect(batch.reduce(HealthChecks.JSONReducer.bind({}), [])).toEqual([
+        {
+          protocol: "MESOS_HTTPS",
+          ipProtocol: "IPv6",
+          path: "/test"
+        }
+      ]);
+    });
+
+    it("sets http ipProtocol to IPv6 if docker set", function() {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(["container", "type"], "DOCKER"));
+      batch = batch.add(
+        new Transaction(["container", "docker", "image"], "alpine")
+      );
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
+      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "ipProtocol"], true)
+      );
+
+      expect(batch.reduce(HealthChecks.JSONReducer.bind({}), [])).toEqual([
+        {
+          protocol: "MESOS_HTTP",
+          ipProtocol: "IPv6",
+          path: "/test"
+        }
+      ]);
+    });
+
+    it("sets IPv4", function() {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(["container", "type"], "DOCKER"));
+      batch = batch.add(
+        new Transaction(["container", "docker", "image"], "alpine")
+      );
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
+      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "ipProtocol"], true)
+      );
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "ipProtocol"], false)
+      );
+
+      expect(batch.reduce(HealthChecks.JSONReducer.bind({}), [])).toEqual([
+        {
+          protocol: "MESOS_HTTP",
+          path: "/test",
+          ipProtocol: "IPv4"
+        }
+      ]);
+    });
+
+    it("sets https ipProtocol to IPv6 if docker set", function() {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(["container", "type"], "DOCKER"));
+      batch = batch.add(
+        new Transaction(["container", "docker", "image"], "alpine")
+      );
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
+      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "ipProtocol"], true)
+      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "https"], true));
+
+      expect(batch.reduce(HealthChecks.JSONReducer.bind({}), [])).toEqual([
+        {
+          protocol: "MESOS_HTTPS",
+          ipProtocol: "IPv6",
+          path: "/test"
+        }
+      ]);
+    });
+
+    it("does not set ipProtocol to IPv6 if mesos is set (UCR)", function() {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(["container", "type"], "DOCKER"));
+      batch = batch.add(
+        new Transaction(["container", "docker", "image"], "alpine")
+      );
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
+      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "ipProtocol"], true)
+      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "https"], true));
+      batch = batch.add(new Transaction(["container", "type"], "MESOS"));
+
+      expect(batch.reduce(HealthChecks.JSONReducer.bind({}), [])).toEqual([
+        {
+          protocol: "MESOS_HTTPS",
+          path: "/test"
+        }
+      ]);
+    });
   });
 
   describe("#JSONParser", function() {

--- a/src/styles/components/form-elements/form-control-toggle/styles.less
+++ b/src/styles/components/form-elements/form-control-toggle/styles.less
@@ -5,5 +5,9 @@
     &.disabled {
       cursor: not-allowed;
     }
+
+    .truecase {
+      text-transform: none;
+    }
   }
 }


### PR DESCRIPTION
This introduces IPv6 form support to healthchecks.

To test this you have to set up a http healthcheck on a service with a docker image, so container type needs to be DOCKER. 

![image](https://user-images.githubusercontent.com/156010/33383665-3ba4e6c4-d524-11e7-9df3-729ddf56b088.png)


**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
