### PR TITLE
DCOS-19579: add persistent volumes to multicontainer services

### DIFF
--- a/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
@@ -119,6 +119,9 @@ class MultiContainerVolumesFormSection extends Component {
                 <option value={VolumeConstants.type.ephemeral}>
                   Ephemeral Volume
                 </option>
+                <option value={VolumeConstants.type.localPersistent}>
+                  Local Persistent Volume
+                </option>
               </FieldSelect>
             </FormGroup>
             <FormGroup className="column-6" showError={Boolean(nameError)}>
@@ -138,6 +141,7 @@ class MultiContainerVolumesFormSection extends Component {
             </FormGroup>
           </FormRow>
           {this.getHostPathInput(volumes, key)}
+          {this.getLocalPersistentInput(volumes, key)}
           {this.getContainerMounts(containers, key)}
         </FormGroupContainer>
       );
@@ -167,6 +171,33 @@ class MultiContainerVolumesFormSection extends Component {
         </FormRow>
       );
     }
+  }
+
+  getLocalPersistentInput(volumes, key) {
+    if (volumes.type !== VolumeConstants.type.localPersistent) {
+      return null;
+    }
+
+    return (
+      <FormRow>
+        <FormGroup className="column-3">
+          <FieldLabel>
+            <FormGroupHeading>
+              <FormGroupHeadingContent primary={true}>
+                Size (GiB)
+              </FormGroupHeadingContent>
+            </FormGroupHeading>
+          </FieldLabel>
+          <FieldAutofocus>
+            <FieldInput
+              name={`volumeMounts.${key}.size`}
+              type="number"
+              value={volumes.size}
+            />
+          </FieldAutofocus>
+        </FormGroup>
+      </FormRow>
+    );
   }
 
   getHeadline() {

--- a/plugins/services/src/js/constants/VolumeConstants.js
+++ b/plugins/services/src/js/constants/VolumeConstants.js
@@ -2,6 +2,7 @@ module.exports = {
   type: {
     host: "HOST",
     ephemeral: "EPHEMERAL",
+    localPersistent: "LOCAL_PERSISTENT",
     unknown: "UNKNOWN"
   },
   mode: {

--- a/plugins/services/src/js/reducers/JSONMultiContainerParser.js
+++ b/plugins/services/src/js/reducers/JSONMultiContainerParser.js
@@ -19,7 +19,9 @@ import {
 import { JSONParser as labels } from "./serviceForm/JSONReducers/Labels";
 import { JSONParser as portDefinitions } from "./serviceForm/PortDefinitions";
 import { JSONParser as portMappings } from "./serviceForm/PortMappings";
-import { JSONParser as residency } from "./serviceForm/JSONReducers/Residency";
+import {
+  JSONParser as residency
+} from "./serviceForm/JSONReducers/MultiContainerResidency";
 import { JSONParser as scaling } from "./serviceForm/MultiContainerScaling";
 import { JSONParser as networks } from "./serviceForm/JSONReducers/Networks";
 import {

--- a/plugins/services/src/js/reducers/JSONMultiContainerReducers.js
+++ b/plugins/services/src/js/reducers/JSONMultiContainerReducers.js
@@ -9,6 +9,9 @@ import {
 import {
   JSONReducer as environment
 } from "./serviceForm/JSONReducers/EnvironmentVariables";
+import {
+  JSONReducer as residency
+} from "./serviceForm/JSONReducers/MultiContainerResidency";
 import { JSONReducer as fetch } from "./serviceForm/JSONReducers/Artifacts";
 import { JSONReducer as scaling } from "./serviceForm/MultiContainerScaling";
 import { JSONReducer as labels } from "./serviceForm/JSONReducers/Labels";
@@ -21,10 +24,18 @@ module.exports = {
   environment,
   scaling,
   labels,
-  scheduling(state, transaction) {
+  scheduling(
+    state = { residency: {}, placement: { constraints: [] } },
+    transaction
+  ) {
+    const constraintsState = state != null && state.placement != null
+      ? state.placement.constraints
+      : [];
+
     return {
+      residency: residency.bind(this)(state.residency, transaction),
       placement: {
-        constraints: constraints.bind(this)(state, transaction)
+        constraints: constraints.bind(this)(constraintsState, transaction)
       }
     };
   },

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/MultiContainerResidency.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/MultiContainerResidency.js
@@ -1,0 +1,67 @@
+import { SET, ADD_ITEM, REMOVE_ITEM } from "#SRC/js/constants/TransactionTypes";
+import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
+import Transaction from "#SRC/js/structs/Transaction";
+import VolumeConstants from "../../../constants/VolumeConstants";
+
+module.exports = {
+  JSONReducer(state, { type, path, value }) {
+    if (path == null) {
+      return state;
+    }
+
+    if (this.volumeMounts == null) {
+      this.volumeMounts = [];
+    }
+
+    const joinedPath = path.join(".");
+
+    if (joinedPath.search("volumeMounts") !== -1) {
+      if (joinedPath === "volumeMounts") {
+        switch (type) {
+          case ADD_ITEM:
+            this.volumeMounts.push(false);
+            break;
+          case REMOVE_ITEM:
+            this.volumeMounts = this.volumeMounts.filter((item, index) => {
+              return index !== value;
+            });
+            break;
+        }
+      }
+      const index = path[1];
+      if (type === SET && `volumeMounts.${index}.type` === joinedPath) {
+        this.volumeMounts[index] =
+          value === VolumeConstants.type.localPersistent;
+      }
+
+      const hasLocalVolumes = this.volumeMounts.find(value => {
+        return value;
+      });
+      if (hasLocalVolumes && this.residency == null) {
+        return {
+          relaunchEscalationTimeoutSeconds: 10,
+          taskLostBehavior: "WAIT_FOREVER"
+        };
+      } else if (!hasLocalVolumes) {
+        return;
+      } else {
+        return this.residency;
+      }
+    }
+    if (type === SET && joinedPath === "residency") {
+      this.residency = value;
+
+      return value;
+    }
+
+    return state;
+  },
+  JSONParser(state) {
+    const residency = findNestedPropertyInObject(state, "scheduling.residency");
+    if (residency == null) {
+      return [];
+    }
+
+    return new Transaction(["residency"], residency);
+  }
+};

--- a/plugins/services/src/js/service-configuration/PodStorageConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodStorageConfigSection.js
@@ -64,6 +64,9 @@ class PodStorageConfigSection extends React.Component {
       if (volume.host != null) {
         type = VolumeConstants.type.host;
       }
+      if (volume.persistent != null) {
+        type = VolumeConstants.type.localPersistent;
+      }
       if (Object.keys(volume).length === 1 && volume.name != null) {
         type = VolumeConstants.type.ephemeral;
       }


### PR DESCRIPTION
This introduces the support for persistent volumes in multi container services. 
For testing create a volume and select Persistent type add a name and a size.

In the JSON mode you should see something similar to this:

```JSON
...
"volumes": [
    {
      "persistent": {
        "size": 1
      },
      "name": "home"
    }
  ]
...
```

![image](https://user-images.githubusercontent.com/156010/33609363-13d38e86-d9c8-11e7-92de-7cdb52c23d00.png)


Closes DCOS-19579