### PR TITLE
fix(PackageDetailTab) add version query

### DIFF
--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -138,7 +138,7 @@ class PackageDetailTab extends mixin(StoreMixin) {
     const { params, location } = this.props;
 
     router.push(
-      `/catalog/packages/${encodeURIComponent(params.packageName)}/deploy?${location.query.version}`
+      `/catalog/packages/${encodeURIComponent(params.packageName)}/deploy?version=${location.query.version}`
     );
   }
 


### PR DESCRIPTION
Fix missing version query lost in latest changes made in PackageDetailTab

Closes DCOS-20939

**How to test:**
- Go to catalog page
- select a package
- on package detail choose an older version in the dropdown located at the top by the package name
- Go to Review & Run
- Run the package and go to package detail > configuration tab and note the version installed

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
