### PR TITLE
DCOS-21190: hide service status if it's N/A

### DIFF
--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -359,6 +359,7 @@ class ServicesTable extends React.Component {
     const instancesCount = service.getInstancesCount();
     const runningInstances = service.getRunningInstancesCount();
     const tooltipContent = `${runningInstances} ${StringUtil.pluralize("instance", runningInstances)} running out of ${instancesCount}`;
+    const hasStatusText = serviceStatusText !== ServiceStatus.NA.displayName;
 
     return (
       <div className="flex">
@@ -368,7 +369,8 @@ class ServicesTable extends React.Component {
             showTooltip={true}
             tooltipContent={tooltipContent}
           />
-          <span className="status-bar-text">{serviceStatusText}</span>
+          {hasStatusText &&
+            <span className="status-bar-text">{serviceStatusText}</span>}
         </div>
         <div className="service-status-progressbar-wrapper">
           <ServiceStatusProgressBar service={service} />

--- a/plugins/services/src/js/containers/services/__tests__/ServicesTable-test.js
+++ b/plugins/services/src/js/containers/services/__tests__/ServicesTable-test.js
@@ -5,8 +5,10 @@ jest.mock("../../../components/modals/ServiceActionDisabledModal");
 const React = require("react");
 /* eslint-enable no-unused-vars */
 const ReactDOM = require("react-dom");
+const renderer = require("react-test-renderer");
 const ServicesTable = require("../ServicesTable");
 const Application = require("../../../structs/Application");
+const ServiceStatus = require("../../../constants/ServiceStatus");
 
 let thisContainer, thisInstance;
 
@@ -33,6 +35,54 @@ describe("ServicesTable", function() {
 
   afterEach(function() {
     ReactDOM.unmountComponentAtNode(thisContainer);
+  });
+
+  describe("#renderStatus", function() {
+    const renderStatus = ServicesTable.WrappedComponent.prototype.renderStatus;
+    let mockService;
+    beforeEach(function() {
+      mockService = {
+        getStatus: jest.fn(),
+        getServiceStatus: jest.fn(),
+        getQueue: jest.fn(),
+        getInstancesCount: jest.fn().mockReturnValue(10),
+        getRunningInstancesCount: jest.fn().mockReturnValue(3)
+      };
+    });
+
+    it("renders with running status", function() {
+      mockService.getStatus.mockReturnValue(ServiceStatus.RUNNING.displayName);
+
+      expect(
+        renderer.create(renderStatus(null, mockService)).toJSON()
+      ).toMatchSnapshot();
+    });
+
+    it("renders with stopped status", function() {
+      mockService.getStatus.mockReturnValue(ServiceStatus.STOPPED.displayName);
+
+      expect(
+        renderer.create(renderStatus(null, mockService)).toJSON()
+      ).toMatchSnapshot();
+    });
+
+    it("renders with deploying status", function() {
+      mockService.getStatus.mockReturnValue(
+        ServiceStatus.DEPLOYING.displayName
+      );
+
+      expect(
+        renderer.create(renderStatus(null, mockService)).toJSON()
+      ).toMatchSnapshot();
+    });
+
+    it("renders with not available status", function() {
+      mockService.getStatus.mockReturnValue(ServiceStatus.NA.displayName);
+
+      expect(
+        renderer.create(renderStatus(null, mockService)).toJSON()
+      ).toMatchSnapshot();
+    });
   });
 
   describe("#renderStats", function() {

--- a/plugins/services/src/js/containers/services/__tests__/__snapshots__/ServicesTable-test.js.snap
+++ b/plugins/services/src/js/containers/services/__tests__/__snapshots__/ServicesTable-test.js.snap
@@ -1,0 +1,200 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ServicesTable #renderStatus renders with deploying status 1`] = `
+<div
+  className="flex"
+>
+  <div
+    className=" service-status-icon-wrapper"
+  >
+    <div
+      className="tooltip-wrapper"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <svg
+        className="icon icon-yellow icon-mini"
+      >
+        <use
+          xlinkHref="#icon-system--yield"
+        />
+      </svg>
+    </div>
+    <span
+      className="status-bar-text"
+    >
+      Deploying
+    </span>
+  </div>
+  <div
+    className="service-status-progressbar-wrapper"
+  >
+    <div
+      className="tooltip-wrapper text-align-center"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="status-bar flex-box status-bar--large staged"
+      >
+        <span
+          className="bar success"
+          style={
+            Object {
+              "width": "30%",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ServicesTable #renderStatus renders with not available status 1`] = `
+<div
+  className="flex"
+>
+  <div
+    className=" service-status-icon-wrapper"
+  >
+    <div
+      className="tooltip-wrapper"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <svg
+        className="icon icon-yellow icon-mini"
+      >
+        <use
+          xlinkHref="#icon-system--yield"
+        />
+      </svg>
+    </div>
+  </div>
+  <div
+    className="service-status-progressbar-wrapper"
+  >
+    <div
+      className="tooltip-wrapper text-align-center"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="status-bar flex-box status-bar--large staged"
+      >
+        <span
+          className="bar success"
+          style={
+            Object {
+              "width": "30%",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ServicesTable #renderStatus renders with running status 1`] = `
+<div
+  className="flex"
+>
+  <div
+    className="running-state service-status-icon-wrapper"
+  >
+    <div
+      className="tooltip-wrapper"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <svg
+        className="icon icon-yellow icon-mini"
+      >
+        <use
+          xlinkHref="#icon-system--yield"
+        />
+      </svg>
+    </div>
+    <span
+      className="status-bar-text"
+    >
+      Running
+    </span>
+  </div>
+  <div
+    className="service-status-progressbar-wrapper"
+  >
+    <div
+      className="tooltip-wrapper text-align-center"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="status-bar flex-box status-bar--large staged"
+      >
+        <span
+          className="bar success"
+          style={
+            Object {
+              "width": "30%",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ServicesTable #renderStatus renders with stopped status 1`] = `
+<div
+  className="flex"
+>
+  <div
+    className=" service-status-icon-wrapper"
+  >
+    <div
+      className="tooltip-wrapper"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <svg
+        className="icon icon-yellow icon-mini"
+      >
+        <use
+          xlinkHref="#icon-system--yield"
+        />
+      </svg>
+    </div>
+    <span
+      className="status-bar-text"
+    >
+      Stopped
+    </span>
+  </div>
+  <div
+    className="service-status-progressbar-wrapper"
+  >
+    <div
+      className="tooltip-wrapper text-align-center"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <div
+        className="status-bar flex-box status-bar--large staged"
+      >
+        <span
+          className="bar success"
+          style={
+            Object {
+              "width": "30%",
+            }
+          }
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
This PR removes the service status if the status is N/A.
<img width="1362" alt="bildschirmfoto 2018-03-19 um 14 29 55" src="https://user-images.githubusercontent.com/1337046/37598264-099723f4-2b82-11e8-89e3-6259904af3a8.png">

For testing I would recommend to remove everything from this functions except for the line I highlighted:

- https://github.com/dcos/dcos-ui/blob/danielmschmidt/DCOS-21190-remove-n-a/plugins/services/src/js/structs/Pod.js#L142
- https://github.com/dcos/dcos-ui/blob/danielmschmidt/DCOS-21190-remove-n-a/plugins/services/src/js/structs/Application.js#L158

**Checklist**
- [X] Did you add a JIRA issue in a commit message or as part of the branch name?
- [X] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
