### PR TITLE
fix(labelsReducer): fix labels reducer to accept empty strings

### DIFF
--- a/plugins/services/src/js/components/modals/CreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModalForm.js
@@ -84,7 +84,20 @@ class CreateServiceModalForm extends Component {
     // Hint: When you add something to the state, make sure to update the
     //       shouldComponentUpdate function, since we are trying to reduce
     //       the number of updates as much as possible.
+    // In the Next line we are destructing the config to keep labels as it is and even keep labels with an empty value
+    const { labels = {}, ...serviceConfig } = ServiceUtil.getServiceJSON(
+      this.props.service
+    );
 
+    let newServiceConfig = {
+      labels,
+      ...CreateServiceModalFormUtil.stripEmptyProperties(serviceConfig)
+    };
+    if (Object.keys(labels).length === 0) {
+      newServiceConfig = CreateServiceModalFormUtil.stripEmptyProperties(
+        serviceConfig
+      );
+    }
     this.state = Object.assign(
       {
         appConfig: null,
@@ -97,9 +110,7 @@ class CreateServiceModalForm extends Component {
         jsonParser() {}
       },
       this.getNewStateForJSON(
-        CreateServiceModalFormUtil.stripEmptyProperties(
-          ServiceUtil.getServiceJSON(this.props.service)
-        ),
+        newServiceConfig,
         this.props.service instanceof PodSpec
       )
     );
@@ -309,7 +320,17 @@ class CreateServiceModalForm extends Component {
       baseConfigCopy
     );
 
-    return CreateServiceModalFormUtil.stripEmptyProperties(newConfig);
+    // In the Next line we are destructing the config to keep labels as it is and even keep labels with an empty value
+    const { labels, ...config } = newConfig;
+
+    if (Object.keys(labels).length === 0) {
+      return CreateServiceModalFormUtil.stripEmptyProperties(config);
+    }
+
+    return {
+      labels,
+      ...CreateServiceModalFormUtil.stripEmptyProperties(config)
+    };
   }
 
   getErrors() {

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Labels.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Labels.js
@@ -22,7 +22,7 @@ module.exports = {
       if (joinedPath === "labels") {
         switch (type) {
           case ADD_ITEM:
-            this.labels.push({ key: null, value: null });
+            this.labels.push({ key: null, value: "" });
             break;
           case REMOVE_ITEM:
             this.labels = this.labels.filter((item, index) => {
@@ -32,7 +32,7 @@ module.exports = {
         }
 
         return this.labels.reduce((memo, item) => {
-          if (item.key != null || item.value != null) {
+          if (item.key != null) {
             memo[item.key] = item.value;
           }
 
@@ -50,7 +50,7 @@ module.exports = {
     }
 
     return this.labels.reduce((memo, item) => {
-      if (item.key != null || item.value != null) {
+      if (item.key != null) {
         memo[item.key] = item.value;
       }
 


### PR DESCRIPTION
This pull request is fixing the labels reducer to support labels with an empty string value.

**To Test:**

You should be able to create an app with:

```JSON
{
  "labels": {
    "Label": ""
  }
}
```

Closes DCOS-19693