### PR TITLE
[Backport 1.10] DCOS-19865 fix focus/change/blur behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
   "scripts": {
     "check-env": "./scripts/validate-engine-versions",
     "clean": "rm -rf dist",
+    "cypress": "cypress run",
     "shrinkwrap": "npm shrinkwrap --dev && ./node_modules/.bin/gulp fixShrinkwrap",
     "preinstall": "./scripts/pre-install",
     "prebuild-assets": "./node_modules/.bin/gulp checkDependencies",

--- a/plugins/services/src/js/components/modals/CreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModalForm.js
@@ -52,6 +52,7 @@ const METHODS_TO_BIND = [
   "handleConvertToPod",
   "handleDropdownNavigationSelection",
   "handleFormBlur",
+  "handleFormFocus",
   "handleFormChange",
   "handleJSONChange",
   "handleJSONPropertyChange",
@@ -244,6 +245,18 @@ class CreateServiceModalForm extends Component {
     if (!editedFieldPaths.includes(fieldName)) {
       newState.editedFieldPaths = editedFieldPaths.concat([fieldName]);
     }
+    this.setState(newState);
+  }
+
+  handleFormFocus(event) {
+    const fieldName = event.target.getAttribute("name");
+    const newState = {
+      editingFieldPath: fieldName
+    };
+
+    if (!fieldName) {
+      return;
+    }
 
     this.setState(newState);
   }
@@ -264,8 +277,7 @@ class CreateServiceModalForm extends Component {
 
     const newState = {
       appConfig: this.getAppConfig(batch),
-      batch,
-      editingFieldPath: fieldName
+      batch
     };
 
     this.setState(newState);
@@ -664,6 +676,7 @@ class CreateServiceModalForm extends Component {
                 className="create-service-modal-form container container-wide"
                 onChange={this.handleFormChange}
                 onBlur={this.handleFormBlur}
+                onFocus={this.handleFormFocus}
               >
                 <Tabs
                   activeTab={activeTab}

--- a/tests/components/PageHeader.js
+++ b/tests/components/PageHeader.js
@@ -39,7 +39,7 @@ describe("Page Header Component", function() {
         const beforeLastItem = $breadcrumbs[$breadcrumbs.length - 3];
 
         expect(beforeLastItem.textContent).to.equal("group-with-pods");
-        expect(lastItem.textContent).to.equal("podEFGHDeploying (0 of 10)");
+        expect(lastItem.textContent).to.equal("podEFGHDeploying (1 of 10)");
       });
     });
 

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1012,7 +1012,8 @@ describe("Service Form Modal", function() {
               cy
                 .get("@tabView")
                 .find('.form-control[name="portDefinitions.0.hostPort"]')
-                .type(7);
+                .type(7)
+                .blur();
 
               cy.contains(".marathon.l4lb.thisdcos.directory:7");
             });


### PR DESCRIPTION
ℹ️ Backport of https://github.com/dcos/dcos-ui/pull/2761

---

This commit changes the onChange handler of the ServiceForm so that
it no longer implicitly sets state.editingFieldPath, instead a new
internal function `handleFormFocus` is introduced.

The old implementation was broken and also was one of the reasons
why our tests were flaky, in fact some tests had to be fixed
after changing the form - they were expecting the broken state.

Also the previous implementation caused the form to lose information
when a radio or checkbox inpout was changed last in some situations.

Firefox for Example doesnt focus a radio input and therefore
never fires a blur event.