### PR TITLE
fix(Jenkinsfile): adjust timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
   }
 
   options {
-    timeout(time: 1, unit: 'HOURS')
+    timeout(time: 3, unit: 'HOURS')
   }
 
   stages {


### PR DESCRIPTION
Some of our jobs take rather long to complete which esp. in combination with retires leads to false negatives. This PR increase the timeout to reduce the number of false negatives due to timeouts. I thought about removing the timeout but decided that we should always investigate what happened if a pipeline runs for longer than 3 hours and thus kept the timeout. The timeout also saves us form rouge builds that run for ever, an issue other teams ran into.