### PR TITLE
DCOS 21173: Update status bar styles

### DIFF
--- a/src/styles/components/status-bar/styles.less
+++ b/src/styles/components/status-bar/styles.less
@@ -58,7 +58,7 @@
 
     .bar {
       background-color: currentColor;
-      box-shadow: 1px 0 0 0 @body-background-color;
+      box-shadow: 1px 0 0 0 @white;
       display: inline-block;
       height: 100%;
       transition: width 600ms;
@@ -120,8 +120,8 @@
     }
 
     &--large {
-      height: @base-spacing-unit * 1/3;
-      line-height: @base-spacing-unit * 1/3;
+      height: @base-spacing-unit * 1/4;
+      line-height: @base-spacing-unit * 1/4;
     }
   }
 }

--- a/src/styles/layout/page-header/breadcrumbs/styles.less
+++ b/src/styles/layout/page-header/breadcrumbs/styles.less
@@ -108,15 +108,11 @@
         .tooltip-wrapper {
           align-items: center;
           display: flex;
-          flex: 0 1 60px;
-          width: 60px;
         }
 
         .status-bar {
           flex: 1 1 auto;
-          height: 4px;
           vertical-align: middle;
-          width: auto;
         }
       }
     }


### PR DESCRIPTION
We have some old legacy styles from the dark UI in the status bars. This PR removes the dark line on status bars and removes the CSS that was making the bar smaller in headers. Making these more inline with our UI kit vision.

Before
![image](https://user-images.githubusercontent.com/15963/36232670-8eff7776-1197-11e8-9c0c-058d625c4eb5.png)
![image](https://user-images.githubusercontent.com/15963/36232721-be80e75a-1197-11e8-984b-954cfe1837df.png)


After
![image](https://user-images.githubusercontent.com/15963/36232679-976efe7c-1197-11e8-87f4-0e0f87b84619.png)
![image](https://user-images.githubusercontent.com/15963/36232727-c3666592-1197-11e8-9dbc-1ffa60b6d2d4.png)

Closes DCOS-21173