### PR TITLE
fix(PodStorageConfigSection): display DSS type and size

### DIFF
--- a/plugins/services/src/js/service-configuration/PodStorageConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodStorageConfigSection.js
@@ -28,7 +28,7 @@ class PodStorageConfigSection extends React.Component {
         prop: "type"
       },
       {
-        heading: "Size",
+        heading: "Size (MiB)",
         prop: "size"
       },
       {
@@ -66,16 +66,26 @@ class PodStorageConfigSection extends React.Component {
         type = VolumeConstants.type.host;
       }
       if (volume.persistent != null) {
-        type = VolumeConstants.type.localPersistent;
+        if (volume.persistent.profileName != null) {
+          type = VolumeConstants.type.dss;
+        } else {
+          type = VolumeConstants.type.localPersistent;
+        }
       }
       if (Object.keys(volume).length === 1 && volume.name != null) {
         type = VolumeConstants.type.ephemeral;
       }
 
+      let size;
+      if (volume.persistent != null && volume.persistent.size != null) {
+        size = volume.persistent.size;
+      }
+
       const volumeInfo = {
         type,
         volume: volume.name,
-        hostPath: volume.host
+        hostPath: volume.host,
+        size
       };
 
       // Fetch all mounts for this volume in the containers
@@ -128,7 +138,7 @@ class PodStorageConfigSection extends React.Component {
               columns={this.getColumns()}
               data={volumeSummary}
               onEditClick={onEditClick}
-              tabViewID="multivolumes"
+              tabViewID="volumes"
             />
           </MountService.Mount>
         </ConfigurationMapSection>


### PR DESCRIPTION
Three fixes for the volumes pod review screen:
1. Show type as DSS
2. Show a size column
3. Fix the edit button (previously the ID was wrong)

**Before**:
![screen shot 2018-01-11 at 3 34 08 pm](https://user-images.githubusercontent.com/1527504/34852710-e495005c-f6e4-11e7-8727-8cc55954e27b.png)

**After**:
![screen shot 2018-01-11 at 3 32 19 pm](https://user-images.githubusercontent.com/1527504/34852692-c8529210-f6e4-11e7-8b96-1776358c1e39.png)

Closes DCOS-20258

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
