### PR TITLE
fix(SchemaField): avoid framework regex errors

### DIFF
--- a/src/js/components/SchemaField.js
+++ b/src/js/components/SchemaField.js
@@ -147,6 +147,16 @@ class SchemaField extends Component {
       onFocus
     } = props;
 
+    const handleChange = event => {
+      const value = event.target.value;
+
+      if (value === "" && !required) {
+        onChange(undefined);
+      } else {
+        onChange(value);
+      }
+    };
+
     let field = (
       <FieldInput
         id={name}
@@ -155,7 +165,7 @@ class SchemaField extends Component {
         autoFocus={autofocus}
         name={name}
         value={formData}
-        onChange={event => onChange(event.target.value)}
+        onChange={handleChange}
         onBlur={onBlur && (event => onBlur(name, event.target.value))}
         onFocus={onFocus && (event => onFocus(name, event.target.value))}
       />
@@ -193,7 +203,9 @@ class SchemaField extends Component {
     const handleChange = event => {
       const value = event.target.value;
 
-      if (value === "") {
+      if (value === "" && !required) {
+        onChange(undefined);
+      } else if (value === "") {
         onChange("");
       } else {
         onChange(Number(value));
@@ -208,7 +220,7 @@ class SchemaField extends Component {
         autoFocus={autofocus}
         name={name}
         value={formData}
-        onChange={handleChange.bind(this)}
+        onChange={handleChange}
         onBlur={onBlur && (event => onBlur(name, event.target.value))}
         onFocus={onFocus && (event => onFocus(name, event.target.value))}
       />

--- a/src/js/pages/catalog/DeployFrameworkConfiguration.js
+++ b/src/js/pages/catalog/DeployFrameworkConfiguration.js
@@ -82,11 +82,6 @@ class DeployFrameworkConfiguration extends mixin(StoreMixin) {
       return value;
     }
     if (!value.properties) {
-      // handle schemas that don't provided a default value
-      if (value.type === "string") {
-        return value.default || "";
-      }
-
       return value.default;
     }
 


### PR DESCRIPTION
This is a sort of complicated situation, let me explain:

Marathon has a schema entry like this (notice there's **no** default value and the field is **not** required):
```
group: {
     regex: <must-be-two-alphanumeric-characters>,
     description: "service group"
}
```

Currently, when fetching this package configuration we were setting `""` as the form value for `group` because no default value was provided by the schema. This caused an error in the framework form like this:

![screen shot 2017-12-08 at 11 25 28 am](https://user-images.githubusercontent.com/1527504/33781727-8ab97a80-dc0a-11e7-82cc-f51d2e48e3c9.png)

Which makes sense, because `""` does not validate against the regex. It was a bad idea to set `""` as the fallback value when no default is provided and the field is not required.

**What this PR does:**
 This PR removes the `""` as the empty state for optional fields. Instead, we will set the field as `undefined`. This affects two places:

1. When initializing the data in DeployFrameworkConfigurationwhen, remove the `""` as the fallback value.
2. In onChange for text and number inputs, set the field as `undefined` when the field is optional. When it's required, still set as `""`, this will keep our validation working.

**Testing**:
1. Checkout this branch.
2. Search for marathon package in catalog.
3. When the form opens, the regex errors won't be there. Change the `group` value in the form and JSON. When the `group` is empty, it won't give an error.
 
Closes DCOS-19771

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

