### PR TITLE
chore(build): changes filename of release

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -31,6 +31,7 @@ pipeline {
       when {
         expression { params.SHOULD_UPLOAD_BUILD == true }
       }
+
       steps {
         user_is_authorized(master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#frontend-dev')
       }
@@ -79,7 +80,7 @@ pipeline {
             string(credentialsId: '3f0dbb48-de33-431f-b91c-2366d2f0e1cf',variable: 'AWS_ACCESS_KEY_ID'),
             string(credentialsId: 'f585ec9a-3c38-4f67-8bdb-79e5d4761937',variable: 'AWS_SECRET_ACCESS_KEY')
         ]) {
-          sh '''./scripts/ci/upload-build'''
+          sh "BRANCH_NAME=${env.BRANCH_NAME} ./scripts/ci/upload-build"
         }
       }
     }

--- a/scripts/ci/upload-build
+++ b/scripts/ci/upload-build
@@ -1,22 +1,29 @@
 #!/bin/bash
 set -ex
 
-DIST_PATH=${DIST_PATH:-dist}
-BUILD_PREFIX=${BUILD_PREFIX:-oss}
+# configuration
+BUILD_VARIANT=${BUILD_VARIANT:-''}
+BRANCH_NAME=${BRANCH_NAME:-'master'}
+DIST_PATH=${DIST_PATH:-'dist'}
+PACKAGE_PATH=${PACKAGE_PATH:-'.'}
+SHA_SLUG=${SHA_SLUG:-$(git rev-parse --short HEAD)}
 
+# aws settings
 AWS_BUCKET='downloads.mesosphere.io'
 BUCKET_PATH='dcos-ui'
 
+# build release filename
+FILENAME='dcos-ui'
 PKG_VERSION=$(python -c "import sys, json; \
-      pkg = json.load(open('package.json')); \
-      sys.stdout.write(str(pkg['version']));")
-GIT_SHA=$(git rev-parse HEAD)
+  pkg = json.load(open('$PACKAGE_PATH/package.json')); \
+  sys.stdout.write(str(pkg['version']));")
+PKG_BRANCH=$(echo ${BRANCH_NAME} | sed -E 's/([^/]*)$|./\1/g')
+RELEASE_NAME="${PKG_BRANCH}+${FILENAME}${BUILD_VARIANT}-v${PKG_VERSION}+${SHA_SLUG}.tar.gz"
 
-RELEASE_NAME="$BUILD_PREFIX-$PKG_VERSION-$GIT_SHA.tar.gz"
-
-cd $DIST_PATH
+# tar dist
+cd "$DIST_PATH"
 tar czf "../$RELEASE_NAME" .
 cd ..
 
-
+# upload
 aws s3 cp $RELEASE_NAME s3://$AWS_BUCKET/$BUCKET_PATH/$RELEASE_NAME


### PR DESCRIPTION
this commit changes the filename of a release to a, what we hope, more rubust one.

the new name is built up with different parts:
1. dcos-ui branchname
   DCOS introduces new features so old versions which can lead to
   an updated minor version, for this reason and to prevent
   conflicts, we have chosen to prepent the "DCOS Target" as the
   first name of the filename
2. dcos-ui-variant
   This will define the variant of the built UI.
3. package version
   the package version taken from the package.json
4. package version metadata
   semver compliant metadata to define the git sha
   this release is built from