### PR TITLE
fix(PlacementConstraintsSchemaField): escape/unescape output

### DIFF
--- a/src/js/components/PlacementConstraintsSchemaField.js
+++ b/src/js/components/PlacementConstraintsSchemaField.js
@@ -52,7 +52,7 @@ export default class PlacementConstraintsSchemaField extends Component {
 
     let json;
     try {
-      json = JSON.parse(formData);
+      json = JSON.parse(formData.replace(/\\"/g, '"'));
     } catch (error) {
       return this.state.batch || new Batch();
     }
@@ -67,7 +67,7 @@ export default class PlacementConstraintsSchemaField extends Component {
   handleBatchChange(batch) {
     const { formData, onChange } = this.props.fieldProps;
     const newJson = batch.reduce(jsonReducer, []);
-    const newData = JSON.stringify(newJson.constraints);
+    const newData = JSON.stringify(newJson.constraints).replace(/"/g, '\\"');
 
     if (newData !== formData) {
       onChange(newData);


### PR DESCRIPTION
SDK uses handlebars engine to generate JSON definition, and handlebars would escape quotes in partial JSONs so that we cant just parse JSON, we should unescape it first. But since SDK expects it to be escaped we should escape the output back again.

The fastest way to do this was regexp.