### PR TITLE
chore(system-tests): skip test involving MesosStream

### DIFF
--- a/system-tests/services/test-apps.js
+++ b/system-tests/services/test-apps.js
@@ -251,7 +251,7 @@ describe("Services", function() {
         .should("have.value", "http://lorempicsum.com/simpsons/600/400/3");
     });
 
-    it("creates an app with command health check", function() {
+    it.skip("creates an app with command health check", function() {
       const serviceName = "app-with-command-health-check";
 
       // Select 'Single Container'


### PR DESCRIPTION
Skip failing test. Not possible to verify without having MesosStream working in cypress thus no point in running the test ATM.