### PR TITLE
DCOS-20468: upload build to S3 bucket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ COPY scripts/docker-entrypoint /usr/local/bin/dcos-ui-docker-entrypoint
 
 # Install required components & prepare environment
 RUN set -x \
+  # Install aws-cli
+  && pip install awscli --upgrade \
   # Install node 4.4.7 & npm 3.9
   && curl -o- https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz | tar -C /usr/local --strip-components=1 -zx \
   && npm install -g npm@${NPM_VERSION} \

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -1,0 +1,87 @@
+#!/usr/bin/env groovy
+
+// This Jenkinsfile is only temporary until we switch completley to the Jenkinsfile only setup
+
+@Library('sec_ci_libs@v2-latest') _
+
+def master_branches = ["master", ] as String[]
+
+pipeline {
+  agent {
+    dockerfile {
+      args  '--shm-size=2g'
+    }
+  }
+
+  parameters {
+    booleanParam(defaultValue: false, description: 'Should the build be uploaded to S3?', name: 'SHOULD_UPLOAD_BUILD')
+  }
+
+  environment {
+    JENKINS_VERSION = 'yes'
+    NODE_PATH = 'node_modules'
+  }
+
+  options {
+    timeout(time: 1, unit: 'HOURS')
+  }
+
+  stages {
+    stage('Authorization') {
+      when {
+        expression { params.SHOULD_UPLOAD_BUILD == true }
+      }
+      steps {
+        user_is_authorized(master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#frontend-dev')
+      }
+    }
+
+    stage('Initialization') {
+      when {
+        expression { params.SHOULD_UPLOAD_BUILD == true }
+      }
+      steps {
+        ansiColor('xterm') {
+          retry(2) {
+            sh '''npm --unsafe-perm install'''
+          }
+
+          sh '''npm run scaffold'''
+        }
+      }
+    }
+
+    stage('Build') {
+      when {
+        expression { params.SHOULD_UPLOAD_BUILD == true }
+      }
+      steps {
+        ansiColor('xterm') {
+          sh '''npm run build-assets'''
+        }
+      }
+
+      post {
+        always {
+          stash includes: 'dist/*', name: 'dist'
+        }
+      }
+    }
+
+     stage('Upload Build') {
+      when {
+        expression { params.SHOULD_UPLOAD_BUILD == true }
+      }
+
+      steps {
+        unstash 'dist'
+        withCredentials([
+            string(credentialsId: '3f0dbb48-de33-431f-b91c-2366d2f0e1cf',variable: 'AWS_ACCESS_KEY_ID'),
+            string(credentialsId: 'f585ec9a-3c38-4f67-8bdb-79e5d4761937',variable: 'AWS_SECRET_ACCESS_KEY')
+        ]) {
+          sh '''./scripts/ci/upload-build'''
+        }
+      }
+    }
+  }
+}

--- a/scripts/ci/upload-build
+++ b/scripts/ci/upload-build
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -ex
+
+DIST_PATH=${DIST_PATH:-dist}
+BUILD_PREFIX=${BUILD_PREFIX:-oss}
+
+AWS_BUCKET='downloads.mesosphere.io'
+BUCKET_PATH='dcos-ui'
+
+PKG_VERSION=$(python -c "import sys, json; \
+      pkg = json.load(open('package.json')); \
+      sys.stdout.write(str(pkg['version']));")
+GIT_SHA=$(git rev-parse HEAD)
+
+RELEASE_NAME="$BUILD_PREFIX-$PKG_VERSION-$GIT_SHA.tar.gz"
+
+cd $DIST_PATH
+tar czf "../$RELEASE_NAME" .
+cd ..
+
+
+aws s3 cp $RELEASE_NAME s3://$AWS_BUCKET/$BUCKET_PATH/$RELEASE_NAME


### PR DESCRIPTION
With this PR a new jenkinsfile is introduced that only handles a build of our UI together with an upload to S3. This is only triggered once you triggered a build with the checkmark on:

<img width="916" alt="bildschirmfoto 2018-01-30 um 16 55 32" src="https://user-images.githubusercontent.com/1337046/35576100-7ca7f91e-05de-11e8-89c6-74e6153440f8.png">


What happens is that later stages are excluded, see second build by default. If its  triggered by hand we go off to build a release:

![bildschirmfoto 2018-01-30 um 16 23 14](https://user-images.githubusercontent.com/1337046/35576112-83d5c810-05de-11e8-8cc5-0e7c52488d74.png)

The release is send to the downloads.mesosphere.io bucket for later use in the main repo. See docs/docs#2367 as an example.

**Checklist**
- [X] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
