### PR TITLE
fix(FullScreenModal): remove animation and fix loader

### DIFF
--- a/src/styles/components/loaders/styles.less
+++ b/src/styles/components/loaders/styles.less
@@ -1,4 +1,5 @@
 .loader {
+  background: @white;
 
   .loader-element {
     background: @loaders-elements-background;

--- a/src/styles/components/modal/full-screen/styles.less
+++ b/src/styles/components/modal/full-screen/styles.less
@@ -42,66 +42,12 @@
     }
   }
 
-  .modal-full-screen-enter,
-  .modal-full-screen-appear {
-
-    .modal {
-      opacity: 0;
-      transform: scale(0.9);
-    }
-
-    .modal-backdrop {
-      opacity: 0;
-    }
-
-    &.modal-full-screen-enter-active,
-    &.modal-full-screen-appear-active {
-
-      .modal {
-        opacity: 1;
-        transform: scale(1);
-        transition: transform @modal-animation-duration @modal-animation-easing, opacity @modal-animation-duration @modal-animation-easing;
-      }
-
-      .modal-backdrop {
-        opacity: 1;
-        transition: opacity @modal-animation-duration @modal-animation-easing;
-      }
-    }
-  }
-
   .modal-full-screen-fill-body {
     height: 100%;
     left: 0;
     position: absolute;
     top: 0;
     width: 100%;
-  }
-
-  .modal-full-screen-leave {
-
-    .modal {
-      opacity: 1;
-      transform: scale(1);
-    }
-
-    .modal-backdrop {
-      opacity: 1;
-    }
-
-    &.modal-full-screen-leave-active {
-
-      .modal {
-        opacity: 0;
-        transform: scale(0.9);
-        transition: transform @modal-animation-duration @modal-animation-easing, opacity @modal-animation-duration @modal-animation-easing;
-      }
-
-      .modal-backdrop {
-        opacity: 0;
-        transition: opacity @modal-animation-duration @modal-animation-easing;
-      }
-    }
   }
 
   .modal-full-screen-header {


### PR DESCRIPTION
This fixes the flashes of dark-grey when opening and closing full screen modals. 

Two parts:
1) Make the loader background white. This because the background of DC/OS is now dark-grey, so now we must manually set the loader background to white. 
2) Removing animations from the full screen modal. This is smoother, and prevents short flashing of the dark-grey background.

**Before**:
![screen recording 2018-01-23 at 11 48 am](https://user-images.githubusercontent.com/1527504/35297327-7c05e346-0033-11e8-8dff-ec75b09dc03c.gif)


**After**:
![screen recording 2018-01-23 at 11 46 am](https://user-images.githubusercontent.com/1527504/35297300-6b1c5358-0033-11e8-82c0-14845f83f36f.gif)

Closes DCOS-20343

Thanks for @ashenden for direction on this.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
