### PR TITLE
1.11: DCOS-21229: fix sorting in tables

### DIFF
--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -73,6 +73,7 @@ class TaskTable extends React.Component {
   getColumns() {
     var className = this.getClassName;
     var heading = ResourceTableUtil.renderHeading(TaskTableHeaderLabels);
+    // Sorts the table columns by their value and if the value is the same it sorts by id
     const sortFunction = TaskTableUtil.getSortFunction("id");
     const getHealthSorting = TableUtil.getHealthSortingOrder;
 

--- a/plugins/services/src/js/utils/TaskTableUtil.js
+++ b/plugins/services/src/js/utils/TaskTableUtil.js
@@ -3,6 +3,7 @@ import React from "react";
 /* eslint-enable no-unused-vars */
 import TableUtil from "#SRC/js/utils/TableUtil";
 import Util from "#SRC/js/utils/Util";
+import TaskUtil from "#PLUGINS/services/src/js/utils/TaskUtil";
 import TaskStatusSortingOrder from "../constants/TaskStatusSortingOrder";
 
 function getUpdatedTimestamp(model) {
@@ -18,6 +19,18 @@ const TaskTableUtil = {
 
       if (prop === "updated") {
         return getUpdatedTimestamp(item) || 0;
+      }
+
+      if (prop === "zone") {
+        return TaskUtil.getZoneName(item);
+      }
+
+      if (prop === "host") {
+        return TaskUtil.getHostName(item);
+      }
+
+      if (prop === "region") {
+        return TaskUtil.getRegionName(item);
       }
 
       if (prop === "status" && !hasGetter) {

--- a/tests/_fixtures/marathon-1-task/mesos-subscribe.js
+++ b/tests/_fixtures/marathon-1-task/mesos-subscribe.js
@@ -733,7 +733,6 @@ var response = JSON.stringify({
               }
             ]
           },
-
           {
             executor_id: { value: "" },
             framework_id: {
@@ -782,6 +781,104 @@ var response = JSON.stringify({
                 }
               }
             ]
+          },
+          {
+            executor_id: { value: "" },
+            framework_id: {
+              value: "20150827-210452-1695027628-5050-1445-0000"
+            },
+            task_id: { value: "sleep.7084272b-6b76-11e5-a953-08002719334b" },
+            labels: [],
+            name: "sleep",
+            resources: [
+              { name: "cpus", type: "SCALAR", scalar: { value: 0.5 } },
+              { name: "disk", type: "SCALAR", scalar: { value: 0 } },
+              { name: "mem", type: "SCALAR", scalar: { value: 16 } },
+              {
+                name: "ports",
+                type: "RANGES",
+                ranges: { range: "[10000-10000]" }
+              }
+            ],
+            agent_id: { value: "20151002-000353-1695027628-5050-1177-S1" },
+            state: "TASK_RUNNING",
+            statuses: [
+              {
+                state: "TASK_RUNNING",
+                timestamp: 1444059214.32713,
+                container_status: {
+                  container_id: {
+                    value: "2f6cd6c5-cc11-4ea6-adbe-a4f02439d9d2"
+                  },
+                  network_infos: [
+                    {
+                      labels: [
+                        {
+                          key: "DCOS_SPACE",
+                          value: "/sleep"
+                        }
+                      ],
+                      ip_addresses: [
+                        {
+                          protocol: "IPv4",
+                          ip_address: "9.0.2.34"
+                        }
+                      ],
+                      name: "dcos-1"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            executor_id: { value: "" },
+            framework_id: {
+              value: "20150827-210452-1695027628-5050-1445-0000"
+            },
+            task_id: { value: "sleep.7084272b-6b76-11e5-a953-08002719334c" },
+            labels: [],
+            name: "sleep",
+            resources: [
+              { name: "cpus", type: "SCALAR", scalar: { value: 0.1 } },
+              { name: "disk", type: "SCALAR", scalar: { value: 0 } },
+              { name: "mem", type: "SCALAR", scalar: { value: 16 } },
+              {
+                name: "ports",
+                type: "RANGES",
+                ranges: { range: "[10000-10000]" }
+              }
+            ],
+            agent_id: { value: "20151002-000353-1695027628-5050-1177-S2" },
+            state: "TASK_RUNNING",
+            statuses: [
+              {
+                state: "TASK_RUNNING",
+                timestamp: 1444059214.32713,
+                container_status: {
+                  container_id: {
+                    value: "2f6cd6c5-cc11-4ea6-adbe-a4f02439d9d2"
+                  },
+                  network_infos: [
+                    {
+                      labels: [
+                        {
+                          key: "DCOS_SPACE",
+                          value: "/sleep"
+                        }
+                      ],
+                      ip_addresses: [
+                        {
+                          protocol: "IPv4",
+                          ip_address: "9.0.2.34"
+                        }
+                      ],
+                      name: "dcos-1"
+                    }
+                  ]
+                }
+              }
+            ]
           }
         ]
       },
@@ -796,6 +893,96 @@ var response = JSON.stringify({
               cpus: 0,
               disk: 0,
               mem: 0
+            },
+            domain: {
+              fault_domain: {
+                region: {
+                  name: "eu-central-1"
+                },
+                zone: { name: "eu-central-1c" }
+              }
+            },
+            pid: "slave(1)@172.17.8.101:5051",
+            registered_time: 1443995289.19971,
+            reregistered_time: 1443995289.19981,
+            reserved_resources: {},
+            resources: {
+              cpus: 4,
+              disk: 10823,
+              mem: 2933,
+              ports: "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+            },
+            unreserved_resources: {
+              cpus: 4,
+              disk: 10823,
+              mem: 2933,
+              ports: "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+            },
+            used_resources: {
+              cpus: 0.1,
+              disk: 0,
+              mem: 16,
+              ports: "[10000-10000]"
+            }
+          },
+          {
+            active: true,
+            attributes: {},
+            hostname: "dcos-02",
+            id: { value: "20151002-000353-1695027628-5050-1177-S1" },
+            offered_resources: {
+              cpus: 0,
+              disk: 0,
+              mem: 0
+            },
+            domain: {
+              fault_domain: {
+                region: {
+                  name: "eu-central-1"
+                },
+                zone: { name: "eu-central-1b" }
+              }
+            },
+            pid: "slave(1)@172.17.8.101:5051",
+            registered_time: 1443995289.19971,
+            reregistered_time: 1443995289.19981,
+            reserved_resources: {},
+            resources: {
+              cpus: 4,
+              disk: 10823,
+              mem: 2933,
+              ports: "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+            },
+            unreserved_resources: {
+              cpus: 4,
+              disk: 10823,
+              mem: 2933,
+              ports: "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+            },
+            used_resources: {
+              cpus: 0.1,
+              disk: 0,
+              mem: 16,
+              ports: "[10000-10000]"
+            }
+          },
+          {
+            active: true,
+            attributes: {},
+            hostname: "dcos-03",
+            id: { value: "20151002-000353-1695027628-5050-1177-S2" },
+            offered_resources: {
+              cpus: 0,
+              disk: 0,
+              mem: 0
+            },
+            domain: {
+              fault_domain: {
+                region: {
+                  name: "ap-northeast-1"
+                },
+                zone: { name: "ap-northeast-1a" }
+              }
             },
             pid: "slave(1)@172.17.8.101:5051",
             registered_time: 1443995289.19971,

--- a/tests/_fixtures/marathon-1-task/summary.json
+++ b/tests/_fixtures/marathon-1-task/summary.json
@@ -20,7 +20,9 @@
       },
       "pid": "scheduler-88e0ffb7-5d54-4bc4-984b-e546d4b1ebb1@172.17.8.101:47277",
       "slave_ids": [
-        "20151002-000353-1695027628-5050-1177-S0"
+        "20151002-000353-1695027628-5050-1177-S0",
+        "20151002-000353-1695027628-5050-1177-S1",
+        "20151002-000353-1695027628-5050-1177-S2"
       ],
       "used_resources": {
         "cpus": 0.1,
@@ -44,7 +46,7 @@
       "TASK_STARTING": 0,
       "active": true,
       "attributes": {
-        
+
       },
       "framework_ids": [
         "20150827-210452-1695027628-5050-1445-0000"
@@ -60,7 +62,7 @@
       "registered_time": 1443995289.19971,
       "reregistered_time": 1443995289.19981,
       "reserved_resources": {
-        
+
       },
       "resources": {
         "cpus": 4,
@@ -80,6 +82,149 @@
         "mem": 16,
         "ports": "[10000-10000]"
       }
+    },
+    {
+    "TASK_ERROR": 0,
+    "TASK_FAILED": 0,
+    "TASK_FINISHED": 22,
+    "TASK_KILLED": 0,
+    "TASK_LOST": 0,
+    "TASK_RUNNING": 1,
+    "TASK_STAGING": 0,
+    "TASK_STARTING": 0,
+    "active": true,
+    "attributes": {
+
+    },
+    "framework_ids": [
+      "20150827-210452-1695027628-5050-1445-0000"
+    ],
+    "hostname": "dcos-01",
+    "id": "20151002-000353-1695027628-5050-1177-S0",
+    "offered_resources": {
+      "cpus": 0,
+      "disk": 0,
+      "mem": 0
+    },
+    "pid": "slave(1)@172.17.8.101:5051",
+    "registered_time": 1443995289.19971,
+    "reregistered_time": 1443995289.19981,
+    "reserved_resources": {
+
+    },
+    "resources": {
+      "cpus": 4,
+      "disk": 10823,
+      "mem": 2933,
+      "ports": "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+    },
+    "unreserved_resources": {
+      "cpus": 4,
+      "disk": 10823,
+      "mem": 2933,
+      "ports": "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+    },
+    "used_resources": {
+      "cpus": 0.1,
+      "disk": 0,
+      "mem": 16,
+      "ports": "[10000-10000]"
     }
+  },
+  {
+    "TASK_ERROR": 0,
+    "TASK_FAILED": 0,
+    "TASK_FINISHED": 22,
+    "TASK_KILLED": 0,
+    "TASK_LOST": 0,
+    "TASK_RUNNING": 1,
+    "TASK_STAGING": 0,
+    "TASK_STARTING": 0,
+    "active": true,
+    "attributes": {
+
+    },
+    "framework_ids": [
+      "20150827-210452-1695027628-5050-1445-0000"
+    ],
+    "hostname": "dcos-02",
+    "id": "20151002-000353-1695027628-5050-1177-S1",
+    "offered_resources": {
+      "cpus": 0,
+      "disk": 0,
+      "mem": 0
+    },
+    "pid": "slave(1)@172.17.8.101:5051",
+    "registered_time": 1443995289.19971,
+    "reregistered_time": 1443995289.19981,
+    "reserved_resources": {
+
+    },
+    "resources": {
+      "cpus": 4,
+      "disk": 10823,
+      "mem": 2933,
+      "ports": "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+    },
+    "unreserved_resources": {
+      "cpus": 4,
+      "disk": 10823,
+      "mem": 2933,
+      "ports": "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+    },
+    "used_resources": {
+      "cpus": 0.1,
+      "disk": 0,
+      "mem": 16,
+      "ports": "[10000-10000]"
+    }
+  }, {
+    "TASK_ERROR": 0,
+    "TASK_FAILED": 0,
+    "TASK_FINISHED": 22,
+    "TASK_KILLED": 0,
+    "TASK_LOST": 0,
+    "TASK_RUNNING": 1,
+    "TASK_STAGING": 0,
+    "TASK_STARTING": 0,
+    "active": true,
+    "attributes": {
+
+    },
+    "framework_ids": [
+      "20150827-210452-1695027628-5050-1445-0000"
+    ],
+    "hostname": "dcos-03",
+    "id": "20151002-000353-1695027628-5050-1177-S2",
+    "offered_resources": {
+      "cpus": 0,
+      "disk": 0,
+      "mem": 0
+    },
+    "pid": "slave(1)@172.17.8.101:5051",
+    "registered_time": 1443995289.19971,
+    "reregistered_time": 1443995289.19981,
+    "reserved_resources": {
+
+    },
+    "resources": {
+      "cpus": 4,
+      "disk": 10823,
+      "mem": 2933,
+      "ports": "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+    },
+    "unreserved_resources": {
+      "cpus": 4,
+      "disk": 10823,
+      "mem": 2933,
+      "ports": "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+    },
+    "used_resources": {
+      "cpus": 0.1,
+      "disk": 0,
+      "mem": 16,
+      "ports": "[10000-10000]"
+    }
+  }
   ]
 }

--- a/tests/_fixtures/marathon-pods/groups.json
+++ b/tests/_fixtures/marathon-pods/groups.json
@@ -373,6 +373,139 @@
             ]
           }
         ]
+      },
+      {
+        "id": "/podWithMultipleRegions",
+        "spec": {
+          "id": "/podWithMultipleRegions",
+          "version": "2016-08-29T01:01:01.001",
+          "containers": [
+            {
+              "name": "my-web-app",
+              "image": { "kind": "DOCKER", "id": "jdef/my-web-service-abc:v1.1.1" },
+              "endpoints": [
+                {
+                  "name": "nginx",
+                  "containerPort": 8888,
+                  "hostPort": 0,
+                  "protocol": "http",
+                  "labels": {
+                    "VIP_0": "1.2.3.4:80"
+                  }
+                }
+              ],
+              "resources": { "cpus": 0.5, "mem": 64 }
+            }
+          ],
+          "scaling": {
+            "kind": "fixed",
+            "instances": 10
+          },
+          "scheduling": {
+            "placement": {
+              "constraints": [
+                { "fieldName": "hostname", "operator": "UNIQUE" }
+              ],
+              "acceptedResourceRoles": ["slave_public"]
+            }
+          }
+        },
+        "status": "STABLE",
+        "statusSince": "2018-01-31T01:01:01.001",
+        "message": "All pod instances are running and in good health",
+        "lastUpdated": "2018-01-31T01:01:01.001",
+        "lastChanged": "2018-01-31T01:01:01.001",
+        "instances": [
+          {
+            "id": "pod-1-1518189324281",
+            "status": "STABLE",
+            "statusSince": "2018-01-31T01:01:01.001",
+            "agentHostname": "node-123-123-123-123",
+            "resources": { "cpus": 0.6, "mem": 96 },
+            "lastUpdated": "2018-01-31T01:01:01.001",
+            "lastChanged": "2018-01-31T01:01:01.001",
+            "containers": [
+              {
+                "name": "my-web-app",
+                "status": "RUNNING",
+                "statusSince": "2018-01-31T01:01:01.001",
+                "containerId": "podtask-3490824906824564563456",
+                "endpoints": [
+                  { "name": "nginx", "allocatedHostPort": 31001 }
+                ],
+                "lastUpdated": "2018-01-31T01:01:01.001",
+                "lastChanged": "2018-01-31T01:01:01.001"
+              }
+            ]
+          },
+          {
+            "id": "pod-2-1518189324281",
+            "status": "STABLE",
+            "statusSince": "2018-01-31T01:01:01.001",
+            "agentHostname": "node-123-123-123-123",
+            "resources": { "cpus": 0.6, "mem": 96 },
+            "lastUpdated": "2018-01-31T01:01:01.001",
+            "lastChanged": "2018-01-31T01:01:01.001",
+            "containers": [
+              {
+                "name": "my-web-app",
+                "status": "RUNNING",
+                "statusSince": "2018-01-31T01:01:01.001",
+                "containerId": "podtask-3490824906824564563456",
+                "endpoints": [
+                  { "name": "nginx", "allocatedHostPort": 31001 }
+                ],
+                "lastUpdated": "2018-01-31T01:01:01.001",
+                "lastChanged": "2018-01-31T01:01:01.001"
+              }
+            ]
+          },
+          {
+            "id": "pod-3-1518189324281",
+            "status": "STABLE",
+            "statusSince": "2018-01-31T01:01:01.001",
+            "agentHostname": "node-123-123-123-123",
+            "resources": { "cpus": 0.6, "mem": 96 },
+            "lastUpdated": "2018-01-31T01:01:01.001",
+            "lastChanged": "2018-01-31T01:01:01.001",
+            "containers": [
+              {
+                "name": "my-web-app",
+                "status": "RUNNING",
+                "statusSince": "2018-01-31T01:01:01.001",
+                "containerId": "podtask-3490824906824564563456",
+                "endpoints": [
+                  { "name": "nginx", "allocatedHostPort": 31001 }
+                ],
+                "lastUpdated": "2018-01-31T01:01:01.001",
+                "lastChanged": "2018-01-31T01:01:01.001"
+              }
+            ]
+          },
+          {
+            "id": "pod-4-1518189324281",
+            "status": "STABLE",
+            "statusSince": "2018-01-31T01:01:01.001",
+            "agentHostname": "node-123-123-123-123",
+            "resources": { "cpus": 0.6, "mem": 96 },
+            "lastUpdated": "2018-01-31T01:01:01.001",
+            "lastChanged": "2018-01-31T01:01:01.001",
+            "containers": [
+              {
+                "name": "my-web-app",
+                "status": "RUNNING",
+                "statusSince": "2018-01-31T01:01:01.001",
+                "containerId": "podtask-3490824906824564563456",
+                "endpoints": [
+                  { "name": "nginx", "allocatedHostPort": 31001 }
+                ],
+                "lastUpdated": "2018-01-31T01:01:01.001",
+                "lastChanged": "2018-01-31T01:01:01.001"
+              }
+            ]
+          }
+        ],
+        "terminationHistory": []
       }
   ],
   "id": "/"

--- a/tests/pages/nodes/NodesPage-cy.js
+++ b/tests/pages/nodes/NodesPage-cy.js
@@ -69,8 +69,8 @@ describe("Nodes Page", function() {
       cy
         .get(".nodes-grid-dials")
         .should("contain", "3%")
-        .should("contain", "5%")
-        .should("contain", "19%");
+        .should("contain", "13%")
+        .should("contain", "1%");
     });
 
     context("Filters nodes grid", function() {
@@ -109,8 +109,7 @@ describe("Nodes Page", function() {
 
         cy
           .get(".nodes-grid-dials")
-          .should("not.contain", "3%")
-          .should("contain", "5%")
+          .should("contain", "13%")
           .should("not.contain", "19%");
       });
     });

--- a/tests/pages/services/TasksTable-cy.js
+++ b/tests/pages/services/TasksTable-cy.js
@@ -197,4 +197,108 @@ describe("Tasks Table", function() {
       cy.get("td.task-table-column-zone-address").eq(1).contains("N/A");
     });
   });
+
+  describe("Sorting", function() {
+    beforeEach(function() {
+      cy.configureCluster({
+        mesos: "1-task-healthy"
+      });
+    });
+
+    it("sorts DESC by hostname", function() {
+      cy.visitUrl({ url: "/services/detail/%2Fsleep/tasks" });
+      cy.get("th.task-table-column-host-address").click();
+
+      cy
+        .get(":nth-child(2) > .task-table-column-host-address")
+        .contains("dcos-01");
+      cy
+        .get(":nth-child(3) > .task-table-column-host-address")
+        .contains("dcos-02");
+      cy
+        .get(":nth-child(4) > .task-table-column-host-address")
+        .contains("dcos-03");
+    });
+
+    it("sorts ASC by hostname", function() {
+      cy.visitUrl({ url: "/services/detail/%2Fsleep/tasks" });
+      cy.get("th.task-table-column-host-address").click();
+      cy.get("th.task-table-column-host-address").click();
+
+      cy
+        .get(":nth-child(2) > .task-table-column-host-address")
+        .contains("dcos-03");
+      cy
+        .get(":nth-child(3) > .task-table-column-host-address")
+        .contains("dcos-02");
+      cy
+        .get(":nth-child(4) > .task-table-column-host-address")
+        .contains("dcos-01");
+    });
+
+    it("sorts DESC by region", function() {
+      cy.visitUrl({ url: "/services/detail/%2Fsleep/tasks" });
+
+      cy.get("th.task-table-column-region-address").click();
+
+      cy
+        .get(":nth-child(2) > .task-table-column-region-address")
+        .contains("ap-northeast-1");
+      cy
+        .get(":nth-child(3) > .task-table-column-region-address")
+        .contains("eu-central-1");
+      cy
+        .get(":nth-child(4) > .task-table-column-region-address")
+        .contains("eu-central-1");
+    });
+
+    it("sorts ASC by region", function() {
+      cy.visitUrl({ url: "/services/detail/%2Fsleep/tasks" });
+
+      cy.get("th.task-table-column-region-address").click();
+      cy.get("th.task-table-column-region-address").click();
+
+      cy
+        .get(":nth-child(2) > .task-table-column-region-address")
+        .contains("eu-central-1");
+      cy
+        .get(":nth-child(3) > .task-table-column-region-address")
+        .contains("eu-central-1");
+      cy
+        .get(":nth-child(4) > .task-table-column-region-address")
+        .contains("ap-northeast-1");
+    });
+
+    it("sorts DESC by zone", function() {
+      cy.visitUrl({ url: "/services/detail/%2Fsleep/tasks" });
+
+      cy.get("th.task-table-column-zone-address").click();
+
+      cy
+        .get(":nth-child(2) > .task-table-column-zone-address")
+        .contains("ap-northeast-1a");
+      cy
+        .get(":nth-child(3) > .task-table-column-zone-address")
+        .contains("eu-central-1b");
+      cy
+        .get(":nth-child(4) > .task-table-column-zone-address")
+        .contains("eu-central-1c");
+    });
+
+    it("sorts ASC by zone", function() {
+      cy.visitUrl({ url: "/services/detail/%2Fsleep/tasks" });
+
+      cy.get("th.task-table-column-zone-address").click();
+      cy.get("th.task-table-column-zone-address").click();
+      cy
+        .get(":nth-child(2) > .task-table-column-zone-address")
+        .contains("eu-central-1c");
+      cy
+        .get(":nth-child(3) > .task-table-column-zone-address")
+        .contains("eu-central-1b");
+      cy
+        .get(":nth-child(4) > .task-table-column-zone-address")
+        .contains("ap-northeast-1a");
+    });
+  });
 });


### PR DESCRIPTION
The sorting of the service task tables was broken, this PR aims to fix this. Namely fields that are not in the original JSON of the task type but fetched from other sources to be displayed are not being considered while sorting. As the "tie breaker" argument resorts the table anyways and we normally don't have nice test data for region and zone no one spotted the mistake earlier.

I added stubs for our integration tests for this part, the real change is much smaller than 500 lines.
I also did not refactor the table but let the leaky abstraction be as we plan to rewrite that part soon.

\cc @nLight pinging you so that you are aware of this problem for the next iteration 👍 

![feb -12-2018 11-28-46](https://user-images.githubusercontent.com/1337046/36092569-14514d98-0fe8-11e8-80a5-adc7ced2f847.gif)


**Checklist**
- [X] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [X] Did you add new integration tests?
- [X] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
