### PR TITLE
Run integration tests file by file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,23 +51,7 @@ pipeline {
     stage('Unit Test') {
       steps {
         ansiColor('xterm') {
-          sh '''npm run test -- --coverage'''
-        }
-      }
-
-      post {
-        always {
-          junit 'jest/test-results/*.xml'
-          step([$class             : 'CoberturaPublisher',
-                autoUpdateHealth   : false,
-                autoUpdateStability: false,
-                coberturaReportFile: 'coverage/cobertura-coverage.xml',
-                failUnhealthy      : true,
-                failUnstable       : true,
-                maxNumberOfBuilds  : 0,
-                onlyStable         : false,
-                sourceEncoding     : 'ASCII',
-                zoomCoverageChart  : false])
+          sh '''npm run test -- --maxWorkers=2'''
         }
       }
     }
@@ -95,7 +79,7 @@ pipeline {
           'export PATH=`pwd`/node_modules/.bin:$PATH',
           'http-server -p 4200 dist&',
           'SERVER_PID=$!',
-          'npm run cypress -- --reporter junit --reporter-options \'mochaFile=cypress/results.xml\'',
+          './scripts/ci/run-integration-tests',
           'RET=$?',
           'echo "cypress exit status: ${RET}"',
           'sleep 10',

--- a/scripts/ci/run-integration-tests
+++ b/scripts/ci/run-integration-tests
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# This script is a temporary solution to run the integration tests in a <= 1.GB
+# memory environment and with support for retries per test file. We should
+# replace it with a test runner in the future, please see it more as a proof of
+# concept
+
+set -e
+shopt -s globstar # to allow ** in globs
+
+PROJECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )"
+RETRIES=3
+
+function executeCypress {
+  echo "=====> Executing cypress for $1"
+  local testResultPath="cypress/$(basename $1)-result.xml"
+  npm run cypress -- -s "$1" --reporter junit --reporter-options "\"mochaFile=cypress/$testResultPath.xml\""
+}
+
+function runTestFile {
+  echo "==> Running tests for $1"
+  i="0"
+  while [ $i -lt $RETRIES ]; do
+    i=$((i+1))
+    echo "===> Executing run $i"
+    local exit_code
+
+    # We don't want to let an error in the block below to end the entire script
+    set +e # undo instant error flag
+
+    executeCypress "$1"
+    exit_code=$?
+
+    set -e # redo flag
+    echo "==> $i run exit code: $exit_code"
+
+    if [ $exit_code -eq 0 ]; then
+      return 0
+    fi
+  done
+
+  echo "==> Couldn't get a success in $RETRIES retries"
+  exit 1
+}
+
+
+for f in $PROJECT_ROOT/tests/**/*-cy.js; do
+  runTestFile "$f"
+done
+


### PR DESCRIPTION
## Proof of Concept
This is a proof of concept, please be aware that there is no intention of getting this exact code to master.

**Question**: Will running the tests one by one help us switch back to a smaller jenkins node label? (Currently we use one which is way too big for what we do)

**Other Metrics**:

- How long does the test run take opposed to "normal"?
- Will the flackiness be positively effected by retrying individual files instead of everything?

**How to move forward if this is a success**:

My idea would be to discuss the findings in the team and identify what we need to change in our system test runner to have a similar experience

**How to move forward if this is a failure**:

If we can't get under the 1GB threshold we should discuss about different testing frameworks and see if we can somehow get a feeling for weather they improve the situation or not.

**Is there anything worse after taking this route?**

Yes, indeed. We have lost the overall video & the overall run xml for jenkins and we need to somehow come up with a solution on that and on our own (or see whats out there)


## Findings

**Answer**: Yes, 100% success rate in 4 tries on our old jenkins label. Jenkins is able to pick up the XML files and doesn't care if it's one or more (guessing from the readme), so this isn't a problem once we have adjusted the setup accordingly.


**Other Metrics**:

- Duration: 24 - 46 minutes depending on the amount of retriess (currently ~ 18-48 minutes)
- Flakiness: No more complete errors due to flaky tests
