### PR TITLE
fix(FrameworkConfigurationForm): improve schema errors

### DIFF
--- a/src/js/components/FrameworkConfigurationForm.js
+++ b/src/js/components/FrameworkConfigurationForm.js
@@ -8,6 +8,7 @@ import TabButton from "#SRC/js/components/TabButton";
 import TabButtonList from "#SRC/js/components/TabButtonList";
 import Tabs from "#SRC/js/components/Tabs";
 import Util from "#SRC/js/utils/Util";
+import ErrorsAlert from "#SRC/js/components/ErrorsAlert";
 import JSONEditor from "#SRC/js/components/JSONEditor";
 import FluidGeminiScrollbar from "#SRC/js/components/FluidGeminiScrollbar";
 import PageHeaderNavigationDropdown
@@ -41,7 +42,8 @@ const METHODS_TO_BIND = [
   "handleFormChange",
   "handleJSONChange",
   "handleBadgeClick",
-  "validate"
+  "validate",
+  "jsonSchemaErrorList"
 ];
 class FrameworkConfigurationForm extends Component {
   constructor(props) {
@@ -236,6 +238,16 @@ class FrameworkConfigurationForm extends Component {
       });
   }
 
+  jsonSchemaErrorList(props) {
+    return (
+      <ErrorsAlert
+        errors={props.errors.map(error => {
+          return { message: error.stack };
+        })}
+      />
+    );
+  }
+
   render() {
     const {
       packageDetails,
@@ -327,7 +339,7 @@ class FrameworkConfigurationForm extends Component {
                       fields={{ SchemaField, TitleField }}
                       liveValidate={true}
                       validate={this.validate}
-                      showErrorList={false}
+                      ErrorList={this.jsonSchemaErrorList}
                       transformErrors={this.transformErrors}
                     >
                       <div />

--- a/src/styles/components/framework-configuration/styles.less
+++ b/src/styles/components/framework-configuration/styles.less
@@ -2,6 +2,10 @@
   border: 0;
   margin: 0;
   padding: 0;
+
+  .error-detail {
+    display: none;
+  }
 }
 
 .pre-install-notes.message.message-warning {


### PR DESCRIPTION
This is the lowest hanging fruit on improving schema validation errors for Frameworks. This commit merely improves styling, and not the content of the error.

We have talked with cosmos and data services about this general issue, and in the future someone will work on a solution to improve the contents of this error message. Currently this disappointingly obscure message is delivered by the mozilla json-schema library. Data services would like to use these json-schema clauses like oneOf, allOf - but the challenge is mapping this onto a good UX for the UI and CLI. The improved messages in the future might come directly from a "validate" endpoint in cosmos. This would be ideal because then CLI can also get good errors.

Closes DCOS-19740

**It looks like this now**:

![screen shot 2018-03-19 at 11 05 40 am](https://user-images.githubusercontent.com/1527504/37614398-e9115844-2b67-11e8-98d7-750f6193a11d.png)
![screen recording 2018-03-19 at 11 06 am](https://user-images.githubusercontent.com/1527504/37614436-f841b660-2b67-11e8-8092-b480c02b0de3.gif)

**Testing**:
1. Deploy kafka from catalog
2. Toggle "enabled" for SSL Authentication
3. See the error message appear
4. Toggling "enabled" for transport encryption (further down the form) will remove the error.

^The reason for the error is the [allOf json schema clause](https://spacetelescope.github.io/understanding-json-schema/reference/combining.html#allof).


**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
