### PR TITLE
fix(package.json): use github dep for eslint-config-dcos

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "conventional-changelog-lint-config-angular": "0.4.1",
     "css-loader": "0.23.1",
     "eslint": "3.15.0",
-    "eslint-config-dcos": "0.2.0",
+    "eslint-config-dcos": "github:dcos/javascript#v0.2.1",
     "eslint-plugin-compat": "1.0.2",
     "eslint-plugin-destructuring": "2.1.0",
     "eslint-plugin-import": "1.13.0",


### PR DESCRIPTION
The package eslint-config-dcos is not on npm. So we can't use plain version.
It went undetected because `npm install` relies on npm-shrinkwrap.json

Introduced https://github.com/dcos/dcos-ui/commit/d7e679f3df5a69621d71d9baac5f92d50e4b45e8#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L88
