### PR TITLE
DCOS-19832: Filter active frameworks only

### DIFF
--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -246,7 +246,7 @@ class MesosStateStore extends GetSetBaseStore {
     let serviceTasks = [];
     if (serviceIsFramework) {
       const framework = frameworks.find(function(framework) {
-        return framework.name === serviceFrameworkName;
+        return framework.active && framework.name === serviceFrameworkName;
       });
 
       if (framework) {

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -46,11 +46,18 @@ describe("MesosStateStore", function() {
           frameworks: [
             {
               name: "marathon",
-              id: "marathon_1"
+              id: "marathon_1",
+              active: true
             },
             {
               name: "spark",
-              id: "spark_1"
+              id: "spark_0",
+              active: false
+            },
+            {
+              name: "spark",
+              id: "spark_1",
+              active: true
             }
           ],
           tasks: [


### PR DESCRIPTION
To test:
start confluent-kafka
kill confluent-kafka
start a new one (with the same name)
observe that you see it's tasks

without the fix you wouldn't see `kafka_broker` because MesosStateStore would pick tasks for the killed instance.

<img width="1408" alt="screen shot 2017-12-06 at 16 44 16" src="https://user-images.githubusercontent.com/186223/33692934-c095157c-daa4-11e7-8ef7-116d6392cb94.png">
