### PR TITLE
fix(launch-cluster): add missing exhibitor_storage_backend config

### DIFF
--- a/system-tests/_scripts/launch-cluster.sh
+++ b/system-tests/_scripts/launch-cluster.sh
@@ -29,6 +29,7 @@ dcos_config:
     - 8.8.8.8
   dns_search: mesos
   master_discovery: static
+  exhibitor_storage_backend: static
 num_masters: 1
 num_private_agents: 1
 num_public_agents: 1


### PR DESCRIPTION
Add missing `exhibitor_storage_backend` config as the generate config command will otherwise fail. 