### PR TITLE
feat(EditFrameworkConfiguration): handle empty resolvedOptions

### DIFF
--- a/plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.js
+++ b/plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.js
@@ -9,9 +9,9 @@ import FrameworkConfigurationReviewScreen
 import Loader from "src/js/components/Loader";
 import CosmosPackagesStore from "#SRC/js/stores/CosmosPackagesStore";
 import { COSMOS_SERVICE_DESCRIBE_CHANGE } from "#SRC/js/constants/EventTypes";
+import { getDefaultFormState } from "react-jsonschema-form/lib/utils";
 
 const METHODS_TO_BIND = [
-  "reorderResolvedOptions",
   "handleEditClick",
   "onCosmosPackagesStoreServiceDescriptionSuccess"
 ];
@@ -51,23 +51,14 @@ class FrameworkConfigurationContainer extends React.Component {
     const fullPackage = CosmosPackagesStore.getServiceDetails();
     const packageDetails = new UniversePackage(fullPackage.package);
 
-    // necessary to have review screen same order of tabs as the form
-    const frameworkData = this.reorderResolvedOptions(
+    const schema = packageDetails.getConfig();
+    const frameworkData = getDefaultFormState(
+      schema,
       fullPackage.resolvedOptions,
-      packageDetails.getConfig()
+      schema.definitions
     );
 
     this.setState({ frameworkData });
-  }
-
-  reorderResolvedOptions(resolvedOptions, config) {
-    const order = Object.keys(config.properties);
-    const orderedResolvedOptions = {};
-    order.forEach(tab => {
-      orderedResolvedOptions[tab] = resolvedOptions[tab];
-    });
-
-    return orderedResolvedOptions;
   }
 
   handleEditClick() {

--- a/src/js/components/FrameworkConfiguration.js
+++ b/src/js/components/FrameworkConfiguration.js
@@ -217,11 +217,28 @@ class FrameworkConfiguration extends Component {
   }
 
   getReviewScreen() {
-    const { deployErrors, isInitialDeploy, formData } = this.props;
+    const {
+      deployErrors,
+      isInitialDeploy,
+      formData,
+      defaultConfigWarning
+    } = this.props;
 
     let warningMessage = null;
     if (isInitialDeploy) {
       warningMessage = this.getWarningMessage();
+    }
+
+    let defaultConfigWarningMessage = null;
+    if (defaultConfigWarning) {
+      const message = {};
+      message.__html = `<strong>Warning: </strong>${defaultConfigWarning}`;
+      defaultConfigWarningMessage = (
+        <div
+          dangerouslySetInnerHTML={message}
+          className="message message-warning"
+        />
+      );
     }
 
     let errorsAlert = null;
@@ -234,6 +251,7 @@ class FrameworkConfiguration extends Component {
         <div className="container">
           {errorsAlert}
           {warningMessage}
+          {defaultConfigWarningMessage}
           <FrameworkConfigurationReviewScreen
             frameworkData={formData}
             title={"Configuration"}
@@ -285,7 +303,8 @@ class FrameworkConfiguration extends Component {
       formErrors,
       formData,
       onFormDataChange,
-      onFormErrorChange
+      onFormErrorChange,
+      defaultConfigWarning
     } = this.props;
 
     let pageContents;
@@ -294,17 +313,18 @@ class FrameworkConfiguration extends Component {
     } else {
       pageContents = (
         <FrameworkConfigurationForm
-          packageDetails={packageDetails}
           jsonEditorActive={jsonEditorActive}
-          formData={formData}
-          formErrors={formErrors}
           focusField={focusField}
           activeTab={activeTab}
+          handleActiveTabChange={this.handleActiveTabChange}
+          handleFocusFieldChange={this.handleFocusFieldChange}
+          formData={formData}
+          formErrors={formErrors}
+          packageDetails={packageDetails}
           deployErrors={deployErrors}
           onFormDataChange={onFormDataChange}
           onFormErrorChange={onFormErrorChange}
-          handleActiveTabChange={this.handleActiveTabChange}
-          handleFocusFieldChange={this.handleFocusFieldChange}
+          defaultConfigWarning={defaultConfigWarning}
         />
       );
     }
@@ -339,12 +359,15 @@ class FrameworkConfiguration extends Component {
 
 FrameworkConfiguration.propTypes = {
   formData: PropTypes.object.isRequired,
+  formErrors: PropTypes.object.isRequired,
   onFormDataChange: PropTypes.func.isRequired,
+  onFormErrorChange: PropTypes.func.isRequired,
   packageDetails: PropTypes.instanceOf(UniversePackage).isRequired,
   handleRun: PropTypes.func.isRequired,
   handleGoBack: PropTypes.func.isRequired,
   isInitialDeploy: PropTypes.bool.isRequired,
-  deployErrors: PropTypes.object
+  deployErrors: PropTypes.object,
+  defaultConfigWarning: PropTypes.string
 };
 
 module.exports = FrameworkConfiguration;

--- a/src/js/components/FrameworkConfigurationForm.js
+++ b/src/js/components/FrameworkConfigurationForm.js
@@ -239,7 +239,8 @@ class FrameworkConfigurationForm extends Component {
       jsonEditorActive,
       formData,
       activeTab,
-      deployErrors
+      deployErrors,
+      defaultConfigWarning
     } = this.props;
 
     const TitleField = props => {
@@ -261,6 +262,18 @@ class FrameworkConfigurationForm extends Component {
     let errorsAlert = null;
     if (deployErrors) {
       errorsAlert = <CosmosErrorMessage error={deployErrors} />;
+    }
+
+    let defaultConfigWarningMessage = null;
+    if (defaultConfigWarning) {
+      const message = {};
+      message.__html = `<strong>Warning: </strong>${defaultConfigWarning}`;
+      defaultConfigWarningMessage = (
+        <div
+          dangerouslySetInnerHTML={message}
+          className="message message-warning"
+        />
+      );
     }
 
     return (
@@ -286,6 +299,7 @@ class FrameworkConfigurationForm extends Component {
                   </TabButtonList>
                   <div className="menu-tabbed-view-container">
                     {errorsAlert}
+                    {defaultConfigWarningMessage}
                     <SchemaForm
                       schema={packageDetails.getConfig()}
                       formData={formData}
@@ -327,13 +341,15 @@ FrameworkConfigurationForm.propTypes = {
   packageDetails: PropTypes.instanceOf(UniversePackage).isRequired,
   jsonEditorActive: PropTypes.bool.isRequired,
   formData: PropTypes.object.isRequired,
+  formErrors: PropTypes.object.isRequired,
   focusField: PropTypes.string.isRequired,
   activeTab: PropTypes.string.isRequired,
   deployErrors: PropTypes.object,
   onFormDataChange: PropTypes.func.isRequired,
   onFormErrorChange: PropTypes.func.isRequired,
   handleActiveTabChange: PropTypes.func.isRequired,
-  handleFocusFieldChange: PropTypes.func.isRequired
+  handleFocusFieldChange: PropTypes.func.isRequired,
+  defaultConfigWarning: PropTypes.string
 };
 
 module.exports = FrameworkConfigurationForm;

--- a/src/js/components/FrameworkConfigurationReviewScreen.js
+++ b/src/js/components/FrameworkConfigurationReviewScreen.js
@@ -6,7 +6,7 @@ import StringUtil from "#SRC/js/utils/StringUtil";
 import Icon from "#SRC/js/components/Icon";
 import RouterUtil from "#SRC/js/utils/RouterUtil";
 
-const METHODS_TO_BIND = ["reorderResolvedOptions", "getHashMapRenderKeys"];
+const METHODS_TO_BIND = ["getHashMapRenderKeys"];
 
 class FrameworkConfigurationReviewScreen extends React.Component {
   constructor(props) {
@@ -15,16 +15,6 @@ class FrameworkConfigurationReviewScreen extends React.Component {
     METHODS_TO_BIND.forEach(method => {
       this[method] = this[method].bind(this);
     });
-  }
-
-  reorderResolvedOptions(resolvedOptions, config) {
-    const order = Object.keys(config.properties);
-    const orderedResolvedOptions = {};
-    order.forEach(tab => {
-      orderedResolvedOptions[tab] = resolvedOptions[tab];
-    });
-
-    return orderedResolvedOptions;
   }
 
   getHashMapRenderKeys(formData) {

--- a/src/js/pages/catalog/DeployFrameworkConfiguration.js
+++ b/src/js/pages/catalog/DeployFrameworkConfiguration.js
@@ -5,10 +5,10 @@ import deepEqual from "deep-equal";
 import { StoreMixin } from "mesosphere-shared-reactjs";
 import { routerShape } from "react-router";
 import CosmosPackagesStore from "#SRC/js/stores/CosmosPackagesStore";
-import Util from "#SRC/js/utils/Util";
 import FrameworkConfiguration from "#SRC/js/components/FrameworkConfiguration";
 import Loader from "#SRC/js/components/Loader";
 import RequestErrorMsg from "#SRC/js/components/RequestErrorMsg";
+import { getDefaultFormState } from "react-jsonschema-form/lib/utils";
 
 const METHODS_TO_BIND = [
   "handleGoBack",
@@ -52,7 +52,8 @@ class DeployFrameworkConfiguration extends mixin(StoreMixin) {
 
   onCosmosPackagesStorePackageDescriptionSuccess() {
     const packageDetails = CosmosPackagesStore.getPackageDetails();
-    const formData = this.initializeFormDataFromSchema(packageDetails.config);
+    const schema = packageDetails.getConfig();
+    const formData = getDefaultFormState(schema, undefined, schema.definitions);
     this.setState({ packageDetails, formData });
   }
 
@@ -75,24 +76,6 @@ class DeployFrameworkConfiguration extends mixin(StoreMixin) {
 
   onCosmosPackagesStoreInstallError(deployErrors) {
     this.setState({ deployErrors });
-  }
-
-  initializeFormDataFromSchema(value) {
-    if (!Util.isObject(value)) {
-      return value;
-    }
-    if (!value.properties) {
-      return value.default;
-    }
-
-    const defaults = {};
-    Object.keys(value.properties).forEach(property => {
-      defaults[property] = this.initializeFormDataFromSchema(
-        value.properties[property]
-      );
-    });
-
-    return defaults;
   }
 
   handleRun() {


### PR DESCRIPTION
Frameworks that are deployed prior to version 1.10 of DC/OS won't have configuration information saved from `cosmos/service/describe`. This PR handles this in the UI by displaying a warning, and populating the edit flow with default package configuration.

In doing this change, I also refactor this flow a bit by adding some methods to `ServiceUtil` and cleaning up passing props.

**Testing**:
1. Toggle enterprise = true in config.dev.json
2. Since we don't have access to old running services, and I don't want to change the fixture to be this case, manually paste this code into **line 44 of src/js/pages/EditFrameworkConfiguration**:
```
fullPackage.resolvedOptions = null;
```
4. Click the edit on any running framework
5. The form will show the default framework configuration values, and show the warning message.

Closes DCOS-19688

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
