### PR TITLE
DCOS_OSS-1888: Fix input in ServicesResumeModal to update value when changed…

### DIFF
--- a/plugins/services/src/js/components/modals/ServiceResumeModal.js
+++ b/plugins/services/src/js/components/modals/ServiceResumeModal.js
@@ -18,7 +18,7 @@ class ServiceResumeModal extends React.Component {
     super(...arguments);
 
     this.state = {
-      instancesFieldValue: null,
+      instancesFieldValue: 1,
       errorMsg: null
     };
 
@@ -39,7 +39,12 @@ class ServiceResumeModal extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { errors } = nextProps;
+    const { errors, open } = nextProps;
+
+    if (open && !this.props.open) {
+      this.setState({ instancesFieldValue: 1 });
+    }
+
     if (!errors) {
       this.setState({ errorMsg: null });
 
@@ -120,7 +125,7 @@ class ServiceResumeModal extends React.Component {
               name="instances"
               onChange={this.handleInstancesFieldChange}
               type="number"
-              value="1"
+              value={this.state.instancesFieldValue}
             />
           </FormGroup>
         </FormRow>


### PR DESCRIPTION
the input value was hardcoded to 1 before 😲

test: create an app, stop it, resume it, stop it, resume it. the resume modal should always have "1" when opened and reflect all changes made by the user.