### PR TITLE
DCOS-20051: fixes the infinite increase of CPU usage

### DIFF
--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -1,5 +1,8 @@
 import { isSDKService } from "#SRC/js/utils/ServiceUtil";
+
+import StructUtil from "#SRC/js/utils/StructUtil";
 import TaskStates from "#PLUGINS/services/src/js/constants/TaskStates";
+
 import PodInstanceState
   from "../../../plugins/services/src/js/constants/PodInstanceState";
 import Util from "./Util";
@@ -103,7 +106,9 @@ const MesosStateUtil = {
 
         const resources = task.resources;
         if (memo[task.slave_id][frameworkKey] == null) {
-          memo[task.slave_id][frameworkKey] = resources;
+          memo[task.slave_id][frameworkKey] = StructUtil.copyRawObject(
+            resources
+          );
         } else {
           // Aggregates used resources from each executor
           RESOURCE_KEYS.forEach(function(key) {

--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -5,6 +5,7 @@ import PodInstanceState
 import Util from "./Util";
 
 const RESOURCE_KEYS = ["cpus", "disk", "mem"];
+
 const COMPLETED_TASK_STATES = Object.keys(TaskStates).filter(function(
   taskState
 ) {
@@ -80,34 +81,38 @@ const MesosStateUtil = {
   },
 
   /**
+   * Returns resource usage of non completed tasks grouped by Host and Framework
+   *
    * @param  {Object} state A document of mesos state
    * @param  {Array} filter Allows us to filter by framework id
    *   All other frameworks will be put into an 'other' category
    * @returns {Object} A map of frameworks running on host
    */
   getHostResourcesByFramework(state, filter = []) {
-    return (state.tasks || []).reduce(function(memo, task) {
-      if (memo[task.slave_id] == null) {
-        memo[task.slave_id] = {};
-      }
+    return (state.tasks || [])
+      .filter(task => !COMPLETED_TASK_STATES.includes(task.state))
+      .reduce(function(memo, task) {
+        if (memo[task.slave_id] == null) {
+          memo[task.slave_id] = {};
+        }
 
-      let frameworkKey = task.framework_id;
-      if (filter.includes(frameworkKey)) {
-        frameworkKey = "other";
-      }
+        let frameworkKey = task.framework_id;
+        if (filter.includes(frameworkKey)) {
+          frameworkKey = "other";
+        }
 
-      const resources = task.resources;
-      if (memo[task.slave_id][frameworkKey] == null) {
-        memo[task.slave_id][frameworkKey] = resources;
-      } else {
-        // Aggregates used resources from each executor
-        RESOURCE_KEYS.forEach(function(key) {
-          memo[task.slave_id][frameworkKey][key] += resources[key];
-        });
-      }
+        const resources = task.resources;
+        if (memo[task.slave_id][frameworkKey] == null) {
+          memo[task.slave_id][frameworkKey] = resources;
+        } else {
+          // Aggregates used resources from each executor
+          RESOURCE_KEYS.forEach(function(key) {
+            memo[task.slave_id][frameworkKey][key] += resources[key];
+          });
+        }
 
-      return memo;
-    }, {});
+        return memo;
+      }, {});
   },
 
   getRunningTasksFromVirtualNetworkName({ tasks = [] } = {}, overlayName) {

--- a/src/js/utils/__tests__/MesosStateUtil-test.js
+++ b/src/js/utils/__tests__/MesosStateUtil-test.js
@@ -311,16 +311,6 @@ describe("MesosStateUtil", function() {
   describe("#getHostResourcesByFramework", function() {
     beforeEach(function() {
       this.mesosState = {
-        frameworks: [
-          {
-            name: "marathon",
-            id: "marathon_1"
-          },
-          {
-            name: "spark",
-            id: "spark_1"
-          }
-        ],
         tasks: [
           {
             name: "spark",
@@ -431,6 +421,13 @@ describe("MesosStateUtil", function() {
           }
         }
       });
+    });
+
+    it("does not overwrite the resources of the original object", function() {
+      const previousMesosState = JSON.parse(JSON.stringify(this.mesosState));
+      MesosStateUtil.getHostResourcesByFramework(this.mesosState);
+
+      expect(this.mesosState).toEqual(previousMesosState);
     });
   });
 });


### PR DESCRIPTION
Fixes [DCOS-20051](https://jira.mesosphere.com/browse/DCOS-20051) by ignoring completed tasks when asking for the Host resources grouped by Framework.

**Need help**
- There are two uses of `getHostResourcesByFramework`. IMHO with this function name, it should never return results including resources that are completed (TASK_FINISHED, TASK_FAILED), but I am not sure that the second usage at [MesosStateStore](https://github.com/dcos/dcos-ui/blob/8d619d24b32e06d8b5e734fb31d5aed1142436cf/src/js/stores/MesosStateStore.js#L90) relies on that behavior. No unit tests failed because of that anyway.

  