### PR TITLE
fix(status-bar): adjust styling to address jitter

### DIFF
--- a/src/styles/components/status-bar/styles.less
+++ b/src/styles/components/status-bar/styles.less
@@ -41,6 +41,7 @@
   }
 
   .status-bar {
+    backface-visibility: hidden;
     background-color: color-lighten(@neutral, 90);
     border-radius: 1000px;
     color: color-lighten(@neutral, 90);


### PR DESCRIPTION
Add `backface-visibility` property to address jitter in Google Chrome. The property does not affect 2D transforms, which have no perspective in any other browser but Google Chrome. It's the least intrusive way to force Chrome to render the respective layers properly.

| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/647035/35150571-2c4223a8-fd1b-11e7-8772-d0e01dda5e01.gif) | ![jitter-after mov](https://user-images.githubusercontent.com/647035/35150579-358b12da-fd1b-11e7-8399-6f79a199d625.gif) |



Closes DCOS-20392