### PR TITLE
feat(EmptyStates): consolidate config value empty states

### DIFF
--- a/plugins/services/src/js/components/ConfigurationMapBooleanValue.js
+++ b/plugins/services/src/js/components/ConfigurationMapBooleanValue.js
@@ -3,6 +3,7 @@ import React from "react";
 
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
 import ValidatorUtil from "#SRC/js/utils/ValidatorUtil";
+import EmptyStates from "#SRC/js/constants/EmptyStates";
 
 /**
  * Render a boolean value as a <ConfigurationMapValue>, with it's values being
@@ -33,7 +34,7 @@ class ConfigurationMapBooleanValue extends React.Component {
 }
 
 ConfigurationMapBooleanValue.defaultProps = {
-  defaultValue: <em>Not Configured</em>,
+  defaultValue: <em>{EmptyStates.CONFIG_VALUE}</em>,
   options: {
     truthy: "Enabled",
     falsy: "Disabled"

--- a/plugins/services/src/js/components/ConfigurationMapDurationValue.js
+++ b/plugins/services/src/js/components/ConfigurationMapDurationValue.js
@@ -4,6 +4,7 @@ import React from "react";
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
 import DateUtil from "#SRC/js/utils/DateUtil";
 import ValidatorUtil from "#SRC/js/utils/ValidatorUtil";
+import EmptyStates from "#SRC/js/constants/EmptyStates";
 
 const MULTIPLICANTS = {
   ms: 1,
@@ -53,7 +54,7 @@ class ConfigurationMapDurationValue extends React.Component {
 }
 
 ConfigurationMapDurationValue.defaultProps = {
-  defaultValue: <em>Not Configured</em>,
+  defaultValue: <em>{EmptyStates.CONFIG_VALUE}</em>,
   multiplicants: MULTIPLICANTS,
   units: "ms",
   value: 0

--- a/plugins/services/src/js/components/ConfigurationMapMultilineValue.js
+++ b/plugins/services/src/js/components/ConfigurationMapMultilineValue.js
@@ -3,6 +3,7 @@ import React from "react";
 
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
 import ValidatorUtil from "#SRC/js/utils/ValidatorUtil";
+import EmptyStates from "#SRC/js/constants/EmptyStates";
 
 /**
  * Render a multiline value as a <ConfigurationMapValue>, within the
@@ -26,7 +27,7 @@ class ConfigurationMapMultilineValue extends React.Component {
 }
 
 ConfigurationMapMultilineValue.defaultProps = {
-  defaultValue: <em>Not Configured</em>,
+  defaultValue: <em>{EmptyStates.CONFIG_VALUE}</em>,
   value: ""
 };
 

--- a/plugins/services/src/js/components/ConfigurationMapSizeValue.js
+++ b/plugins/services/src/js/components/ConfigurationMapSizeValue.js
@@ -4,6 +4,7 @@ import React from "react";
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
 import ValidatorUtil from "#SRC/js/utils/ValidatorUtil";
 import Units from "#SRC/js/utils/Units";
+import EmptyStates from "#SRC/js/constants/EmptyStates";
 
 /**
  * Render a size value as a <ConfigurationMapValue>, with it's values being
@@ -39,7 +40,7 @@ class ConfigurationMapSizeValue extends React.Component {
 
 ConfigurationMapSizeValue.defaultProps = {
   decimals: 2,
-  defaultValue: <em>Not Configured</em>,
+  defaultValue: <em>{EmptyStates.CONFIG_VALUE}</em>,
   multiplier: 1024,
   scale: 1024 * 1024,
   threshold: 800,

--- a/plugins/services/src/js/components/ConfigurationMapTable.js
+++ b/plugins/services/src/js/components/ConfigurationMapTable.js
@@ -1,10 +1,10 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { Table } from "reactjs-components";
-
+import EmptyStates from "#SRC/js/constants/EmptyStates";
 import ValidatorUtil from "#SRC/js/utils/ValidatorUtil.js";
-
 import ServiceConfigDisplayUtil from "../utils/ServiceConfigDisplayUtil";
+
 /**
  * Optimized method to check if all row props are empty for a given column
  *
@@ -98,7 +98,7 @@ class ConfigurationMapTable extends React.Component {
           className = "",
           heading,
           hideIfEmpty = false,
-          placeholder = <em>Not Configured</em>,
+          placeholder = <em>{EmptyStates.CONFIG_VALUE}</em>,
           prop,
           render = defaultRenderFunction
         } = column;

--- a/plugins/services/src/js/components/ConfigurationMapValueWithDefault.js
+++ b/plugins/services/src/js/components/ConfigurationMapValueWithDefault.js
@@ -3,6 +3,7 @@ import React from "react";
 
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
 import ValidatorUtil from "#SRC/js/utils/ValidatorUtil.js";
+import EmptyStates from "#SRC/js/constants/EmptyStates";
 
 /**
  * Render a defaultValue value if the value is empty or falsy.
@@ -26,7 +27,7 @@ class ConfigurationMapValueWithDefault extends React.Component {
 
 ConfigurationMapValueWithDefault.defaultProps = {
   value: undefined,
-  defaultValue: <em>Not Configured</em>
+  defaultValue: <em>{EmptyStates.CONFIG_VALUE}</em>
 };
 
 ConfigurationMapValueWithDefault.propTypes = {

--- a/plugins/services/src/js/components/__tests__/ConfigurationMapTable-test.js
+++ b/plugins/services/src/js/components/__tests__/ConfigurationMapTable-test.js
@@ -4,6 +4,7 @@ const ReactDOM = require("react-dom");
 /* eslint-enable no-unused-vars */
 const TestUtils = require("react-addons-test-utils");
 const JestUtil = require("#SRC/js/utils/JestUtil");
+const EmptyStates = require("#SRC/js/constants/EmptyStates");
 const ConfigurationMapTable = require("../ConfigurationMapTable");
 
 describe("ConfigurationMapTable", function() {
@@ -132,7 +133,7 @@ describe("ConfigurationMapTable", function() {
     ).map(JestUtil.mapTextContent);
 
     expect(headerText).toEqual(["A", "B"]);
-    expect(cellText).toEqual(["1", "Not Configured"]);
+    expect(cellText).toEqual(["1", EmptyStates.CONFIG_VALUE]);
   });
 
   it("respects `placeholder` column property", function() {

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -7,6 +7,7 @@ import React from "react";
 import { Hooks } from "PluginSDK";
 
 import StringUtil from "#SRC/js/utils/StringUtil";
+import EmptyStates from "#SRC/js/constants/EmptyStates";
 import Icon from "#SRC/js/components/Icon";
 import MetadataStore from "#SRC/js/stores/MetadataStore";
 import NestedServiceLinks from "#SRC/js/components/NestedServiceLinks";
@@ -393,7 +394,9 @@ class ServicesTable extends React.Component {
       ? ` ${runningInstances}`
       : ` ${runningInstances}/${instancesCount}`;
 
-    const content = !Number.isInteger(instancesCount) ? "\u2014" : overview;
+    const content = !Number.isInteger(instancesCount)
+      ? EmptyStates.CONFIG_VALUE
+      : overview;
     const tooltipContent = (
       <span>
         {`${runningInstances} ${StringUtil.pluralize("instance", runningInstances)} running out of ${instancesCount}`}

--- a/plugins/services/src/js/service-configuration/PodGeneralConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodGeneralConfigSection.js
@@ -11,6 +11,7 @@ import ConfigurationMapSection
   from "#SRC/js/components/ConfigurationMapSection";
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
 import Units from "#SRC/js/utils/Units";
+import EmptyStates from "#SRC/js/constants/EmptyStates";
 
 import ConfigurationMapValueWithDefault
   from "../components/ConfigurationMapValueWithDefault";
@@ -39,7 +40,7 @@ function getContainerResourceSummary(resource, { containers = [] }) {
   );
 
   if (!summary.value) {
-    return <em>Not Supported</em>;
+    return <em>{EmptyStates.CONFIG_VALUE}</em>;
   }
 
   return (

--- a/plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceHealthChecksConfigSection.js
@@ -5,6 +5,7 @@ import ConfigurationMapHeading
   from "#SRC/js/components/ConfigurationMapHeading";
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
 import Util from "#SRC/js/utils/Util";
+import EmptyStates from "#SRC/js/constants/EmptyStates";
 
 import {
   getColumnClassNameFn,
@@ -25,7 +26,7 @@ function renderDuration(prop, row) {
 
   return (
     <ConfigurationMapDurationValue
-      defaultValue={<em>Not Configured</em>}
+      defaultValue={<em>{EmptyStates.CONFIG_VALUE}</em>}
       units="sec"
       value={value}
     />

--- a/plugins/services/src/js/utils/ServiceConfigDisplayUtil.js
+++ b/plugins/services/src/js/utils/ServiceConfigDisplayUtil.js
@@ -3,6 +3,7 @@ import React from "react";
 
 import { isObject } from "#SRC/js/utils/Util";
 import Icon from "#SRC/js/components/Icon";
+import EmptyStates from "#SRC/js/constants/EmptyStates";
 
 const ServiceConfigDisplayUtil = {
   getColumnClassNameFn(classes) {
@@ -38,12 +39,9 @@ const ServiceConfigDisplayUtil = {
     );
   },
 
-  getDisplayValue(value, isDisabled = false) {
-    if (!isDisabled && (value == null || value === "")) {
-      return <em>Not Configured</em>;
-    }
-    if (isDisabled && (value == null || value === "")) {
-      return <em>Not Supported</em>;
+  getDisplayValue(value) {
+    if (value == null || value === "") {
+      return <em>{EmptyStates.CONFIG_VALUE}</em>;
     }
 
     // Display nested objects nicely if the render didn't already cover it.

--- a/src/js/components/FrameworkConfigurationReviewScreen.js
+++ b/src/js/components/FrameworkConfigurationReviewScreen.js
@@ -5,6 +5,7 @@ import HashMapDisplay from "#SRC/js/components/HashMapDisplay";
 import Util from "#SRC/js/utils/Util";
 import StringUtil from "#SRC/js/utils/StringUtil";
 import Icon from "#SRC/js/components/Icon";
+import EmptyStates from "#SRC/js/constants/EmptyStates";
 import RouterUtil from "#SRC/js/utils/RouterUtil";
 
 const METHODS_TO_BIND = ["getHashMapRenderKeys"];
@@ -82,7 +83,7 @@ class FrameworkConfigurationReviewScreen extends React.Component {
           hash={frameworkData}
           renderKeys={this.getHashMapRenderKeys(frameworkData)}
           headlineClassName={"text-capitalize"}
-          emptyValue={"\u2014"}
+          emptyValue={EmptyStates.CONFIG_VALUE}
         />
       </div>
     );

--- a/src/js/constants/EmptyStates.js
+++ b/src/js/constants/EmptyStates.js
@@ -1,0 +1,5 @@
+const EMPTY_STATES = {
+  CONFIG_VALUE: "\u2014"
+};
+
+module.exports = EMPTY_STATES;

--- a/tests/pages/services/ServiceExternalVolumes-cy.js
+++ b/tests/pages/services/ServiceExternalVolumes-cy.js
@@ -122,7 +122,7 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()

--- a/tests/pages/services/ServicePodReviewScreen-cy.js
+++ b/tests/pages/services/ServicePodReviewScreen-cy.js
@@ -101,13 +101,13 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Supported");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("Service")
         .configurationMapValue("GPU")
-        .contains("Not Supported");
+        .contains("\u2014");
 
       // per container details
 
@@ -115,13 +115,13 @@ describe("Services", function() {
         .root()
         .configurationSection("container-1")
         .configurationMapValue("Container Image")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("container-1")
         .configurationMapValue("Force Pull On Launch")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()
@@ -461,13 +461,13 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Supported");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("Service")
         .configurationMapValue("GPU")
-        .contains("Not Supported");
+        .contains("\u2014");
 
       cy
         .root()
@@ -479,7 +479,7 @@ describe("Services", function() {
         .root()
         .configurationSection("container-1")
         .configurationMapValue("Force Pull On Launch")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()
@@ -642,25 +642,25 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Supported");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("Service")
         .configurationMapValue("GPU")
-        .contains("Not Supported");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("container-1")
         .configurationMapValue("Container Image")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("container-1")
         .configurationMapValue("Force Pull On Launch")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()
@@ -827,13 +827,13 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Supported");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("Service")
         .configurationMapValue("GPU")
-        .contains("Not Supported");
+        .contains("\u2014");
 
       cy
         .root()
@@ -845,7 +845,7 @@ describe("Services", function() {
         .root()
         .configurationSection("container-1")
         .configurationMapValue("Force Pull On Launch")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()
@@ -1001,25 +1001,25 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Supported");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("Service")
         .configurationMapValue("GPU")
-        .contains("Not Supported");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("container-1")
         .configurationMapValue("Container Image")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("container-1")
         .configurationMapValue("Force Pull On Launch")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()
@@ -1186,25 +1186,25 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Supported");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("Service")
         .configurationMapValue("GPU")
-        .contains("Not Supported");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("container-1")
         .configurationMapValue("Container Image")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("container-1")
         .configurationMapValue("Force Pull On Launch")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()
@@ -1376,25 +1376,25 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Supported");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("Service")
         .configurationMapValue("GPU")
-        .contains("Not Supported");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("container-1")
         .configurationMapValue("Container Image")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("container-1")
         .configurationMapValue("Force Pull On Launch")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()

--- a/tests/pages/services/ServiceReviewScreen-cy.js
+++ b/tests/pages/services/ServiceReviewScreen-cy.js
@@ -95,7 +95,7 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Configured");
+        .contains("\u2014");
     });
 
     it("renders proper review screen and JSON for an app with artifacts", function() {
@@ -199,12 +199,12 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Configured");
+        .contains("\u2014");
       cy
         .root()
         .configurationSection("Service")
         .configurationMapValue("Container Image")
-        .contains("Not Supported");
+        .contains("\u2014");
       cy
         .root()
         .configurationSection("Service")
@@ -332,7 +332,7 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Configured");
+        .contains("\u2014");
       cy
         .root()
         .configurationSection("Service")
@@ -458,7 +458,7 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Configured");
+        .contains("\u2014");
       cy
         .root()
         .configurationSection("Service")
@@ -586,7 +586,7 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Configured");
+        .contains("\u2014");
       cy
         .root()
         .configurationSection("Service")
@@ -710,12 +710,12 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Configured");
+        .contains("\u2014");
       cy
         .root()
         .configurationSection("Service")
         .configurationMapValue("Container Image")
-        .contains("Not Supported");
+        .contains("\u2014");
 
       cy
         .root()
@@ -839,7 +839,7 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()
@@ -975,7 +975,7 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Configured");
+        .contains("\u2014");
       cy
         .root()
         .configurationSection("Service")
@@ -1117,7 +1117,7 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()
@@ -1238,7 +1238,7 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()
@@ -1363,7 +1363,7 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()
@@ -1409,7 +1409,7 @@ describe("Services", function() {
         .children("table")
         .getTableColumn("Protocol")
         .contents()
-        .should("deep.equal", ["Not Configured"]);
+        .should("deep.equal", ["\u2014"]);
 
       cy
         .root()
@@ -1597,7 +1597,7 @@ describe("Services", function() {
         .children("table")
         .getTableColumn("Protocol")
         .contents()
-        .should("deep.equal", ["Not Configured", "tcp"]);
+        .should("deep.equal", ["\u2014", "tcp"]);
 
       cy
         .root()


### PR DESCRIPTION
We have changed the design pattern to use unicode 2014 character (&mdash;) to denote the empty state of value in tables. Frameworks already use this pattern because the forms were recently built. This PR changes pods and services to use the same pattern.

**Testing**:
1. Deploy a service. The review screen should should long dash for unconfigured values.
2. Deploy a pod. The review screen should should long dash for unconfigured values.
3. Deploy a framework. The review screen should should long dash for unconfigured values.
4. Look at the configuration tab of service, pod, and framework. They should all have long dash in this view also.

**Before**:
<img width="1021" alt="screen shot 2018-01-29 at 2 17 06 pm" src="https://user-images.githubusercontent.com/1527504/35497011-576b41aa-0503-11e8-8e40-fe5cb2f2a116.png">

**After**:
<img width="1018" alt="screen shot 2018-01-29 at 2 16 57 pm" src="https://user-images.githubusercontent.com/1527504/35497016-5c721c50-0503-11e8-8660-2dea8fa8728f.png">

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

@leemunroe for visibility.
