### PR TITLE
[Backport] - fix(PodStorageConfigSection): fix variable reference

### DIFF
--- a/plugins/services/src/js/service-configuration/PodStorageConfigSection.js
+++ b/plugins/services/src/js/service-configuration/PodStorageConfigSection.js
@@ -101,7 +101,7 @@ class PodStorageConfigSection extends React.Component {
 
       // Otherwise create one volume entry for each mount
       return containerMounts.reduce((volumesMemo, mountInfo) => {
-        return volumesMemo.concat(Object.assign(volumeInfo, mountInfo));
+        return volumesMemo.concat(Object.assign({}, volumeInfo, mountInfo));
       }, memo);
     }, []);
 


### PR DESCRIPTION
This commit fixes a variable reference which lead to have multiple lines in the volume mount table
with the same values.

Closes DCOS-19219 DCOS-21412
