### PR TITLE
[Backport 1.11] DCOS-21359: fix(ServicesContainer): checks and updates modalProps if needed

### DIFF
--- a/plugins/services/src/js/containers/services/__tests__/ServicesContainer-test.js
+++ b/plugins/services/src/js/containers/services/__tests__/ServicesContainer-test.js
@@ -1,3 +1,5 @@
+jest.mock("#SRC/js/stores/DCOSStore");
+
 /* eslint-disable no-unused-vars */
 const React = require("react");
 /* eslint-enable no-unused-vars */
@@ -7,6 +9,8 @@ const TestUtils = require("react-addons-test-utils");
 const JestUtil = require("#SRC/js/utils/JestUtil");
 const DSLExpression = require("#SRC/js/structs/DSLExpression");
 const MesosStateStore = require("#SRC/js/stores/MesosStateStore");
+const DCOSStore = require("#SRC/js/stores/DCOSStore");
+const Service = require("#PLUGINS/services/src/js/structs/Service");
 
 const ServicesContainer = require("../ServicesContainer");
 
@@ -57,6 +61,74 @@ describe("ServicesContainer", function() {
       expect(this.routerStubs.push.calls.mostRecent().args).toEqual([
         { pathname: "/test", query: { q: "bar" } }
       ]);
+    });
+  });
+
+  describe("#getCorrectedModalProps", function() {
+    const storeService = new Service({ id: "/test" });
+    beforeEach(function() {
+      DCOSStore.serviceTree = {
+        findItemById() {
+          return storeService;
+        }
+      };
+    });
+
+    it("returns modalProps from state with updated service information for given existing service (state)", function() {
+      const modalProps = this.instance.getCorrectedModalProps(
+        { service: storeService },
+        undefined
+      );
+      expect(modalProps).toEqual({ service: storeService });
+    });
+
+    it("returns modalProps from argument with updated service information for given existing service (argument)", function() {
+      const modalProps = this.instance.getCorrectedModalProps(
+        { service: undefined },
+        storeService
+      );
+      expect(modalProps).toEqual({ service: storeService });
+    });
+
+    it("returns modalProps from state with updated service information for given existing service (both)", function() {
+      const modalProps = this.instance.getCorrectedModalProps(
+        { service: storeService },
+        new Service({ id: "/test2" })
+      );
+      expect(modalProps).toEqual({ service: storeService });
+    });
+
+    // the following two tests are the ones which broke the modals before.
+    // the important part is, that `service` is never undefined
+    // (because DCOSStore returns nothing) while a modal is (still)
+    // open.
+    // if service is "unknown", we have to fill in "something" in `service`
+    // and delete the `id` node. this will close the modal.
+
+    it("returns empty modalProps if no service is given but id is set", function() {
+      DCOSStore.serviceTree = {
+        findItemById() {
+          return undefined;
+        }
+      };
+      const modalProps = this.instance.getCorrectedModalProps(
+        { id: "delete", service: undefined },
+        undefined
+      );
+      expect(modalProps).toEqual({});
+    });
+
+    it("returns modalProps without id for already deleted service", function() {
+      DCOSStore.serviceTree = {
+        findItemById() {
+          return undefined;
+        }
+      };
+      const modalProps = this.instance.getCorrectedModalProps(
+        { id: "delete", service: new Service({ id: "/deleted" }) },
+        undefined
+      );
+      expect(modalProps).toEqual({ service: new Service({ id: "/deleted" }) });
     });
   });
 });


### PR DESCRIPTION
---

ℹ️Cherry-picked backport from #2777 - please review the other one 👍

---

This PR adds a `getCleanModalProps` method to the `ServicesContainer`
which cleans and updates the `modalProps` object which is passed down to
the modals.
Before this change it was possible to have an invalid state in `modalProps`
like this: { service: undefined, id: "delete" }. This should be fixed now so
that `service` is always set, if `id` is. If anything is wrong the method
tries to correct the object as good as possible.

Closes DCOS-21359
