### PR TITLE
feat(Jenkinsfile.release): creates artifact with correct buildinfo

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -83,6 +83,13 @@ pipeline {
           sh "BRANCH_NAME=${env.BRANCH_NAME} ./scripts/ci/upload-build"
         }
       }
+
+
+      post {
+        always {
+          archiveArtifacts 'buildinfo.json'
+        }
+      }
     }
   }
 }

--- a/scripts/ci/upload-build
+++ b/scripts/ci/upload-build
@@ -24,6 +24,21 @@ RELEASE_NAME="${PKG_BRANCH}+${FILENAME}${BUILD_VARIANT}-v${PKG_VERSION}+${SHA_SL
 cd "$DIST_PATH"
 tar czf "../$RELEASE_NAME" .
 cd ..
+BUILD_SHA=$(shasum ${RELEASE_NAME} | cut -d " " -f1)
+ENCODED_RELEASE_NAME=$(echo ${RELEASE_NAME} | sed "s/\+/\%2B/g")
+DOWNLOAD_URL=$(echo "https://${AWS_BUCKET}/${BUCKET_PATH}/${ENCODED_RELEASE_NAME}")
+FILENAME='buildinfo.json'
+
+# cat config to artifact file
+cat <<EOF > ${FILENAME}
+{
+  "single_source": {
+    "kind": "url_extract",
+    "url": "${DOWNLOAD_URL}",
+    "sha1": "${BUILD_SHA}"
+  }
+}
+EOF
 
 # upload
 aws s3 cp $RELEASE_NAME s3://$AWS_BUCKET/$BUCKET_PATH/$RELEASE_NAME


### PR DESCRIPTION
This PR creates a ready-to-be-copied `buildinfo.json` to speed up the bump-process and make it "less manual", whoever creates a bump doesnt have to check for the correct sha or something, just fire up the jenkinsjob and copy & paste the buildoinfo to DCOS.

In the Future we want to automate this even more - step by step 👍 