### PR TITLE
chore(cypress): do not upload video when tests pass

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -8,5 +8,7 @@
   "integrationFolder": "tests",
   "projectId": "a209b1cd-e44f-47a4-b22c-d8f26649f43f",
   "supportFile": "tests/_support",
-  "waitForAnimations": true
+  "waitForAnimations": true,
+  "videoUploadOnPasses": false,
+  "numTestsKeptInMemory": 0
 }


### PR DESCRIPTION
`--config videoUploadOnPasses=false,numTestsKeptInMemory=0` CLI command doesn't seem to be working, let's try adding it to the config file. With the settings cypress won't compress/upload video when test are green saving precious minutes. `numTestsKeptInMemory` should also reduce the memory footprint