### PR TITLE
fix(UnitsHealthNodeDetail): node link throwing error

### DIFF
--- a/src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.js
+++ b/src/js/pages/system/ComponentsUnitsHealthNodeDetailPage.js
@@ -43,7 +43,7 @@ const UnitHealthNodeDetailBreadcrumbs = ({ node, unit }) => {
     crumbs.push(
       <Breadcrumb key={2} title={nodeIP}>
         <BreadcrumbTextContent>
-          <Link to={`/components/${unit.get("id")}/${nodeIP}`}>
+          <Link to={`/components/${unit.get("id")}/nodes/${nodeIP}`}>
             {`${nodeIP} `}
             <span className={healthStatus.classNames}>
               ({healthStatus.title})


### PR DESCRIPTION
Back port of #2717 

Fix error when navigating to a node in components page then visiting the node detail
and trying to click on the node link in the breadcrumb throws an error

Closes DCOS-20975
