### PR TITLE
fix(ServiceStatusProgressBar): fix progress bar

### DIFF
--- a/plugins/services/src/js/components/ServiceStatusProgressBar.js
+++ b/plugins/services/src/js/components/ServiceStatusProgressBar.js
@@ -11,7 +11,7 @@ import ServiceStatus from "../constants/ServiceStatus";
 class ServiceStatusProgressBar extends React.Component {
   getTooltipContent() {
     const { service } = this.props;
-    const { tasksRunning } = service.getTasksSummary();
+    const tasksRunning = service.getTaskCount();
     const instancesTotal = service.getInstancesCount();
 
     return (
@@ -27,7 +27,7 @@ class ServiceStatusProgressBar extends React.Component {
     const { service } = this.props;
     const instancesCount = service.getInstancesCount();
     const serviceStatus = service.getServiceStatus();
-    const tasksRunning = service.getTaskCount();
+    let tasksRunning = service.getTaskCount();
 
     if (
       serviceStatus === ServiceStatus.RUNNING ||
@@ -37,19 +37,11 @@ class ServiceStatusProgressBar extends React.Component {
       return null;
     }
 
-    if (serviceStatus === ServiceStatus.DELETING) {
-      return (
-        <ProgressBar
-          className="status-bar--large"
-          data={[
-            {
-              className: "staged",
-              value: instancesCount
-            }
-          ]}
-          total={instancesCount}
-        />
-      );
+    if (
+      serviceStatus === ServiceStatus.DEPLOYING ||
+      serviceStatus === ServiceStatus.DELETING
+    ) {
+      tasksRunning = 0;
     }
 
     return (

--- a/plugins/services/src/js/components/__tests__/ServiceStatusProgressBar-test.js
+++ b/plugins/services/src/js/components/__tests__/ServiceStatusProgressBar-test.js
@@ -54,22 +54,14 @@ describe("#ServiceStatusProgressBar", function() {
 
   describe("Tooltip", function() {
     it("display Tooltip", function() {
+      const app = new Application({
+        queue: {
+          overdue: true
+        }
+      });
+
       this.instance = ReactDOM.render(
-        <ServiceStatusProgressBar
-          service={
-            new Application({
-              deployments: [
-                {
-                  id: "some-id"
-                }
-              ],
-              queue: {
-                delay: true
-              },
-              instances: 10
-            })
-          }
-        />,
+        <ServiceStatusProgressBar service={app} />,
         this.container
       );
 
@@ -81,7 +73,7 @@ describe("#ServiceStatusProgressBar", function() {
     it("get #getTooltipContent", function() {
       const childrenContent = this.instance.getTooltipContent().props.children
         .props.children;
-      expect(childrenContent).toEqual("1 instance running out of 1");
+      expect(childrenContent).toEqual("0 instances running out of 1");
     });
   });
 });


### PR DESCRIPTION
Fix progress bar where it shows fully complete when still deploying.
This commit also improve the logic to always display the tooltip and use less code
for the progress bar.

Closes DCOS-19731

**Scaling/deploying already running service**
![screen shot 2017-12-01 at 2 53 23 pm](https://user-images.githubusercontent.com/549394/33507524-0930b09c-d6aa-11e7-93a3-6d13b78b9e9d.png)

**Deploying**
![screen shot 2017-12-01 at 4 28 32 pm](https://user-images.githubusercontent.com/549394/33509258-cf1e0ce6-d6b4-11e7-9cbf-028e57381e81.png)

**Deleting**
![screen shot 2017-12-01 at 4 27 33 pm](https://user-images.githubusercontent.com/549394/33509273-f926832e-d6b4-11e7-81eb-a945cd3f0088.png)

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
