### PR TITLE
DCOS-21440: keep VIP label

### DIFF
--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -23,6 +23,7 @@ import Networking from "#SRC/js/constants/Networking";
 import ValidatorUtil from "#SRC/js/utils/ValidatorUtil";
 import MetadataStore from "#SRC/js/stores/MetadataStore";
 import VirtualNetworksStore from "#SRC/js/stores/VirtualNetworksStore";
+import VipLabelUtil from "../../utils/VipLabelUtil";
 
 import {
   FormReducer as networks
@@ -273,7 +274,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
     const tooltipContent =
       "This port will be used to load balance this service address internally";
     if (isObject(loadBalancedError)) {
-      vipPortError = loadBalancedError[`VIP_${index}`];
+      vipPortError = loadBalancedError[VipLabelUtil.defaultVip(index)];
       loadBalancedError = null;
     }
 

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -33,6 +33,7 @@ import {
 } from "../../reducers/serviceForm/FormReducers/Networks";
 import ContainerConstants from "../../constants/ContainerConstants";
 import ServiceConfigUtil from "../../utils/ServiceConfigUtil";
+import VipLabelUtil from "../../utils/VipLabelUtil";
 
 const { BRIDGE, HOST, CONTAINER } = Networking.type;
 const { MESOS } = ContainerConstants.type;
@@ -151,7 +152,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
       );
 
     if (isObject(loadBalancedError)) {
-      vipPortError = loadBalancedError[`VIP_${index}`];
+      vipPortError = loadBalancedError[VipLabelUtil.defaultVip(index)];
       loadBalancedError = null;
     }
 
@@ -225,7 +226,7 @@ class NetworkingFormSection extends mixin(StoreMixin) {
     const tooltipContent =
       "This port will be used to load balance this service address internally";
     if (isObject(loadBalancedError)) {
-      vipPortError = loadBalancedError[`VIP_${index}`];
+      vipPortError = loadBalancedError[VipLabelUtil.defaultVip(index)];
       loadBalancedError = null;
     }
 

--- a/plugins/services/src/js/reducers/__tests__/JSONMultiContainer-test.js
+++ b/plugins/services/src/js/reducers/__tests__/JSONMultiContainer-test.js
@@ -37,6 +37,14 @@ describe("JSONMultiContainer", function() {
                 hostPort: 0,
                 protocol: ["tcp"],
                 labels: {
+                  vipDCOS: "1.2.3.4:80" // Custom VIP
+                }
+              },
+              {
+                name: "nginx",
+                hostPort: 0,
+                protocol: ["tcp"],
+                labels: {
                   VIP_0: "1.2.3.4:80" // Custom VIP
                 }
               }

--- a/plugins/services/src/js/reducers/serviceForm/Container.js
+++ b/plugins/services/src/js/reducers/serviceForm/Container.js
@@ -151,7 +151,7 @@ const containerJSONReducer = combineReducers({
 
     // Convert portDefinitions to portMappings
     return this.portDefinitions.map((portDefinition, index) => {
-      const vipLabel = `VIP_${index}`;
+      const vipLabel = portDefinition.vipLabel || `VIP_${index}`;
       const vipPort = Number(portDefinition.vipPort) || null;
       const containerPort = Number(portDefinition.containerPort) || 0;
       const servicePort = parseInt(portDefinition.servicePort, 10) || null;

--- a/plugins/services/src/js/reducers/serviceForm/Container.js
+++ b/plugins/services/src/js/reducers/serviceForm/Container.js
@@ -151,7 +151,8 @@ const containerJSONReducer = combineReducers({
 
     // Convert portDefinitions to portMappings
     return this.portDefinitions.map((portDefinition, index) => {
-      const vipLabel = portDefinition.vipLabel || `VIP_${index}`;
+      const vipLabel =
+        portDefinition.vipLabel || VipLabelUtil.defaultVip(index);
       const vipPort = Number(portDefinition.vipPort) || null;
       const containerPort = Number(portDefinition.containerPort) || 0;
       const servicePort = parseInt(portDefinition.servicePort, 10) || null;

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
@@ -53,7 +53,7 @@ function mapEndpoints(endpoints = [], networkType, appState) {
       labels = VipLabelUtil.generateVipLabel(
         appState.id,
         endpoint,
-        vipLabel || `VIP_${index}`,
+        vipLabel || VipLabelUtil.defaultVip(index),
         vipPort || containerPort || hostPort
       );
 

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Endpoints.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Endpoints.js
@@ -14,7 +14,8 @@ const defaultEndpointsFieldValues = {
   },
   servicePort: null,
   vip: null,
-  vipPort: null
+  vipPort: null,
+  vipLabel: null
 };
 
 module.exports = {
@@ -55,7 +56,8 @@ module.exports = {
       "loadBalanced",
       "labels",
       "vip",
-      "vipPort"
+      "vipPort",
+      "vipLabel"
     ];
     const numericalFiledNames = ["containerPort", "hostPort"];
 

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/PortDefinitionsReducer.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/PortDefinitionsReducer.js
@@ -8,7 +8,8 @@ const FIELDS = [
   "name",
   "servicePort",
   "vip",
-  "vipPort"
+  "vipPort",
+  "vipLabel"
 ];
 
 function transformPortDefinition(definition) {
@@ -54,7 +55,8 @@ function PortDefinitionsReducer(state = [], action) {
             },
             servicePort: null,
             vip: null,
-            vipPort: null
+            vipPort: null,
+            vipLabel: null
           };
           const defaults = { protocol: { tcp: true } };
 

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/PortMappingsReducer.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/PortMappingsReducer.js
@@ -11,7 +11,8 @@ const FIELDS = [
   "name",
   "servicePort",
   "vip",
-  "vipPort"
+  "vipPort",
+  "vipLabel"
 ];
 
 /**
@@ -46,7 +47,8 @@ function PortMappingsReducer(state = [], action) {
               },
               servicePort: null,
               vip: null,
-              vipPort: null
+              vipPort: null,
+              vipLabel: null
             }
           );
           break;

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
@@ -1086,6 +1086,11 @@ describe("Containers", function() {
             SET
           ),
           new Transaction(
+            ["containers", 0, "endpoints", 0, "vipLabel"],
+            "VIP_0",
+            SET
+          ),
+          new Transaction(
             ["containers", 0, "endpoints", 0, "vip"],
             "/:900",
             SET

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Endpoints-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Endpoints-test.js
@@ -24,6 +24,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipLabel: null,
               vipPort: null,
               protocol: {
                 tcp: true,
@@ -58,6 +59,7 @@ describe("Endpoints", function() {
               name: "foo",
               loadBalanced: false,
               vip: null,
+              vipLabel: null,
               vipPort: null,
               protocol: {
                 tcp: true,
@@ -103,6 +105,7 @@ describe("Endpoints", function() {
               name: "foo",
               loadBalanced: false,
               vip: null,
+              vipLabel: null,
               vipPort: null,
               protocol: {
                 tcp: true,
@@ -142,6 +145,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipLabel: null,
               vipPort: null,
               protocol: {
                 tcp: true,
@@ -181,6 +185,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipLabel: null,
               vipPort: null,
               protocol: {
                 tcp: true,
@@ -216,6 +221,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipLabel: null,
               vipPort: null,
               protocol: {
                 tcp: true,
@@ -252,6 +258,7 @@ describe("Endpoints", function() {
               name: "foo",
               loadBalanced: false,
               vip: null,
+              vipLabel: null,
               vipPort: null,
               protocol: {
                 tcp: true,
@@ -299,6 +306,7 @@ describe("Endpoints", function() {
               name: "foo",
               loadBalanced: false,
               vip: null,
+              vipLabel: null,
               vipPort: null,
               protocol: {
                 tcp: true,
@@ -338,6 +346,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipLabel: null,
               vipPort: null,
               protocol: {
                 tcp: true,
@@ -377,6 +386,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipLabel: null,
               vipPort: null,
               protocol: {
                 foo: true,
@@ -417,6 +427,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipLabel: null,
               vipPort: null,
               protocol: {
                 tcp: true,
@@ -464,6 +475,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: true,
               vip: null,
+              vipLabel: null,
               vipPort: null,
               protocol: {
                 tcp: true,
@@ -503,6 +515,10 @@ describe("Endpoints", function() {
         );
 
         batch = batch.add(
+          new Transaction(["containers", 0, "endpoints", 0, "vipLabel"], "vip0")
+        );
+
+        batch = batch.add(
           new Transaction(
             ["containers", 0, "endpoints", 0, "vip"],
             "1.3.3.7:8080"
@@ -518,6 +534,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: true,
               vip: "1.3.3.7:8080",
+              vipLabel: "vip0",
               vipPort: null,
               protocol: {
                 tcp: true,
@@ -567,6 +584,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: true,
               vip: null,
+              vipLabel: null,
               vipPort: null,
               protocol: {
                 tcp: true,
@@ -606,6 +624,10 @@ describe("Endpoints", function() {
         );
 
         batch = batch.add(
+          new Transaction(["containers", 0, "endpoints", 0, "vipLabel"], "vip1")
+        );
+
+        batch = batch.add(
           new Transaction(
             ["containers", 0, "endpoints", 0, "vip"],
             "1.3.3.7:8080"
@@ -624,6 +646,7 @@ describe("Endpoints", function() {
               loadBalanced: true,
               containerPort: 8080,
               vip: "1.3.3.7:8080",
+              vipLabel: "vip1",
               vipPort: null,
               protocol: {
                 tcp: true,

--- a/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
+++ b/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
@@ -61,7 +61,8 @@ module.exports = {
     // Create JSON port definitions from state
     return this.portDefinitions.map((portDefinition, index) => {
       const { name } = portDefinition;
-      const vipLabel = portDefinition.vipLabel || `VIP_${index}`;
+      const vipLabel =
+        portDefinition.vipLabel || VipLabelUtil.defaultVip(index);
       const hostPort = portDefinition.hostPort
         ? Number(portDefinition.hostPort)
         : 0;

--- a/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
+++ b/plugins/services/src/js/reducers/serviceForm/PortDefinitions.js
@@ -1,7 +1,6 @@
 import { ADD_ITEM, SET } from "#SRC/js/constants/TransactionTypes";
 import Transaction from "#SRC/js/structs/Transaction";
 import Networking from "#SRC/js/constants/Networking";
-import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
 import PortDefinitionsReducer from "./JSONReducers/PortDefinitionsReducer";
 import { PROTOCOLS } from "../../constants/PortDefinitionConstants";
 import VipLabelUtil from "../../utils/VipLabelUtil";
@@ -62,7 +61,7 @@ module.exports = {
     // Create JSON port definitions from state
     return this.portDefinitions.map((portDefinition, index) => {
       const { name } = portDefinition;
-      const vipLabel = `VIP_${index}`;
+      const vipLabel = portDefinition.vipLabel || `VIP_${index}`;
       const hostPort = portDefinition.hostPort
         ? Number(portDefinition.hostPort)
         : 0;
@@ -134,19 +133,26 @@ module.exports = {
         });
       }
 
-      const vip = findNestedPropertyInObject(item, `labels.VIP_${index}`);
+      const vip = VipLabelUtil.findVip(item.labels);
+
       if (vip != null) {
+        const [vipLabel, vipValue] = vip;
+
         memo.push(
           new Transaction(["portDefinitions", index, "loadBalanced"], true, SET)
         );
 
-        if (!vip.startsWith(`${state.id}:`)) {
+        memo.push(
+          new Transaction(["portDefinitions", index, "vipLabel"], vipLabel, SET)
+        );
+
+        if (!vipValue.startsWith(`${state.id}:`)) {
           memo.push(
-            new Transaction(["portDefinitions", index, "vip"], vip, SET)
+            new Transaction(["portDefinitions", index, "vip"], vipValue, SET)
           );
         }
 
-        const vipPortMatch = vip.match(/.+:(\d+)/);
+        const vipPortMatch = vipValue.match(/.+:(\d+)/);
         if (vipPortMatch) {
           memo.push(
             new Transaction(

--- a/plugins/services/src/js/reducers/serviceForm/PortMappings.js
+++ b/plugins/services/src/js/reducers/serviceForm/PortMappings.js
@@ -2,6 +2,7 @@ import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
 import { ADD_ITEM, SET } from "#SRC/js/constants/TransactionTypes";
 import Transaction from "#SRC/js/structs/Transaction";
 import { PROTOCOLS } from "../../constants/PortDefinitionConstants";
+import VipLabelUtil from "../../utils/VipLabelUtil";
 
 module.exports = {
   /**
@@ -119,19 +120,26 @@ module.exports = {
         });
       }
 
-      const vip = findNestedPropertyInObject(item, `labels.VIP_${index}`);
+      const vip = VipLabelUtil.findVip(item.labels);
+
       if (vip != null) {
+        const [vipLabel, vipValue] = vip;
+
         memo.push(
           new Transaction(["portDefinitions", index, "loadBalanced"], true, SET)
         );
 
-        if (!vip.startsWith(`${state.id}:`)) {
+        memo.push(
+          new Transaction(["portDefinitions", index, "vipLabel"], vipLabel, SET)
+        );
+
+        if (!vipValue.startsWith(`${state.id}:`)) {
           memo.push(
-            new Transaction(["portDefinitions", index, "vip"], vip, SET)
+            new Transaction(["portDefinitions", index, "vip"], vipValue, SET)
           );
         }
 
-        const vipPortMatch = vip.match(/.+:(\d+)/);
+        const vipPortMatch = vipValue.match(/.+:(\d+)/);
         if (vipPortMatch) {
           memo.push(
             new Transaction(

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/PortMappings-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/PortMappings-test.js
@@ -105,13 +105,14 @@ describe("#JSONParser", function() {
         new Transaction(["portDefinitions"], null, ADD_ITEM),
         new Transaction(["portDefinitions", 0, "portMapping"], false),
         new Transaction(["portDefinitions", 0, "loadBalanced"], true),
+        new Transaction(["portDefinitions", 0, "vipLabel"], "VIP_0"),
         new Transaction(["portDefinitions", 0, "vip"], "/:0"),
         new Transaction(["portDefinitions", 0, "vipPort"], "0"),
         new Transaction(["portDefinitions", 0, "labels"], { VIP_0: "/:0" })
       ]);
     });
 
-    it("doesn't add loadBalanced for wrong label", function() {
+    it("adds loadBalanced for any vip-label", function() {
       expect(
         PortMappings.JSONParser({
           type: DOCKER,
@@ -120,7 +121,7 @@ describe("#JSONParser", function() {
             portMappings: [
               {
                 labels: {
-                  VIP_1: "/:0"
+                  vip1: "/:0"
                 }
               }
             ]
@@ -129,7 +130,11 @@ describe("#JSONParser", function() {
       ).toEqual([
         new Transaction(["portDefinitions"], null, ADD_ITEM),
         new Transaction(["portDefinitions", 0, "portMapping"], false),
-        new Transaction(["portDefinitions", 0, "labels"], { VIP_1: "/:0" })
+        new Transaction(["portDefinitions", 0, "loadBalanced"], true),
+        new Transaction(["portDefinitions", 0, "vipLabel"], "vip1"),
+        new Transaction(["portDefinitions", 0, "vip"], "/:0"),
+        new Transaction(["portDefinitions", 0, "vipPort"], "0"),
+        new Transaction(["portDefinitions", 0, "labels"], { vip1: "/:0" })
       ]);
     });
 
@@ -202,6 +207,7 @@ describe("#JSONParser", function() {
         new Transaction(["portDefinitions", 1, "protocol", "udp"], false),
         new Transaction(["portDefinitions", 1, "protocol", "tcp"], true),
         new Transaction(["portDefinitions", 1, "loadBalanced"], true),
+        new Transaction(["portDefinitions", 1, "vipLabel"], "VIP_1"),
         new Transaction(["portDefinitions", 1, "vip"], "/:0"),
         new Transaction(["portDefinitions", 1, "vipPort"], "0"),
         new Transaction(["portDefinitions", 1, "labels"], { VIP_1: "/:0" })

--- a/plugins/services/src/js/utils/VipLabelUtil.js
+++ b/plugins/services/src/js/utils/VipLabelUtil.js
@@ -21,6 +21,10 @@ const VipLabelUtil = {
     }
 
     return labels;
+  },
+
+  findVip(labels = {}) {
+    return Object.entries(labels).find(([key, _]) => key.match(/^(vip|VIP)/));
   }
 };
 

--- a/plugins/services/src/js/utils/VipLabelUtil.js
+++ b/plugins/services/src/js/utils/VipLabelUtil.js
@@ -25,6 +25,10 @@ const VipLabelUtil = {
 
   findVip(labels = {}) {
     return Object.entries(labels).find(([key, _]) => key.match(/^(vip|VIP)/));
+  },
+
+  defaultVip(index) {
+    return `VIP_${index}`;
   }
 };
 

--- a/plugins/services/src/js/utils/__tests__/VipLabelUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/VipLabelUtil-test.js
@@ -114,4 +114,10 @@ describe("VipLabelUtil", function() {
       ).toEqual(undefined);
     });
   });
+
+  describe("#defaultVip", function() {
+    it("constructs the value", function() {
+      expect(VipLabelUtil.defaultVip(1)).toEqual("VIP_1");
+    });
+  });
 });

--- a/plugins/services/src/js/utils/__tests__/VipLabelUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/VipLabelUtil-test.js
@@ -82,4 +82,36 @@ describe("VipLabelUtil", function() {
       });
     });
   });
+
+  describe("#findVip", function() {
+    it("returns the first occurance with VIP prefix", function() {
+      expect(
+        VipLabelUtil.findVip({
+          other: "not_vip",
+          VIP1: "vip",
+          VIP2: "vip"
+        })
+      ).toEqual(["VIP1", "vip"]);
+    });
+
+    it("returns the first occurance with vip prefix", function() {
+      expect(
+        VipLabelUtil.findVip({
+          other: "not_vip",
+          vip1: "vip1",
+          vip2: "vip2"
+        })
+      ).toEqual(["vip1", "vip1"]);
+    });
+
+    it("ignores mixed case variants", function() {
+      expect(
+        VipLabelUtil.findVip({
+          Vip: "not_vip",
+          vIP: "vip1",
+          viP: "vip2"
+        })
+      ).toEqual(undefined);
+    });
+  });
 });


### PR DESCRIPTION
This PR fixes the way the UI supports VIPs. 

UI used to be very opinionated about the way VIPs should be. It would require a VIP to be `VIP_<enpoint_index>` but that's not the way backend expects them. Backend allows anything that starts with `vip|VIP` to be a valid VIP label. Because of that we need to keep vip label that we're getting from JSON.

## Testing

Please create an app with a few Service Endpoints and override VIP_* to anything valid:
- vipBla
- VIPblop
- VIP_129312

Please check different network modes along with single and multi container.

NB! `Vip` `vIp` etc are invalid.

Closes DCOS-21440

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
