### PR TITLE
feat(scripts): add basic link checker script

### DIFF
--- a/scripts/are-links-broken
+++ b/scripts/are-links-broken
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# example usage: $ are-links-broken 1.11
+#  it will print the links that won't return 200 to stdout: <link> <http-status-code>
+
+docsVersion=$1
+
+files=$(git ls-files)
+for file in $files
+do
+  # skip files types we know won't contain links
+  matchesNonCodeFile=$(echo $file | grep -Eo "(\.gif|\.png|\.svg)")
+  if [ "${matchesNonCodeFile}" ]; then
+    continue
+  fi
+
+  # find the easy urls that have https or https
+  urls=$(cat $file | grep -Eo "(http|https)://[a-zA-Z0-9./?=_-]*" | sort | uniq)
+
+  for url in $urls
+  do
+    status=$(curl -o /dev/null -Isw '%{http_code}\n' $url)
+    if [ $status != 200 ]; then
+      echo $url $status
+    fi
+  done
+
+
+  # find the urls built from buildDocsURI() method
+  docsUrls=$(cat $file | tr -d "\n" |  grep -Eo "MetadataStore\.buildDocsURI\((.*?)\)" | grep -Eo "\"(.*)\"" )
+  prefix="https://dcos.io/docs/$docsVersion"
+  echo $prefix
+
+  for docsUrl in $docsUrls
+  do
+    fullDocsUrl=$prefix${docsUrl:1:${#docsUrl}-2}
+    status=$(curl -o /dev/null -Isw '%{http_code}\n' $fullDocsUrl)
+    if [ $status != 200 ]; then
+      echo $fullDocsUrl $status
+    fi
+  done
+done


### PR DESCRIPTION
Purpose of this script is to automate the process of detecting broken links to docs in our code.

**How it works:**
1. It loops through the file checked into git
2. It skips the files that are known files without links (png, gif, svg). I can probably add more to this blacklist.
3. It checks for direct hardcoded links in the files.
4. It then checks for usages of buildDocsURI.
5. It sends requests to these links, and prints the links to stdout that fail.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
