### PR TITLE
DCOS-21337: Add linearBackoff retry to the Mesos stream

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -325,6 +325,53 @@ follow these guidelines. Some of the most common ones to follow:
 For more on this topic, and examples we recommend 
 [Better Specs](http://www.betterspecs.org/).
 
+### Testing rxjs observables with marbles diagrams
+
+Before you begin please read the introduction on [what the marbles diagrams are](https://github.com/ReactiveX/rxjs/blob/5.4.2/doc/writing-marble-tests.md).
+Since there's no official helpers to write tests levereging the marbles diagrams we're using [rxjs-marbles](https://github.com/cartant/rxjs-marbles) library.
+
+The most important thing you should do is wrapping your usual test case function with `marble` function
+
+```js
+import { marbles } from "rxjs-marbles/jest";
+
+it("tests marbles", marble(function(m) {
+  // My test case
+}));
+```
+
+it will inject the Context conventionally named `m` that exposes the helpers API.
+
+#### Example of a marble test
+
+```js
+import { marbles } from "rxjs-marbles/jest";
+import { linearBackoff } from "../rxjsUtils";
+
+describe("linearBackoff", function() {
+  it(
+    "retries maxRetries times",
+    // To setup marbles test env pass your function wrapped with `marbels`
+    // it will inject Context as the first argument named `m` by convention
+    marbles(function(m) {
+      // with `m.bind` we bind all time dependent operators to a TestScheduler
+      // so that we can use mocked time intervals.
+      // But we also could create our own TestScheduler and use it instead.
+      m.bind();
+
+      const source = m.cold("1--2#");
+      const expected = m.cold("1--2--1--2----1--2------1--2#");
+
+      // In test env we don't want to wait for the real wall clock
+      // so we encode time intervals with a special helper `m.time`
+      const result = source.retryWhen(linearBackoff(3, m.time("--|")));
+
+      m.expect(result).toBeObservable(expected);
+    })
+  );
+});
+```
+
 ## Integration Testing
 
 At the integration level, we are interested in verifying that the composition of

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -67,9 +67,9 @@
       "resolved": "https://registry.npmjs.org/@dcos/http-service/-/http-service-0.2.1.tgz"
     },
     "@dcos/mesos-client": {
-      "version": "0.1.10",
-      "from": "@dcos/mesos-client@0.1.10",
-      "resolved": "https://registry.npmjs.org/@dcos/mesos-client/-/mesos-client-0.1.10.tgz"
+      "version": "0.2.0",
+      "from": "@dcos/mesos-client@0.2.0",
+      "resolved": "https://registry.npmjs.org/@dcos/mesos-client/-/mesos-client-0.2.0.tgz"
     },
     "@dcos/recordio": {
       "version": "0.1.6",
@@ -105,6 +105,11 @@
       "version": "4.14.87",
       "from": "@types/lodash@4.14.87",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.87.tgz"
+    },
+    "@types/lodash-es": {
+      "version": "4.17.0",
+      "from": "@types/lodash-es@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.0.tgz"
     },
     "@types/minimatch": {
       "version": "3.0.1",
@@ -398,7 +403,8 @@
         "chokidar": {
           "version": "1.6.1",
           "from": "chokidar@>=1.6.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz"
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+          "dependencies": {}
         },
         "core-js": {
           "version": "2.4.1",
@@ -3756,7 +3762,7 @@
     },
     "eslint-plugin-test-names": {
       "version": "1.0.1",
-      "from": "eslint-plugin-test-names@1.0.1",
+      "from": "eslint-plugin-test-names@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-test-names/-/eslint-plugin-test-names-1.0.1.tgz"
     },
     "espree": {
@@ -9054,6 +9060,11 @@
       "version": "5.4.3",
       "from": "rxjs@latest",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.3.tgz"
+    },
+    "rxjs-marbles": {
+      "version": "2.3.1",
+      "from": "rxjs-marbles@latest",
+      "resolved": "https://registry.npmjs.org/rxjs-marbles/-/rxjs-marbles-2.3.1.tgz"
     },
     "safe-buffer": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@dcos/http-service": "0.2.1",
-    "@dcos/mesos-client": "0.1.10",
+    "@dcos/mesos-client": "0.2.0",
     "babel-polyfill": "6.23.0",
     "browser-info": "0.4.0",
     "classnames": "2.2.3",
@@ -127,6 +127,7 @@
     "raml-validator-loader": "0.1.10",
     "react-hot-loader": "1.3.1",
     "react-test-renderer": "15.4.1",
+    "rxjs-marbles": "2.3.1",
     "source-map-loader": "0.1.5",
     "string-replace-webpack-plugin": "0.0.3",
     "style-loader": "0.13.1",

--- a/src/js/core/MesosStream.js
+++ b/src/js/core/MesosStream.js
@@ -1,6 +1,7 @@
 import { stream } from "@dcos/mesos-client";
+import { ReplaySubject } from "rxjs/ReplaySubject";
 
 export const MesosStreamType = Symbol("MesosStreamType");
 export default stream({ type: "SUBSCRIBE" }, "/mesos/api/v1?subscribe")
-  .publishReplay()
+  .multicast(() => new ReplaySubject())
   .refCount();

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -15,10 +15,13 @@ import {
 } from "../constants/EventTypes";
 import MesosStateUtil from "../utils/MesosStateUtil";
 import pipe from "../utils/pipe";
+import { linearBackoff } from "../utils/rxjsUtils";
 import { MesosStreamType } from "../core/MesosStream";
 import container from "../container";
 import * as mesosStreamParsers from "./MesosStream/parsers";
 
+const MAX_RETRIES = 5;
+const RETRY_DELAY = 5000;
 const METHODS_TO_BIND = ["setState", "onStreamData", "onStreamError"];
 
 class MesosStateStore extends GetSetBaseStore {
@@ -70,7 +73,7 @@ class MesosStateStore extends GetSetBaseStore {
     const getMasterRequest = request(
       { type: "GET_MASTER" },
       "/mesos/api/v1?get_master"
-    ).retry(3);
+    ).retryWhen(linearBackoff(MAX_RETRIES, RETRY_DELAY));
 
     const parsers = pipe(...Object.values(mesosStreamParsers));
     const dataStream = mesosStream
@@ -102,6 +105,7 @@ class MesosStateStore extends GetSetBaseStore {
     this.stream = waitStream
       .concat(eventTriggerStream)
       .debounceTime(Config.getRefreshRate() * 0.5)
+      .retryWhen(linearBackoff(MAX_RETRIES, RETRY_DELAY))
       .subscribe(this.onStreamData, this.onStreamError);
   }
 

--- a/src/js/utils/__tests__/rxjsUtils-test.js
+++ b/src/js/utils/__tests__/rxjsUtils-test.js
@@ -1,0 +1,27 @@
+import "rxjs/add/operator/retryWhen";
+import { marbles } from "rxjs-marbles/jest";
+
+import { linearBackoff } from "../rxjsUtils";
+
+describe("linearBackoff", function() {
+  it(
+    "retries maxRetries times",
+    // To setup marbles test env pass your function wrapped with `marbels`
+    // it will inject Context as the first argument named `m` by convention
+    marbles(function(m) {
+      // with `m.bind` we bind all time dependent operators to a TestScheduler
+      // so that we can use mocked time intervals.
+      // But we also could create our own TestScheduler and use it instead.
+      m.bind();
+
+      const source = m.cold("1--2#");
+      const expected = m.cold("1--2--1--2----1--2------1--2#");
+
+      // In test env we don't want to wait for the real wall clock
+      // so we encode time intervals with a special helper `m.time`
+      const result = source.retryWhen(linearBackoff(3, m.time("--|")));
+
+      m.expect(result).toBeObservable(expected);
+    })
+  );
+});

--- a/src/js/utils/rxjsUtils.js
+++ b/src/js/utils/rxjsUtils.js
@@ -1,0 +1,18 @@
+import { timer } from "rxjs/observable/timer";
+
+import "rxjs/add/operator/delayWhen";
+import "rxjs/add/operator/scan";
+
+/* eslint-disable import/prefer-default-export */
+export function linearBackoff(maxRetries = 5, delay = 1000, scheduler = null) {
+  return errors =>
+    errors
+      .scan((count, error) => {
+        if (count >= maxRetries) {
+          throw error;
+        }
+
+        return count + 1;
+      }, 0)
+      .delayWhen(val => timer(val * delay, null, scheduler));
+}


### PR DESCRIPTION
We have a retry in the https://github.com/dcos-labs/mesos-client but it will catch only the Network errors and in a very stubborn fashion. This PR addresses all the parsing errors that can happen when processing messages and  consuming the stream.

`linearBackoff` ensures that we don't bombard the server with retries.

To enable easier testing I added `rxjs-marbles` library that provides some helpers.

To test this in the browser you could emulate the network split and monitor the Networking tab in the Inspector. You could also add some `throw` and `console.log` if that pleases you.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->

Closes DCOS-21337