### PR TITLE
[1.10] DCOS-20672: add defaults to resources

### DIFF
--- a/plugins/services/src/js/structs/ApplicationSpec.js
+++ b/plugins/services/src/js/structs/ApplicationSpec.js
@@ -80,10 +80,10 @@ module.exports = class ApplicationSpec extends ServiceSpec {
    */
   getResources() {
     return {
-      cpus: this.get("cpus"),
-      mem: this.get("mem"),
-      gpus: this.get("gpus"),
-      disk: this.get("disk")
+      cpus: this.get("cpus") || 0,
+      mem: this.get("mem") || 0,
+      gpus: this.get("gpus") || 0,
+      disk: this.get("disk") || 0
     };
   }
 

--- a/plugins/services/src/js/structs/Framework.js
+++ b/plugins/services/src/js/structs/Framework.js
@@ -102,7 +102,7 @@ module.exports = class Framework extends Application {
         return task.state === "TASK_RUNNING" && !task.isStartedByMarathon;
       })
       .reduce(function(memo, task) {
-        const { cpus, mem, gpus, disk } = task.resources;
+        const { cpus = 0, mem = 0, gpus = 0, disk = 0 } = task.resources;
 
         return {
           cpus: memo.cpus + cpus,

--- a/plugins/services/src/js/structs/__tests__/ApplicationSpec-test.js
+++ b/plugins/services/src/js/structs/__tests__/ApplicationSpec-test.js
@@ -288,6 +288,17 @@ describe("ApplicationSpec", function() {
         disk: 0
       });
     });
+
+    it("returns zeros by default", function() {
+      const service = new ApplicationSpec({});
+
+      expect(service.getResources()).toEqual({
+        cpus: 0,
+        mem: 0,
+        gpus: 0,
+        disk: 0
+      });
+    });
   });
 
   describe("#getUpdateStrategy", function() {

--- a/plugins/services/src/js/structs/__tests__/Framework-test.js
+++ b/plugins/services/src/js/structs/__tests__/Framework-test.js
@@ -235,12 +235,12 @@ describe("Framework", function() {
             id: "/fake_1",
             isStartedByMarathon: true,
             state: "TASK_RUNNING",
-            resources: { cpus: 0.2, mem: 300, gpus: 0, disk: 0 }
+            resources: { cpus: 0.2, mem: 300, gpus: 0 }
           },
           {
             id: "/fake_2",
             state: "TASK_RUNNING",
-            resources: { cpus: 0.8, mem: 700, gpus: 0, disk: 0 }
+            resources: { cpus: 0.8, mem: 700, gpus: 0, disk: 1000 }
           },
           {
             id: "/fake_2",
@@ -260,7 +260,7 @@ describe("Framework", function() {
         cpus: 1.8,
         mem: 1700,
         gpus: 0,
-        disk: 0
+        disk: 1000
       });
     });
   });


### PR DESCRIPTION
Default missing resource declaration to 0 to fix framework resource aggregation.

Spotted on soak cluster when there are few frameworks running in a group group would report 0 Disk even though frameworks inside the group report some disk usage.

Closes DCOS-20675