### PR TITLE
DCOS-20252: Add (Local) suffix to NodesTable (& Details Tab)

### DIFF
--- a/plugins/nodes/src/js/components/NodesTable.js
+++ b/plugins/nodes/src/js/components/NodesTable.js
@@ -1,8 +1,7 @@
 import classNames from "classnames";
+import React, { PureComponent } from "react";
 import { Link } from "react-router";
-import PureRender from "react-addons-pure-render-mixin";
 import PropTypes from "prop-types";
-import React from "react";
 import { Table, Tooltip } from "reactjs-components";
 
 import NodesList from "#SRC/js/structs/NodesList";
@@ -20,20 +19,11 @@ const COLOR_CLASSNAMES = {
   disk: "color-3"
 };
 
-var NodesTable = React.createClass({
-  displayName: "NodesTable",
-
-  mixins: [PureRender],
-
-  propTypes: {
-    hosts: PropTypes.instanceOf(NodesList).isRequired
-  },
-
-  getDefaultProps() {
-    return {
-      hosts: new NodesList([])
-    };
-  },
+class NodesTable extends PureComponent {
+  constructor() {
+    super();
+    this.displayName = "NodesTable";
+  }
 
   renderRegion(_prop, node) {
     return (
@@ -41,7 +31,7 @@ var NodesTable = React.createClass({
         {node.getRegionName()}
       </span>
     );
-  },
+  }
 
   renderZone(_prop, node) {
     return (
@@ -49,7 +39,7 @@ var NodesTable = React.createClass({
         {node.getZoneName()}
       </span>
     );
-  },
+  }
 
   renderHeadline(prop, node) {
     let headline = node.get(prop);
@@ -74,10 +64,10 @@ var NodesTable = React.createClass({
         {headline}
       </Link>
     );
-  },
+  }
 
   renderHealth(prop, node) {
-    const requestReceived = this.props.receivedNodeHealthResponse;
+    const requestReceived = this.props.nodeHealthResponse;
 
     if (!requestReceived) {
       return <Loader size="small" type="ballBeat" />;
@@ -90,7 +80,7 @@ var NodesTable = React.createClass({
         {health.title}
       </span>
     );
-  },
+  }
 
   renderTask(prop, node) {
     return (
@@ -98,7 +88,7 @@ var NodesTable = React.createClass({
         {node[prop]}
       </span>
     );
-  },
+  }
 
   renderStats(prop, node) {
     var value = node.getUsageStats(prop).percentage;
@@ -113,7 +103,7 @@ var NodesTable = React.createClass({
         <span className="label">{value}%</span>
       </span>
     );
-  },
+  }
 
   getColumns() {
     const className = ResourceTableUtil.getClassName;
@@ -215,7 +205,7 @@ var NodesTable = React.createClass({
         heading
       }
     ];
-  },
+  }
 
   getColGroup() {
     return (
@@ -230,7 +220,7 @@ var NodesTable = React.createClass({
         <col className="hidden-small-down" />
       </colgroup>
     );
-  },
+  }
 
   getRowAttributes(node) {
     return {
@@ -238,7 +228,7 @@ var NodesTable = React.createClass({
         danger: node.isActive() === false
       })
     };
-  },
+  }
 
   render() {
     const { hosts } = this.props;
@@ -256,6 +246,16 @@ var NodesTable = React.createClass({
       />
     );
   }
-});
+}
+
+NodesTable.propTypes = {
+  hosts: PropTypes.instanceOf(NodesList).isRequired,
+  nodeHealthResponse: PropTypes.bool
+};
+
+NodesTable.defaultProps = {
+  hosts: new NodesList([]),
+  nodeHealthResponse: false
+};
 
 module.exports = NodesTable;

--- a/plugins/nodes/src/js/components/NodesTable.js
+++ b/plugins/nodes/src/js/components/NodesTable.js
@@ -23,12 +23,16 @@ class NodesTable extends PureComponent {
   constructor() {
     super();
     this.displayName = "NodesTable";
+
+    this.renderHealth = this.renderHealth.bind(this);
+    this.renderRegion = this.renderRegion.bind(this);
   }
 
   renderRegion(_prop, node) {
     return (
       <span>
         {node.getRegionName()}
+        {this.props.masterRegion === node.getRegionName() ? " (Local)" : null}
       </span>
     );
   }
@@ -250,12 +254,14 @@ class NodesTable extends PureComponent {
 
 NodesTable.propTypes = {
   hosts: PropTypes.instanceOf(NodesList).isRequired,
-  nodeHealthResponse: PropTypes.bool
+  nodeHealthResponse: PropTypes.bool,
+  masterRegion: PropTypes.string
 };
 
 NodesTable.defaultProps = {
   hosts: new NodesList([]),
-  nodeHealthResponse: false
+  nodeHealthResponse: false,
+  masterRegion: ""
 };
 
 module.exports = NodesTable;

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
@@ -1,6 +1,5 @@
-import PureRender from "react-addons-pure-render-mixin";
+import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
-import React from "react";
 
 import ConfigurationMap from "#SRC/js/components/ConfigurationMap";
 import ConfigurationMapHeading
@@ -17,12 +16,7 @@ import Node from "#SRC/js/structs/Node";
 import StringUtil from "#SRC/js/utils/StringUtil";
 import Units from "#SRC/js/utils/Units";
 
-class NodeDetailTab extends React.Component {
-  constructor() {
-    super(...arguments);
-    this.shouldComponentUpdate = PureRender.shouldComponentUpdate.bind(this);
-  }
-
+class NodeDetailTab extends PureComponent {
   render() {
     const { node } = this.props;
     const resources = node.get("resources");

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
@@ -1,6 +1,9 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 
+import { MESOS_STATE_CHANGE } from "#SRC/js/constants/EventTypes";
+import MesosStateStore from "#SRC/js/stores/MesosStateStore";
+import CompositeState from "#SRC/js/structs/CompositeState";
 import ConfigurationMap from "#SRC/js/components/ConfigurationMap";
 import ConfigurationMapHeading
   from "#SRC/js/components/ConfigurationMapHeading";
@@ -11,12 +14,42 @@ import ConfigurationMapSection
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
 import DateUtil from "#SRC/js/utils/DateUtil";
 import HashMapDisplay from "#SRC/js/components/HashMapDisplay";
-import MesosStateStore from "#SRC/js/stores/MesosStateStore";
 import Node from "#SRC/js/structs/Node";
 import StringUtil from "#SRC/js/utils/StringUtil";
 import Units from "#SRC/js/utils/Units";
 
 class NodeDetailTab extends PureComponent {
+  constructor() {
+    super(...arguments);
+
+    this.onMesosStateChange = this.onMesosStateChange.bind(this);
+
+    this.state = {
+      masterRegion: null
+    };
+  }
+
+  componentDidMount() {
+    MesosStateStore.addChangeListener(
+      MESOS_STATE_CHANGE,
+      this.onMesosStateChange
+    );
+    this.onMesosStateChange();
+  }
+
+  componentWillUnmount() {
+    MesosStateStore.removeChangeListener(
+      MESOS_STATE_CHANGE,
+      this.onMesosStateChange
+    );
+  }
+
+  onMesosStateChange() {
+    this.setState({
+      masterRegion: CompositeState.getMasterNode().getRegionName()
+    });
+  }
+
   render() {
     const { node } = this.props;
     const resources = node.get("resources");
@@ -63,6 +96,9 @@ class NodeDetailTab extends PureComponent {
               </ConfigurationMapLabel>
               <ConfigurationMapValue>
                 {node.getRegionName()}
+                {this.state.masterRegion === node.getRegionName()
+                  ? " (Local)"
+                  : null}
               </ConfigurationMapValue>
             </ConfigurationMapRow>
             <ConfigurationMapRow>

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -65,7 +65,7 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
     return (
       <NodesTable
         hosts={filteredNodes}
-        receivedNodeHealthResponse={receivedNodeHealthResponse}
+        nodeHealthResponse={receivedNodeHealthResponse}
       />
     );
   }

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -29,6 +29,10 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
     ];
   }
 
+  componentWillMount() {
+    this.onStateStoreSuccess();
+  }
+
   componentWillReceiveProps(nextProps) {
     const { location: { query }, hosts } = nextProps;
     const filters = {
@@ -61,14 +65,20 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
     });
   }
 
+  onStateStoreSuccess() {
+    this.setState({
+      masterRegion: CompositeState.getMasterNode().getRegionName()
+    });
+  }
+
   render() {
-    const { nodeHealthResponse, filteredNodes } = this.state;
+    const { nodeHealthResponse, filteredNodes, masterRegion } = this.state;
 
     return (
       <NodesTable
         hosts={filteredNodes}
         nodeHealthResponse={nodeHealthResponse}
-        masterRegion={CompositeState.getMasterNode().getRegionName()}
+        masterRegion={masterRegion}
       />
     );
   }

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -15,7 +15,7 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
     this.state = {
       filteredNodes: new NodesList([]),
       filters: { health: "all", name: "", service: null },
-      receivedNodeHealthResponse: false,
+      nodeHealthResponse: false,
       masterRegion: null
     };
     this.store_listeners = [
@@ -57,17 +57,17 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
   onNodeHealthStoreSuccess() {
     this.setState({
       filteredNodes: this.getFilteredNodes(),
-      receivedNodeHealthResponse: true
+      nodeHealthResponse: true
     });
   }
 
   render() {
-    const { receivedNodeHealthResponse, filteredNodes } = this.state;
+    const { nodeHealthResponse, filteredNodes } = this.state;
 
     return (
       <NodesTable
         hosts={filteredNodes}
-        nodeHealthResponse={receivedNodeHealthResponse}
+        nodeHealthResponse={nodeHealthResponse}
         masterRegion={CompositeState.getMasterNode().getRegionName()}
       />
     );

--- a/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
+++ b/plugins/nodes/src/js/pages/nodes/nodes-table/NodesTableContainer.js
@@ -15,7 +15,8 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
     this.state = {
       filteredNodes: new NodesList([]),
       filters: { health: "all", name: "", service: null },
-      receivedNodeHealthResponse: false
+      receivedNodeHealthResponse: false,
+      masterRegion: null
     };
     this.store_listeners = [
       {
@@ -23,7 +24,8 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
         listenAlways: false,
         name: "nodeHealth",
         suppressUpdate: true
-      }
+      },
+      { name: "state", events: ["success"], suppressUpdate: false }
     ];
   }
 
@@ -66,6 +68,7 @@ class NodesTableContainer extends mixin(StoreMixin, QueryParamsMixin) {
       <NodesTable
         hosts={filteredNodes}
         nodeHealthResponse={receivedNodeHealthResponse}
+        masterRegion={CompositeState.getMasterNode().getRegionName()}
       />
     );
   }


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/DCOS-20252

Not sure if this is the best way to archive this, so please tell me if there is a better way 🤔 

---

I sneaked in a little refactoring of `NodeTables` because I had to touch it anyway 👍 

---

After addressing the comments, this PRs scope increased a little bit. 
On this branch it should display `(Local)` for regions (but not zones) on all of these pages **after reloading on the page** (to clear old state):
- /nodes
- /nodes/<NODE_ID>/tasks
- /nodes/<NODE_ID>/tasks/<TASK_ID>/details [*]
- /nodes/<NODE_ID>/details

[*] this one is broken - go to logs and then back to details, @Fabs already created a ticket for this issue