### PR TITLE
fix(HealthChecks): use bool as internal representation

### DIFF
--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -267,10 +267,9 @@ class HealthChecksFormSection extends Component {
       <FormGroup showError={false} className="column-12">
         <FieldLabel>
           <FieldInput
-            checked={healthCheck.ipProtocol === "IPv6"}
-            name={`healthChecks.${key}.ipProtocol`}
+            checked={healthCheck.isIPv6}
+            name={`healthChecks.${key}.isIPv6`}
             type="checkbox"
-            value="IPv6"
           />
           {"Make "}
           <span className="truecase">IPv6</span>

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/HealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/HealthChecks.js
@@ -38,7 +38,7 @@ module.exports = {
       if (joinedPath === "healthChecks") {
         switch (type) {
           case ADD_ITEM:
-            state.push(value || {});
+            state.push(Object.assign({}, value) || {});
             break;
           case REMOVE_ITEM:
             state = state.filter((item, index) => {
@@ -64,10 +64,8 @@ module.exports = {
         if (`healthChecks.${index}.command` === joinedPath) {
           state[index].command = value;
         }
-        if (`healthChecks.${index}.ipProtocol` === joinedPath) {
-          state[index].ipProtocol = value === true || value === "IPv6"
-            ? "IPv6"
-            : "IPv4";
+        if (`healthChecks.${index}.isIPv6` === joinedPath) {
+          state[index].isIPv6 = value;
         }
         if (`healthChecks.${index}.path` === joinedPath) {
           state[index].path = value;

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/HealthChecks-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/HealthChecks-test.js
@@ -176,39 +176,35 @@ describe("HealthChecks", function() {
       ]);
     });
 
-    it("sets ipProtocol to IPv6 if set", function() {
+    it("sets isIPv6 to true if set", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
       );
-      batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], true)
-      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "isIPv6"], true));
 
       expect(batch.reduce(HealthChecks.FormReducer.bind({}), [])).toEqual([
         {
           protocol: "MESOS_HTTP",
-          ipProtocol: "IPv6"
+          isIPv6: true
         }
       ]);
     });
 
-    it("sets https ipProtocol to IPv6 if set", function() {
+    it("sets https isIPv6 to IPv6 if set", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["healthChecks"], null, ADD_ITEM));
       batch = batch.add(
         new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
       );
       batch = batch.add(new Transaction(["healthChecks", 0, "https"], true));
-      batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], true)
-      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "isIPv6"], true));
 
       expect(batch.reduce(HealthChecks.FormReducer.bind({}), [])).toEqual([
         {
           protocol: "MESOS_HTTPS",
-          ipProtocol: "IPv6"
+          isIPv6: true
         }
       ]);
     });

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/HealthChecks.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/HealthChecks.js
@@ -113,11 +113,8 @@ module.exports = {
         if (`healthChecks.${index}.command` === joinedPath) {
           this.healthChecks[index].command = value;
         }
-        if (`healthChecks.${index}.ipProtocol` === joinedPath) {
-          this.healthChecks[index].ipProtocol = value === true ||
-            value === "IPv6"
-            ? "IPv6"
-            : "IPv4";
+        if (`healthChecks.${index}.isIPv6` === joinedPath) {
+          this.healthChecks[index].ipProtocol = value ? "IPv6" : "IPv4";
         }
         if (`healthChecks.${index}.path` === joinedPath) {
           this.healthChecks[index].path = value;
@@ -187,10 +184,19 @@ module.exports = {
           );
         }
       }
+      if (item.ipProtocol != null) {
+        memo.push(
+          new Transaction(
+            ["healthChecks", index, "isIPv6"],
+            item.ipProtocol === "IPv6",
+            SET
+          )
+        );
+      }
+
       [
         "path",
         "portIndex",
-        "ipProtocol",
         "gracePeriodSeconds",
         "intervalSeconds",
         "timeoutSeconds",

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/HealthChecks-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/HealthChecks-test.js
@@ -171,9 +171,7 @@ describe("HealthChecks", function() {
         new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
       );
       batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
-      batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], true)
-      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "isIPv6"], true));
 
       expect(batch.reduce(HealthChecks.JSONReducer.bind({}), [])).toEqual([
         {
@@ -196,9 +194,7 @@ describe("HealthChecks", function() {
       );
       batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
       batch = batch.add(new Transaction(["healthChecks", 0, "https"], true));
-      batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], true)
-      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "isIPv6"], true));
 
       expect(batch.reduce(HealthChecks.JSONReducer.bind({}), [])).toEqual([
         {
@@ -220,9 +216,7 @@ describe("HealthChecks", function() {
         new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
       );
       batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
-      batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], true)
-      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "isIPv6"], true));
 
       expect(batch.reduce(HealthChecks.JSONReducer.bind({}), [])).toEqual([
         {
@@ -244,12 +238,8 @@ describe("HealthChecks", function() {
         new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
       );
       batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
-      batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], true)
-      );
-      batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], false)
-      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "isIPv6"], true));
+      batch = batch.add(new Transaction(["healthChecks", 0, "isIPv6"], false));
 
       expect(batch.reduce(HealthChecks.JSONReducer.bind({}), [])).toEqual([
         {
@@ -271,9 +261,7 @@ describe("HealthChecks", function() {
         new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
       );
       batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
-      batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], true)
-      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "isIPv6"], true));
       batch = batch.add(new Transaction(["healthChecks", 0, "https"], true));
 
       expect(batch.reduce(HealthChecks.JSONReducer.bind({}), [])).toEqual([
@@ -296,9 +284,7 @@ describe("HealthChecks", function() {
         new Transaction(["healthChecks", 0, "protocol"], "MESOS_HTTP")
       );
       batch = batch.add(new Transaction(["healthChecks", 0, "path"], "/test"));
-      batch = batch.add(
-        new Transaction(["healthChecks", 0, "ipProtocol"], true)
-      );
+      batch = batch.add(new Transaction(["healthChecks", 0, "isIPv6"], true));
       batch = batch.add(new Transaction(["healthChecks", 0, "https"], true));
       batch = batch.add(new Transaction(["container", "type"], "MESOS"));
 


### PR DESCRIPTION
This fixes the earlier introduced feature for IPv6 Support. The problem was that the field is
setting a string but is providing a boolean. By parsing the JSON we made it possible to have the
value true and IPv6 as valid values for the checkbox to be ticked.

Now it should be impossible to set `true` in JSON and have checkbox to be checked.

How to test: PLEASE give it a hard time. Check the checkbox, set path from JSON, go back and forth from editing JSON to editing form multiple times. Verify that there's no side effects

<img width="767" alt="screen shot 2017-12-06 at 15 20 30" src="https://user-images.githubusercontent.com/186223/33690612-2475e910-da99-11e7-80c8-feeb3aab892a.png">
