### PR TITLE
refactor(githooks): move and improve post-checkout checks into validate-engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,12 +163,13 @@
     "serve": "npm run build-assets && ./node_modules/.bin/gulp serve",
     "serve-notify": "export NOTIFY=true && npm run serve",
     "scaffold": "./node_modules/.bin/gulp ensureConfig && ./node_modules/.bin/gulp ensureDevProxy",
+    "prestart": "npm run check-env",
     "start": "NODE_ENV=development webpack-dev-server --config ./webpack/webpack.dev.babel.js --hot --progress --colors --content-base ./build --host 0.0.0.0 --port $npm_package_config_port",
     "test": "node jest/gen-config.js && NODE_PATH=node_modules jest --config=jest.config.json --no-cache",
     "test:watch": "npm test -- --watch",
     "testing": "NODE_ENV=testing webpack-dev-server --config ./webpack/webpack.dev.babel.js --progress --colors --content-base ./build --host 0.0.0.0 --port $npm_package_config_port",
     "validate-build": "scripts/validate-build dist/*.js",
-    "versions": "npm --version && node --version"
+    "versions": "echo npm: $(npm --version) && echo node: $(node --version)"
   },
   "jest-webpack-alias": {
     "configFile": "./webpack/webpack.test.js"

--- a/scripts/post-checkout
+++ b/scripts/post-checkout
@@ -2,41 +2,4 @@
 
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
 
-# Import utils
-source ${SCRIPT_PATH}/utils/message
-
-# uncomment for debugging
-# set -x
-
-# storing some numbers
-NPM_VERSION="$(npm -v)"
-NPM_VERSION_MINOR="${NPM_VERSION%.*}"
-NPM_VERSION_MAJOR="${NPM_VERSION_MINOR%.*}"
-NPM_PACKAGE_ENGINE_DEPENDENCY="$(node -p -e "require('./package.json').engines.npm")"
-NPM_PACKAGE_ENGINE_DEPENDENCY_MINOR="${NPM_PACKAGE_ENGINE_DEPENDENCY%.*}"
-NPM_LEGACY_DEPENDENCY="3.9.x"
-
-NODE_VERSION="$(node -v | sed s/v//)"
-NODE_VERSION_MINOR="${NODE_VERSION%.*}"
-NODE_PACKAGE_DEV_DEPENDENCY="$(node -p -e "require('./package.json').devDependencies.node")"
-NODE_PACKAGE_ENGINE_DEPENDENCY="$(node -p -e "require('./package.json').engines.node")"
-NODE_PACKAGE_ENGINE_DEPENDENCY_MINOR="${NODE_PACKAGE_ENGINE_DEPENDENCY%.*}"
-NODE_LEGACY_DEPENDENCY="4.4.x"
-
-
-# checking versions
-if [ "$NODE_PACKAGE_DEV_DEPENDENCY" != "undefined" ] &&
- [ "$NPM_VERSION_MAJOR" -lt "5" ]; then
-  warning "This branch uses node as a dependency, but you are running npm ${NPM_VERSION} which doesnt support it. Please upgrade to npm version 5 or higher."
-  exit 0
-fi
-
-if [ "$NODE_PACKAGE_ENGINE_DEPENDENCY" == "$NODE_LEGACY_DEPENDENCY" ] && [ "$NODE_PACKAGE_ENGINE_DEPENDENCY_MINOR" != "$NODE_VERSION_MINOR" ]; then
-  warning "This branch requires node version v${NODE_PACKAGE_ENGINE_DEPENDENCY}, but you're running ${NODE_VERSION}."
-  exit 0
-fi
-
-if [ "$NPM_PACKAGE_ENGINE_DEPENDENCY" == "$NPM_LEGACY_DEPENDENCY" ] && [ "$NPM_PACKAGE_ENGINE_DEPENDENCY_MINOR" != "$NPM_VERSION_MINOR" ]; then
-  warning "This branch requires node version v${NPM_PACKAGE_ENGINE_DEPENDENCY}, but you're running ${NPM_VERSION}."
-  exit 0
-fi
+${SCRIPT_PATH}/validate-engine-versions

--- a/scripts/post-checkout
+++ b/scripts/post-checkout
@@ -5,26 +5,38 @@ SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
 # Import utils
 source ${SCRIPT_PATH}/utils/message
 
-# strong some numbers
+# uncomment for debugging
+# set -x
+
+# storing some numbers
 NPM_VERSION="$(npm -v)"
-MAJOR_NPM_VERSION="$(npm -v | cut -d. -f1)"
+NPM_VERSION_MINOR="${NPM_VERSION%.*}"
+NPM_VERSION_MAJOR="${NPM_VERSION_MINOR%.*}"
+NPM_PACKAGE_ENGINE_DEPENDENCY="$(node -p -e "require('./package.json').engines.npm")"
+NPM_PACKAGE_ENGINE_DEPENDENCY_MINOR="${NPM_PACKAGE_ENGINE_DEPENDENCY%.*}"
+NPM_LEGACY_DEPENDENCY="3.9.x"
 
-NODE_VERSION="$(node -v)"
+NODE_VERSION="$(node -v | sed s/v//)"
+NODE_VERSION_MINOR="${NODE_VERSION%.*}"
+NODE_PACKAGE_DEV_DEPENDENCY="$(node -p -e "require('./package.json').devDependencies.node")"
+NODE_PACKAGE_ENGINE_DEPENDENCY="$(node -p -e "require('./package.json').engines.node")"
+NODE_PACKAGE_ENGINE_DEPENDENCY_MINOR="${NODE_PACKAGE_ENGINE_DEPENDENCY%.*}"
+NODE_LEGACY_DEPENDENCY="4.4.x"
 
-PACKAGE_DEV_DEPENDENCY="$(node -p -e "require('./package.json').devDependencies.node")"
-PACKAGE_ENGINE_DEPENDENCY="$(node -p -e "require('./package.json').engines.node")"
 
-VALIDATION_EXIT_CODE=$(${SCRIPT_PATH}/validate-engine-versions > /dev/null; echo $?)
-
-# checking some stuff
-if [ "$PACKAGE_DEV_DEPENDENCY" != "undefined" ] && [ "$MAJOR_NPM_VERSION" -lt 5 ]; then
-  warning "This branch uses node as a dependency, \
-    but you are running npm ${NPM_VERSION} which doesnt support that."
-  exit 0;
-elif [ $VALIDATION_EXIT_CODE -ne 0 ]; then
-  warning "This branch requires node version v${PACKAGE_ENGINE_DEPENDENCY}, \
-    but you're running ${NODE_VERSION}."
+# checking versions
+if [ "$NODE_PACKAGE_DEV_DEPENDENCY" != "undefined" ] &&
+ [ "$NPM_VERSION_MAJOR" -lt "5" ]; then
+  warning "This branch uses node as a dependency, but you are running npm ${NPM_VERSION} which doesnt support it. Please upgrade to npm version 5 or higher."
   exit 0
 fi
 
-info "Looks like your node version is fine."
+if [ "$NODE_PACKAGE_ENGINE_DEPENDENCY" == "$NODE_LEGACY_DEPENDENCY" ] && [ "$NODE_PACKAGE_ENGINE_DEPENDENCY_MINOR" != "$NODE_VERSION_MINOR" ]; then
+  warning "This branch requires node version v${NODE_PACKAGE_ENGINE_DEPENDENCY}, but you're running ${NODE_VERSION}."
+  exit 0
+fi
+
+if [ "$NPM_PACKAGE_ENGINE_DEPENDENCY" == "$NPM_LEGACY_DEPENDENCY" ] && [ "$NPM_PACKAGE_ENGINE_DEPENDENCY_MINOR" != "$NPM_VERSION_MINOR" ]; then
+  warning "This branch requires node version v${NPM_PACKAGE_ENGINE_DEPENDENCY}, but you're running ${NPM_VERSION}."
+  exit 0
+fi

--- a/scripts/validate-engine-versions
+++ b/scripts/validate-engine-versions
@@ -1,30 +1,42 @@
 #!/usr/bin/env bash
-#
-# This script will check the following versions provided in package.json,
-# based on current versions of node and npm
-# {
-#   ...
-#   "engines": {
-#     "node": "4.4.x",
-#     "npm": "3.9.x"
-#   }
-#   ...
-# }
-#
-PACKAGE_NODE_VERSION=$(node -p -e "require('./package.json').engines.node")
-NODE_VERSION=$(node -v)
-if [[ "v${PACKAGE_NODE_VERSION%.*}" == "${NODE_VERSION%.*}" ]]; then
-  echo "Node version is valid ($NODE_VERSION)"
-else
-  echo "ERROR: Node version ${NODE_VERSION%.*}.x does not match required version v${PACKAGE_NODE_VERSION%.*}.x"
-  exit 1;
+
+SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
+
+# Import utils
+source ${SCRIPT_PATH}/utils/message
+
+# uncomment for debugging
+# set -x
+
+# storing some numbers
+NPM_VERSION="$(npm -v)"
+NPM_VERSION_MINOR="${NPM_VERSION%.*}"
+NPM_VERSION_MAJOR="${NPM_VERSION_MINOR%.*}"
+NPM_PACKAGE_ENGINE_DEPENDENCY="$(node -p -e "require('./package.json').engines.npm")"
+NPM_PACKAGE_ENGINE_DEPENDENCY_MINOR="${NPM_PACKAGE_ENGINE_DEPENDENCY%.*}"
+NPM_LEGACY_DEPENDENCY="3.9.x"
+
+NODE_VERSION="$(node -v | sed s/v//)"
+NODE_VERSION_MINOR="${NODE_VERSION%.*}"
+NODE_PACKAGE_DEV_DEPENDENCY="$(node -p -e "require('./package.json').devDependencies.node")"
+NODE_PACKAGE_ENGINE_DEPENDENCY="$(node -p -e "require('./package.json').engines.node")"
+NODE_PACKAGE_ENGINE_DEPENDENCY_MINOR="${NODE_PACKAGE_ENGINE_DEPENDENCY%.*}"
+NODE_LEGACY_DEPENDENCY="4.4.x"
+
+
+# checking versions
+if [ "$NODE_PACKAGE_DEV_DEPENDENCY" != "undefined" ] &&
+ [ "$NPM_VERSION_MAJOR" -lt "5" ]; then
+  warning "This branch uses node as a dependency, but you are running npm ${NPM_VERSION} which doesnt support it. Please upgrade to npm version 5 or higher."
+  exit 0
 fi
 
-PACKAGE_NPM_VERSION=$(node -p -e "require('./package.json').engines.npm")
-NPM_VERSION=$(npm -v)
-if [[ "${PACKAGE_NPM_VERSION%.*}" == "${NPM_VERSION%.*}" ]]; then
-  echo "NPM version is valid (v$NPM_VERSION)"
-else
-  echo "ERROR: NPM version v${NPM_VERSION%.*}.x does not match required version v${PACKAGE_NPM_VERSION%.*}.x"
-  exit 1;
+if [ "$NODE_PACKAGE_ENGINE_DEPENDENCY" == "$NODE_LEGACY_DEPENDENCY" ] && [ "$NODE_PACKAGE_ENGINE_DEPENDENCY_MINOR" != "$NODE_VERSION_MINOR" ]; then
+  warning "This branch requires node version v${NODE_PACKAGE_ENGINE_DEPENDENCY}, but you're running ${NODE_VERSION}."
+  exit 0
+fi
+
+if [ "$NPM_PACKAGE_ENGINE_DEPENDENCY" == "$NPM_LEGACY_DEPENDENCY" ] && [ "$NPM_PACKAGE_ENGINE_DEPENDENCY_MINOR" != "$NPM_VERSION_MINOR" ]; then
+  warning "This branch requires node version v${NPM_PACKAGE_ENGINE_DEPENDENCY}, but you're running ${NPM_VERSION}."
+  exit 0
 fi

--- a/scripts/validate-engine-versions
+++ b/scripts/validate-engine-versions
@@ -12,6 +12,7 @@ source ${SCRIPT_PATH}/utils/message
 NPM_VERSION="$(npm -v)"
 NPM_VERSION_MINOR="${NPM_VERSION%.*}"
 NPM_VERSION_MAJOR="${NPM_VERSION_MINOR%.*}"
+NPM_PACKAGE_DEV_DEPENDENCY="$(node -p -e "require('./package.json').devDependencies.npm")"
 NPM_PACKAGE_ENGINE_DEPENDENCY="$(node -p -e "require('./package.json').engines.npm")"
 NPM_PACKAGE_ENGINE_DEPENDENCY_MINOR="${NPM_PACKAGE_ENGINE_DEPENDENCY%.*}"
 NPM_LEGACY_DEPENDENCY="3.9.x"
@@ -24,19 +25,25 @@ NODE_PACKAGE_ENGINE_DEPENDENCY_MINOR="${NODE_PACKAGE_ENGINE_DEPENDENCY%.*}"
 NODE_LEGACY_DEPENDENCY="4.4.x"
 
 
-# checking versions
+# branch has node and npm as devDependency
 if [ "$NODE_PACKAGE_DEV_DEPENDENCY" != "undefined" ] &&
- [ "$NPM_VERSION_MAJOR" -lt "5" ]; then
-  warning "This branch uses node as a dependency, but you are running npm ${NPM_VERSION} which doesnt support it. Please upgrade to npm version 5 or higher."
+   [ "$NPM_PACKAGE_DEV_DEPENDENCY" != "undefined" ]
+then
   exit 0
 fi
 
-if [ "$NODE_PACKAGE_ENGINE_DEPENDENCY" == "$NODE_LEGACY_DEPENDENCY" ] && [ "$NODE_PACKAGE_ENGINE_DEPENDENCY_MINOR" != "$NODE_VERSION_MINOR" ]; then
+# legacy branch - incorrect node version
+if [ "$NODE_PACKAGE_ENGINE_DEPENDENCY" == "$NODE_LEGACY_DEPENDENCY" ] &&
+   [ "$NODE_PACKAGE_ENGINE_DEPENDENCY_MINOR" != "$NODE_VERSION_MINOR" ]
+then
   warning "This branch requires node version v${NODE_PACKAGE_ENGINE_DEPENDENCY}, but you're running ${NODE_VERSION}."
-  exit 0
+  exit 1
 fi
 
-if [ "$NPM_PACKAGE_ENGINE_DEPENDENCY" == "$NPM_LEGACY_DEPENDENCY" ] && [ "$NPM_PACKAGE_ENGINE_DEPENDENCY_MINOR" != "$NPM_VERSION_MINOR" ]; then
+# legacy branch - incorrect npm version
+if [ "$NPM_PACKAGE_ENGINE_DEPENDENCY" == "$NPM_LEGACY_DEPENDENCY" ] &&
+   [ "$NPM_PACKAGE_ENGINE_DEPENDENCY_MINOR" != "$NPM_VERSION_MINOR" ]
+then
   warning "This branch requires node version v${NPM_PACKAGE_ENGINE_DEPENDENCY}, but you're running ${NPM_VERSION}."
-  exit 0
+  exit 1
 fi


### PR DESCRIPTION
the current version of this check complains about node version 9.x being incorrect (it needs 8.9.4). this fixes this issue and also moves the checks into our validate-engines script.

to test this, please checkout this branch with latest node version (should NOT complain), then downgrade node to v4 and try `npm start` (should complain)