### PR TITLE
fix(PodContainer): adjust hasHealthChecks condition

### DIFF
--- a/plugins/services/src/js/structs/PodContainer.js
+++ b/plugins/services/src/js/structs/PodContainer.js
@@ -76,20 +76,10 @@ module.exports = class PodContainer extends Item {
     // https://github.com/mesosphere/marathon/blob/feature/pods/docs/docs/rest-api/public/api/v2/types/container-status.raml#L49
     // 'healthy: should only be present if a health check is defined for this endpoint'
     //
-    const endpoints = this.getEndpoints();
-    let allHaveChecks = endpoints.length > 0;
-    let hasFailure = false;
 
-    this.getEndpoints().forEach(function(ep) {
-      if (ep.healthy === undefined) {
-        allHaveChecks = false;
-      }
-      if (ep.healthy === false) {
-        hasFailure = true;
-      }
+    return this.getEndpoints().some(function(ep) {
+      return ep.healthy !== undefined;
     });
-
-    return allHaveChecks || hasFailure;
   }
 
   isHealthy() {

--- a/plugins/services/src/js/structs/PodInstance.js
+++ b/plugins/services/src/js/structs/PodInstance.js
@@ -101,8 +101,7 @@ module.exports = class PodInstance extends Item {
   }
 
   hasHealthChecks() {
-    // If for any reason any of the containers has at least 1 health
-    // check that is failing, assume that we have health checks
+    // Assume we have health checks if instance isn't healthy
     if (!this.isHealthy()) {
       return true;
     }
@@ -113,8 +112,7 @@ module.exports = class PodInstance extends Item {
       return false;
     }
 
-    // Otherwise ALL container must have health checks in order to be
-    // considered healthy.
+    // If there are containers ALL of them must have health checks
     return containers.every(function(container) {
       return container.hasHealthChecks();
     });

--- a/plugins/services/src/js/structs/__tests__/PodContainer-test.js
+++ b/plugins/services/src/js/structs/__tests__/PodContainer-test.js
@@ -234,7 +234,7 @@ describe("PodContainer", function() {
       expect(podContainer.hasHealthChecks()).toBeFalsy();
     });
 
-    it("should return false if healthy is not defined everywhere", function() {
+    it("returns true if 'healthy' is defined for at least one container", function() {
       const podContainer = new PodContainer({
         endpoints: [
           { name: "nginx", allocatedHostPort: 31001, healthy: true },
@@ -242,7 +242,7 @@ describe("PodContainer", function() {
         ]
       });
 
-      expect(podContainer.hasHealthChecks()).toBeFalsy();
+      expect(podContainer.hasHealthChecks()).toEqual(true);
     });
 
     it("should return true if at least one check has failed", function() {

--- a/plugins/services/src/js/structs/__tests__/PodInstance-test.js
+++ b/plugins/services/src/js/structs/__tests__/PodInstance-test.js
@@ -226,7 +226,7 @@ describe("PodInstance", function() {
       expect(podInstance.hasHealthChecks()).toBeTruthy();
     });
 
-    it("should return false if even one container has no checks", function() {
+    it("returns true if at least one container has checks", function() {
       const podInstance = new PodInstance({
         status: "stable",
         containers: [
@@ -242,7 +242,7 @@ describe("PodInstance", function() {
         ]
       });
 
-      expect(podInstance.hasHealthChecks()).toBeFalsy();
+      expect(podInstance.hasHealthChecks()).toEqual(true);
     });
 
     it("should return true if instance state is not STABLE", function() {


### PR DESCRIPTION
Adjust the `PodContainer.hasHealthChecks` condition to properly flag containers even if there are only health checks for one endpoint.

Closes DCOS-19720