### PR TITLE
feat(EditServiceModal): show cosmos services in json-schema form

### DIFF
--- a/plugins/services/src/js/components/HighOrderServiceConfiguration.js
+++ b/plugins/services/src/js/components/HighOrderServiceConfiguration.js
@@ -1,7 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
 
-import Framework from "#PLUGINS/services/src/js/structs/Framework";
 import Pod from "../structs/Pod";
 import PodConfigurationContainer
   from "../containers/pod-configuration/PodConfigurationContainer";
@@ -17,7 +16,10 @@ const HighOrderServiceConfiguration = function(props) {
     return <PodConfigurationContainer pod={service} />;
   }
 
-  if (service instanceof Framework) {
+  if (
+    service.getLabels().DCOS_PACKAGE_DEFINITION != null ||
+    service.getLabels().DCOS_PACKAGE_METADATA != null
+  ) {
     return <FrameworkConfigurationContainer service={service} />;
   }
 

--- a/plugins/services/src/js/components/modals/EditServiceModal.js
+++ b/plugins/services/src/js/components/modals/EditServiceModal.js
@@ -4,7 +4,6 @@ import EditFrameworkConfiguration
   from "#PLUGINS/services/src/js/pages/EditFrameworkConfiguration";
 import CreateServiceModal
   from "#PLUGINS/services/src/js/components/modals/CreateServiceModal";
-import Framework from "#PLUGINS/services/src/js/structs/Framework";
 import DCOSStore from "#SRC/js/stores/DCOSStore";
 
 class EditServiceModal extends Component {
@@ -13,7 +12,10 @@ class EditServiceModal extends Component {
     const serviceID = decodeURIComponent(id);
     const service = DCOSStore.serviceTree.findItemById(serviceID);
 
-    if (service instanceof Framework) {
+    if (
+      service.getLabels().DCOS_PACKAGE_DEFINITION != null ||
+      service.getLabels().DCOS_PACKAGE_METADATA != null
+    ) {
       return <EditFrameworkConfiguration {...this.props} />;
     }
 


### PR DESCRIPTION
Edit all services installed with cosmos in the json-schema form. Previouly we only showed `Framework`s. 

We detect if something is installed from cosmos if had has either of two labels `DCOS_PACKAGE_DEFINITION` and `DCOS_PACKAGE_METADATA`. Frameworks are a subset of all services from cosmos and will also have these labels. This also changes the "Configuration" tab to show the `cosmos/service/describe` config for all services installed from cosmos.

Closes DCOS-21614

**Testing**:
1. install package "Registry" from the catalog.
2. click edit on the running framework (it will show in json-schema form, previously showing in marathon form).
3. go to the configuration tab for registry in service detail (it will be cosmos config, previously was the marathon config).

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
