### PR TITLE
DCOS-14753: adds unanchored property to marathon errors

### DIFF
--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -32,14 +32,27 @@ const MarathonAppValidators = {
     if (hasCmd && hasArgs) {
       const notBothMessage = "Please specify only one of `cmd` or `args`";
       const type = PROP_CONFLICT;
+      const isUnanchored = true;
       const variables = {
         feature1: "cmd",
         feature2: "args"
       };
 
       return [
-        { path: ["cmd"], message: notBothMessage, type, variables },
-        { path: ["args"], message: notBothMessage, type, variables }
+        {
+          path: ["cmd"],
+          message: notBothMessage,
+          type,
+          isUnanchored,
+          variables
+        },
+        {
+          path: ["args"],
+          message: notBothMessage,
+          type,
+          isUnanchored,
+          variables
+        }
       ];
     }
 
@@ -85,11 +98,18 @@ const MarathonAppValidators = {
     const variables = {
       names: "cmd, args, container.docker.image"
     };
+    const isUnanchored = true;
 
     return [
-      { path: ["cmd"], message, type, variables },
-      { path: ["args"], message, type, variables },
-      { path: ["container", "docker", "image"], message, type, variables }
+      { path: ["cmd"], message, type, isUnanchored, variables },
+      { path: ["args"], message, type, isUnanchored, variables },
+      {
+        path: ["container", "docker", "image"],
+        message,
+        type,
+        isUnanchored,
+        variables
+      }
     ];
   },
 

--- a/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
@@ -19,6 +19,7 @@ const CMDORDOCKERIMAGE_ERRORS = [
     path: ["cmd"],
     message: "You must specify a command, an argument or a container",
     type: "PROP_MISSING_ONE",
+    isUnanchored: true,
     variables: {
       names: "cmd, args, container.docker.image"
     }
@@ -27,6 +28,7 @@ const CMDORDOCKERIMAGE_ERRORS = [
     path: ["args"],
     message: "You must specify a command, an argument or a container",
     type: "PROP_MISSING_ONE",
+    isUnanchored: true,
     variables: {
       names: "cmd, args, container.docker.image"
     }
@@ -35,6 +37,7 @@ const CMDORDOCKERIMAGE_ERRORS = [
     path: ["container", "docker", "image"],
     message: "You must specify a command, an argument or a container",
     type: "PROP_MISSING_ONE",
+    isUnanchored: true,
     variables: {
       names: "cmd, args, container.docker.image"
     }
@@ -55,6 +58,7 @@ const NOTBOTHCMDARGS_ERRORS = [
     path: ["cmd"],
     message: "Please specify only one of `cmd` or `args`",
     type: "PROP_CONFLICT",
+    isUnanchored: true,
     variables: {
       feature1: "cmd",
       feature2: "args"
@@ -64,6 +68,7 @@ const NOTBOTHCMDARGS_ERRORS = [
     path: ["args"],
     message: "Please specify only one of `cmd` or `args`",
     type: "PROP_CONFLICT",
+    isUnanchored: true,
     variables: {
       feature1: "cmd",
       feature2: "args"

--- a/src/js/utils/ErrorMessageUtil.js
+++ b/src/js/utils/ErrorMessageUtil.js
@@ -17,6 +17,9 @@ const ErrorMessageUtil = {
       return rule.match.exec(pathString);
     });
 
+    if (error.isUnanchored) {
+      return message;
+    }
     if (!rule && !pathString) {
       return message;
     }


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/DCOS-14753

---

This adds a new `unanchored` property to errors which enable the `ErrorMessageUtil` to remove the path from the displayed message.

This change will allow the ErrorAlert to de-duplicate these messages.

Example:
```
cmd: You must specify a command, an argument or a container
args: You must specify a command, an argument or a container
container.docker.image: You must specify a command, an argument or a container
```
becomes
```
You must specify a command, an argument or a container
```