### PR TITLE
Improve visual hierarchy in new service config and review screens

### DIFF
--- a/plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormAdvancedSection.js
@@ -213,9 +213,9 @@ class ContainerServiceFormAdvancedSection extends Component {
 
     return (
       <div>
-        <h3 className="short-bottom">
+        <h2 className="short-bottom">
           Advanced Settings
-        </h3>
+        </h2>
         <p>Advanced settings related to the runtime you have selected above.</p>
         {this.getContainerSettings()}
         <FormRow>

--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -192,13 +192,13 @@ class EnvironmentFormSection extends Component {
 
     return (
       <div>
-        <h2 className="flush-top short-bottom">
+        <h1 className="flush-top short-bottom">
           <FormGroupHeading>
             <FormGroupHeadingContent primary={true}>
               Environment
             </FormGroupHeadingContent>
           </FormGroupHeading>
-        </h2>
+        </h1>
         <p>
           Configure any environment values to be attached to each instance that is launched.
         </p>

--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -202,7 +202,7 @@ class EnvironmentFormSection extends Component {
         <p>
           Configure any environment values to be attached to each instance that is launched.
         </p>
-        <h3 className="short-bottom">
+        <h2 className="short-bottom">
           <FormGroupHeading>
             <FormGroupHeadingContent primary={true}>
               Environment Variables
@@ -218,7 +218,7 @@ class EnvironmentFormSection extends Component {
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>
-        </h3>
+        </h2>
         <p>
           Set up environment variables for each instance your service launches.
         </p>
@@ -234,7 +234,7 @@ class EnvironmentFormSection extends Component {
             </AddButton>
           </FormGroup>
         </FormRow>
-        <h3 className="short-bottom">
+        <h2 className="short-bottom">
           <FormGroupHeading>
             <FormGroupHeadingContent primary={true}>
               Labels
@@ -250,7 +250,7 @@ class EnvironmentFormSection extends Component {
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>
-        </h3>
+        </h2>
         <p>
           Attach metadata to expose additional information to other services.
         </p>

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -166,9 +166,9 @@ class GeneralServiceFormSection extends Component {
 
     return (
       <div>
-        <h3 className="short-bottom">
+        <h2 className="short-bottom">
           Containers
-        </h3>
+        </h2>
         {containerElements}
         <AddButton
           onClick={this.props.onAddItem.bind(this, {
@@ -203,7 +203,7 @@ class GeneralServiceFormSection extends Component {
 
     return (
       <div>
-        <h3 className="short-bottom">
+        <h2 className="short-bottom">
           <FormGroupHeading>
             <FormGroupHeadingContent primary={true}>
               Container Runtime
@@ -219,7 +219,7 @@ class GeneralServiceFormSection extends Component {
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>
-        </h3>
+        </h2>
         <p>
           The container runtime is responsible for running your service. We
           support the Docker Engine and Universal Container Runtime (UCR).

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -322,9 +322,9 @@ class GeneralServiceFormSection extends Component {
 
     return (
       <div>
-        <h2 className="flush-top short-bottom">
+        <h1 className="flush-top short-bottom">
           {title}
-        </h2>
+        </h1>
         <p>
           Configure your service below. Start by giving your service an ID.
         </p>

--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -486,7 +486,7 @@ class HealthChecksFormSection extends Component {
 
     return (
       <div>
-        <h2 className="flush-top short-bottom">
+        <h1 className="flush-top short-bottom">
           <FormGroupHeading>
             <FormGroupHeadingContent primary={true}>
               Health Checks
@@ -503,7 +503,7 @@ class HealthChecksFormSection extends Component {
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>
-        </h2>
+        </h1>
         <p>
           Health checks may be specified per application to be run against
           the application{"'"}s instances.

--- a/plugins/services/src/js/components/forms/MultiContainerFormAdvancedSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerFormAdvancedSection.js
@@ -29,9 +29,9 @@ const getForcePullSection = function(data, path) {
 const MultiContainerFormAdvancedSection = ({ data, path }) => {
   return (
     <div>
-      <h3 className="short-top short-bottom">
+      <h2 className="short-top short-bottom">
         Advanced Settings
-      </h3>
+      </h2>
       <p>Advanced settings of the container.</p>
       <p>
         {getForcePullSection(data, path)}

--- a/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
@@ -427,7 +427,7 @@ class MultiContainerHealthChecksFormSection extends Component {
       return (
         <div key={container.name}>
           <div className="form-row-element">
-            <h4 className="form-header short-bottom">
+            <h3 className="form-header short-bottom">
               <FormGroupHeading>
                 <FormGroupHeadingContent>
                   <Icon id="container" size="mini" color="purple" />
@@ -436,7 +436,7 @@ class MultiContainerHealthChecksFormSection extends Component {
                   {container.name}
                 </FormGroupHeadingContent>
               </FormGroupHeading>
-            </h4>
+            </h3>
           </div>
           {this.getHealthChecksBody(container, index)}
         </div>

--- a/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
@@ -481,9 +481,9 @@ class MultiContainerHealthChecksFormSection extends Component {
     if (!data.containers || !data.containers.length) {
       return (
         <div>
-          <h2 className="flush-top short-bottom">
+          <h1 className="flush-top short-bottom">
             {heading}
-          </h2>
+          </h1>
           <p>
             {"Please "}
             <a
@@ -500,9 +500,9 @@ class MultiContainerHealthChecksFormSection extends Component {
 
     return (
       <div className="form flush-bottom">
-        <h2 className="form-header flush-top short-bottom">
+        <h1 className="form-header flush-top short-bottom">
           {heading}
-        </h2>
+        </h1>
         <p>
           Health checks may be specified per application to be run against
           the application{"'"}s instances.

--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -381,10 +381,10 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
 
       return (
         <div key={index}>
-          <h4 className="short-bottom">
+          <h3 className="short-bottom">
             <Icon id="container" size="mini" color="purple" />
             {` ${container.name}`}
-          </h4>
+          </h3>
           {this.getServiceContainerEndpoints(endpoints, index)}
           <div>
             <AddButton

--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -479,9 +479,9 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
 
     return (
       <div className="form flush-bottom">
-        <h2 className="flush-top short-bottom">
+        <h1 className="flush-top short-bottom">
           Networking
-        </h2>
+        </h1>
         <p>
           Configure the networking for your service.
         </p>

--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -511,7 +511,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
             <FieldError>{networkError}</FieldError>
           </FormGroup>
         </FormRow>
-        <h3 className="short-bottom">
+        <h2 className="short-bottom">
           <FormGroupHeading>
             <FormGroupHeadingContent primary={true}>
               Service Endpoints
@@ -528,7 +528,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>
-        </h3>
+        </h2>
         <p>
           DC/OS can automatically generate a Service Address to connect to each of your load balanced endpoints
         </p>

--- a/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
@@ -269,7 +269,7 @@ class MultiContainerVolumesFormSection extends Component {
     );
 
     return (
-      <h2 className="flush-top short-bottom">
+      <h1 className="flush-top short-bottom">
         <FormGroupHeading>
           <FormGroupHeadingContent primary={true}>
             Volumes
@@ -285,7 +285,7 @@ class MultiContainerVolumesFormSection extends Component {
             </Tooltip>
           </FormGroupHeadingContent>
         </FormGroupHeading>
-      </h2>
+      </h1>
     );
   }
 

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -609,9 +609,9 @@ class NetworkingFormSection extends mixin(StoreMixin) {
           wrapperClassName="tooltip-wrapper tooltip-block-wrapper"
           wrapText={true}
         >
-          <h3 className="short-bottom muted" key="service-endpoints-header">
+          <h2 className="short-bottom muted" key="service-endpoints-header">
             {heading}
-          </h3>
+          </h2>
           <p key="service-endpoints-description">
             DC/OS can automatically generate a Service Address to connect to each of your load balanced endpoints.
           </p>
@@ -621,9 +621,9 @@ class NetworkingFormSection extends mixin(StoreMixin) {
 
     return (
       <div>
-        <h3 className="short-bottom" key="service-endpoints-header">
+        <h2 className="short-bottom" key="service-endpoints-header">
           {heading}
-        </h3>
+        </h2>
         <p key="service-endpoints-description">
           DC/OS can automatically generate a Service Address to connect to each of your load balanced endpoints.
         </p>

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -726,9 +726,9 @@ class NetworkingFormSection extends mixin(StoreMixin) {
 
     return (
       <div>
-        <h2 className="flush-top short-bottom">
+        <h1 className="flush-top short-bottom">
           Networking
-        </h2>
+        </h1>
         <p>
           Configure the networking for your service.
         </p>

--- a/plugins/services/src/js/components/forms/PlacementSection.js
+++ b/plugins/services/src/js/components/forms/PlacementSection.js
@@ -27,7 +27,7 @@ export default class PlacementSection extends Component {
 
     return (
       <div>
-        <h2 className="flush-top short-bottom">
+        <h1 className="flush-top short-bottom">
           <FormGroupHeading>
             <FormGroupHeadingContent primary={true}>
               Placement Constraints
@@ -43,7 +43,7 @@ export default class PlacementSection extends Component {
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>
-        </h2>
+        </h1>
         <p>
           Constraints control where apps run to allow optimization for either fault tolerance or locality.
         </p>

--- a/plugins/services/src/js/components/forms/VolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/VolumesFormSection.js
@@ -406,7 +406,7 @@ class VolumesFormSection extends Component {
 
     return (
       <div>
-        <h2 className="flush-top short-bottom">
+        <h1 className="flush-top short-bottom">
           <FormGroupHeading>
             <FormGroupHeadingContent primary={true}>
               Volumes
@@ -422,7 +422,7 @@ class VolumesFormSection extends Component {
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>
-        </h2>
+        </h1>
         <p>
           Create a stateful service by configuring a persistent volume. Persistent volumes enable instances to be restarted without data loss.
         </p>

--- a/plugins/services/src/js/components/modals/CreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModal.js
@@ -897,7 +897,7 @@ class CreateServiceModal extends Component {
           open={this.state.isConfirmOpen}
           onClose={this.handleCloseConfirmModal}
           leftButtonText="Cancel"
-          leftButtonClassName="button button-primary-link"
+          leftButtonClassName="button button-primary-link flush-left"
           leftButtonCallback={this.handleCloseConfirmModal}
           rightButtonText="Discard"
           rightButtonClassName="button button-danger"

--- a/plugins/services/src/js/components/modals/CreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModalForm.js
@@ -358,9 +358,9 @@ class CreateServiceModalForm extends Component {
             pathMapping={ServiceErrorPathMapping}
             hideTopLevelErrors={!showAllErrors}
           />
-          <h2 className="flush-top short-bottom">
+          <h1 className="flush-top short-bottom">
             Container
-          </h2>
+          </h1>
           <p>
             Configure your container below. Enter a container image or command you want to run.
           </p>

--- a/plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodPlacementConstraintsConfigSection.js
@@ -55,8 +55,8 @@ class PodPlacementConstraintsConfigSection extends React.Component {
 
     return (
       <div>
-        <ConfigurationMapHeading level={3}>
-          Placement Constraints
+        <ConfigurationMapHeading level={1}>
+          Placement
         </ConfigurationMapHeading>
         <ConfigurationMapSection>
           <MountService.Mount

--- a/plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js
@@ -236,7 +236,7 @@ class ServiceGeneralConfigSection extends ServiceConfigBaseSectionDisplay {
         {
           key: "fetch",
           heading: "Container Artifacts",
-          headingLevel: 3
+          headingLevel: 2
         },
         {
           key: "fetch",

--- a/plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServicePlacementConstraintsConfigSection.js
@@ -52,8 +52,8 @@ class ServicePlacementConstraintsConfigSection extends React.Component {
 
     return (
       <div>
-        <ConfigurationMapHeading level={3}>
-          Placement Constraints
+        <ConfigurationMapHeading level={1}>
+          Placement
         </ConfigurationMapHeading>
         <ConfigurationMapSection>
           <MountService.Mount

--- a/src/js/components/CreateServiceModalServicePickerOptionContent.js
+++ b/src/js/components/CreateServiceModalServicePickerOptionContent.js
@@ -2,9 +2,9 @@ import React from "react";
 
 function CreateServiceModalServicePickerOptionContent({ children }) {
   return (
-    <h5 className="flush text-align-center">
+    <h3 className="flush text-align-center">
       {children}
-    </h5>
+    </h3>
   );
 }
 

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -78,7 +78,7 @@ describe("Service Form Modal", function() {
         cy.get(".menu-tabbed-item").contains("Networking").click();
 
         cy
-          .get(".menu-tabbed-view-container h2")
+          .get(".menu-tabbed-view-container h1")
           .first()
           .should("to.have.text", "Networking");
 
@@ -99,7 +99,7 @@ describe("Service Form Modal", function() {
           .click();
 
         cy
-          .get(".menu-tabbed-view-container h2")
+          .get(".menu-tabbed-view-container h1")
           .first()
           .should("to.have.text", "Networking");
       });
@@ -331,7 +331,7 @@ describe("Service Form Modal", function() {
     });
 
     it("should have four options to choose from", function() {
-      cy.get(".panel-grid h5").should(function(items) {
+      cy.get(".panel-grid h3").should(function(items) {
         const texts = items
           .map(function(i, el) {
             return cy.$(el).text();
@@ -400,7 +400,7 @@ describe("Service Form Modal", function() {
         cy.get(".menu-tabbed-item").contains("Networking").click();
 
         cy
-          .get(".menu-tabbed-view-container h2")
+          .get(".menu-tabbed-view-container h1")
           .first()
           .should("to.have.text", "Networking");
       });
@@ -1537,7 +1537,7 @@ describe("Service Form Modal", function() {
           .get(".menu-tabbed-item-label")
           .eq(0)
           .click()
-          .get(".menu-tabbed-view h2")
+          .get(".menu-tabbed-view h1")
           .contains("Service");
       });
 


### PR DESCRIPTION
With the new CNVS update and UI Kit alignment we've decided to focus on using h1,h2,h3.

This PR updates the headings in the run service flow and review screens. It also fixes other minor bugs.

* H2s > H1s
* H3s > H2s
* H4s > H3s
* Fixed cancel button alignment on dismiss alert
* Fixed uppercase placement labels

It does not fix the hierarchy issues with package configuration (this is slightly more complicated and will be tracked separately).

Before

![image](https://user-images.githubusercontent.com/15963/35019740-5a5f8ad6-fadd-11e7-97c0-b0fb63cfbbc9.png)
![image](https://user-images.githubusercontent.com/15963/35019745-60ed1b3e-fadd-11e7-84b8-4de85ae96214.png)
![image](https://user-images.githubusercontent.com/15963/35019750-67179d72-fadd-11e7-80f9-12ce26566707.png)
![image](https://user-images.githubusercontent.com/15963/35019770-87fa5b60-fadd-11e7-85f6-8a45006cd8a9.png)


After
![image](https://user-images.githubusercontent.com/15963/35019773-8e94d658-fadd-11e7-9efa-51d80d49bb93.png)
![image](https://user-images.githubusercontent.com/15963/35019784-96a3ff54-fadd-11e7-88c4-c28002b178c5.png)
![image](https://user-images.githubusercontent.com/15963/35019793-a101454c-fadd-11e7-9de4-672c8e7b389b.png)
![image](https://user-images.githubusercontent.com/15963/35019817-bb4a4124-fadd-11e7-985b-6b0f83b3252a.png)


