### PR TITLE
DCOS-20253: Fix Nodes Table Spacing

### DIFF
--- a/plugins/nodes/src/js/components/NodesTable.js
+++ b/plugins/nodes/src/js/components/NodesTable.js
@@ -219,14 +219,14 @@ var NodesTable = React.createClass({
   getColGroup() {
     return (
       <colgroup>
-        <col />
-        <col />
-        <col />
-        <col style={{ width: "150px" }} />
-        <col style={{ width: "90px" }} />
-        <col className="hidden-small-down" />
-        <col className="hidden-small-down" />
-        <col className="hidden-small-down" />
+        <col className="node-table--col-hostname" />
+        <col className="node-table--col-region" />
+        <col className="node-table--col-zone" />
+        <col className="node-table--col-health" />
+        <col className="node-table--col-tasks" />
+        <col className="node-table--col-cpus hidden-small-down" />
+        <col className="node-table--col-mem hidden-small-down" />
+        <col className="node-table--col-disk hidden-small-down" />
       </colgroup>
     );
   },
@@ -245,7 +245,7 @@ var NodesTable = React.createClass({
     return (
       <Table
         buildRowOptions={this.getRowAttributes}
-        className="node-table table table-flush table-borderless-outer table-borderless-inner-columns table-hover flush-bottom"
+        className="nodes-table table table-flush table-borderless-outer table-borderless-inner-columns table-hover flush-bottom"
         colGroup={this.getColGroup()}
         columns={this.getColumns()}
         containerSelector=".gm-scroll-view"

--- a/plugins/nodes/src/js/components/NodesTable.js
+++ b/plugins/nodes/src/js/components/NodesTable.js
@@ -36,7 +36,7 @@ var NodesTable = React.createClass({
 
   renderRegion(_prop, node) {
     return (
-      <span>
+      <span title={node.getRegionName()}>
         {node.getRegionName()}
       </span>
     );
@@ -44,7 +44,7 @@ var NodesTable = React.createClass({
 
   renderZone(_prop, node) {
     return (
-      <span>
+      <span title={node.getZoneName()}>
         {node.getZoneName()}
       </span>
     );
@@ -70,7 +70,7 @@ var NodesTable = React.createClass({
 
     return (
       <Link className="table-cell-link-primary" to={`/nodes/${nodeID}`}>
-        {headline}
+        <span title={headline}>{headline}</span>
       </Link>
     );
   },

--- a/src/styles/components/nodes-table/styles.less
+++ b/src/styles/components/nodes-table/styles.less
@@ -1,0 +1,13 @@
+& when (@nodes-table-enabled) {
+
+  .nodes-table {
+
+    col.node-table--col-health {
+      width: 150px;
+    }
+
+    col.node-table--col-tasks {
+      width: 90px;
+    }
+  }
+}

--- a/src/styles/components/nodes-table/variables.less
+++ b/src/styles/components/nodes-table/variables.less
@@ -1,0 +1,1 @@
+@nodes-table-enabled: true;

--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -106,7 +106,10 @@
       // This property is necessary for table cells to respect the text-overflow
       // property. http://stackoverflow.com/questions/9789723/css-text-overflow-in-a-table-cell
       max-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
       vertical-align: middle;
+      white-space: nowrap;
 
       & when not (@table-cell-content-margin-horizontal = null) {
 

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -380,6 +380,11 @@
 @import 'components/nodes-grid-view/variables.less';
 @import 'components/nodes-grid-view/styles.less';
 
+// Nodes Table
+
+@import 'components/nodes-table/variables.less';
+@import 'components/nodes-table/styles.less';
+
 // Panel
 
 @import 'components/panel/variables.less';

--- a/tests/pages/nodes/node/HealthTab-cy.js
+++ b/tests/pages/nodes/node/HealthTab-cy.js
@@ -9,7 +9,7 @@ describe("Node Health Tab [0fa]", function() {
   context("Navigate to tab [0fb]", function() {
     it("navigates to health tab [0fc]", function() {
       cy.visitUrl({ url: "/nodes", identify: true, fakeAnalytics: true });
-      cy.get("tr a").eq(0).click();
+      cy.get("tr a").eq(0).click({ force: true });
       cy.get(".menu-tabbed-item").contains("Health").click();
 
       cy.hash().should("match", /nodes\/[a-zA-Z0-9-]+/);
@@ -22,7 +22,7 @@ describe("Node Health Tab [0fa]", function() {
   context("Health Tab [0fd]", function() {
     beforeEach(function() {
       cy.visitUrl({ url: "/nodes", identify: true, fakeAnalytics: true });
-      cy.get("tr a").eq(0).click();
+      cy.get("tr a").eq(0).click({ force: true });
       cy.get(".menu-tabbed-item").contains("Health").click();
 
       cy

--- a/tests/pages/nodes/node/NodeDetail-cy.js
+++ b/tests/pages/nodes/node/NodeDetail-cy.js
@@ -16,7 +16,7 @@ describe("Nodes Detail Page", function() {
         .should(function($row) {
           nodeName = $row[0].textContent;
         })
-        .click();
+        .click({ force: true });
 
       cy.hash().should("match", /nodes\/[a-zA-Z0-9-]+/);
       cy.get(".page-header").should(function($title) {

--- a/tests/pages/services/VolumesTable-cy.js
+++ b/tests/pages/services/VolumesTable-cy.js
@@ -42,7 +42,7 @@ describe("Volumes", function() {
       cy
         .get(".table tbody tr a")
         .contains("sleep#data-1#c1fbf257-efb2-11e6-a361-5edc614b8201")
-        .click();
+        .click({ force: true });
     });
 
     it("routes to the volume details by id", function() {


### PR DESCRIPTION
This fixes the sizing issue in the nodes table. Now the text is rightly abbreviated if the column is to small.

![image](https://user-images.githubusercontent.com/156010/34940830-6f04f576-f9f1-11e7-9d3e-605c645aa12c.png)
