### PR TITLE
feat(ServiceTree): stay in group view when service deleted

### DIFF
--- a/plugins/services/src/js/components/modals/ServiceDestroyModal.js
+++ b/plugins/services/src/js/components/modals/ServiceDestroyModal.js
@@ -8,6 +8,7 @@ import { injectIntl, intlShape } from "react-intl";
 import ModalHeading from "#SRC/js/components/modals/ModalHeading";
 import StringUtil from "#SRC/js/utils/StringUtil";
 import UserActions from "#SRC/js/constants/UserActions";
+import DCOSStore from "#SRC/js/stores/DCOSStore";
 
 import AppLockedMessage from "./AppLockedMessage";
 import Framework from "../../structs/Framework";
@@ -131,11 +132,17 @@ class ServiceDestroyModal extends React.Component {
 
   redirectToServices() {
     const { router } = this.context;
+    const { service } = this.props;
+
+    const parentService = DCOSStore.serviceTree.getItemParent(service.getId());
+    const servicePath = parentService
+      ? `/services/overview/${encodeURIComponent(parentService.getId())}`
+      : "/services/overview";
 
     // Close the modal and redirect after the close animation has completed
     this.handleModalClose();
     setTimeout(() => {
-      router.push({ pathname: "/services/overview" });
+      router.push({ pathname: servicePath });
     }, REDIRECT_DELAY);
   }
 

--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
@@ -438,9 +438,7 @@ class PodInstancesTable extends React.Component {
 
     return this.renderWithClickHandler(
       rowOptions,
-      <div className="flex-box flex-box-align-vertical-center
-        table-cell-flex-box flex-align-items-center
-        flex-direction-top-to-bottom">
+      <div className="flex-box flex-box-align-vertical-center table-cell-flex-box flex-align-items-center flex-direction-top-to-bottom">
         <div className="table-cell-icon">
           <Tooltip anchor="center" content={tooltipContent}>
             <span className={classNames("flush", status.dotClassName)} />

--- a/plugins/services/src/js/structs/ServiceTree.js
+++ b/plugins/services/src/js/structs/ServiceTree.js
@@ -99,6 +99,24 @@ module.exports = class ServiceTree extends Tree {
     });
   }
 
+  getItemParent(id) {
+    if (!this.list || this.list.length === 0) {
+      return null;
+    }
+
+    let parentFound = null;
+
+    this.list.forEach(child => {
+      if (child instanceof ServiceTree) {
+        parentFound = child.getItemParent(id);
+      } else if (child.getId() === id) {
+        parentFound = this;
+      }
+    });
+
+    return parentFound;
+  }
+
   /**
    * @param {string} id
    * @return {Service|ServiceTree} matching item

--- a/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
+++ b/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
@@ -287,6 +287,54 @@ describe("ServiceTree", function() {
     });
   });
 
+  describe("#getItemParent", function() {
+    beforeEach(function() {
+      this.instance = new ServiceTree({
+        id: "/",
+        items: [
+          {
+            id: "/test",
+            items: [
+              {
+                id: "/test/foo"
+              },
+              {
+                id: "/test/bar"
+              }
+            ]
+          },
+          {
+            id: "/alpha",
+            cmd: "cmd"
+          },
+          {
+            id: "/beta",
+            cmd: "cmd",
+            items: {
+              DCOS_PACKAGE_FRAMEWORK_NAME: "beta"
+            }
+          }
+        ]
+      });
+    });
+
+    it("finds matching parent from item two levels deep", function() {
+      expect(this.instance.getItemParent("/test/foo").getId()).toEqual("/test");
+    });
+
+    it("finds matching parent from item one level deep", function() {
+      expect(this.instance.getItemParent("/alpha").getId()).toEqual("/");
+    });
+
+    it("returns null when root item searched", function() {
+      expect(this.instance.getItemParent("/")).toEqual(null);
+    });
+
+    it("returns null when no parent found", function() {
+      expect(this.instance.getItemParent("/not/found")).toEqual(null);
+    });
+  });
+
   describe("#findItemById", function() {
     beforeEach(function() {
       this.instance = new ServiceTree({


### PR DESCRIPTION
---

ℹ️ Cherry-picked backport of #2702 - no actual work was done here.

---

When deleting a group inside a group, instead of staying inside that group you're being thrown back to the root of the namespace.

Closes DCOS_OSS-1341

Regarding the Backport: Closes DCOS_OSS-2004