### PR TITLE
DCOS-21044: Fix SDK tasks health indication

### DIFF
--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -2,9 +2,10 @@ import { isSDKService } from "#SRC/js/utils/ServiceUtil";
 
 import StructUtil from "#SRC/js/utils/StructUtil";
 import TaskStates from "#PLUGINS/services/src/js/constants/TaskStates";
-
+import Framework from "#PLUGINS/services/src/js/structs/Framework";
 import PodInstanceState
-  from "../../../plugins/services/src/js/constants/PodInstanceState";
+  from "#PLUGINS/services/src/js/constants/PodInstanceState";
+
 import Util from "./Util";
 
 const RESOURCE_KEYS = ["cpus", "disk", "mem"];
@@ -295,11 +296,24 @@ const MesosStateUtil = {
    * @return {Object} task
    */
   flagSDKTask(task, service) {
-    if (isSDKService(service) && task.sdkTask === undefined) {
+    if (task.sdkTask === undefined && isSDKService(service)) {
       return Object.assign({}, task, { sdkTask: true });
     }
 
     return task;
+  },
+
+  getFrameworkToServicesMap(frameworks, serviceTree) {
+    return frameworks.reduce((acc, framework) => {
+      acc[framework.id] = serviceTree.findItem(function(item) {
+        return (
+          item instanceof Framework &&
+          item.getFrameworkName() === framework.name
+        );
+      });
+
+      return acc;
+    }, {});
   }
 };
 

--- a/src/js/utils/__tests__/MesosStateUtil-test.js
+++ b/src/js/utils/__tests__/MesosStateUtil-test.js
@@ -1,9 +1,28 @@
+const Pod = require("#PLUGINS/services/src/js/structs/Pod");
+const Framework = require("#PLUGINS/services/src/js/structs/Framework");
+const ServiceTree = require("#PLUGINS/services/src/js/structs/ServiceTree");
 const MesosStateUtil = require("../MesosStateUtil");
-const Pod = require("../../../../plugins/services/src/js/structs/Pod");
 
 const MESOS_STATE_WITH_HISTORY = require("./fixtures/MesosStateWithHistory");
 
 describe("MesosStateUtil", function() {
+  describe("#getFrameworkToServicesMap", function() {
+    it("maps frameworks to services", function() {
+      const frameworks = [{ name: "foo", id: "foo_1" }];
+      const fooFramework = new Framework({
+        name: "foo",
+        labels: { DCOS_PACKAGE_FRAMEWORK_NAME: "foo" }
+      });
+      const serviceTree = new ServiceTree({ items: [fooFramework] });
+
+      expect(
+        MesosStateUtil.getFrameworkToServicesMap(frameworks, serviceTree)
+      ).toEqual({
+        foo_1: fooFramework
+      });
+    });
+  });
+
   describe("#flagMarathonTasks", function() {
     it("returns state when frameworks is undefined", function() {
       expect(MesosStateUtil.flagMarathonTasks({})).toEqual({});


### PR DESCRIPTION
⚠️ Back port to 1.11 needed
*TL;DR*: all tasks launched by an SDK framework should be shown as healthy

We don't get info whether a task launched by an SDK framework is healthy or not, but it's confusing for our customers to see gray dots. So when we detect a task is an SDK task and it is running we say it's healthy. 

In our performance PR I introduced the regression by moving the flagging logic and eventually breaking it.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [x] If this is a regression, did you write a test to catch this in the future?

Closes DCOS-21044