### PR TITLE
Add fixture for multi region and zone pod

### DIFF
--- a/tests/_fixtures/marathon-1-task/mesos-subscribe.js
+++ b/tests/_fixtures/marathon-1-task/mesos-subscribe.js
@@ -797,6 +797,96 @@ var response = JSON.stringify({
               disk: 0,
               mem: 0
             },
+            domain: {
+              fault_domain: {
+                region: {
+                  name: "eu-central-1"
+                },
+                zone: { name: "eu-central-1a" }
+              }
+            },
+            pid: "slave(1)@172.17.8.101:5051",
+            registered_time: 1443995289.19971,
+            reregistered_time: 1443995289.19981,
+            reserved_resources: {},
+            resources: {
+              cpus: 4,
+              disk: 10823,
+              mem: 2933,
+              ports: "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+            },
+            unreserved_resources: {
+              cpus: 4,
+              disk: 10823,
+              mem: 2933,
+              ports: "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+            },
+            used_resources: {
+              cpus: 0.1,
+              disk: 0,
+              mem: 16,
+              ports: "[10000-10000]"
+            }
+          },
+          {
+            active: true,
+            attributes: {},
+            hostname: "dcos-02",
+            id: { value: "20151002-000353-1695027628-5050-1177-S0" },
+            offered_resources: {
+              cpus: 0,
+              disk: 0,
+              mem: 0
+            },
+            domain: {
+              fault_domain: {
+                region: {
+                  name: "eu-central-1"
+                },
+                zone: { name: "eu-central-1c" }
+              }
+            },
+            pid: "slave(1)@172.17.8.101:5051",
+            registered_time: 1443995289.19971,
+            reregistered_time: 1443995289.19981,
+            reserved_resources: {},
+            resources: {
+              cpus: 4,
+              disk: 10823,
+              mem: 2933,
+              ports: "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+            },
+            unreserved_resources: {
+              cpus: 4,
+              disk: 10823,
+              mem: 2933,
+              ports: "[1025-2180, 2182-3887, 3889-5049, 5052-8079, 8082-8180, 8182-32000]"
+            },
+            used_resources: {
+              cpus: 0.1,
+              disk: 0,
+              mem: 16,
+              ports: "[10000-10000]"
+            }
+          },
+          {
+            active: true,
+            attributes: {},
+            hostname: "dcos-03",
+            id: { value: "20151002-000353-1695027628-5050-1177-S0" },
+            offered_resources: {
+              cpus: 0,
+              disk: 0,
+              mem: 0
+            },
+            domain: {
+              fault_domain: {
+                region: {
+                  name: "eu-central-1"
+                },
+                zone: { name: "eu-central-1b" }
+              }
+            },
             pid: "slave(1)@172.17.8.101:5051",
             registered_time: 1443995289.19971,
             reregistered_time: 1443995289.19981,

--- a/tests/_fixtures/marathon-pods/groups.json
+++ b/tests/_fixtures/marathon-pods/groups.json
@@ -373,6 +373,287 @@
             ]
           }
         ]
+      },
+      {
+        "id": "/mutli-region-pod",
+        "spec": {
+          "id": "/mutli-region-pod",
+          "version": "2016-08-29T01:01:01.001",
+          "containers": [
+            {
+              "name": "my-web-app",
+              "image": { "kind": "DOCKER", "id": "jdef/my-web-service-abc:v1.1.1" },
+              "endpoints": [
+                {
+                  "name": "nginx",
+                  "containerPort": 8888,
+                  "hostPort": 0,
+                  "protocol": "http",
+                  "labels": {
+                    "VIP_0": "1.2.3.4:80"
+                  }
+                }
+              ],
+              "resources": { "cpus": 0.5, "mem": 64 }
+            }
+          ],
+          "scaling": {
+            "kind": "fixed",
+            "instances": 10
+          },
+          "scheduling": {
+            "placement": {
+              "constraints": [
+                { "fieldName": "hostname", "operator": "UNIQUE" }
+              ],
+              "acceptedResourceRoles": ["slave_public"]
+            }
+          }
+        },
+        "status": "STABLE",
+        "statusSince": "2016-08-31T01:01:01.001",
+        "message": "All pod instances are running and in good health",
+        "lastUpdated": "2016-08-31T01:01:01.001",
+        "lastChanged": "2016-08-31T01:01:01.001",
+        "instances": [
+          {
+            "id": "pod-15185360019560",
+            "status": "STABLE",
+            "statusSince": "2016-08-31T01:01:01.001",
+            "agentHostname": "node-123-123-123-123",
+            "resources": { "cpus": 0.6, "mem": 96 },
+            "lastUpdated": "2016-08-31T01:01:01.001",
+            "lastChanged": "2016-08-31T01:01:01.001",
+            "containers": [
+              {
+                "name": "my-web-app",
+                "status": "RUNNING",
+                "statusSince": "2016-08-31T01:01:01.001",
+                "containerId": "podtask-3490824906824564563456",
+                "endpoints": [
+                  { "name": "nginx", "allocatedHostPort": 31001 }
+                ],
+                "lastUpdated": "2016-08-31T01:01:01.001",
+                "lastChanged": "2016-08-31T01:01:01.001"
+              }
+            ]
+          },
+          {
+            "id": "pod-15185360019561",
+            "status": "STABLE",
+            "statusSince": "2016-08-31T01:01:01.001",
+            "agentHostname": "node-123-123-123-123",
+            "resources": { "cpus": 0.6, "mem": 96 },
+            "lastUpdated": "2016-08-31T01:01:01.001",
+            "lastChanged": "2016-08-31T01:01:01.001",
+            "containers": [
+              {
+                "name": "my-web-app",
+                "status": "RUNNING",
+                "statusSince": "2016-08-31T01:01:01.001",
+                "containerId": "podtask-3490824906824564563456",
+                "endpoints": [
+                  { "name": "nginx", "allocatedHostPort": 31001 }
+                ],
+                "lastUpdated": "2016-08-31T01:01:01.001",
+                "lastChanged": "2016-08-31T01:01:01.001"
+              }
+            ]
+          },
+          {
+            "id": "pod-15185360019562",
+            "status": "STABLE",
+            "statusSince": "2016-08-31T01:01:01.001",
+            "agentHostname": "node-123-123-123-123",
+            "resources": { "cpus": 0.6, "mem": 96 },
+            "lastUpdated": "2016-08-31T01:01:01.001",
+            "lastChanged": "2016-08-31T01:01:01.001",
+            "containers": [
+              {
+                "name": "my-web-app",
+                "status": "RUNNING",
+                "statusSince": "2016-08-31T01:01:01.001",
+                "containerId": "podtask-3490824906824564563456",
+                "endpoints": [
+                  { "name": "nginx", "allocatedHostPort": 31001 }
+                ],
+                "lastUpdated": "2016-08-31T01:01:01.001",
+                "lastChanged": "2016-08-31T01:01:01.001"
+              }
+            ]
+          },
+          {
+            "id": "pod-15185360019563",
+            "status": "STABLE",
+            "statusSince": "2016-08-31T01:01:01.001",
+            "agentHostname": "node-123-123-123-123",
+            "resources": { "cpus": 0.6, "mem": 96 },
+            "lastUpdated": "2016-08-31T01:01:01.001",
+            "lastChanged": "2016-08-31T01:01:01.001",
+            "containers": [
+              {
+                "name": "my-web-app",
+                "status": "RUNNING",
+                "statusSince": "2016-08-31T01:01:01.001",
+                "containerId": "podtask-3490824906824564563456",
+                "endpoints": [
+                  { "name": "nginx", "allocatedHostPort": 31001 }
+                ],
+                "lastUpdated": "2016-08-31T01:01:01.001",
+                "lastChanged": "2016-08-31T01:01:01.001"
+              }
+            ]
+          },
+          {
+            "id": "pod-15185360019564",
+            "status": "STABLE",
+            "statusSince": "2016-08-31T01:01:01.001",
+            "agentHostname": "node-123-123-123-123",
+            "resources": { "cpus": 0.6, "mem": 96 },
+            "lastUpdated": "2016-08-31T01:01:01.001",
+            "lastChanged": "2016-08-31T01:01:01.001",
+            "containers": [
+              {
+                "name": "my-web-app",
+                "status": "RUNNING",
+                "statusSince": "2016-08-31T01:01:01.001",
+                "containerId": "podtask-3490824906824564563456",
+                "endpoints": [
+                  { "name": "nginx", "allocatedHostPort": 31001 }
+                ],
+                "lastUpdated": "2016-08-31T01:01:01.001",
+                "lastChanged": "2016-08-31T01:01:01.001"
+              }
+            ]
+          },
+          {
+            "id": "pod-15185360019565",
+            "status": "STABLE",
+            "statusSince": "2016-08-31T01:01:01.001",
+            "agentHostname": "node-123-123-123-123",
+            "resources": { "cpus": 0.6, "mem": 96 },
+            "lastUpdated": "2016-08-31T01:01:01.001",
+            "lastChanged": "2016-08-31T01:01:01.001",
+            "containers": [
+              {
+                "name": "my-web-app",
+                "status": "RUNNING",
+                "statusSince": "2016-08-31T01:01:01.001",
+                "containerId": "podtask-3490824906824564563456",
+                "endpoints": [
+                  { "name": "nginx", "allocatedHostPort": 31001 }
+                ],
+                "lastUpdated": "2016-08-31T01:01:01.001",
+                "lastChanged": "2016-08-31T01:01:01.001"
+              }
+            ]
+          },
+          {
+            "id": "pod-15185360019566",
+            "status": "STABLE",
+            "statusSince": "2016-08-31T01:01:01.001",
+            "agentHostname": "node-123-123-123-123",
+            "resources": { "cpus": 0.6, "mem": 96 },
+            "lastUpdated": "2016-08-31T01:01:01.001",
+            "lastChanged": "2016-08-31T01:01:01.001",
+            "containers": [
+              {
+                "name": "my-web-app",
+                "status": "RUNNING",
+                "statusSince": "2016-08-31T01:01:01.001",
+                "containerId": "podtask-3490824906824564563456",
+                "endpoints": [
+                  { "name": "nginx", "allocatedHostPort": 31001 }
+                ],
+                "lastUpdated": "2016-08-31T01:01:01.001",
+                "lastChanged": "2016-08-31T01:01:01.001"
+              }
+            ]
+          },
+          {
+            "id": "pod-15185360019567",
+            "status": "STABLE",
+            "statusSince": "2016-08-31T01:01:01.001",
+            "agentHostname": "node-123-123-123-123",
+            "resources": { "cpus": 0.6, "mem": 96 },
+            "lastUpdated": "2016-08-31T01:01:01.001",
+            "lastChanged": "2016-08-31T01:01:01.001",
+            "containers": [
+              {
+                "name": "my-web-app",
+                "status": "RUNNING",
+                "statusSince": "2016-08-31T01:01:01.001",
+                "containerId": "podtask-3490824906824564563456",
+                "endpoints": [
+                  { "name": "nginx", "allocatedHostPort": 31001 }
+                ],
+                "lastUpdated": "2016-08-31T01:01:01.001",
+                "lastChanged": "2016-08-31T01:01:01.001"
+              }
+            ]
+          },
+          {
+            "id": "pod-15185360019568",
+            "status": "STABLE",
+            "statusSince": "2016-08-31T01:01:01.001",
+            "agentHostname": "dcos-01",
+            "resources": { "cpus": 0.6, "mem": 96 },
+            "lastUpdated": "2016-08-31T01:01:01.001",
+            "lastChanged": "2016-08-31T01:01:01.001",
+            "containers": [
+              {
+                "name": "my-web-app",
+                "status": "RUNNING",
+                "statusSince": "2016-08-31T01:01:01.001",
+                "containerId": "podtask-3490824906824564563456",
+                "endpoints": [
+                  { "name": "nginx", "allocatedHostPort": 31001 }
+                ],
+                "lastUpdated": "2016-08-31T01:01:01.001",
+                "lastChanged": "2016-08-31T01:01:01.001"
+              }
+            ]
+          },
+          {
+            "id": "pod-15185360019569",
+            "status": "STABLE",
+            "statusSince": "2016-08-31T01:01:01.001",
+            "agentHostname": "dcos-01",
+            "resources": { "cpus": 0.6, "mem": 96 },
+            "lastUpdated": "2016-08-31T01:01:01.001",
+            "lastChanged": "2016-08-31T01:01:01.001",
+            "containers": [
+              {
+                "name": "my-web-app",
+                "status": "RUNNING",
+                "statusSince": "2016-08-31T01:01:01.001",
+                "containerId": "podtask-3490824906824564563456",
+                "endpoints": [
+                  { "name": "nginx", "allocatedHostPort": 31001 }
+                ],
+                "lastUpdated": "2016-08-31T01:01:01.001",
+                "lastChanged": "2016-08-31T01:01:01.001"
+              }
+            ]
+          }
+        ],
+        "terminationHistory": [
+          {
+            "instanceID": "pod-1518536001956",
+            "startedAt": "2016-08-31T01:01:01.001",
+            "terminatedAt": "2016-08-31T01:01:01.001",
+            "containers": [
+                {
+                  "containerId": "podtask-3490824906824564563455",
+                  "lastKnownState": "RUNNING",
+                  "termination": {
+                    "exitCode": 2,
+                    "message": "I/O Error"
+                  }
+                }
+            ]
+          }
+        ]
       }
   ],
   "id": "/"


### PR DESCRIPTION
**Discontinued**

It appears that we don't stub the nodes endpoint at all in the fixtures which means that we would need to add this stub here, too. This opens up a big rabbit hole and I don't feel ok with spending so much time in the fixtures right now. I will leave this here to remind us to be working on that somewhen in the future.


**What would need to happen?**

- [ ] stub away the nodes endpoint entirely
- [ ] add different regions and zones to the nodes
- [ ] in the marathon group tasks lists set the `agent: {id}` to the id of the nodes