### PR TITLE
refactor(ServiceStatusIcon): add tooltip to serviceStatusIcon

### DIFF
--- a/plugins/services/src/js/components/ServiceList.js
+++ b/plugins/services/src/js/components/ServiceList.js
@@ -3,6 +3,7 @@ import { List } from "reactjs-components";
 import React from "react";
 import { Link, routerShape } from "react-router";
 
+import StringUtil from "#SRC/js/utils/StringUtil";
 import ServiceStatusIcon from "./ServiceStatusIcon";
 
 const ServiceList = React.createClass({
@@ -45,6 +46,10 @@ const ServiceList = React.createClass({
 
   getServices(services) {
     return services.map(service => {
+      const instancesCount = service.getInstancesCount();
+      const tasksRunning = service.getTaskCount();
+      const tooltipContent = `${tasksRunning} ${StringUtil.pluralize("instance", tasksRunning)} running out of ${instancesCount}`;
+
       return {
         content: [
           {
@@ -63,7 +68,14 @@ const ServiceList = React.createClass({
           },
           {
             className: "dashboard-health-list-health-label",
-            content: <ServiceStatusIcon key="icon" service={service} />,
+            content: (
+              <ServiceStatusIcon
+                key="icon"
+                service={service}
+                showTooltip={true}
+                tooltipContent={tooltipContent}
+              />
+            ),
             tag: "div"
           }
         ]

--- a/plugins/services/src/js/components/ServiceStatusIcon.js
+++ b/plugins/services/src/js/components/ServiceStatusIcon.js
@@ -115,6 +115,26 @@ class ServiceStatusIcon extends Component {
     );
   }
 
+  renderIcon(iconState) {
+    const icon = <Icon {...iconState} size="mini" />;
+
+    if (this.props.showTooltip) {
+      return (
+        <Tooltip
+          interactive={true}
+          content={this.props.tooltipContent}
+          width={250}
+          wrapText={true}
+          wrapperClassName="tooltip-wrapper"
+        >
+          {icon}
+        </Tooltip>
+      );
+    }
+
+    return icon;
+  }
+
   render() {
     const { service } = this.props;
     const serviceStatus = service.getServiceStatus();
@@ -146,10 +166,7 @@ class ServiceStatusIcon extends Component {
     }
 
     if (service instanceof ServiceTree) {
-      return (
-        this.getServiceTreeWarning(service) ||
-        <Icon {...iconState} size="mini" />
-      );
+      return this.getServiceTreeWarning(service) || this.renderIcon(iconState);
     }
 
     // Display the declined offers warning if that's causing a delay.
@@ -162,21 +179,7 @@ class ServiceStatusIcon extends Component {
       return this.getUnableToLaunchWarning(service);
     }
 
-    if (this.props.showTooltip) {
-      return (
-        <Tooltip
-          interactive={true}
-          content={this.props.tooltipContent}
-          width={250}
-          wrapText={true}
-          wrapperClassName="tooltip-wrapper"
-        >
-          <Icon {...iconState} size="mini" />
-        </Tooltip>
-      );
-    }
-
-    return <Icon {...iconState} size="mini" />;
+    return this.renderIcon(iconState);
   }
 }
 

--- a/plugins/services/src/js/components/__tests__/__snapshots__/ServiceList-test.js.snap
+++ b/plugins/services/src/js/components/__tests__/__snapshots__/ServiceList-test.js.snap
@@ -16,11 +16,16 @@ exports[`ServiceList #getServices returns services that have a value of two elem
       </span>
       <div
         className="dashboard-health-list-health-label">
-        <svg
-          className="icon icon-light-grey icon-mini">
-          <use
-            xlinkHref="#icon-system--circle-minus" />
-        </svg>
+        <div
+          className="tooltip-wrapper"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}>
+          <svg
+            className="icon icon-light-grey icon-mini">
+            <use
+              xlinkHref="#icon-system--circle-minus" />
+          </svg>
+        </div>
       </div>
     </li>
   </ul>

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -354,11 +354,18 @@ class ServicesTable extends React.Component {
   renderStatus(prop, service) {
     const serviceStatusText = service.getStatus();
     const serviceStatusClassSet = StatusMapping[serviceStatusText] || "";
+    const instancesCount = service.getInstancesCount();
+    const tasksRunning = service.getTaskCount();
+    const tooltipContent = `${tasksRunning} ${StringUtil.pluralize("instance", tasksRunning)} running out of ${instancesCount}`;
 
     return (
       <div className="flex">
         <div className={`${serviceStatusClassSet} service-status-icon-wrapper`}>
-          <ServiceStatusIcon service={service} />
+          <ServiceStatusIcon
+            service={service}
+            showTooltip={true}
+            tooltipContent={tooltipContent}
+          />
           <span className="status-bar-text">{serviceStatusText}</span>
         </div>
         <div className="service-status-progressbar-wrapper">


### PR DESCRIPTION
Keep the UI consistent by adding tooltip to serviceStatusIcon displaying # of services running

Closes DCOS-19747

**How to test:**
The icons in service table (status column) should display tooltips
Same goes for service breadcrumb and panel section in dashboard page

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
