### PR TITLE
DCOS-21369: fix(TasksView): fix undefined service in TasksView

### DIFF
--- a/plugins/services/src/js/containers/tasks/TasksView.js
+++ b/plugins/services/src/js/containers/tasks/TasksView.js
@@ -123,13 +123,16 @@ class TasksView extends mixin(SaveStateMixin) {
     const isDeploying = Object.keys(checkedItems).some(function(taskId) {
       const service = DCOSStore.serviceTree.getServiceFromTaskID(taskId);
 
-      return service.getServiceStatus().key === ServiceStatusTypes.DEPLOYING;
+      return (
+        service &&
+        service.getServiceStatus().key === ServiceStatusTypes.DEPLOYING
+      );
     });
 
     const isSDK = Object.keys(checkedItems).some(function(taskId) {
       const service = DCOSStore.serviceTree.getServiceFromTaskID(taskId);
 
-      return isSDKService(service);
+      return service && isSDKService(service);
     });
 
     // Only show Stop if a scheduler task isn't selected


### PR DESCRIPTION
Small fix which assures that service is set before accessing its childnodes.

Closes DCOS-21369
