### PR TITLE
DCOS-20485: Adjust implementation to improve performance

### DIFF
--- a/plugins/services/src/js/structs/Framework.js
+++ b/plugins/services/src/js/structs/Framework.js
@@ -9,6 +9,21 @@ import Application from "./Application";
 import FrameworkSpec from "./FrameworkSpec";
 
 module.exports = class Framework extends Application {
+  constructor() {
+    super(...arguments);
+
+    // For performance reasons only one instance of the spec is created
+    // instead of creating a new instance every time a user calls `getSpec()`.
+    //
+    // State and other _useless_ information is removed to create a clean
+    // service spec.
+    //
+    // The variable is prefixed because `Item` will expose all the properties
+    // it gets as a properties of this object and we want to avoid any naming
+    // collisions.
+    this._spec = new FrameworkSpec(cleanServiceJSON(this.get()));
+  }
+
   getPackageName() {
     return this.getLabels().DCOS_PACKAGE_NAME;
   }
@@ -28,8 +43,11 @@ module.exports = class Framework extends Application {
     return ROUTE_ACCESS_PREFIX + (this.get("name") || "").replace(regexp, "");
   }
 
+  /**
+   * @override
+   */
   getSpec() {
-    return new FrameworkSpec(cleanServiceJSON(this.get()));
+    return this._spec;
   }
 
   getTasksSummary() {

--- a/src/js/stores/ConfigStore.js
+++ b/src/js/stores/ConfigStore.js
@@ -10,6 +10,7 @@ import {
 import AppDispatcher from "../events/AppDispatcher";
 import ConfigActions from "../events/ConfigActions";
 import {
+  APP_STORE_CHANGE,
   CLUSTER_CCID_ERROR,
   CLUSTER_CCID_SUCCESS,
   CONFIG_ERROR,
@@ -63,6 +64,17 @@ class ConfigStore extends GetSetBaseStore {
       }
 
       return true;
+    });
+  }
+
+  set(config) {
+    super.set(config);
+
+    // Dispatch new Store data
+    PluginSDK.dispatch({
+      type: APP_STORE_CHANGE,
+      storeID: this.storeID,
+      data: this.getSet_data
     });
   }
 

--- a/src/js/stores/GetSetBaseStore.js
+++ b/src/js/stores/GetSetBaseStore.js
@@ -1,7 +1,4 @@
-import PluginSDK from "PluginSDK";
-
 import BaseStore from "./BaseStore";
-import { APP_STORE_CHANGE } from "../constants/EventTypes";
 
 // TODO: DCOS-6404, remove getters and setters from stores
 class GetSetBaseStore extends BaseStore {
@@ -25,13 +22,6 @@ class GetSetBaseStore extends BaseStore {
     }
 
     Object.assign(this.getSet_data, data);
-
-    // Dispatch new Store data
-    PluginSDK.dispatch({
-      type: APP_STORE_CHANGE,
-      storeID: this.storeID,
-      data: this.getSet_data
-    });
   }
 }
 

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -73,6 +73,7 @@ class MesosStateStore extends GetSetBaseStore {
     const parsers = pipe(...Object.values(mesosStreamParsers));
     const dataStream = mesosStream
       .merge(getMasterRequest)
+      .distinctUntilChanged()
       .map(message => parsers(this.getLastMesosState(), JSON.parse(message)))
       .do(state => {
         CompositeState.addState(state);

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -24,8 +24,7 @@ class MesosStateStore extends GetSetBaseStore {
     super(...arguments);
 
     this.getSet_data = {
-      lastMesosState: {},
-      taskCache: {}
+      lastMesosState: {}
     };
 
     PluginSDK.addStoreConfig({
@@ -179,13 +178,14 @@ class MesosStateStore extends GetSetBaseStore {
   }
 
   getTaskFromTaskID(taskID) {
-    const taskCache = this.get("taskCache");
-    const foundTask = taskCache[taskID];
-    if (foundTask == null) {
+    const { tasks } = this.getLastMesosState();
+    const task = tasks.find(({ id }) => id === taskID);
+
+    if (!task) {
       return null;
     }
 
-    return new Task(foundTask);
+    return new Task(task);
   }
 
   /**
@@ -277,8 +277,7 @@ class MesosStateStore extends GetSetBaseStore {
 
   setState(state) {
     this.set({
-      lastMesosState: state,
-      taskCache: MesosStateUtil.indexTasksByID(state)
+      lastMesosState: state
     });
   }
 

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -4,7 +4,6 @@ import { Observable } from "rxjs/Observable";
 
 import CompositeState from "../structs/CompositeState";
 import Config from "../config/Config";
-import DCOSStore from "./DCOSStore";
 import Framework from "../../../plugins/services/src/js/structs/Framework";
 import GetSetBaseStore from "./GetSetBaseStore";
 import {
@@ -76,7 +75,6 @@ class MesosStateStore extends GetSetBaseStore {
     const dataStream = mesosStream
       .merge(getMasterRequest)
       .map(message => parsers(this.getLastMesosState(), JSON.parse(message)))
-      .map(MesosStateUtil.flagMarathonTasks)
       .do(state => {
         CompositeState.addState(state);
         this.setState(state);
@@ -169,30 +167,15 @@ class MesosStateStore extends GetSetBaseStore {
   }
 
   getTasksFromNodeID(nodeID) {
-    const { tasks, frameworks } = this.getLastMesosState();
-    const memberTasks = {};
+    const { tasks } = this.getLastMesosState();
 
     const schedulerTasks = this.getSchedulerTasks();
 
-    tasks.forEach(function(task) {
-      const framework = frameworks.find(
-        current => current.id === task.framework_id
+    return tasks
+      .filter(({ slave_id }) => slave_id === nodeID)
+      .map(task =>
+        MesosStateUtil.assignSchedulerTaskField(task, schedulerTasks)
       );
-      if (task.slave_id === nodeID) {
-        // Need to get service from Marathon because we need the labels.
-        const service = DCOSStore.serviceTree.findItem(function(item) {
-          return (
-            item instanceof Framework &&
-            item.getFrameworkName() === framework.name
-          );
-        });
-        task = MesosStateUtil.assignSchedulerTaskField(task, schedulerTasks);
-        task = MesosStateUtil.flagSDKTask(task, service);
-        memberTasks[task.id] = task;
-      }
-    });
-
-    return Object.values(memberTasks);
   }
 
   getTaskFromTaskID(taskID) {
@@ -211,23 +194,13 @@ class MesosStateStore extends GetSetBaseStore {
   getSchedulerTasks() {
     const tasks = this.getTasksFromServiceName("marathon");
 
-    return tasks.filter(function({ labels }) {
-      if (!labels) {
-        return false;
-      }
-
-      return labels.some(({ key }) => key === "DCOS_PACKAGE_FRAMEWORK_NAME");
-    });
+    return tasks.filter(({ isSchedulerTask }) => isSchedulerTask);
   }
 
   getSchedulerTaskFromServiceName(serviceName) {
     const tasks = this.getSchedulerTasks();
 
     return tasks.find(function({ labels }) {
-      if (!labels) {
-        return false;
-      }
-
       return labels.some(({ key, value }) => {
         return key === "DCOS_PACKAGE_FRAMEWORK_NAME" && value === serviceName;
       });
@@ -246,9 +219,7 @@ class MesosStateStore extends GetSetBaseStore {
     });
 
     if (framework) {
-      return tasks.filter(task => task != null).filter(task => {
-        return task.framework_id === framework.id;
-      });
+      return tasks.filter(({ framework_id }) => framework_id === framework.id);
     }
 
     return [];
@@ -285,23 +256,16 @@ class MesosStateStore extends GetSetBaseStore {
           .filter(task => task.framework_id === framework.id)
           .map(task =>
             MesosStateUtil.assignSchedulerTaskField(task, schedulerTasks)
-          )
-          .map(task => MesosStateUtil.flagSDKTask(task, service));
+          );
       }
     }
 
-    const marathon = frameworks.find(framework => {
-      return framework.name === "marathon";
-    });
-
     return tasks
-      .filter(task => task.framework_id === marathon.id)
-      .filter(({ name }) => name === mesosTaskName)
-      .concat(serviceTasks)
+      .filter(task => task.isStartedByMarathon && task.name === mesosTaskName)
       .map(task =>
         MesosStateUtil.assignSchedulerTaskField(task, schedulerTasks)
       )
-      .map(task => MesosStateUtil.flagSDKTask(task, service));
+      .concat(serviceTasks);
   }
 
   getRunningTasksFromVirtualNetworkName(overlayName) {

--- a/src/js/stores/MesosStream/parsers/__tests__/fixtures/getTasksMessage.json
+++ b/src/js/stores/MesosStream/parsers/__tests__/fixtures/getTasksMessage.json
@@ -105,6 +105,10 @@
             {
               "key": "LABEL_1",
               "value": "VALUE_1"
+            },
+            {
+              "key": "DCOS_COMMONS_API_VERSION",
+              "value": "1"
             }
           ]
         },

--- a/src/js/stores/MesosStream/parsers/__tests__/tasks-test.js
+++ b/src/js/stores/MesosStream/parsers/__tests__/tasks-test.js
@@ -22,7 +22,8 @@ describe("tasks parser", function() {
             executor_id: "default",
             framework_id: "d4bd102f-e25f-46dc-bb5d-8b10bca133d8-0000",
             resources: {},
-            labels: undefined
+            labels: undefined,
+            isStartedByMarathon: false
           },
           {
             slave_id: "d4bd102f-e25f-46dc-bb5d-8b10bca133d8-S0",
@@ -78,12 +79,18 @@ describe("tasks parser", function() {
               {
                 key: "LABEL_1",
                 value: "VALUE_1"
+              },
+              {
+                key: "DCOS_COMMONS_API_VERSION",
+                value: "1"
               }
             ],
             id: "1",
             task_id: {
               value: "1"
-            }
+            },
+            isStartedByMarathon: false,
+            sdkTask: true
           }
         ]
       });
@@ -126,7 +133,8 @@ describe("tasks parser", function() {
             },
             id: "1",
             resources: {},
-            labels: undefined
+            labels: undefined,
+            isStartedByMarathon: false
           }
         ]
       });

--- a/src/js/stores/MesosStream/parsers/state.js
+++ b/src/js/stores/MesosStream/parsers/state.js
@@ -26,7 +26,10 @@ export default function getStateAction(state, message) {
     type: GET_TASKS,
     get_tasks: message.get_state.get_tasks
   };
-  const tasksPartial = getTasksAction({}, getTasksMessage);
+  const tasksPartial = getTasksAction(
+    { ...frameworksPartial },
+    getTasksMessage
+  );
 
   const getExecutorsMessage = {
     type: GET_EXECUTORS,

--- a/src/js/stores/MesosStream/parsers/subscribed.js
+++ b/src/js/stores/MesosStream/parsers/subscribed.js
@@ -14,9 +14,6 @@ export default function subscribedAction(state, message) {
     type: GET_STATE,
     get_state: message.subscribed.get_state
   };
-  const statePartial = getStateAction({}, getStateMessage);
 
-  return Object.assign({}, state, {
-    ...statePartial
-  });
+  return getStateAction({}, getStateMessage);
 }

--- a/src/js/stores/MesosStream/parsers/tasks.js
+++ b/src/js/stores/MesosStream/parsers/tasks.js
@@ -64,20 +64,18 @@ export function taskUpdatedAction(state, message) {
 
   const taskUpdate = message.task_updated;
   const task_id = scalar(taskUpdate.status.task_id);
-  const tasks = state.tasks.reduce(function(acc, task) {
+  const tasks = state.tasks.map(function(task) {
     if (task.task_id.value === task_id) {
       const statuses = task.statuses || [];
 
-      return acc.concat(
-        Object.assign({}, task, {
-          state: taskUpdate.state,
-          statuses: [...statuses, taskUpdate.status]
-        })
-      );
+      return Object.assign({}, task, {
+        state: taskUpdate.state,
+        statuses: [...statuses, taskUpdate.status]
+      });
     }
 
-    return acc.concat(task);
-  }, []);
+    return task;
+  });
 
   return Object.assign({}, state, { tasks });
 }

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -382,12 +382,7 @@ describe("MesosStateStore", function() {
         tasks: [{ id: 1 }, { id: 2 }]
       };
 
-      const taskCache = MesosStateUtil.indexTasksByID(data);
-      MesosStateStore.get = function(id) {
-        if (id === "taskCache") {
-          return taskCache;
-        }
-
+      MesosStateStore.get = function() {
         return data;
       };
     });

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -153,10 +153,30 @@ describe("MesosStateStore", function() {
             }
           ],
           tasks: [
-            { name: "spark", id: "spark.1", framework_id: "marathon_1" },
-            { name: "alpha", id: "alpha.1", framework_id: "marathon_1" },
-            { name: "alpha", id: "alpha.2", framework_id: "marathon_1" },
-            { name: "alpha", id: "alpha.3", framework_id: "marathon_1" },
+            {
+              name: "spark",
+              id: "spark.1",
+              framework_id: "marathon_1",
+              isStartedByMarathon: true
+            },
+            {
+              name: "alpha",
+              id: "alpha.1",
+              framework_id: "marathon_1",
+              isStartedByMarathon: true
+            },
+            {
+              name: "alpha",
+              id: "alpha.2",
+              framework_id: "marathon_1",
+              isStartedByMarathon: true
+            },
+            {
+              name: "alpha",
+              id: "alpha.3",
+              framework_id: "marathon_1",
+              isStartedByMarathon: true
+            },
             { name: "1", framework_id: "spark_1" },
             { name: "2", framework_id: "spark_1" },
             { name: "3", framework_id: "spark_1" }
@@ -177,7 +197,12 @@ describe("MesosStateStore", function() {
         })
       );
       expect(tasks).toEqual([
-        { name: "spark", id: "spark.1", framework_id: "marathon_1" },
+        {
+          name: "spark",
+          id: "spark.1",
+          framework_id: "marathon_1",
+          isStartedByMarathon: true
+        },
         { name: "1", framework_id: "spark_1" },
         { name: "2", framework_id: "spark_1" },
         { name: "3", framework_id: "spark_1" }
@@ -189,9 +214,24 @@ describe("MesosStateStore", function() {
         new Application({ id: "/alpha" })
       );
       expect(tasks).toEqual([
-        { name: "alpha", id: "alpha.1", framework_id: "marathon_1" },
-        { name: "alpha", id: "alpha.2", framework_id: "marathon_1" },
-        { name: "alpha", id: "alpha.3", framework_id: "marathon_1" }
+        {
+          name: "alpha",
+          id: "alpha.1",
+          framework_id: "marathon_1",
+          isStartedByMarathon: true
+        },
+        {
+          name: "alpha",
+          id: "alpha.2",
+          framework_id: "marathon_1",
+          isStartedByMarathon: true
+        },
+        {
+          name: "alpha",
+          id: "alpha.3",
+          framework_id: "marathon_1",
+          isStartedByMarathon: true
+        }
       ]);
     });
 
@@ -398,14 +438,14 @@ describe("MesosStateStore", function() {
           tasks: [
             {
               id: "foo",
-              labels: [{ key: "DCOS_PACKAGE_FRAMEWORK_NAME", value: "foo" }]
+              isSchedulerTask: true
             },
             {
               id: "bar"
             },
             {
               id: "baz",
-              labels: [{ key: "DCOS_PACKAGE_FRAMEWORK_NAME", value: "baz" }]
+              isSchedulerTask: true
             }
           ]
         };
@@ -415,11 +455,11 @@ describe("MesosStateStore", function() {
       expect(schedulerTasks).toEqual([
         {
           id: "foo",
-          labels: [{ key: "DCOS_PACKAGE_FRAMEWORK_NAME", value: "foo" }]
+          isSchedulerTask: true
         },
         {
           id: "baz",
-          labels: [{ key: "DCOS_PACKAGE_FRAMEWORK_NAME", value: "baz" }]
+          isSchedulerTask: true
         }
       ]);
     });
@@ -460,7 +500,8 @@ describe("MesosStateStore", function() {
           tasks: [
             {
               id: "foo",
-              labels: [{ key: "DCOS_PACKAGE_FRAMEWORK_NAME", value: "foo" }]
+              labels: [{ key: "DCOS_PACKAGE_FRAMEWORK_NAME", value: "foo" }],
+              isSchedulerTask: true
             },
             {
               id: "bar"
@@ -481,7 +522,8 @@ describe("MesosStateStore", function() {
 
       expect(schedulerTask).toEqual({
         id: "foo",
-        labels: [{ key: "DCOS_PACKAGE_FRAMEWORK_NAME", value: "foo" }]
+        labels: [{ key: "DCOS_PACKAGE_FRAMEWORK_NAME", value: "foo" }],
+        isSchedulerTask: true
       });
     });
 

--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -300,16 +300,6 @@ const MesosStateUtil = {
     }
 
     return task;
-  },
-
-  indexTasksByID(state) {
-    const { tasks = [] } = state;
-
-    return tasks.reduce((acc, task) => {
-      acc[task.id] = task;
-
-      return acc;
-    }, {});
   }
 };
 

--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -295,7 +295,7 @@ const MesosStateUtil = {
    * @return {Object} task
    */
   flagSDKTask(task, service) {
-    if (isSDKService(service)) {
+    if (isSDKService(service) && task.sdkTask === undefined) {
       return Object.assign({}, task, { sdkTask: true });
     }
 


### PR DESCRIPTION
This PR adds a simple memoize utility and memoize the `cleanJobJSON`, `cleanServiceJSON` and `copyRawObject` utils to address performance issues due to very frequent invocations. It also adjusts the `flagSDKTask` utility to only flag tasks that aren't already flagged to further improve the performance. 

Closes DCOS-20485