### PR TITLE
DCOS-20070 - restores the close X on all form groups

### DIFF
--- a/src/js/components/form/FormGroupContainer.js
+++ b/src/js/components/form/FormGroupContainer.js
@@ -17,7 +17,7 @@ const FormGroupContainer = props => {
           wrapText={true}
         >
           <a className="button button-primary-link" onClick={props.onRemove}>
-            <Icon id="close" color="grey" size="mini" family="mini" />
+            <Icon id="close" color="grey" size="tiny" family="tiny" />
           </a>
         </Tooltip>
       </div>


### PR DESCRIPTION
A previous consistency change on 44c47001291c15da5ce21b68f00da3d65a60ce6c added an invalid `family` value to the icons on all FormGroupContainers. 

This reverts it, as shown in the examples below. All icons "X" to close should be appearing on forms now.

I believe there is a refactor on the Icon component properties needed, out of the scope of this PR, that is proposed here: https://jira.mesosphere.com/browse/DCOS-20134

Volumes Form:
![image](https://user-images.githubusercontent.com/10524/34565372-e7728ff4-f15a-11e7-9293-1355cb9b8489.png)

Health Check Form:
![image](https://user-images.githubusercontent.com/10524/34565392-02b147d8-f15b-11e7-8af3-592ac7a4c421.png)

Questions:
@weblancaster - Shouldn't we have a test for that already? @juliangieseke mentioned that you said something about deactivating a test about this topic. I personally believe that it is important to assure that the deletion function is always present, and hence this needs a test.

  