### PR TITLE
DCOS-21305: Respect DC/OS min required version when installing a package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "redux": "3.3.1",
     "reflect-metadata": "0.1.10",
     "rxjs": "5.4.3",
+    "semver": "5.5.0",
     "tv4": "1.2.7"
   },
   "devDependencies": {

--- a/tests/_fixtures/dcos/dcos-version.json
+++ b/tests/_fixtures/dcos/dcos-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6",
+  "version": "1.12",
   "dcos-image-commit": "43eff42b8eb9c5bf5d27b0d56e42b9ffe9ae2b32",
   "bootstrap-id": "88d5b8c52eba580b9ee8418410a0d85cfe4c19e5"
 }

--- a/tests/pages/catalog/packages/PackagesTab-cy.js
+++ b/tests/pages/catalog/packages/PackagesTab-cy.js
@@ -165,4 +165,24 @@ describe("Packages Tab", function() {
       });
     });
   });
+
+  context("respect DCOS version", function() {
+    beforeEach(function() {
+      cy
+        .route(/dcos-version/, {
+          version: "1.6",
+          "dcos-image-commit": "null",
+          "bootstrap-id": "null"
+        })
+        .visitUrl({ url: "/catalog", logIn: true });
+    });
+
+    it("cant install package because of DCOS version", function() {
+      cy.get(".panel").contains("arangodb").click();
+      cy
+        .get(".button.button-primary")
+        .contains("Review & Run")
+        .should("be.disabled");
+    });
+  });
 });


### PR DESCRIPTION
This disables the install button when the current dcos
version is incompatible

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
