### PR TITLE
test(ServiceList-test): add jest snapshot

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8143,6 +8143,11 @@
         }
       }
     },
+    "react-test-renderer": {
+      "version": "15.4.1",
+      "from": "react-test-renderer@15.4.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-15.4.1.tgz"
+    },
     "react-transform-catch-errors": {
       "version": "1.0.2",
       "from": "react-transform-catch-errors@>=1.0.2 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "purify-css": "1.1.9",
     "raml-validator-loader": "0.1.10",
     "react-hot-loader": "1.3.1",
+    "react-test-renderer": "15.4.1",
     "source-map-loader": "0.1.5",
     "string-replace-webpack-plugin": "0.0.3",
     "style-loader": "0.13.1",

--- a/plugins/services/src/js/components/__tests__/ServiceList-test.js
+++ b/plugins/services/src/js/components/__tests__/ServiceList-test.js
@@ -3,6 +3,8 @@ const React = require("react");
 /* eslint-enable no-unused-vars */
 const ReactDOM = require("react-dom");
 
+const renderer = require("react-test-renderer");
+
 const ServiceList = require("../ServiceList");
 const ServiceTree = require("../../structs/ServiceTree");
 
@@ -62,10 +64,12 @@ describe("ServiceList", function() {
     });
 
     it("returns services that have a value of two elements", function() {
-      var result = this.instance.getServices(services.getServices().getItems());
+      const component = renderer.create(
+        <ServiceList services={services.getServices().getItems()} />
+      );
+      const tree = component.toJSON();
 
-      expect(result[0].content[0].content.key).toEqual("title");
-      expect(result[0].content[1].content.key).toEqual("icon");
+      expect(tree).toMatchSnapshot();
     });
   });
 });

--- a/plugins/services/src/js/components/__tests__/__snapshots__/ServiceList-test.js.snap
+++ b/plugins/services/src/js/components/__tests__/__snapshots__/ServiceList-test.js.snap
@@ -1,0 +1,28 @@
+exports[`ServiceList #getServices returns services that have a value of two elements 1`] = `
+<div
+  className="dashboard-health-list">
+  <ul
+    className="list list-unstyled">
+    <li
+      className="list-item">
+      <span
+        className="dashboard-health-list-item-description text-overflow">
+        <a
+          className="dashboard-health-list-item-cell emphasis"
+          href={null}
+          onClick={[Function]}>
+          
+        </a>
+      </span>
+      <div
+        className="dashboard-health-list-health-label">
+        <svg
+          className="icon icon-light-grey icon-mini">
+          <use
+            xlinkHref="#icon-system--circle-minus" />
+        </svg>
+      </div>
+    </li>
+  </ul>
+</div>
+`;


### PR DESCRIPTION
More about [snapshots](https://facebook.github.io/jest/docs/en/snapshot-testing.html#content)

Replace "manual" component test to use snapshot instead.

**Before example**:
`expect(componetBlaInstance.props.className).toEqual("someClass")`

**Now**:
You match the expected render result.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
