### PR TITLE
DCOS-21520: check node version on checkout

### DIFF
--- a/scripts/post-checkout
+++ b/scripts/post-checkout
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
+
+# Import utils
+source ${SCRIPT_PATH}/utils/message
+
+# strong some numbers
+NPM_VERSION="$(npm -v)"
+MAJOR_NPM_VERSION="$(npm -v | cut -d. -f1)"
+
+NODE_VERSION="$(node -v)"
+
+PACKAGE_DEV_DEPENDENCY="$(node -p -e "require('./package.json').devDependencies.node")"
+PACKAGE_ENGINE_DEPENDENCY="$(node -p -e "require('./package.json').engines.node")"
+
+VALIDATION_EXIT_CODE=$(${SCRIPT_PATH}/validate-engine-versions > /dev/null; echo $?)
+
+# checking some stuff
+if [ "$PACKAGE_DEV_DEPENDENCY" != "undefined" ] && [ "$MAJOR_NPM_VERSION" -lt 5 ]; then
+  warning "This branch uses node as a dependency, \
+    but you are running npm ${NPM_VERSION} which doesnt support that."
+  exit 1;
+elif [ $VALIDATION_EXIT_CODE -ne 0 ]; then
+  warning "This branch requires node version v${PACKAGE_ENGINE_DEPENDENCY}, \
+    but you're running ${NODE_VERSION}."
+  exit 1
+fi
+
+info "Looks like your node version is fine."

--- a/scripts/pre-install
+++ b/scripts/pre-install
@@ -12,6 +12,6 @@ source ${SCRIPT_PATH}/utils/marathon
 # git hooks fail to install
 ${SCRIPT_PATH}/validate-engine-versions && \
   install_marathon_raml "$MARATHON_VERSION" && \
-  install_hooks "pre-commit post-rewrite post-commit"
+  install_hooks "pre-commit post-rewrite post-commit post-checkout"
 
 exit 0


### PR DESCRIPTION
This adds a small notice after you changed the branch, this should come in handy once we introduced the node upgrade but still have to work on older releases 👍 

Example with correct Node version:
![screen shot 2018-03-02 at 17 15 22](https://user-images.githubusercontent.com/530632/36909182-9f5457ba-1e3d-11e8-8817-1e46be3da786.png)
And wrong one:
![screen shot 2018-03-02 at 17 20 18](https://user-images.githubusercontent.com/530632/36909338-038c813a-1e3e-11e8-8fe6-9c747e3ce0cc.png)

