### PR TITLE
DCOS-20376: Fetch master version from api/v1

### DIFF
--- a/plugins/nodes/src/js/pages/__tests__/NodeDetailPage-test.js
+++ b/plugins/nodes/src/js/pages/__tests__/NodeDetailPage-test.js
@@ -40,17 +40,6 @@ describe("NodeDetailPage", function() {
       return [];
     };
 
-    MesosStateStore.get = function(key) {
-      if (key === "lastMesosState") {
-        return {
-          version: "1"
-        };
-      }
-      if (key === "statesProcessed") {
-        return true;
-      }
-    };
-
     MesosStateStore.getNodeFromID = function(id) {
       if (id === "nonExistent") {
         return null;

--- a/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
+++ b/plugins/nodes/src/js/pages/nodes/NodeDetailTab.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
+import { request } from "@dcos/mesos-client";
 
 import { MESOS_STATE_CHANGE } from "#SRC/js/constants/EventTypes";
 import MesosStateStore from "#SRC/js/stores/MesosStateStore";
@@ -17,6 +18,7 @@ import HashMapDisplay from "#SRC/js/components/HashMapDisplay";
 import Node from "#SRC/js/structs/Node";
 import StringUtil from "#SRC/js/utils/StringUtil";
 import Units from "#SRC/js/utils/Units";
+import Loader from "#SRC/js/components/Loader";
 
 class NodeDetailTab extends PureComponent {
   constructor() {
@@ -34,6 +36,12 @@ class NodeDetailTab extends PureComponent {
       MESOS_STATE_CHANGE,
       this.onMesosStateChange
     );
+    request({ type: "GET_VERSION" }).subscribe(message => {
+      const { version = null } = JSON.parse(message).get_version.version_info;
+
+      this.setState({ version });
+    });
+
     this.onMesosStateChange();
   }
 
@@ -87,7 +95,7 @@ class NodeDetailTab extends PureComponent {
                 Master Version
               </ConfigurationMapLabel>
               <ConfigurationMapValue>
-                {MesosStateStore.get("lastMesosState").version}
+                {this.state.version || <Loader size="small" type="ballBeat" />}
               </ConfigurationMapValue>
             </ConfigurationMapRow>
             <ConfigurationMapRow>


### PR DESCRIPTION
A MesosStream migration leftover. Switched this page from taking the info from the MesosStateStor to getting in from the GET_VERSION request.

Before:
<img width="560" alt="screen shot 2018-01-18 at 18 30 15" src="https://user-images.githubusercontent.com/186223/35113399-926e67bc-fc81-11e7-97a1-e0f58afdf8a5.png">

Closes DCOS-20376