### PR TITLE
chore(reactjs-components): update package to 0.20.3

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2897,7 +2897,7 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "from": "decamelize@>=1.0.0 <2.0.0",
+      "from": "decamelize@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
     "decompress": {
@@ -3646,7 +3646,7 @@
     },
     "eslint-config-airbnb": {
       "version": "10.0.1",
-      "from": "eslint-config-airbnb@10.0.1",
+      "from": "eslint-config-airbnb@>=10.0.1 <11.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-10.0.1.tgz"
     },
     "eslint-config-airbnb-base": {
@@ -4148,7 +4148,7 @@
     },
     "find-up": {
       "version": "1.1.2",
-      "from": "find-up@>=1.1.2 <2.0.0",
+      "from": "find-up@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "dependencies": {
         "path-exists": {
@@ -5494,7 +5494,7 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "from": "isarray@1.0.0",
+      "from": "isarray@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
     },
     "isexe": {
@@ -6880,7 +6880,7 @@
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+      "from": "lodash._reinterpolate@>=3.0.0 <3.1.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
     },
     "lodash._root": {
@@ -7181,7 +7181,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "from": "meow@>=3.5.0 <4.0.0",
+      "from": "meow@3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "dependencies": {
         "object-assign": {
@@ -7275,7 +7275,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "from": "minimist@>=1.1.0 <2.0.0",
+      "from": "minimist@>=1.1.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
     },
     "mkdirp": {
@@ -8334,7 +8334,7 @@
     },
     "prop-types": {
       "version": "15.6.0",
-      "from": "prop-types@latest",
+      "from": "prop-types@>=15.5.6 <16.0.0",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
       "dependencies": {
         "fbjs": {
@@ -8344,12 +8344,12 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "from": "js-tokens@>=3.0.0 <4.0.0",
+          "from": "js-tokens@^3.0.0",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
         },
         "loose-envify": {
           "version": "1.3.1",
-          "from": "loose-envify@>=1.3.1 <2.0.0",
+          "from": "loose-envify@^1.3.1",
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
         },
         "object-assign": {
@@ -8680,9 +8680,9 @@
       }
     },
     "reactjs-components": {
-      "version": "0.20.1",
-      "from": "reactjs-components@0.20.1",
-      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.20.1.tgz"
+      "version": "0.20.3",
+      "from": "reactjs-components@0.20.3",
+      "resolved": "https://registry.npmjs.org/reactjs-components/-/reactjs-components-0.20.3.tgz"
     },
     "reactjs-mixin": {
       "version": "0.0.2",
@@ -9523,7 +9523,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "from": "strip-ansi@>=3.0.1 <4.0.0",
+      "from": "strip-ansi@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
     },
     "strip-bom": {
@@ -9830,7 +9830,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.3.4 <2.4.0",
+      "from": "through@>=2.2.7 <3.0.0",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
@@ -10672,7 +10672,7 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <5.0.0",
+      "from": "xtend@>=4.0.1 <4.1.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react-redux": "4.4.6",
     "react-router": "2.8.1",
     "react-transition-group": "1.2.1",
-    "reactjs-components": "0.20.1",
+    "reactjs-components": "0.20.3",
     "reactjs-mixin": "0.0.2",
     "redux": "3.3.1",
     "reflect-metadata": "0.1.10",


### PR DESCRIPTION
The new version of VirtualList on 0.20.3 does not cause
react to render infinitely when, while rendering the list
there is an exception.

This fixed behavior helps prevent a few bugs we had in the ui.

**Testing**

The new version of reacts components have changed on the virtual list. You can check some of the lists around the app.

More specifically, you can go on the struct/Node and make it throw an exception by adding an error in any of the methods that are used on the Nodes Table. There you should see there is an error in console, but the list does not render wrong content.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Test it myself