### PR TITLE
fix(ServiceTableUtil): fix status sorting

### DIFF
--- a/plugins/services/src/js/constants/StatusSorting.js
+++ b/plugins/services/src/js/constants/StatusSorting.js
@@ -1,0 +1,16 @@
+/**
+ * Order service by status weight of importance
+ * This will depend on the sorting method/function
+ * suggested use is ascending 0 meaning (top of the list) more important
+ * visibility and 6 meaning least important (bottom of the order)
+ */
+const StatusSorting = {
+  Recovering: 0,
+  Deploying: 1,
+  Deleting: 2,
+  Stopped: 3,
+  Running: 4,
+  NA: 5
+};
+
+module.exports = StatusSorting;

--- a/plugins/services/src/js/utils/ServiceTableUtil.js
+++ b/plugins/services/src/js/utils/ServiceTableUtil.js
@@ -1,4 +1,4 @@
-import HealthSorting from "../constants/HealthSorting";
+import StatusSorting from "../constants/StatusSorting";
 import ServiceTree from "../structs/ServiceTree";
 
 /**
@@ -40,16 +40,16 @@ function taskCompareFunction(a, b) {
 }
 
 /**
- * Compare service health
+ * Compare service status
  * @param {Service|ServiceTree} a
  * @param {Service|ServiceTree} b
  * @returns {number} a number indicating whether "a" comes before or after or
  * is the same as "b" in sort order.
  */
-function healthCompareFunction(a, b) {
+function statusCompareFunction(a, b) {
   return numberCompareFunction(
-    HealthSorting[a.getHealth().key],
-    HealthSorting[b.getHealth().key]
+    StatusSorting[a.getServiceStatus().displayName],
+    StatusSorting[b.getServiceStatus().displayName]
   );
 }
 
@@ -108,7 +108,7 @@ function getCompareFunctionByProp(prop) {
     case "tasks":
       return taskCompareFunction;
     case "status":
-      return healthCompareFunction;
+      return statusCompareFunction;
     case "cpus":
       return cpusCompareFunction;
     case "mem":

--- a/plugins/services/src/js/utils/__tests__/ServiceTableUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceTableUtil-test.js
@@ -29,6 +29,18 @@ describe("ServiceTableUtil", function() {
     tasksUnhealthy: 1
   });
 
+  const stoppedService = new Application({
+    id: "/stopped-service",
+    instances: 0,
+    tasksRunning: 0
+  });
+
+  const recoveringService = new Application({
+    id: "/recovering-service",
+    queue: true,
+    deployments: null
+  });
+
   const serviceTree = new ServiceTree({
     id: "/tree",
     items: []
@@ -134,9 +146,7 @@ describe("ServiceTableUtil", function() {
       });
 
       it("returns 1 if a comes after b in the status sorting", function() {
-        expect(this.compareFunction(healthyService, unhealthyService)).toEqual(
-          1
-        );
+        expect(this.compareFunction(healthyService, stoppedService)).toEqual(1);
       });
 
       it("returns 0 if a has the same status as b", function() {
@@ -144,7 +154,7 @@ describe("ServiceTableUtil", function() {
       });
 
       it("returns -1 if a comes beforeEach b in the status sorting", function() {
-        expect(this.compareFunction(unhealthyService, healthyService)).toEqual(
+        expect(this.compareFunction(recoveringService, stoppedService)).toEqual(
           -1
         );
       });


### PR DESCRIPTION
Fix Service status column sorting

Closes DCOS-19732

**How to test:**
- Go to service page
- Start a couple services with different statuses (Deploying, Running, Recovering, etc)
- Click the status name/header column
- You will see the service page sort by the order below

_ps: be aware that sometimes they can have the same status but might have the warning icon which is expected and shouldn't change anything._

Order:
```
Recovering
Deploying
Deleting
Stopped
Running
NA
```

![service-status-sorting](https://user-images.githubusercontent.com/549394/35310809-2226ba3c-0068-11e8-966c-f75db7897656.gif)


**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
