### PR TITLE
fix(docker-compose): fix yml to use mapping instead of list

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,10 @@ services:
     build:
       context: .
     environment:
-       - CLUSTER_URL="${CLUSTER_URL}"
-       - INSTALLER_URL="${INSTALLER_URL}"
-       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      CLUSTER_URL: "${CLUSTER_URL}"
+      INSTALLER_URL: "${INSTALLER_URL}"
+      AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
+      AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
     ports:
       - 4200:4200
     volumes:


### PR DESCRIPTION
_further reading:_
https://github.com/docker/compose/issues/2854
https://docs.docker.com/compose/compose-file/#args

---

this PR unblocks #2547 - rebase it on this one and it should run successfully when run through `docker-compose exec toolchain dcos-system-test-driver /dcos-ui/system-tests/driver-config/jenkins.sh`

---

HINT: you can prevent the cluster (and tests) from being started with adding `exit 1` in the first line of `system-tests/_scripts/launch-cluster.sh` - it will fail with `Process '../_scripts/launch-cluster.sh' exited with 1` which is okay and means the config is correctly parsed.

if you see the error @nLight mentioned in #2547 it didnt work.
