### PR TITLE
DCOS-19828: Fix mesos stream parsers 😅

### DIFF
--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -211,7 +211,7 @@ class MesosStateStore extends GetSetBaseStore {
     }
 
     const framework = frameworks.find(function(framework) {
-      return framework.name === serviceName;
+      return framework.active && framework.name === serviceName;
     });
 
     if (framework) {

--- a/src/js/stores/MesosStream/parsers/__tests__/agents-test.js
+++ b/src/js/stores/MesosStream/parsers/__tests__/agents-test.js
@@ -95,16 +95,8 @@ describe("agents parser", function() {
       const message = {
         type: "AGENT_REMOVED",
         agent_removed: {
-          agent: {
-            active: true,
-            agent_info: {
-              hostname: "myhost",
-              id: {
-                value: "628984d0-4213-4140-bcb0-99d7ef46b1df-S0"
-              }
-            },
-            pid: "slave(3)@127.0.1.1:34626",
-            version: "1.1.0"
+          agent_id: {
+            value: "628984d0-4213-4140-bcb0-99d7ef46b1df-S0"
           }
         }
       };

--- a/src/js/stores/MesosStream/parsers/__tests__/frameworks-test.js
+++ b/src/js/stores/MesosStream/parsers/__tests__/frameworks-test.js
@@ -126,14 +126,12 @@ describe("frameworks parser", function() {
       const message = {
         type: "FRAMEWORK_REMOVED",
         framework_removed: {
-          framework: {
-            framework_info: {
-              id: {
-                value: "628984d0-4213-4140-bcb0-99d7ef46b1df-0000"
-              },
-              name: "default",
-              user: "root"
-            }
+          framework_info: {
+            id: {
+              value: "628984d0-4213-4140-bcb0-99d7ef46b1df-0000"
+            },
+            name: "default",
+            user: "root"
           }
         }
       };

--- a/src/js/stores/MesosStream/parsers/agents.js
+++ b/src/js/stores/MesosStream/parsers/agents.js
@@ -46,8 +46,8 @@ export function agentRemovedAction(state, message) {
     return state;
   }
 
-  const removedAgent = processAgent(message.agent_removed.agent);
-  const slaves = state.slaves.filter(agent => removedAgent.id !== agent.id);
+  const removedAgentID = scalar(message.agent_removed.agent_id);
+  const slaves = state.slaves.filter(agent => removedAgentID !== agent.id);
 
   return Object.assign({}, state, { slaves });
 }

--- a/src/js/stores/MesosStream/parsers/frameworks.js
+++ b/src/js/stores/MesosStream/parsers/frameworks.js
@@ -61,9 +61,9 @@ export function frameworkRemovedAction(state, message) {
     return state;
   }
 
-  const removedFramework = processFramework(
-    message.framework_removed.framework
-  );
+  const removedFramework = processFramework({
+    framework_info: message.framework_removed.framework_info
+  });
   const frameworks = state.frameworks.filter(
     framework => removedFramework.id !== framework.id
   );

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -15,6 +15,7 @@ describe("MesosStateStore", function() {
         return {
           frameworks: [
             {
+              active: true,
               name: "marathon"
             }
           ],
@@ -198,6 +199,7 @@ describe("MesosStateStore", function() {
         return {
           frameworks: [
             {
+              active: true,
               name: "marathon"
             }
           ],
@@ -235,6 +237,7 @@ describe("MesosStateStore", function() {
         return {
           frameworks: [
             {
+              active: true,
               name: "marathon"
             }
           ],
@@ -258,6 +261,7 @@ describe("MesosStateStore", function() {
         return {
           frameworks: [
             {
+              active: true,
               name: "marathon"
             }
           ],


### PR DESCRIPTION
This PR fixes various bugs in the MesosStream. 

1. Fix FRAMEWORK_REMOVED message format
2. Fix AGENT_REMOVED message format
3. Checking only active frameworks when filtering

Testing :trollface: 

1. Easy: Install `beta-confluent-kafka`, wait until it's fully up and running, then delete it. Install  `beta-confluent-kafka` again. UI should show all the tasks etc _without_ reloading the browser.
2. Hard: You gotta remove an agent to see what happens. I may even have an idea how to do that. Sometimes our precious colleagues from the customer  support team know those tricks better.
3. Nightmare: I don't really know how to test this one. Since we're using this function only when we're fetching tasks that's been launched by Marathon and in theory we can't have killed root Marathon on the cluster I fixed that one *just in case*.

Closes DCOS-19828