### PR TITLE
refactor(launch-cluster): adjust scrip to improve compatibility

### DIFF
--- a/system-tests/_scripts/launch-cluster.sh
+++ b/system-tests/_scripts/launch-cluster.sh
@@ -52,5 +52,5 @@ fi
 echo "http://$(dcos-launch describe -i ${CLUSTER_INFO} | python -c \
                 'import sys, json; \
                  contents = json.load(sys.stdin); \
-                 print(contents["masters"][0]["public_ip"], end="")')"
+                 sys.stdout.write(str(contents["masters"][0]["public_ip"]))')"
 exit 0

--- a/system-tests/_scripts/launch-cluster.sh
+++ b/system-tests/_scripts/launch-cluster.sh
@@ -29,6 +29,7 @@ dcos_config:
     - 8.8.8.8
   dns_search: mesos
   master_discovery: static
+  exhibitor_storage_backend: static
 num_masters: 1
 num_private_agents: 1
 num_public_agents: 1


### PR DESCRIPTION

---
⚠️  _This PR includea changes that will be introduced with #2594._ 

---

Adjust the python call to output the "public_ip" to use `sys.stdout` instead of print to make the call compatible with both python2 as well as python3