### PR TITLE
fix(HealthChecks): fix IPv6 support to set right values

### DIFF
--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -267,10 +267,9 @@ class HealthChecksFormSection extends Component {
       <FormGroup showError={false} className="column-12">
         <FieldLabel>
           <FieldInput
-            checked={healthCheck.ipProtocol === "IPv6"}
-            name={`healthChecks.${key}.ipProtocol`}
+            checked={healthCheck.ipProtocolCheckbox === true}
+            name={`healthChecks.${key}.ipProtocolCheckbox`}
             type="checkbox"
-            value="IPv6"
           />
           {"Make "}
           <span className="truecase">IPv6</span>

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/HealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/HealthChecks.js
@@ -65,9 +65,12 @@ module.exports = {
           state[index].command = value;
         }
         if (`healthChecks.${index}.ipProtocol` === joinedPath) {
-          state[index].ipProtocol = value === true || value === "IPv6"
-            ? "IPv6"
-            : "IPv4";
+          state[index].ipProtocolCheckbox = value === "IPv6";
+          state[index].ipProtocol = value;
+        }
+        if (`healthChecks.${index}.ipProtocolCheckbox` === joinedPath) {
+          state[index].ipProtocolCheckbox = value;
+          state[index].ipProtocol = value === true ? "IPv6" : "IPv4";
         }
         if (`healthChecks.${index}.path` === joinedPath) {
           state[index].path = value;

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/HealthChecks-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/HealthChecks-test.js
@@ -183,13 +183,14 @@ describe("HealthChecks", function() {
         new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
       );
       batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], true)
+        new Transaction(["healthChecks", 0, "ipProtocolCheckbox"], true)
       );
 
       expect(batch.reduce(HealthChecks.FormReducer.bind({}), [])).toEqual([
         {
           protocol: "MESOS_HTTP",
-          ipProtocol: "IPv6"
+          ipProtocol: "IPv6",
+          ipProtocolCheckbox: true
         }
       ]);
     });
@@ -202,13 +203,14 @@ describe("HealthChecks", function() {
       );
       batch = batch.add(new Transaction(["healthChecks", 0, "https"], true));
       batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], true)
+        new Transaction(["healthChecks", 0, "ipProtocolCheckbox"], true)
       );
 
       expect(batch.reduce(HealthChecks.FormReducer.bind({}), [])).toEqual([
         {
           protocol: "MESOS_HTTPS",
-          ipProtocol: "IPv6"
+          ipProtocol: "IPv6",
+          ipProtocolCheckbox: true
         }
       ]);
     });

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/HealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/HealthChecks.js
@@ -114,8 +114,10 @@ module.exports = {
           this.healthChecks[index].command = value;
         }
         if (`healthChecks.${index}.ipProtocol` === joinedPath) {
-          this.healthChecks[index].ipProtocol = value === true ||
-            value === "IPv6"
+          this.healthChecks[index].ipProtocol = value;
+        }
+        if (`healthChecks.${index}.ipProtocolCheckbox` === joinedPath) {
+          this.healthChecks[index].ipProtocol = value === true
             ? "IPv6"
             : "IPv4";
         }

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/HealthChecks-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/HealthChecks-test.js
@@ -172,7 +172,7 @@ describe("HealthChecks", function() {
       );
       batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
       batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], true)
+        new Transaction(["healthChecks", 0, "ipProtocolCheckbox"], true)
       );
 
       expect(batch.reduce(HealthChecks.JSONReducer.bind({}), [])).toEqual([
@@ -197,7 +197,7 @@ describe("HealthChecks", function() {
       batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
       batch = batch.add(new Transaction(["healthChecks", 0, "https"], true));
       batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], true)
+        new Transaction(["healthChecks", 0, "ipProtocolCheckbox"], true)
       );
 
       expect(batch.reduce(HealthChecks.JSONReducer.bind({}), [])).toEqual([
@@ -221,7 +221,7 @@ describe("HealthChecks", function() {
       );
       batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
       batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], true)
+        new Transaction(["healthChecks", 0, "ipProtocolCheckbox"], true)
       );
 
       expect(batch.reduce(HealthChecks.JSONReducer.bind({}), [])).toEqual([
@@ -236,19 +236,16 @@ describe("HealthChecks", function() {
     it("sets IPv4", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["container", "type"], "DOCKER"));
-      batch = batch.add(
-        new Transaction(["container", "docker", "image"], "alpine")
-      );
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
       );
       batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
       batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], true)
+        new Transaction(["healthChecks", 0, "ipProtocolCheckbox"], true)
       );
       batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], false)
+        new Transaction(["healthChecks", 0, "ipProtocolCheckbox"], false)
       );
 
       expect(batch.reduce(HealthChecks.JSONReducer.bind({}), [])).toEqual([
@@ -260,19 +257,37 @@ describe("HealthChecks", function() {
       ]);
     });
 
-    it("sets https ipProtocol to IPv6 if docker set", function() {
+    it("sets exact ipProtocol value", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["container", "type"], "DOCKER"));
-      batch = batch.add(
-        new Transaction(["container", "docker", "image"], "alpine")
-      );
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
       );
       batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
       batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], true)
+        new Transaction(["healthChecks", 0, "ipProtocol"], "exact")
+      );
+
+      expect(batch.reduce(HealthChecks.JSONReducer.bind({}), [])).toEqual([
+        {
+          protocol: "MESOS_HTTP",
+          path: "/test",
+          ipProtocol: "exact"
+        }
+      ]);
+    });
+
+    it("sets https ipProtocol to IPv6 if docker set", function() {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(["container", "type"], "DOCKER"));
+      batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
+      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
+      batch = batch.add(
+        new Transaction(["healthChecks", 0, "ipProtocolCheckbox"], true)
       );
       batch = batch.add(new Transaction(["healthChecks", 0, "https"], true));
 
@@ -297,7 +312,7 @@ describe("HealthChecks", function() {
       );
       batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
       batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], true)
+        new Transaction(["healthChecks", 0, "ipProtocolCheckbox"], true)
       );
       batch = batch.add(new Transaction(["healthChecks", 0, "https"], true));
       batch = batch.add(new Transaction(["container", "type"], "MESOS"));


### PR DESCRIPTION
This fixes the earlier introduced feature for IPv6 Support. The problem was that the field is
setting a string but is providing a boolean. By parsing the JSON we made it possible to have the
value `true` and `IPv6` as valid values for the checkbox to be ticked.

The solution to the problem was to change the name of the field to something else and set the value
based on the boolean. And have the parsed JSON set the boolean based on the input.

Because code explains better then a thousand words see this exert:
```JS
if (`healthChecks.${index}.ipProtocol` === joinedPath) {
  state[index].ipProtocolCheckbox = value === "IPv6";
  state[index].ipProtocol = value;
}
if (`healthChecks.${index}.ipProtocolCheckbox` ===
    joinedPath) {
  state[index].ipProtocolCheckbox = value;
  state[index].ipProtocol = value ===
    true ? "IPv6" : "IPv4";
}
```

- For testing create a new single container service.
- Add a Healthcheck
- Select the HTTP type
- Go to the JSON editor
- Add to the HealthCheck the `ipProtocol` field with arbitrary values

Expected behavior is that only the value "IPv6" should add the check mark to the check box. Please
do test `"IPv4"`, `true` and `false`.