### PR TITLE
DCOS-19658: Adjust system tests cluster config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN set -x \
   # Install cypress
   && cypress install --cypress-version ${CYPRESS_VERSION} \
   # Install dcos-launch
-  && curl 'https://downloads.dcos.io/dcos-test-utils/bin/linux/dcos-launch' > /usr/local/bin/dcos-launch \
+  && curl 'https://downloads.dcos.io/dcos-launch/bin/linux/dcos-launch' > /usr/local/bin/dcos-launch \
   && chmod +x /usr/local/bin/dcos-launch \
   # Ensure entrypoint is executable
   && chmod +x /usr/local/bin/dcos-ui-docker-entrypoint \

--- a/system-tests/_scripts/launch-cluster.sh
+++ b/system-tests/_scripts/launch-cluster.sh
@@ -20,7 +20,7 @@ installer_url: ${1:-$INSTALLER_URL}
 platform: aws
 provider: onprem
 aws_region: us-west-2
-os_name: cent-os-7
+os_name: cent-os-7-dcos-prereqs
 instance_type: m4.large
 dcos_config:
   cluster_name: DC/OS UI System Integration Tests


### PR DESCRIPTION
Turned out we have to  use `cent-os-7-dcos-prereqs` image that has all the good stuff and the `dcos-launch` link was outdated

Ask for credentials, then:
```
$ docker-compose build
$ docker-compose up -d
$ docker-compose exec toolchain system-tests/_scripts/launch-cluster.sh
```

It should create a cluster, don't forget to tear it down with:
```
$ docker-compose exec toolchain system-tests/_scripts/delete-cluster.sh
```

And shut down the toolchain
```
$ docker-compose down
```