### PR TITLE
Lily/dcos oss 2086 update config headings

### DIFF
--- a/plugins/services/src/js/service-configuration/PodGeneralConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodGeneralConfigSection.js
@@ -108,7 +108,7 @@ const PodGeneralConfigSection = ({ appConfig, onEditClick }) => {
 
   return (
     <div>
-      <ConfigurationMapHeading level={1}>General</ConfigurationMapHeading>
+      <ConfigurationMapHeading level={1}>Service</ConfigurationMapHeading>
       <ConfigurationMapSection key="pod-general-section">
         <MountService.Mount
           type="CreateService:ServiceConfigDisplay:Pod:General"

--- a/plugins/services/src/js/service-configuration/PodNetworkConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodNetworkConfigSection.js
@@ -105,7 +105,7 @@ class PodNetworkConfigSection extends React.Component {
 
     return (
       <div>
-        <ConfigurationMapHeading level={1}>Network</ConfigurationMapHeading>
+        <ConfigurationMapHeading level={1}>Networking</ConfigurationMapHeading>
         <ConfigurationMapSection key="pod-general-section">
           <MountService.Mount
             type="CreateService:ServiceConfigDisplay:Pod:Network"

--- a/plugins/services/src/js/service-configuration/PodStorageConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodStorageConfigSection.js
@@ -116,7 +116,7 @@ class PodStorageConfigSection extends React.Component {
 
     return (
       <div>
-        <ConfigurationMapHeading level={1}>Storage</ConfigurationMapHeading>
+        <ConfigurationMapHeading level={1}>Volumes</ConfigurationMapHeading>
         <ConfigurationMapSection key="pod-general-section">
           <MountService.Mount
             type="CreateService:ServiceConfigDisplay:Pod:Storage"

--- a/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
+++ b/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
@@ -38,9 +38,9 @@ const DEFAULT_DISPLAY_COMPONENTS = [
       ServicePlacementConstraintsConfigSection,
       ServiceNetworkingConfigSection,
       ServiceStorageConfigSection,
+      ServiceHealthChecksConfigSection,
       ServiceEnvironmentVariablesConfigSection,
-      ServiceLabelsConfigSection,
-      ServiceHealthChecksConfigSection
+      ServiceLabelsConfigSection
     ]
   },
   {

--- a/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
+++ b/plugins/services/src/js/service-configuration/ServiceConfigDisplay.js
@@ -51,9 +51,9 @@ const DEFAULT_DISPLAY_COMPONENTS = [
       PodPlacementConstraintsConfigSection,
       PodNetworkConfigSection,
       PodStorageConfigSection,
+      PodHealthChecksConfigSection,
       PodEnvironmentVariablesConfigSection,
-      PodLabelsConfigSection,
-      PodHealthChecksConfigSection
+      PodLabelsConfigSection
     ]
   }
 ];

--- a/plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceGeneralConfigSection.js
@@ -72,7 +72,7 @@ class ServiceGeneralConfigSection extends ServiceConfigBaseSectionDisplay {
       tabViewID: "services",
       values: [
         {
-          heading: "General",
+          heading: "Service",
           headingLevel: 1
         },
         {

--- a/plugins/services/src/js/service-configuration/ServiceLabelsConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceLabelsConfigSection.js
@@ -40,7 +40,7 @@ class ServiceLabelsConfigSection extends ServiceConfigBaseSectionDisplay {
           render(labelsDataMap) {
             const columns = [
               {
-                heading: ServiceConfigDisplayUtil.getColumnHeadingFn(),
+                heading: ServiceConfigDisplayUtil.getColumnHeadingFn("Key"),
                 prop: "key",
                 render: (prop, row) => {
                   return <code>{row[prop]}</code>;
@@ -51,7 +51,7 @@ class ServiceLabelsConfigSection extends ServiceConfigBaseSectionDisplay {
                 sortable: true
               },
               {
-                heading: ServiceConfigDisplayUtil.getColumnHeadingFn(),
+                heading: ServiceConfigDisplayUtil.getColumnHeadingFn("Value"),
                 prop: "value",
                 className: ServiceConfigDisplayUtil.getColumnClassNameFn(
                   "configuration-map-table-value"

--- a/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
@@ -47,7 +47,7 @@ class ServiceNetworkingConfigSection extends ServiceConfigBaseSectionDisplay {
       tabViewID: "networking",
       values: [
         {
-          heading: "Network",
+          heading: "Networking",
           headingLevel: 1
         },
         {

--- a/plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js
@@ -42,7 +42,7 @@ class ServiceStorageConfigSection extends ServiceConfigBaseSectionDisplay {
       values: [
         {
           key: "container.volumes",
-          heading: "Storage",
+          heading: "Volumes",
           headingLevel: 1
         },
         {

--- a/tests/pages/services/ServiceExternalVolumes-cy.js
+++ b/tests/pages/services/ServiceExternalVolumes-cy.js
@@ -100,54 +100,54 @@ describe("Services", function() {
       // Verify the review screen
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Runtime")
         .contains("Universal Container Runtime (UCR)");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.1");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("64 MiB");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Configured");
 
       cy
         .root()
-        .configurationSection("Storage")
+        .configurationSection("Volumes")
         .children("table")
         .getTableColumn("Volume")
         .contents()
         .should("deep.equal", [`External (${volumeName})`]);
       cy
         .root()
-        .configurationSection("Storage")
+        .configurationSection("Volumes")
         .children("table")
         .getTableColumn("Size")
         .contents()
         .should("deep.equal", ["1 GiB"]);
       cy
         .root()
-        .configurationSection("Storage")
+        .configurationSection("Volumes")
         .children("table")
         .getTableColumn("Mode")
         .contents()
         .should("deep.equal", ["RW"]);
       cy
         .root()
-        .configurationSection("Storage")
+        .configurationSection("Volumes")
         .children("table")
         .getTableColumn("Container Mount Path")
         .contents()

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1468,10 +1468,10 @@ describe("Service Form Modal", function() {
           expect($h1).to.have.length(2);
 
           // First should be General
-          expect($h1.eq(0)).to.contain("General");
+          expect($h1.eq(0)).to.contain("Service");
 
           // Second should be Network
-          expect($h1.eq(1)).to.contain("Network");
+          expect($h1.eq(1)).to.contain("Networking");
         });
       });
 

--- a/tests/pages/services/ServicePodReviewScreen-cy.js
+++ b/tests/pages/services/ServicePodReviewScreen-cy.js
@@ -81,31 +81,31 @@ describe("Services", function() {
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.1 (0.1 container-1)");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("10 MiB (10 MiB container-1)");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Supported");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("GPU")
         .contains("Not Supported");
 
@@ -274,19 +274,19 @@ describe("Services", function() {
       // Verify the review screen
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.2 (0.1 first-container, 0.1 second-container)");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("20 MiB (10 MiB first-container, 10 MiB second-container)");
 
@@ -435,37 +435,37 @@ describe("Services", function() {
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Instances")
         .contains("1");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.1 (0.1 container-1)");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("32 MiB (32 MiB container-1)");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Supported");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("GPU")
         .contains("Not Supported");
 
@@ -501,7 +501,7 @@ describe("Services", function() {
 
       cy
         .root()
-        .configurationSection("Network")
+        .configurationSection("Networking")
         .configurationMapValue("Network Type")
         .contains("Container");
 
@@ -616,37 +616,37 @@ describe("Services", function() {
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Instances")
         .contains("1");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.1 (0.1 container-1)");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("10 MiB (10 MiB container-1)");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Supported");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("GPU")
         .contains("Not Supported");
 
@@ -807,31 +807,31 @@ describe("Services", function() {
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.1 (0.1 container-1)");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("32 MiB (32 MiB container-1)");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Supported");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("GPU")
         .contains("Not Supported");
 
@@ -867,7 +867,7 @@ describe("Services", function() {
 
       cy
         .root()
-        .configurationSection("Network")
+        .configurationSection("Networking")
         .configurationMapValue("Network Type")
         .contains("Container");
 
@@ -975,37 +975,37 @@ describe("Services", function() {
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Instances")
         .contains("1");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.1 (0.1 container-1)");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("10 MiB (10 MiB container-1)");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Supported");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("GPU")
         .contains("Not Supported");
 
@@ -1039,7 +1039,7 @@ describe("Services", function() {
         .configurationMapValue("Command")
         .contains(command);
 
-      cy.root().configurationSection("Storage").then(function($storageSection) {
+      cy.root().configurationSection("Volumes").then(function($storageSection) {
         const $tableRow = $storageSection
           .find("tbody tr")
           .filter(function(index, row) {
@@ -1160,37 +1160,37 @@ describe("Services", function() {
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Instances")
         .contains("1");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.1 (0.1 container-1)");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("10 MiB (10 MiB container-1)");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Supported");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("GPU")
         .contains("Not Supported");
 
@@ -1350,37 +1350,37 @@ describe("Services", function() {
       // Verify the review screen
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Instances")
         .contains("1");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains(`0.1 (0.1 ${containerName})`);
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains(`10 MiB (10 MiB ${containerName})`);
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Supported");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("GPU")
         .contains("Not Supported");
 

--- a/tests/pages/services/ServiceReviewScreen-cy.js
+++ b/tests/pages/services/ServiceReviewScreen-cy.js
@@ -73,27 +73,27 @@ describe("Services", function() {
       // Verify the review screen
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Runtime")
         .contains("Universal Container Runtime (UCR)");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.1");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("10 MiB");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Configured");
     });
@@ -177,37 +177,37 @@ describe("Services", function() {
       // Verify the review screen
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Runtime")
         .contains("Universal Container Runtime (UCR)");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.1");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("10 MiB");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Configured");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Image")
         .contains("Not Supported");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Command")
         .contains(cmdline);
       cy
@@ -310,32 +310,32 @@ describe("Services", function() {
       // Verify the review screen
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Runtime")
         .contains("Docker Engine");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.1");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("32 MiB");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Configured");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Image")
         .contains("nginx");
       cy
@@ -436,32 +436,32 @@ describe("Services", function() {
       // Verify the review screen
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Runtime")
         .contains("Docker Engine");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.1");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("32 MiB");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Configured");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Image")
         .contains("python:3");
 
@@ -564,32 +564,32 @@ describe("Services", function() {
       // Verify the review screen
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Runtime")
         .contains("Universal Container Runtime (UCR)");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.5");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("32 MiB");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Configured");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Image")
         .contains("python:3");
 
@@ -688,32 +688,32 @@ describe("Services", function() {
       // Verify the review screen
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Runtime")
         .contains("Universal Container Runtime (UCR)");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.5");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("32 MiB");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Configured");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Image")
         .contains("Not Supported");
 
@@ -817,27 +817,27 @@ describe("Services", function() {
       // Verify the review screen
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Runtime")
         .contains("Universal Container Runtime (UCR)");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.1");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("10 MiB");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Configured");
 
@@ -953,32 +953,32 @@ describe("Services", function() {
       // Verify the review screen
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Runtime")
         .contains("Docker Engine");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.1");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("32 MiB");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Configured");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Image")
         .contains("nginx");
 
@@ -1095,27 +1095,27 @@ describe("Services", function() {
       // Verify the review screen
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Runtime")
         .contains("Universal Container Runtime (UCR)");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.1");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("10 MiB");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Configured");
 
@@ -1220,54 +1220,54 @@ describe("Services", function() {
       // Verify the review screen
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Runtime")
         .contains("Universal Container Runtime (UCR)");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.1");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("10 MiB");
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Configured");
 
       cy
         .root()
-        .configurationSection("Storage")
+        .configurationSection("Volumes")
         .children("table")
         .getTableColumn("Volume")
         .contents()
         .should("deep.equal", ["Persistent Local"]);
       cy
         .root()
-        .configurationSection("Storage")
+        .configurationSection("Volumes")
         .children("table")
         .getTableColumn("Size")
         .contents()
         .should("deep.equal", ["128 MiB"]);
       cy
         .root()
-        .configurationSection("Storage")
+        .configurationSection("Volumes")
         .children("table")
         .getTableColumn("Mode")
         .contents()
         .should("deep.equal", ["RW"]);
       cy
         .root()
-        .configurationSection("Storage")
+        .configurationSection("Volumes")
         .children("table")
         .getTableColumn("Container Mount Path")
         .contents()
@@ -1358,49 +1358,49 @@ describe("Services", function() {
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Instances")
         .contains("1");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.5");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("32 MiB");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Disk")
         .contains("Not Configured");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Runtime")
         .contains("Docker Engine");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Command")
         .contains(command);
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Image")
         .contains(containerImage);
 
@@ -1550,43 +1550,43 @@ describe("Services", function() {
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Service ID")
         .contains(`/${serviceName}`);
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Runtime")
         .contains("Docker Engine");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Instances")
         .contains(1);
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("CPU")
         .contains("0.5");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Memory")
         .contains("32 MiB");
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Container Image")
         .contains(containerImage);
 
       cy
         .root()
-        .configurationSection("General")
+        .configurationSection("Service")
         .configurationMapValue("Command")
         .contains(command);
 


### PR DESCRIPTION
Problem: 
1. Labels across configuration flow, confirmation page and confirmation tab are inconsistent. 

Labels in configuration flow:

Service
Placement
Networking 
Volumes
Health Checks
Environment

Labels in Confirmation page and Confirmation tab: 

General
Placement
Network 
Storage
Environment Variables
Labels
Secrets
Health Checks

2. "key" and "value" labels in the Label section of the Confirmation page and Configuration tab are lower-case when they should be title-case. 

Solution:
1. Make labels consistent across configuration flow, confirmation page and configuration tab. 

All three pages should have the following labels for config flow: 

Service
Placement
Networking
Volumes
Health Checks
Environment

All three pages should have the following labels for confirmation screen and configuration tab: 

Service
Placement
Networking
Volumes
Health Checks
Environment Variables
Labels
Secrets

2. Make labels in the Label section title-case for Confirmation page and Configuration tab. 

Closes [DCOS_OSS-2086](https://jira.mesosphere.com/browse/DCOS_OSS-2086)

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?