### PR TITLE
feat(FrameworkConfiguration): open to form when deploying

### DIFF
--- a/plugins/services/src/js/pages/EditFrameworkConfiguration.js
+++ b/plugins/services/src/js/pages/EditFrameworkConfiguration.js
@@ -122,7 +122,6 @@ class EditFrameworkConfiguration extends mixin(StoreMixin) {
         handleRun={this.handleRun.bind(this)}
         onFormDataChange={this.onFormDataChange.bind(this)}
         onFormErrorChange={this.onFormErrorChange.bind(this)}
-        isInitialDeploy={false}
         packageDetails={packageDetails}
         deployErrors={deployErrors}
         formData={formData}

--- a/src/js/components/FrameworkConfiguration.js
+++ b/src/js/components/FrameworkConfiguration.js
@@ -39,7 +39,7 @@ class FrameworkConfiguration extends Component {
     const { activeTab, focusField } = this.getFirstTabAndField();
 
     this.state = {
-      reviewActive: props.isInitialDeploy,
+      reviewActive: false,
       activeTab,
       focusField,
       jsonEditorActive: false,
@@ -366,7 +366,7 @@ FrameworkConfiguration.propTypes = {
   packageDetails: PropTypes.instanceOf(UniversePackage).isRequired,
   handleRun: PropTypes.func.isRequired,
   handleGoBack: PropTypes.func.isRequired,
-  isInitialDeploy: PropTypes.bool.isRequired,
+  isInitialDeploy: PropTypes.bool,
   deployErrors: PropTypes.object,
   defaultConfigWarning: PropTypes.string
 };

--- a/system-tests/universe/test-universe.js
+++ b/system-tests/universe/test-universe.js
@@ -24,6 +24,9 @@ describe("Universe", function() {
     // Click the Review & Run button
     cy.contains("Review & Run").click();
 
+    // Move to the review screen
+    cy.contains("Review & Run").click();
+
     // Click the Run Service button
     cy.contains("Run Service").click();
 
@@ -51,6 +54,9 @@ describe("Universe", function() {
     // Click the Review & Run button
     cy.contains("Review & Run").click();
 
+    // Move to the review screen
+    cy.contains("Review & Run").click();
+
     // Click the Run Service button
     cy.contains("Run Service").click();
 
@@ -73,6 +79,9 @@ describe("Universe", function() {
     cy.contains("Community");
 
     // Click the Review & Run button
+    cy.contains("Review & Run").click();
+
+    // Move to the review screen
     cy.contains("Review & Run").click();
 
     // Click the Run Service button

--- a/tests/pages/catalog/packages/package/PackageTab-cy.js
+++ b/tests/pages/catalog/packages/package/PackageTab-cy.js
@@ -114,6 +114,8 @@ describe("Package Detail Tab", function() {
         .get(".page-body-content .package-action-buttons button")
         .contains("Review & Run")
         .click();
+
+      cy.get(".modal .modal-header button").contains("Review & Run").click();
     });
 
     it("opens framework configuration when Review & Run clicked", function() {


### PR DESCRIPTION
Based on feedback from users, we want to open the service to the form when deploying. This also makes it the same as when editing a running framework.

![screen recording 2018-02-01 at 03 56 pm](https://user-images.githubusercontent.com/1527504/35667438-9df60fbc-0768-11e8-9621-9c8627cc45e9.gif)

Closes DCOS-19301

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
