### PR TITLE
[backport 1.11] fix(find-broken-links): fix regex in script

### DIFF
--- a/scripts/find-broken-links
+++ b/scripts/find-broken-links
@@ -15,7 +15,7 @@ do
   fi
 
   # find the easy urls that have https or https
-  urls=$(cat $file | grep -Eo "(http|https)://[a-zA-Z0-9./?=_-]*(?:\:\d{2,4})" | sort | uniq)
+  urls=$(cat $file | grep -Eo "(http|https):\/\/[a-zA-Z0-9.:\/?&%+=_-]*" | sort | uniq)
 
   for url in $urls
   do


### PR DESCRIPTION
Previously was broken and it would stop matching after the port number. This fixes it. Now it simply matches http|https followed by an unlimited amount of (sane) valid URL characters.

Testing:
https://regex101.com/r/KwvvN5/1

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
