### PR TITLE
[Regression] fix(integrationTests): fixes empty state of tests

### DIFF
--- a/tests/pages/services/ServicePodReviewScreen-cy.js
+++ b/tests/pages/services/ServicePodReviewScreen-cy.js
@@ -1222,25 +1222,25 @@ describe("Services", function() {
         .root()
         .configurationSection("Service")
         .configurationMapValue("Disk")
-        .contains("Not Supported");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("Service")
         .configurationMapValue("GPU")
-        .contains("Not Supported");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("container-1")
         .configurationMapValue("Container Image")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()
         .configurationSection("container-1")
         .configurationMapValue("Force Pull On Launch")
-        .contains("Not Configured");
+        .contains("\u2014");
 
       cy
         .root()


### PR DESCRIPTION
looks like two simultaneously merged PRs introduced a regression on master…

FYI: this is just a quick fix for the regression, we should refactor the tests to use the EmptyStates constants file at some point. JIRA: https://jira.mesosphere.com/browse/DCOS-21358