### PR TITLE
fix(FrameworkForm): dont update state if form field is `initial`

### DIFF
--- a/src/js/components/SchemaField.js
+++ b/src/js/components/SchemaField.js
@@ -25,15 +25,6 @@ class SchemaField extends Component {
     );
   }
 
-  componentDidUpdate(prevProps) {
-    if (
-      prevProps.schema.type !== "object" &&
-      prevProps.formData !== this.props.formData
-    ) {
-      this.props.onChange(this.props.formData);
-    }
-  }
-
   componentDidMount() {
     // trigger an onChange for the top-most schema field
     // this will trigger validation in FrameworkConfiguration


### PR DESCRIPTION
The FrameworkForm fires two change events when something is changed.
This commit ignores the `initial` one.

---

Maybe this can help solving the cypress flakiness issue..

---

This PR is mostly to check if it breaks anything on Jenkins, not sure if we actually need to merge it.

edit: I'm referring to the "elast" issue we had a while back, it was somehow related to a "wrong re-render" of the form which could be initiated by this "double change"