### PR TITLE
feat(mesos-stream): repeat the stream

### DIFF
--- a/src/js/core/MesosStream.js
+++ b/src/js/core/MesosStream.js
@@ -3,5 +3,6 @@ import { ReplaySubject } from "rxjs/ReplaySubject";
 
 export const MesosStreamType = Symbol("MesosStreamType");
 export default stream({ type: "SUBSCRIBE" }, "/mesos/api/v1?subscribe")
+  .repeat()
   .multicast(() => new ReplaySubject())
   .refCount();


### PR DESCRIPTION
This PR adds `repeat()` operator that will re-connect to the stream in case Mesos closes the connection.

To test this I wrote a simple mock server and pointed MesosStream.js to the `http://localhost:3000`. Server yields messages with the minimum possible payload that RecordIO is able to parse. Without that fix UI would try connecting once. 

NB! In the Networking tab you will see two calls because one of them is OPTIONS

```js
const http = require('http')
const port = 3000

const requestHandler = (request, response) => {
  console.log("Connected")
  response.setHeader("Access-Control-Allow-Origin", "*")
  response.setHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
  response.write("2\n{}")
  setTimeout(function() {
    response.write("2\n{}")
  }, 5000)
  setTimeout(function() {
    response.end("2\n{}")
  }, 10000)
}

const server = http.createServer(requestHandler)

server.listen(port, (err) => {
  if (err) {
    return console.log('something bad happened', err)
  }

  console.log(`server is listening on ${port}`)
})
```

Closes DCOS-21701

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
