### PR TITLE
DCOS-20493: fix system-tests cypress

### DIFF
--- a/system-tests/Systemtests
+++ b/system-tests/Systemtests
@@ -16,6 +16,7 @@ isolation:
   shell:
     wrapper: (source .env/bin/activate; {})
   scripts:
+    sandbox-setup: ./_scripts/sandbox-setup.sh
     setup: ./_scripts/setup.sh
   files:
     - .

--- a/system-tests/_scripts/launch-cluster.sh
+++ b/system-tests/_scripts/launch-cluster.sh
@@ -52,7 +52,7 @@ fi
 URL="http://$(dcos-launch describe -i ${CLUSTER_INFO} | python -c \
                 'import sys, json; \
                  contents = json.load(sys.stdin); \
-                 print(contents["masters"][0]["public_ip"], end="")')"
+                 sys.stdout.write(str(contents["masters"][0]["public_ip"]))')"
 
 BACKOFF=1
 

--- a/system-tests/_scripts/sandbox-setup.sh
+++ b/system-tests/_scripts/sandbox-setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Create a python virtual environment
+SCRIPT=`realpath $0`
+SCRIPT_PATH=`dirname $SCRIPT`
+CYPRESS=`realpath "${SCRIPT_PATH}/../../node_modules/cypress/bin/cypress"`
+
+ln -s $CYPRESS "$TMPDIR/cypress"

--- a/system-tests/_scripts/setup.sh
+++ b/system-tests/_scripts/setup.sh
@@ -11,6 +11,10 @@ else
 fi
 chmod +x .env/bin/dcos
 
+# Symlink cypress in isolation so we don't need to install it every time
+mv "$TMPDIR/cypress" .env/bin/cypress
+# /dcos-ui/jenkins/workspace/Frontend/dcos-ui-pull-requests-system-tests/node_modules/cypress/bin/cypress
+
 # Configure DC/OS CLI
 CONFIG_DIR=~/.dcos
 CONFIG_FILE=${CONFIG_DIR}/dcos.toml

--- a/system-tests/cypress.json
+++ b/system-tests/cypress.json
@@ -6,5 +6,8 @@
   "reporter": "junit",
   "reporterOptions": {
     "mochaFile": "cypress/results.xml"
-  }
+  },
+  "videoUploadOnPasses": false,
+  "numTestsKeptInMemory": 0,
+  "screenshotOnHeadlessFailure": false
 }

--- a/system-tests/dashboard/tests.yml
+++ b/system-tests/dashboard/tests.yml
@@ -7,6 +7,6 @@
       assets:
         - cypress
     scripts:
-      setup: ./services/_scripts/setup
-      run: cd /dcos-ui; ./node_modules/.bin/cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec dashboard/test-dashboard.js
+      setup: ./dashboard/_scripts/setup
+      run: cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec dashboard/test-dashboard.js
       teardown: ./dashboard/_scripts/teardown

--- a/system-tests/jobs/tests.yml
+++ b/system-tests/jobs/tests.yml
@@ -7,5 +7,5 @@
       assets:
         - cypress
     scripts:
-      run: cd /dcos-ui; ./node_modules/.bin/cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec jobs/test-jobs.js
+      run: cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec jobs/test-jobs.js
       teardown: ./jobs/_scripts/teardown

--- a/system-tests/services/tests.yml
+++ b/system-tests/services/tests.yml
@@ -8,7 +8,7 @@
         - cypress
     scripts:
       setup: ./services/_scripts/setup
-      run: cd /dcos-ui; ./node_modules/.bin/cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec services/test-environment.js --spec services/test-apps.js
+      run: cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec services/test-environment.js --spec services/test-apps.js
       teardown: ./services/_scripts/teardown
   - name: services.pods
     title: Pods
@@ -20,7 +20,7 @@
         - cypress
     scripts:
       setup: ./services/_scripts/setup
-      run: cd /dcos-ui; ./node_modules/.bin/cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec services/test-environment.js --spec services/test-pods.js
+      run: cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec services/test-environment.js --spec services/test-pods.js
       teardown: ./services/_scripts/teardown
   - name: services.external-volumes
     title: External Volumes
@@ -32,5 +32,5 @@
         - cypress
     scripts:
       setup: ./services/_scripts/setup; ./services/_scripts/external-volumes/setup
-      run: cd /dcos-ui; ./node_modules/.bin/cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec system-tests/services/test-environment.js --spec system-tests/services/test-external-volumes.js
+      run: cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec services/test-environment.js --spec services/test-external-volumes.js
       teardown: ./services/_scripts/teardown

--- a/system-tests/universe/tests.yml
+++ b/system-tests/universe/tests.yml
@@ -7,5 +7,5 @@
       assets:
         - cypress
     scripts:
-      run: cd /dcos-ui; ./node_modules/.bin/cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec universe/test-universe.js
+      run: cypress run --env CLUSTER_URL=$CLUSTER_URL,CLUSTER_AUTH_TOKEN=$CLUSTER_AUTH_TOKEN,CLUSTER_AUTH_INFO=$CLUSTER_AUTH_INFO,TEST_UUID=$TEST_UUID --spec universe/test-universe.js
       teardown: ./universe/_scripts/teardown


### PR DESCRIPTION
NB! System tests won't be green with the fix. The PR just fixes the setup!

Cypress recommends installing 1.4.1 as a dependency. In previous releases of dcos-ui we had cypress installed globally. To keep backward compatibility I managed to symlink cypress in the test environment.

**Why having a separate `sandbox-setup` script?**
`setup` is being executed _inside_ the shell isolation and doesn't have a way out I could find. `sandbox-setup` is being executed outside of isolation and has all the info about the sandbox. So I construct link to cypress and symlink it into sandbox.

I also fixed various bugs here and there.

## Testing

Please go to Jenkins and check logs for the system-tests job. It should run cypress 1.4.1
Should look like something like this:
```
DEBUG 2018-01-24 15:42:35 proc[shell.test.services.apps:run]: O:   - Tests:           13
DEBUG 2018-01-24 15:42:35 proc[shell.test.services.apps:run]: O:   - Passes:          3
DEBUG 2018-01-24 15:42:35 proc[shell.test.services.apps:run]: O:   - Failures:        8
DEBUG 2018-01-24 15:42:35 proc[shell.test.services.apps:run]: O:   - Pending:         2
DEBUG 2018-01-24 15:42:35 proc[shell.test.services.apps:run]: O:   - Duration:        6 minutes, 18 seconds
DEBUG 2018-01-24 15:42:35 proc[shell.test.services.apps:run]: O:   - Screenshots:     0
DEBUG 2018-01-24 15:42:35 proc[shell.test.services.apps:run]: O:   - Video Recorded:  true
DEBUG 2018-01-24 15:42:35 proc[shell.test.services.apps:run]: O:   - Cypress Version: 1.4.1
```