### PR TITLE
fix(createServiceModal): disabled review and run button

### DIFF
--- a/plugins/services/src/js/components/modals/CreateServiceModal.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModal.js
@@ -785,6 +785,7 @@ class CreateServiceModal extends Component {
         {
           className: "button-primary flush-vertical",
           clickHandler: this.handleServiceReview,
+          disabled: this.getAllErrors().length > 0,
           label: "Review & Run"
         }
       ];
@@ -795,6 +796,7 @@ class CreateServiceModal extends Component {
         {
           className: "button-primary flush-vertical",
           clickHandler: this.handleServiceReview,
+          disabled: this.getAllErrors().length > 0,
           label: "Review & Run"
         }
       ];

--- a/system-tests/services/test-apps.js
+++ b/system-tests/services/test-apps.js
@@ -44,7 +44,7 @@ describe("Services", function() {
       //   .type('{selectall}0.5');
       //
       cy.root().getFormGroupInputFor("Memory (MiB) *").type("{selectall}10");
-      cy.root().getFormGroupInputFor("Command").type(cmdline);
+      cy.root().getFormGroupInputFor("Command").type(cmdline).blur();
 
       // Click Review and Run
       cy
@@ -119,7 +119,7 @@ describe("Services", function() {
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
 
-      cy.root().getFormGroupInputFor("Command").type(cmdline);
+      cy.root().getFormGroupInputFor("Command").type(cmdline).blur();
 
       // Check JSON view
       cy.contains("JSON Editor").click();
@@ -1166,7 +1166,7 @@ describe("Services", function() {
         .contains(".dropdown-select-item-title", "Local Persistent Volume")
         .click();
       cy.root().getFormGroupInputFor("Size (MiB)").type("128");
-      cy.root().getFormGroupInputFor("Container Path").type("test");
+      cy.root().getFormGroupInputFor("Container Path").type("test").blur();
 
       // Click Review and Run
       cy

--- a/system-tests/services/test-external-volumes.js
+++ b/system-tests/services/test-external-volumes.js
@@ -55,7 +55,7 @@ describe("Services", function() {
         .click();
       cy.root().getFormGroupInputFor("Name").type(volumeName);
       cy.root().getFormGroupInputFor("Size (GiB)").type("1");
-      cy.root().getFormGroupInputFor("Container Path").type("test");
+      cy.root().getFormGroupInputFor("Container Path").type("test").blur();
 
       // Click Review and Run
       cy.contains("Review & Run").click();

--- a/system-tests/services/test-pods.js
+++ b/system-tests/services/test-pods.js
@@ -514,7 +514,11 @@ describe("Services", function() {
 
       cy.root().getFormGroupInputFor("Container Port").type("8080");
 
-      cy.root().getFormGroupInputFor("Service Endpoint Name").type("http");
+      cy
+        .root()
+        .getFormGroupInputFor("Service Endpoint Name")
+        .type("http")
+        .blur();
 
       cy
         .get("button")

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -104,6 +104,15 @@ describe("Service Form Modal", function() {
           .first()
           .should("to.have.text", "Networking");
       });
+
+      it("disable review and run button on error", function() {
+        openServiceModal();
+        openServiceJSON();
+
+        cy
+          .get(".modal-full-screen-actions-primary > .button")
+          .should("be.disabled");
+      });
     });
 
     context("Group level", function() {
@@ -1444,7 +1453,8 @@ describe("Service Form Modal", function() {
         cy
           .get('.form-control[name="container.docker.image"]')
           .clear()
-          .type("nginx");
+          .type("nginx")
+          .blur();
 
         // Click review and run
         cy
@@ -1686,7 +1696,7 @@ describe("Service Form Modal", function() {
     it("Should show network form when clicking on Network Configuration Edit", function() {
       cy.get(".menu-tabbed-item").contains("Networking").click();
       cy.get(".menu-tabbed-view .button.button-primary-link").first().click();
-      cy.get('input[name="containers.0.endpoints.0.name"]').type("test");
+      cy.get('input[name="containers.0.endpoints.0.name"]').type("test").blur();
       // Click review and run
       cy
         .get(".modal-full-screen-actions")


### PR DESCRIPTION
This commit reintroduces the functionality to disable the `Review & Run` Button if an error is
present.

Closes DCOS-20080

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [x] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
