### PR TITLE
fix(UniversePackage): fallback to type: "object" for config

### DIFF
--- a/src/js/structs/UniversePackage.js
+++ b/src/js/structs/UniversePackage.js
@@ -32,7 +32,7 @@ class UniversePackage extends Item {
   }
 
   getConfig() {
-    return this.get("config");
+    return Object.assign({}, this.get("config"), { type: "object" });
   }
 
   getDescription() {

--- a/src/js/structs/__tests__/UniversePackage-test.js
+++ b/src/js/structs/__tests__/UniversePackage-test.js
@@ -59,4 +59,18 @@ describe("UniversePackage", function() {
       expect(pkg.getMaintainer()).toEqual(undefined);
     });
   });
+
+  describe("#getConfig", function() {
+    it("returns config passed into package", function() {
+      var pkg = new UniversePackage({
+        config: { properties: {}, type: "object" }
+      });
+      expect(pkg.getConfig()).toEqual({ properties: {}, type: "object" });
+    });
+
+    it("adds type object to config when not provided", function() {
+      var pkg = new UniversePackage({ config: { properties: {} } });
+      expect(pkg.getConfig()).toEqual({ properties: {}, type: "object" });
+    });
+  });
 });


### PR DESCRIPTION
⚠️ backport me

When there is no type, use `type: "object"`. This fixes an issue with mysql and postgres not including this field in their schema and then breaking our form data init because of the missing type. We use [this code](https://github.com/mozilla-services/react-jsonschema-form/blob/51d403ab448326183f58b5cc7c2c750c200f0242/src/utils.js#L139) to parse the initial form data and it expects a type. 

**Testing**:
1. Deploy mysql and postgres from catalog. There should be no issues rendering the form. The configuration tab of these running services should also render properly.
2. Try deploying a few other services to become confident there is no regression. 

Closes DCOS-21115

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
