### PR TITLE
refactor(SchemaField): improve framework heading sizes

### DIFF
--- a/src/js/components/FrameworkConfigurationForm.js
+++ b/src/js/components/FrameworkConfigurationForm.js
@@ -245,11 +245,26 @@ class FrameworkConfigurationForm extends Component {
     } = this.props;
 
     const TitleField = props => {
-      return (
-        <h2 className="flush-top short-bottom">
-          {StringUtil.capitalizeEveryWord(props.title)}
-        </h2>
-      );
+      const level = props.formContext.level;
+      if (level === 1) {
+        return (
+          <h1 className="flush-top short-bottom">
+            {StringUtil.capitalizeEveryWord(props.title)}
+          </h1>
+        );
+      } else if (level === 2) {
+        return (
+          <h2 className="short-bottom">
+            {StringUtil.capitalizeEveryWord(props.title)}
+          </h2>
+        );
+      } else {
+        return (
+          <h3 className="short-bottom">
+            {StringUtil.capitalizeEveryWord(props.title)}
+          </h3>
+        );
+      }
     };
 
     const jsonEditorPlaceholderClasses = classNames(
@@ -311,6 +326,7 @@ class FrameworkConfigurationForm extends Component {
                       validate={this.validate}
                       showErrorList={false}
                       transformErrors={this.transformErrors}
+                      formContext={{ level: -1 }}
                     >
                       <div />
                     </SchemaForm>

--- a/src/js/components/FrameworkConfigurationForm.js
+++ b/src/js/components/FrameworkConfigurationForm.js
@@ -254,19 +254,20 @@ class FrameworkConfigurationForm extends Component {
             {StringUtil.capitalizeEveryWord(props.title)}
           </h1>
         );
-      } else if (level === FrameworkConfigurationConstants.headingLevel.H2) {
+      }
+      if (level === FrameworkConfigurationConstants.headingLevel.H2) {
         return (
           <h2 className="short-bottom">
             {StringUtil.capitalizeEveryWord(props.title)}
           </h2>
         );
-      } else {
-        return (
-          <h3 className="short-bottom">
-            {StringUtil.capitalizeEveryWord(props.title)}
-          </h3>
-        );
       }
+
+      return (
+        <h3 className="short-bottom">
+          {StringUtil.capitalizeEveryWord(props.title)}
+        </h3>
+      );
     };
 
     const jsonEditorPlaceholderClasses = classNames(

--- a/src/js/components/FrameworkConfigurationForm.js
+++ b/src/js/components/FrameworkConfigurationForm.js
@@ -19,6 +19,8 @@ import StringUtil from "#SRC/js/utils/StringUtil";
 import PlacementConstraintsSchemaField
   from "#SRC/js/components/PlacementConstraintsSchemaField";
 import YamlEditorSchemaField from "#SRC/js/components/YamlEditorSchemaField";
+import FrameworkConfigurationConstants
+  from "#SRC/js/constants/FrameworkConfigurationConstants";
 
 MountService.MountService.registerComponent(
   PlacementConstraintsSchemaField,
@@ -246,13 +248,13 @@ class FrameworkConfigurationForm extends Component {
 
     const TitleField = props => {
       const level = props.formContext.level;
-      if (level === 1) {
+      if (level === FrameworkConfigurationConstants.headingLevel.H1) {
         return (
           <h1 className="flush-top short-bottom">
             {StringUtil.capitalizeEveryWord(props.title)}
           </h1>
         );
-      } else if (level === 2) {
+      } else if (level === FrameworkConfigurationConstants.headingLevel.H2) {
         return (
           <h2 className="short-bottom">
             {StringUtil.capitalizeEveryWord(props.title)}
@@ -326,7 +328,6 @@ class FrameworkConfigurationForm extends Component {
                       validate={this.validate}
                       showErrorList={false}
                       transformErrors={this.transformErrors}
-                      formContext={{ level: -1 }}
                     >
                       <div />
                     </SchemaForm>

--- a/src/js/components/PlacementConstraintsSchemaField.js
+++ b/src/js/components/PlacementConstraintsSchemaField.js
@@ -110,7 +110,7 @@ export default class PlacementConstraintsSchemaField extends Component {
   }
 
   render() {
-    const { errorMessage, fieldProps } = this.props;
+    const { label, fieldProps, errorMessage } = this.props;
     const { batch } = this.state;
 
     const appendToList = (memo, transaction) => memo.concat(transaction);

--- a/src/js/components/PlacementConstraintsSchemaField.js
+++ b/src/js/components/PlacementConstraintsSchemaField.js
@@ -8,6 +8,8 @@ import PlacementConstraintsPartial
   from "#SRC/js/components/PlacementConstraintsPartial";
 import BatchContainer from "#SRC/js/components/BatchContainer";
 import DataValidatorUtil from "#SRC/js/utils/DataValidatorUtil";
+import { Tooltip } from "reactjs-components";
+import Icon from "#SRC/js/components/Icon";
 import {
   JSONReducer,
   JSONParser
@@ -108,7 +110,7 @@ export default class PlacementConstraintsSchemaField extends Component {
   }
 
   render() {
-    const { label, errorMessage } = this.props;
+    const { errorMessage, fieldProps } = this.props;
     const { batch } = this.state;
 
     const appendToList = (memo, transaction) => memo.concat(transaction);
@@ -129,11 +131,22 @@ export default class PlacementConstraintsSchemaField extends Component {
         batch.reduce(combineReducers({ constraints: JSONReducer }))
       )
     );
+    const isRequired = fieldProps.required ? "*" : "";
 
     return (
-      <div>
+      <div className="extra-bottom">
         <FieldLabel>
-          {label}
+          <h2>
+            {`Placement Constraints ${isRequired}`}
+            <Tooltip
+              content={fieldProps.schema.description}
+              interactive={true}
+              maxWidth={300}
+              wrapText={true}
+            >
+              <Icon color="grey" id="circle-question" size="mini" />
+            </Tooltip>
+          </h2>
         </FieldLabel>
         <BatchContainer batch={batch} onChange={this.handleBatchChange}>
           <PlacementConstraintsPartial errors={errors} data={data} />

--- a/src/js/components/PlacementConstraintsSchemaField.js
+++ b/src/js/components/PlacementConstraintsSchemaField.js
@@ -134,20 +134,18 @@ export default class PlacementConstraintsSchemaField extends Component {
     const isRequired = fieldProps.required ? "*" : "";
 
     return (
-      <div className="extra-bottom">
-        <FieldLabel>
-          <h2>
-            {`Placement Constraints ${isRequired}`}
-            <Tooltip
-              content={fieldProps.schema.description}
-              interactive={true}
-              maxWidth={300}
-              wrapText={true}
-            >
-              <Icon color="grey" id="circle-question" size="mini" />
-            </Tooltip>
-          </h2>
-        </FieldLabel>
+      <div className="pod flush-left flush-right flush-top">
+        <h2>
+          {`Placement Constraints ${isRequired}`}
+          <Tooltip
+            content={fieldProps.schema.description}
+            interactive={true}
+            maxWidth={300}
+            wrapText={true}
+          >
+            <Icon color="grey" id="circle-question" size="mini" />
+          </Tooltip>
+        </h2>
         <BatchContainer batch={batch} onChange={this.handleBatchChange}>
           <PlacementConstraintsPartial errors={errors} data={data} />
         </BatchContainer>

--- a/src/js/components/SchemaField.js
+++ b/src/js/components/SchemaField.js
@@ -4,6 +4,7 @@ import { Tooltip } from "reactjs-components";
 import DefaultSchemaField
   from "react-jsonschema-form/lib/components/fields/SchemaField";
 import { MountService } from "foundation-ui";
+import StringUtil from "#SRC/js/utils/StringUtil";
 
 import Icon from "#SRC/js/components/Icon";
 import FieldInput from "#SRC/js/components/form/FieldInput";
@@ -257,7 +258,7 @@ class SchemaField extends Component {
     return (
       <FormGroupHeading>
         <FormGroupHeadingContent primary={true}>
-          {name.split(/[_-]/).join(" ")}
+          {StringUtil.capitalizeEveryWord(name)}
         </FormGroupHeadingContent>
         {requiredSymbol}
         <FormGroupHeadingContent primary={false}>
@@ -317,10 +318,15 @@ class SchemaField extends Component {
   }
 
   render() {
-    const { schema, errorSchema, uiSchema } = this.props;
+    const { schema, errorSchema, uiSchema, registry } = this.props;
 
     if (schema.type === "object") {
-      return <DefaultSchemaField {...this.props} />;
+      const nextRegistry = {
+        ...registry,
+        formContext: { level: registry.formContext.level + 1 }
+      };
+
+      return <DefaultSchemaField {...this.props} registry={nextRegistry} />;
     }
 
     const autofocus = uiSchema && uiSchema["ui:autofocus"];

--- a/src/js/components/SchemaField.js
+++ b/src/js/components/SchemaField.js
@@ -318,12 +318,15 @@ class SchemaField extends Component {
   }
 
   render() {
-    const { schema, errorSchema, uiSchema, registry } = this.props;
+    const { schema, errorSchema, uiSchema, registry, idSchema } = this.props;
 
     if (schema.type === "object") {
+      const nextLevel = idSchema.$id === "root"
+        ? 0
+        : registry.formContext.level + 1;
       const nextRegistry = {
         ...registry,
-        formContext: { level: registry.formContext.level + 1 }
+        formContext: { level: nextLevel }
       };
 
       return <DefaultSchemaField {...this.props} registry={nextRegistry} />;

--- a/src/js/components/__tests__/PlacementConstraintsSchemaFields-test.js
+++ b/src/js/components/__tests__/PlacementConstraintsSchemaFields-test.js
@@ -24,7 +24,8 @@ describe("PlacementConstraintsSchemaField", function() {
       const fieldProps = {
         formData: "[['hostname', 'MAX_PER', '1']]",
         disabled: false,
-        name: "placement_constraints"
+        name: "placement_constraints",
+        schema: {}
       };
       this.instance = renderer.create(
         <PlacementConstraintsSchemaFields

--- a/src/js/components/__tests__/__snapshots__/PlacementConstraintsSchemaFields-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/PlacementConstraintsSchemaFields-test.js.snap
@@ -19,23 +19,20 @@ exports[`PlacementConstraintsSchemaField with invalid content displays form to e
 
 exports[`PlacementConstraintsSchemaField with valid content displays edit constraints area 1`] = `
 <div
-  className="extra-bottom">
-  <label
-    className="">
-    <h2>
-      Placement Constraints 
-      <div
-        className="tooltip-wrapper text-align-center"
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}>
-        <svg
-          className="icon icon-grey icon-mini">
-          <use
-            xlinkHref="#icon-system--circle-question" />
-        </svg>
-      </div>
-    </h2>
-  </label>
+  className="pod flush-left flush-right flush-top">
+  <h2>
+    Placement Constraints 
+    <div
+      className="tooltip-wrapper text-align-center"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}>
+      <svg
+        className="icon icon-grey icon-mini">
+        <use
+          xlinkHref="#icon-system--circle-question" />
+      </svg>
+    </div>
+  </h2>
   <div
     onChange={[Function]}>
     <div>

--- a/src/js/components/__tests__/__snapshots__/PlacementConstraintsSchemaFields-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/PlacementConstraintsSchemaFields-test.js.snap
@@ -18,10 +18,23 @@ exports[`PlacementConstraintsSchemaField with invalid content displays form to e
 `;
 
 exports[`PlacementConstraintsSchemaField with valid content displays edit constraints area 1`] = `
-<div>
+<div
+  className="extra-bottom">
   <label
     className="">
-    label
+    <h2>
+      Placement Constraints 
+      <div
+        className="tooltip-wrapper text-align-center"
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}>
+        <svg
+          className="icon icon-grey icon-mini">
+          <use
+            xlinkHref="#icon-system--circle-question" />
+        </svg>
+      </div>
+    </h2>
   </label>
   <div
     onChange={[Function]}>

--- a/src/js/constants/FrameworkConfigurationConstants.js
+++ b/src/js/constants/FrameworkConfigurationConstants.js
@@ -1,0 +1,8 @@
+const constants = {
+  headingLevel: {
+    H1: 1,
+    H2: 2
+  }
+};
+
+module.exports = constants;

--- a/src/styles/components/form-elements/form-group/styles.less
+++ b/src/styles/components/form-elements/form-group/styles.less
@@ -10,6 +10,10 @@
       }
     }
 
+    .extra-bottom {
+      margin-bottom: 30px;
+    }
+
     &-heading {
       align-items: center;
       display: flex;

--- a/src/styles/components/form-elements/form-group/styles.less
+++ b/src/styles/components/form-elements/form-group/styles.less
@@ -10,10 +10,6 @@
       }
     }
 
-    .extra-bottom {
-      margin-bottom: 30px;
-    }
-
     &-heading {
       align-items: center;
       display: flex;


### PR DESCRIPTION
The purpose of this is to make the framework forms more visually parsable. Changes:
1. Give each TitleField it sizing appropriate to it's location in the json schema. Previously, they were all rendered as `<h2>` for simplicity, but this made it hard to notice which were nested fields.
2. Bigger sizing on Placement Constraints widget label.
3. Capitalize each word in all field labels
4. Extra margin below Placement section to visually separate from rest of form

**Testing**:
1. Turn enterprise off
2. Open the catalog for beta-kafka. Notice the form differences. H1 and H2 and H3 for layers of config headings, and Placement Constraints label is proper size.

Thanks to @leemunroe for suggestions and assistance. 

**Before**:
![screen shot 2018-01-22 at 4 31 58 pm](https://user-images.githubusercontent.com/1527504/35251793-ce29e67e-ff91-11e7-931c-86f6b44c3b78.png)
![screen shot 2018-01-22 at 4 31 50 pm](https://user-images.githubusercontent.com/1527504/35251794-d0ec753e-ff91-11e7-9994-ca1303db50da.png)

**After**:
![screen shot 2018-01-22 at 4 30 32 pm](https://user-images.githubusercontent.com/1527504/35251798-d837940e-ff91-11e7-8b0d-5b107a6fa0f5.png)
![screen shot 2018-01-22 at 4 30 20 pm](https://user-images.githubusercontent.com/1527504/35251801-daf8d09a-ff91-11e7-8961-fa291f666976.png)


**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
