### PR TITLE
feat(PodEndpoints): Add vip input to virtual networks

### DIFF
--- a/plugins/services/src/js/reducers/__tests__/JSONMultiContainer-test.js
+++ b/plugins/services/src/js/reducers/__tests__/JSONMultiContainer-test.js
@@ -23,7 +23,8 @@ describe("JSONMultiContainer", function() {
         },
         networks: [
           {
-            mode: "host"
+            mode: "container",
+            name: "dcos"
           }
         ],
         containers: [
@@ -36,7 +37,7 @@ describe("JSONMultiContainer", function() {
                 hostPort: 0,
                 protocol: ["tcp"],
                 labels: {
-                  VIP_0: "1.2.3.4:80"
+                  VIP_0: "1.2.3.4:80" // Custom VIP
                 }
               }
             ],
@@ -52,7 +53,7 @@ describe("JSONMultiContainer", function() {
                 hostPort: 0,
                 protocol: ["udp", "tcp"],
                 labels: {
-                  VIP_0: "1.2.3.4:80"
+                  VIP_0: "/podABCD:81" // App ID based VIP
                 }
               }
             ],

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/Endpoints.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/Endpoints.js
@@ -13,7 +13,8 @@ const defaultEndpointsFieldValues = {
     udp: false
   },
   servicePort: null,
-  vip: null
+  vip: null,
+  vipPort: null
 };
 
 module.exports = {
@@ -45,7 +46,13 @@ module.exports = {
         break;
     }
 
-    const fieldNames = ["name", "automaticPort", "loadBalanced", "vip"];
+    const fieldNames = [
+      "name",
+      "automaticPort",
+      "loadBalanced",
+      "vip",
+      "vipPort"
+    ];
     const numericalFiledNames = ["containerPort", "hostPort"];
 
     if (type === SET && name === "protocol") {

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Containers-test.js
@@ -31,6 +31,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -71,6 +72,7 @@ describe("Containers", function() {
                   name: "foo",
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -122,6 +124,7 @@ describe("Containers", function() {
                   name: "foo",
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -167,6 +170,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: true
@@ -212,6 +216,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false,
@@ -253,6 +258,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -295,6 +301,7 @@ describe("Containers", function() {
                   name: "foo",
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -348,6 +355,7 @@ describe("Containers", function() {
                   name: "foo",
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -393,6 +401,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: true
@@ -438,6 +447,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     foo: true,
                     tcp: true,
@@ -484,6 +494,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -537,6 +548,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: true,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -597,6 +609,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: true,
                   vip: "1.3.3.7:8080",
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -652,6 +665,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: true,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -715,6 +729,7 @@ describe("Containers", function() {
                   loadBalanced: true,
                   containerPort: 8080,
                   vip: "1.3.3.7:8080",
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Endpoints-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Endpoints-test.js
@@ -23,6 +23,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -54,6 +55,7 @@ describe("Endpoints", function() {
             name: "foo",
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -96,6 +98,7 @@ describe("Endpoints", function() {
             name: "foo",
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -132,6 +135,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: true
@@ -168,6 +172,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false,
@@ -200,6 +205,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -233,6 +239,7 @@ describe("Endpoints", function() {
             name: "foo",
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -277,6 +284,7 @@ describe("Endpoints", function() {
             name: "foo",
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -313,6 +321,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: true
@@ -349,6 +358,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               foo: true,
               tcp: true,
@@ -386,6 +396,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -430,6 +441,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: true,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -481,6 +493,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: true,
             vip: "1.3.3.7:8080",
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -527,6 +540,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: true,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -581,6 +595,7 @@ describe("Endpoints", function() {
             loadBalanced: true,
             containerPort: 8080,
             vip: "1.3.3.7:8080",
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
@@ -228,10 +228,12 @@ function containersParser(state) {
               endpoint.containerPort
             )
           );
+
           const vip = findNestedPropertyInObject(
             endpoint,
             `labels.VIP_${endpointIndex}`
           );
+
           if (vip != null) {
             memo.push(
               new Transaction(
@@ -253,10 +255,14 @@ function containersParser(state) {
                   vip
                 )
               );
+            }
+
+            const vipPortMatch = vip.match(/.+:(\d+)/);
+            if (vipPortMatch) {
               memo.push(
                 new Transaction(
                   ["containers", index, "endpoints", endpointIndex, "vipPort"],
-                  vip
+                  vipPortMatch[1]
                 )
               );
             }

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
@@ -36,6 +36,7 @@ function mapEndpoints(endpoints = [], networkType, appState) {
       containerPort,
       automaticPort,
       protocol,
+      vipPort,
       labels
     } = endpoint;
 
@@ -54,7 +55,7 @@ function mapEndpoints(endpoints = [], networkType, appState) {
         appState.id,
         endpoint,
         vipLabel,
-        containerPort || hostPort
+        vipPort || containerPort || hostPort
       );
 
       return {
@@ -249,6 +250,12 @@ function containersParser(state) {
               memo.push(
                 new Transaction(
                   ["containers", index, "endpoints", endpointIndex, "vip"],
+                  vip
+                )
+              );
+              memo.push(
+                new Transaction(
+                  ["containers", index, "endpoints", endpointIndex, "vipPort"],
                   vip
                 )
               );

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Endpoints.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Endpoints.js
@@ -13,7 +13,8 @@ const defaultEndpointsFieldValues = {
     udp: false
   },
   servicePort: null,
-  vip: null
+  vip: null,
+  vipPort: null
 };
 
 module.exports = {
@@ -53,7 +54,8 @@ module.exports = {
       "automaticPort",
       "loadBalanced",
       "labels",
-      "vip"
+      "vip",
+      "vipPort"
     ];
     const numericalFiledNames = ["containerPort", "hostPort"];
 

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
@@ -1007,6 +1007,109 @@ describe("Containers", function() {
         )
       ]);
     });
+
+    describe("endpoints", function() {
+      it("parses VIP ports", function() {
+        expect(
+          Containers.JSONParser({
+            networks: [
+              {
+                mode: "container"
+              }
+            ],
+            containers: [
+              {
+                endpoints: [
+                  {
+                    labels: {
+                      VIP_0: "/:900"
+                    }
+                  }
+                ]
+              }
+            ]
+          })
+        ).toEqual([
+          new Transaction(
+            ["containers"],
+            {
+              endpoints: [
+                {
+                  labels: {
+                    VIP_0: "/:900"
+                  }
+                }
+              ]
+            },
+            ADD_ITEM
+          ),
+          new Transaction(
+            ["containers", 0, "endpoints"],
+            {
+              labels: { VIP_0: "/:900" }
+            },
+            ADD_ITEM
+          ),
+          new Transaction(
+            ["containers", 0, "endpoints", 0, "hostPort"],
+            undefined,
+            SET
+          ),
+          new Transaction(
+            ["containers", 0, "endpoints", 0, "automaticPort"],
+            false,
+            SET
+          ),
+          new Transaction(
+            ["containers", 0, "endpoints", 0, "servicePort"],
+            false,
+            SET
+          ),
+          new Transaction(
+            ["containers", 0, "endpoints", 0, "name"],
+            undefined,
+            SET
+          ),
+          new Transaction(
+            ["containers", 0, "endpoints", 0, "labels"],
+            { VIP_0: "/:900" },
+            SET
+          ),
+          new Transaction(
+            ["containers", 0, "endpoints", 0, "containerPort"],
+            undefined,
+            SET
+          ),
+          new Transaction(
+            ["containers", 0, "endpoints", 0, "loadBalanced"],
+            true,
+            SET
+          ),
+          new Transaction(
+            ["containers", 0, "endpoints", 0, "vip"],
+            "/:900",
+            SET
+          ),
+          new Transaction(
+            ["containers", 0, "endpoints", 0, "vipPort"],
+            "900",
+            SET
+          ),
+
+          new Transaction(
+            ["containers", 0, "endpoints", 0, "protocol", "udp"],
+            false,
+            SET
+          ),
+          new Transaction(
+            ["containers", 0, "endpoints", 0, "protocol", "tcp"],
+            false,
+            SET
+          )
+        ]);
+      });
+    });
+
     describe("artifacts", function() {
       it("parses JSON correctly", function() {
         expect(

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Endpoints-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Endpoints-test.js
@@ -24,6 +24,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -57,6 +58,7 @@ describe("Endpoints", function() {
               name: "foo",
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -101,6 +103,7 @@ describe("Endpoints", function() {
               name: "foo",
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -139,6 +142,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: true
@@ -177,6 +181,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false,
@@ -211,6 +216,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -246,6 +252,7 @@ describe("Endpoints", function() {
               name: "foo",
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -292,6 +299,7 @@ describe("Endpoints", function() {
               name: "foo",
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -330,6 +338,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: true
@@ -368,6 +377,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 foo: true,
                 tcp: true,
@@ -407,6 +417,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -453,6 +464,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: true,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -506,6 +518,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: true,
               vip: "1.3.3.7:8080",
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -554,6 +567,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: true,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -610,6 +624,7 @@ describe("Endpoints", function() {
               loadBalanced: true,
               containerPort: 8080,
               vip: "1.3.3.7:8080",
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1533,6 +1533,39 @@ describe("Service Form Modal", function() {
       });
     });
 
+    context("Networking", function() {
+      beforeEach(function() {
+        cy.get(".menu-tabbed-item-label").contains("Networking").click();
+      });
+
+      context("Virtual Network: dcos-1", function() {
+        beforeEach(function() {
+          cy.get('select[name="networks.0"]').select("Virtual Network: dcos-1");
+        });
+
+        context("Load balanced ports", function() {
+          beforeEach(function() {
+            cy
+              .get(".button.button-primary-link")
+              .contains("Add Service Endpoint")
+              .click();
+            cy
+              .get(".form-group-heading-content")
+              .contains("Enable Load Balanced Service Address")
+              .click();
+          });
+
+          it("sets vip port", function() {
+            cy
+              .get('.form-control[name="containers.0.endpoints.0.vipPort"]')
+              .type(9007);
+
+            cy.contains(".marathon.l4lb.thisdcos.directory:9007");
+          });
+        });
+      });
+    });
+
     context("Multi-container (pod)", function() {
       beforeEach(function() {
         cy


### PR DESCRIPTION
Add the vip port input field to the virtual networks of pods Multi container services.
![image](https://user-images.githubusercontent.com/156010/36030944-696244f4-0da9-11e8-8241-a031f9ba7f95.png)


Closes DCOS_OSS-1553
