### PR TITLE
feat(Packages): disable "review & run" button on not supported package version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9104,6 +9104,11 @@
       "from": "semver@>=4.0.3 <5.0.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
     },
+    "semver-compare": {
+      "version": "1.0.0",
+      "from": "semver-compare@latest",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz"
+    },
     "semver-regex": {
       "version": "1.0.0",
       "from": "semver-regex@>=1.0.0 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "redux": "3.3.1",
     "reflect-metadata": "0.1.10",
     "rxjs": "5.4.3",
+    "semver-compare": "1.0.0",
     "tv4": "1.2.7"
   },
   "devDependencies": {

--- a/src/js/pages/catalog/PackageDetailTab.js
+++ b/src/js/pages/catalog/PackageDetailTab.js
@@ -265,8 +265,6 @@ class PackageDetailTab extends mixin(StoreMixin) {
   }
 
   getInstallButtons(cosmosPackage) {
-    const tooltipContent = "Loading selected version";
-
     if (cosmosPackage.isCLIOnly()) {
       return (
         <div>
@@ -287,6 +285,23 @@ class PackageDetailTab extends mixin(StoreMixin) {
     }
 
     const { isLoadingSelectedVersion } = this.state;
+    let tooltipContent = "";
+    let installButtonIsDisabled = false;
+
+    if (isLoadingSelectedVersion) {
+      tooltipContent = "Loading selected version";
+      installButtonIsDisabled = true;
+    }
+
+    if (
+      StringUtil.compareVersionStrings(
+        MetadataStore.parsedVersion,
+        cosmosPackage.minDcosReleaseVersion
+      ) < 0
+    ) {
+      tooltipContent = `This Package requires version ${cosmosPackage.minDcosReleaseVersion} or higher, but you are running ${MetadataStore.parsedVersion}`;
+      installButtonIsDisabled = true;
+    }
 
     return (
       <div className="button-collection">
@@ -294,11 +309,11 @@ class PackageDetailTab extends mixin(StoreMixin) {
           wrapperClassName="button-group"
           wrapText={true}
           content={tooltipContent}
-          suppress={!isLoadingSelectedVersion}
+          suppress={!installButtonIsDisabled}
           width={200}
         >
           <button
-            disabled={isLoadingSelectedVersion}
+            disabled={installButtonIsDisabled}
             className="button button-primary"
             onClick={this.handleReviewAndRunClick}
           >

--- a/src/js/utils/StringUtil.js
+++ b/src/js/utils/StringUtil.js
@@ -1,4 +1,5 @@
 import marked from "marked";
+import semverCompare from "semver-compare";
 /* eslint-disable no-unused-vars */
 import React from "react";
 /* eslint-enable no-unused-vars */
@@ -239,6 +240,10 @@ const StringUtil = {
     }, []);
 
     return this.idToTitle(splitID, splitBy, replace, removeConsecutive);
+  },
+
+  compareVersionStrings(versionStringA, versionStringB) {
+    return semverCompare(versionStringA, versionStringB);
   }
 };
 


### PR DESCRIPTION
**⚠️  PR is a work from @juliangieseke** 

This commit disables the install button when the current dcos version is lower than the support versions

Closes DCOS-21305

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
