### PR TITLE
DCOS-20475: Fix residency validators

### DIFF
--- a/plugins/services/src/js/reducers/JSONMultiContainerReducers.js
+++ b/plugins/services/src/js/reducers/JSONMultiContainerReducers.js
@@ -24,10 +24,7 @@ module.exports = {
   environment,
   scaling,
   labels,
-  scheduling(
-    state = { residency: {}, placement: { constraints: [] } },
-    transaction
-  ) {
+  scheduling(state = { placement: { constraints: [] } }, transaction) {
     const constraintsState = state != null && state.placement != null
       ? state.placement.constraints
       : [];

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/MultiContainerResidency.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/MultiContainerResidency.js
@@ -1,7 +1,6 @@
-import { SET, ADD_ITEM, REMOVE_ITEM } from "#SRC/js/constants/TransactionTypes";
+import { SET } from "#SRC/js/constants/TransactionTypes";
 import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
 import Transaction from "#SRC/js/structs/Transaction";
-import VolumeConstants from "../../../constants/VolumeConstants";
 
 module.exports = {
   JSONReducer(state, { type, path, value }) {
@@ -15,39 +14,6 @@ module.exports = {
 
     const joinedPath = path.join(".");
 
-    if (joinedPath.search("volumeMounts") !== -1) {
-      if (joinedPath === "volumeMounts") {
-        switch (type) {
-          case ADD_ITEM:
-            this.volumeMounts.push(false);
-            break;
-          case REMOVE_ITEM:
-            this.volumeMounts = this.volumeMounts.filter((item, index) => {
-              return index !== value;
-            });
-            break;
-        }
-      }
-      const index = path[1];
-      if (type === SET && `volumeMounts.${index}.type` === joinedPath) {
-        this.volumeMounts[index] =
-          value === VolumeConstants.type.localPersistent;
-      }
-
-      const hasLocalVolumes = this.volumeMounts.find(value => {
-        return value;
-      });
-      if (hasLocalVolumes && this.residency == null) {
-        return {
-          relaunchEscalationTimeoutSeconds: 10,
-          taskLostBehavior: "WAIT_FOREVER"
-        };
-      } else if (!hasLocalVolumes) {
-        return;
-      } else {
-        return this.residency;
-      }
-    }
     if (type === SET && joinedPath === "residency") {
       this.residency = value;
 


### PR DESCRIPTION
This fixes a legacy issue which was introduced into marathon a very long time ago. The issue was when you wanted to create a app with a persistent volume you needed to also define the residency setting, otherwise the volume would be present but not persistent ... unfortunately there was only one residency setting and changing it did not have any other purpose. With the latest changes Marathon is going to set residency if there is a persistent volume defined. So it is not mandatory to add it via the ui. 

With this PR we are removing the validators which were checking if the residency was set. And also we are removing the logic which was adding residency if a persistent volume was added. This has been done for single container and multi container services.

For Pods (multi container service) Use the Form to add a local persistent volume and check if the residency is set in: `scheduling.residency`

Closes DCOS-20475