### PR TITLE
DCOS-19669: Add Mount for custom media type fields to FrameworkConfigurationForm

### DIFF
--- a/src/js/components/FrameworkConfigurationForm.js
+++ b/src/js/components/FrameworkConfigurationForm.js
@@ -1,6 +1,8 @@
 import React, { Component, PropTypes } from "react";
 import classNames from "classnames";
 import SchemaForm from "react-jsonschema-form";
+import { MountService } from "foundation-ui";
+
 import TabButton from "#SRC/js/components/TabButton";
 import TabButtonList from "#SRC/js/components/TabButtonList";
 import Tabs from "#SRC/js/components/Tabs";
@@ -13,6 +15,22 @@ import UniversePackage from "#SRC/js/structs/UniversePackage";
 import CosmosErrorMessage from "#SRC/js/components/CosmosErrorMessage";
 import SchemaField from "#SRC/js/components/SchemaField";
 import StringUtil from "#SRC/js/utils/StringUtil";
+import PlacementConstraintsSchemaField
+  from "#SRC/js/components/PlacementConstraintsSchemaField";
+import YamlEditorSchemaField from "#SRC/js/components/YamlEditorSchemaField";
+
+MountService.MountService.registerComponent(
+  PlacementConstraintsSchemaField,
+  "SchemaField:application/x-region-zone-constraints+json"
+);
+MountService.MountService.registerComponent(
+  PlacementConstraintsSchemaField,
+  "SchemaField:application/x-zone-constraints+json"
+);
+MountService.MountService.registerComponent(
+  YamlEditorSchemaField,
+  "SchemaField:application/x-yaml"
+);
 
 const METHODS_TO_BIND = [
   "handleDropdownNavigationSelection",

--- a/src/js/components/YamlEditorSchemaField.js
+++ b/src/js/components/YamlEditorSchemaField.js
@@ -1,0 +1,57 @@
+import React, { Component } from "react";
+import AceEditor from "react-ace";
+import "brace/mode/yaml";
+
+import FieldLabel from "#SRC/js/components/form/FieldLabel";
+import FieldError from "#SRC/js/components/form/FieldError";
+
+export default class YamlEditorSchemaField extends Component {
+  render() {
+    const { errorMessage, label } = this.props;
+    const { formData, onChange } = this.props.fieldProps;
+
+    let decodedValue;
+    try {
+      decodedValue = atob(formData);
+    } catch (error) {
+      if (error instanceof DOMException) {
+        decodedValue = "Invalid base64 encoding detected.";
+      }
+    }
+
+    return (
+      <div>
+        <FieldLabel>
+          {label}
+        </FieldLabel>
+        <div>
+          <AceEditor
+            mode="yaml"
+            value={decodedValue}
+            height="300"
+            width=""
+            className="framework-form-yaml-editor"
+            highlightActiveLine={false}
+            fontSize={14}
+            showPrintMargin={false}
+            tabSize={2}
+            onChange={value => onChange(btoa(value))}
+          />
+        </div>
+        <FieldError>{errorMessage}</FieldError>
+      </div>
+    );
+  }
+}
+
+YamlEditorSchemaField.propTypes = {
+  label: React.PropTypes.string.isRequired,
+  fieldProps: React.PropTypes.object.isRequired,
+  schema: React.PropTypes.object.isRequired,
+  errorMessage: React.PropTypes.oneOfType([
+    React.PropTypes.arrayOf(React.PropTypes.node),
+    React.PropTypes.node
+  ]),
+  autofocus: React.PropTypes.boolean,
+  onChange: React.PropTypes.func
+};

--- a/tests/_fixtures/cosmos/package-describe.json
+++ b/tests/_fixtures/cosmos/package-describe.json
@@ -88,7 +88,7 @@
             },
             "uris": {
               "default": [
-
+                
               ],
               "description": "List of URIs that will be downloaded and made available in the current working directory of Marathon. For example this can be used to download a Java keystore file for SSL configuration.",
               "items": {
@@ -111,7 +111,7 @@
                 "type": "application/x-region-zone-constraints+json"
               },
               "type": "string",
-              "default": "[[\"hostname\", \"UNIQUE\"]]"
+              "default": "[]"
             }
           },
           "required": [

--- a/tests/pages/catalog/packages/package/PackageTab-cy.js
+++ b/tests/pages/catalog/packages/package/PackageTab-cy.js
@@ -166,5 +166,81 @@ describe("Package Detail Tab", function() {
         .contains("Success")
         .should("to.have.length", 1);
     });
+
+    context("Framework: Placement", function() {
+      beforeEach(function() {
+        cy.get(".modal button").contains("Edit Config").click();
+      });
+
+      context("Add Placement Constraint", function() {
+        beforeEach(function() {
+          cy.get(".menu-tabbed-view-container").as("tabView");
+          cy
+            .get(".button-primary-link")
+            .contains("Add Placement Constraint")
+            .click();
+        });
+
+        it('Should add rows when "Add Placement Constraint" link clicked', function() {
+          // Field
+          cy
+            .get("@tabView")
+            .find('.form-control[name="constraints.0.fieldName"]')
+            .should("exist");
+
+          // operator
+          cy
+            .get("@tabView")
+            .find('select[name="constraints.0.operator"]')
+            .should("exist");
+
+          // value
+          cy
+            .get("@tabView")
+            .find('.form-control[name="constraints.0.value"]')
+            .should("exist");
+        });
+
+        it("Should remove rows when remove button clicked", function() {
+          cy.contains(".form-row", "Operator").within(function() {
+            // Click delete button
+            cy.get("a.button").click();
+          });
+
+          // Field
+          cy
+            .get("@tabView")
+            .find('.form-control[name="constraints.0.fieldName"]')
+            .should("not.exist");
+
+          // operator
+          cy
+            .get("@tabView")
+            .find('select[name="constraints.0.operator"]')
+            .should("not.exist");
+
+          // value
+          cy
+            .get("@tabView")
+            .find('.form-control[name="constraints.0.value"]')
+            .should("not.exist");
+        });
+
+        it('Should hide the "value" when "Unique" is selected in operator dropdown', function() {
+          cy
+            .get("@tabView")
+            .find('select[name="constraints.0.operator"]')
+            .select("UNIQUE");
+
+          // value
+          cy
+            .get("@tabView")
+            .find('select[name="constraints.0.operator"]')
+            .parents(".form-group")
+            .next()
+            .should("have.class", "hidden");
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
To enable plugins and cleaner extensibility I've refactored the way we add custom media-type specific fields like YamlEditor and PlacementConstraints.

Closes DCOS-19669
