### PR TITLE
fix(struct/Node): does not throw exception when resources are empty

### DIFF
--- a/src/js/structs/Node.js
+++ b/src/js/structs/Node.js
@@ -39,8 +39,13 @@ class Node extends Item {
   }
 
   getUsageStats(resource) {
-    const total = this.get("resources")[resource];
-    const value = this.get("used_resources")[resource];
+    const total = (this.get("resources") || {})[resource];
+    const value = (this.get("used_resources") || {})[resource];
+
+    if (total === undefined || value === undefined) {
+      return { percentage: 0, total: 0, value: 0 };
+    }
+
     const percentage = Math.round(100 * value / Math.max(1, total));
 
     return { percentage, total, value };

--- a/src/js/structs/__tests__/Node-test.js
+++ b/src/js/structs/__tests__/Node-test.js
@@ -108,18 +108,36 @@ describe("Node", function() {
   });
 
   describe("#getUsageStats", function() {
-    it("returns usage stats for given resource", function() {
-      const node = new Node({
-        resources: { cpus: 10 },
-        used_resources: { cpus: 5 }
-      });
-      const stats = {
-        percentage: 50,
-        total: 10,
-        value: 5
-      };
+    describe("with resources from mesos", function() {
+      it("returns usage stats for given resource", function() {
+        const node = new Node({
+          resources: { cpus: 10 },
+          used_resources: { cpus: 5 }
+        });
+        const stats = {
+          percentage: 50,
+          total: 10,
+          value: 5
+        };
 
-      expect(node.getUsageStats("cpus")).toEqual(stats);
+        expect(node.getUsageStats("cpus")).toEqual(stats);
+      });
+    });
+
+    describe("without resources from mesos", function() {
+      it("returns empty resources and used_resources", function() {
+        const node = new Node({
+          resources: null,
+          used_resources: undefined
+        });
+        const stats = {
+          percentage: 0,
+          total: 0,
+          value: 0
+        };
+
+        expect(node.getUsageStats("cpus")).toEqual(stats);
+      });
     });
   });
 });


### PR DESCRIPTION
JIRA - https://jira.mesosphere.com/browse/DCOS-21361

Guards against resources being empty.

CLOSES DCOS-21361

This is tough to reproduce, especially because mesos team tells us it is a state that does not happen, but somehow we get to this problem, and it causes the NodeTable to render infinitely.

I would go by adding the following lines on Nodes.js:42

```
    this._itemData["resources"] = null;
    this._itemData["used_resources"] = null;
```

No need for integration tests.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
