### PR TITLE
🚨 Save stream to prevent resubscribes

### DIFF
--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -99,7 +99,7 @@ class MesosStateStore extends GetSetBaseStore {
     // LEAST once every tick of Config.getRefreshRate() ms in Observable.interval
     //
     // TODO: https://jira.mesosphere.com/browse/DCOS-18277
-    waitStream
+    this.stream = waitStream
       .concat(eventTriggerStream)
       .debounceTime(Config.getRefreshRate() * 0.5)
       .subscribe(this.onStreamData, this.onStreamError);

--- a/tests/pages/services/ServiceReviewScreen-cy.js
+++ b/tests/pages/services/ServiceReviewScreen-cy.js
@@ -1185,11 +1185,10 @@ describe("Services", function() {
       cy.get("#brace-editor").contents().asJson().should("deep.equal", [
         {
           id: `/${serviceName}`,
-          cmd: cmdline,
-          cpus: 0.1,
-          mem: 10,
           instances: 1,
+          portDefinitions: [],
           container: {
+            type: "MESOS",
             volumes: [
               {
                 persistent: {
@@ -1198,19 +1197,16 @@ describe("Services", function() {
                 mode: "RW",
                 containerPath: "test"
               }
-            ],
-            type: "MESOS"
+            ]
           },
-          residency: {
-            relaunchEscalationTimeoutSeconds: 10,
-            taskLostBehavior: "WAIT_FOREVER"
-          },
-          portDefinitions: [],
+          cpus: 0.1,
+          mem: 10,
           requirePorts: false,
           networks: [],
           healthChecks: [],
           fetch: [],
-          constraints: []
+          constraints: [],
+          cmd: "while true ; do echo 'test' > test/echo ; sleep 100 ; done"
         }
       ]);
 


### PR DESCRIPTION
This PR addresses the duplicated tasks ids issue.

`this.stream` went missing but we're using it as a check whether we have to subscribe or not here https://github.com/dcos/dcos-ui/compare/drozhkov/fix-mesos-stream-resubscribe?expand=1#diff-22eec13077e445e982cd1a9232667028R65

Closes DCOS-20625