### PR TITLE
fix(Constraints): fix unique constraints operator change

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/Constraints.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/Constraints.js
@@ -21,18 +21,21 @@ function processTransaction(state, { type, path, value }) {
 
     newState.push(defaultValue);
   }
+
   if (type === REMOVE_ITEM) {
     newState = newState.filter((item, index) => {
       return index !== value;
     });
   }
+
   if (type === SET && name === "type") {
     newState[index].type = value;
   }
+
   if (
     type === SET &&
     CONSTRAINT_FIELDS.includes(name) &&
-    !requiresEmptyValue(newState[index].operator)
+    !(requiresEmptyValue(newState[index].operator) && name === "value")
   ) {
     newState[index][name] = value;
   }

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Constraints-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Constraints-test.js
@@ -39,5 +39,38 @@ describe("Constraints", function() {
 
       expect(batch.reduce(Constraints.FormReducer.bind({}), {})).toEqual({});
     });
+
+    it("add unique constraint", function() {
+      const batch = new Batch([
+        new Transaction(["constraints"], null, ADD_ITEM),
+        new Transaction(["constraints", 0, "operator"], "UNIQUE", SET),
+        new Transaction(["constraints", 0, "fieldName"], "HOSTNAME", SET)
+      ]);
+
+      expect(batch.reduce(Constraints.FormReducer.bind({}), [])).toEqual([
+        {
+          fieldName: "HOSTNAME",
+          operator: "UNIQUE",
+          value: null
+        }
+      ]);
+    });
+
+    it("changes operator value from UNIQUE to CLUSTER", function() {
+      const batch = new Batch([
+        new Transaction(["constraints"], null, ADD_ITEM),
+        new Transaction(["constraints", 0, "operator"], "UNIQUE", SET),
+        new Transaction(["constraints", 0, "fieldName"], "LOCAL", SET),
+        new Transaction(["constraints", 0, "operator"], "CLUSTER", SET)
+      ]);
+
+      expect(batch.reduce(Constraints.FormReducer.bind({}), [])).toEqual([
+        {
+          fieldName: "LOCAL",
+          operator: "CLUSTER",
+          value: null
+        }
+      ]);
+    });
   });
 });

--- a/plugins/services/src/js/reducers/serviceForm/common/Constraints.js
+++ b/plugins/services/src/js/reducers/serviceForm/common/Constraints.js
@@ -26,7 +26,7 @@ function processTransaction(state, { type, path, value }) {
   if (
     type === SET &&
     CONSTRAINT_FIELDS.includes(name) &&
-    !requiresEmptyValue(newState[index].operator)
+    !(requiresEmptyValue(newState[index].operator) && name === "value")
   ) {
     newState[index][name] = value;
   }

--- a/plugins/services/src/js/reducers/serviceForm/common/__tests__/Constraints-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/common/__tests__/Constraints-test.js
@@ -1,0 +1,42 @@
+const { ADD_ITEM, SET } = require("#SRC/js/constants/TransactionTypes");
+const Batch = require("#SRC/js/structs/Batch");
+const Transaction = require("#SRC/js/structs/Transaction");
+
+const Constraints = require("../Constraints");
+
+describe("Constraints", function() {
+  describe("#JSONReducer", function() {
+    it("add unique constraint", function() {
+      const batch = new Batch([
+        new Transaction(["constraints"], null, ADD_ITEM),
+        new Transaction(["constraints", 0, "operator"], "UNIQUE", SET),
+        new Transaction(["constraints", 0, "fieldName"], "HOSTNAME", SET)
+      ]);
+
+      expect(batch.reduce(Constraints.JSONReducer.bind({}), [])).toEqual([
+        {
+          fieldName: "HOSTNAME",
+          operator: "UNIQUE",
+          value: null
+        }
+      ]);
+    });
+
+    it("changes operator value from UNIQUE to CLUSTER", function() {
+      const batch = new Batch([
+        new Transaction(["constraints"], null, ADD_ITEM),
+        new Transaction(["constraints", 0, "operator"], "UNIQUE", SET),
+        new Transaction(["constraints", 0, "fieldName"], "LOCAL", SET),
+        new Transaction(["constraints", 0, "operator"], "CLUSTER", SET)
+      ]);
+
+      expect(batch.reduce(Constraints.JSONReducer.bind({}), [])).toEqual([
+        {
+          fieldName: "LOCAL",
+          operator: "CLUSTER",
+          value: null
+        }
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Fix constraint when changing/editing unique.
**Closes DCOS-19573**

**How to test**:
Create a pod with the config below
Edit the pod and go to `Placement` tab
Then try changing the `operator` in the constraint section
```
{
  "id": "/pod",
  "containers": [
    {
      "name": "container-1",
      "resources": {
        "cpus": 0.1,
        "mem": 32,
        "disk": 0
      },
      "image": {
        "kind": "DOCKER",
        "id": "nginx"
      }
    }
  ],
  "networks": [
    {
      "mode": "host"
    }
  ],
  "scaling": {
    "instances": 1,
    "kind": "fixed"
  },
  "scheduling": {
    "placement": {
      "constraints": [
        {
          "fieldName": "hostname",
          "operator": "UNIQUE"
        }
      ]
    }
  },
  "executorResources": {
    "cpus": 0.1,
    "mem": 32,
    "disk": 10
  },
  "volumes": [],
  "fetch": []
}
```

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

