### PR TITLE
DCOS_OSS-2243: fix(taskdetails): remove misleading endpoints row from config table

### DIFF
--- a/plugins/services/src/js/pages/task-details/TaskDetailsTab.js
+++ b/plugins/services/src/js/pages/task-details/TaskDetailsTab.js
@@ -17,7 +17,7 @@ import Units from "#SRC/js/utils/Units";
 
 import MarathonTaskDetailsList from "../../components/MarathonTaskDetailsList";
 import TaskDirectoryStore from "../../stores/TaskDirectoryStore";
-import TaskEndpointsList from "../../components/TaskEndpointsList";
+// import TaskEndpointsList from "../../components/TaskEndpointsList";
 import TaskUtil from "../../utils/TaskUtil";
 
 class TaskDetailsTab extends React.Component {
@@ -132,14 +132,15 @@ class TaskDetailsTab extends React.Component {
         {serviceRow}
         {nodeRow}
         {sandBoxRow}
-        <ConfigurationMapRow>
+        {/* Todo: replace this with IP Addresses: https://jira.mesosphere.com/browse/DCOS_OSS-1554
+         <ConfigurationMapRow>
           <ConfigurationMapLabel>
             Endpoints
           </ConfigurationMapLabel>
           <ConfigurationMapValue>
             <TaskEndpointsList task={mesosTask} node={node} />
           </ConfigurationMapValue>
-        </ConfigurationMapRow>
+        </ConfigurationMapRow> */}
         {resourceRows}
         <ConfigurationMapRow>
           <ConfigurationMapLabel>


### PR DESCRIPTION
This removes the endpoints Row from the Task Detail Table because it was misleading (Discussion over there: https://jira.mesosphere.com/browse/DCOS_OSS-1554 )

To test this create a service or pod, go to Services > <SERVICENAME> > <TASK> and check that Endpoints is not listed anymore.

A follow-up ticket will implement a new "IP Addresses" row which is what this should have been in the first place: https://jira.mesosphere.com/browse/DCOS_OSS-2244