### PR TITLE
DCOS-21122: fix(ServiceForm): fixes focus/change/blur behaviour

### DIFF
--- a/plugins/services/src/js/components/modals/CreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModalForm.js
@@ -55,6 +55,7 @@ const METHODS_TO_BIND = [
   "handleConvertToPod",
   "handleDropdownNavigationSelection",
   "handleFormBlur",
+  "handleFormFocus",
   "handleFormChange",
   "handleJSONChange",
   "handleJSONPropertyChange",
@@ -258,6 +259,18 @@ class CreateServiceModalForm extends Component {
     if (!editedFieldPaths.includes(fieldName)) {
       newState.editedFieldPaths = editedFieldPaths.concat([fieldName]);
     }
+    this.setState(newState);
+  }
+
+  handleFormFocus(event) {
+    const fieldName = event.target.getAttribute("name");
+    const newState = {
+      editingFieldPath: fieldName
+    };
+
+    if (!fieldName) {
+      return;
+    }
 
     this.setState(newState);
   }
@@ -278,8 +291,7 @@ class CreateServiceModalForm extends Component {
 
     const newState = {
       appConfig: this.getAppConfig(batch),
-      batch,
-      editingFieldPath: fieldName
+      batch
     };
 
     this.setState(newState);
@@ -733,6 +745,7 @@ class CreateServiceModalForm extends Component {
                 className="create-service-modal-form container"
                 onChange={this.handleFormChange}
                 onBlur={this.handleFormBlur}
+                onFocus={this.handleFormFocus}
               >
                 <Tabs
                   activeTab={activeTab}

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -990,7 +990,8 @@ describe("Service Form Modal", function() {
               cy
                 .get("@tabView")
                 .find('.form-control[name="portDefinitions.0.hostPort"]')
-                .type(7);
+                .type(7)
+                .blur();
 
               cy.contains(".marathon.l4lb.thisdcos.directory:7");
             });

--- a/tests/pages/services/ServicePodReviewScreen-cy.js
+++ b/tests/pages/services/ServicePodReviewScreen-cy.js
@@ -396,7 +396,7 @@ describe("Services", function() {
                   hostPort: 0,
                   protocol: ["tcp"],
                   labels: {
-                    VIP_0: `/pod-with-service-address:8080`
+                    VIP_0: `/${serviceName}:8080`
                   }
                 }
               ],
@@ -518,7 +518,14 @@ describe("Services", function() {
             });
 
           const $tableCells = $tableRows.find("td");
-          const cellValues = ["http", "tcp", "8080", "container-1", "Edit"];
+          const cellValues = [
+            "http",
+            "tcp",
+            "8080",
+            `${serviceName}.marathon.l4lb.thisdcos.directory:8080`,
+            "container-1",
+            "Edit"
+          ];
 
           $tableCells.each(function(index) {
             expect(this.textContent.trim()).to.equal(cellValues[index]);

--- a/tests/pages/services/ServiceReviewScreen-cy.js
+++ b/tests/pages/services/ServiceReviewScreen-cy.js
@@ -1433,9 +1433,9 @@ describe("Services", function() {
         .children("table")
         .getTableColumn("Load Balanced Address")
         .contents()
-        .should(function(elem) {
-          expect(elem[0]).to.equal("Not Enabled");
-        });
+        .should("deep.equal", [
+          `${serviceName}.marathon.l4lb.thisdcos.directory:8080`
+        ]);
     });
 
     it("renders proper review screen and JSON for an app with virtual network", function() {


### PR DESCRIPTION
---

ℹ️ Backport: #2762 

---

This ~commit~ PR changes the onChange handler of the ServiceForm so that
it no longer implicitly sets state.editingFieldPath, instead a new
internal function `handleFormFocus` is introduced.

Closes DCOS-21122