### PR TITLE
fix(MetronomeStore): cleanup deleted jobs

### DIFF
--- a/src/js/stores/MetronomeStore.js
+++ b/src/js/stores/MetronomeStore.js
@@ -165,6 +165,7 @@ class MetronomeStore extends EventEmitter {
           this.emit(METRONOME_JOB_SCHEDULE_UPDATE_SUCCESS, action.jobID);
           break;
         case REQUEST_METRONOME_JOBS_SUCCESS:
+          this.removeOldJobs(action.data);
           action.data.forEach(this.setJob.bind(this));
 
           this.emit(METRONOME_JOBS_CHANGE);
@@ -193,6 +194,16 @@ class MetronomeStore extends EventEmitter {
     }
 
     this.data.jobMap.set(id, job);
+    this.data.jobTree = null;
+  }
+
+  removeOldJobs(jobs) {
+    this.data.jobMap.forEach((job, id) => {
+      if (!jobs.includes(id)) {
+        this.data.jobMap.delete(id);
+      }
+    });
+
     this.data.jobTree = null;
   }
 

--- a/system-tests/jobs/test-jobs.js
+++ b/system-tests/jobs/test-jobs.js
@@ -474,4 +474,51 @@ describe("Jobs", function() {
       .getFormGroupInputFor("Cron Schedule *")
       .should("have.value", "* * * * *");
   });
+
+  it("should remove job from table when deleted", function() {
+    // first create a simple job
+    const jobName = "job-to-delete";
+    const fullJobName = `${Cypress.env("TEST_UUID")}.${jobName}`;
+    const cmdline = "while true; do echo 'test' ; sleep 100 ; done";
+
+    // Visit jobs
+    cy.visitUrl("jobs/overview");
+    cy.get(".button.button-primary-link.button-narrow").click();
+    cy.get(".modal-header").contains("New Job").should("exist");
+
+    // Fill-in the input elements
+    cy.root().getFormGroupInputFor("ID *").type(`{selectall}${fullJobName}`);
+    cy.root().getFormGroupInputFor("Command").type(cmdline);
+
+    // Click create job
+    cy.contains("Create Job").click();
+
+    // Switch to the group that will contain the service
+    cy.visitUrl(`jobs/overview/${Cypress.env("TEST_UUID")}`);
+
+    // Wait for the table and the service to appear
+    cy
+      .get(".page-body-content table")
+      .contains(jobName, { timeout: Timeouts.JOB_DEPLOYMENT_TIMEOUT })
+      .get("a.table-cell-link-primary")
+      .contains(`${jobName}`)
+      .click();
+
+    // open edit screen
+    cy
+      .get(".page-header-actions .dropdown")
+      .click()
+      .get(".dropdown-menu-items")
+      .contains("Delete")
+      .click();
+
+    // click delete
+    cy.get(".modal .button-danger").contains("Delete Job").click();
+
+    // Switch to the group that will contain the service
+    cy.visitUrl(`jobs/overview/${Cypress.env("TEST_UUID")}`);
+
+    // The job should no longer be in the table
+    cy.get(".page-body-content table").contains(jobName).should("not.exist");
+  });
 });


### PR DESCRIPTION
When setting the new jobs, remove the previously deleted jobs from the
`jobMap`.

**Now:**
![screen recording 2018-01-04 at 05 25 pm](https://user-images.githubusercontent.com/1527504/34591727-6c995050-f174-11e7-954c-77838d89747d.gif)


**Before this change:**
![screen recording 2018-01-04 at 05 32 pm](https://user-images.githubusercontent.com/1527504/34591877-5d9c7216-f175-11e7-86d5-e96c775d5ca1.gif)



**Testing**:
1. Checkout this branch
2. Create a job
3. Delete the job
4. It will now delete from the jobs table without needing a page reload

Closes DCOS-20118

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
