### PR TITLE
DCOS_OSS-2011: Add IPv6 to the networks table

### DIFF
--- a/src/js/pages/network/VirtualNetworksTable.js
+++ b/src/js/pages/network/VirtualNetworksTable.js
@@ -37,7 +37,15 @@ class VirtualNetworksTable extends React.Component {
       {
         className: getClassName,
         getValue(overlay) {
-          return overlay.getSubnet();
+          if (overlay.getSubnet() && overlay.getSubnet6()) {
+            return (
+              <span>
+                IPv4: {overlay.getSubnet()}<br />IPv6: {overlay.getSubnet6()}
+              </span>
+            );
+          }
+
+          return overlay.getSubnet() || overlay.getSubnet6();
         },
         headerClassName: getClassName,
         heading,
@@ -47,7 +55,15 @@ class VirtualNetworksTable extends React.Component {
       {
         className: getClassName,
         getValue(overlay) {
-          return overlay.getPrefix();
+          if (overlay.getPrefix() && overlay.getPrefix6()) {
+            return (
+              <span>
+                IPv4: {overlay.getPrefix()}<br />IPv6: {overlay.getPrefix6()}
+              </span>
+            );
+          }
+
+          return overlay.getPrefix() || overlay.getPrefix6();
         },
         headerClassName: getClassName,
         heading,

--- a/src/js/stores/VirtualNetworksStore.js
+++ b/src/js/stores/VirtualNetworksStore.js
@@ -102,10 +102,13 @@ class VirtualNetworksStore extends BaseStore {
     return VirtualNetworksActions.fetch(...arguments);
   }
 
-  processVirtualNetworks({ overlays, vtep_mac_oui, vtep_subnet } = {}) {
+  processVirtualNetworks(
+    { overlays, vtep_mac_oui, vtep_subnet, vtep_subnet6 } = {}
+  ) {
     this.data.overlays = overlays || [];
     this.data.vtep_mac_oui = vtep_mac_oui;
     this.data.vtep_subnet = vtep_subnet;
+    this.data.vtep_subnet6 = vtep_subnet6;
     this.emit(VIRTUAL_NETWORKS_CHANGE);
   }
 

--- a/src/js/structs/Overlay.js
+++ b/src/js/structs/Overlay.js
@@ -21,4 +21,12 @@ module.exports = class Overlay extends Item {
   getSubnet() {
     return this.get("info").subnet;
   }
+
+  getPrefix6() {
+    return this.get("info").prefix6;
+  }
+
+  getSubnet6() {
+    return this.get("info").subnet6;
+  }
 };

--- a/tests/_fixtures/networking/virtual-networks.json
+++ b/tests/_fixtures/networking/virtual-networks.json
@@ -64,10 +64,13 @@
       {
         "name": "vxlan-2",
         "prefix": 24,
-        "subnet": "192.168.128.0/17"
+        "subnet": "192.168.128.0/17",
+        "prefix6": 80,
+        "subnet6": "fd01:b::/64"
       }
     ],
     "vtep_mac_oui": "70:B3:D5:00:00:00",
-    "vtep_subnet": "44.128.0.0/16"
+    "vtep_subnet": "44.128.0.0/16",
+    "vtep_subnet6": "fd01:a::/64"
   }
 }


### PR DESCRIPTION
this adds the functionality to display ipv6 subnets in
the networks overview table

networks now are able to have IPv4 and/or IPV6 subnets, so we need to display both. 

To test this you can turn on fixtures, I've added an IPv6 subnet to one of them.