### PR TITLE
chore(Docker): add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules/
+.git/
+.github/


### PR DESCRIPTION
We currently send too much information into our docker container.
This ignores the most basic folders to reduce the amount needed to be
send to the docker deamon.

Effects:
Before: ```Sending build context to Docker daemon  862.8MB``` (super slow)
After: ```Sending build context to Docker daemon   24.3MB``` (super fast)