### PR TITLE
refactor(deletegroupmodal): fix width and button style

### DIFF
--- a/plugins/services/src/js/components/modals/DisabledGroupDestroyModal.js
+++ b/plugins/services/src/js/components/modals/DisabledGroupDestroyModal.js
@@ -6,7 +6,7 @@ import ModalHeading from "#SRC/js/components/modals/ModalHeading";
 const DisabledGroupDestroyModal = props => {
   const modalFooter = (
     <div className="text-align-center">
-      <button className="button button-medium" onClick={props.onClose}>
+      <button className="button button-primary-link" onClick={props.onClose}>
         OK
       </button>
     </div>
@@ -20,7 +20,7 @@ const DisabledGroupDestroyModal = props => {
 
   return (
     <Modal
-      modalClass="modal"
+      modalClass="modal modal-small"
       footer={modalFooter}
       header={modalHeading}
       onClose={props.onClose}


### PR DESCRIPTION
Before: 
<img width="1675" alt="screen shot 2018-02-09 at 3 04 15 pm" src="https://user-images.githubusercontent.com/8737825/36054372-d8d13e34-0daa-11e8-915a-ad6333f657d4.png">

After: 
<img width="1678" alt="screen shot 2018-02-09 at 3 04 02 pm" src="https://user-images.githubusercontent.com/8737825/36054374-deeb288e-0daa-11e8-8261-3eabaa16917d.png">

Changed width and button style of the modal to be consistent with our modal and button styles. 


**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?