### PR TITLE
1.11 / fix(raml-scripts): updates the download link for the raml files

### DIFF
--- a/scripts/pre-install
+++ b/scripts/pre-install
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
-MARATHON_VERSION="1.6.0-pre-218-g36ad9bd"
+MARATHON_VERSION="1.6.315-523385977"
 
 # Import utils
 source ${SCRIPT_PATH}/utils/git

--- a/scripts/utils/marathon
+++ b/scripts/utils/marathon
@@ -29,7 +29,7 @@ function install_marathon_raml() {
 
   # Download and expand on-the-fly the marathon tarball into a temporary folder
   header "Downloading marathon ${VERSION} archive"
-  local URL="https://downloads.mesosphere.com/marathon/builds/marathon-docs-${VERSION}.tgz"
+  local URL="https://downloads.mesosphere.com/marathon/builds/${VERSION}/marathon-docs-${VERSION}.tgz"
   local TMP_DIR=`mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'`
   curl -L ${URL} | tar -zx -C $TMP_DIR
 


### PR DESCRIPTION
backport of #2746