### PR TITLE
DCOS-20095: Fix Network Task Table to only show running tasks.

### DIFF
--- a/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
+++ b/src/js/pages/network/virtual-network-detail/VirtualNetworkTaskTab.js
@@ -279,7 +279,7 @@ class VirtualNetworkTaskTab extends mixin(StoreMixin) {
       return VirtualNetworkUtil.getEmptyNetworkScreen();
     }
 
-    const tasks = MesosStateStore.getTasksFromVirtualNetworkName(
+    const tasks = MesosStateStore.getRunningTasksFromVirtualNetworkName(
       overlay.getName()
     );
     const filteredTasks = this.getFilteredTasks(tasks, searchString);

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -276,8 +276,8 @@ class MesosStateStore extends GetSetBaseStore {
       .map(task => MesosStateUtil.flagSDKTask(task, service));
   }
 
-  getTasksFromVirtualNetworkName(overlayName) {
-    return MesosStateUtil.getTasksFromVirtualNetworkName(
+  getRunningTasksFromVirtualNetworkName(overlayName) {
+    return MesosStateUtil.getRunningTasksFromVirtualNetworkName(
       this.get("lastMesosState"),
       overlayName
     );

--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -1,8 +1,8 @@
 import { isSDKService } from "#SRC/js/utils/ServiceUtil";
+import TaskStates from "#PLUGINS/services/src/js/constants/TaskStates";
 import PodInstanceState
   from "../../../plugins/services/src/js/constants/PodInstanceState";
 import Util from "./Util";
-import TaskStates from "../../../plugins/services/src/js/constants/TaskStates";
 
 const RESOURCE_KEYS = ["cpus", "disk", "mem"];
 const COMPLETED_TASK_STATES = Object.keys(TaskStates).filter(function(
@@ -110,14 +110,15 @@ const MesosStateUtil = {
     }, {});
   },
 
-  getTasksFromVirtualNetworkName({ tasks = [] } = {}, overlayName) {
+  getRunningTasksFromVirtualNetworkName({ tasks = [] } = {}, overlayName) {
     return tasks.filter(function(task) {
       const appPath = "container.network_infos.0.name";
       const podPath = "statuses.0.container_status.network_infos.0.name";
 
       return (
-        Util.findNestedPropertyInObject(task, appPath) === overlayName ||
-        Util.findNestedPropertyInObject(task, podPath) === overlayName
+        TaskStates[task.state].stateTypes.includes("active") &&
+        (Util.findNestedPropertyInObject(task, appPath) === overlayName ||
+          Util.findNestedPropertyInObject(task, podPath) === overlayName)
       );
     });
   },

--- a/src/js/utils/__tests__/MesosStateUtil-test.js
+++ b/src/js/utils/__tests__/MesosStateUtil-test.js
@@ -127,9 +127,9 @@ describe("MesosStateUtil", function() {
     });
   });
 
-  describe("#getTasksFromVirtualNetworkName", function() {
+  describe("#getRunningTasksFromVirtualNetworkName", function() {
     beforeEach(function() {
-      this.instance = MesosStateUtil.getTasksFromVirtualNetworkName(
+      this.instance = MesosStateUtil.getRunningTasksFromVirtualNetworkName(
         {
           frameworks: [
             { id: "foo" },
@@ -138,9 +138,18 @@ describe("MesosStateUtil", function() {
             { id: "qux" }
           ],
           tasks: [
-            { container: { network_infos: [{ name: "alpha" }] } },
-            { container: { network_infos: [{ name: "alpha" }] } },
-            { container: { network_infos: [{ name: "beta" }] } }
+            {
+              state: "TASK_RUNNING",
+              container: { network_infos: [{ name: "alpha" }] }
+            },
+            {
+              state: "TASK_KILLED",
+              container: { network_infos: [{ name: "alpha" }] }
+            },
+            {
+              state: "TASK_RUNNING",
+              container: { network_infos: [{ name: "beta" }] }
+            }
           ]
         },
         "alpha"
@@ -148,31 +157,33 @@ describe("MesosStateUtil", function() {
     });
 
     it("should handle empty object well", function() {
-      expect(MesosStateUtil.getTasksFromVirtualNetworkName({}, "foo")).toEqual(
-        []
-      );
+      expect(
+        MesosStateUtil.getRunningTasksFromVirtualNetworkName({}, "foo")
+      ).toEqual([]);
     });
 
     it("should throw when a null state is provided", function() {
       expect(function() {
-        MesosStateUtil.getTasksFromVirtualNetworkName(null, "foo");
+        MesosStateUtil.getRunningTasksFromVirtualNetworkName(null, "foo");
       }).toThrow();
     });
 
     it("should handle empty undefined well", function() {
       expect(
-        MesosStateUtil.getTasksFromVirtualNetworkName(undefined, "foo")
+        MesosStateUtil.getRunningTasksFromVirtualNetworkName(undefined, "foo")
       ).toEqual([]);
     });
 
-    it("should filter tasks that doesn't have the overlay name", function() {
-      expect(this.instance.length).toEqual(2);
+    it("should filter running tasks that doesn't have the overlay name", function() {
+      expect(this.instance.length).toEqual(1);
     });
 
-    it("should find tasks from different frameworks", function() {
+    it("should find running tasks from different frameworks", function() {
       expect(this.instance).toEqual([
-        { container: { network_infos: [{ name: "alpha" }] } },
-        { container: { network_infos: [{ name: "alpha" }] } }
+        {
+          state: "TASK_RUNNING",
+          container: { network_infos: [{ name: "alpha" }] }
+        }
       ]);
     });
   });


### PR DESCRIPTION
This fixes the old `MesosStateUtil.getTasksFromVirtualNetworkName` to only return running tasks, also renames it to `getRunningTasksFromVirtualNetworkName`.
 
To test this:
1. create a service with network and multiple instances (>=2)
2. wait for deplyment and scale down
3. go to http://localhost:4200/#/networking/networks/dcos

it should only show the currently running tasks (scaled down number), not all.