### PR TITLE
1.11 / chore(Jenkinsfiles): changes release branch to "master" in jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 @Library('sec_ci_libs@v2-latest') _
 
-def master_branches = ["master", ] as String[]
+def master_branches = ["release/1.11"] as String[]
 
 pipeline {
   agent {


### PR DESCRIPTION
this prevents the pipeline from asking us in the channel.