### PR TITLE
DCOS-20158: Backport marked fix to 1.9

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5635,9 +5635,9 @@
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
     },
     "marked": {
-      "version": "0.3.5",
-      "from": "marked@0.3.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz"
+      "version": "0.3.12",
+      "from": "marked@0.3.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz"
     },
     "marked-terminal": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "less-loader": "2.2.3",
     "license-checker": "5.1.2",
     "localStorage": "1.0.3",
-    "marked": "0.3.5",
+    "marked": "0.3.12",
     "node-libs-browser": "1.0.0",
     "postcss": "5.0.21",
     "postcss-loader": "0.8.2",


### PR DESCRIPTION
This puts the port introduced in https://github.com/dcos/dcos-ui/pull/2631 to the `1.9` release.

**Checklist**
- [X] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
