### PR TITLE
refactor(tables): fix purple links in table

### DIFF
--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -251,10 +251,13 @@ class TaskTable extends React.Component {
   }
 
   renderHeadline(options) {
-    const anchorClasses = classNames("text-overflow", {
-      "table-cell-link-primary": options.primary,
-      "table-cell-link-secondary": options.secondary
-    });
+    const anchorClasses = classNames(
+      {
+        "table-cell-link-primary": options.primary,
+        "table-cell-link-secondary": options.secondary
+      },
+      "text-overflow"
+    );
 
     return (prop, task) => {
       const title = task[prop];


### PR DESCRIPTION
Problem: Table columns that have links should not have purple styling. Too overwhelming to have all links colored purple. In service detail views the task list has purple links. [See example](https://cl.ly/1D0z0e2d0C2y)

What was changed: Made the "table-cell-link-primary" the first class on the link. [Here's what it looks like now. ](https://cl.ly/3N3s443R0T1E)

Closes [DCOS_OSS-2057 ](https://jira.mesosphere.com/browse/DCOS_OSS-2057)

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?