### PR TITLE
DCOS_OSS-2058: Fix running service tooltip width

### DIFF
--- a/plugins/services/src/js/components/ServiceStatusIcon.js
+++ b/plugins/services/src/js/components/ServiceStatusIcon.js
@@ -85,7 +85,6 @@ class ServiceStatusIcon extends Component {
       <Tooltip
         interactive={true}
         content={content}
-        width={250}
         wrapText={true}
         wrapperClassName="tooltip-wrapper"
       >
@@ -124,7 +123,6 @@ class ServiceStatusIcon extends Component {
         <Tooltip
           interactive={true}
           content={this.props.tooltipContent}
-          width={250}
           wrapText={true}
           wrapperClassName="tooltip-wrapper"
         >

--- a/src/styles/components/tooltip/styles.less
+++ b/src/styles/components/tooltip/styles.less
@@ -1,6 +1,7 @@
 & when (@tooltip-enabled) {
 
   .tooltip {
+    max-width: 250px;
     will-change: opacity, transform, visibility;
     z-index: @z-index-tooltip;
 


### PR DESCRIPTION
Tooltips on running service icons had a fixed width which meant there was extra unwanted space in the tooltip.

This PR removes the fixed width for these status tooltips and introduces a max-width for .tooltip components.

Before
![image](https://user-images.githubusercontent.com/15963/35074379-71286628-fba2-11e7-8e49-cb03d678eb86.png)
![image](https://user-images.githubusercontent.com/15963/35074384-75882b40-fba2-11e7-8dbe-8a2b2a1a5436.png)
![image](https://user-images.githubusercontent.com/15963/35074386-7a6a6c2c-fba2-11e7-9b74-91097ec60a73.png)


After
![image](https://user-images.githubusercontent.com/15963/35074393-80b5fb8c-fba2-11e7-9789-5bb68c57beec.png)
![image](https://user-images.githubusercontent.com/15963/35074399-882ce81c-fba2-11e7-9143-80c781a8c515.png)
![image](https://user-images.githubusercontent.com/15963/35074402-8d4da4bc-fba2-11e7-8e44-109288359d53.png)
![image](https://user-images.githubusercontent.com/15963/35074413-93361c6a-fba2-11e7-989d-9af80455a023.png)
