### PR TITLE
chore(cypress): enable new Jenkins setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "webpack-notifier": "1.3.0"
   },
   "scripts": {
+    "cypress": "cypress run",
     "check-env": "./scripts/validate-engine-versions",
     "clean": "rm -rf dist",
     "shrinkwrap": "npm shrinkwrap --dev && ./node_modules/.bin/gulp fixShrinkwrap",


### PR DESCRIPTION
This PR enables the upcoming change in Jenkins as cypress has switched from a global installation to a dependency.