### PR TITLE
DCOS_OSS-1341: stay in group view when service/group deleted

### DIFF
--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -8,6 +8,7 @@ import { injectIntl, intlShape } from "react-intl";
 import ModalHeading from "#SRC/js/components/modals/ModalHeading";
 import StringUtil from "#SRC/js/utils/StringUtil";
 import UserActions from "#SRC/js/constants/UserActions";
+import DCOSStore from "#SRC/js/stores/DCOSStore";
 
 import AppLockedMessage from "./AppLockedMessage";
 import Framework from "../../structs/Framework";
@@ -131,11 +132,17 @@ class ServiceDestroyModal extends React.Component {
 
   redirectToServices() {
     const { router } = this.context;
+    const { service } = this.props;
+
+    const parentService = DCOSStore.serviceTree.getItemParent(service.getId());
+    const servicePath = parentService
+      ? `/services/overview/${encodeURIComponent(parentService.getId())}`
+      : "/services/overview";
 
     // Close the modal and redirect after the close animation has completed
     this.handleModalClose();
     setTimeout(() => {
-      router.push({ pathname: "/services/overview" });
+      router.push({ pathname: servicePath });
     }, REDIRECT_DELAY);
   }
 

--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
@@ -425,9 +425,7 @@ class PodInstancesTable extends React.Component {
 
     return this.renderWithClickHandler(
       rowOptions,
-      <div className="flex-box flex-box-align-vertical-center
-        table-cell-flex-box flex-align-items-center
-        flex-direction-top-to-bottom">
+      <div className="flex-box flex-box-align-vertical-center table-cell-flex-box flex-align-items-center flex-direction-top-to-bottom">
         <div className="table-cell-icon">
           <Tooltip anchor="center" content={tooltipContent}>
             <span className={classNames("flush", status.dotClassName)} />

--- a/plugins/services/src/js/structs/ServiceTree.js
+++ b/plugins/services/src/js/structs/ServiceTree.js
@@ -110,13 +110,16 @@ module.exports = class ServiceTree extends Tree {
 
     let parentFound = null;
 
-    this.list.forEach(child => {
+    for (let i = 0; i < this.list.length; i++) {
+      const child = this.list[i];
       if (child instanceof ServiceTree) {
         parentFound = child.getItemParent(id, this);
       } else if (child.getId() === id) {
         parentFound = this;
+
+        break;
       }
-    });
+    }
 
     return parentFound;
   }

--- a/plugins/services/src/js/structs/ServiceTree.js
+++ b/plugins/services/src/js/structs/ServiceTree.js
@@ -99,6 +99,24 @@ module.exports = class ServiceTree extends Tree {
     });
   }
 
+  getItemParent(id) {
+    if (!this.list || this.list.length === 0) {
+      return null;
+    }
+
+    let parentFound = null;
+
+    this.list.forEach(child => {
+      if (child instanceof ServiceTree) {
+        parentFound = child.getItemParent(id);
+      } else if (child.getId() === id) {
+        parentFound = this;
+      }
+    });
+
+    return parentFound;
+  }
+
   /**
    * @param {string} id
    * @return {Service|ServiceTree} matching item

--- a/plugins/services/src/js/structs/ServiceTree.js
+++ b/plugins/services/src/js/structs/ServiceTree.js
@@ -99,7 +99,11 @@ module.exports = class ServiceTree extends Tree {
     });
   }
 
-  getItemParent(id) {
+  getItemParent(id, parent = null) {
+    if (this.getId() === id) {
+      return parent;
+    }
+
     if (!this.list || this.list.length === 0) {
       return null;
     }
@@ -108,7 +112,7 @@ module.exports = class ServiceTree extends Tree {
 
     this.list.forEach(child => {
       if (child instanceof ServiceTree) {
-        parentFound = child.getItemParent(id);
+        parentFound = child.getItemParent(id, this);
       } else if (child.getId() === id) {
         parentFound = this;
       }

--- a/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
+++ b/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
@@ -293,6 +293,14 @@ describe("ServiceTree", function() {
         id: "/",
         items: [
           {
+            id: "test2",
+            items: [
+              {
+                id: "test/testasd"
+              }
+            ]
+          },
+          {
             id: "/test",
             items: [
               {
@@ -300,6 +308,14 @@ describe("ServiceTree", function() {
               },
               {
                 id: "/test/bar"
+              },
+              {
+                id: "/test/baz/boo",
+                items: [
+                  {
+                    id: "/test/baz/boo/1"
+                  }
+                ]
               }
             ]
           },
@@ -320,6 +336,16 @@ describe("ServiceTree", function() {
 
     it("finds matching parent from item two levels deep", function() {
       expect(this.instance.getItemParent("/test/foo").getId()).toEqual("/test");
+    });
+
+    it("finds matching parent from item two levels deep", function() {
+      expect(this.instance.getItemParent("/test/bar").getId()).toEqual("/test");
+    });
+
+    it("finds matching parent from item three levels deep", function() {
+      expect(this.instance.getItemParent("/test/baz/boo/1").getId()).toEqual(
+        "/test/baz/boo"
+      );
     });
 
     it("finds matching parent from item one level deep", function() {

--- a/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
+++ b/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
@@ -287,6 +287,54 @@ describe("ServiceTree", function() {
     });
   });
 
+  describe("#getItemParent", function() {
+    beforeEach(function() {
+      this.instance = new ServiceTree({
+        id: "/",
+        items: [
+          {
+            id: "/test",
+            items: [
+              {
+                id: "/test/foo"
+              },
+              {
+                id: "/test/bar"
+              }
+            ]
+          },
+          {
+            id: "/alpha",
+            cmd: "cmd"
+          },
+          {
+            id: "/beta",
+            cmd: "cmd",
+            items: {
+              DCOS_PACKAGE_FRAMEWORK_NAME: "beta"
+            }
+          }
+        ]
+      });
+    });
+
+    it("finds matching parent from item two levels deep", function() {
+      expect(this.instance.getItemParent("/test/foo").getId()).toEqual("/test");
+    });
+
+    it("finds matching parent from item one level deep", function() {
+      expect(this.instance.getItemParent("/alpha").getId()).toEqual("/");
+    });
+
+    it("returns null when root item searched", function() {
+      expect(this.instance.getItemParent("/")).toEqual(null);
+    });
+
+    it("returns null when no parent found", function() {
+      expect(this.instance.getItemParent("/not/found")).toEqual(null);
+    });
+  });
+
   describe("#findItemById", function() {
     beforeEach(function() {
       this.instance = new ServiceTree({


### PR DESCRIPTION
When deleting a group inside a group, instead of staying inside that group you're being thrown back to the root of the namespace.

Closes DCOS_OSS-1341

![delete group](https://dha4w82d62smt.cloudfront.net/items/1f131d001v1B3r2h0F26/Screen%20Recording%202018-02-02%20at%2010.48%20AM.gif?X-CloudApp-Visitor-Id=2947615&v=62a0be99)



**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
