### PR TITLE
Add shellcheck prevent obvious errors using bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN set -x \
   # Install cypress dependencies & JRE (required by Jenkins)
   && echo 'deb http://ftp.debian.org/debian jessie-backports main' >> /etc/apt/sources.list \
   && apt-get update \
-  && apt-get install -y xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 \
+  && apt-get install -y xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 shellcheck \
   && apt-get install -t jessie-backports -y openjdk-8-jre-headless ca-certificates-java \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,6 +44,7 @@ pipeline {
       steps {
         ansiColor('xterm') {
           sh '''npm run lint'''
+          sh '''shellcheck ./system-tests/**/*.sh ./scripts/**/*'''
         }
       }
     }


### PR DESCRIPTION
I hope that this tooling helps us write less error-prone shell scripts. As we don't test them at all, I think linting them makes a lot of sense and doesn't take that much effort