### PR TITLE
POC - testing mesos state store stream

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -106,6 +106,11 @@
       "from": "@types/lodash@4.14.87",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.87.tgz"
     },
+    "@types/lodash-es": {
+      "version": "4.17.0",
+      "from": "@types/lodash-es@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.0.tgz"
+    },
     "@types/minimatch": {
       "version": "3.0.1",
       "from": "@types/minimatch@3.0.1",
@@ -2897,7 +2902,7 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "from": "decamelize@>=1.0.0 <2.0.0",
+      "from": "decamelize@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
     "decompress": {
@@ -3646,7 +3651,7 @@
     },
     "eslint-config-airbnb": {
       "version": "10.0.1",
-      "from": "eslint-config-airbnb@10.0.1",
+      "from": "eslint-config-airbnb@>=10.0.1 <11.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-10.0.1.tgz"
     },
     "eslint-config-airbnb-base": {
@@ -4148,7 +4153,7 @@
     },
     "find-up": {
       "version": "1.1.2",
-      "from": "find-up@>=1.1.2 <2.0.0",
+      "from": "find-up@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "dependencies": {
         "path-exists": {
@@ -5494,7 +5499,7 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "from": "isarray@1.0.0",
+      "from": "isarray@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
     },
     "isexe": {
@@ -6880,7 +6885,7 @@
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+      "from": "lodash._reinterpolate@>=3.0.0 <3.1.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
     },
     "lodash._root": {
@@ -7181,7 +7186,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "from": "meow@>=3.5.0 <4.0.0",
+      "from": "meow@3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "dependencies": {
         "object-assign": {
@@ -7275,7 +7280,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "from": "minimist@>=1.1.0 <2.0.0",
+      "from": "minimist@>=1.1.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
     },
     "mkdirp": {
@@ -8334,7 +8339,7 @@
     },
     "prop-types": {
       "version": "15.6.0",
-      "from": "prop-types@latest",
+      "from": "prop-types@>=15.5.6 <16.0.0",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
       "dependencies": {
         "fbjs": {
@@ -8344,12 +8349,12 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "from": "js-tokens@>=3.0.0 <4.0.0",
+          "from": "js-tokens@^3.0.0",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
         },
         "loose-envify": {
           "version": "1.3.1",
-          "from": "loose-envify@>=1.3.1 <2.0.0",
+          "from": "loose-envify@^1.3.1",
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
         },
         "object-assign": {
@@ -9055,6 +9060,11 @@
       "from": "rxjs@latest",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.3.tgz"
     },
+    "rxjs-marbles": {
+      "version": "2.3.0",
+      "from": "rxjs-marbles@2.3.0",
+      "resolved": "https://registry.npmjs.org/rxjs-marbles/-/rxjs-marbles-2.3.0.tgz"
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "from": "safe-buffer@>=5.1.0 <5.2.0",
@@ -9523,7 +9533,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "from": "strip-ansi@>=3.0.1 <4.0.0",
+      "from": "strip-ansi@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
     },
     "strip-bom": {
@@ -9830,7 +9840,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.3.4 <2.4.0",
+      "from": "through@>=2.2.7 <3.0.0",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
@@ -10672,7 +10682,7 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <5.0.0",
+      "from": "xtend@>=4.0.1 <4.1.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "redux": "3.3.1",
     "reflect-metadata": "0.1.10",
     "rxjs": "5.4.3",
+    "rxjs-marbles": "2.3.0",
     "tv4": "1.2.7"
   },
   "devDependencies": {

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -1,3 +1,4 @@
+const { MESOS_STATE_CHANGE } = require("../../constants/EventTypes");
 const MesosStateUtil = require("../../utils/MesosStateUtil");
 const Pod = require("../../../../plugins/services/src/js/structs/Pod");
 const Framework = require("../../../../plugins/services/src/js/structs/Framework");
@@ -8,6 +9,12 @@ const Task = require("../../../../plugins/services/src/js/structs/Task");
 const MESOS_STATE_WITH_HISTORY = require("../../utils/__tests__/fixtures/MesosStateWithHistory");
 
 describe("MesosStateStore", function() {
+  beforeEach(function() {
+    // Because the store a singleton, once you set the stream it is never reset
+    MesosStateStore.stream = null;
+    MesosStateStore.customStream = null;
+  });
+
   describe("#new", function() {
     beforeEach(function() {
       this.mockStream = { stream: "mockStream" };
@@ -51,6 +58,42 @@ describe("MesosStateStore", function() {
         this.store.subscribe();
         expect(MesosStateStore.stream).toBe(this.customStream);
       });
+    });
+  });
+
+  describe("#addChangeListener", function() {
+    beforeEach(function() {
+      this.customStream = { stream: "mockStream" };
+      this.store = MesosStateStore.withStream(this.customStream);
+
+      this.restoreSubscribe = MesosStateStore.subscribe;
+      this.mockSubscribe = jest.fn(this.restoreSubscribe);
+      MesosStateStore.subscribe = this.mockSubscribe;
+    });
+
+    afterEach(function() {
+      MesosStateStore.subscribe = this.restoreSubscribe;
+    });
+
+    it("calls subscribe once when adding listener", function() {
+      const listener = () => {};
+      this.store.addChangeListener(MESOS_STATE_CHANGE, listener);
+
+      expect(this.mockSubscribe.mock.calls.length).toBe(1);
+
+      this.store.removeChangeListener(MESOS_STATE_CHANGE, listener);
+    });
+
+    it("does not call subscribe more than once", function() {
+      const listener1 = () => {};
+      const listener2 = () => {};
+      this.store.addChangeListener(MESOS_STATE_CHANGE, listener1);
+      this.store.addChangeListener(MESOS_STATE_CHANGE, listener2);
+
+      expect(this.mockSubscribe.mock.calls.length).toBe(1);
+
+      this.store.removeChangeListener(MESOS_STATE_CHANGE, listener1);
+      this.store.removeChangeListener(MESOS_STATE_CHANGE, listener2);
     });
   });
 

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -8,6 +8,52 @@ const Task = require("../../../../plugins/services/src/js/structs/Task");
 const MESOS_STATE_WITH_HISTORY = require("../../utils/__tests__/fixtures/MesosStateWithHistory");
 
 describe("MesosStateStore", function() {
+  describe("#new", function() {
+    beforeEach(function() {
+      this.mockStream = { stream: "mockStream" };
+      this.buildStream = MesosStateStore.buildStream;
+      this.mockBuildStream = jest.fn(() => this.mockStream);
+      MesosStateStore.buildStream = this.mockBuildStream;
+    });
+
+    afterEach(function() {
+      MesosStateStore.buildStream = this.buildStream;
+    });
+
+    describe("with default stream", function() {
+      it("calls buildStream on submit", function() {
+        MesosStateStore.subscribe();
+        expect(this.mockBuildStream.mock.calls.length).toBe(1);
+      });
+
+      it("assigns the store as the default one", function() {
+        MesosStateStore.subscribe();
+        expect(MesosStateStore.stream).toBe(this.mockStream);
+      });
+    });
+
+    describe("with custom stream", function() {
+      beforeEach(function() {
+        this.customStream = { stream: "customStream" };
+        this.store = MesosStateStore.withStream(this.customStream);
+      });
+
+      afterEach(function() {
+        MesosStateStore.buildStream = this.buildStream;
+      });
+
+      it("does not calls buildStream on submit", function() {
+        this.store.subscribe();
+        expect(this.mockBuildStream.mock.calls.length).toBe(0);
+      });
+
+      it("assigns the store as the default one", function() {
+        this.store.subscribe();
+        expect(MesosStateStore.stream).toBe(this.customStream);
+      });
+    });
+  });
+
   describe("#getTasksFromServiceName", function() {
     beforeEach(function() {
       this.get = MesosStateStore.get;


### PR DESCRIPTION
Refactoring the MesosStateStore so I can pass it the stream. That would allow marble testing, as well as testing behavior independently of the stream. 

- [x] Support custom streams
- [x] Get addChangeListener tested
- [ ] Add [marble testing](https://github.com/ReactiveX/rxjs/blob/master/doc/writing-marble-tests.md)

This is motivated because we got the bug at (https://github.com/dcos/dcos-ui/pull/2675) but we did not manage to get the test at that point.

#