### PR TITLE
fix(volumes): fix parser to ignore unknown volumes

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/UnknownVolumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/UnknownVolumes.js
@@ -12,7 +12,8 @@ module.exports = {
         return (
           item.persistent == null &&
           item.external == null &&
-          item.hostPath == null
+          item.hostPath == null &&
+          item.mode == null
         );
       })
       .reduce(function(memo, item) {

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Volumes-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Volumes-test.js
@@ -419,6 +419,45 @@ describe("Volumes", function() {
         expect(Volumes.JSONParser({})).toEqual([]);
       });
 
+      it("returns an empty array for unknown values", function() {
+        const state = {
+          container: {
+            volumes: [
+              {
+                test: "RW"
+              }
+            ]
+          }
+        };
+        expect(Volumes.JSONParser(state)).toEqual([]);
+      });
+
+      it("returns an array consisting of one transaction", function() {
+        const state = {
+          container: {
+            volumes: [
+              {
+                mode: "RW"
+              }
+            ]
+          }
+        };
+        expect(Volumes.JSONParser(state)).toEqual([
+          {
+            type: ADD_ITEM,
+            value: {
+              mode: "RW"
+            },
+            path: ["volumes"]
+          },
+          {
+            type: SET,
+            value: "RW",
+            path: ["volumes", 0, "mode"]
+          }
+        ]);
+      });
+
       it("should contain the transaction for one local volume", function() {
         const state = {
           container: {


### PR DESCRIPTION
This fixes the JSON parser for volumes to ignore volumes of type unknown.

To test use this JSON

```
{
  "id": "/",
  "instances": 1,
  "portDefinitions": [],
  "container": {
    "type": "DOCKER",
    "volumes": [
    {
      "hostPath": "s",
      "mode": "RW"
    },
    {
      "mode": "RW"
    }
    ]
  },
  "cpus": 0.1,
  "mem": 128,
  "requirePorts": false,
  "networks": [],
  "healthChecks": [],
  "fetch": [],
  "constraints": []
}
```

If you edit the JSON and then the form and then the JSON again, only one volume should exist in the form.