### PR TITLE
fix(SchemaField): fix z-index issue with YAML editor

### DIFF
--- a/src/styles/components/framework-configuration/styles.less
+++ b/src/styles/components/framework-configuration/styles.less
@@ -16,4 +16,8 @@
   .ace_scroller.ace_scroll-left {
     box-shadow: none;
   }
+
+  .ace_gutter {
+    z-index: 0;
+  }
 }


### PR DESCRIPTION
This resets the YAML gutter to `z-index: 0`, preventing it from rendering on top of the JSON editor when screen narrow and JSON is expanded.

Repro to find the bug:
1. Checkout latest master
2. Turn fixtures on
3. Open the catalog deploy framework form
3. Narrow the window and open JSON so it takes up fullscreen
4. The unpleasant bug is below:
![screen shot 2017-11-29 at 1 04 17 pm](https://user-images.githubusercontent.com/1527504/33399033-dd70c7da-d505-11e7-8883-7eaf2ca70506.png)

Thanks for @nLight for finding this issue. My bad for not testing this case on the original PR. 


**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
