### PR TITLE
DCOS_OSS-2017 - fixes the description of the IS operator

### DIFF
--- a/plugins/services/src/js/constants/OperatorTypes.js
+++ b/plugins/services/src/js/constants/OperatorTypes.js
@@ -36,7 +36,7 @@ const OperatorTypes = {
     tooltipContent: null,
     helpContent: DEFAULT_HELP,
     name: "Is",
-    description: "Run app tasks on nodes that share a certain attribute ID"
+    description: "Run app tasks on nodes having attribute ID with a specific value"
   },
   LIKE: {
     requiresValue: true,


### PR DESCRIPTION
The current description for the IS operator is a copy and paste from the CLUSTER one. Because of that, based on [Marathon Documentation](https://github.com/mesosphere/marathon/blob/master/docs/docs/constraints.md) we are providing an adequate description.

![image](https://user-images.githubusercontent.com/10524/34522898-40384500-f095-11e7-936d-c1ed953b41ff.png)