### PR TITLE
DCOS-19585: Volumes Table Single Container Overview

### DIFF
--- a/plugins/services/src/js/components/VolumeTable.js
+++ b/plugins/services/src/js/components/VolumeTable.js
@@ -24,9 +24,9 @@ class VolumeTable extends React.Component {
         id: volume.getId(),
         host: volume.getHost(),
         type: volume.getType(),
+        profile: volume.getProfile(),
         path: volume.getContainerPath(),
         size: volume.getSize(),
-        mode: volume.getMode(),
         status: volume.getStatus()
       };
     });
@@ -40,7 +40,6 @@ class VolumeTable extends React.Component {
         <col style={{ width: "10%" }} />
         <col style={{ width: "10%" }} />
         <col style={{ width: "10%" }} />
-        <col style={{ width: "5%" }} />
         <col style={{ width: "10%" }} />
       </colgroup>
     );
@@ -49,7 +48,8 @@ class VolumeTable extends React.Component {
   getColumnClassName(prop, sortBy, row) {
     return classNames({
       active: prop === sortBy.prop,
-      clickable: row == null
+      clickable: row == null,
+      "text-overflow": prop === "profile"
     });
   }
 
@@ -62,10 +62,10 @@ class VolumeTable extends React.Component {
     const headingStrings = {
       id: "ID",
       host: "Host",
-      type: "Type",
+      type: "Volume Type",
+      profile: "Volume Profile",
       path: "Path",
       size: "Size",
-      mode: "Mode",
       status: "Status"
     };
 
@@ -101,6 +101,12 @@ class VolumeTable extends React.Component {
       {
         className: this.getColumnClassName,
         heading: this.getColumnHeading,
+        prop: "profile",
+        sortable: true
+      },
+      {
+        className: this.getColumnClassName,
+        heading: this.getColumnHeading,
         prop: "path",
         sortable: true
       },
@@ -108,12 +114,6 @@ class VolumeTable extends React.Component {
         className: this.getColumnClassName,
         heading: this.getColumnHeading,
         prop: "size",
-        sortable: true
-      },
-      {
-        className: this.getColumnClassName,
-        heading: this.getColumnHeading,
-        prop: "mode",
         sortable: true
       },
       {

--- a/plugins/services/src/js/constants/VolumeProfile.js
+++ b/plugins/services/src/js/constants/VolumeProfile.js
@@ -1,0 +1,5 @@
+var VolumeProfile = {
+  UNAVAILABLE: "Not Available"
+};
+
+module.exports = VolumeProfile;

--- a/plugins/services/src/js/structs/Volume.js
+++ b/plugins/services/src/js/structs/Volume.js
@@ -1,5 +1,6 @@
 import Item from "#SRC/js/structs/Item";
 import VolumeStatus from "../constants/VolumeStatus";
+import VolumeProfile from "../constants/VolumeProfile";
 
 class Volume extends Item {
   getContainerPath() {
@@ -16,6 +17,10 @@ class Volume extends Item {
 
   getMode() {
     return this.get("mode");
+  }
+
+  getProfile() {
+    return this.get("profileName") || VolumeProfile.UNAVAILABLE;
   }
 
   getStatus() {

--- a/plugins/services/src/js/structs/__tests__/Volume-test.js
+++ b/plugins/services/src/js/structs/__tests__/Volume-test.js
@@ -1,6 +1,7 @@
 const Volume = require("../Volume");
 const VolumeStatus = require("../../constants/VolumeStatus");
 const VolumeTypes = require("../../constants/VolumeTypes");
+const VolumeProfile = require("../../constants/VolumeProfile");
 
 describe("Volume", function() {
   describe("#getContainerPath", function() {
@@ -40,6 +41,22 @@ describe("Volume", function() {
       });
 
       expect(service.getMode()).toEqual("rw");
+    });
+  });
+
+  describe("#getType", function() {
+    it("should return unavailable if no profile is defined", function() {
+      const service = new Volume({});
+
+      expect(service.getProfile()).toEqual(VolumeProfile.UNAVAILABLE);
+    });
+
+    it("returns correct profile", function() {
+      const service = new Volume({
+        profileName: "SSD"
+      });
+
+      expect(service.getProfile()).toEqual("SSD");
     });
   });
 

--- a/tests/pages/services/VolumesTable-cy.js
+++ b/tests/pages/services/VolumesTable-cy.js
@@ -27,9 +27,9 @@ describe("Volumes", function() {
         );
         expect(children[1].textContent).to.equal("10.0.2.93");
         expect(children[2].textContent).to.equal("Persistent");
-        expect(children[3].textContent).to.equal("data-1");
-        expect(children[4].textContent).to.equal("1");
-        expect(children[5].textContent).to.equal("RW");
+        expect(children[3].textContent).to.equal("Not Available");
+        expect(children[4].textContent).to.equal("data-1");
+        expect(children[5].textContent).to.equal("1");
         expect(children[6].textContent).to.equal("Attached");
       });
     });


### PR DESCRIPTION
The goal is to change the overview table as mentioned in the parent issue.

![bildschirmfoto 2018-01-04 um 17 48 31](https://user-images.githubusercontent.com/1337046/34574465-c3a677d0-f177-11e7-93d4-c86e170439d9.png)

I am a bit unsure about the design differences, so I changed no CSS so far to not introduce any inconsistencies, please give me feedback if this is okay. 
Also it would be great to get some feedback on the commit messages 😇 

P.S.: There is one test missing about the profile being set, but that is impossible with mesos not being able to schedule these resources. I think it might make sense to add it later
  