### PR TITLE
DCOS-19883: fix duplicate local string in region/ zone column

### DIFF
--- a/plugins/services/src/js/utils/TaskUtil.js
+++ b/plugins/services/src/js/utils/TaskUtil.js
@@ -119,50 +119,44 @@ const TaskUtil = {
 
   getRegionName(task) {
     const node = this.getNode(task);
+
     if (!node) {
-      return "(Local)";
+      return "N/A";
     }
 
-    const masterNode = CompositeState.getMasterNode();
     const nodeRegionName = node.getRegionName();
-    const regionNameParts = [];
-
-    if (nodeRegionName) {
-      regionNameParts.push(nodeRegionName);
-    }
+    const masterNode = CompositeState.getMasterNode();
 
     if (
-      !nodeRegionName ||
-      (masterNode && nodeRegionName === masterNode.getRegionName())
+      masterNode &&
+      nodeRegionName === masterNode.getRegionName() &&
+      nodeRegionName !== "N/A"
     ) {
-      regionNameParts.push("(Local)");
+      return `${nodeRegionName} (Local)`;
     }
 
-    return regionNameParts.join(" ");
+    return nodeRegionName;
   },
 
   getZoneName(task) {
     const node = this.getNode(task);
+
     if (!node) {
-      return "(Local)";
+      return "N/A";
     }
 
-    const masterNode = CompositeState.getMasterNode();
     const nodeZoneName = node.getZoneName();
-    const zoneNameParts = [];
-
-    if (nodeZoneName) {
-      zoneNameParts.push(nodeZoneName);
-    }
+    const masterNode = CompositeState.getMasterNode();
 
     if (
-      !nodeZoneName ||
-      (masterNode && nodeZoneName === masterNode.getZoneName())
+      masterNode &&
+      nodeZoneName === masterNode.getZoneName() &&
+      nodeZoneName !== "N/A"
     ) {
-      zoneNameParts.push("(Local)");
+      return `${nodeZoneName} (Local)`;
     }
 
-    return zoneNameParts.join(" ");
+    return nodeZoneName;
   },
 
   getHostName(task) {

--- a/plugins/services/src/js/utils/__tests__/TaskUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/TaskUtil-test.js
@@ -141,10 +141,10 @@ describe("TaskUtil", function() {
         return new Node(MasterNodeLocal);
       };
     });
-    it("returns (Local) when no region name exists", function() {
+    it("returns N/A when no region name exists", function() {
       const task = Object.assign({}, NodeTask);
       task.slave_id = "2";
-      expect(TaskUtil.getRegionName(task)).toEqual("(Local)");
+      expect(TaskUtil.getRegionName(task)).toEqual("N/A");
     });
     it("adds (Local) when no slave/ master in the same region", function() {
       expect(TaskUtil.getRegionName(NodeTask)).toEqual("us-west-2 (Local)");
@@ -166,10 +166,10 @@ describe("TaskUtil", function() {
         return new Node(MasterNodeLocal);
       };
     });
-    it("returns (Local) when no zone name exists", function() {
+    it("returns N/A when no zone name exists", function() {
       const task = Object.assign({}, NodeTask);
       task.slave_id = "2";
-      expect(TaskUtil.getZoneName(task)).toEqual("(Local)");
+      expect(TaskUtil.getZoneName(task)).toEqual("N/A");
     });
     it("adds (Local) when no slave/ master in the same zone", function() {
       expect(TaskUtil.getZoneName(NodeTask)).toEqual("us-west-2a (Local)");

--- a/src/js/structs/Node.js
+++ b/src/js/structs/Node.js
@@ -26,7 +26,7 @@ class Node extends Item {
       "fault_domain.region.name"
     );
 
-    return nodeRegionName || "(Local)";
+    return nodeRegionName || "N/A";
   }
 
   getZoneName() {
@@ -35,7 +35,7 @@ class Node extends Item {
       "fault_domain.zone.name"
     );
 
-    return nodeZoneName || "(Local)";
+    return nodeZoneName || "N/A";
   }
 
   getUsageStats(resource) {

--- a/tests/pages/services/TasksTable-cy.js
+++ b/tests/pages/services/TasksTable-cy.js
@@ -150,7 +150,7 @@ describe("Tasks Table", function() {
 
     it("Shows the correct region", function() {
       cy.visitUrl({ url: "/services/detail/%2Fcassandra/tasks?_k=rh67gf" });
-      cy.get("td.task-table-column-zone-address").eq(1).contains("(Local)");
+      cy.get("td.task-table-column-zone-address").eq(1).contains("N/A");
     });
   });
 });


### PR DESCRIPTION
Fix duplicate local string [(Local) (Local)] if region/ zone doesn't exist in region/ zone task columns.
If no zone/ region exists show "N/A"

Closes DCOS-19869

To test:
- create an open cluster
- create a service with a task
- go to tasks page and see "N/A" in the region/ zone column


**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
