### PR TITLE
fix(docs): update to correct link for install cli

### DIFF
--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -168,10 +168,7 @@ class CliInstallModal extends React.Component {
           {
             "Choose your operating system and follow the instructions. For any issues or questions, please refer to our "
           }
-          <a
-            href={MetadataStore.buildDocsURI("/installing/ent/custom/cli/")}
-            target="_blank"
-          >
+          <a href={MetadataStore.buildDocsURI("/cli/install")} target="_blank">
             documentation
           </a>.
         </p>


### PR DESCRIPTION
Previously I fixed this link because it was 404. Unfortunately I fixed it to the wrong new link. This PR corrects to the proper docs: https://docs.mesosphere.com/1.11/cli/install/.

This will have to be backported to 1.11 after this merges.

Closes DCOS-20978

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
