### PR TITLE
Disable chrome security to allow self signed https

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -10,5 +10,6 @@
   "supportFile": "tests/_support",
   "waitForAnimations": true,
   "videoUploadOnPasses": false,
-  "numTestsKeptInMemory": 0
+  "numTestsKeptInMemory": 0,
+  "chromeWebSecurity": false
 }

--- a/system-tests/cypress.json
+++ b/system-tests/cypress.json
@@ -9,5 +9,6 @@
   },
   "videoUploadOnPasses": false,
   "numTestsKeptInMemory": 0,
-  "screenshotOnHeadlessFailure": false
+  "screenshotOnHeadlessFailure": false,
+  "chromeWebSecurity": false
 }


### PR DESCRIPTION
Cypress isn't able to open self signed HTTPS pages unless this option is disabled. https://github.com/cypress-io/cypress/issues/771

Blocks https://github.com/mesosphere/dcos-ui-plugins-private/pull/729
