### PR TITLE
fix(volumes): fix any volume to external conversion

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Volumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Volumes.js
@@ -93,16 +93,20 @@ function reduceVolumes(state, { type, path, value }) {
       switch (type) {
         case ADD_ITEM:
           this.volumes.push(
-            value || {
-              containerPath: null,
-              persistent: { size: null, profileName: null },
-              external: {
-                name: null,
-                provider: "dvdi",
-                options: { "dvdi/driver": "rexray" }
+            Object.assign(
+              {},
+              {
+                containerPath: null,
+                persistent: { size: null, profileName: null },
+                external: {
+                  name: null,
+                  provider: "dvdi",
+                  options: { "dvdi/driver": "rexray" }
+                },
+                mode: "RW"
               },
-              mode: "RW"
-            }
+              value
+            )
           );
           break;
         case REMOVE_ITEM:

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Volumes-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Volumes-test.js
@@ -156,7 +156,8 @@ describe("Volumes", function() {
           containerPath: "test",
           external: {
             name: "test",
-            size: null
+            provider: "dvdi",
+            options: { "dvdi/driver": "rexray" }
           }
         }
       ]);


### PR DESCRIPTION
This makes sure that the right external fields are getting set after a JSON has been parsed.

To test create a service with a local volume (persistent, dss, host) and then edit something in the
JSON editor or edit a application with a local volume and try to change that volume to a external
volume. The JSON should now consist of the provider information.