### PR TITLE
DCOS-20475: Fix residency validators

### DIFF
--- a/plugins/services/src/js/components/modals/CreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModal.js
@@ -96,7 +96,6 @@ const METHODS_TO_BIND = [
 const APP_VALIDATORS = [
   AppValidators.App,
   MarathonAppValidators.containsCmdArgsOrContainer,
-  MarathonAppValidators.complyWithResidencyRules,
   MarathonAppValidators.mustContainImageOnDocker,
   MarathonAppValidators.validateConstraints,
   MarathonAppValidators.validateLabels,

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Residency.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Residency.js
@@ -1,4 +1,4 @@
-import { SET, ADD_ITEM, REMOVE_ITEM } from "#SRC/js/constants/TransactionTypes";
+import { SET } from "#SRC/js/constants/TransactionTypes";
 import Transaction from "#SRC/js/structs/Transaction";
 
 module.exports = {
@@ -7,44 +7,8 @@ module.exports = {
       return state;
     }
 
-    if (this.volumes == null) {
-      this.volumes = [];
-    }
-
     const joinedPath = path.join(".");
 
-    if (joinedPath.search("volumes") !== -1) {
-      if (joinedPath === "volumes") {
-        switch (type) {
-          case ADD_ITEM:
-            this.volumes.push(false);
-            break;
-          case REMOVE_ITEM:
-            this.volumes = this.volumes.filter((item, index) => {
-              return index !== value;
-            });
-            break;
-        }
-      }
-      const index = path[1];
-      if (type === SET && `volumes.${index}.type` === joinedPath) {
-        this.volumes[index] = value === "PERSISTENT" || value === "DSS";
-      }
-
-      const hasVolumes = this.volumes.find(value => {
-        return value;
-      });
-      if (hasVolumes && this.residency == null) {
-        return {
-          relaunchEscalationTimeoutSeconds: 10,
-          taskLostBehavior: "WAIT_FOREVER"
-        };
-      } else if (!hasVolumes) {
-        return;
-      } else {
-        return this.residency;
-      }
-    }
     if (type === SET && joinedPath === "residency") {
       this.residency = value;
 

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Residency-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Residency-test.js
@@ -27,23 +27,12 @@ describe("Residency", function() {
       });
     });
 
-    it("returns undefined if a host volume is set", function() {
-      let batch = new Batch();
-      batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
-      batch = batch.add(new Transaction(["volumes", 0, "type"], "HOST"));
-
-      expect(batch.reduce(Residency.JSONReducer.bind({}))).toEqual(undefined);
-    });
-
-    it("returns residency if a persistent volume is set", function() {
+    it("returns undefined residency if a persistent volume is set", function() {
       let batch = new Batch();
       batch = batch.add(new Transaction(["volumes"], null, ADD_ITEM));
       batch = batch.add(new Transaction(["volumes", 0, "type"], "PERSISTENT"));
 
-      expect(batch.reduce(Residency.JSONReducer.bind({}))).toEqual({
-        relaunchEscalationTimeoutSeconds: 10,
-        taskLostBehavior: "WAIT_FOREVER"
-      });
+      expect(batch.reduce(Residency.JSONReducer.bind({}))).toBeUndefined();
     });
 
     it("returns undefined if a persistent volume is removed", function() {
@@ -52,7 +41,7 @@ describe("Residency", function() {
       batch = batch.add(new Transaction(["volumes", 0, "type"], "PERSISTENT"));
       batch = batch.add(new Transaction(["volumes"], 0, REMOVE_ITEM));
 
-      expect(batch.reduce(Residency.JSONReducer.bind({}))).toEqual(undefined);
+      expect(batch.reduce(Residency.JSONReducer.bind({}))).toBeUndefined();
     });
 
     it("respects the parsed residency", function() {

--- a/plugins/services/src/js/validators/MarathonAppValidators.js
+++ b/plugins/services/src/js/validators/MarathonAppValidators.js
@@ -3,7 +3,6 @@ import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
 import {
   PROP_CONFLICT,
   PROP_DEPRECATED,
-  PROP_MISSING_ALL,
   PROP_MISSING_ONE,
   SYNTAX_ERROR
 } from "../constants/ServiceErrorTypes";
@@ -92,39 +91,6 @@ const MarathonAppValidators = {
       { path: ["args"], message, type, variables },
       { path: ["container", "docker", "image"], message, type, variables }
     ];
-  },
-
-  /**
-   * @param {Object} app - The data to validate
-   * @returns {Array} Returns an array with validation errors
-   */
-  complyWithResidencyRules(app) {
-    const hasAppResidency = !ValidatorUtil.isEmpty(app.residency);
-    let hasPersistentVolumes = false;
-
-    // Check if app has at leas one persistent volume
-    if (app.container && app.container.volumes) {
-      hasPersistentVolumes = app.container.volumes.some(
-        volume => !ValidatorUtil.isEmpty(volume.persistent)
-      );
-    }
-
-    if (hasAppResidency !== hasPersistentVolumes) {
-      const message =
-        "AppDefinition must contain persistent volumes and " +
-        "define residency";
-      const type = PROP_MISSING_ALL;
-      const variables = {
-        names: "residency, container.volumes"
-      };
-
-      return [
-        { path: ["residency"], message, type, variables },
-        { path: ["container", "volumes"], message, type, variables }
-      ];
-    }
-
-    return [];
   },
 
   /**

--- a/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
+++ b/plugins/services/src/js/validators/__tests__/MarathonAppValidators-test.js
@@ -41,25 +41,6 @@ const CMDORDOCKERIMAGE_ERRORS = [
   }
 ];
 
-const COMPLYWITHRESIDENCY_ERRORS = [
-  {
-    path: ["residency"],
-    message: "AppDefinition must contain persistent volumes and define residency",
-    type: "PROP_MISSING_ALL",
-    variables: {
-      names: "residency, container.volumes"
-    }
-  },
-  {
-    path: ["container", "volumes"],
-    message: "AppDefinition must contain persistent volumes and define residency",
-    type: "PROP_MISSING_ALL",
-    variables: {
-      names: "residency, container.volumes"
-    }
-  }
-];
-
 const MUSTCONTAINIMAGEONDOCKER_ERRORS = [
   {
     path: ["container", "docker", "image"],
@@ -194,59 +175,6 @@ describe("MarathonAppValidators", function() {
       const spec = { container: { appc: { image: "foo", id: "sha512-test" } } };
       expect(MarathonAppValidators.containsCmdArgsOrContainer(spec)).toEqual(
         []
-      );
-    });
-  });
-
-  describe("#complyWithResidencyRules", function() {
-    it("returns no errors if residency and container is undefined", function() {
-      const spec = {};
-
-      expect(MarathonAppValidators.complyWithResidencyRules(spec)).toEqual([]);
-    });
-
-    it("returns no errors if residency and volumes is undefined", function() {
-      const spec = { container: {} };
-
-      expect(MarathonAppValidators.complyWithResidencyRules(spec)).toEqual([]);
-    });
-
-    it("returns no errors if residency is undefined and volumes empty", function() {
-      const spec = { container: { volumes: [] } };
-
-      expect(MarathonAppValidators.complyWithResidencyRules(spec)).toEqual([]);
-    });
-
-    it("returns no errors if residency and persistent is undefined", function() {
-      const spec = { container: { volumes: [{}] } };
-
-      expect(MarathonAppValidators.complyWithResidencyRules(spec)).toEqual([]);
-    });
-
-    it("returns no errors if both of residency and persistent is defined", function() {
-      const spec = {
-        residency: "foo",
-        container: { volumes: [{ persistent: { size: "524288" } }] }
-      };
-
-      expect(MarathonAppValidators.complyWithResidencyRules(spec)).toEqual([]);
-    });
-
-    it("returns errors if only `residency` defined", function() {
-      const spec = { residency: "foo" };
-
-      expect(MarathonAppValidators.complyWithResidencyRules(spec)).toEqual(
-        COMPLYWITHRESIDENCY_ERRORS
-      );
-    });
-
-    it("returns errors if only `persistentVolumes` defined", function() {
-      const spec = {
-        container: { volumes: [{ persistent: { size: "524288" } }] }
-      };
-
-      expect(MarathonAppValidators.complyWithResidencyRules(spec)).toEqual(
-        COMPLYWITHRESIDENCY_ERRORS
       );
     });
   });


### PR DESCRIPTION
This fixes a legacy issue which was introduced into marathon a very long time ago. The issue was when you wanted to create a app with a persistent volume you needed to also define the residency setting, otherwise the volume would be present but not persistent ... unfortunately there was only one residency setting and changing it did not have any other purpose. With the latest changes Marathon is going to set residency if there is a persistent volume defined. So it is not mandatory to add it via the ui. 

With this PR we are removing the validators which were checking if the residency was set. And also we are removing the logic which was adding residency if a persistent volume was added. This has been done for single container and multi container services.

To test this take this JSON:
```JSON
{
  "id": "/foo",
  "instances": 1,
  "cpus": 0.1,
  "mem": 32,
  "cmd": "echo Running && sleep 1000",
  "container": {
    "type": "MESOS",
    "volumes": [
      {
        "containerPath": "data",
        "mode": "RW",
        "persistent": {
          "size": 32
        }
      }
    ]
  }
}
```

And bring it to the create service modal and put it in the JSON editor of the Single container form then hit Review and run and go back again. Check the JSON there should be no residency present but the JSON may look different.

Also bring the JSON to the JSON-configuration form (aka JSON only mode) there should be no validation errors and hit Review and run and go back the JSON should not be changed.

Extra points: If you deploy the app(single container service) and hit edit there should be a residency present in the JSON. 

For Pods (multi container service) Use the Form to add a local persistent volume and check if the residency is set in: `scheduling.residency`

Closes DCOS-20475