### PR TITLE
feat(EditServiceModal): re-enable framework editing

### DIFF
--- a/plugins/services/src/js/components/modals/EditServiceModal.js
+++ b/plugins/services/src/js/components/modals/EditServiceModal.js
@@ -6,7 +6,6 @@ import CreateServiceModal
   from "#PLUGINS/services/src/js/components/modals/CreateServiceModal";
 import Framework from "#PLUGINS/services/src/js/structs/Framework";
 import DCOSStore from "#SRC/js/stores/DCOSStore";
-import { Hooks } from "PluginSDK";
 
 class EditServiceModal extends Component {
   render() {
@@ -14,12 +13,7 @@ class EditServiceModal extends Component {
     const serviceID = decodeURIComponent(id);
     const service = DCOSStore.serviceTree.findItemById(serviceID);
 
-    // when API migrated: https://jira.mesosphere.com/browse/DCOS-19824
-    // also re-add "Edit Action" tests in ServiceActions-cy
-    if (
-      service instanceof Framework &&
-      Hooks.applyFilter("hasCosmosServiceUpdateAPI", false)
-    ) {
+    if (service instanceof Framework) {
       return <EditFrameworkConfiguration {...this.props} />;
     }
 


### PR DESCRIPTION
`$ git revert e5d7402913d0cb7f2aa05a2332f67811b1397209`. The service update API is migrated, so we can reenable this feature. Related PR in private-plugins: https://github.com/mesosphere/dcos-ui-plugins-private/pull/702

Hold merge until this is merged: https://github.com/dcos/dcos/pull/2194

**Test:** 
- use this open cluster: http://ahoskins-elasticl-1dccl5gxjpkxp-1189911906.us-west-2.elb.amazonaws.com/
- make sure you can edit and update a running framework

Closes DCOS-19824

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
