### PR TITLE
DCOS_OSS-2054: Make icons light grey

### DIFF
--- a/plugins/services/src/js/components/TaskDirectoryTable.js
+++ b/plugins/services/src/js/components/TaskDirectoryTable.js
@@ -62,7 +62,7 @@ class TaskDirectoryTable extends React.Component {
         >
           <Icon
             className="icon-margin-left"
-            color="grey"
+            color="light-grey"
             id="search"
             size="mini"
           />

--- a/plugins/services/src/js/components/forms/ArtifactsSection.js
+++ b/plugins/services/src/js/components/forms/ArtifactsSection.js
@@ -41,7 +41,7 @@ class ArtifactsSection extends Component {
           maxWidth={300}
           wrapText={true}
         >
-          <Icon color="grey" id="circle-question" size="mini" />
+          <Icon color="light-grey" id="circle-question" size="mini" />
         </Tooltip>
       </FieldLabel>
     );

--- a/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/ContainerServiceFormSection.js
@@ -81,7 +81,7 @@ class ContainerServiceFormSection extends Component {
               wrapText={true}
               maxWidth={300}
             >
-              <Icon color="grey" id="circle-question" size="mini" />
+              <Icon color="light-grey" id="circle-question" size="mini" />
             </Tooltip>
           </FormGroupHeadingContent>
         </FormGroupHeading>
@@ -121,7 +121,7 @@ class ContainerServiceFormSection extends Component {
               wrapText={true}
               maxWidth={300}
             >
-              <Icon color="grey" id="circle-question" size="mini" />
+              <Icon color="light-grey" id="circle-question" size="mini" />
             </Tooltip>
           </FormGroupHeadingContent>
         </FormGroupHeading>

--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -216,7 +216,7 @@ class EnvironmentFormSection extends Component {
                 maxWidth={300}
                 wrapText={true}
               >
-                <Icon color="grey" id="circle-question" size="mini" />
+                <Icon color="light-grey" id="circle-question" size="mini" />
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>
@@ -248,7 +248,7 @@ class EnvironmentFormSection extends Component {
                 maxWidth={300}
                 wrapText={true}
               >
-                <Icon color="grey" id="circle-question" size="mini" />
+                <Icon color="light-grey" id="circle-question" size="mini" />
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>

--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -215,7 +215,7 @@ class GeneralServiceFormSection extends Component {
                 maxWidth={300}
                 wrapText={true}
               >
-                <Icon color="grey" id="circle-question" size="mini" />
+                <Icon color="light-grey" id="circle-question" size="mini" />
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>
@@ -347,7 +347,7 @@ class GeneralServiceFormSection extends Component {
                     maxWidth={300}
                     wrapText={true}
                   >
-                    <Icon color="grey" id="circle-question" size="mini" />
+                    <Icon color="light-grey" id="circle-question" size="mini" />
                   </Tooltip>
                 </FormGroupHeadingContent>
               </FormGroupHeading>

--- a/plugins/services/src/js/components/forms/HealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/HealthChecksFormSection.js
@@ -101,7 +101,11 @@ class HealthChecksFormSection extends Component {
                       maxWidth={300}
                       wrapText={true}
                     >
-                      <Icon color="grey" id="circle-question" size="mini" />
+                      <Icon
+                        color="light-grey"
+                        id="circle-question"
+                        size="mini"
+                      />
                     </Tooltip>
                   </FormGroupHeadingContent>
                 </FormGroupHeading>
@@ -133,7 +137,11 @@ class HealthChecksFormSection extends Component {
                       maxWidth={300}
                       wrapText={true}
                     >
-                      <Icon color="grey" id="circle-question" size="mini" />
+                      <Icon
+                        color="light-grey"
+                        id="circle-question"
+                        size="mini"
+                      />
                     </Tooltip>
                   </FormGroupHeadingContent>
                 </FormGroupHeading>
@@ -163,7 +171,11 @@ class HealthChecksFormSection extends Component {
                       maxWidth={300}
                       wrapText={true}
                     >
-                      <Icon color="grey" id="circle-question" size="mini" />
+                      <Icon
+                        color="light-grey"
+                        id="circle-question"
+                        size="mini"
+                      />
                     </Tooltip>
                   </FormGroupHeadingContent>
                 </FormGroupHeading>
@@ -193,7 +205,11 @@ class HealthChecksFormSection extends Component {
                       maxWidth={300}
                       wrapText={true}
                     >
-                      <Icon color="grey" id="circle-question" size="mini" />
+                      <Icon
+                        color="light-grey"
+                        id="circle-question"
+                        size="mini"
+                      />
                     </Tooltip>
                   </FormGroupHeadingContent>
                 </FormGroupHeading>
@@ -317,7 +333,7 @@ class HealthChecksFormSection extends Component {
                   wrapperClassName="tooltip-wrapper tooltip-block-wrapper text-align-center"
                   wrapText={true}
                 >
-                  <Icon color="grey" id="circle-question" size="mini" />
+                  <Icon color="light-grey" id="circle-question" size="mini" />
                 </Tooltip>
               </FormGroupHeadingContent>
             </FormGroupHeading>
@@ -343,7 +359,7 @@ class HealthChecksFormSection extends Component {
                   maxWidth={300}
                   wrapText={true}
                 >
-                  <Icon color="grey" id="circle-question" size="mini" />
+                  <Icon color="light-grey" id="circle-question" size="mini" />
                 </Tooltip>
               </FormGroupHeadingContent>
             </FormGroupHeading>
@@ -444,7 +460,11 @@ class HealthChecksFormSection extends Component {
                       wrapperClassName="tooltip-wrapper text-align-center"
                       wrapText={true}
                     >
-                      <Icon color="grey" id="circle-question" size="mini" />
+                      <Icon
+                        color="light-grey"
+                        id="circle-question"
+                        size="mini"
+                      />
                     </Tooltip>
                   </FormGroupHeadingContent>
                 </FormGroupHeading>
@@ -504,7 +524,7 @@ class HealthChecksFormSection extends Component {
                 wrapperClassName="tooltip-wrapper text-align-center"
                 wrapText={true}
               >
-                <Icon color="grey" id="circle-question" size="mini" />
+                <Icon color="light-grey" id="circle-question" size="mini" />
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>

--- a/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerHealthChecksFormSection.js
@@ -80,7 +80,11 @@ class MultiContainerHealthChecksFormSection extends Component {
                       maxWidth={300}
                       wrapText={true}
                     >
-                      <Icon color="grey" id="circle-question" size="mini" />
+                      <Icon
+                        color="light-grey"
+                        id="circle-question"
+                        size="mini"
+                      />
                     </Tooltip>
                   </FormGroupHeadingContent>
                 </FormGroupHeading>
@@ -110,7 +114,11 @@ class MultiContainerHealthChecksFormSection extends Component {
                       maxWidth={300}
                       wrapText={true}
                     >
-                      <Icon color="grey" id="circle-question" size="mini" />
+                      <Icon
+                        color="light-grey"
+                        id="circle-question"
+                        size="mini"
+                      />
                     </Tooltip>
                   </FormGroupHeadingContent>
                 </FormGroupHeading>
@@ -140,7 +148,11 @@ class MultiContainerHealthChecksFormSection extends Component {
                       maxWidth={300}
                       wrapText={true}
                     >
-                      <Icon color="grey" id="circle-question" size="mini" />
+                      <Icon
+                        color="light-grey"
+                        id="circle-question"
+                        size="mini"
+                      />
                     </Tooltip>
                   </FormGroupHeadingContent>
                 </FormGroupHeading>
@@ -170,7 +182,11 @@ class MultiContainerHealthChecksFormSection extends Component {
                       maxWidth={300}
                       wrapText={true}
                     >
-                      <Icon color="grey" id="circle-question" size="mini" />
+                      <Icon
+                        color="light-grey"
+                        id="circle-question"
+                        size="mini"
+                      />
                     </Tooltip>
                   </FormGroupHeadingContent>
                 </FormGroupHeading>
@@ -272,7 +288,7 @@ class MultiContainerHealthChecksFormSection extends Component {
                   wrapperClassName="tooltip-wrapper tooltip-block-wrapper text-align-center"
                   wrapText={true}
                 >
-                  <Icon color="grey" id="circle-question" size="mini" />
+                  <Icon color="light-grey" id="circle-question" size="mini" />
                 </Tooltip>
               </FormGroupHeadingContent>
             </FormGroupHeading>
@@ -298,7 +314,7 @@ class MultiContainerHealthChecksFormSection extends Component {
                   maxWidth={300}
                   wrapText={true}
                 >
-                  <Icon color="grey" id="circle-question" size="mini" />
+                  <Icon color="light-grey" id="circle-question" size="mini" />
                 </Tooltip>
               </FormGroupHeadingContent>
             </FormGroupHeading>
@@ -404,7 +420,7 @@ class MultiContainerHealthChecksFormSection extends Component {
                     wrapperClassName="tooltip-wrapper text-align-center"
                     wrapText={true}
                   >
-                    <Icon color="grey" id="circle-question" size="mini" />
+                    <Icon color="light-grey" id="circle-question" size="mini" />
                   </Tooltip>
                 </FormGroupHeadingContent>
               </FormGroupHeading>
@@ -477,7 +493,7 @@ class MultiContainerHealthChecksFormSection extends Component {
             wrapperClassName="tooltip-wrapper text-align-center"
             wrapText={true}
           >
-            <Icon color="grey" id="circle-question" size="mini" />
+            <Icon color="light-grey" id="circle-question" size="mini" />
           </Tooltip>
         </FormGroupHeadingContent>
       </FormGroupHeading>

--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -147,7 +147,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
                 maxWidth={300}
                 wrapText={true}
               >
-                <Icon color="grey" id="circle-question" size="mini" />
+                <Icon color="light-grey" id="circle-question" size="mini" />
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>
@@ -241,7 +241,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
                   wrapperClassName="tooltip-wrapper text-align-center"
                   wrapText={true}
                 >
-                  <Icon color="grey" id="circle-question" size="mini" />
+                  <Icon color="light-grey" id="circle-question" size="mini" />
                 </Tooltip>
               </FormGroupHeadingContent>
             </FormGroupHeading>
@@ -320,7 +320,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
                   maxWidth={300}
                   wrapText={true}
                 >
-                  <Icon color="grey" id="circle-question" size="mini" />
+                  <Icon color="light-grey" id="circle-question" size="mini" />
                 </Tooltip>
               </FormGroupHeadingContent>
             </FormGroupHeading>
@@ -389,7 +389,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
                 maxWidth={300}
                 wrapText={true}
               >
-                <Icon color="grey" id="circle-question" size="mini" />
+                <Icon color="light-grey" id="circle-question" size="mini" />
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>
@@ -613,7 +613,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
                     maxWidth={300}
                     wrapText={true}
                   >
-                    <Icon color="grey" id="circle-question" size="mini" />
+                    <Icon color="light-grey" id="circle-question" size="mini" />
                   </Tooltip>
                 </FormGroupHeadingContent>
               </FormGroupHeading>
@@ -638,7 +638,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
                 wrapperClassName="tooltip-wrapper text-align-center"
                 wrapText={true}
               >
-                <Icon color="grey" id="circle-question" size="mini" />
+                <Icon color="light-grey" id="circle-question" size="mini" />
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>

--- a/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerVolumesFormSection.js
@@ -281,7 +281,7 @@ class MultiContainerVolumesFormSection extends Component {
               maxWidth={300}
               wrapText={true}
             >
-              <Icon color="grey" id="circle-question" size="mini" />
+              <Icon color="light-grey" id="circle-question" size="mini" />
             </Tooltip>
           </FormGroupHeadingContent>
         </FormGroupHeading>

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -119,7 +119,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
                 maxWidth={300}
                 wrapText={true}
               >
-                <Icon color="grey" id="circle-question" size="mini" />
+                <Icon color="light-grey" id="circle-question" size="mini" />
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>
@@ -193,7 +193,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
                   wrapperClassName="tooltip-wrapper text-align-center"
                   wrapText={true}
                 >
-                  <Icon color="grey" id="circle-question" size="mini" />
+                  <Icon color="light-grey" id="circle-question" size="mini" />
                 </Tooltip>
               </FormGroupHeadingContent>
             </FormGroupHeading>
@@ -272,7 +272,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
                   maxWidth={300}
                   wrapText={true}
                 >
-                  <Icon color="grey" id="circle-question" size="mini" />
+                  <Icon color="light-grey" id="circle-question" size="mini" />
                 </Tooltip>
               </FormGroupHeadingContent>
             </FormGroupHeading>
@@ -343,7 +343,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
                 maxWidth={300}
                 wrapText={true}
               >
-                <Icon color="grey" id="circle-question" size="mini" />
+                <Icon color="light-grey" id="circle-question" size="mini" />
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>
@@ -495,7 +495,11 @@ class NetworkingFormSection extends mixin(StoreMixin) {
                       wrapperClassName="tooltip-wrapper text-align-center"
                       wrapText={true}
                     >
-                      <Icon color="grey" id="circle-question" size="mini" />
+                      <Icon
+                        color="light-grey"
+                        id="circle-question"
+                        size="mini"
+                      />
                     </Tooltip>
                   </FormGroupHeadingContent>
                 </FormGroupHeading>
@@ -599,7 +603,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
             wrapperClassName="tooltip-wrapper text-align-center"
             wrapText={true}
           >
-            <Icon color="grey" id="circle-question" size="mini" />
+            <Icon color="light-grey" id="circle-question" size="mini" />
           </Tooltip>
         </FormGroupHeadingContent>
       </FormGroupHeading>
@@ -755,7 +759,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
                     maxWidth={300}
                     wrapText={true}
                   >
-                    <Icon color="grey" id="circle-question" size="mini" />
+                    <Icon color="light-grey" id="circle-question" size="mini" />
                   </Tooltip>
                 </FormGroupHeadingContent>
               </FormGroupHeading>

--- a/plugins/services/src/js/components/forms/PlacementSection.js
+++ b/plugins/services/src/js/components/forms/PlacementSection.js
@@ -43,7 +43,7 @@ export default class PlacementSection extends Component {
                 maxWidth={300}
                 wrapText={true}
               >
-                <Icon color="grey" id="circle-question" size="mini" />
+                <Icon color="light-grey" id="circle-question" size="mini" />
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>

--- a/plugins/services/src/js/components/forms/VolumesFormSection.js
+++ b/plugins/services/src/js/components/forms/VolumesFormSection.js
@@ -75,7 +75,7 @@ class VolumesFormSection extends Component {
                   maxWidth={300}
                   wrapText={true}
                 >
-                  <Icon color="grey" id="circle-question" size="mini" />
+                  <Icon color="light-grey" id="circle-question" size="mini" />
                 </Tooltip>
               </FormGroupHeadingContent>
             </FormGroupHeading>
@@ -162,7 +162,7 @@ class VolumesFormSection extends Component {
                   maxWidth={300}
                   wrapText={true}
                 >
-                  <Icon color="grey" id="circle-question" size="mini" />
+                  <Icon color="light-grey" id="circle-question" size="mini" />
                 </Tooltip>
               </FormGroupHeadingContent>
             </FormGroupHeading>
@@ -418,7 +418,7 @@ class VolumesFormSection extends Component {
                 maxWidth={300}
                 wrapText={true}
               >
-                <Icon color="grey" id="circle-question" size="mini" />
+                <Icon color="light-grey" id="circle-question" size="mini" />
               </Tooltip>
             </FormGroupHeadingContent>
           </FormGroupHeading>

--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
@@ -379,7 +379,7 @@ class PodInstancesTable extends React.Component {
 
     return (
       <Link to={`/services/detail/${id}/tasks/${taskID}/logs`} title={row.name}>
-        <Icon color="grey" id="page-document" size="mini" />
+        <Icon color="light-grey" id="page-document" size="mini" />
       </Link>
     );
   }

--- a/plugins/services/src/js/containers/service-connection/EndpointClipboardTrigger.js
+++ b/plugins/services/src/js/containers/service-connection/EndpointClipboardTrigger.js
@@ -15,7 +15,12 @@ class EndpointClipboardTrigger extends React.Component {
             copyText={command}
             useTooltip={true}
           >
-            <Icon id="clipboard" size="mini" ref="copyButton" color="grey" />
+            <Icon
+              id="clipboard"
+              size="mini"
+              ref="copyButton"
+              color="light-grey"
+            />
           </ClipboardTrigger>
         </div>
         {command}

--- a/plugins/services/src/js/containers/tasks/TaskTable.js
+++ b/plugins/services/src/js/containers/tasks/TaskTable.js
@@ -298,7 +298,7 @@ class TaskTable extends React.Component {
           wrapperClassName="tooltip-wrapper text-align-center description"
         >
           <Link to={linkTo} title={title}>
-            <Icon color="grey" id="page-document" size="mini" />
+            <Icon color="light-grey" id="page-document" size="mini" />
           </Link>
         </Tooltip>
       </div>

--- a/src/js/components/SchemaField.js
+++ b/src/js/components/SchemaField.js
@@ -268,7 +268,7 @@ class SchemaField extends Component {
             maxWidth={300}
             wrapText={true}
           >
-            <Icon color="grey" id="circle-question" size="mini" />
+            <Icon color="light-grey" id="circle-question" size="mini" />
           </Tooltip>
         </FormGroupHeadingContent>
       </FormGroupHeading>

--- a/src/js/components/SchemaForm.js
+++ b/src/js/components/SchemaForm.js
@@ -306,7 +306,7 @@ class SchemaForm extends mixin(StoreMixin) {
           wrapText={true}
           maxWidth={300}
         >
-          <Icon color="grey" id="circle-question" size="mini" />
+          <Icon color="light-grey" id="circle-question" size="mini" />
         </Tooltip>
       );
     } else if (description && levelsDeep === 0) {
@@ -347,7 +347,7 @@ class SchemaForm extends mixin(StoreMixin) {
         maxWidth={300}
         interactive={true}
       >
-        <Icon color="grey" id="circle-question" size="mini" />
+        <Icon color="light-grey" id="circle-question" size="mini" />
       </Tooltip>
     );
 

--- a/src/js/components/TabForm.js
+++ b/src/js/components/TabForm.js
@@ -120,7 +120,7 @@ class TabForm extends mixin(InternalStorageMixin) {
               wrapText={true}
               maxWidth={300}
             >
-              <Icon color="grey" id="circle-question" size="mini" />
+              <Icon color="light-grey" id="circle-question" size="mini" />
             </Tooltip>
           </div>
         </span>

--- a/src/js/utils/ResourceTableUtil.js
+++ b/src/js/utils/ResourceTableUtil.js
@@ -67,7 +67,7 @@ const ResourceTableUtil = {
             interactive={true}
             wrapperClassName="tooltip-wrapper text-align-center table-header-icon"
           >
-            <Icon id="circle-question" size="mini" color="grey" />
+            <Icon id="circle-question" size="mini" color="light-grey" />
           </Tooltip>
         );
       }

--- a/src/styles/components/icons/styles.less
+++ b/src/styles/components/icons/styles.less
@@ -72,20 +72,21 @@
     &.light-grey {
       color: @grey-dark;
 
-      a & {
-
-        &:hover {
-          color: tint(@grey-dark, 20%);
-        }
-      }
-
       &.inverse {
         color: color-lighten(@neutral, 70%);
       }
     }
 
     &.icon-light-grey {
-      color: color-lighten(@neutral, 60%);
+      color: @grey-light-darken-1;
+
+      a &,
+      .tooltip-wrapper & {
+
+        &:hover {
+          color: @grey-light-darken-2;
+        }
+      }
     }
 
     .button &,


### PR DESCRIPTION
With the UI Kit update our icons got very dark which makes the UI more dense. This was not the intent. This PR makes logs icons in tables and help icons with tooltips a lighter shade of grey with hover. 

Note: Associated private plugin PR.

Before
![image](https://user-images.githubusercontent.com/15963/36236547-79849a16-11ab-11e8-9049-945e938a8537.png)
![image](https://user-images.githubusercontent.com/15963/36236562-7ee7451c-11ab-11e8-98f1-40a67626dafd.png)


After
<img width="878" alt="screen shot 2018-02-14 at 4 52 33 pm" src="https://user-images.githubusercontent.com/15963/36236519-5b7f9ffc-11ab-11e8-9bc0-6666ba6e44d1.png">

<img width="1022" alt="screen shot 2018-02-14 at 4 52 50 pm" src="https://user-images.githubusercontent.com/15963/36236532-638efcba-11ab-11e8-8b57-75f8bec60c1d.png">

