### PR TITLE
fix(Endpoints): remove spaces from the comma delimited list of endpoints

### DIFF
--- a/plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js
+++ b/plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js
@@ -39,9 +39,9 @@ class ServiceConnectionEndpointList extends React.Component {
     let protocol = portDefinition.protocol || "";
 
     if (Array.isArray(protocol)) {
-      protocol = protocol.join(", ");
+      protocol = protocol.join(",");
     }
-    protocol = protocol.replace(/,\s*/g, ", ");
+    protocol = protocol.replace(/,\s*/g, ",");
 
     if (protocol !== "") {
       return <EndpointClipboardTrigger command={getDisplayValue(protocol)} />;

--- a/plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.js
+++ b/plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.js
@@ -40,7 +40,7 @@ class ServicePodConnectionEndpointList extends React.Component {
 
   getProtocolValue(portDefinition) {
     let protocol = portDefinition.protocol || [];
-    protocol = protocol.join(", ");
+    protocol = protocol.join(",");
 
     if (protocol !== "") {
       return this.getClipboardTrigger(getDisplayValue(protocol));

--- a/plugins/services/src/js/structs/ServiceEndpoint.js
+++ b/plugins/services/src/js/structs/ServiceEndpoint.js
@@ -14,7 +14,7 @@ class ServiceEndpoint extends Item {
     }
 
     return Array.isArray(endpointData.vip)
-      ? endpointData.vip.join(", ")
+      ? endpointData.vip.join(",")
       : endpointData.vip;
   }
   getAddress() {
@@ -24,7 +24,7 @@ class ServiceEndpoint extends Item {
     }
 
     return Array.isArray(endpointData.address)
-      ? endpointData.address.join(", ")
+      ? endpointData.address.join(",")
       : endpointData.address;
   }
   getDns() {
@@ -34,7 +34,7 @@ class ServiceEndpoint extends Item {
     }
 
     return Array.isArray(endpointData.dns)
-      ? endpointData.dns.join(", ")
+      ? endpointData.dns.join(",")
       : endpointData.dns;
   }
   isJSON() {

--- a/plugins/services/src/js/structs/__tests__/ServiceEndpoint-test.js
+++ b/plugins/services/src/js/structs/__tests__/ServiceEndpoint-test.js
@@ -34,13 +34,13 @@ describe("ServiceEndpoint", function() {
 
   describe("#getAddress", function() {
     it("returns correct address", function() {
-      expect(this.endpointJSON.getAddress()).toEqual("address1, address2");
+      expect(this.endpointJSON.getAddress()).toEqual("address1,address2");
     });
   });
 
   describe("#getDns", function() {
     it("returns correct dns", function() {
-      expect(this.endpointJSON.getDns()).toEqual("dns1, dns2");
+      expect(this.endpointJSON.getDns()).toEqual("dns1,dns2");
     });
   });
 


### PR DESCRIPTION
Remove spaces from the comma delimited list of endpoints.

This is a big problem for people that want to copy and paste to the terminal. They extra space that we add between the information (address, dns, vip e.t.c), throws errors in some cases when using them as raw input.

![image](https://user-images.githubusercontent.com/180432/36124145-d28fa852-1003-11e8-8b1f-c6c6d7a8ad24.png)


**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
