### PR TITLE
DCOS-21768: Improve Integration Test Script (prepares backport to 1.11)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN set -x \
   /var/lib/dpkg/info/ca-certificates-java.postinst configure \
   # Install npm dependencies
   && cd /dcos-ui \
-  && npm install -g junit-merge@1.3.0 git://github.com/johntron/http-server.git#proxy-secure-flag \
+  && npm install -g git://github.com/johntron/http-server.git#proxy-secure-flag \
   # Install dcos-launch
   && curl 'https://downloads.dcos.io/dcos-launch/bin/linux/dcos-launch' > /usr/local/bin/dcos-launch \
   && chmod +x /usr/local/bin/dcos-launch \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN set -x \
   && rm -rf /var/lib/apt/lists/* \
   # Post-install java certificates
   /var/lib/dpkg/info/ca-certificates-java.postinst configure \
-  # Install npm dependencies
+  # Install npm dependencies (System Tests!)
   && cd /dcos-ui \
   && npm install -g git://github.com/johntron/http-server.git#proxy-secure-flag \
   # Install dcos-launch

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,28 +75,8 @@ pipeline {
 
     stage('Integration Test') {
       steps {
-        // Run a simple webserver serving the dist folder statically
-        // before we run the cypress tests
-        writeFile file: 'integration-tests.sh', text: [
-          'export PATH=`pwd`/node_modules/.bin:$PATH',
-          'http-server -p 4200 dist&',
-          'SERVER_PID=$!',
-          './scripts/ci/run-integration-tests',
-          'RET=$?',
-          'echo "cypress exit status: ${RET}"',
-          'sleep 10',
-          'echo "kill server"',
-          'kill $SERVER_PID',
-          'exit $RET'
-        ].join('\n')
-
         unstash 'dist'
-
-        ansiColor('xterm') {
-          retry(2) {
-            sh '''bash integration-tests.sh'''
-          }
-        }
+        sh "npm run integration-tests"
       }
 
       post {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5,18 +5,18 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-      "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+      "version": "7.0.0-beta.42",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.42.tgz",
+      "integrity": "sha512-L8i94FLSyaLQpRfDo/qqSm8Ndb44zMtXParXo0MebJICG1zoCCL4+GkzUOlB4BNTRSXXQdb3feam/qw7bKPipQ==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0-beta.44"
+        "@babel/highlight": "7.0.0-beta.42"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-      "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+      "version": "7.0.0-beta.42",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.42.tgz",
+      "integrity": "sha512-X3Ur/A/lIbbP8W0pmwgqtDXIxhQmxPaiwY9SKP7kF9wvZfjZRwMvbJE92ozUhF3UDK3DCKaV7oGqmI1rP/zqWA==",
       "dev": true,
       "requires": {
         "chalk": "2.3.2",
@@ -89,7 +89,7 @@
           "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
-            "core-js": "2.5.4",
+            "core-js": "2.5.3",
             "regenerator-runtime": "0.10.5"
           }
         },
@@ -99,7 +99,7 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.4",
+            "core-js": "2.5.3",
             "regenerator-runtime": "0.11.1"
           },
           "dependencies": {
@@ -167,7 +167,7 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.4",
+            "core-js": "2.5.3",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -272,7 +272,7 @@
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "1.6.6",
-        "conventional-commits-parser": "2.1.7"
+        "conventional-commits-parser": "2.1.6"
       }
     },
     "@commitlint/read": {
@@ -284,7 +284,7 @@
         "@commitlint/top-level": "6.1.3",
         "@marionebl/sander": "0.6.1",
         "babel-runtime": "6.23.0",
-        "git-raw-commits": "1.3.6"
+        "git-raw-commits": "1.3.5"
       }
     },
     "@commitlint/resolve-extends": {
@@ -307,7 +307,7 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.4",
+            "core-js": "2.5.3",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -361,7 +361,7 @@
     "@cypress/xvfb": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.1.3.tgz",
-      "integrity": "sha1-YpSn0f63UfEjAiSPIIn8U0xKy38=",
+      "integrity": "sha512-EfRzw+wgI0Zdb4ZlhSvjh3q7I+oenqEYPXvr7oH/2RnzQqGDrPr7IU1Pi2yzGwoXmkNUQbo6qvntnItvQj0F4Q==",
       "dev": true,
       "requires": {
         "lodash.once": "4.1.1"
@@ -419,7 +419,7 @@
     "@dcos/recordio": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@dcos/recordio/-/recordio-0.1.6.tgz",
-      "integrity": "sha1-wrwEXvPUjClifgCKKzJukO1v27Q=",
+      "integrity": "sha512-ej0oXW9T3Hpm25JY3ifuWalXGjASPQ3u6z4GokHwH5J5chziae8BkXtgisDsQFgz5C0CUG1wWjU+xGP9N8lD7w==",
       "requires": {
         "@dcos/copychars": "0.1.0"
       }
@@ -451,25 +451,25 @@
     "@types/blob-util": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@types/blob-util/-/blob-util-1.3.3.tgz",
-      "integrity": "sha1-rbpkSuNPiOHdmlhkxmrWUcqvYoo=",
+      "integrity": "sha512-4ahcL/QDnpjWA2Qs16ZMQif7HjGP2cw3AGjHabybjw7Vm1EKu+cfQN1D78BaZbS1WJNa1opSMF5HNMztx7lR0w==",
       "dev": true
     },
     "@types/bluebird": {
       "version": "3.5.18",
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.18.tgz",
-      "integrity": "sha1-amBDXUZj4pDzcJiYpPdQFPJ5xNY=",
+      "integrity": "sha512-OTPWHmsyW18BhrnG5x8F7PzeZ2nFxmHGb42bZn79P9hl+GI5cMzyPgQTwNjbem0lJhoru/8vtjAFCUOu3+gE2w==",
       "dev": true
     },
     "@types/chai": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.8.tgz",
-      "integrity": "sha1-0nYA6bovNx4IaV2QoP4ECNice+c=",
+      "integrity": "sha512-m812CONwdZn/dMzkIJEY0yAs4apyTkTORgfB2UsMOxgkUbC205AHnm4T8I0I5gPg9MHrFc1dJ35iS75c0CJkjg==",
       "dev": true
     },
     "@types/chai-jquery": {
       "version": "1.1.35",
       "resolved": "https://registry.npmjs.org/@types/chai-jquery/-/chai-jquery-1.1.35.tgz",
-      "integrity": "sha1-mo8KOewIUbJ2io+MdkFYwqJWjQQ=",
+      "integrity": "sha512-7aIt9QMRdxuagLLI48dPz96YJdhu64p6FCa6n4qkGN5DQLHnrIjZpD9bXCvV2G0NwgZ1FAmfP214dxc5zNCfgQ==",
       "dev": true,
       "requires": {
         "@types/chai": "4.0.8",
@@ -479,13 +479,13 @@
     "@types/jquery": {
       "version": "3.2.16",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.2.16.tgz",
-      "integrity": "sha1-BEGcQEoxlDUOfT8zmpDnLIjbMRE=",
+      "integrity": "sha512-q2WC02YxQoX2nY1HRKlYGHpGP1saPmD7GN0pwCDlTz35a4eOtJG+aHRlXyjCuXokUukSrR2aXyBhSW3j+jPc0A==",
       "dev": true
     },
     "@types/lodash": {
       "version": "4.14.87",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.87.tgz",
-      "integrity": "sha1-Vfkhg7BIwsZEAq/kcvgzP04xmms=",
+      "integrity": "sha512-AqRC+aEF4N0LuNHtcjKtvF9OTfqZI0iaBoe3dA6m/W+/YZJBZjBmW/QIZ8fBeXC6cnytSY9tBoFBqZ9uSCeVsw==",
       "dev": true
     },
     "@types/lodash-es": {
@@ -500,19 +500,19 @@
     "@types/minimatch": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz",
-      "integrity": "sha1-toPrYL41gwTvFG9XddtMDjaWpVA=",
+      "integrity": "sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw==",
       "dev": true
     },
     "@types/mocha": {
       "version": "2.2.44",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.44.tgz",
-      "integrity": "sha1-HUp5jlPzUhL9WtTQQFBiAXHNW14=",
+      "integrity": "sha512-k2tWTQU8G4+iSMvqKi0Q9IIsWAp/n8xzdZS4Q4YVIltApoMA00wFBFdlJnmoaK1/z7B0Cy0yPe6GgXteSmdUNw==",
       "dev": true
     },
     "@types/node": {
-      "version": "9.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.2.tgz",
-      "integrity": "sha512-UWkRY9X7RQHp5OhhRIIka58/gVVycL1zHZu0OTsT5LI86ABaMOSbUjAl+b0FeDhQcxclrkyft3kW5QWdMRs8wQ==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.0.tgz",
+      "integrity": "sha512-h3YZbOq2+ZoDFI1z8Zx0Ck/xRWkOESVaLdgLdd/c25mMQ1Y2CAkILu9ny5A15S5f32gGcQdaUIZ2jzYr8D7IFg==",
       "dev": true
     },
     "@types/react": {
@@ -524,13 +524,13 @@
     "@types/sinon": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.0.0.tgz",
-      "integrity": "sha1-mpP/pO4TKehRZieKXtmfgdxMg2I=",
+      "integrity": "sha512-cuK4xM8Lg2wd8cxshcQa8RG4IK/xfyB6TNE6tNVvkrShR4xdrYgsV04q6Dp6v1Lp6biEFdzD8k8zg/ujQeiw+A==",
       "dev": true
     },
     "@types/sinon-chai": {
       "version": "2.7.29",
       "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-2.7.29.tgz",
-      "integrity": "sha1-TbAUl+LdGQiyvTDReC9FY1P19yM=",
+      "integrity": "sha512-EkI/ZvJT4hglWo7Ipf9SX+J+R9htNOMjW8xiOhce7+0csqvgoF5IXqY5Ae1GqRgNtWCuaywR5HjVa1snkTqpOw==",
       "dev": true,
       "requires": {
         "@types/chai": "4.0.8",
@@ -1024,9 +1024,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
-      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
+      "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
       "dev": true
     },
     "autoprefixer": {
@@ -1036,7 +1036,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000823",
+        "caniuse-db": "1.0.30000820",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1208,7 +1208,7 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.4",
+            "core-js": "2.5.3",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -1260,7 +1260,7 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.4",
+            "core-js": "2.5.3",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -1302,7 +1302,7 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.4",
+            "core-js": "2.5.3",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -1391,7 +1391,7 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.4",
+            "core-js": "2.5.3",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -1632,7 +1632,7 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.4",
+            "core-js": "2.5.3",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -1754,7 +1754,7 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.4",
+            "core-js": "2.5.3",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -1908,7 +1908,7 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.4",
+            "core-js": "2.5.3",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -1984,7 +1984,7 @@
       "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
       "requires": {
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.4",
+        "core-js": "2.5.3",
         "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
@@ -1993,7 +1993,7 @@
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "requires": {
-            "core-js": "2.5.4",
+            "core-js": "2.5.3",
             "regenerator-runtime": "0.11.1"
           },
           "dependencies": {
@@ -2095,7 +2095,7 @@
       "requires": {
         "babel-core": "6.24.1",
         "babel-runtime": "6.23.0",
-        "core-js": "2.5.4",
+        "core-js": "2.5.3",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.5",
         "mkdirp": "0.5.1",
@@ -2116,7 +2116,7 @@
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.4",
+        "core-js": "2.5.3",
         "regenerator-runtime": "0.10.5"
       }
     },
@@ -2139,7 +2139,7 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.4",
+            "core-js": "2.5.3",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -2180,7 +2180,7 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.4",
+            "core-js": "2.5.3",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -2216,7 +2216,7 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.4",
+            "core-js": "2.5.3",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -2713,9 +2713,9 @@
       }
     },
     "browserify-aes": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
+      "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
       "dev": true,
       "requires": {
         "buffer-xor": "1.0.3",
@@ -2732,7 +2732,7 @@
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.2.0",
+        "browserify-aes": "1.1.1",
         "browserify-des": "1.0.0",
         "evp_bytestokey": "1.0.3"
       }
@@ -2773,22 +2773,13 @@
         "parse-asn1": "5.1.0"
       }
     },
-    "browserify-zlib": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-      "dev": true,
-      "requires": {
-        "pako": "1.0.6"
-      }
-    },
     "browserslist": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.3.6.tgz",
       "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000823"
+        "caniuse-db": "1.0.30000820"
       }
     },
     "bser": {
@@ -3053,15 +3044,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000823",
+        "caniuse-db": "1.0.30000820",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000823",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000823.tgz",
-      "integrity": "sha1-5o5fjHB4PvQFnS6g3oH1UWUdpvw=",
+      "version": "1.0.30000820",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000820.tgz",
+      "integrity": "sha1-fCDiXOoXaLJhtyT4LjpqJTqqFGg=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -3951,6 +3942,12 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
+    "content-type-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
+      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
+      "dev": true
+    },
     "conventional-changelog-angular": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
@@ -3991,7 +3988,7 @@
           "dev": true,
           "requires": {
             "babel-runtime": "6.23.0",
-            "core-js": "2.5.4",
+            "core-js": "2.5.3",
             "regenerator-runtime": "0.10.5"
           }
         },
@@ -4108,9 +4105,9 @@
       "dev": true
     },
     "conventional-commits-parser": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
-      "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.6.tgz",
+      "integrity": "sha512-3Z77cAKSvEG3D5BSm3IFkOTP2qz8TZX8e8OPU7BGP2ruP7zPs7laHSqiZ7eYup835FKP4yyj+DHjmcvmOyp/0w==",
       "dev": true,
       "requires": {
         "JSONStream": "1.3.2",
@@ -4243,9 +4240,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
-      "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -5099,7 +5096,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.41"
       }
     },
     "d3": {
@@ -5130,17 +5127,6 @@
         "assert-plus": "1.0.0"
       }
     },
-    "data-urls": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
-      "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
-      "dev": true,
-      "requires": {
-        "abab": "1.0.4",
-        "whatwg-mimetype": "2.1.0",
-        "whatwg-url": "6.4.0"
-      }
-    },
     "date-and-time": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.3.0.tgz",
@@ -5150,7 +5136,7 @@
     "date-fns": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-      "integrity": "sha1-EuYJzcuTUScxHQTTMzTilgoqVOY=",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
       "dev": true
     },
     "date-now": {
@@ -5896,7 +5882,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000823",
+        "caniuse-db": "1.0.30000820",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
@@ -6131,7 +6117,7 @@
         "got": "5.7.1",
         "gulp-decompress": "1.2.0",
         "gulp-rename": "1.2.2",
-        "is-url": "1.2.4",
+        "is-url": "1.2.3",
         "object-assign": "4.1.1",
         "read-all-stream": "3.1.0",
         "readable-stream": "2.3.5",
@@ -6453,9 +6439,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.42",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz",
-      "integrity": "sha1-lcM78B0MxAVVauyJn+Yf1NduoPk=",
+      "version": "1.3.40",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.40.tgz",
+      "integrity": "sha1-H71tl779crim+SHcONIkE9L2/d8=",
       "dev": true
     },
     "elegant-spinner": {
@@ -6700,9 +6686,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.42",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
-      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
+      "version": "0.10.41",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.41.tgz",
+      "integrity": "sha1-urPpgtdQ8BEvDLnmq+1yxZ6zPrI=",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -6725,7 +6711,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.41",
         "es6-symbol": "3.1.1"
       }
     },
@@ -6736,7 +6722,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.41",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -6756,7 +6742,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.41",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -6769,7 +6755,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.41"
       }
     },
     "es6-templates": {
@@ -6789,7 +6775,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.41",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -6957,7 +6943,7 @@
           "dev": true,
           "requires": {
             "caniuse-db": "1.0.30000626",
-            "electron-to-chromium": "1.3.42"
+            "electron-to-chromium": "1.3.40"
           }
         },
         "caniuse-db": {
@@ -7171,7 +7157,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.41"
       }
     },
     "event-stream": {
@@ -7421,7 +7407,7 @@
             "content-type": "1.0.4",
             "debug": "2.6.9",
             "depd": "1.1.2",
-            "http-errors": "1.6.3",
+            "http-errors": "1.6.2",
             "iconv-lite": "0.4.19",
             "on-finished": "2.3.0",
             "qs": "6.5.1",
@@ -7475,15 +7461,29 @@
           "dev": true
         },
         "http-errors": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
           "dev": true,
           "requires": {
-            "depd": "1.1.2",
+            "depd": "1.1.1",
             "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
+            "setprototypeof": "1.0.3",
             "statuses": "1.4.0"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+              "dev": true
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+              "dev": true
+            }
           }
         },
         "mime": {
@@ -7514,32 +7514,6 @@
             "http-errors": "1.6.2",
             "iconv-lite": "0.4.19",
             "unpipe": "1.0.0"
-          },
-          "dependencies": {
-            "depd": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-              "dev": true
-            },
-            "http-errors": {
-              "version": "1.6.2",
-              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-              "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-              "dev": true,
-              "requires": {
-                "depd": "1.1.1",
-                "inherits": "2.0.3",
-                "setprototypeof": "1.0.3",
-                "statuses": "1.4.0"
-              }
-            },
-            "setprototypeof": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-              "dev": true
-            }
           }
         },
         "send": {
@@ -7555,7 +7529,7 @@
             "escape-html": "1.0.3",
             "etag": "1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "1.6.3",
+            "http-errors": "1.6.2",
             "mime": "1.4.1",
             "ms": "2.0.0",
             "on-finished": "2.3.0",
@@ -7574,12 +7548,6 @@
             "parseurl": "1.3.2",
             "send": "0.16.2"
           }
-        },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-          "dev": true
         },
         "utils-merge": {
           "version": "1.0.1",
@@ -9657,7 +9625,7 @@
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.11"
@@ -9794,7 +9762,7 @@
         "lodash": {
           "version": "4.17.5",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha1-maktZcAnLevoyWtgV7yPv6O+1RE=",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
           "dev": true
         }
       }
@@ -9819,9 +9787,9 @@
       }
     },
     "git-raw-commits": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
-      "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.5.tgz",
+      "integrity": "sha512-r6NFrgh9oGzHwMA0go6sEa8jgR+N2/74HPXIXR59asiJzxPXpmk3aM5SMH2bLGsmTPwJtysgbf8EE/LwWHqGgg==",
       "dev": true,
       "requires": {
         "dargs": "4.1.0",
@@ -10969,7 +10937,7 @@
       "requires": {
         "es6-templates": "0.2.3",
         "fastparse": "1.1.1",
-        "html-minifier": "3.5.13",
+        "html-minifier": "3.5.12",
         "loader-utils": "1.1.0",
         "object-assign": "4.1.1"
       },
@@ -10983,18 +10951,19 @@
       }
     },
     "html-minifier": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.13.tgz",
-      "integrity": "sha512-B7P99uf0LPQ5lslyhrAZAXE7Lk1tpiv52KVapKbeFhgqNMUI7JBd/fYLX55imu3Rz7sCTzZM6r/IBe4oT7qCjg==",
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.12.tgz",
+      "integrity": "sha512-+N778qLf0RWBscD0TPGoYdeGNDZ0s76/0pQhY1/409EOudcENkm9IbSkk37RDyPdg/09GVHTKotU4ya93RF1Gg==",
       "dev": true,
       "requires": {
         "camel-case": "3.0.0",
         "clean-css": "4.1.11",
         "commander": "2.15.1",
         "he": "1.1.1",
+        "ncname": "1.0.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.3.18"
+        "uglify-js": "3.3.16"
       }
     },
     "html-tags": {
@@ -11010,7 +10979,7 @@
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
-        "html-minifier": "3.5.13",
+        "html-minifier": "3.5.12",
         "loader-utils": "0.2.17",
         "lodash": "4.17.5",
         "pretty-error": "2.1.1",
@@ -11121,7 +11090,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "statuses": "1.5.0"
+        "statuses": "1.4.0"
       }
     },
     "http-parser-js": {
@@ -11197,12 +11166,6 @@
       "integrity": "sha512-puSi8M8WNlFJm9Pk4c/Mbz9Gwparuj3gO9/RRO5zv6piQ0FY+9Qywp0PdWshYgsMJSalixFY7eC6oPu0zRxLAQ==",
       "dev": true,
       "optional": true
-    },
-    "https-browserify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
-      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.19",
@@ -11578,7 +11541,7 @@
     "inversify": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/inversify/-/inversify-4.3.0.tgz",
-      "integrity": "sha1-0uzSrhg0Dn8atRSKPkS4cIA5E2Y="
+      "integrity": "sha512-BbKzOP4nLl7DSHx31vN5KgUkkJc759+OLocDGryldXPjogixzOs/n4qvT25lbNN67uB6aWlFF84NS/zI5j8pfg=="
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -12118,9 +12081,9 @@
       }
     },
     "is-url": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.3.tgz",
+      "integrity": "sha512-vmOHLvzbcnsdFz8wQPXj1lgI5SE8AUlUGMenzuZzRFjoReb1WB+pLt9GrIo7BTker+aTcwrjTDle7odioWeqyw==",
       "dev": true
     },
     "is-utf8": {
@@ -12186,7 +12149,7 @@
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
         "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.4"
+        "whatwg-fetch": "2.0.3"
       }
     },
     "isstream": {
@@ -12634,7 +12597,7 @@
       "requires": {
         "jest-mock": "22.4.3",
         "jest-util": "22.4.3",
-        "jsdom": "11.7.0"
+        "jsdom": "11.6.2"
       }
     },
     "jest-environment-node": {
@@ -12804,7 +12767,7 @@
       "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/code-frame": "7.0.0-beta.42",
         "chalk": "2.3.2",
         "micromatch": "2.3.11",
         "slash": "1.0.0",
@@ -13347,18 +13310,19 @@
       "optional": true
     },
     "jsdom": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.7.0.tgz",
-      "integrity": "sha512-9NzSc4Iz4gN9p4uoPbBUzro21QdgL32swaWIaWS8eEVQ2I69fRJAy/MKyvlEIk0V7HtKgfMbbOKyTZUrzR2Hsw==",
+      "version": "11.6.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
+      "integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
       "dev": true,
       "requires": {
         "abab": "1.0.4",
         "acorn": "5.5.3",
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
+        "browser-process-hrtime": "0.1.2",
+        "content-type-parser": "1.0.2",
         "cssom": "0.3.2",
         "cssstyle": "0.2.37",
-        "data-urls": "1.0.0",
         "domexception": "1.0.1",
         "escodegen": "1.9.1",
         "html-encoding-sniffer": "1.0.2",
@@ -13374,7 +13338,6 @@
         "w3c-hr-time": "1.0.1",
         "webidl-conversions": "4.0.2",
         "whatwg-encoding": "1.0.3",
-        "whatwg-mimetype": "2.1.0",
         "whatwg-url": "6.4.0",
         "ws": "4.1.0",
         "xml-name-validator": "3.0.0"
@@ -13401,9 +13364,9 @@
       "dev": true
     },
     "json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
       "dev": true
     },
     "json-schema": {
@@ -13535,9 +13498,9 @@
       "dev": true
     },
     "jsonschema": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
+      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA=="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -13555,6 +13518,18 @@
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
       "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
       "dev": true
+    },
+    "junit-merge": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/junit-merge/-/junit-merge-1.3.0.tgz",
+      "integrity": "sha1-NSGkZskN1yfHj9CXGFECrj8EjVk=",
+      "dev": true,
+      "requires": {
+        "commander": "2.15.1",
+        "fs-readdir-recursive": "1.1.0",
+        "mkdirp": "0.5.1",
+        "xmldoc": "1.1.0"
+      }
     },
     "kew": {
       "version": "0.7.0",
@@ -14053,9 +14028,9 @@
       "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE="
     },
     "lodash-es": {
-      "version": "4.17.8",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.8.tgz",
-      "integrity": "sha512-I9mjAxengFAleSThFhhAhvba6fsO0hunb9/0sQ6qQihSZsJRBofv2rYH58WXaOb/O++eUmYpCLywSQ22GfU+sA=="
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.7.tgz",
+      "integrity": "sha512-jzqTi3vk4J5Dxq43cNjB0ekfCjPLHixoY2Sc0WHTo+0r928taLqe/VCt02vY5uQBvg0rdXgL3xWkK4X0MCmZcw=="
     },
     "lodash._arraymap": {
       "version": "3.0.0",
@@ -14642,7 +14617,7 @@
     "marked": {
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
-      "integrity": "sha1-fPJf8iUmMvP+JAa94ljpTu6SdRk=",
+      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==",
       "dev": true
     },
     "math-expression-evaluator": {
@@ -15248,7 +15223,7 @@
     "moment": {
       "version": "2.21.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-      "integrity": "sha1-KhFLUdKm7J5tg8+AP4OKh42KAjo="
+      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
     },
     "morgan": {
       "version": "1.6.1",
@@ -15462,6 +15437,15 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "ncname": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
+      "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
+      "dev": true,
+      "requires": {
+        "xml-char-classes": "1.0.0"
+      }
+    },
     "nearley": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.13.0.tgz",
@@ -15541,103 +15525,6 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
-    },
-    "node-libs-browser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
-      "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
-      "dev": true,
-      "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.2.0",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.2.0",
-        "events": "1.1.1",
-        "https-browserify": "1.0.0",
-        "os-browserify": "0.3.0",
-        "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.5",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.8.1",
-        "string_decoder": "1.1.1",
-        "timers-browserify": "2.0.6",
-        "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
-        "vm-browserify": "0.0.4"
-      },
-      "dependencies": {
-        "base64-js": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
-          "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
-          "dev": true
-        },
-        "buffer": {
-          "version": "4.9.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-          "dev": true,
-          "requires": {
-            "base64-js": "1.2.3",
-            "ieee754": "1.1.11",
-            "isarray": "1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "process": {
-          "version": "0.11.10",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          },
-          "dependencies": {
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "dev": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
     },
     "node-notifier": {
       "version": "5.2.1",
@@ -16043,7 +15930,8 @@
       "dependencies": {
         "JSONStream": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
           "dev": true,
           "requires": {
             "jsonparse": "1.3.1",
@@ -16052,49 +15940,58 @@
           "dependencies": {
             "jsonparse": {
               "version": "1.3.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
               "dev": true
             },
             "through": {
               "version": "2.3.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
               "dev": true
             }
           }
         },
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "ansicolors": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
           "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "bin-links": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.0.tgz",
+          "integrity": "sha512-3desjIEoSt86s+BRZlkLpBPPcHhr4vyUPL/+X1cQuE96NIlkELqnb4Yq+I5gZe47gHsZztA6cm38uMrT9+FWpA==",
           "dev": true,
           "requires": {
             "bluebird": "3.5.1",
@@ -16107,12 +16004,14 @@
         },
         "bluebird": {
           "version": "3.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
           "dev": true
         },
         "cacache": {
           "version": "10.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.1.tgz",
+          "integrity": "sha512-dRHYcs9LvG9cHgdPzjiI+/eS7e1xRhULrcyOx04RZQsszNJXU2SL9CyG60yLnge282Qq5nwTv+ieK2fH+WPZmA==",
           "dev": true,
           "requires": {
             "bluebird": "3.5.1",
@@ -16132,7 +16031,8 @@
           "dependencies": {
             "ssri": {
               "version": "5.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz",
+              "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "5.1.1"
@@ -16140,24 +16040,28 @@
             },
             "y18n": {
               "version": "3.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
               "dev": true
             }
           }
         },
         "call-limit": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.0.tgz",
+          "integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o=",
           "dev": true
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true
         },
         "cli-table2": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cli-table2/-/cli-table2-0.2.0.tgz",
+          "integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
           "dev": true,
           "requires": {
             "colors": "1.1.2",
@@ -16167,18 +16071,21 @@
           "dependencies": {
             "colors": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+              "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
               "dev": true,
               "optional": true
             },
             "lodash": {
               "version": "3.10.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
               "dev": true
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
@@ -16188,12 +16095,14 @@
               "dependencies": {
                 "code-point-at": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                   "dev": true
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
                   "requires": {
                     "number-is-nan": "1.0.1"
@@ -16201,14 +16110,16 @@
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                       "dev": true
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
                     "ansi-regex": "2.1.1"
@@ -16216,7 +16127,8 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                       "dev": true
                     }
                   }
@@ -16227,7 +16139,8 @@
         },
         "cmd-shim": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+          "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -16236,7 +16149,8 @@
         },
         "columnify": {
           "version": "1.5.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "dev": true,
           "requires": {
             "strip-ansi": "3.0.1",
@@ -16245,7 +16159,8 @@
           "dependencies": {
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "2.1.1"
@@ -16253,14 +16168,16 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                   "dev": true
                 }
               }
             },
             "wcwidth": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+              "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
               "dev": true,
               "requires": {
                 "defaults": "1.0.3"
@@ -16268,7 +16185,8 @@
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+                  "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                   "dev": true,
                   "requires": {
                     "clone": "1.0.2"
@@ -16276,7 +16194,8 @@
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
                       "dev": true
                     }
                   }
@@ -16287,7 +16206,8 @@
         },
         "config-chain": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+          "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
           "dev": true,
           "requires": {
             "ini": "1.3.4",
@@ -16296,24 +16216,28 @@
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+              "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
               "dev": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
           "dev": true
         },
         "detect-indent": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
           "dev": true
         },
         "dezalgo": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
           "dev": true,
           "requires": {
             "asap": "2.0.5",
@@ -16322,24 +16246,28 @@
           "dependencies": {
             "asap": {
               "version": "2.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+              "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
               "dev": true
             }
           }
         },
         "editor": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
           "dev": true
         },
         "find-npm-prefix": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.1.tgz",
+          "integrity": "sha512-I9R7ZnsjlKRvXBJjA1PE4wAkSc24YChoomWdEPTZgeB4DHxf87OutNGV5McFj6WwPghH97nZRejH58XvY6ga6Q==",
           "dev": true
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+          "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -16349,7 +16277,8 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+          "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -16360,7 +16289,8 @@
         },
         "gentle-fs": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.0.1.tgz",
+          "integrity": "sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==",
           "dev": true,
           "requires": {
             "aproba": "1.2.0",
@@ -16375,7 +16305,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -16388,12 +16319,14 @@
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
                 "brace-expansion": "1.1.8"
@@ -16401,7 +16334,8 @@
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                   "dev": true,
                   "requires": {
                     "balanced-match": "1.0.0",
@@ -16410,12 +16344,14 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                       "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                       "dev": true
                     }
                   }
@@ -16424,39 +16360,46 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true
             }
           }
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
           "dev": true
         },
         "iferr": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+          "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -16465,17 +16408,20 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
           "dev": true
         },
         "init-package-json": {
           "version": "1.10.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.1.tgz",
+          "integrity": "sha1-zYc6FneWvvuZYSsodioLY5P9j2o=",
           "dev": true,
           "requires": {
             "glob": "7.1.2",
@@ -16490,7 +16436,8 @@
           "dependencies": {
             "npm-package-arg": {
               "version": "5.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
+              "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
               "dev": true,
               "requires": {
                 "hosted-git-info": "2.5.0",
@@ -16501,7 +16448,8 @@
             },
             "promzard": {
               "version": "0.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+              "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
               "dev": true,
               "requires": {
                 "read": "1.0.7"
@@ -16511,7 +16459,8 @@
         },
         "is-cidr": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-1.0.0.tgz",
+          "integrity": "sha1-+1qs9lklUxA1naMsrgPkDGocKvw=",
           "dev": true,
           "requires": {
             "cidr-regex": "1.0.6"
@@ -16519,19 +16468,22 @@
           "dependencies": {
             "cidr-regex": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-1.0.6.tgz",
+              "integrity": "sha1-dKv9YZ3zcLnVSrFEdVaOl91kwME=",
               "dev": true
             }
           }
         },
         "lazy-property": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
+          "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
           "dev": true
         },
         "libnpx": {
           "version": "9.7.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpx/-/libnpx-9.7.1.tgz",
+          "integrity": "sha512-OktT775uhfL93SoUfERj4ilM3D7c0hyUyALX9oJ2D/yO4Msm5hbkOKHcrOVHXRcEX9ytstviYQAEygFIiDj2bQ==",
           "dev": true,
           "requires": {
             "dotenv": "4.0.0",
@@ -16546,12 +16498,14 @@
           "dependencies": {
             "dotenv": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+              "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
               "dev": true
             },
             "npm-package-arg": {
               "version": "5.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
+              "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
               "dev": true,
               "requires": {
                 "hosted-git-info": "2.5.0",
@@ -16562,12 +16516,14 @@
             },
             "y18n": {
               "version": "3.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
               "dev": true
             },
             "yargs": {
               "version": "8.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+              "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
               "dev": true,
               "requires": {
                 "camelcase": "4.1.0",
@@ -16587,12 +16543,14 @@
               "dependencies": {
                 "camelcase": {
                   "version": "4.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                  "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                   "dev": true
                 },
                 "cliui": {
                   "version": "3.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                  "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                   "dev": true,
                   "requires": {
                     "string-width": "1.0.2",
@@ -16602,7 +16560,8 @@
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
                       "requires": {
                         "code-point-at": "1.1.0",
@@ -16612,12 +16571,14 @@
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                           "dev": true
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "dev": true,
                           "requires": {
                             "number-is-nan": "1.0.1"
@@ -16625,7 +16586,8 @@
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                               "dev": true
                             }
                           }
@@ -16634,7 +16596,8 @@
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "dev": true,
                       "requires": {
                         "ansi-regex": "2.1.1"
@@ -16642,14 +16605,16 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                           "dev": true
                         }
                       }
                     },
                     "wrap-ansi": {
                       "version": "2.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+                      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
                       "dev": true,
                       "requires": {
                         "string-width": "1.0.2",
@@ -16660,17 +16625,20 @@
                 },
                 "decamelize": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                  "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
                   "dev": true
                 },
                 "get-caller-file": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+                  "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
                   "dev": true
                 },
                 "os-locale": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+                  "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                   "dev": true,
                   "requires": {
                     "execa": "0.7.0",
@@ -16680,7 +16648,8 @@
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+                      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                       "dev": true,
                       "requires": {
                         "cross-spawn": "5.1.0",
@@ -16694,7 +16663,8 @@
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                           "dev": true,
                           "requires": {
                             "lru-cache": "4.1.1",
@@ -16704,7 +16674,8 @@
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
                               "dev": true,
                               "requires": {
                                 "shebang-regex": "1.0.0"
@@ -16712,7 +16683,8 @@
                               "dependencies": {
                                 "shebang-regex": {
                                   "version": "1.0.0",
-                                  "bundled": true,
+                                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                                  "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
                                   "dev": true
                                 }
                               }
@@ -16721,17 +16693,20 @@
                         },
                         "get-stream": {
                           "version": "3.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                           "dev": true
                         },
                         "is-stream": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                           "dev": true
                         },
                         "npm-run-path": {
                           "version": "2.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+                          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
                           "dev": true,
                           "requires": {
                             "path-key": "2.0.1"
@@ -16739,31 +16714,36 @@
                           "dependencies": {
                             "path-key": {
                               "version": "2.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
                               "dev": true
                             }
                           }
                         },
                         "p-finally": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+                          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
                           "dev": true
                         },
                         "signal-exit": {
                           "version": "3.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                           "dev": true
                         },
                         "strip-eof": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
                           "dev": true
                         }
                       }
                     },
                     "lcid": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                       "dev": true,
                       "requires": {
                         "invert-kv": "1.0.0"
@@ -16771,14 +16751,16 @@
                       "dependencies": {
                         "invert-kv": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
                           "dev": true
                         }
                       }
                     },
                     "mem": {
                       "version": "1.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+                      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
                       "dev": true,
                       "requires": {
                         "mimic-fn": "1.1.0"
@@ -16786,7 +16768,8 @@
                       "dependencies": {
                         "mimic-fn": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+                          "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
                           "dev": true
                         }
                       }
@@ -16795,7 +16778,8 @@
                 },
                 "read-pkg-up": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+                  "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
                   "dev": true,
                   "requires": {
                     "find-up": "2.1.0",
@@ -16804,7 +16788,8 @@
                   "dependencies": {
                     "find-up": {
                       "version": "2.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                       "dev": true,
                       "requires": {
                         "locate-path": "2.0.0"
@@ -16812,7 +16797,8 @@
                       "dependencies": {
                         "locate-path": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
                           "dev": true,
                           "requires": {
                             "p-locate": "2.0.0",
@@ -16821,7 +16807,8 @@
                           "dependencies": {
                             "p-locate": {
                               "version": "2.0.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                              "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
                               "dev": true,
                               "requires": {
                                 "p-limit": "1.1.0"
@@ -16829,14 +16816,16 @@
                               "dependencies": {
                                 "p-limit": {
                                   "version": "1.1.0",
-                                  "bundled": true,
+                                  "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+                                  "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
                                   "dev": true
                                 }
                               }
                             },
                             "path-exists": {
                               "version": "3.0.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
                               "dev": true
                             }
                           }
@@ -16845,7 +16834,8 @@
                     },
                     "read-pkg": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+                      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
                       "dev": true,
                       "requires": {
                         "load-json-file": "2.0.0",
@@ -16855,7 +16845,8 @@
                       "dependencies": {
                         "load-json-file": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+                          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
                           "dev": true,
                           "requires": {
                             "graceful-fs": "4.1.11",
@@ -16866,7 +16857,8 @@
                           "dependencies": {
                             "parse-json": {
                               "version": "2.2.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                              "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                               "dev": true,
                               "requires": {
                                 "error-ex": "1.3.1"
@@ -16874,7 +16866,8 @@
                               "dependencies": {
                                 "error-ex": {
                                   "version": "1.3.1",
-                                  "bundled": true,
+                                  "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+                                  "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
                                   "dev": true,
                                   "requires": {
                                     "is-arrayish": "0.2.1"
@@ -16882,7 +16875,8 @@
                                   "dependencies": {
                                     "is-arrayish": {
                                       "version": "0.2.1",
-                                      "bundled": true,
+                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
                                       "dev": true
                                     }
                                   }
@@ -16891,19 +16885,22 @@
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                               "dev": true
                             },
                             "strip-bom": {
                               "version": "3.0.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
                               "dev": true
                             }
                           }
                         },
                         "path-type": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+                          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
                           "dev": true,
                           "requires": {
                             "pify": "2.3.0"
@@ -16911,7 +16908,8 @@
                           "dependencies": {
                             "pify": {
                               "version": "2.3.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                               "dev": true
                             }
                           }
@@ -16922,22 +16920,26 @@
                 },
                 "require-directory": {
                   "version": "2.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+                  "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
                   "dev": true
                 },
                 "require-main-filename": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                  "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
                   "dev": true
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                   "dev": true
                 },
                 "string-width": {
                   "version": "2.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                  "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                   "dev": true,
                   "requires": {
                     "is-fullwidth-code-point": "2.0.0",
@@ -16946,19 +16948,22 @@
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                       "dev": true
                     }
                   }
                 },
                 "which-module": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                  "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
                   "dev": true
                 },
                 "yargs-parser": {
                   "version": "7.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+                  "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
                   "dev": true,
                   "requires": {
                     "camelcase": "4.1.0"
@@ -16970,17 +16975,20 @@
         },
         "lockfile": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
+          "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k=",
           "dev": true
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
           "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+          "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
           "dev": true,
           "requires": {
             "lodash._createset": "4.0.3",
@@ -16989,29 +16997,34 @@
           "dependencies": {
             "lodash._createset": {
               "version": "4.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+              "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
               "dev": true
             },
             "lodash._root": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+              "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
               "dev": true
             }
           }
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
           "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
           "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
           "dev": true,
           "requires": {
             "lodash._getnative": "3.9.1"
@@ -17019,37 +17032,44 @@
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
           "dev": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
           "dev": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
           "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+          "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
           "dev": true
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+          "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
           "dev": true
         },
         "lodash.without": {
           "version": "4.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+          "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -17058,24 +17078,28 @@
           "dependencies": {
             "pseudomap": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
               "dev": true
             },
             "yallist": {
               "version": "2.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
               "dev": true
             }
           }
         },
         "meant": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/meant/-/meant-1.0.1.tgz",
+          "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg==",
           "dev": true
         },
         "mississippi": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
+          "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
           "dev": true,
           "requires": {
             "concat-stream": "1.6.0",
@@ -17092,7 +17116,8 @@
           "dependencies": {
             "concat-stream": {
               "version": "1.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+              "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
               "dev": true,
               "requires": {
                 "inherits": "2.0.3",
@@ -17102,14 +17127,16 @@
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                   "dev": true
                 }
               }
             },
             "duplexify": {
               "version": "3.5.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+              "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
               "dev": true,
               "requires": {
                 "end-of-stream": "1.0.0",
@@ -17120,7 +17147,8 @@
               "dependencies": {
                 "end-of-stream": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                  "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
                   "dev": true,
                   "requires": {
                     "once": "1.3.3"
@@ -17128,7 +17156,8 @@
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                       "dev": true,
                       "requires": {
                         "wrappy": "1.0.2"
@@ -17138,14 +17167,16 @@
                 },
                 "stream-shift": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                   "dev": true
                 }
               }
             },
             "end-of-stream": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+              "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
               "dev": true,
               "requires": {
                 "once": "1.4.0"
@@ -17153,7 +17184,8 @@
             },
             "flush-write-stream": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+              "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
               "dev": true,
               "requires": {
                 "inherits": "2.0.3",
@@ -17162,7 +17194,8 @@
             },
             "from2": {
               "version": "2.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+              "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
               "dev": true,
               "requires": {
                 "inherits": "2.0.3",
@@ -17171,7 +17204,8 @@
             },
             "parallel-transform": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+              "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
               "dev": true,
               "requires": {
                 "cyclist": "0.2.2",
@@ -17181,14 +17215,16 @@
               "dependencies": {
                 "cyclist": {
                   "version": "0.2.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+                  "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
                   "dev": true
                 }
               }
             },
             "pump": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
+              "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
               "dev": true,
               "requires": {
                 "end-of-stream": "1.4.0",
@@ -17197,7 +17233,8 @@
             },
             "pumpify": {
               "version": "1.3.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
+              "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
               "dev": true,
               "requires": {
                 "duplexify": "3.5.0",
@@ -17207,7 +17244,8 @@
             },
             "stream-each": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.0.tgz",
+              "integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE=",
               "dev": true,
               "requires": {
                 "end-of-stream": "1.4.0",
@@ -17216,14 +17254,16 @@
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                   "dev": true
                 }
               }
             },
             "through2": {
               "version": "2.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+              "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
               "dev": true,
               "requires": {
                 "readable-stream": "2.3.3",
@@ -17232,7 +17272,8 @@
               "dependencies": {
                 "xtend": {
                   "version": "4.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                   "dev": true
                 }
               }
@@ -17241,7 +17282,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -17249,14 +17291,16 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             }
           }
         },
         "move-concurrently": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+          "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
           "dev": true,
           "requires": {
             "aproba": "1.2.0",
@@ -17269,7 +17313,8 @@
           "dependencies": {
             "copy-concurrently": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+              "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
               "dev": true,
               "requires": {
                 "aproba": "1.2.0",
@@ -17282,7 +17327,8 @@
             },
             "run-queue": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+              "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
               "dev": true,
               "requires": {
                 "aproba": "1.2.0"
@@ -17292,7 +17338,8 @@
         },
         "node-gyp": {
           "version": "3.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+          "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
           "dev": true,
           "requires": {
             "fstream": "1.0.11",
@@ -17312,7 +17359,8 @@
           "dependencies": {
             "fstream": {
               "version": "1.0.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+              "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
               "dev": true,
               "requires": {
                 "graceful-fs": "4.1.11",
@@ -17323,7 +17371,8 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
                 "brace-expansion": "1.1.8"
@@ -17331,7 +17380,8 @@
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                   "dev": true,
                   "requires": {
                     "balanced-match": "1.0.0",
@@ -17340,12 +17390,14 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                       "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                       "dev": true
                     }
                   }
@@ -17354,7 +17406,8 @@
             },
             "nopt": {
               "version": "3.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
               "dev": true,
               "requires": {
                 "abbrev": "1.1.1"
@@ -17362,12 +17415,14 @@
             },
             "semver": {
               "version": "5.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
               "dev": true
             },
             "tar": {
               "version": "2.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "dev": true,
               "requires": {
                 "block-stream": "0.0.9",
@@ -17377,7 +17432,8 @@
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
                   "dev": true,
                   "requires": {
                     "inherits": "2.0.3"
@@ -17389,7 +17445,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "requires": {
             "abbrev": "1.1.1",
@@ -17398,7 +17455,8 @@
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
             "hosted-git-info": "2.5.0",
@@ -17409,7 +17467,8 @@
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
               "dev": true,
               "requires": {
                 "builtin-modules": "1.1.1"
@@ -17417,7 +17476,8 @@
               "dependencies": {
                 "builtin-modules": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                  "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
                   "dev": true
                 }
               }
@@ -17426,12 +17486,14 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
           "dev": true
         },
         "npm-install-checks": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
+          "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
           "dev": true,
           "requires": {
             "semver": "5.4.1"
@@ -17439,7 +17501,8 @@
         },
         "npm-lifecycle": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-2.0.0.tgz",
+          "integrity": "sha512-aE7H012O01GKXT9BWnsGMLVci+MOgkhpSwq02ok20aXcNHxFs7enfampNMkiOV1DJEU0LynzemwdjbtXahXKcw==",
           "dev": true,
           "requires": {
             "byline": "5.0.0",
@@ -17454,19 +17517,22 @@
           "dependencies": {
             "byline": {
               "version": "5.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+              "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
               "dev": true
             },
             "resolve-from": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+              "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
               "dev": true
             }
           }
         },
         "npm-package-arg": {
           "version": "6.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.0.0.tgz",
+          "integrity": "sha512-hwC7g81KLgRmchv9ol6f3Fx4Yyc9ARX5X5niDHVILgpuvf08JRIgOZcEfpFXli3BgESoTrkauqorXm6UbvSgSg==",
           "dev": true,
           "requires": {
             "hosted-git-info": "2.5.0",
@@ -17477,7 +17543,8 @@
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "dev": true,
           "requires": {
             "ignore-walk": "3.0.1",
@@ -17486,7 +17553,8 @@
           "dependencies": {
             "ignore-walk": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+              "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "dev": true,
               "requires": {
                 "minimatch": "3.0.4"
@@ -17494,7 +17562,8 @@
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "requires": {
                     "brace-expansion": "1.1.8"
@@ -17502,7 +17571,8 @@
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "dev": true,
                       "requires": {
                         "balanced-match": "1.0.0",
@@ -17511,12 +17581,14 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "dev": true
                         }
                       }
@@ -17527,14 +17599,16 @@
             },
             "npm-bundled": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+              "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
               "dev": true
             }
           }
         },
         "npm-profile": {
           "version": "2.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-2.0.5.tgz",
+          "integrity": "sha512-tLmpDUCV72f/1/oXoyb+VwsZjOlsanp34pZeIZS0mxDoQUOX4Ld1hgPeOqoX4XggE88m7W47DHET2v+qd6sihg==",
           "dev": true,
           "requires": {
             "aproba": "1.2.0",
@@ -17543,7 +17617,8 @@
           "dependencies": {
             "make-fetch-happen": {
               "version": "2.5.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.5.0.tgz",
+              "integrity": "sha512-JPD5R43T02wIkcxjcmZuR7D06nB20fMR8aC9VEyYsSBXvJa5hOR/QhCxKY+5SXhy3uU5OUY/r+A6r+fJ2mFndA==",
               "dev": true,
               "requires": {
                 "agentkeepalive": "3.3.0",
@@ -17561,7 +17636,8 @@
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.3.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.3.0.tgz",
+                  "integrity": "sha512-9yhcpXti2ZQE7bxuCsjjWNIZoQOd9sZ1ZBovHG0YeCRohFv73SLvcm73PC9T3olM4GyozaQb+4MGdQpcD8m7NQ==",
                   "dev": true,
                   "requires": {
                     "humanize-ms": "1.2.1"
@@ -17569,7 +17645,8 @@
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+                      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
                       "dev": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -17577,7 +17654,8 @@
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                           "dev": true
                         }
                       }
@@ -17586,7 +17664,8 @@
                 },
                 "cacache": {
                   "version": "9.3.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/cacache/-/cacache-9.3.0.tgz",
+                  "integrity": "sha512-Vbi8J1XfC8v+FbQ6QkOtKXsHpPnB0i9uMeYFJoj40EbdOsEqWB3DPpNjfsnYBkqOPYA8UvrqH6FZPpBP0zdN7g==",
                   "dev": true,
                   "requires": {
                     "bluebird": "3.5.1",
@@ -17606,19 +17685,22 @@
                   "dependencies": {
                     "y18n": {
                       "version": "3.2.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
                       "dev": true
                     }
                   }
                 },
                 "http-cache-semantics": {
                   "version": "3.8.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.0.tgz",
+                  "integrity": "sha512-HGQFfBdru2fj/dwPn1oLx1fy6QMPeTAD1yzKcxD4l5biw+5QVaui/ehCqxaitoKJC/vHMLKv3Yd+nTlxboOJig==",
                   "dev": true
                 },
                 "http-proxy-agent": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.0.0.tgz",
+                  "integrity": "sha1-RkgqLwUjpNYIJVFwn0acs+SoX/Q=",
                   "dev": true,
                   "requires": {
                     "agent-base": "4.1.1",
@@ -17627,7 +17709,8 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.1.tgz",
+                      "integrity": "sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==",
                       "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -17635,7 +17718,8 @@
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
                             "es6-promise": "4.1.1"
@@ -17643,7 +17727,8 @@
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                               "dev": true
                             }
                           }
@@ -17652,7 +17737,8 @@
                     },
                     "debug": {
                       "version": "2.6.9",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                       "dev": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -17660,7 +17746,8 @@
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                           "dev": true
                         }
                       }
@@ -17669,7 +17756,8 @@
                 },
                 "https-proxy-agent": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.0.tgz",
+                  "integrity": "sha512-/DTVSUCbRc6AiyOV4DBRvPDpKKCJh4qQJNaCgypX0T41quD9hp/PB5iUyx/60XobuMPQa9ce1jNV9UOUq6PnTg==",
                   "dev": true,
                   "requires": {
                     "agent-base": "4.1.1",
@@ -17678,7 +17766,8 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.1.tgz",
+                      "integrity": "sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==",
                       "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -17686,7 +17775,8 @@
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
                             "es6-promise": "4.1.1"
@@ -17694,7 +17784,8 @@
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                               "dev": true
                             }
                           }
@@ -17703,7 +17794,8 @@
                     },
                     "debug": {
                       "version": "2.6.9",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                       "dev": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -17711,7 +17803,8 @@
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                           "dev": true
                         }
                       }
@@ -17720,7 +17813,8 @@
                 },
                 "node-fetch-npm": {
                   "version": "2.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+                  "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
                   "dev": true,
                   "requires": {
                     "encoding": "0.1.12",
@@ -17730,7 +17824,8 @@
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                       "dev": true,
                       "requires": {
                         "iconv-lite": "0.4.19"
@@ -17738,21 +17833,24 @@
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.19",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+                          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
                           "dev": true
                         }
                       }
                     },
                     "json-parse-better-errors": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+                      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
                       "dev": true
                     }
                   }
                 },
                 "promise-retry": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+                  "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
                   "dev": true,
                   "requires": {
                     "err-code": "1.1.2",
@@ -17761,14 +17859,16 @@
                   "dependencies": {
                     "err-code": {
                       "version": "1.1.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+                      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
                       "dev": true
                     }
                   }
                 },
                 "socks-proxy-agent": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
+                  "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
                   "dev": true,
                   "requires": {
                     "agent-base": "4.1.1",
@@ -17777,7 +17877,8 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.1.tgz",
+                      "integrity": "sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==",
                       "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -17785,7 +17886,8 @@
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
                             "es6-promise": "4.1.1"
@@ -17793,7 +17895,8 @@
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                               "dev": true
                             }
                           }
@@ -17802,7 +17905,8 @@
                     },
                     "socks": {
                       "version": "1.1.10",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+                      "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
                       "dev": true,
                       "requires": {
                         "ip": "1.1.5",
@@ -17811,12 +17915,14 @@
                       "dependencies": {
                         "ip": {
                           "version": "1.1.5",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+                          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
                           "dev": true
                         },
                         "smart-buffer": {
                           "version": "1.1.15",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+                          "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
                           "dev": true
                         }
                       }
@@ -17825,7 +17931,8 @@
                 },
                 "ssri": {
                   "version": "4.1.6",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
+                  "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
                   "dev": true,
                   "requires": {
                     "safe-buffer": "5.1.1"
@@ -17837,7 +17944,8 @@
         },
         "npm-registry-client": {
           "version": "8.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.5.0.tgz",
+          "integrity": "sha512-Nkcw24bfECKFNt0FLDQ+PjVqSlKxMggcboXiUBIvjbCnA15xjRO4kCwRDluGNXZjHFLx/vPjN4+ESXyVjpXLbQ==",
           "dev": true,
           "requires": {
             "concat-stream": "1.6.0",
@@ -17855,7 +17963,8 @@
           "dependencies": {
             "concat-stream": {
               "version": "1.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+              "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
               "dev": true,
               "requires": {
                 "inherits": "2.0.3",
@@ -17865,14 +17974,16 @@
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                   "dev": true
                 }
               }
             },
             "npm-package-arg": {
               "version": "5.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
+              "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
               "dev": true,
               "requires": {
                 "hosted-git-info": "2.5.0",
@@ -17883,7 +17994,8 @@
             },
             "ssri": {
               "version": "4.1.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
+              "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
               "dev": true,
               "requires": {
                 "safe-buffer": "5.1.1"
@@ -17893,12 +18005,14 @@
         },
         "npm-user-validate": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
+          "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
           "dev": true
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
@@ -17909,7 +18023,8 @@
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+              "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
               "dev": true,
               "requires": {
                 "delegates": "1.0.0",
@@ -17918,19 +18033,22 @@
               "dependencies": {
                 "delegates": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                  "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                   "dev": true
                 }
               }
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true
             },
             "gauge": {
               "version": "2.7.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "requires": {
                 "aproba": "1.2.0",
@@ -17945,17 +18063,20 @@
               "dependencies": {
                 "object-assign": {
                   "version": "4.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                   "dev": true
                 },
                 "signal-exit": {
                   "version": "3.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                  "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                   "dev": true
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
                   "requires": {
                     "code-point-at": "1.1.0",
@@ -17965,12 +18086,14 @@
                   "dependencies": {
                     "code-point-at": {
                       "version": "1.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                       "dev": true
                     },
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                       "dev": true,
                       "requires": {
                         "number-is-nan": "1.0.1"
@@ -17978,7 +18101,8 @@
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                           "dev": true
                         }
                       }
@@ -17987,7 +18111,8 @@
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
                     "ansi-regex": "2.1.1"
@@ -17995,14 +18120,16 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                       "dev": true
                     }
                   }
                 },
                 "wide-align": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+                  "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
                   "dev": true,
                   "requires": {
                     "string-width": "1.0.2"
@@ -18012,14 +18139,16 @@
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true
             }
           }
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -18027,12 +18156,14 @@
         },
         "opener": {
           "version": "1.4.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+          "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
           "dev": true
         },
         "osenv": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
           "requires": {
             "os-homedir": "1.0.2",
@@ -18041,19 +18172,22 @@
           "dependencies": {
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true
             }
           }
         },
         "pacote": {
           "version": "7.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pacote/-/pacote-7.0.2.tgz",
+          "integrity": "sha512-cTiugiG2ujDcqDtYtJ3doDrS6E3eU0bhuYAHhMTWgBezrhoqTEjc0axSBpbjw4QQkNT5AGRF15Mj2tF2HuBz7w==",
           "dev": true,
           "requires": {
             "bluebird": "3.5.1",
@@ -18082,12 +18216,14 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "dev": true
             },
             "make-fetch-happen": {
               "version": "2.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.6.0.tgz",
+              "integrity": "sha512-FFq0lNI0ax+n9IWzWpH8A4JdgYiAp2DDYIZ3rsaav8JDe8I+72CzK6PQW/oom15YDZpV5bYW/9INd6nIJ2ZfZw==",
               "dev": true,
               "requires": {
                 "agentkeepalive": "3.3.0",
@@ -18105,7 +18241,8 @@
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.3.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.3.0.tgz",
+                  "integrity": "sha512-9yhcpXti2ZQE7bxuCsjjWNIZoQOd9sZ1ZBovHG0YeCRohFv73SLvcm73PC9T3olM4GyozaQb+4MGdQpcD8m7NQ==",
                   "dev": true,
                   "requires": {
                     "humanize-ms": "1.2.1"
@@ -18113,7 +18250,8 @@
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+                      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
                       "dev": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -18121,7 +18259,8 @@
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                           "dev": true
                         }
                       }
@@ -18130,12 +18269,14 @@
                 },
                 "http-cache-semantics": {
                   "version": "3.8.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.0.tgz",
+                  "integrity": "sha512-HGQFfBdru2fj/dwPn1oLx1fy6QMPeTAD1yzKcxD4l5biw+5QVaui/ehCqxaitoKJC/vHMLKv3Yd+nTlxboOJig==",
                   "dev": true
                 },
                 "http-proxy-agent": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.0.0.tgz",
+                  "integrity": "sha1-RkgqLwUjpNYIJVFwn0acs+SoX/Q=",
                   "dev": true,
                   "requires": {
                     "agent-base": "4.1.2",
@@ -18144,7 +18285,8 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
+                      "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
                       "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -18152,7 +18294,8 @@
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
                             "es6-promise": "4.1.1"
@@ -18160,7 +18303,8 @@
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                               "dev": true
                             }
                           }
@@ -18169,7 +18313,8 @@
                     },
                     "debug": {
                       "version": "2.6.9",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                       "dev": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -18177,7 +18322,8 @@
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                           "dev": true
                         }
                       }
@@ -18186,7 +18332,8 @@
                 },
                 "https-proxy-agent": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.0.tgz",
+                  "integrity": "sha512-/DTVSUCbRc6AiyOV4DBRvPDpKKCJh4qQJNaCgypX0T41quD9hp/PB5iUyx/60XobuMPQa9ce1jNV9UOUq6PnTg==",
                   "dev": true,
                   "requires": {
                     "agent-base": "4.1.2",
@@ -18195,7 +18342,8 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
+                      "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
                       "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -18203,7 +18351,8 @@
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
                             "es6-promise": "4.1.1"
@@ -18211,7 +18360,8 @@
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                               "dev": true
                             }
                           }
@@ -18220,7 +18370,8 @@
                     },
                     "debug": {
                       "version": "2.6.9",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                       "dev": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -18228,7 +18379,8 @@
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                           "dev": true
                         }
                       }
@@ -18237,7 +18389,8 @@
                 },
                 "node-fetch-npm": {
                   "version": "2.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+                  "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
                   "dev": true,
                   "requires": {
                     "encoding": "0.1.12",
@@ -18247,7 +18400,8 @@
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                       "dev": true,
                       "requires": {
                         "iconv-lite": "0.4.19"
@@ -18255,21 +18409,24 @@
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.19",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+                          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
                           "dev": true
                         }
                       }
                     },
                     "json-parse-better-errors": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+                      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
                       "dev": true
                     }
                   }
                 },
                 "socks-proxy-agent": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
+                  "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
                   "dev": true,
                   "requires": {
                     "agent-base": "4.1.2",
@@ -18278,7 +18435,8 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
+                      "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
                       "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -18286,7 +18444,8 @@
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
                             "es6-promise": "4.1.1"
@@ -18294,7 +18453,8 @@
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                               "dev": true
                             }
                           }
@@ -18303,7 +18463,8 @@
                     },
                     "socks": {
                       "version": "1.1.10",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+                      "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
                       "dev": true,
                       "requires": {
                         "ip": "1.1.5",
@@ -18312,12 +18473,14 @@
                       "dependencies": {
                         "ip": {
                           "version": "1.1.5",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+                          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
                           "dev": true
                         },
                         "smart-buffer": {
                           "version": "1.1.15",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+                          "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
                           "dev": true
                         }
                       }
@@ -18328,7 +18491,8 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
                 "brace-expansion": "1.1.8"
@@ -18336,7 +18500,8 @@
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                   "dev": true,
                   "requires": {
                     "balanced-match": "1.0.0",
@@ -18345,12 +18510,14 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                       "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                       "dev": true
                     }
                   }
@@ -18359,7 +18526,8 @@
             },
             "npm-pick-manifest": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.1.0.tgz",
+              "integrity": "sha512-q9zLP8cTr8xKPmMZN3naxp1k/NxVFsjxN6uWuO1tiw9gxg7wZWQ/b5UTfzD0ANw2q1lQxdLKTeCCksq+bPSgbQ==",
               "dev": true,
               "requires": {
                 "npm-package-arg": "6.0.0",
@@ -18368,7 +18536,8 @@
             },
             "promise-retry": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+              "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
               "dev": true,
               "requires": {
                 "err-code": "1.1.2",
@@ -18377,14 +18546,16 @@
               "dependencies": {
                 "err-code": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+                  "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
                   "dev": true
                 }
               }
             },
             "protoduck": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-4.0.0.tgz",
+              "integrity": "sha1-/kh02MeRM2bP2erRJFOiLNNlf44=",
               "dev": true,
               "requires": {
                 "genfun": "4.0.1"
@@ -18392,7 +18563,8 @@
               "dependencies": {
                 "genfun": {
                   "version": "4.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz",
+                  "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E=",
                   "dev": true
                 }
               }
@@ -18401,22 +18573,26 @@
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
           "dev": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+          "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
           "dev": true
         },
         "qrcode-terminal": {
           "version": "0.11.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.11.0.tgz",
+          "integrity": "sha1-/8bCii/Av7RwUrR+I/T0RqX7254=",
           "dev": true
         },
         "query-string": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.0.1.tgz",
+          "integrity": "sha512-aM+MkQClojlNiKkO09tiN2Fv8jM/L7GWIjG2liWeKljlOdOPNWr+bW3KQ+w5V/uKprpezC7fAsAMsJtJ+2rLKA==",
           "dev": true,
           "requires": {
             "decode-uri-component": "0.2.0",
@@ -18426,29 +18602,34 @@
           "dependencies": {
             "decode-uri-component": {
               "version": "0.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+              "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
               "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true
             },
             "strict-uri-encode": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+              "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
               "dev": true
             }
           }
         },
         "qw": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/qw/-/qw-1.0.1.tgz",
+          "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
           "dev": true
         },
         "read": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "dev": true,
           "requires": {
             "mute-stream": "0.0.7"
@@ -18456,14 +18637,16 @@
           "dependencies": {
             "mute-stream": {
               "version": "0.0.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+              "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
               "dev": true
             }
           }
         },
         "read-cmd-shim": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
+          "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11"
@@ -18471,7 +18654,8 @@
         },
         "read-installed": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
@@ -18485,14 +18669,16 @@
           "dependencies": {
             "util-extend": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+              "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
               "dev": true
             }
           }
         },
         "read-package-json": {
           "version": "2.0.12",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.12.tgz",
+          "integrity": "sha512-m7/I0+tP6D34EVvSlzCtuVA4D/dHL6OpLcn2e4XVP5X57pCKGUy1JjRSBVKHWpB+vUU91sL85h84qX0MdXzBSw==",
           "dev": true,
           "requires": {
             "glob": "7.1.2",
@@ -18504,19 +18690,22 @@
           "dependencies": {
             "json-parse-better-errors": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+              "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
               "dev": true
             },
             "slash": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+              "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
               "dev": true
             }
           }
         },
         "read-package-tree": {
           "version": "5.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.6.tgz",
+          "integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg==",
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
@@ -18528,7 +18717,8 @@
         },
         "readable-stream": {
           "version": "2.3.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -18542,22 +18732,26 @@
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
               "dev": true
             },
             "string_decoder": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
               "dev": true,
               "requires": {
                 "safe-buffer": "5.1.1"
@@ -18565,14 +18759,16 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true
             }
           }
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+          "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
@@ -18583,7 +18779,8 @@
         },
         "request": {
           "version": "2.83.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
           "dev": true,
           "requires": {
             "aws-sign2": "0.7.0",
@@ -18612,22 +18809,26 @@
           "dependencies": {
             "aws-sign2": {
               "version": "0.7.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+              "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
               "dev": true
             },
             "aws4": {
               "version": "1.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+              "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
               "dev": true
             },
             "caseless": {
               "version": "0.12.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
               "dev": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
               "dev": true,
               "requires": {
                 "delayed-stream": "1.0.0"
@@ -18635,24 +18836,28 @@
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                   "dev": true
                 }
               }
             },
             "extend": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
               "dev": true
             },
             "forever-agent": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
               "dev": true
             },
             "form-data": {
               "version": "2.3.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+              "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
               "dev": true,
               "requires": {
                 "asynckit": "0.4.0",
@@ -18662,14 +18867,16 @@
               "dependencies": {
                 "asynckit": {
                   "version": "0.4.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                  "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
                   "dev": true
                 }
               }
             },
             "har-validator": {
               "version": "5.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+              "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
               "dev": true,
               "requires": {
                 "ajv": "5.2.3",
@@ -18678,7 +18885,8 @@
               "dependencies": {
                 "ajv": {
                   "version": "5.2.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+                  "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
                   "dev": true,
                   "requires": {
                     "co": "4.6.0",
@@ -18689,22 +18897,26 @@
                   "dependencies": {
                     "co": {
                       "version": "4.6.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
                       "dev": true
                     },
                     "fast-deep-equal": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+                      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
                       "dev": true
                     },
                     "json-schema-traverse": {
                       "version": "0.3.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+                      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
                       "dev": true
                     },
                     "json-stable-stringify": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                       "dev": true,
                       "requires": {
                         "jsonify": "0.0.0"
@@ -18712,7 +18924,8 @@
                       "dependencies": {
                         "jsonify": {
                           "version": "0.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
                           "dev": true
                         }
                       }
@@ -18721,14 +18934,16 @@
                 },
                 "har-schema": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+                  "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
                   "dev": true
                 }
               }
             },
             "hawk": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+              "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
               "dev": true,
               "requires": {
                 "boom": "4.3.1",
@@ -18739,7 +18954,8 @@
               "dependencies": {
                 "boom": {
                   "version": "4.3.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+                  "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
                   "dev": true,
                   "requires": {
                     "hoek": "4.2.0"
@@ -18747,7 +18963,8 @@
                 },
                 "cryptiles": {
                   "version": "3.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+                  "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
                   "dev": true,
                   "requires": {
                     "boom": "5.2.0"
@@ -18755,7 +18972,8 @@
                   "dependencies": {
                     "boom": {
                       "version": "5.2.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                      "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                       "dev": true,
                       "requires": {
                         "hoek": "4.2.0"
@@ -18765,12 +18983,14 @@
                 },
                 "hoek": {
                   "version": "4.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+                  "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
                   "dev": true
                 },
                 "sntp": {
                   "version": "2.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
+                  "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
                   "dev": true,
                   "requires": {
                     "hoek": "4.2.0"
@@ -18780,7 +19000,8 @@
             },
             "http-signature": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+              "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
               "dev": true,
               "requires": {
                 "assert-plus": "1.0.0",
@@ -18790,12 +19011,14 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "dev": true
                 },
                 "jsprim": {
                   "version": "1.4.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+                  "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
                   "dev": true,
                   "requires": {
                     "assert-plus": "1.0.0",
@@ -18806,17 +19029,20 @@
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.3.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+                      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
                       "dev": true
                     },
                     "json-schema": {
                       "version": "0.2.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
                       "dev": true
                     },
                     "verror": {
                       "version": "1.10.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+                      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
                       "dev": true,
                       "requires": {
                         "assert-plus": "1.0.0",
@@ -18826,7 +19052,8 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                           "dev": true
                         }
                       }
@@ -18835,7 +19062,8 @@
                 },
                 "sshpk": {
                   "version": "1.13.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+                  "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
                   "dev": true,
                   "requires": {
                     "asn1": "0.2.3",
@@ -18850,12 +19078,14 @@
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
                       "dev": true
                     },
                     "bcrypt-pbkdf": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
                       "dev": true,
                       "optional": true,
                       "requires": {
@@ -18864,7 +19094,8 @@
                     },
                     "dashdash": {
                       "version": "1.14.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                       "dev": true,
                       "requires": {
                         "assert-plus": "1.0.0"
@@ -18872,7 +19103,8 @@
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                       "dev": true,
                       "optional": true,
                       "requires": {
@@ -18881,7 +19113,8 @@
                     },
                     "getpass": {
                       "version": "0.1.7",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                       "dev": true,
                       "requires": {
                         "assert-plus": "1.0.0"
@@ -18889,13 +19122,15 @@
                     },
                     "jsbn": {
                       "version": "0.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                       "dev": true,
                       "optional": true
                     },
                     "tweetnacl": {
                       "version": "0.14.5",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                       "dev": true,
                       "optional": true
                     }
@@ -18905,22 +19140,26 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
               "dev": true
             },
             "isstream": {
               "version": "0.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
               "dev": true
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
               "dev": true
             },
             "mime-types": {
               "version": "2.1.17",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+              "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
               "dev": true,
               "requires": {
                 "mime-db": "1.30.0"
@@ -18928,34 +19167,40 @@
               "dependencies": {
                 "mime-db": {
                   "version": "1.30.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+                  "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
                   "dev": true
                 }
               }
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
               "dev": true
             },
             "performance-now": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+              "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
               "dev": true
             },
             "qs": {
               "version": "6.5.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+              "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
               "dev": true
             },
             "stringstream": {
               "version": "0.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
               "dev": true
             },
             "tough-cookie": {
               "version": "2.3.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+              "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
               "dev": true,
               "requires": {
                 "punycode": "1.4.1"
@@ -18963,14 +19208,16 @@
               "dependencies": {
                 "punycode": {
                   "version": "1.4.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                  "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
                   "dev": true
                 }
               }
             },
             "tunnel-agent": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
               "dev": true,
               "requires": {
                 "safe-buffer": "5.1.1"
@@ -18980,12 +19227,14 @@
         },
         "retry": {
           "version": "0.10.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+          "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
           "dev": true
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -18993,17 +19242,20 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "semver": {
           "version": "5.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         },
         "sha": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+          "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -19012,17 +19264,20 @@
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "sorted-object": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
+          "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
           "dev": true
         },
         "sorted-union-stream": {
           "version": "2.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
+          "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
           "dev": true,
           "requires": {
             "from2": "1.3.0",
@@ -19031,7 +19286,8 @@
           "dependencies": {
             "from2": {
               "version": "1.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
+              "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
               "dev": true,
               "requires": {
                 "inherits": "2.0.3",
@@ -19040,7 +19296,8 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                   "dev": true,
                   "requires": {
                     "core-util-is": "1.0.2",
@@ -19051,17 +19308,20 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                       "dev": true
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
                       "dev": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                       "dev": true
                     }
                   }
@@ -19070,7 +19330,8 @@
             },
             "stream-iterate": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
+              "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
               "dev": true,
               "requires": {
                 "readable-stream": "2.3.3",
@@ -19079,7 +19340,8 @@
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                   "dev": true
                 }
               }
@@ -19088,7 +19350,8 @@
         },
         "ssri": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz",
+          "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -19096,7 +19359,8 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
@@ -19104,14 +19368,16 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             }
           }
         },
         "tar": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.0.2.tgz",
+          "integrity": "sha512-4lWN4uAEWzw8aHyBUx9HWXvH3vIFEhOyvN22HfBzWpE07HaTBXM8ttSeCQpswRo5On4q3nmmYmk7Tomn0uhUaw==",
           "dev": true,
           "requires": {
             "chownr": "1.0.1",
@@ -19123,7 +19389,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.1.tgz",
+              "integrity": "sha512-u1aUllxPJUI07cOqzR7reGmQxmCqlH88uIIsf6XZFEWgw7gXKpJdR+5R9Y3KEDmWYkdIz9wXZs3C0jOPxejk/Q==",
               "dev": true,
               "requires": {
                 "yallist": "3.0.2"
@@ -19131,7 +19398,8 @@
             },
             "minizlib": {
               "version": "1.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.0.4.tgz",
+              "integrity": "sha512-sN4U9tIJtBRwKbwgFh9qJfrPIQ/GGTRr1MGqkgOeMTLy8/lM0FcWU//FqlnZ3Vb7gJ+Mxh3FOg1EklibdajbaQ==",
               "dev": true,
               "requires": {
                 "minipass": "2.2.1"
@@ -19139,29 +19407,34 @@
             },
             "yallist": {
               "version": "3.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+              "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
               "dev": true
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
           "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
           "dev": true
         },
         "unique-filename": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+          "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
           "dev": true,
           "requires": {
             "unique-slug": "2.0.0"
@@ -19169,7 +19442,8 @@
           "dependencies": {
             "unique-slug": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+              "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
               "dev": true,
               "requires": {
                 "imurmurhash": "0.1.4"
@@ -19179,12 +19453,14 @@
         },
         "unpipe": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
           "dev": true
         },
         "update-notifier": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
+          "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
           "dev": true,
           "requires": {
             "boxen": "1.2.1",
@@ -19200,7 +19476,8 @@
           "dependencies": {
             "boxen": {
               "version": "1.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.1.tgz",
+              "integrity": "sha1-DxHn/jRO25OXl3/BPt5/ZNlWSB0=",
               "dev": true,
               "requires": {
                 "ansi-align": "2.0.0",
@@ -19214,7 +19491,8 @@
               "dependencies": {
                 "ansi-align": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+                  "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
                   "dev": true,
                   "requires": {
                     "string-width": "2.1.1"
@@ -19222,17 +19500,20 @@
                 },
                 "camelcase": {
                   "version": "4.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                  "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                   "dev": true
                 },
                 "cli-boxes": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+                  "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
                   "dev": true
                 },
                 "string-width": {
                   "version": "2.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                  "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                   "dev": true,
                   "requires": {
                     "is-fullwidth-code-point": "2.0.0",
@@ -19241,14 +19522,16 @@
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                       "dev": true
                     }
                   }
                 },
                 "term-size": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+                  "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
                   "dev": true,
                   "requires": {
                     "execa": "0.7.0"
@@ -19256,7 +19539,8 @@
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+                      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                       "dev": true,
                       "requires": {
                         "cross-spawn": "5.1.0",
@@ -19270,7 +19554,8 @@
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                           "dev": true,
                           "requires": {
                             "lru-cache": "4.1.1",
@@ -19280,7 +19565,8 @@
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
                               "dev": true,
                               "requires": {
                                 "shebang-regex": "1.0.0"
@@ -19288,7 +19574,8 @@
                               "dependencies": {
                                 "shebang-regex": {
                                   "version": "1.0.0",
-                                  "bundled": true,
+                                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                                  "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
                                   "dev": true
                                 }
                               }
@@ -19297,17 +19584,20 @@
                         },
                         "get-stream": {
                           "version": "3.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                           "dev": true
                         },
                         "is-stream": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                           "dev": true
                         },
                         "npm-run-path": {
                           "version": "2.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+                          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
                           "dev": true,
                           "requires": {
                             "path-key": "2.0.1"
@@ -19315,24 +19605,28 @@
                           "dependencies": {
                             "path-key": {
                               "version": "2.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
                               "dev": true
                             }
                           }
                         },
                         "p-finally": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+                          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
                           "dev": true
                         },
                         "signal-exit": {
                           "version": "3.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                           "dev": true
                         },
                         "strip-eof": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
                           "dev": true
                         }
                       }
@@ -19341,7 +19635,8 @@
                 },
                 "widest-line": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+                  "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
                   "dev": true,
                   "requires": {
                     "string-width": "1.0.2"
@@ -19349,7 +19644,8 @@
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
                       "requires": {
                         "code-point-at": "1.1.0",
@@ -19359,12 +19655,14 @@
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                           "dev": true
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "dev": true,
                           "requires": {
                             "number-is-nan": "1.0.1"
@@ -19372,14 +19670,16 @@
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                               "dev": true
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                           "dev": true,
                           "requires": {
                             "ansi-regex": "2.1.1"
@@ -19387,7 +19687,8 @@
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                               "dev": true
                             }
                           }
@@ -19400,7 +19701,8 @@
             },
             "chalk": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+              "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
               "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
@@ -19410,7 +19712,8 @@
               "dependencies": {
                 "ansi-styles": {
                   "version": "3.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                  "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                   "dev": true,
                   "requires": {
                     "color-convert": "1.9.0"
@@ -19418,7 +19721,8 @@
                   "dependencies": {
                     "color-convert": {
                       "version": "1.9.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+                      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
                       "dev": true,
                       "requires": {
                         "color-name": "1.1.3"
@@ -19426,7 +19730,8 @@
                       "dependencies": {
                         "color-name": {
                           "version": "1.1.3",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
                           "dev": true
                         }
                       }
@@ -19435,12 +19740,14 @@
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
                   "dev": true
                 },
                 "supports-color": {
                   "version": "4.4.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+                  "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                   "dev": true,
                   "requires": {
                     "has-flag": "2.0.0"
@@ -19448,7 +19755,8 @@
                   "dependencies": {
                     "has-flag": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
                       "dev": true
                     }
                   }
@@ -19457,7 +19765,8 @@
             },
             "configstore": {
               "version": "3.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
+              "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
               "dev": true,
               "requires": {
                 "dot-prop": "4.2.0",
@@ -19470,7 +19779,8 @@
               "dependencies": {
                 "dot-prop": {
                   "version": "4.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+                  "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
                   "dev": true,
                   "requires": {
                     "is-obj": "1.0.1"
@@ -19478,14 +19788,16 @@
                   "dependencies": {
                     "is-obj": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+                      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
                       "dev": true
                     }
                   }
                 },
                 "make-dir": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+                  "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
                   "dev": true,
                   "requires": {
                     "pify": "2.3.0"
@@ -19493,14 +19805,16 @@
                   "dependencies": {
                     "pify": {
                       "version": "2.3.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                       "dev": true
                     }
                   }
                 },
                 "unique-string": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+                  "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
                   "dev": true,
                   "requires": {
                     "crypto-random-string": "1.0.0"
@@ -19508,7 +19822,8 @@
                   "dependencies": {
                     "crypto-random-string": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+                      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
                       "dev": true
                     }
                   }
@@ -19517,12 +19832,14 @@
             },
             "import-lazy": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+              "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
               "dev": true
             },
             "is-installed-globally": {
               "version": "0.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+              "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
               "dev": true,
               "requires": {
                 "global-dirs": "0.1.0",
@@ -19531,7 +19848,8 @@
               "dependencies": {
                 "global-dirs": {
                   "version": "0.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.0.tgz",
+                  "integrity": "sha1-ENNAOeDfBCcuJizyQiT3IJQ0308=",
                   "dev": true,
                   "requires": {
                     "ini": "1.3.4"
@@ -19539,7 +19857,8 @@
                 },
                 "is-path-inside": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+                  "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
                   "dev": true,
                   "requires": {
                     "path-is-inside": "1.0.2"
@@ -19549,12 +19868,14 @@
             },
             "is-npm": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+              "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
               "dev": true
             },
             "latest-version": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+              "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
               "dev": true,
               "requires": {
                 "package-json": "4.0.1"
@@ -19562,7 +19883,8 @@
               "dependencies": {
                 "package-json": {
                   "version": "4.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+                  "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
                   "dev": true,
                   "requires": {
                     "got": "6.7.1",
@@ -19573,7 +19895,8 @@
                   "dependencies": {
                     "got": {
                       "version": "6.7.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+                      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
                       "dev": true,
                       "requires": {
                         "create-error-class": "3.0.2",
@@ -19591,7 +19914,8 @@
                       "dependencies": {
                         "create-error-class": {
                           "version": "3.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+                          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
                           "dev": true,
                           "requires": {
                             "capture-stack-trace": "1.0.0"
@@ -19599,54 +19923,64 @@
                           "dependencies": {
                             "capture-stack-trace": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+                              "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
                               "dev": true
                             }
                           }
                         },
                         "duplexer3": {
                           "version": "0.1.4",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+                          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
                           "dev": true
                         },
                         "get-stream": {
                           "version": "3.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                           "dev": true
                         },
                         "is-redirect": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+                          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
                           "dev": true
                         },
                         "is-retry-allowed": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+                          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
                           "dev": true
                         },
                         "is-stream": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                           "dev": true
                         },
                         "lowercase-keys": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+                          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
                           "dev": true
                         },
                         "timed-out": {
                           "version": "4.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+                          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
                           "dev": true
                         },
                         "unzip-response": {
                           "version": "2.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+                          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
                           "dev": true
                         },
                         "url-parse-lax": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+                          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
                           "dev": true,
                           "requires": {
                             "prepend-http": "1.0.4"
@@ -19654,7 +19988,8 @@
                           "dependencies": {
                             "prepend-http": {
                               "version": "1.0.4",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+                              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
                               "dev": true
                             }
                           }
@@ -19663,7 +19998,8 @@
                     },
                     "registry-auth-token": {
                       "version": "3.3.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+                      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
                       "dev": true,
                       "requires": {
                         "rc": "1.2.1",
@@ -19672,7 +20008,8 @@
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                           "dev": true,
                           "requires": {
                             "deep-extend": "0.4.2",
@@ -19683,17 +20020,20 @@
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+                              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
                               "dev": true
                             },
                             "minimist": {
                               "version": "1.2.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                               "dev": true
                             },
                             "strip-json-comments": {
                               "version": "2.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                               "dev": true
                             }
                           }
@@ -19702,7 +20042,8 @@
                     },
                     "registry-url": {
                       "version": "3.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+                      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
                       "dev": true,
                       "requires": {
                         "rc": "1.2.1"
@@ -19710,7 +20051,8 @@
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                           "dev": true,
                           "requires": {
                             "deep-extend": "0.4.2",
@@ -19721,17 +20063,20 @@
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+                              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
                               "dev": true
                             },
                             "minimist": {
                               "version": "1.2.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                               "dev": true
                             },
                             "strip-json-comments": {
                               "version": "2.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                               "dev": true
                             }
                           }
@@ -19744,7 +20089,8 @@
             },
             "semver-diff": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+              "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
               "dev": true,
               "requires": {
                 "semver": "5.4.1"
@@ -19752,19 +20098,22 @@
             },
             "xdg-basedir": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+              "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
               "dev": true
             }
           }
         },
         "uuid": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "dev": true,
           "requires": {
             "spdx-correct": "1.0.2",
@@ -19773,7 +20122,8 @@
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
               "dev": true,
               "requires": {
                 "spdx-license-ids": "1.2.2"
@@ -19781,21 +20131,24 @@
               "dependencies": {
                 "spdx-license-ids": {
                   "version": "1.2.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                  "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
                   "dev": true
                 }
               }
             },
             "spdx-expression-parse": {
               "version": "1.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+              "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
               "dev": true
             }
           }
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "dev": true,
           "requires": {
             "builtins": "1.0.3"
@@ -19803,14 +20156,16 @@
           "dependencies": {
             "builtins": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+              "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
               "dev": true
             }
           }
         },
         "which": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
             "isexe": "2.0.0"
@@ -19818,14 +20173,16 @@
           "dependencies": {
             "isexe": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
               "dev": true
             }
           }
         },
         "worker-farm": {
           "version": "1.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.1.tgz",
+          "integrity": "sha512-T5NH6Wqsd8MwGD4AK8BBllUy6LmHaqjEOyo/YIUEegZui6/v5Bqde//3jwyE3PGiGYMmWi06exFBi5LNhhPFNw==",
           "dev": true,
           "requires": {
             "errno": "0.1.4",
@@ -19834,7 +20191,8 @@
           "dependencies": {
             "errno": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+              "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
               "dev": true,
               "requires": {
                 "prr": "0.0.0"
@@ -19842,26 +20200,30 @@
               "dependencies": {
                 "prr": {
                   "version": "0.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+                  "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
                   "dev": true
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
               "dev": true
             }
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
+          "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -19893,7 +20255,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
         "are-we-there-yet": "1.1.4",
@@ -20318,12 +20680,6 @@
         }
       }
     },
-    "os-browserify": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
-      "dev": true
-    },
     "os-filter-obj": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz",
@@ -20430,7 +20786,7 @@
     "p-map": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-      "integrity": "sha1-5OlPMR6rvIYzoeeZCBZfyiYkG2s=",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
     },
     "p-map-series": {
@@ -20467,12 +20823,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-      "dev": true
-    },
-    "pako": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
       "dev": true
     },
     "parallel-transform": {
@@ -20534,7 +20884,7 @@
       "dev": true,
       "requires": {
         "asn1.js": "4.10.1",
-        "browserify-aes": "1.2.0",
+        "browserify-aes": "1.1.1",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
         "pbkdf2": "3.0.14"
@@ -20570,7 +20920,7 @@
       "dev": true,
       "requires": {
         "error-ex": "1.3.1",
-        "json-parse-better-errors": "1.0.2"
+        "json-parse-better-errors": "1.0.1"
       }
     },
     "parse-passwd": {
@@ -20585,7 +20935,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.2"
+        "@types/node": "9.6.0"
       }
     },
     "parseurl": {
@@ -22084,8 +22434,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000823",
-            "electron-to-chromium": "1.3.42"
+            "caniuse-db": "1.0.30000820",
+            "electron-to-chromium": "1.3.40"
           }
         },
         "has-flag": {
@@ -23250,7 +23600,7 @@
         "clean-css": "4.1.11",
         "glob": "7.1.2",
         "rework": "1.0.1",
-        "uglify-js": "3.3.18",
+        "uglify-js": "3.3.16",
         "yargs": "8.0.2"
       },
       "dependencies": {
@@ -23939,9 +24289,9 @@
     "react-jsonschema-form": {
       "version": "0.50.0",
       "resolved": "https://registry.npmjs.org/react-jsonschema-form/-/react-jsonschema-form-0.50.0.tgz",
-      "integrity": "sha1-w5mJJDwgTo0TVRyvdEnkDTWtF0E=",
+      "integrity": "sha512-tvBL2sERUIG61U1Qzy3yvIOEi8mPG/4bPF9hVxZ1YB6o4nFgFQpV/1uvSW2OdxALweC/lwKlEN2gjTfaKMXvYg==",
       "requires": {
-        "jsonschema": "1.2.4",
+        "jsonschema": "1.2.2",
         "lodash.topath": "4.5.2",
         "prop-types": "15.6.0",
         "setimmediate": "1.0.5"
@@ -24028,7 +24378,7 @@
     "react-transition-group": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
-      "integrity": "sha1-4R9yslf5IbITIpp3TfRmEjRsfKY=",
+      "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
       "requires": {
         "chain-function": "1.0.0",
         "dom-helpers": "3.3.1",
@@ -24135,7 +24485,7 @@
       "requires": {
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
-        "json-parse-better-errors": "1.0.2",
+        "json-parse-better-errors": "1.0.1",
         "normalize-package-data": "2.4.0",
         "slash": "1.0.0"
       },
@@ -24404,7 +24754,7 @@
       "integrity": "sha1-cW34AEeG3q8ByTrjlshPwQQeQks=",
       "requires": {
         "lodash": "4.17.5",
-        "lodash-es": "4.17.8",
+        "lodash-es": "4.17.7",
         "loose-envify": "1.3.1"
       },
       "dependencies": {
@@ -24895,7 +25245,7 @@
     "rxjs": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.3.tgz",
-      "integrity": "sha1-B1jN3uYDPWjg/VNnbw81ls49SD8=",
+      "integrity": "sha512-fSNi+y+P9ss+EZuV0GcIIqPUK07DEaMRUtLJvdcvMyFjc9dizuDjere+A4V7JrLGnm9iCc+nagV/4QdMTkqC4A==",
       "requires": {
         "symbol-observable": "1.2.0"
       }
@@ -24907,13 +25257,13 @@
       "dev": true,
       "requires": {
         "@types/lodash-es": "4.17.0",
-        "lodash-es": "4.17.8"
+        "lodash-es": "4.17.7"
       }
     },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -25266,7 +25616,7 @@
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs="
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "semver-regex": {
       "version": "1.0.0",
@@ -25812,7 +26162,7 @@
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
-        "atob": "2.1.0",
+        "atob": "2.0.3",
         "decode-uri-component": "0.2.0",
         "resolve-url": "0.2.1",
         "source-map-url": "0.4.0",
@@ -26176,9 +26526,9 @@
       }
     },
     "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
       "dev": true
     },
     "stealthy-require": {
@@ -26337,7 +26687,7 @@
     "stream-exhaust": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
-      "integrity": "sha1-rNrI2lnvK8HheiwMz2wyDRIOVV0="
+      "integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw=="
     },
     "stream-http": {
       "version": "2.8.1",
@@ -28053,15 +28403,6 @@
       "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
       "dev": true
     },
-    "timers-browserify": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
-      "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
-      "dev": true,
-      "requires": {
-        "setimmediate": "1.0.5"
-      }
-    },
     "tiny-emitter": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-1.2.0.tgz",
@@ -28939,9 +29280,9 @@
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
     },
     "uglify-js": {
-      "version": "3.3.18",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.18.tgz",
-      "integrity": "sha512-VhjIFv93KnTx/ntNi9yTBbfrsWnQnqUy02MT32uqU/5i2oEJ8GAEJ0AwYV206JeOmIzSjm41Ba0iXVKv6j7y9g==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.16.tgz",
+      "integrity": "sha512-FMh5SRqJRGhv9BbaTffENIpDDQIoPDR8DBraunGORGhySArsXlw9++CN+BWzPBLpoI4RcSnpfGPnilTxWL3Vvg==",
       "dev": true,
       "requires": {
         "commander": "2.15.1",
@@ -30058,6 +30399,32 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "base64-js": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
+          "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
+          "dev": true
+        },
+        "browserify-zlib": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+          "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+          "dev": true,
+          "requires": {
+            "pako": "1.0.6"
+          }
+        },
+        "buffer": {
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "dev": true,
+          "requires": {
+            "base64-js": "1.2.3",
+            "ieee754": "1.1.11",
+            "isarray": "1.0.0"
+          }
+        },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -30076,6 +30443,18 @@
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
+        "https-browserify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+          "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
         "load-json-file": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -30087,6 +30466,49 @@
             "pify": "2.3.0",
             "strip-bom": "3.0.0"
           }
+        },
+        "node-libs-browser": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
+          "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+          "dev": true,
+          "requires": {
+            "assert": "1.4.1",
+            "browserify-zlib": "0.2.0",
+            "buffer": "4.9.1",
+            "console-browserify": "1.1.0",
+            "constants-browserify": "1.0.0",
+            "crypto-browserify": "3.12.0",
+            "domain-browser": "1.2.0",
+            "events": "1.1.1",
+            "https-browserify": "1.0.0",
+            "os-browserify": "0.3.0",
+            "path-browserify": "0.0.0",
+            "process": "0.11.10",
+            "punycode": "1.4.1",
+            "querystring-es3": "0.2.1",
+            "readable-stream": "2.3.5",
+            "stream-browserify": "2.0.1",
+            "stream-http": "2.8.1",
+            "string_decoder": "1.1.0",
+            "timers-browserify": "2.0.6",
+            "tty-browserify": "0.0.0",
+            "url": "0.11.0",
+            "util": "0.10.3",
+            "vm-browserify": "0.0.4"
+          }
+        },
+        "os-browserify": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+          "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+          "dev": true
+        },
+        "pako": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+          "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+          "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
@@ -30112,6 +30534,12 @@
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
+        "process": {
+          "version": "0.11.10",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+          "dev": true
+        },
         "read-pkg": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -30131,6 +30559,32 @@
           "requires": {
             "find-up": "2.1.0",
             "read-pkg": "2.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          },
+          "dependencies": {
+            "string_decoder": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "5.1.1"
+              }
+            }
           }
         },
         "source-map": {
@@ -30166,6 +30620,15 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.0.tgz",
+          "integrity": "sha512-8zQpRF6juocE69ae7CSPmYEGJe4VCXwP6S6dxUWI7i53Gwv54/ec41fiUA+X7BPGGv7fRSQJjBQVa0gomGaOgg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -30179,6 +30642,15 @@
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
+          }
+        },
+        "timers-browserify": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
+          "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
+          "dev": true,
+          "requires": {
+            "setimmediate": "1.0.5"
           }
         },
         "uglify-js": {
@@ -30995,15 +31467,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
-    },
-    "whatwg-mimetype": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
-      "integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
-      "dev": true
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
     },
     "whatwg-url": {
       "version": "6.4.0",
@@ -31040,7 +31506,7 @@
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
         "string-width": "1.0.2"
@@ -31183,6 +31649,12 @@
       "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8=",
       "dev": true
     },
+    "xml-char-classes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
+      "integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0=",
+      "dev": true
+    },
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
@@ -31204,6 +31676,15 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
+    },
+    "xmldoc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-1.1.0.tgz",
+      "integrity": "sha1-JckvCPJj80TayNCzI3CnAe6dDpM=",
+      "dev": true,
+      "requires": {
+        "sax": "1.2.4"
+      }
     },
     "xmldom": {
       "version": "0.1.27",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -44,6 +44,12 @@
             "supports-color": "5.3.0"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
@@ -122,6 +128,12 @@
             "supports-color": "5.3.0"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
@@ -150,6 +162,14 @@
         "lodash.snakecase": "4.1.1",
         "lodash.startcase": "4.4.0",
         "lodash.upperfirst": "4.3.1"
+      },
+      "dependencies": {
+        "lodash.camelcase": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+          "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+          "dev": true
+        }
       }
     },
     "@commitlint/execute-rule": {
@@ -209,6 +229,12 @@
             "supports-color": "5.3.0"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
@@ -257,6 +283,58 @@
         "lodash.pick": "4.4.0",
         "lodash.topairs": "4.3.0",
         "resolve-from": "4.0.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+          "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+          "dev": true,
+          "requires": {
+            "is-directory": "0.3.1",
+            "js-yaml": "3.11.0",
+            "parse-json": "4.0.0",
+            "require-from-string": "2.0.1"
+          }
+        },
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.11.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+          "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.10",
+            "esprima": "4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
+          }
+        },
+        "require-from-string": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+          "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
       }
     },
     "@commitlint/message": {
@@ -272,7 +350,221 @@
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "1.6.6",
-        "conventional-commits-parser": "2.1.6"
+        "conventional-commits-parser": "2.1.5"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "camelcase-keys": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+          "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
+          }
+        },
+        "conventional-changelog-angular": {
+          "version": "1.6.6",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
+          "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
+          "dev": true,
+          "requires": {
+            "compare-func": "1.3.2",
+            "q": "1.5.1"
+          }
+        },
+        "conventional-commits-parser": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.5.tgz",
+          "integrity": "sha512-jaAP61py+ISMF3/n3yIiIuY5h6mJlucOqawu5mLB1HaQADLvg/y5UB3pT7HSucZJan34lp7+7ylQPfbKEGmxrA==",
+          "dev": true,
+          "requires": {
+            "JSONStream": "1.3.2",
+            "is-text-path": "1.0.1",
+            "lodash": "4.17.5",
+            "meow": "4.0.0",
+            "split2": "2.2.0",
+            "through2": "2.0.3",
+            "trim-off-newlines": "1.0.1"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "dev": true
+        },
+        "map-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+          "dev": true
+        },
+        "meow": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
+          "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "redent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+          "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+          "dev": true,
+          "requires": {
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        },
+        "through2": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
+          }
+        },
+        "trim-newlines": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+          "dev": true
+        }
       }
     },
     "@commitlint/read": {
@@ -284,7 +576,222 @@
         "@commitlint/top-level": "6.1.3",
         "@marionebl/sander": "0.6.1",
         "babel-runtime": "6.23.0",
-        "git-raw-commits": "1.3.5"
+        "git-raw-commits": "1.3.4"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "camelcase-keys": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+          "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "git-raw-commits": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.4.tgz",
+          "integrity": "sha512-G3O+41xHbscpgL5nA0DUkbFVgaAz5rd57AMSIMew8p7C8SyFwZDyn08MoXHkTl9zcD0LmxsLFPxbqFY4YPbpPA==",
+          "dev": true,
+          "requires": {
+            "dargs": "4.1.0",
+            "lodash.template": "4.4.0",
+            "meow": "4.0.0",
+            "split2": "2.2.0",
+            "through2": "2.0.3"
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "lodash.template": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+          "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.templatesettings": "4.1.0"
+          }
+        },
+        "lodash.templatesettings": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+          "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "3.0.0"
+          }
+        },
+        "map-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+          "dev": true
+        },
+        "meow": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
+          "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "redent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+          "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+          "dev": true,
+          "requires": {
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        },
+        "through2": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
+          }
+        },
+        "trim-newlines": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+          "dev": true
+        }
       }
     },
     "@commitlint/resolve-extends": {
@@ -316,6 +823,12 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
           "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
           "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
         }
       }
     },
@@ -344,6 +857,17 @@
       "dev": true,
       "requires": {
         "find-up": "2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
       }
     },
     "@cypress/listr-verbose-renderer": {
@@ -438,14 +962,6 @@
         "graceful-fs": "4.1.11",
         "mkdirp": "0.5.1",
         "rimraf": "2.6.2"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        }
       }
     },
     "@types/blob-util": {
@@ -510,9 +1026,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.0.tgz",
-      "integrity": "sha512-h3YZbOq2+ZoDFI1z8Zx0Ck/xRWkOESVaLdgLdd/c25mMQ1Y2CAkILu9ny5A15S5f32gGcQdaUIZ2jzYr8D7IFg==",
+      "version": "9.4.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.7.tgz",
+      "integrity": "sha512-4Ba90mWNx8ddbafuyGGwjkZMigi+AWfYLSDCpovwsE63ia8w93r3oJ8PIAQc3y8U+XHcnMOHPIzNe3o438Ywcw==",
       "dev": true
     },
     "@types/react": {
@@ -631,14 +1147,12 @@
       }
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "requires": {
         "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "json-stable-stringify": "1.0.1"
       }
     },
     "ajv-keywords": {
@@ -743,14 +1257,6 @@
       "dev": true,
       "requires": {
         "file-type": "3.9.0"
-      },
-      "dependencies": {
-        "file-type": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-          "dev": true
-        }
       }
     },
     "archy": {
@@ -855,9 +1361,9 @@
       "dev": true
     },
     "array-flatten": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
-      "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
     "array-ify": {
@@ -873,7 +1379,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.11.0"
+        "es-abstract": "1.10.0"
       }
     },
     "array-slice": {
@@ -909,7 +1415,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.11.0"
+        "es-abstract": "1.10.0"
       }
     },
     "arrify": {
@@ -919,10 +1425,9 @@
       "dev": true
     },
     "asap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
-      "integrity": "sha1-sqRdpf36ILBJb8N2jMJ8EvqRan0=",
-      "optional": true
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.3",
@@ -950,9 +1455,9 @@
       }
     },
     "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -973,21 +1478,10 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.5"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-          "dev": true
-        }
-      }
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+      "dev": true
     },
     "async-done": {
       "version": "0.4.0",
@@ -1036,19 +1530,13 @@
       "dev": true,
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000820",
+        "caniuse-db": "1.0.30000815",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
         "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -1060,12 +1548,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -1079,9 +1561,9 @@
       }
     },
     "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
     },
     "aws4": {
       "version": "1.6.0",
@@ -1115,12 +1597,6 @@
           "version": "4.17.5",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
           "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
@@ -1177,12 +1653,6 @@
           "requires": {
             "brace-expansion": "1.1.11"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         }
       }
     },
@@ -1222,12 +1692,6 @@
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
           "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
@@ -1447,22 +1911,22 @@
       }
     },
     "babel-jest": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.3.tgz",
-      "integrity": "sha512-BgSjmtl3mW3i+VeVHEr9d2zFSAT66G++pJcHQiUjd00pkW+voYXFctIm/indcqOWWXw5a1nUpR1XWszD9fJ1qg==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.1.tgz",
+      "integrity": "sha512-rEdN/jevSuX0IQKcUqwqOGa0gDNis4jGY52Rq53aizfDGPwQYNJq+f9NCMT1HUhtUZhYSjvfGUfHQWBRT1/icA==",
       "dev": true,
       "requires": {
         "babel-plugin-istanbul": "4.1.5",
-        "babel-preset-jest": "22.4.3"
+        "babel-preset-jest": "22.4.1"
       },
       "dependencies": {
         "babel-preset-jest": {
-          "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz",
-          "integrity": "sha512-a+M3LTEXTq3gxv0uBN9Qm6ahUl7a8pj923nFbCUdqFUSsf3YrX8Uc+C3MEwji5Af3LiQjSC7w4ooYewlz8HRTA==",
+          "version": "22.4.1",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.1.tgz",
+          "integrity": "sha512-gW3+spyB8fkSAI9fX+41BQMwar5LjR+nyKa2QRvK22snxnI29+jJVAMfId+osucFJzJJvhlvzKWnfwX8Omodvg==",
           "dev": true,
           "requires": {
-            "babel-plugin-jest-hoist": "22.4.3",
+            "babel-plugin-jest-hoist": "22.4.1",
             "babel-plugin-syntax-object-rest-spread": "6.13.0"
           }
         }
@@ -1477,6 +1941,48 @@
         "find-cache-dir": "1.0.0",
         "loader-utils": "1.1.0",
         "mkdirp": "0.5.1"
+      },
+      "dependencies": {
+        "find-cache-dir": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+          "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+          "dev": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "make-dir": "1.2.0",
+            "pkg-dir": "2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0"
+          }
+        }
       }
     },
     "babel-messages": {
@@ -1506,12 +2012,23 @@
         "find-up": "2.1.0",
         "istanbul-lib-instrument": "1.10.1",
         "test-exclude": "4.2.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz",
-      "integrity": "sha512-zhvv4f6OTWy2bYevcJftwGCWXMFe7pqoz41IhMi4xna7xNsX5NygdagsrE0y6kkfuXq8UalwvPwKTyAxME2E/g==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.1.tgz",
+      "integrity": "sha512-gmj5FvFflXSnRapWmF/jDjx5Lof1kX0OwXibCxMOx38V3CFMOnTxLTUrAFfLkhCey3FJvv0ACvv/+h4nzFRxhg==",
       "dev": true
     },
     "babel-plugin-react-transform": {
@@ -1983,27 +2500,9 @@
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
       "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
       "requires": {
-        "babel-runtime": "6.26.0",
+        "babel-runtime": "6.23.0",
         "core-js": "2.5.3",
         "regenerator-runtime": "0.10.5"
-      },
-      "dependencies": {
-        "babel-runtime": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-          "requires": {
-            "core-js": "2.5.3",
-            "regenerator-runtime": "0.11.1"
-          },
-          "dependencies": {
-            "regenerator-runtime": {
-              "version": "0.11.1",
-              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-              "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-            }
-          }
-        }
       }
     },
     "babel-preset-es2015": {
@@ -2044,7 +2543,7 @@
       "integrity": "sha512-p61cPMGYlSgfNScn1yQuVnLguWE4bjhB/br4KQDMbYZG+v6ryE5Ch7TKukjA6mRuIQj1zhyou7Sbpqrh4/N6Pg==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "22.4.3",
+        "babel-plugin-jest-hoist": "22.4.1",
         "babel-plugin-syntax-object-rest-spread": "6.13.0"
       }
     },
@@ -2114,7 +2613,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-      "dev": true,
       "requires": {
         "core-js": "2.5.3",
         "regenerator-runtime": "0.10.5"
@@ -2278,9 +2776,9 @@
       }
     },
     "base64-js": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-      "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
+      "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
       "dev": true
     },
     "base64-url": {
@@ -2342,12 +2840,6 @@
             "minimist": "1.2.0",
             "repeating": "1.1.3"
           }
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
         },
         "meow": {
           "version": "2.0.0",
@@ -2429,24 +2921,6 @@
         "rimraf": "2.6.2",
         "tempfile": "1.1.1",
         "url-regex": "3.2.0"
-      },
-      "dependencies": {
-        "tempfile": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
-          "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "uuid": "2.0.3"
-          }
-        },
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-          "dev": true
-        }
       }
     },
     "bin-check": {
@@ -2508,13 +2982,12 @@
       "dev": true
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.5",
-        "safe-buffer": "5.1.1"
+        "readable-stream": "2.3.5"
       },
       "dependencies": {
         "isarray": {
@@ -2634,6 +3107,14 @@
         "dns-txt": "2.0.2",
         "multicast-dns": "6.2.3",
         "multicast-dns-service-types": "1.1.0"
+      },
+      "dependencies": {
+        "array-flatten": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
+          "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
+          "dev": true
+        }
       }
     },
     "boolbase": {
@@ -2643,11 +3124,11 @@
       "dev": true
     },
     "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "2.16.3"
       }
     },
     "brace": {
@@ -2779,7 +3260,7 @@
       "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000820"
+        "caniuse-db": "1.0.30000815"
       }
     },
     "bser": {
@@ -2792,13 +3273,13 @@
       }
     },
     "buffer": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
-      "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "0.0.8",
-        "ieee754": "1.1.11",
+        "base64-js": "1.2.3",
+        "ieee754": "1.1.10",
         "isarray": "1.0.0"
       },
       "dependencies": {
@@ -2814,12 +3295,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true
-    },
-    "buffer-from": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
       "dev": true
     },
     "buffer-indexof": {
@@ -2840,12 +3315,6 @@
         "vinyl": "1.1.1"
       },
       "dependencies": {
-        "file-type": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-          "dev": true
-        },
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -2943,12 +3412,6 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
         "lru-cache": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
@@ -2967,6 +3430,12 @@
           "requires": {
             "brace-expansion": "1.1.11"
           }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
         }
       }
     },
@@ -3011,30 +3480,29 @@
       "dev": true
     },
     "camel-case": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz",
+      "integrity": "sha1-Gsp8TRlTWaLOmVV5NDPG5VQlEfI=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2",
+        "sentence-case": "1.1.3",
         "upper-case": "1.1.3"
       }
     },
     "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
       "dev": true
     },
     "camelcase-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0",
-        "map-obj": "2.0.0",
-        "quick-lru": "1.1.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       }
     },
     "caniuse-api": {
@@ -3044,15 +3512,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000820",
+        "caniuse-db": "1.0.30000815",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000820",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000820.tgz",
-      "integrity": "sha1-fCDiXOoXaLJhtyT4LjpqJTqqFGg=",
+      "version": "1.0.30000815",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000815.tgz",
+      "integrity": "sha1-DiGPoTPQ0HHIhqoEG0NSWMx0aJE=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -3135,27 +3603,6 @@
         "title-case": "1.1.2",
         "upper-case": "1.1.3",
         "upper-case-first": "1.1.2"
-      },
-      "dependencies": {
-        "camel-case": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz",
-          "integrity": "sha1-Gsp8TRlTWaLOmVV5NDPG5VQlEfI=",
-          "dev": true,
-          "requires": {
-            "sentence-case": "1.1.3",
-            "upper-case": "1.1.3"
-          }
-        },
-        "param-case": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz",
-          "integrity": "sha1-3LCRpDwlm5Io8cNB57akTqC/l0M=",
-          "dev": true,
-          "requires": {
-            "sentence-case": "1.1.3"
-          }
-        }
       }
     },
     "charenc": {
@@ -3183,11 +3630,64 @@
         "parse5": "3.0.3"
       },
       "dependencies": {
+        "domhandler": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+          "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.9.2",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+          "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0",
+            "domhandler": "2.4.1",
+            "domutils": "1.5.1",
+            "entities": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.5"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
         "lodash": {
           "version": "4.17.5",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
           "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
           "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
         }
       }
     },
@@ -3346,23 +3846,6 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.3.tgz",
       "integrity": "sha1-VRt3S2dioMCplxh/e6Tx1gOWGsU="
     },
-    "clean-css": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
-      "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
-      }
-    },
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -3424,18 +3907,18 @@
       }
     },
     "clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
     },
     "clone-regexp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
-      "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.0.tgz",
+      "integrity": "sha1-6uCiQT9VwJQvgYwin+/OhF1/Oxw=",
       "dev": true,
       "requires": {
         "is-regexp": "1.0.0",
-        "is-supported-regexp-flag": "1.0.1"
+        "is-supported-regexp-flag": "1.0.0"
       }
     },
     "clone-stats": {
@@ -3487,7 +3970,7 @@
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "dev": true,
       "requires": {
-        "clone": "1.0.4",
+        "clone": "1.0.3",
         "color-convert": "1.9.1",
         "color-string": "0.3.0"
       }
@@ -3545,12 +4028,6 @@
         "yargs": "1.3.3"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3568,12 +4045,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -3711,6 +4182,74 @@
         "find-cache-dir": "1.0.0",
         "serialize-javascript": "1.4.0",
         "webpack-sources": "1.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.5"
+          }
+        },
+        "find-cache-dir": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+          "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+          "dev": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "make-dir": "1.2.0",
+            "pkg-dir": "2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0"
+          }
+        },
+        "source-list-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+          "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "webpack-sources": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+          "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+          "dev": true,
+          "requires": {
+            "source-list-map": "2.0.0",
+            "source-map": "0.6.1"
+          }
+        }
       }
     },
     "concat-map": {
@@ -3719,12 +4258,11 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
+      "integrity": "sha1-JhuPUYMB8dg042NCuf6gldJiCiY=",
       "dev": true,
       "requires": {
-        "buffer-from": "1.0.0",
         "inherits": "2.0.3",
         "readable-stream": "2.3.5",
         "typedarray": "0.0.6"
@@ -3739,7 +4277,7 @@
         "readable-stream": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+          "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -3754,7 +4292,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -3839,12 +4377,6 @@
           "dev": true
         }
       }
-    },
-    "connect-history-api-fallback": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-      "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
-      "dev": true
     },
     "connect-livereload": {
       "version": "0.5.4",
@@ -3949,12 +4481,13 @@
       "dev": true
     },
     "conventional-changelog-angular": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
-      "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.3.0.tgz",
+      "integrity": "sha1-P2QYWXiqE6sJVMnkaniWn9WcaAE=",
       "dev": true,
       "requires": {
         "compare-func": "1.3.2",
+        "github-url-from-git": "1.5.0",
         "q": "1.5.1"
       }
     },
@@ -3992,108 +4525,22 @@
             "regenerator-runtime": "0.10.5"
           }
         },
-        "conventional-changelog-angular": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.3.0.tgz",
-          "integrity": "sha1-P2QYWXiqE6sJVMnkaniWn9WcaAE=",
-          "dev": true,
-          "requires": {
-            "compare-func": "1.3.2",
-            "github-url-from-git": "1.5.0",
-            "q": "1.5.1"
-          }
-        },
-        "conventional-commits-parser": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-1.3.0.tgz",
-          "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
-          "dev": true,
-          "requires": {
-            "JSONStream": "1.3.2",
-            "is-text-path": "1.0.1",
-            "lodash": "4.17.4",
-            "meow": "3.7.0",
-            "split2": "2.2.0",
-            "through2": "2.0.3",
-            "trim-off-newlines": "1.0.1"
-          }
-        },
-        "git-raw-commits": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.1.2.tgz",
-          "integrity": "sha1-oS2Ekq66KIGALXAIJe2ByfOeby8=",
-          "dev": true,
-          "requires": {
-            "dargs": "4.1.0",
-            "lodash.template": "4.4.0",
-            "meow": "3.7.0",
-            "split2": "2.2.0",
-            "through2": "2.0.3"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
-        "lodash.template": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-          "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+        "rc": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
+          "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "3.0.0",
-            "lodash.templatesettings": "4.1.0"
-          }
-        },
-        "lodash.templatesettings": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
-          "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-          "dev": true,
-          "requires": {
-            "lodash._reinterpolate": "3.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "through2": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "2.3.5",
-            "xtend": "4.0.1"
+            "deep-extend": "0.4.2",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           }
         }
       }
@@ -4105,15 +4552,15 @@
       "dev": true
     },
     "conventional-commits-parser": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.6.tgz",
-      "integrity": "sha512-3Z77cAKSvEG3D5BSm3IFkOTP2qz8TZX8e8OPU7BGP2ruP7zPs7laHSqiZ7eYup835FKP4yyj+DHjmcvmOyp/0w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-1.3.0.tgz",
+      "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
       "dev": true,
       "requires": {
         "JSONStream": "1.3.2",
         "is-text-path": "1.0.1",
         "lodash": "4.17.5",
-        "meow": "4.0.0",
+        "meow": "3.7.0",
         "split2": "2.2.0",
         "through2": "2.0.3",
         "trim-off-newlines": "1.0.1"
@@ -4130,23 +4577,6 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
           "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
           "dev": true
-        },
-        "meow": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
-          "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
-          "dev": true,
-          "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist": "1.2.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.4.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0"
-          }
         },
         "readable-stream": {
           "version": "2.3.5",
@@ -4256,15 +4686,27 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
-      "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
+      "integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
       "dev": true,
       "requires": {
-        "is-directory": "0.3.1",
-        "js-yaml": "3.11.0",
-        "parse-json": "4.0.0",
-        "require-from-string": "2.0.1"
+        "graceful-fs": "4.1.11",
+        "js-yaml": "3.7.0",
+        "minimist": "1.2.0",
+        "object-assign": "4.1.1",
+        "os-homedir": "1.0.2",
+        "parse-json": "2.2.0",
+        "pinkie-promise": "2.0.1",
+        "require-from-string": "1.2.1"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
       }
     },
     "crc": {
@@ -4396,21 +4838,11 @@
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        }
+        "boom": "2.10.1"
       }
     },
     "crypto-browserify": {
@@ -4518,10 +4950,41 @@
         "source-list-map": "2.0.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "css-selector-tokenizer": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+          "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+          "dev": true,
+          "requires": {
+            "cssesc": "0.1.0",
+            "fastparse": "1.1.1",
+            "regexpu-core": "1.0.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        },
+        "lodash.camelcase": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+          "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
           "dev": true
         },
         "object-assign": {
@@ -4542,10 +5005,75 @@
             "supports-color": "3.2.3"
           }
         },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+        "postcss-modules-extract-imports": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
+          "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
+          "dev": true,
+          "requires": {
+            "postcss": "6.0.21"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+              "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.3.0"
+              }
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.21",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+              "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+              "dev": true,
+              "requires": {
+                "chalk": "2.3.2",
+                "source-map": "0.6.1",
+                "supports-color": "5.3.0"
+              }
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "5.3.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+              "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+              "dev": true,
+              "requires": {
+                "has-flag": "3.0.0"
+              }
+            }
+          }
+        },
+        "regexpu-core": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+          "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+          "dev": true,
+          "requires": {
+            "regenerate": "1.3.3",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
+          }
+        },
+        "source-list-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+          "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
           "dev": true
         },
         "supports-color": {
@@ -4588,30 +5116,6 @@
       "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.3.0.tgz",
       "integrity": "sha1-XxrUPi2O77/cME/NOaUhZklD4+s=",
       "dev": true
-    },
-    "css-selector-tokenizer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
-      "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
-      "dev": true,
-      "requires": {
-        "cssesc": "0.1.0",
-        "fastparse": "1.1.1",
-        "regexpu-core": "1.0.0"
-      },
-      "dependencies": {
-        "regexpu-core": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-          "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-          "dev": true,
-          "requires": {
-            "regenerate": "1.3.3",
-            "regjsgen": "0.2.0",
-            "regjsparser": "0.1.5"
-          }
-        }
-      }
     },
     "css-tokenize": {
       "version": "1.0.1",
@@ -4681,12 +5185,6 @@
         "postcss-zindex": "2.2.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4704,12 +5202,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -4730,14 +5222,6 @@
       "requires": {
         "clap": "1.2.3",
         "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "cssom": {
@@ -4851,16 +5335,6 @@
         "yauzl": "2.8.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -4870,32 +5344,11 @@
             "color-convert": "1.9.1"
           }
         },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
-        },
         "bluebird": {
           "version": "3.5.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
           "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
           "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
         },
         "chalk": {
           "version": "2.1.0",
@@ -4925,15 +5378,6 @@
           "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
           "dev": true
         },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -4941,17 +5385,6 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
-          }
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
           }
         },
         "glob": {
@@ -4968,56 +5401,11 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "har-schema": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-          "dev": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "dev": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
         "has-flag": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.1"
-          }
         },
         "lodash": {
           "version": "4.17.4",
@@ -5034,55 +5422,13 @@
             "brace-expansion": "1.1.11"
           }
         },
-        "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+        "request-progress": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+          "integrity": "sha1-ByHBBdipasayzossia4tXs/Pazo=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
+            "throttleit": "0.0.2"
           }
         },
         "supports-color": {
@@ -5092,6 +5438,22 @@
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
+          }
+        },
+        "throttleit": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+          "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
+          "dev": true
+        },
+        "yauzl": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz",
+          "integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=",
+          "dev": true,
+          "requires": {
+            "buffer-crc32": "0.2.13",
+            "fd-slicer": "1.0.1"
           }
         }
       }
@@ -5131,6 +5493,13 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
       }
     },
     "date-and-time": {
@@ -5190,14 +5559,6 @@
       "requires": {
         "decamelize": "1.2.0",
         "map-obj": "1.0.1"
-      },
-      "dependencies": {
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        }
       }
     },
     "decode-uri-component": {
@@ -5213,7 +5574,7 @@
       "dev": true,
       "requires": {
         "buffer-to-vinyl": "1.1.0",
-        "concat-stream": "1.6.2",
+        "concat-stream": "1.6.1",
         "decompress-tar": "3.1.0",
         "decompress-tarbz2": "3.1.0",
         "decompress-targz": "3.1.0",
@@ -5297,12 +5658,6 @@
               }
             }
           }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
         },
         "is-extglob": {
           "version": "2.1.1",
@@ -5566,7 +5921,7 @@
         "strip-dirs": "1.1.1",
         "through2": "2.0.3",
         "vinyl": "1.1.1",
-        "yauzl": "2.8.0"
+        "yauzl": "2.9.1"
       },
       "dependencies": {
         "isarray": {
@@ -5654,7 +6009,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "1.0.4"
+        "clone": "1.0.3"
       }
     },
     "define-properties": {
@@ -5699,7 +6054,7 @@
       "requires": {
         "globby": "5.0.0",
         "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
+        "is-path-in-cwd": "1.0.0",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
@@ -5710,12 +6065,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
       }
@@ -5805,14 +6154,6 @@
       "requires": {
         "asap": "2.0.6",
         "wrappy": "1.0.2"
-      },
-      "dependencies": {
-        "asap": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-          "dev": true
-        }
       }
     },
     "diff": {
@@ -5888,7 +6229,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000820",
+        "caniuse-db": "1.0.30000815",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
@@ -5898,46 +6239,14 @@
         "postcss": "5.2.18",
         "source-map": "0.4.4",
         "through2": "0.6.5",
-        "yargs": "3.32.0"
+        "yargs": "3.10.0"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "lodash": {
           "version": "4.17.5",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
           "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
           "dev": true
-        },
-        "os-locale": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-          "dev": true,
-          "requires": {
-            "lcid": "1.0.0"
-          }
         },
         "postcss": {
           "version": "5.2.18",
@@ -5975,33 +6284,6 @@
           "dev": true,
           "requires": {
             "has-flag": "1.0.0"
-          }
-        },
-        "window-size": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
-          "dev": true
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-          "dev": true,
-          "requires": {
-            "camelcase": "2.1.1",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "os-locale": "1.4.0",
-            "string-width": "1.0.2",
-            "window-size": "0.1.4",
-            "y18n": "3.2.1"
           }
         }
       }
@@ -6074,9 +6356,9 @@
       }
     },
     "domhandler": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
-      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
+      "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
       "dev": true,
       "requires": {
         "domelementtype": "1.3.0"
@@ -6117,13 +6399,13 @@
       "dev": true,
       "requires": {
         "caw": "1.2.0",
-        "concat-stream": "1.6.2",
+        "concat-stream": "1.6.1",
         "each-async": "1.1.1",
         "filenamify": "1.2.1",
         "got": "5.7.1",
         "gulp-decompress": "1.2.0",
         "gulp-rename": "1.2.2",
-        "is-url": "1.2.3",
+        "is-url": "1.2.2",
         "object-assign": "4.1.1",
         "read-all-stream": "3.1.0",
         "readable-stream": "2.3.5",
@@ -6207,12 +6489,6 @@
               }
             }
           }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
         },
         "is-extglob": {
           "version": "2.1.1",
@@ -6445,7 +6721,7 @@
       "dev": true,
       "requires": {
         "he": "1.1.1",
-        "mime": "1.6.0",
+        "mime": "1.3.4",
         "minimist": "1.2.0",
         "url-join": "2.0.5"
       }
@@ -6457,9 +6733,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.40",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.40.tgz",
-      "integrity": "sha1-H71tl779crim+SHcONIkE9L2/d8=",
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.39.tgz",
+      "integrity": "sha1-16RpZAnKCZXidQFW2mEsIhr62E0=",
       "dev": true
     },
     "elegant-spinner": {
@@ -6533,12 +6809,6 @@
         "tapable": "0.2.8"
       },
       "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6680,9 +6950,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
-      "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
@@ -6851,7 +7121,7 @@
       "requires": {
         "babel-code-frame": "6.26.0",
         "chalk": "1.1.3",
-        "concat-stream": "1.6.2",
+        "concat-stream": "1.6.1",
         "debug": "2.6.9",
         "doctrine": "1.5.0",
         "escope": "3.6.0",
@@ -6866,7 +7136,7 @@
         "inquirer": "0.12.0",
         "is-my-json-valid": "2.17.2",
         "is-resolvable": "1.1.0",
-        "js-yaml": "3.11.0",
+        "js-yaml": "3.7.0",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.5",
@@ -6961,7 +7231,7 @@
           "dev": true,
           "requires": {
             "caniuse-db": "1.0.30000626",
-            "electron-to-chromium": "1.3.40"
+            "electron-to-chromium": "1.3.39"
           }
         },
         "caniuse-db": {
@@ -7013,16 +7283,6 @@
             "isarray": "1.0.0"
           }
         },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -7034,24 +7294,6 @@
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pkg-dir": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2"
-          }
         }
       }
     },
@@ -7224,19 +7466,6 @@
         "safe-buffer": "5.1.1"
       }
     },
-    "exec-buffer": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-3.2.0.tgz",
-      "integrity": "sha512-wsiD+2Tp6BWHoVv3B+5Dcx6E7u5zky+hUwOHjuH2hKSLR3dvRmX8fk8UD8uqQixHs4Wk6eDmiegVrMPjKj7wpA==",
-      "dev": true,
-      "requires": {
-        "execa": "0.7.0",
-        "p-finally": "1.0.0",
-        "pify": "3.0.0",
-        "rimraf": "2.6.2",
-        "tempfile": "2.0.0"
-      }
-    },
     "exec-series": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/exec-series/-/exec-series-1.0.3.tgz",
@@ -7285,7 +7514,7 @@
       "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
       "dev": true,
       "requires": {
-        "clone-regexp": "1.0.1"
+        "clone-regexp": "1.0.0"
       }
     },
     "executable": {
@@ -7337,17 +7566,17 @@
       }
     },
     "expect": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
-      "integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-22.4.0.tgz",
+      "integrity": "sha512-Fiy862jT3qc70hwIHwwCBNISmaqBrfWKKrtqyMJ6iwZr+6KXtcnHojZFtd63TPRvRl8EQTJ+YXYy2lK6/6u+Hw==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.1",
-        "jest-diff": "22.4.3",
-        "jest-get-type": "22.4.3",
-        "jest-matcher-utils": "22.4.3",
-        "jest-message-util": "22.4.3",
-        "jest-regex-util": "22.4.3"
+        "jest-diff": "22.4.0",
+        "jest-get-type": "22.1.0",
+        "jest-matcher-utils": "22.4.0",
+        "jest-message-util": "22.4.0",
+        "jest-regex-util": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7408,12 +7637,6 @@
             "mime-types": "2.1.18",
             "negotiator": "0.6.1"
           }
-        },
-        "array-flatten": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-          "dev": true
         },
         "body-parser": {
           "version": "1.18.2",
@@ -7514,6 +7737,12 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
           "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg=",
           "dev": true
         },
         "range-parser": {
@@ -7694,6 +7923,56 @@
         "loader-utils": "1.1.0",
         "schema-utils": "0.3.0",
         "webpack-sources": "1.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.5"
+          }
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "dev": true
+        },
+        "source-list-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+          "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "webpack-sources": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+          "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+          "dev": true,
+          "requires": {
+            "source-list-map": "2.0.0",
+            "source-map": "0.6.1"
+          }
+        }
       }
     },
     "extract-zip": {
@@ -7819,7 +8098,8 @@
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
     },
     "fast-diff": {
       "version": "1.1.2",
@@ -7830,7 +8110,8 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -8002,12 +8283,25 @@
       "requires": {
         "loader-utils": "1.1.0",
         "schema-utils": "0.3.0"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        }
       }
     },
     "file-type": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
-      "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU=",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
       "dev": true
     },
     "filename-regex": {
@@ -8029,7 +8323,7 @@
       "dev": true,
       "requires": {
         "filename-reserved-regex": "1.0.0",
-        "strip-outer": "1.0.1",
+        "strip-outer": "1.0.0",
         "trim-repeated": "1.0.0"
       }
     },
@@ -8102,29 +8396,19 @@
         }
       }
     },
-    "find-cache-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-      "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-      "dev": true,
-      "requires": {
-        "commondir": "1.0.1",
-        "make-dir": "1.2.0",
-        "pkg-dir": "2.0.0"
-      }
-    },
     "find-index": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
       "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ="
     },
     "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "find-versions": {
@@ -8155,7 +8439,7 @@
       "requires": {
         "detect-file": "1.0.0",
         "is-glob": "3.1.0",
-        "micromatch": "3.1.10",
+        "micromatch": "3.1.9",
         "resolve-dir": "1.0.1"
       },
       "dependencies": {
@@ -8410,9 +8694,9 @@
           "dev": true
         },
         "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
+          "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
           "dev": true,
           "requires": {
             "arr-diff": "4.0.0",
@@ -8466,14 +8750,6 @@
         "del": "2.2.2",
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        }
       }
     },
     "flatten": {
@@ -8567,9 +8843,9 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
@@ -8663,14 +8939,6 @@
         "graceful-fs": "4.1.11",
         "jsonfile": "3.0.1",
         "universalify": "0.1.1"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        }
       }
     },
     "fs-readdir-recursive": {
@@ -8689,14 +8957,6 @@
         "iferr": "0.1.5",
         "imurmurhash": "0.1.4",
         "readable-stream": "1.1.14"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        }
       }
     },
     "fs.realpath": {
@@ -8710,7 +8970,6 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
-      "optional": true,
       "requires": {
         "nan": "2.10.0",
         "node-pre-gyp": "0.6.39"
@@ -8719,14 +8978,12 @@
         "abbrev": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ajv": {
           "version": "4.11.8",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "co": "4.6.0",
             "json-stable-stringify": "1.0.1"
@@ -8740,14 +8997,12 @@
         "aproba": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "delegates": "1.0.0",
             "readable-stream": "2.2.9"
@@ -8756,32 +9011,27 @@
         "asn1": {
           "version": "0.2.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "assert-plus": {
           "version": "0.2.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aws-sign2": {
           "version": "0.6.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aws4": {
           "version": "1.6.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "balanced-match": {
           "version": "0.4.2",
@@ -8830,14 +9080,12 @@
         "caseless": {
           "version": "0.12.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "co": {
           "version": "4.6.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "code-point-at": {
           "version": "1.1.0",
@@ -8879,7 +9127,6 @@
           "version": "1.14.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
           },
@@ -8887,8 +9134,7 @@
             "assert-plus": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -8896,7 +9142,6 @@
           "version": "2.6.8",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -8904,8 +9149,7 @@
         "deep-extend": {
           "version": "0.4.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "delayed-stream": {
           "version": "1.0.0",
@@ -8915,14 +9159,12 @@
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "detect-libc": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
@@ -8936,8 +9178,7 @@
         "extend": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "extsprintf": {
           "version": "1.0.2",
@@ -8947,14 +9188,12 @@
         "forever-agent": {
           "version": "0.6.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "form-data": {
           "version": "2.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.5",
@@ -8981,7 +9220,6 @@
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "fstream": "1.0.11",
             "inherits": "2.0.3",
@@ -8992,7 +9230,6 @@
           "version": "2.7.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "aproba": "1.1.1",
             "console-control-strings": "1.1.0",
@@ -9008,7 +9245,6 @@
           "version": "0.1.7",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "assert-plus": "1.0.0"
           },
@@ -9016,8 +9252,7 @@
             "assert-plus": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -9042,14 +9277,12 @@
         "har-schema": {
           "version": "1.0.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "har-validator": {
           "version": "4.2.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ajv": "4.11.8",
             "har-schema": "1.0.5"
@@ -9058,8 +9291,7 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "hawk": {
           "version": "3.1.3",
@@ -9081,7 +9313,6 @@
           "version": "1.1.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "assert-plus": "0.2.0",
             "jsprim": "1.4.0",
@@ -9105,8 +9336,7 @@
         "ini": {
           "version": "1.3.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -9119,8 +9349,7 @@
         "is-typedarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "isarray": {
           "version": "1.0.0",
@@ -9130,8 +9359,7 @@
         "isstream": {
           "version": "0.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "jodid25519": {
           "version": "1.0.2",
@@ -9151,14 +9379,12 @@
         "json-schema": {
           "version": "0.2.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "jsonify": "0.0.0"
           }
@@ -9166,20 +9392,17 @@
         "json-stringify-safe": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "jsonify": {
           "version": "0.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "jsprim": {
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.0.2",
@@ -9190,8 +9413,7 @@
             "assert-plus": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -9232,14 +9454,12 @@
         "ms": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "node-pre-gyp": {
           "version": "0.6.39",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "detect-libc": "1.0.2",
             "hawk": "3.1.3",
@@ -9258,7 +9478,6 @@
           "version": "4.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "abbrev": "1.1.0",
             "osenv": "0.1.4"
@@ -9268,7 +9487,6 @@
           "version": "4.1.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
             "console-control-strings": "1.1.0",
@@ -9284,14 +9502,12 @@
         "oauth-sign": {
           "version": "0.8.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "once": {
           "version": "1.4.0",
@@ -9304,20 +9520,17 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "osenv": {
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
@@ -9331,8 +9544,7 @@
         "performance-now": {
           "version": "0.2.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
@@ -9342,20 +9554,17 @@
         "punycode": {
           "version": "1.4.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "qs": {
           "version": "6.4.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "rc": {
           "version": "1.2.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "deep-extend": "0.4.2",
             "ini": "1.3.4",
@@ -9366,8 +9575,7 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -9389,7 +9597,6 @@
           "version": "2.81.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "aws-sign2": "0.6.0",
             "aws4": "1.6.0",
@@ -9431,20 +9638,17 @@
         "semver": {
           "version": "5.3.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "sntp": {
           "version": "1.0.9",
@@ -9458,7 +9662,6 @@
           "version": "1.13.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "asn1": "0.2.3",
             "assert-plus": "1.0.0",
@@ -9474,8 +9677,7 @@
             "assert-plus": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -9500,8 +9702,7 @@
         "stringstream": {
           "version": "0.0.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -9514,8 +9715,7 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "tar": {
           "version": "2.2.1",
@@ -9531,7 +9731,6 @@
           "version": "3.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "debug": "2.6.8",
             "fstream": "1.0.11",
@@ -9547,7 +9746,6 @@
           "version": "2.3.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "punycode": "1.4.1"
           }
@@ -9556,7 +9754,6 @@
           "version": "0.6.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "5.0.1"
           }
@@ -9570,8 +9767,7 @@
         "uid-number": {
           "version": "0.0.6",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "util-deprecate": {
           "version": "1.0.2",
@@ -9581,14 +9777,12 @@
         "uuid": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "verror": {
           "version": "1.3.6",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "extsprintf": "1.0.2"
           }
@@ -9597,7 +9791,6 @@
           "version": "1.1.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "string-width": "1.0.2"
           }
@@ -9619,14 +9812,6 @@
         "inherits": "2.0.3",
         "mkdirp": "0.5.1",
         "rimraf": "2.6.2"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        }
       }
     },
     "fstream-ignore": {
@@ -9738,7 +9923,7 @@
       "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
       "dev": true,
       "requires": {
-        "rc": "1.1.7"
+        "rc": "1.2.6"
       }
     },
     "get-stdin": {
@@ -9791,6 +9976,13 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
       }
     },
     "gifsicle": {
@@ -9805,14 +9997,14 @@
       }
     },
     "git-raw-commits": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.5.tgz",
-      "integrity": "sha512-r6NFrgh9oGzHwMA0go6sEa8jgR+N2/74HPXIXR59asiJzxPXpmk3aM5SMH2bLGsmTPwJtysgbf8EE/LwWHqGgg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.1.2.tgz",
+      "integrity": "sha1-oS2Ekq66KIGALXAIJe2ByfOeby8=",
       "dev": true,
       "requires": {
         "dargs": "4.1.0",
         "lodash.template": "4.4.0",
-        "meow": "4.0.0",
+        "meow": "3.7.0",
         "split2": "2.2.0",
         "through2": "2.0.3"
       },
@@ -9840,23 +10032,6 @@
           "dev": true,
           "requires": {
             "lodash._reinterpolate": "3.0.0"
-          }
-        },
-        "meow": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
-          "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
-          "dev": true,
-          "requires": {
-            "camelcase-keys": "4.2.0",
-            "decamelize-keys": "1.1.0",
-            "loud-rejection": "1.6.0",
-            "minimist": "1.2.0",
-            "minimist-options": "3.0.2",
-            "normalize-package-data": "2.4.0",
-            "read-pkg-up": "3.0.0",
-            "redent": "2.0.0",
-            "trim-newlines": "2.0.0"
           }
         },
         "readable-stream": {
@@ -10077,12 +10252,6 @@
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
         }
       }
     },
@@ -10111,6 +10280,11 @@
             "inherits": "1.0.2",
             "minimatch": "0.2.14"
           }
+        },
+        "graceful-fs": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q="
         },
         "inherits": {
           "version": "1.0.2",
@@ -10146,7 +10320,7 @@
         "is-redirect": "1.0.0",
         "is-retry-allowed": "1.1.0",
         "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.1",
+        "lowercase-keys": "1.0.0",
         "node-status-codes": "1.0.0",
         "object-assign": "4.1.1",
         "parse-json": "2.2.0",
@@ -10179,15 +10353,6 @@
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
         "readable-stream": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
@@ -10215,9 +10380,10 @@
       }
     },
     "graceful-fs": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q="
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -10346,12 +10512,6 @@
         "vinyl": "1.1.1"
       },
       "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -10469,7 +10629,7 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
           "requires": {
-            "clone": "1.0.4",
+            "clone": "1.0.3",
             "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
@@ -10519,6 +10679,12 @@
         "through2": "0.6.5"
       },
       "dependencies": {
+        "asap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
+          "integrity": "sha1-sqRdpf36ILBJb8N2jMJ8EvqRan0=",
+          "optional": true
+        },
         "graceful-fs": {
           "version": "3.0.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
@@ -10528,6 +10694,12 @@
             "natives": "1.1.2"
           }
         },
+        "image-size": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz",
+          "integrity": "sha1-gyQOqy+1sAsEqrjHSwRx6cunrYw=",
+          "optional": true
+        },
         "less": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/less/-/less-2.3.1.tgz",
@@ -10536,11 +10708,29 @@
             "errno": "0.1.7",
             "graceful-fs": "3.0.11",
             "image-size": "0.3.5",
-            "mime": "1.6.0",
+            "mime": "1.3.4",
             "mkdirp": "0.5.1",
             "promise": "6.1.0",
-            "request": "2.85.0",
+            "request": "2.81.0",
             "source-map": "0.2.0"
+          }
+        },
+        "promise": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
+          "integrity": "sha1-LOcp9rlLRcJoka0GAsXJDgTG7vY=",
+          "optional": true,
+          "requires": {
+            "asap": "1.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -10568,7 +10758,7 @@
         "async": "1.5.2",
         "optimist": "0.6.1",
         "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "uglify-js": "2.6.4"
       },
       "dependencies": {
         "async": {
@@ -10576,13 +10766,6 @@
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true,
-          "optional": true
         },
         "source-map": {
           "version": "0.4.4",
@@ -10592,55 +10775,21 @@
           "requires": {
             "amdefine": "1.0.1"
           }
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
         }
       }
     },
     "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
     },
     "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "4.11.8",
+        "har-schema": "1.0.5"
       }
     },
     "has": {
@@ -10661,9 +10810,9 @@
       }
     },
     "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
     "has-gulplog": {
@@ -10791,14 +10940,14 @@
       }
     },
     "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
       }
     },
     "he": {
@@ -10848,9 +10997,9 @@
       }
     },
     "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "hoist-non-react-statics": {
       "version": "1.2.0",
@@ -10960,28 +11109,91 @@
         "object-assign": "4.1.1"
       },
       "dependencies": {
+        "camel-case": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+          "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+          "dev": true,
+          "requires": {
+            "no-case": "2.3.2",
+            "upper-case": "1.1.3"
+          }
+        },
+        "clean-css": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
+          "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        },
+        "he": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+          "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+          "dev": true
+        },
+        "html-minifier": {
+          "version": "3.5.12",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.12.tgz",
+          "integrity": "sha512-+N778qLf0RWBscD0TPGoYdeGNDZ0s76/0pQhY1/409EOudcENkm9IbSkk37RDyPdg/09GVHTKotU4ya93RF1Gg==",
+          "dev": true,
+          "requires": {
+            "camel-case": "3.0.0",
+            "clean-css": "4.1.11",
+            "commander": "2.15.1",
+            "he": "1.1.1",
+            "ncname": "1.0.0",
+            "param-case": "2.1.1",
+            "relateurl": "0.2.7",
+            "uglify-js": "3.3.16"
+          }
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
+        },
+        "param-case": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+          "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+          "dev": true,
+          "requires": {
+            "no-case": "2.3.2"
+          }
+        },
+        "uglify-js": {
+          "version": "3.3.16",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.16.tgz",
+          "integrity": "sha512-FMh5SRqJRGhv9BbaTffENIpDDQIoPDR8DBraunGORGhySArsXlw9++CN+BWzPBLpoI4RcSnpfGPnilTxWL3Vvg==",
+          "dev": true,
+          "requires": {
+            "commander": "2.15.1",
+            "source-map": "0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
         }
-      }
-    },
-    "html-minifier": {
-      "version": "3.5.12",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.12.tgz",
-      "integrity": "sha512-+N778qLf0RWBscD0TPGoYdeGNDZ0s76/0pQhY1/409EOudcENkm9IbSkk37RDyPdg/09GVHTKotU4ya93RF1Gg==",
-      "dev": true,
-      "requires": {
-        "camel-case": "3.0.0",
-        "clean-css": "4.1.11",
-        "commander": "2.15.1",
-        "he": "1.1.1",
-        "ncname": "1.0.0",
-        "param-case": "2.1.1",
-        "relateurl": "0.2.7",
-        "uglify-js": "3.3.16"
       }
     },
     "html-tags": {
@@ -11004,16 +11216,45 @@
         "toposort": "1.0.6"
       },
       "dependencies": {
-        "loader-utils": {
-          "version": "0.2.17",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+        "camel-case": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+          "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
           "dev": true,
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
+            "no-case": "2.3.2",
+            "upper-case": "1.1.3"
+          }
+        },
+        "clean-css": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
+          "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        },
+        "he": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+          "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+          "dev": true
+        },
+        "html-minifier": {
+          "version": "3.5.12",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.12.tgz",
+          "integrity": "sha512-+N778qLf0RWBscD0TPGoYdeGNDZ0s76/0pQhY1/409EOudcENkm9IbSkk37RDyPdg/09GVHTKotU4ya93RF1Gg==",
+          "dev": true,
+          "requires": {
+            "camel-case": "3.0.0",
+            "clean-css": "4.1.11",
+            "commander": "2.15.1",
+            "he": "1.1.1",
+            "ncname": "1.0.0",
+            "param-case": "2.1.1",
+            "relateurl": "0.2.7",
+            "uglify-js": "3.3.16"
           }
         },
         "lodash": {
@@ -11022,56 +11263,72 @@
           "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
           "dev": true
         },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+        "param-case": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+          "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+          "dev": true,
+          "requires": {
+            "no-case": "2.3.2"
+          }
+        },
+        "toposort": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.6.tgz",
+          "integrity": "sha1-wxdI5V0hDv/AD9zcfW5o19e7nOw=",
           "dev": true
+        },
+        "uglify-js": {
+          "version": "3.3.16",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.16.tgz",
+          "integrity": "sha512-FMh5SRqJRGhv9BbaTffENIpDDQIoPDR8DBraunGORGhySArsXlw9++CN+BWzPBLpoI4RcSnpfGPnilTxWL3Vvg==",
+          "dev": true,
+          "requires": {
+            "commander": "2.15.1",
+            "source-map": "0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
         }
       }
     },
     "htmlparser2": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
+      "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
       "dev": true,
       "requires": {
         "domelementtype": "1.3.0",
-        "domhandler": "2.4.1",
-        "domutils": "1.5.1",
-        "entities": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.5"
+        "domhandler": "2.1.0",
+        "domutils": "1.1.6",
+        "readable-stream": "1.0.34"
       },
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+        "domutils": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
+          "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0"
+          }
         },
         "readable-stream": {
-          "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
           }
         }
       }
@@ -11083,7 +11340,7 @@
       "dev": true,
       "requires": {
         "caseless": "0.11.0",
-        "concat-stream": "1.6.2",
+        "concat-stream": "1.6.1",
         "http-response-object": "1.1.0"
       },
       "dependencies": {
@@ -11191,11 +11448,11 @@
       }
     },
     "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "0.2.0",
         "jsprim": "1.4.1",
         "sshpk": "1.14.1"
       }
@@ -11228,9 +11485,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
-      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.10.tgz",
+      "integrity": "sha1-cZpvewJoMeZL24OLDeG7ACm79xY=",
       "dev": true
     },
     "iferr": {
@@ -11246,9 +11503,10 @@
       "dev": true
     },
     "image-size": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz",
-      "integrity": "sha1-gyQOqy+1sAsEqrjHSwRx6cunrYw=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.4.0.tgz",
+      "integrity": "sha1-1LTh9hlS5MvBzqmmsMkV/stwdRA=",
+      "dev": true,
       "optional": true
     },
     "image-webpack-loader": {
@@ -11268,28 +11526,235 @@
         "object-assign": "4.1.1"
       },
       "dependencies": {
-        "object-assign": {
+        "bin-build": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-3.0.0.tgz",
+          "integrity": "sha512-jcUOof71/TNAI2uM5uoUaDq2ePcVBQ3R/qhxAz1rX7UfvduAL/RXD3jXzvn8cVcDJdGVkiR1shal3OH0ImpuhA==",
+          "dev": true,
+          "requires": {
+            "decompress": "4.2.0",
+            "download": "6.2.5",
+            "execa": "0.7.0",
+            "p-map-series": "1.0.0",
+            "tempfile": "2.0.0"
+          }
+        },
+        "caw": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
+          "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
+          "dev": true,
+          "requires": {
+            "get-proxy": "2.1.0",
+            "isurl": "1.0.0",
+            "tunnel-agent": "0.6.0",
+            "url-to-options": "1.0.1"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "1.0.4",
+            "path-key": "2.0.1",
+            "semver": "5.5.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "decompress": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
+          "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+          "dev": true,
+          "requires": {
+            "decompress-tar": "4.1.1",
+            "decompress-tarbz2": "4.1.1",
+            "decompress-targz": "4.1.1",
+            "decompress-unzip": "4.0.1",
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.2.0",
+            "pify": "2.3.0",
+            "strip-dirs": "2.1.0"
+          }
+        },
+        "decompress-tar": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+          "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+          "dev": true,
+          "requires": {
+            "file-type": "5.2.0",
+            "is-stream": "1.1.0",
+            "tar-stream": "1.5.5"
+          },
+          "dependencies": {
+            "file-type": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+              "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+              "dev": true
+            }
+          }
+        },
+        "decompress-tarbz2": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+          "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+          "dev": true,
+          "requires": {
+            "decompress-tar": "4.1.1",
+            "file-type": "6.2.0",
+            "is-stream": "1.1.0",
+            "seek-bzip": "1.0.5",
+            "unbzip2-stream": "1.2.5"
+          },
+          "dependencies": {
+            "file-type": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+              "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+              "dev": true
+            }
+          }
+        },
+        "decompress-targz": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+          "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+          "dev": true,
+          "requires": {
+            "decompress-tar": "4.1.1",
+            "file-type": "5.2.0",
+            "is-stream": "1.1.0"
+          },
+          "dependencies": {
+            "file-type": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+              "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+              "dev": true
+            }
+          }
+        },
+        "decompress-unzip": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+          "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
+          "dev": true,
+          "requires": {
+            "file-type": "3.9.0",
+            "get-stream": "2.3.1",
+            "pify": "2.3.0",
+            "yauzl": "2.9.1"
+          },
+          "dependencies": {
+            "file-type": {
+              "version": "3.9.0",
+              "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+              "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
+              "dev": true
+            },
+            "get-stream": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+              "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+              "dev": true,
+              "requires": {
+                "object-assign": "4.1.1",
+                "pinkie-promise": "2.0.1"
+              }
+            }
+          }
+        },
+        "download": {
+          "version": "6.2.5",
+          "resolved": "https://registry.npmjs.org/download/-/download-6.2.5.tgz",
+          "integrity": "sha512-DpO9K1sXAST8Cpzb7kmEhogJxymyVUd5qz/vCOSyvwtp2Klj2XcDt5YUuasgxka44SxF0q5RriKIwJmQHG2AuA==",
+          "dev": true,
+          "requires": {
+            "caw": "2.0.1",
+            "content-disposition": "0.5.2",
+            "decompress": "4.2.0",
+            "ext-name": "5.0.0",
+            "file-type": "5.2.0",
+            "filenamify": "2.0.0",
+            "get-stream": "3.0.0",
+            "got": "7.1.0",
+            "make-dir": "1.2.0",
+            "p-event": "1.3.0",
+            "pify": "3.0.0"
+          },
+          "dependencies": {
+            "file-type": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+              "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+              "dev": true
+            },
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            }
+          }
+        },
+        "exec-buffer": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-3.2.0.tgz",
+          "integrity": "sha512-wsiD+2Tp6BWHoVv3B+5Dcx6E7u5zky+hUwOHjuH2hKSLR3dvRmX8fk8UD8uqQixHs4Wk6eDmiegVrMPjKj7wpA==",
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "p-finally": "1.0.0",
+            "pify": "3.0.0",
+            "rimraf": "2.6.2",
+            "tempfile": "2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            }
+          }
+        },
+        "file-type": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
+          "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU=",
           "dev": true
-        }
-      }
-    },
-    "imagemin": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-5.3.1.tgz",
-      "integrity": "sha1-8Zwu7h5xumxlWMUV+fyWaAGJptQ=",
-      "dev": true,
-      "requires": {
-        "file-type": "4.4.0",
-        "globby": "6.1.0",
-        "make-dir": "1.2.0",
-        "p-pipe": "1.2.0",
-        "pify": "2.3.0",
-        "replace-ext": "1.0.0"
-      },
-      "dependencies": {
+        },
+        "filename-reserved-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+          "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
+          "dev": true
+        },
+        "filenamify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.0.0.tgz",
+          "integrity": "sha1-vRYiYsC26Uv7zc8Zo7uzdk94VpU=",
+          "dev": true,
+          "requires": {
+            "filename-reserved-regex": "2.0.0",
+            "strip-outer": "1.0.0",
+            "trim-repeated": "1.0.0"
+          }
+        },
+        "get-proxy": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
+          "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
+          "dev": true,
+          "requires": {
+            "npm-conf": "1.1.3"
+          }
+        },
         "globby": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
@@ -11303,35 +11768,186 @@
             "pinkie-promise": "2.0.1"
           }
         },
+        "got": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+          "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+          "dev": true,
+          "requires": {
+            "decompress-response": "3.3.0",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-plain-obj": "1.1.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "isurl": "1.0.0",
+            "lowercase-keys": "1.0.0",
+            "p-cancelable": "0.3.0",
+            "p-timeout": "1.2.1",
+            "safe-buffer": "5.1.1",
+            "timed-out": "4.0.1",
+            "url-parse-lax": "1.0.0",
+            "url-to-options": "1.0.1"
+          }
+        },
+        "imagemin": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-5.3.1.tgz",
+          "integrity": "sha1-8Zwu7h5xumxlWMUV+fyWaAGJptQ=",
+          "dev": true,
+          "requires": {
+            "file-type": "4.4.0",
+            "globby": "6.1.0",
+            "make-dir": "1.2.0",
+            "p-pipe": "1.2.0",
+            "pify": "2.3.0",
+            "replace-ext": "1.0.0"
+          }
+        },
+        "imagemin-gifsicle": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/imagemin-gifsicle/-/imagemin-gifsicle-5.2.0.tgz",
+          "integrity": "sha512-K01m5QuPK+0en8oVhiOOAicF7KjrHlCZxS++mfLI2mV/Ksfq/Y9nCXCWDz6jRv13wwlqe5T7hXT+ji2DnLc2yQ==",
+          "dev": true,
+          "requires": {
+            "exec-buffer": "3.2.0",
+            "gifsicle": "3.0.4",
+            "is-gif": "1.0.0"
+          }
+        },
+        "imagemin-optipng": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/imagemin-optipng/-/imagemin-optipng-5.2.1.tgz",
+          "integrity": "sha1-0i2kEsCfX/AKQzmWC5ioix2+hpU=",
+          "dev": true,
+          "requires": {
+            "exec-buffer": "3.2.0",
+            "is-png": "1.1.0",
+            "optipng-bin": "3.1.4"
+          }
+        },
+        "imagemin-pngquant": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/imagemin-pngquant/-/imagemin-pngquant-5.1.0.tgz",
+          "integrity": "sha512-RtIUPbp8/HYX5EKY6p/L1NLKnkxNj37I92IFNsrptzBVql8FqBgPra9DO/eUgE4EWx+zq6ih4a/Y9YhF3pNM5A==",
+          "dev": true,
+          "requires": {
+            "execa": "0.10.0",
+            "is-png": "1.1.0",
+            "is-stream": "1.1.0",
+            "pngquant-bin": "4.0.0"
+          },
+          "dependencies": {
+            "execa": {
+              "version": "0.10.0",
+              "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+              "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+              "dev": true,
+              "requires": {
+                "cross-spawn": "6.0.5",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+              }
+            }
+          }
+        },
+        "imagemin-svgo": {
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/imagemin-svgo/-/imagemin-svgo-5.2.4.tgz",
+          "integrity": "sha512-1bNZdlWVKdfxzu0xDD1pWjwK/G8FLcztUh/GWaI7xLgCFrn0j35o+uBbY7VcdY2AmKgiLYTXhrzrbkQk6xj8aA==",
+          "dev": true,
+          "requires": {
+            "is-svg": "2.1.0",
+            "svgo": "0.7.2"
+          }
+        },
+        "is-natural-number": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+          "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
+          "dev": true
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
+        "pngquant-bin": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/pngquant-bin/-/pngquant-bin-4.0.0.tgz",
+          "integrity": "sha512-jhjMp87bvaUeQOfNaPhSKx3tLCEwRaAycgDpIhMflgFr2+vYhw4ZrcK06eQeYg4OprXPanFljXLl5VuuAP2IHw==",
+          "dev": true,
+          "requires": {
+            "bin-build": "3.0.0",
+            "bin-wrapper": "3.0.2",
+            "execa": "0.10.0",
+            "logalot": "2.1.0"
+          },
+          "dependencies": {
+            "execa": {
+              "version": "0.10.0",
+              "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+              "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+              "dev": true,
+              "requires": {
+                "cross-spawn": "6.0.5",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+              }
+            }
+          }
         },
         "replace-ext": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
           "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
           "dev": true
+        },
+        "strip-dirs": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+          "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+          "dev": true,
+          "requires": {
+            "is-natural-number": "4.0.1"
+          }
+        },
+        "tempfile": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
+          "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
+          "dev": true,
+          "requires": {
+            "temp-dir": "1.0.0",
+            "uuid": "3.2.1"
+          }
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+          "dev": true
         }
-      }
-    },
-    "imagemin-gifsicle": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/imagemin-gifsicle/-/imagemin-gifsicle-5.2.0.tgz",
-      "integrity": "sha512-K01m5QuPK+0en8oVhiOOAicF7KjrHlCZxS++mfLI2mV/Ksfq/Y9nCXCWDz6jRv13wwlqe5T7hXT+ji2DnLc2yQ==",
-      "dev": true,
-      "requires": {
-        "exec-buffer": "3.2.0",
-        "gifsicle": "3.0.4",
-        "is-gif": "1.0.0"
       }
     },
     "imagemin-mozjpeg": {
@@ -11341,7 +11957,7 @@
       "dev": true,
       "requires": {
         "execa": "0.8.0",
-        "is-jpg": "1.0.1",
+        "is-jpg": "1.0.0",
         "mozjpeg": "5.0.0"
       },
       "dependencies": {
@@ -11362,69 +11978,6 @@
         }
       }
     },
-    "imagemin-optipng": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/imagemin-optipng/-/imagemin-optipng-5.2.1.tgz",
-      "integrity": "sha1-0i2kEsCfX/AKQzmWC5ioix2+hpU=",
-      "dev": true,
-      "requires": {
-        "exec-buffer": "3.2.0",
-        "is-png": "1.1.0",
-        "optipng-bin": "3.1.4"
-      }
-    },
-    "imagemin-pngquant": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/imagemin-pngquant/-/imagemin-pngquant-5.1.0.tgz",
-      "integrity": "sha512-RtIUPbp8/HYX5EKY6p/L1NLKnkxNj37I92IFNsrptzBVql8FqBgPra9DO/eUgE4EWx+zq6ih4a/Y9YhF3pNM5A==",
-      "dev": true,
-      "requires": {
-        "execa": "0.10.0",
-        "is-png": "1.1.0",
-        "is-stream": "1.1.0",
-        "pngquant-bin": "4.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "dev": true,
-          "requires": {
-            "nice-try": "1.0.4",
-            "path-key": "2.0.1",
-            "semver": "5.5.0",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
-          }
-        },
-        "execa": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "6.0.5",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          }
-        }
-      }
-    },
-    "imagemin-svgo": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/imagemin-svgo/-/imagemin-svgo-5.2.4.tgz",
-      "integrity": "sha512-1bNZdlWVKdfxzu0xDD1pWjwK/G8FLcztUh/GWaI7xLgCFrn0j35o+uBbY7VcdY2AmKgiLYTXhrzrbkQk6xj8aA==",
-      "dev": true,
-      "requires": {
-        "is-svg": "2.1.0",
-        "svgo": "0.7.2"
-      }
-    },
     "imagemin-webp": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/imagemin-webp/-/imagemin-webp-4.1.0.tgz",
@@ -11434,6 +11987,37 @@
         "cwebp-bin": "4.0.0",
         "exec-buffer": "3.2.0",
         "is-cwebp-readable": "2.0.1"
+      },
+      "dependencies": {
+        "exec-buffer": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-3.2.0.tgz",
+          "integrity": "sha512-wsiD+2Tp6BWHoVv3B+5Dcx6E7u5zky+hUwOHjuH2hKSLR3dvRmX8fk8UD8uqQixHs4Wk6eDmiegVrMPjKj7wpA==",
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "p-finally": "1.0.0",
+            "pify": "3.0.0",
+            "rimraf": "2.6.2",
+            "tempfile": "2.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "tempfile": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
+          "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
+          "dev": true,
+          "requires": {
+            "temp-dir": "1.0.0",
+            "uuid": "3.2.1"
+          }
+        }
       }
     },
     "immutable": {
@@ -11449,6 +12033,26 @@
       "requires": {
         "pkg-dir": "2.0.0",
         "resolve-cwd": "2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0"
+          }
+        }
       }
     },
     "imurmurhash": {
@@ -11458,10 +12062,13 @@
       "dev": true
     },
     "indent-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
     },
     "indexes-of": {
       "version": "1.0.1",
@@ -11709,6 +12316,14 @@
       "dev": true,
       "requires": {
         "file-type": "4.4.0"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
+          "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU=",
+          "dev": true
+        }
       }
     },
     "is-data-descriptor": {
@@ -11842,9 +12457,9 @@
       }
     },
     "is-jpg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-jpg/-/is-jpg-1.0.1.tgz",
-      "integrity": "sha1-KW1X/dmc4BBDSnKD40armhA16XU=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-jpg/-/is-jpg-1.0.0.tgz",
+      "integrity": "sha1-KVnBfnNDDbOCZNp1uQ3VTy2G2hw=",
       "dev": true
     },
     "is-lower-case": {
@@ -11932,9 +12547,9 @@
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
         "is-path-inside": "1.0.1"
@@ -12062,9 +12677,9 @@
       "dev": true
     },
     "is-supported-regexp-flag": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
-      "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.0.tgz",
+      "integrity": "sha1-i1IMhfrnolM4LUsCZS4EVXbhO7g=",
       "dev": true
     },
     "is-svg": {
@@ -12121,9 +12736,9 @@
       }
     },
     "is-url": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.3.tgz",
-      "integrity": "sha512-vmOHLvzbcnsdFz8wQPXj1lgI5SE8AUlUGMenzuZzRFjoReb1WB+pLt9GrIo7BTker+aTcwrjTDle7odioWeqyw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
+      "integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY=",
       "dev": true
     },
     "is-utf8": {
@@ -12212,11 +12827,20 @@
         "istanbul-lib-report": "1.1.4",
         "istanbul-lib-source-maps": "1.2.4",
         "istanbul-reports": "1.3.0",
-        "js-yaml": "3.11.0",
+        "js-yaml": "3.7.0",
         "mkdirp": "0.5.1",
         "once": "1.4.0"
       },
       "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.5"
+          }
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -12239,10 +12863,10 @@
             "source-map": "0.5.7"
           }
         },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
           "dev": true
         }
       }
@@ -12289,12 +12913,6 @@
         "supports-color": "3.2.3"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
@@ -12327,12 +12945,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         }
       }
     },
@@ -12373,9 +12985,9 @@
       }
     },
     "jest-changed-files": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.4.3.tgz",
-      "integrity": "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.2.0.tgz",
+      "integrity": "sha512-SzqOvoPMrXB0NPvDrSPeKETpoUNCtNDOsFbCzAGWxqWVvNyrIMLpUjVExT3u3LfdVrENlrNGCfh5YoFd8+ZeXg==",
       "dev": true,
       "requires": {
         "throat": "4.1.0"
@@ -12387,7 +12999,7 @@
       "integrity": "sha512-0JlBb/PvHGQZR2I9GZwsycHgWHhriBmvBWPaaPYUT186oiIIDY4ezDxFOFt2Ts0yNTRg3iY9mTyHsfWbT5VRWA==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.1.0",
+        "ansi-escapes": "3.0.0",
         "chalk": "2.3.2",
         "exit": "0.1.2",
         "glob": "7.1.2",
@@ -12398,20 +13010,20 @@
         "istanbul-lib-coverage": "1.2.0",
         "istanbul-lib-instrument": "1.10.1",
         "istanbul-lib-source-maps": "1.2.3",
-        "jest-changed-files": "22.4.3",
-        "jest-config": "22.4.3",
-        "jest-environment-jsdom": "22.4.3",
-        "jest-get-type": "22.4.3",
-        "jest-haste-map": "22.4.3",
-        "jest-message-util": "22.4.3",
-        "jest-regex-util": "22.4.3",
-        "jest-resolve-dependencies": "22.4.3",
-        "jest-runner": "22.4.3",
-        "jest-runtime": "22.4.3",
-        "jest-snapshot": "22.4.3",
-        "jest-util": "22.4.3",
-        "jest-validate": "22.4.3",
-        "jest-worker": "22.4.3",
+        "jest-changed-files": "22.2.0",
+        "jest-config": "22.4.2",
+        "jest-environment-jsdom": "22.4.1",
+        "jest-get-type": "22.1.0",
+        "jest-haste-map": "22.4.2",
+        "jest-message-util": "22.4.0",
+        "jest-regex-util": "22.1.0",
+        "jest-resolve-dependencies": "22.1.0",
+        "jest-runner": "22.4.2",
+        "jest-runtime": "22.4.2",
+        "jest-snapshot": "22.4.0",
+        "jest-util": "22.4.1",
+        "jest-validate": "22.4.2",
+        "jest-worker": "22.2.2",
         "micromatch": "2.3.11",
         "node-notifier": "5.2.1",
         "realpath-native": "1.0.0",
@@ -12424,9 +13036,9 @@
       },
       "dependencies": {
         "ansi-escapes": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+          "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
           "dev": true
         },
         "ansi-regex": {
@@ -12455,6 +13067,26 @@
             "supports-color": "5.3.0"
           }
         },
+        "cliui": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+          "dev": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -12469,11 +13101,30 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "jest-validate": {
+          "version": "22.4.2",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.2.tgz",
+          "integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.2",
+            "jest-config": "22.4.2",
+            "jest-get-type": "22.1.0",
+            "leven": "2.1.0",
+            "pretty-format": "22.4.0"
+          }
         },
         "minimatch": {
           "version": "3.0.4",
@@ -12482,6 +13133,39 @@
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.11"
+          }
+        },
+        "node-notifier": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+          "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+          "dev": true,
+          "requires": {
+            "growly": "1.3.0",
+            "semver": "5.5.0",
+            "shellwords": "0.1.1",
+            "which": "1.3.0"
+          }
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -12501,26 +13185,52 @@
           "requires": {
             "has-flag": "3.0.0"
           }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+          "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+          "dev": true,
+          "requires": {
+            "cliui": "4.0.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "8.1.0"
+          }
         }
       }
     },
     "jest-config": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.3.tgz",
-      "integrity": "sha512-KSg3EOToCgkX+lIvenKY7J8s426h6ahXxaUFJxvGoEk0562Z6inWj1TnKoGycTASwiLD+6kSYFALcjdosq9KIQ==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.2.tgz",
+      "integrity": "sha512-oG31qYO73/3vj/Q8aM2RgzmHndTkz9nRk8ISybfuJqqbf0RW7OUjHVOZPLOUiwLWtz52Yq2HkjIblsyhbA7vrg==",
       "dev": true,
       "requires": {
         "chalk": "2.3.2",
         "glob": "7.1.2",
-        "jest-environment-jsdom": "22.4.3",
-        "jest-environment-node": "22.4.3",
-        "jest-get-type": "22.4.3",
-        "jest-jasmine2": "22.4.3",
-        "jest-regex-util": "22.4.3",
-        "jest-resolve": "22.4.3",
-        "jest-util": "22.4.3",
-        "jest-validate": "22.4.3",
-        "pretty-format": "22.4.3"
+        "jest-environment-jsdom": "22.4.1",
+        "jest-environment-node": "22.4.1",
+        "jest-get-type": "22.1.0",
+        "jest-jasmine2": "22.4.2",
+        "jest-regex-util": "22.1.0",
+        "jest-resolve": "22.4.2",
+        "jest-util": "22.4.1",
+        "jest-validate": "22.4.2",
+        "pretty-format": "22.4.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12555,6 +13265,25 @@
             "minimatch": "3.0.4",
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "jest-validate": {
+          "version": "22.4.2",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.2.tgz",
+          "integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.2",
+            "jest-config": "22.4.2",
+            "jest-get-type": "22.1.0",
+            "leven": "2.1.0",
+            "pretty-format": "22.4.0"
           }
         },
         "minimatch": {
@@ -12578,15 +13307,15 @@
       }
     },
     "jest-diff": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
-      "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.0.tgz",
+      "integrity": "sha512-+/t20WmnkOkB8MOaGaPziI8zWKxquMvYw4Ub+wOzi7AUhmpFXz43buWSxVoZo4J5RnCozpGbX3/FssjJ5KV9Nw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.2",
         "diff": "3.5.0",
-        "jest-get-type": "22.4.3",
-        "pretty-format": "22.4.3"
+        "jest-get-type": "22.1.0",
+        "pretty-format": "22.4.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12609,6 +13338,12 @@
             "supports-color": "5.3.0"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
@@ -12621,80 +13356,72 @@
       }
     },
     "jest-docblock": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
-      "integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.0.tgz",
+      "integrity": "sha512-lDY7GZ+/CJb02oULYLBDj7Hs5shBhVpDYpIm8LUyqw9X2J22QRsM19gmGQwIFqGSJmpc/LRrSYudeSrG510xlQ==",
       "dev": true,
       "requires": {
         "detect-newline": "2.1.0"
       }
     },
     "jest-environment-jsdom": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
-      "integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.1.tgz",
+      "integrity": "sha512-x/JzAoH+dWPBnIMv5OQKiIR0TYf6UvbRjsIuDZ11yDFXkHKGJZg6jNnLAsokAm3cq9kUa2hH5BPUC9XU4n1ELQ==",
       "dev": true,
       "requires": {
-        "jest-mock": "22.4.3",
-        "jest-util": "22.4.3",
+        "jest-mock": "22.2.0",
+        "jest-util": "22.4.1",
         "jsdom": "11.6.2"
       }
     },
     "jest-environment-node": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
-      "integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.1.tgz",
+      "integrity": "sha512-wj9+zzfRgnUbm5VwFOCGgG1QmbucUyrjPKBKUJdLW8K5Ss5zrNc1k+v6feZhFg6sS3ZGnjgtIyklaxEARxu+LQ==",
       "dev": true,
       "requires": {
-        "jest-mock": "22.4.3",
-        "jest-util": "22.4.3"
+        "jest-mock": "22.2.0",
+        "jest-util": "22.4.1"
       }
     },
     "jest-get-type": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.1.0.tgz",
+      "integrity": "sha512-nD97IVOlNP6fjIN5i7j5XRH+hFsHL7VlauBbzRvueaaUe70uohrkz7pL/N8lx/IAwZRTJ//wOdVgh85OgM7g3w==",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz",
-      "integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.2.tgz",
+      "integrity": "sha512-EdQADHGXRqHJYAr7q9B9YYHZnrlcMwhx1+DnIgc9uN05nCW3RvGCxJ91MqWXcC1AzatLoSv7SNd0qXMp2jKBDA==",
       "dev": true,
       "requires": {
         "fb-watchman": "2.0.0",
         "graceful-fs": "4.1.11",
-        "jest-docblock": "22.4.3",
-        "jest-serializer": "22.4.3",
-        "jest-worker": "22.4.3",
+        "jest-docblock": "22.4.0",
+        "jest-serializer": "22.4.0",
+        "jest-worker": "22.2.2",
         "micromatch": "2.3.11",
         "sane": "2.5.0"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        }
       }
     },
     "jest-jasmine2": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.3.tgz",
-      "integrity": "sha512-yZCPCJUcEY6R5KJB/VReo1AYI2b+5Ky+C+JA1v34jndJsRcLpU4IZX4rFJn7yDTtdNbO/nNqg+3SDIPNH2ecnw==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.2.tgz",
+      "integrity": "sha512-KZaIHpXQ0AIlvQJFCU0uoXxtz5GG47X14r9upMe7VXE55UazoMZBFnQb9TX2HoYX2/AxJYnjHuvwKVCFqOrEtw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.2",
         "co": "4.6.0",
-        "expect": "22.4.3",
+        "expect": "22.4.0",
         "graceful-fs": "4.1.11",
         "is-generator-fn": "1.0.0",
-        "jest-diff": "22.4.3",
-        "jest-matcher-utils": "22.4.3",
-        "jest-message-util": "22.4.3",
-        "jest-snapshot": "22.4.3",
-        "jest-util": "22.4.3",
+        "jest-diff": "22.4.0",
+        "jest-matcher-utils": "22.4.0",
+        "jest-message-util": "22.4.0",
+        "jest-snapshot": "22.4.0",
+        "jest-util": "22.4.1",
         "source-map-support": "0.5.4"
       },
       "dependencies": {
@@ -12718,10 +13445,10 @@
             "supports-color": "5.3.0"
           }
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "source-map": {
@@ -12751,23 +13478,23 @@
       }
     },
     "jest-leak-detector": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
-      "integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.0.tgz",
+      "integrity": "sha512-r3NEIVNh4X3fEeJtUIrKXWKhNokwUM2ILp5LD8w1KrEanPsFtZmYjmyZYjDTX2dXYr33TW65OvbRE3hWFAyq6g==",
       "dev": true,
       "requires": {
-        "pretty-format": "22.4.3"
+        "pretty-format": "22.4.0"
       }
     },
     "jest-matcher-utils": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
-      "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.0.tgz",
+      "integrity": "sha512-03m3issxUXpWMwDYTfmL8hRNewUB0yCRTeXPm+eq058rZxLHD9f5NtSSO98CWHqe4UyISIxd9Ao9iDVjHWd2qg==",
       "dev": true,
       "requires": {
         "chalk": "2.3.2",
-        "jest-get-type": "22.4.3",
-        "pretty-format": "22.4.3"
+        "jest-get-type": "22.1.0",
+        "pretty-format": "22.4.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12790,6 +13517,12 @@
             "supports-color": "5.3.0"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
@@ -12802,9 +13535,9 @@
       }
     },
     "jest-message-util": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
-      "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.0.tgz",
+      "integrity": "sha512-eyCJB0T3hrlpFF2FqQoIB093OulP+1qvATQmD3IOgJgMGqPL6eYw8TbC5P/VCWPqKhGL51xvjIIhow5eZ2wHFw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0-beta.42",
@@ -12834,6 +13567,12 @@
             "supports-color": "5.3.0"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
@@ -12846,21 +13585,21 @@
       }
     },
     "jest-mock": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
-      "integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.2.0.tgz",
+      "integrity": "sha512-eOfoUYLOB/JlxChOFkh/bzpWGqUXb9I+oOpkprHHs9L7nUNfL8Rk28h1ycWrqzWCEQ/jZBg/xIv7VdQkfAkOhw==",
       "dev": true
     },
     "jest-regex-util": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
-      "integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.1.0.tgz",
+      "integrity": "sha512-on0LqVS6Xeh69sw3d1RukVnur+lVOl3zkmb0Q54FHj9wHoq6dbtWqb3TSlnVUyx36hqjJhjgs/QLqs07Bzu72Q==",
       "dev": true
     },
     "jest-resolve": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
-      "integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.2.tgz",
+      "integrity": "sha512-P1hSfcc2HJYT5t+WPu/11OfFMa7m8pBb2Gf2vm6W9OVs7YTXQ5RCC3nDqaYZQaTqxEM1ZZaTcQGcE6U2xMOsqQ==",
       "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
@@ -12887,6 +13626,12 @@
             "supports-color": "5.3.0"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
@@ -12899,52 +13644,52 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
-      "integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.1.0.tgz",
+      "integrity": "sha512-76Ll61bD/Sus8wK8d+lw891EtiBJGJkWG8OuVDTEX0z3z2+jPujvQqSB2eQ+kCHyCsRwJ2PSjhn3UHqae/oEtA==",
       "dev": true,
       "requires": {
-        "jest-regex-util": "22.4.3"
+        "jest-regex-util": "22.1.0"
       }
     },
     "jest-runner": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.3.tgz",
-      "integrity": "sha512-U7PLlQPRlWNbvOHWOrrVay9sqhBJmiKeAdKIkvX4n1G2tsvzLlf77nBD28GL1N6tGv4RmuTfI8R8JrkvCa+IBg==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.2.tgz",
+      "integrity": "sha512-W4vwgiVQS0NyXt8hgpw7i0YUtsfoChiQcoHWBJeq2ocV4VF2osEZx8HYgpH5HfNe1Cb5LZeZWxX8Dr3hesbGFg==",
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "jest-config": "22.4.3",
-        "jest-docblock": "22.4.3",
-        "jest-haste-map": "22.4.3",
-        "jest-jasmine2": "22.4.3",
-        "jest-leak-detector": "22.4.3",
-        "jest-message-util": "22.4.3",
-        "jest-runtime": "22.4.3",
-        "jest-util": "22.4.3",
-        "jest-worker": "22.4.3",
+        "jest-config": "22.4.2",
+        "jest-docblock": "22.4.0",
+        "jest-haste-map": "22.4.2",
+        "jest-jasmine2": "22.4.2",
+        "jest-leak-detector": "22.4.0",
+        "jest-message-util": "22.4.0",
+        "jest-runtime": "22.4.2",
+        "jest-util": "22.4.1",
+        "jest-worker": "22.2.2",
         "throat": "4.1.0"
       }
     },
     "jest-runtime": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.3.tgz",
-      "integrity": "sha512-Eat/esQjevhx9BgJEC8udye+FfoJ2qvxAZfOAWshYGS22HydHn5BgsvPdTtt9cp0fSl5LxYOFA1Pja9Iz2Zt8g==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.2.tgz",
+      "integrity": "sha512-9/Fxbj99cqxI7o2nTNzevnI38eDBstkwve8ZeaAD/Kz0fbU3i3eRv2QPEmzbmyCyBvUWxCT7BzNLTzTqH1+pyA==",
       "dev": true,
       "requires": {
         "babel-core": "6.24.1",
-        "babel-jest": "22.4.3",
+        "babel-jest": "22.4.1",
         "babel-plugin-istanbul": "4.1.5",
         "chalk": "2.3.2",
         "convert-source-map": "1.5.1",
         "exit": "0.1.2",
         "graceful-fs": "4.1.11",
-        "jest-config": "22.4.3",
-        "jest-haste-map": "22.4.3",
-        "jest-regex-util": "22.4.3",
-        "jest-resolve": "22.4.3",
-        "jest-util": "22.4.3",
-        "jest-validate": "22.4.3",
+        "jest-config": "22.4.2",
+        "jest-haste-map": "22.4.2",
+        "jest-regex-util": "22.1.0",
+        "jest-resolve": "22.4.2",
+        "jest-util": "22.4.1",
+        "jest-validate": "22.4.2",
         "json-stable-stringify": "1.0.1",
         "micromatch": "2.3.11",
         "realpath-native": "1.0.0",
@@ -12954,6 +13699,12 @@
         "yargs": "10.1.2"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -12974,11 +13725,80 @@
             "supports-color": "5.3.0"
           }
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+        "cliui": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+          "dev": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "jest-validate": {
+          "version": "22.4.2",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.2.tgz",
+          "integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.2",
+            "jest-config": "22.4.2",
+            "jest-get-type": "22.1.0",
+            "leven": "2.1.0",
+            "pretty-format": "22.4.0"
+          }
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
         },
         "strip-bom": {
           "version": "3.0.0",
@@ -12994,27 +13814,53 @@
           "requires": {
             "has-flag": "3.0.0"
           }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+          "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+          "dev": true,
+          "requires": {
+            "cliui": "4.0.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "8.1.0"
+          }
         }
       }
     },
     "jest-serializer": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.3.tgz",
-      "integrity": "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.0.tgz",
+      "integrity": "sha512-dnqde95MiYfdc1ZJpjEiHCRvRGGJHPsZQARJFucEGIaOzxqqS9/tt2WzD/OUSGT6kxaEGLQE92faVJGdoCu+Rw==",
       "dev": true
     },
     "jest-snapshot": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
-      "integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.0.tgz",
+      "integrity": "sha512-6Zz4F9G1Nbr93kfm5h3A2+OkE+WGpgJlskYE4iSNN2uYfoTL5b9W6aB9Orpx+ueReHyqmy7HET7Z3EmYlL3hKw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.2",
-        "jest-diff": "22.4.3",
-        "jest-matcher-utils": "22.4.3",
+        "jest-diff": "22.4.0",
+        "jest-matcher-utils": "22.4.0",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
-        "pretty-format": "22.4.3"
+        "pretty-format": "22.4.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13037,6 +13883,12 @@
             "supports-color": "5.3.0"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
@@ -13049,16 +13901,16 @@
       }
     },
     "jest-util": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
-      "integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.1.tgz",
+      "integrity": "sha512-9ySBdJY2qVWpg0OvZbGcFXE2NgwccpZVj384E9bx7brKFc7l5anpqah15mseWcz7FLDk7/N+LyYgqFme7Rez2Q==",
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
         "chalk": "2.3.2",
         "graceful-fs": "4.1.11",
         "is-ci": "1.0.10",
-        "jest-message-util": "22.4.3",
+        "jest-message-util": "22.4.0",
         "mkdirp": "0.5.1",
         "source-map": "0.6.1"
       },
@@ -13089,10 +13941,10 @@
             "supports-color": "5.3.0"
           }
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "source-map": {
@@ -13113,45 +13965,43 @@
       }
     },
     "jest-validate": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.3.tgz",
-      "integrity": "sha512-CfFM18W3GSP/xgmA4UouIx0ljdtfD2mjeBC6c89Gg17E44D4tQhAcTrZmf9djvipwU30kSTnk6CzcxdCCeSXfA==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-19.0.0.tgz",
+      "integrity": "sha1-jGMYog7P6roLpTeL+7gner3tQXM=",
       "dev": true,
       "requires": {
-        "chalk": "2.3.2",
-        "jest-config": "22.4.3",
-        "jest-get-type": "22.4.3",
+        "chalk": "1.1.3",
+        "jest-matcher-utils": "19.0.0",
         "leven": "2.1.0",
-        "pretty-format": "22.4.3"
+        "pretty-format": "19.0.0"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
           }
         },
-        "chalk": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+        "jest-matcher-utils": {
+          "version": "19.0.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-19.0.0.tgz",
+          "integrity": "sha1-Xs2bY1ZdKwAfYfv37Ex/U3lkVk0=",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "chalk": "1.1.3",
+            "pretty-format": "19.0.0"
           }
         },
-        "supports-color": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+        "pretty-format": {
+          "version": "19.0.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-19.0.0.tgz",
+          "integrity": "sha1-VlMNMqy5ij+khRxOK503tCBoTIQ=",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "ansi-styles": "3.2.1"
           }
         }
       }
@@ -13177,9 +14027,9 @@
       }
     },
     "jest-worker": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
-      "integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
+      "version": "22.2.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.2.2.tgz",
+      "integrity": "sha512-ZylDXjrFNt/OP6cUxwJFWwDgazP7hRjtCQbocFHyiwov+04Wm1x5PYzMGNJT53s4nwr0oo9ocYTImS09xOlUnw==",
       "dev": true,
       "requires": {
         "merge-stream": "1.0.1"
@@ -13201,12 +14051,6 @@
         "nomnom": "1.5.2"
       },
       "dependencies": {
-        "colors": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
-          "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
-          "dev": true
-        },
         "escodegen": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
@@ -13237,16 +14081,6 @@
           "integrity": "sha1-gVHTWOIMisx/t0XnRywAJf5JZXA=",
           "dev": true
         },
-        "nomnom": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
-          "integrity": "sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=",
-          "dev": true,
-          "requires": {
-            "colors": "0.5.1",
-            "underscore": "1.1.7"
-          }
-        },
         "source-map": {
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
@@ -13256,12 +14090,6 @@
           "requires": {
             "amdefine": "1.0.1"
           }
-        },
-        "underscore": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
-          "integrity": "sha1-QLq4S60Z0jAJbo1u9ii/8FXYPbA=",
-          "dev": true
         }
       }
     },
@@ -13273,30 +14101,6 @@
       "requires": {
         "lex-parser": "0.1.4",
         "nomnom": "1.5.2"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
-          "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
-          "dev": true
-        },
-        "nomnom": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
-          "integrity": "sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=",
-          "dev": true,
-          "requires": {
-            "colors": "0.5.1",
-            "underscore": "1.1.7"
-          }
-        },
-        "underscore": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
-          "integrity": "sha1-QLq4S60Z0jAJbo1u9ii/8FXYPbA=",
-          "dev": true
-        }
       }
     },
     "jison-loader": {
@@ -13326,19 +14130,19 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+      "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "dev": true,
       "requires": {
         "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "esprima": "2.7.3"
       },
       "dependencies": {
         "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
           "dev": true
         }
       }
@@ -13383,11 +14187,171 @@
         "xml-name-validator": "3.0.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+          "dev": true
+        },
+        "boom": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+          "dev": true,
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+          "dev": true,
+          "requires": {
+            "boom": "5.2.0"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "dev": true,
+              "requires": {
+                "hoek": "4.2.1"
+              }
+            }
+          }
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "dev": true,
+          "requires": {
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
+          }
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+          "dev": true,
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.1",
+            "sntp": "2.1.0"
+          }
+        },
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.1"
+          }
+        },
         "parse5": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
           "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
           "dev": true
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        },
+        "request": {
+          "version": "2.85.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+          "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
+          }
+        },
+        "sntp": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+          "dev": true,
+          "requires": {
+            "hoek": "4.2.1"
+          }
         }
       }
     },
@@ -13423,13 +14387,13 @@
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
       "requires": {
         "jsonify": "0.0.0"
       }
@@ -13458,15 +14422,6 @@
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "jsonfilter": {
@@ -13512,8 +14467,7 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsonlint": {
       "version": "1.6.0",
@@ -13522,7 +14476,7 @@
       "dev": true,
       "requires": {
         "JSV": "4.0.2",
-        "nomnom": "1.6.2"
+        "nomnom": "1.5.2"
       }
     },
     "jsonparse": {
@@ -13551,6 +14505,13 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
       }
     },
     "jsx-ast-utils": {
@@ -13599,15 +14560,6 @@
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "know-your-http-well": {
@@ -13742,51 +14694,11 @@
         "errno": "0.1.7",
         "graceful-fs": "4.1.11",
         "image-size": "0.4.0",
-        "mime": "1.6.0",
+        "mime": "1.3.4",
         "mkdirp": "0.5.1",
         "promise": "7.3.1",
-        "request": "2.85.0",
+        "request": "2.81.0",
         "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "asap": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-          "dev": true,
-          "optional": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true,
-          "optional": true
-        },
-        "image-size": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.4.0.tgz",
-          "integrity": "sha1-1LTh9hlS5MvBzqmmsMkV/stwdRA=",
-          "dev": true,
-          "optional": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asap": "2.0.6"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "less-color-lighten": {
@@ -13811,11 +14723,16 @@
           "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
           "dev": true
         },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
         }
       }
     },
@@ -13895,6 +14812,15 @@
           "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
           "dev": true
         },
+        "nopt": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+          "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.1.1"
+          }
+        },
         "strip-ansi": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
@@ -13950,17 +14876,6 @@
         "rxjs": "5.4.3",
         "stream-to-observable": "0.1.0",
         "strip-ansi": "3.0.1"
-      },
-      "dependencies": {
-        "indent-string": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-          "dev": true,
-          "requires": {
-            "repeating": "2.0.1"
-          }
-        }
       }
     },
     "listr-silent-renderer": {
@@ -13983,6 +14898,14 @@
         "log-symbols": "1.0.2",
         "log-update": "1.0.2",
         "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        }
       }
     },
     "listr-verbose-renderer": {
@@ -14004,28 +14927,26 @@
       "dev": true
     },
     "load-json-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
-        "parse-json": "4.0.0",
-        "pify": "3.0.0",
-        "strip-bom": "3.0.0"
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
         "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
         }
       }
     },
@@ -14036,14 +14957,23 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+      "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
       "dev": true,
       "requires": {
         "big.js": "3.2.0",
         "emojis-list": "2.1.0",
-        "json5": "0.5.1"
+        "json5": "0.5.1",
+        "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        }
       }
     },
     "localStorage": {
@@ -14060,6 +14990,14 @@
       "requires": {
         "p-locate": "2.0.0",
         "path-exists": "3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
       }
     },
     "lodash": {
@@ -14198,12 +15136,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-      "dev": true
-    },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
     "lodash.cond": {
@@ -14549,9 +15481,9 @@
       }
     },
     "lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
       "dev": true
     },
     "lpad-align": {
@@ -14571,15 +15503,6 @@
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
           "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
           "dev": true
-        },
-        "indent-string": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-          "dev": true,
-          "requires": {
-            "repeating": "2.0.1"
-          }
         }
       }
     },
@@ -14607,6 +15530,14 @@
       "dev": true,
       "requires": {
         "pify": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "make-iterator": {
@@ -14634,9 +15565,9 @@
       "dev": true
     },
     "map-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
     "map-stream": {
@@ -14720,7 +15651,7 @@
       "dev": true,
       "requires": {
         "errno": "0.1.7",
-        "readable-stream": "2.3.5"
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "isarray": {
@@ -14730,9 +15661,9 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -14740,14 +15671,14 @@
             "isarray": "1.0.0",
             "process-nextick-args": "2.0.0",
             "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
+            "string_decoder": "1.1.1",
             "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -14773,166 +15704,10 @@
         "trim-newlines": "1.0.0"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        },
-        "camelcase-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-          "dev": true,
-          "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "get-stdin": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "indent-string": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-          "dev": true,
-          "requires": {
-            "repeating": "2.0.1"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "redent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-          "dev": true,
-          "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
-        "strip-indent": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1"
-          }
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
           "dev": true
         }
       }
@@ -15075,9 +15850,9 @@
       }
     },
     "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
     },
     "mime-db": {
       "version": "1.33.0",
@@ -15155,7 +15930,7 @@
       "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.2",
+        "concat-stream": "1.6.1",
         "duplexify": "3.5.4",
         "end-of-stream": "1.4.1",
         "flush-write-stream": "1.0.3",
@@ -15496,6 +16271,30 @@
         "railroad-diagrams": "1.0.0",
         "randexp": "0.4.6",
         "semver": "5.5.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+          "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
+          "dev": true
+        },
+        "nomnom": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
+          "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
+          "dev": true,
+          "requires": {
+            "colors": "0.5.1",
+            "underscore": "1.4.4"
+          }
+        },
+        "underscore": {
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
+          "dev": true
+        }
       }
     },
     "negotiator": {
@@ -15566,18 +16365,6 @@
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
-    "node-notifier": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-      "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
-      "dev": true,
-      "requires": {
-        "growly": "1.3.0",
-        "semver": "5.5.0",
-        "shellwords": "0.1.1",
-        "which": "1.3.0"
-      }
-    },
     "node-pre-gyp": {
       "version": "0.6.39",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
@@ -15589,171 +16376,12 @@
         "mkdirp": "0.5.1",
         "nopt": "4.0.1",
         "npmlog": "4.1.2",
-        "rc": "1.1.7",
+        "rc": "1.2.6",
         "request": "2.81.0",
         "rimraf": "2.6.2",
         "semver": "5.5.0",
         "tar": "2.2.1",
         "tar-pack": "3.4.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
-          }
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-          "dev": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "dev": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.1"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
-          }
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        }
       }
     },
     "node-status-codes": {
@@ -15775,13 +16403,13 @@
       }
     },
     "nomnom": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
-      "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
+      "integrity": "sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=",
       "dev": true,
       "requires": {
         "colors": "0.5.1",
-        "underscore": "1.4.4"
+        "underscore": "1.1.7"
       },
       "dependencies": {
         "colors": {
@@ -15793,12 +16421,13 @@
       }
     },
     "nopt": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
-      "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1.1.1",
+        "osenv": "0.1.5"
       }
     },
     "normalize-package-data": {
@@ -20281,6 +20910,14 @@
       "requires": {
         "config-chain": "1.1.11",
         "pify": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "npm-run-path": {
@@ -20483,7 +21120,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.11.0",
+        "es-abstract": "1.10.0",
         "function-bind": "1.1.1",
         "has": "1.0.1"
       }
@@ -20495,7 +21132,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.11.0"
+        "es-abstract": "1.10.0"
       }
     },
     "object.map": {
@@ -20553,7 +21190,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.11.0",
+        "es-abstract": "1.10.0",
         "function-bind": "1.1.1",
         "has": "1.0.1"
       }
@@ -20739,14 +21376,12 @@
       "dev": true
     },
     "os-locale": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "lcid": "1.0.0"
       }
     },
     "os-tmpdir": {
@@ -20776,12 +21411,6 @@
         "object-assign": "4.1.1"
       },
       "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -20915,12 +21544,12 @@
       }
     },
     "param-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz",
+      "integrity": "sha1-3LCRpDwlm5Io8cNB57akTqC/l0M=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2"
+        "sentence-case": "1.1.3"
       }
     },
     "parse-asn1": {
@@ -20960,13 +21589,12 @@
       }
     },
     "parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1",
-        "json-parse-better-errors": "1.0.1"
+        "error-ex": "1.3.1"
       }
     },
     "parse-passwd": {
@@ -20981,7 +21609,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.0"
+        "@types/node": "9.4.7"
       }
     },
     "parseurl": {
@@ -20998,18 +21626,6 @@
       "requires": {
         "camel-case": "1.2.2",
         "upper-case-first": "1.1.2"
-      },
-      "dependencies": {
-        "camel-case": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz",
-          "integrity": "sha1-Gsp8TRlTWaLOmVV5NDPG5VQlEfI=",
-          "dev": true,
-          "requires": {
-            "sentence-case": "1.1.3",
-            "upper-case": "1.1.3"
-          }
-        }
       }
     },
     "pascalcase": {
@@ -21040,10 +21656,13 @@
       "dev": true
     },
     "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -21091,12 +21710,14 @@
       "dev": true
     },
     "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "path2glob": {
@@ -21163,9 +21784,9 @@
       "dev": true
     },
     "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
     },
     "phantomjs-prebuilt": {
       "version": "2.1.16",
@@ -21179,7 +21800,7 @@
         "hasha": "2.2.0",
         "kew": "0.7.0",
         "progress": "1.1.8",
-        "request": "2.85.0",
+        "request": "2.81.0",
         "request-progress": "2.0.1",
         "which": "1.3.0"
       },
@@ -21201,12 +21822,6 @@
             "klaw": "1.3.1"
           }
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
         "jsonfile": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -21215,28 +21830,13 @@
           "requires": {
             "graceful-fs": "4.1.11"
           }
-        },
-        "request-progress": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
-          "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
-          "dev": true,
-          "requires": {
-            "throttleit": "1.0.0"
-          }
-        },
-        "throttleit": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-          "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
-          "dev": true
         }
       }
     },
     "pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
@@ -21265,12 +21865,12 @@
       }
     },
     "pkg-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "1.1.2"
       }
     },
     "pkg-up": {
@@ -21280,27 +21880,6 @@
       "dev": true,
       "requires": {
         "find-up": "1.1.2"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        }
       }
     },
     "pkginfo": {
@@ -21329,327 +21908,6 @@
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
-    },
-    "pngquant-bin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pngquant-bin/-/pngquant-bin-4.0.0.tgz",
-      "integrity": "sha512-jhjMp87bvaUeQOfNaPhSKx3tLCEwRaAycgDpIhMflgFr2+vYhw4ZrcK06eQeYg4OprXPanFljXLl5VuuAP2IHw==",
-      "dev": true,
-      "requires": {
-        "bin-build": "3.0.0",
-        "bin-wrapper": "3.0.2",
-        "execa": "0.10.0",
-        "logalot": "2.1.0"
-      },
-      "dependencies": {
-        "bin-build": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-3.0.0.tgz",
-          "integrity": "sha512-jcUOof71/TNAI2uM5uoUaDq2ePcVBQ3R/qhxAz1rX7UfvduAL/RXD3jXzvn8cVcDJdGVkiR1shal3OH0ImpuhA==",
-          "dev": true,
-          "requires": {
-            "decompress": "4.2.0",
-            "download": "6.2.5",
-            "execa": "0.7.0",
-            "p-map-series": "1.0.0",
-            "tempfile": "2.0.0"
-          },
-          "dependencies": {
-            "execa": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-              "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-              "dev": true,
-              "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
-              }
-            },
-            "get-stream": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-              "dev": true
-            }
-          }
-        },
-        "caw": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
-          "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
-          "dev": true,
-          "requires": {
-            "get-proxy": "2.1.0",
-            "isurl": "1.0.0",
-            "tunnel-agent": "0.6.0",
-            "url-to-options": "1.0.1"
-          }
-        },
-        "decompress": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
-          "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
-          "dev": true,
-          "requires": {
-            "decompress-tar": "4.1.1",
-            "decompress-tarbz2": "4.1.1",
-            "decompress-targz": "4.1.1",
-            "decompress-unzip": "4.0.1",
-            "graceful-fs": "4.1.11",
-            "make-dir": "1.2.0",
-            "pify": "2.3.0",
-            "strip-dirs": "2.1.0"
-          }
-        },
-        "decompress-tar": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-          "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
-          "dev": true,
-          "requires": {
-            "file-type": "5.2.0",
-            "is-stream": "1.1.0",
-            "tar-stream": "1.5.5"
-          }
-        },
-        "decompress-tarbz2": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
-          "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
-          "dev": true,
-          "requires": {
-            "decompress-tar": "4.1.1",
-            "file-type": "6.2.0",
-            "is-stream": "1.1.0",
-            "seek-bzip": "1.0.5",
-            "unbzip2-stream": "1.2.5"
-          },
-          "dependencies": {
-            "file-type": {
-              "version": "6.2.0",
-              "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-              "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
-              "dev": true
-            }
-          }
-        },
-        "decompress-targz": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
-          "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
-          "dev": true,
-          "requires": {
-            "decompress-tar": "4.1.1",
-            "file-type": "5.2.0",
-            "is-stream": "1.1.0"
-          }
-        },
-        "decompress-unzip": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
-          "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
-          "dev": true,
-          "requires": {
-            "file-type": "3.9.0",
-            "get-stream": "2.3.1",
-            "pify": "2.3.0",
-            "yauzl": "2.8.0"
-          },
-          "dependencies": {
-            "file-type": {
-              "version": "3.9.0",
-              "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-              "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-              "dev": true
-            }
-          }
-        },
-        "download": {
-          "version": "6.2.5",
-          "resolved": "https://registry.npmjs.org/download/-/download-6.2.5.tgz",
-          "integrity": "sha512-DpO9K1sXAST8Cpzb7kmEhogJxymyVUd5qz/vCOSyvwtp2Klj2XcDt5YUuasgxka44SxF0q5RriKIwJmQHG2AuA==",
-          "dev": true,
-          "requires": {
-            "caw": "2.0.1",
-            "content-disposition": "0.5.2",
-            "decompress": "4.2.0",
-            "ext-name": "5.0.0",
-            "file-type": "5.2.0",
-            "filenamify": "2.0.0",
-            "get-stream": "3.0.0",
-            "got": "7.1.0",
-            "make-dir": "1.2.0",
-            "p-event": "1.3.0",
-            "pify": "3.0.0"
-          },
-          "dependencies": {
-            "get-stream": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-              "dev": true
-            },
-            "pify": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-              "dev": true
-            }
-          }
-        },
-        "execa": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "6.0.5",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          },
-          "dependencies": {
-            "cross-spawn": {
-              "version": "6.0.5",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-              "dev": true,
-              "requires": {
-                "nice-try": "1.0.4",
-                "path-key": "2.0.1",
-                "semver": "5.5.0",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
-              }
-            },
-            "get-stream": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-              "dev": true
-            }
-          }
-        },
-        "file-type": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true
-        },
-        "filename-reserved-regex": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
-          "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
-          "dev": true
-        },
-        "filenamify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.0.0.tgz",
-          "integrity": "sha1-vRYiYsC26Uv7zc8Zo7uzdk94VpU=",
-          "dev": true,
-          "requires": {
-            "filename-reserved-regex": "2.0.0",
-            "strip-outer": "1.0.1",
-            "trim-repeated": "1.0.0"
-          }
-        },
-        "get-proxy": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
-          "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
-          "dev": true,
-          "requires": {
-            "npm-conf": "1.1.3"
-          }
-        },
-        "get-stream": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "got": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-          "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-          "dev": true,
-          "requires": {
-            "decompress-response": "3.3.0",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-plain-obj": "1.1.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "isurl": "1.0.0",
-            "lowercase-keys": "1.0.1",
-            "p-cancelable": "0.3.0",
-            "p-timeout": "1.2.1",
-            "safe-buffer": "5.1.1",
-            "timed-out": "4.0.1",
-            "url-parse-lax": "1.0.0",
-            "url-to-options": "1.0.1"
-          },
-          "dependencies": {
-            "get-stream": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-              "dev": true
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "is-natural-number": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-          "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "strip-dirs": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
-          "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
-          "dev": true,
-          "requires": {
-            "is-natural-number": "4.0.1"
-          }
-        },
-        "timed-out": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-          "dev": true
-        }
-      }
     },
     "portfinder": {
       "version": "1.0.13",
@@ -21713,6 +21971,12 @@
             "supports-color": "5.3.0"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -21741,12 +22005,6 @@
         "reduce-css-calc": "1.3.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -21758,12 +22016,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -21787,12 +22039,6 @@
         "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -21804,12 +22050,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -21832,12 +22072,6 @@
         "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -21849,12 +22083,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -21876,12 +22104,6 @@
         "postcss": "5.2.18"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -21893,12 +22115,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -21920,12 +22136,6 @@
         "postcss": "5.2.18"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -21937,12 +22147,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -21964,12 +22168,6 @@
         "postcss": "5.2.18"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -21981,12 +22179,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -22008,12 +22200,6 @@
         "postcss": "5.2.18"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -22025,12 +22211,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -22053,12 +22233,6 @@
         "uniqs": "2.0.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -22070,12 +22244,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -22098,12 +22266,6 @@
         "uniqid": "4.1.1"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -22115,12 +22277,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -22142,12 +22298,6 @@
         "postcss": "5.2.18"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -22159,12 +22309,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -22196,7 +22340,7 @@
           "dev": true,
           "requires": {
             "is-directory": "0.3.1",
-            "js-yaml": "3.11.0",
+            "js-yaml": "3.7.0",
             "minimist": "1.2.0",
             "object-assign": "4.1.1",
             "os-homedir": "1.0.2",
@@ -22208,21 +22352,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "require-from-string": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-          "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
           "dev": true
         }
       }
@@ -22244,7 +22373,7 @@
           "dev": true,
           "requires": {
             "is-directory": "0.3.1",
-            "js-yaml": "3.11.0",
+            "js-yaml": "3.7.0",
             "minimist": "1.2.0",
             "object-assign": "4.1.1",
             "os-homedir": "1.0.2",
@@ -22256,21 +22385,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "require-from-string": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-          "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
           "dev": true
         }
       }
@@ -22292,7 +22406,7 @@
           "dev": true,
           "requires": {
             "is-directory": "0.3.1",
-            "js-yaml": "3.11.0",
+            "js-yaml": "3.7.0",
             "minimist": "1.2.0",
             "object-assign": "4.1.1",
             "os-homedir": "1.0.2",
@@ -22304,21 +22418,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "require-from-string": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-          "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
           "dev": true
         }
       }
@@ -22353,6 +22452,17 @@
           "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
           "dev": true
         },
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        },
         "schema-utils": {
           "version": "0.4.5",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
@@ -22382,12 +22492,6 @@
         "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -22399,12 +22503,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -22426,12 +22524,6 @@
         "postcss": "5.2.18"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -22443,12 +22535,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -22480,15 +22566,9 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000820",
-            "electron-to-chromium": "1.3.40"
+            "caniuse-db": "1.0.30000815",
+            "electron-to-chromium": "1.3.39"
           }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
         },
         "postcss": {
           "version": "5.2.18",
@@ -22501,12 +22581,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -22536,12 +22610,6 @@
         "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -22559,12 +22627,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -22587,12 +22649,6 @@
         "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -22604,12 +22660,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -22634,12 +22684,6 @@
         "uniqs": "2.0.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -22651,12 +22695,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -22681,12 +22719,6 @@
         "postcss-selector-parser": "2.2.3"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -22698,12 +22730,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -22716,15 +22742,6 @@
         }
       }
     },
-    "postcss-modules-extract-imports": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
-      "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
-      "dev": true,
-      "requires": {
-        "postcss": "6.0.19"
-      }
-    },
     "postcss-modules-local-by-default": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
@@ -22732,7 +22749,83 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "css-selector-tokenizer": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+          "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+          "dev": true,
+          "requires": {
+            "cssesc": "0.1.0",
+            "fastparse": "1.1.1",
+            "regexpu-core": "1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha1-aGEH50OhLVUwy2hDjFkNWyv3LDw=",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
+          }
+        },
+        "regexpu-core": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+          "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+          "dev": true,
+          "requires": {
+            "regenerate": "1.3.3",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "postcss-modules-scope": {
@@ -22742,7 +22835,83 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "css-selector-tokenizer": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+          "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+          "dev": true,
+          "requires": {
+            "cssesc": "0.1.0",
+            "fastparse": "1.1.1",
+            "regexpu-core": "1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha1-aGEH50OhLVUwy2hDjFkNWyv3LDw=",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
+          }
+        },
+        "regexpu-core": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+          "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+          "dev": true,
+          "requires": {
+            "regenerate": "1.3.3",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "postcss-modules-values": {
@@ -22752,7 +22921,61 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha1-aGEH50OhLVUwy2hDjFkNWyv3LDw=",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "postcss-normalize-charset": {
@@ -22764,12 +22987,6 @@
         "postcss": "5.2.18"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -22781,12 +22998,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -22811,12 +23022,6 @@
         "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -22828,12 +23033,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -22856,12 +23055,6 @@
         "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -22873,12 +23066,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -22901,12 +23088,6 @@
         "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -22918,12 +23099,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -22945,12 +23120,6 @@
         "postcss": "5.2.18"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -22962,12 +23131,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -22991,12 +23154,6 @@
         "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -23008,12 +23165,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -23038,12 +23189,6 @@
         "postcss": "5.2.18"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "lodash": {
           "version": "4.17.5",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
@@ -23061,12 +23206,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -23094,12 +23233,6 @@
         "postcss": "5.2.18"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -23111,12 +23244,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -23152,12 +23279,6 @@
         "svgo": "0.7.2"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -23169,12 +23290,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -23198,12 +23313,6 @@
         "uniqs": "2.0.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -23215,12 +23324,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -23250,12 +23353,6 @@
         "uniqs": "2.0.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -23267,12 +23364,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -23321,15 +23412,6 @@
         "minimist": "1.2.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
         "ast-types": {
           "version": "0.9.8",
           "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.8.tgz",
@@ -23367,28 +23449,6 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "jest-matcher-utils": {
-          "version": "19.0.0",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-19.0.0.tgz",
-          "integrity": "sha1-Xs2bY1ZdKwAfYfv37Ex/U3lkVk0=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "pretty-format": "19.0.0"
-          }
-        },
-        "jest-validate": {
-          "version": "19.0.0",
-          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-19.0.0.tgz",
-          "integrity": "sha1-jGMYog7P6roLpTeL+7gner3tQXM=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "jest-matcher-utils": "19.0.0",
-            "leven": "2.1.0",
-            "pretty-format": "19.0.0"
-          }
-        },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -23396,15 +23456,6 @@
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.11"
-          }
-        },
-        "pretty-format": {
-          "version": "19.0.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-19.0.0.tgz",
-          "integrity": "sha1-VlMNMqy5ij+khRxOK503tCBoTIQ=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1"
           }
         }
       }
@@ -23420,9 +23471,9 @@
       }
     },
     "pretty-format": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
-      "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.0.tgz",
+      "integrity": "sha512-pvCxP2iODIIk9adXlo4S3GRj0BrJiil68kByAa1PrgG97c1tClh9dLMgp3Z6cHFZrclaABt0UH8PIhwHuFLqYA==",
       "dev": true,
       "requires": {
         "ansi-regex": "3.0.0",
@@ -23491,12 +23542,11 @@
       "dev": true
     },
     "promise": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
-      "integrity": "sha1-LOcp9rlLRcJoka0GAsXJDgTG7vY=",
-      "optional": true,
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "requires": {
-        "asap": "1.0.0"
+        "asap": "2.0.6"
       }
     },
     "promise-inflight": {
@@ -23521,11 +23571,6 @@
         "object-assign": "4.1.1"
       },
       "dependencies": {
-        "asap": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-        },
         "core-js": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
@@ -23549,14 +23594,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "promise": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "2.0.6"
-          }
         }
       }
     },
@@ -23656,6 +23693,21 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "clean-css": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
+          "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        },
         "cliui": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -23680,6 +23732,15 @@
             }
           }
         },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -23693,12 +23754,6 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
         },
         "load-json-file": {
           "version": "2.0.0",
@@ -23721,13 +23776,15 @@
             "brace-expansion": "1.1.11"
           }
         },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "path-type": {
@@ -23738,12 +23795,6 @@
           "requires": {
             "pify": "2.3.0"
           }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
         },
         "read-pkg": {
           "version": "2.0.0",
@@ -23799,10 +23850,28 @@
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+        "uglify-js": {
+          "version": "3.3.16",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.16.tgz",
+          "integrity": "sha512-FMh5SRqJRGhv9BbaTffENIpDDQIoPDR8DBraunGORGhySArsXlw9++CN+BWzPBLpoI4RcSnpfGPnilTxWL3Vvg==",
+          "dev": true,
+          "requires": {
+            "commander": "2.15.1",
+            "source-map": "0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "yargs": {
@@ -23844,9 +23913,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
     },
     "query-string": {
       "version": "4.1.0",
@@ -23887,6 +23956,14 @@
       "dev": true,
       "requires": {
         "performance-now": "2.1.0"
+      },
+      "dependencies": {
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+          "dev": true
+        }
       }
     },
     "railroad-diagrams": {
@@ -23909,7 +23986,7 @@
       "requires": {
         "base64url": "1.0.6",
         "change-case": "2.3.1",
-        "concat-stream": "1.6.2",
+        "concat-stream": "1.6.1",
         "http-response-object": "1.1.0",
         "invariant": "2.2.4",
         "json-schema-compatibility": "1.1.0",
@@ -24131,9 +24208,9 @@
       }
     },
     "rc": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
-      "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
+      "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
@@ -24512,15 +24589,6 @@
         "semver": "5.5.0",
         "slide": "1.1.6",
         "util-extend": "1.0.3"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "read-package-json": {
@@ -24550,13 +24618,6 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true,
-          "optional": true
-        },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -24569,24 +24630,24 @@
       }
     },
     "read-pkg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "4.0.0",
+        "load-json-file": "1.1.0",
         "normalize-package-data": "2.4.0",
-        "path-type": "3.0.0"
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "3.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       }
     },
     "readable-stream": {
@@ -24610,14 +24671,6 @@
         "dezalgo": "1.0.3",
         "graceful-fs": "4.1.11",
         "once": "1.4.0"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        }
       }
     },
     "readdirp": {
@@ -24632,12 +24685,6 @@
         "set-immediate-shim": "1.0.1"
       },
       "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -24709,14 +24756,6 @@
         "esprima": "3.1.3",
         "private": "0.1.8",
         "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "rechoir": {
@@ -24749,13 +24788,13 @@
       }
     },
     "redent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "3.2.0",
-        "strip-indent": "2.0.0"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       }
     },
     "reduce-css-calc": {
@@ -24916,48 +24955,6 @@
         "utila": "0.3.3"
       },
       "dependencies": {
-        "domhandler": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
-          "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
-          "dev": true,
-          "requires": {
-            "domelementtype": "1.3.0"
-          }
-        },
-        "domutils": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
-          "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
-          "dev": true,
-          "requires": {
-            "domelementtype": "1.3.0"
-          }
-        },
-        "htmlparser2": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
-          "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
-          "dev": true,
-          "requires": {
-            "domelementtype": "1.3.0",
-            "domhandler": "2.1.0",
-            "domutils": "1.1.6",
-            "readable-stream": "1.0.34"
-          }
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
         "utila": {
           "version": "0.3.3",
           "resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
@@ -24993,27 +24990,27 @@
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
     },
     "request": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "version": "2.81.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
       "requires": {
-        "aws-sign2": "0.7.0",
+        "aws-sign2": "0.6.0",
         "aws4": "1.6.0",
         "caseless": "0.12.0",
         "combined-stream": "1.0.6",
         "extend": "3.0.1",
         "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
+        "form-data": "2.1.4",
+        "har-validator": "4.2.1",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
         "mime-types": "2.1.18",
         "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
+        "performance-now": "0.2.0",
+        "qs": "6.4.0",
         "safe-buffer": "5.1.1",
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.4",
@@ -25022,12 +25019,12 @@
       }
     },
     "request-progress": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
-      "integrity": "sha1-ByHBBdipasayzossia4tXs/Pazo=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+      "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "dev": true,
       "requires": {
-        "throttleit": "0.0.2"
+        "throttleit": "1.0.0"
       }
     },
     "request-promise-core": {
@@ -25065,9 +25062,9 @@
       "dev": true
     },
     "require-from-string": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
-      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
       "dev": true
     },
     "require-main-filename": {
@@ -25084,14 +25081,6 @@
       "requires": {
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
-      },
-      "dependencies": {
-        "resolve-from": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-          "dev": true
-        }
       }
     },
     "requireindex": {
@@ -25148,9 +25137,9 @@
       }
     },
     "resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
     "resolve-global": {
@@ -25330,7 +25319,7 @@
         "exec-sh": "0.2.1",
         "fb-watchman": "2.0.0",
         "fsevents": "1.1.3",
-        "micromatch": "3.1.10",
+        "micromatch": "3.1.9",
         "minimist": "1.2.0",
         "walker": "1.0.7",
         "watch": "0.18.0"
@@ -25342,7 +25331,7 @@
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
-            "micromatch": "3.1.10",
+            "micromatch": "3.1.9",
             "normalize-path": "2.1.1"
           }
         },
@@ -25582,9 +25571,9 @@
           "dev": true
         },
         "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
+          "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
           "dev": true,
           "requires": {
             "arr-diff": "4.0.0",
@@ -25617,6 +25606,20 @@
       "dev": true,
       "requires": {
         "ajv": "5.5.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
       }
     },
     "seek-bzip": {
@@ -25712,12 +25715,6 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true
-        },
-        "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
           "dev": true
         },
         "ms": {
@@ -26034,12 +26031,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
           "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         }
       }
     },
@@ -26081,11 +26072,11 @@
       }
     },
     "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "2.16.3"
       }
     },
     "sockjs": {
@@ -26141,20 +26132,11 @@
         "sort-keys": "1.1.2"
       }
     },
-    "source-list-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-      "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
-      "dev": true
-    },
     "source-map": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-      "optional": true,
-      "requires": {
-        "amdefine": "1.0.1"
-      }
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
     },
     "source-map-loader": {
       "version": "0.1.5",
@@ -26171,24 +26153,6 @@
           "version": "0.9.2",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-          "dev": true
-        },
-        "loader-utils": {
-          "version": "0.2.17",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "dev": true,
-          "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "source-map": {
@@ -26222,14 +26186,6 @@
       "dev": true,
       "requires": {
         "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "source-map-url": {
@@ -26458,6 +26414,13 @@
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
       }
     },
     "ssri": {
@@ -26837,12 +26800,6 @@
         "style-loader": "0.8.3"
       },
       "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true
-        },
         "css-loader": {
           "version": "0.9.1",
           "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.9.1.tgz",
@@ -26868,24 +26825,6 @@
           "requires": {
             "loader-utils": "0.2.17"
           }
-        },
-        "loader-utils": {
-          "version": "0.2.17",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "dev": true,
-          "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
         },
         "source-map": {
           "version": "0.1.43",
@@ -27010,10 +26949,21 @@
       "dev": true
     },
     "strip-indent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "dev": true
+        }
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -27022,9 +26972,9 @@
       "dev": true
     },
     "strip-outer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
+      "integrity": "sha1-qsC6YNLpDF1PJ1/Yhp/ZotMQ/7g=",
       "dev": true,
       "requires": {
         "escape-string-regexp": "1.0.5"
@@ -27057,6 +27007,17 @@
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
           "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
           "dev": true
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
         },
         "schema-utils": {
           "version": "0.4.5",
@@ -27095,12 +27056,6 @@
         "write-file-stdout": "0.0.2"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -27112,12 +27067,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -27178,22 +27127,6 @@
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         },
-        "cosmiconfig": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
-          "integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "js-yaml": "3.11.0",
-            "minimist": "1.2.0",
-            "object-assign": "4.1.1",
-            "os-homedir": "1.0.2",
-            "parse-json": "2.2.0",
-            "pinkie-promise": "2.0.1",
-            "require-from-string": "1.2.1"
-          }
-        },
         "globby": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
@@ -27207,18 +27140,6 @@
             "pinkie-promise": "2.0.1"
           }
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "lodash": {
           "version": "4.17.5",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
@@ -27229,21 +27150,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "postcss": {
@@ -27258,22 +27164,10 @@
             "supports-color": "3.2.3"
           }
         },
-        "require-from-string": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-          "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
-          "dev": true
-        },
         "resolve-from": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
           "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         },
         "supports-color": {
@@ -27311,12 +27205,6 @@
         "postcss": "5.2.18"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
@@ -27328,12 +27216,6 @@
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
@@ -27371,7 +27253,7 @@
         "cssmin": "0.4.3",
         "cssom": "0.3.2",
         "glob": "7.0.5",
-        "js-yaml": "3.11.0",
+        "js-yaml": "3.7.0",
         "lodash": "4.17.5",
         "lodash.pluck": "3.1.2",
         "mkdirp": "0.5.1",
@@ -27386,6 +27268,15 @@
         "yargs": "4.8.1"
       },
       "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.5"
+          }
+        },
         "camelcase": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
@@ -27419,120 +27310,11 @@
           "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
           "dev": true
         },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
         "lodash": {
           "version": "4.17.5",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
           "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
           "dev": true
-        },
-        "os-locale": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-          "dev": true,
-          "requires": {
-            "lcid": "1.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
         },
         "svgo": {
           "version": "0.6.6",
@@ -27561,12 +27343,6 @@
             }
           }
         },
-        "which-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-          "dev": true
-        },
         "window-size": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
@@ -27577,12 +27353,6 @@
           "version": "0.1.22",
           "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.22.tgz",
           "integrity": "sha1-EN5OXpZJgfA8jMcvrcCNFLbDqiY=",
-          "dev": true
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yargs": {
@@ -27638,24 +27408,6 @@
         "mkdirp": "0.5.1",
         "sax": "1.2.4",
         "whet.extend": "0.9.9"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-          "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.10",
-            "esprima": "2.7.3"
-          }
-        }
       }
     },
     "swap-case": {
@@ -27710,16 +27462,6 @@
         "string-width": "2.1.1"
       },
       "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -27830,7 +27572,7 @@
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "dev": true,
       "requires": {
-        "bl": "1.2.2",
+        "bl": "1.2.1",
         "end-of-stream": "1.4.1",
         "readable-stream": "2.3.5",
         "xtend": "4.0.1"
@@ -27884,13 +27626,21 @@
       "dev": true
     },
     "tempfile": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
-      "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
+      "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
       "dev": true,
       "requires": {
-        "temp-dir": "1.0.0",
-        "uuid": "3.2.1"
+        "os-tmpdir": "1.0.2",
+        "uuid": "2.0.3"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+          "dev": true
+        }
       }
     },
     "test-exclude": {
@@ -27900,7 +27650,7 @@
       "dev": true,
       "requires": {
         "arrify": "1.0.1",
-        "micromatch": "3.1.10",
+        "micromatch": "3.1.9",
         "object-assign": "4.1.1",
         "read-pkg-up": "1.0.1",
         "require-main-filename": "1.0.1"
@@ -28069,22 +27819,6 @@
             }
           }
         },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -28157,23 +27891,10 @@
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
         "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "version": "3.1.9",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
+          "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
           "dev": true,
           "requires": {
             "arr-diff": "4.0.0",
@@ -28196,71 +27917,6 @@
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
         }
       }
     },
@@ -28283,33 +27939,18 @@
       "dev": true,
       "requires": {
         "caseless": "0.11.0",
-        "concat-stream": "1.6.2",
+        "concat-stream": "1.6.1",
         "http-basic": "2.5.1",
         "http-response-object": "1.1.0",
         "promise": "7.3.1",
-        "qs": "6.5.1"
+        "qs": "6.4.0"
       },
       "dependencies": {
-        "asap": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-          "dev": true
-        },
         "caseless": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
           "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
           "dev": true
-        },
-        "promise": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "dev": true,
-          "requires": {
-            "asap": "2.0.6"
-          }
         }
       }
     },
@@ -28338,9 +27979,9 @@
       "dev": true
     },
     "throttleit": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
       "dev": true
     },
     "through": {
@@ -28634,12 +28275,6 @@
         }
       }
     },
-    "toposort": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.6.tgz",
-      "integrity": "sha1-wxdI5V0hDv/AD9zcfW5o19e7nOw=",
-      "dev": true
-    },
     "tough-cookie": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
@@ -28715,9 +28350,9 @@
       }
     },
     "trim-newlines": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
     "trim-off-newlines": {
@@ -28937,6 +28572,12 @@
             }
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -29008,6 +28649,17 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
         },
         "micromatch": {
           "version": "3.1.10",
@@ -29100,7 +28752,7 @@
         "commander": "2.15.1",
         "diff": "3.5.0",
         "glob": "7.1.2",
-        "js-yaml": "3.11.0",
+        "js-yaml": "3.7.0",
         "minimatch": "3.0.4",
         "resolve": "1.6.0",
         "semver": "5.5.0",
@@ -29141,6 +28793,12 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
@@ -29325,22 +28983,41 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
     },
-    "uglify-js": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.16.tgz",
-      "integrity": "sha512-FMh5SRqJRGhv9BbaTffENIpDDQIoPDR8DBraunGORGhySArsXlw9++CN+BWzPBLpoI4RcSnpfGPnilTxWL3Vvg==",
+    "uglify-es": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
       "dev": true,
       "requires": {
-        "commander": "2.15.1",
+        "commander": "2.13.0",
         "source-map": "0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
+      }
+    },
+    "uglify-js": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
+      "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "async": "0.2.10",
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       }
     },
     "uglify-to-browserify": {
@@ -29384,11 +29061,34 @@
           "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
           "dev": true
         },
-        "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-          "dev": true
+        "find-cache-dir": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+          "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+          "dev": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "make-dir": "1.2.0",
+            "pkg-dir": "2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0"
+          }
         },
         "schema-utils": {
           "version": "0.4.5",
@@ -29400,19 +29100,25 @@
             "ajv-keywords": "3.1.0"
           }
         },
+        "source-list-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+          "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
-        "uglify-es": {
-          "version": "3.3.9",
-          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-          "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+        "webpack-sources": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+          "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
           "dev": true,
           "requires": {
-            "commander": "2.13.0",
+            "source-list-map": "2.0.0",
             "source-map": "0.6.1"
           }
         }
@@ -29441,6 +29147,31 @@
       "requires": {
         "buffer": "3.6.0",
         "through": "2.3.8"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+          "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
+          "dev": true
+        },
+        "buffer": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+          "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
+          "dev": true,
+          "requires": {
+            "base64-js": "0.0.8",
+            "ieee754": "1.1.10",
+            "isarray": "1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        }
       }
     },
     "unc-path-regex": {
@@ -29450,9 +29181,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
+      "integrity": "sha1-QLq4S60Z0jAJbo1u9ii/8FXYPbA=",
       "dev": true
     },
     "union": {
@@ -29867,6 +29598,13 @@
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
       }
     },
     "vhost": {
@@ -29881,7 +29619,7 @@
       "integrity": "sha1-eUCIfu8JOB6zYmrEwPmrU9S35FA=",
       "dev": true,
       "requires": {
-        "clone": "1.0.4",
+        "clone": "1.0.3",
         "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       }
@@ -30070,17 +29808,75 @@
         "minimist": "1.2.0"
       }
     },
-    "watchpack": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.5.0.tgz",
-      "integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
+    "wbuf": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dev": true,
       "requires": {
-        "chokidar": "2.0.3",
-        "graceful-fs": "4.1.11",
-        "neo-async": "2.5.0"
+        "minimalistic-assert": "1.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "webpack": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
+      "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.5.3",
+        "acorn-dynamic-import": "2.0.2",
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.1",
+        "async": "2.6.0",
+        "enhanced-resolve": "3.4.1",
+        "escope": "3.6.0",
+        "interpret": "1.1.0",
+        "json-loader": "0.5.4",
+        "json5": "0.5.1",
+        "loader-runner": "2.3.0",
+        "loader-utils": "1.1.0",
+        "memory-fs": "0.4.1",
+        "mkdirp": "0.5.1",
+        "node-libs-browser": "2.1.0",
+        "source-map": "0.5.7",
+        "supports-color": "4.5.0",
+        "tapable": "0.2.8",
+        "uglifyjs-webpack-plugin": "0.4.6",
+        "watchpack": "1.5.0",
+        "webpack-sources": "1.1.0",
+        "yargs": "8.0.2"
       },
       "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "ajv-keywords": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "anymatch": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
@@ -30102,6 +29898,15 @@
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
           "dev": true
+        },
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.5"
+          }
         },
         "braces": {
           "version": "2.3.1",
@@ -30143,6 +29948,21 @@
             }
           }
         },
+        "browserify-zlib": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+          "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+          "dev": true,
+          "requires": {
+            "pako": "1.0.6"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true
+        },
         "chokidar": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
@@ -30161,6 +29981,18 @@
             "path-is-absolute": "1.0.1",
             "readdirp": "2.1.0",
             "upath": "1.0.4"
+          }
+        },
+        "enhanced-resolve": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+          "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "memory-fs": "0.4.1",
+            "object-assign": "4.1.1",
+            "tapable": "0.2.8"
           }
         },
         "expand-brackets": {
@@ -30274,6 +30106,15 @@
             }
           }
         },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -30295,10 +30136,16 @@
             }
           }
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "https-browserify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+          "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
           "dev": true
         },
         "is-accessor-descriptor": {
@@ -30376,6 +30223,12 @@
             }
           }
         },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -30387,6 +30240,45 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "dev": true
+        },
+        "memory-fs": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+          "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+          "dev": true,
+          "requires": {
+            "errno": "0.1.7",
+            "readable-stream": "2.3.5"
+          }
         },
         "micromatch": {
           "version": "3.1.10",
@@ -30407,133 +30299,6 @@
             "regex-not": "1.0.2",
             "snapdragon": "0.8.2",
             "to-regex": "3.0.2"
-          }
-        }
-      }
-    },
-    "wbuf": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
-      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
-      "dev": true,
-      "requires": {
-        "minimalistic-assert": "1.0.0"
-      }
-    },
-    "webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
-    },
-    "webpack": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
-      "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
-      "dev": true,
-      "requires": {
-        "acorn": "5.5.3",
-        "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "async": "2.6.0",
-        "enhanced-resolve": "3.4.1",
-        "escope": "3.6.0",
-        "interpret": "1.1.0",
-        "json-loader": "0.5.4",
-        "json5": "0.5.1",
-        "loader-runner": "2.3.0",
-        "loader-utils": "1.1.0",
-        "memory-fs": "0.4.1",
-        "mkdirp": "0.5.1",
-        "node-libs-browser": "2.1.0",
-        "source-map": "0.5.7",
-        "supports-color": "4.5.0",
-        "tapable": "0.2.8",
-        "uglifyjs-webpack-plugin": "0.4.6",
-        "watchpack": "1.5.0",
-        "webpack-sources": "1.1.0",
-        "yargs": "8.0.2"
-      },
-      "dependencies": {
-        "ajv-keywords": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "base64-js": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
-          "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
-          "dev": true
-        },
-        "browserify-zlib": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-          "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-          "dev": true,
-          "requires": {
-            "pako": "1.0.6"
-          }
-        },
-        "buffer": {
-          "version": "4.9.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-          "dev": true,
-          "requires": {
-            "base64-js": "1.2.3",
-            "ieee754": "1.1.11",
-            "isarray": "1.0.0"
-          }
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "https-browserify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-          "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
           }
         },
         "node-libs-browser": {
@@ -30559,7 +30324,7 @@
             "readable-stream": "2.3.5",
             "stream-browserify": "2.0.1",
             "stream-http": "2.8.1",
-            "string_decoder": "1.1.0",
+            "string_decoder": "1.0.3",
             "timers-browserify": "2.0.6",
             "tty-browserify": "0.0.0",
             "url": "0.11.0",
@@ -30567,26 +30332,34 @@
             "vm-browserify": "0.0.4"
           }
         },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        },
         "os-browserify": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
           "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
           "dev": true
         },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
         "pako": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
           "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
           "dev": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
         },
         "path-type": {
           "version": "2.0.0",
@@ -30596,12 +30369,6 @@
           "requires": {
             "pify": "2.3.0"
           }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
         },
         "process": {
           "version": "0.11.10",
@@ -30643,23 +30410,12 @@
             "safe-buffer": "5.1.1",
             "string_decoder": "1.0.3",
             "util-deprecate": "1.0.2"
-          },
-          "dependencies": {
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "dev": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
           }
         },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+        "source-list-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+          "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
           "dev": true
         },
         "string-width": {
@@ -30690,9 +30446,9 @@
           }
         },
         "string_decoder": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.0.tgz",
-          "integrity": "sha512-8zQpRF6juocE69ae7CSPmYEGJe4VCXwP6S6dxUWI7i53Gwv54/ec41fiUA+X7BPGGv7fRSQJjBQVa0gomGaOgg==",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -30712,6 +30468,12 @@
           "requires": {
             "has-flag": "2.0.0"
           }
+        },
+        "tapable": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
+          "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
+          "dev": true
         },
         "timers-browserify": {
           "version": "2.0.6",
@@ -30758,10 +30520,39 @@
             "webpack-sources": "1.1.0"
           }
         },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+        "watchpack": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.5.0.tgz",
+          "integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
+          "dev": true,
+          "requires": {
+            "chokidar": "2.0.3",
+            "graceful-fs": "4.1.11",
+            "neo-async": "2.5.0"
+          }
+        },
+        "webpack-sources": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+          "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+          "dev": true,
+          "requires": {
+            "source-list-map": "2.0.0",
+            "source-map": "0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "yargs": {
@@ -30849,6 +30640,52 @@
         "time-stamp": "2.0.0"
       },
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "memory-fs": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+          "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+          "dev": true,
+          "requires": {
+            "errno": "0.1.7",
+            "readable-stream": "2.3.5"
+          }
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
         "time-stamp": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
@@ -30991,6 +30828,12 @@
             "wrap-ansi": "2.1.0"
           }
         },
+        "connect-history-api-fallback": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
+          "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
+          "dev": true
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -31008,7 +30851,7 @@
           "requires": {
             "globby": "6.1.0",
             "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.1",
+            "is-path-in-cwd": "1.0.0",
             "p-map": "1.2.0",
             "pify": "3.0.0",
             "rimraf": "2.6.2"
@@ -31134,16 +30977,6 @@
             }
           }
         },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -31186,10 +31019,10 @@
             }
           }
         },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "is-accessor-descriptor": {
@@ -31279,27 +31112,6 @@
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-              "dev": true
-            }
-          }
-        },
         "micromatch": {
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -31327,81 +31139,11 @@
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
-        "os-locale": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-          "dev": true,
-          "requires": {
-            "lcid": "1.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-              "dev": true
-            }
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
         },
         "supports-color": {
           "version": "5.3.0",
@@ -31411,18 +31153,6 @@
           "requires": {
             "has-flag": "3.0.0"
           }
-        },
-        "which-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-          "dev": true
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-          "dev": true
         },
         "yargs": {
           "version": "6.6.0",
@@ -31484,28 +31214,22 @@
         "strip-ansi": "3.0.1"
       },
       "dependencies": {
+        "node-notifier": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+          "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+          "dev": true,
+          "requires": {
+            "growly": "1.3.0",
+            "semver": "5.5.0",
+            "shellwords": "0.1.1",
+            "which": "1.3.0"
+          }
+        },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
-      }
-    },
-    "webpack-sources": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
-      "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
-      "dev": true,
-      "requires": {
-        "source-list-map": "2.0.0",
-        "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
@@ -31567,9 +31291,9 @@
       }
     },
     "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
       "dev": true
     },
     "wide-align": {
@@ -31686,14 +31410,6 @@
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
         "signal-exit": "3.0.2"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        }
       }
     },
     "write-file-stdout": {
@@ -31786,9 +31502,9 @@
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
     "yallist": {
@@ -31804,71 +31520,21 @@
       "dev": true
     },
     "yargs": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
-      "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
       "requires": {
-        "cliui": "4.0.0",
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
         "decamelize": "1.2.0",
-        "find-up": "2.1.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "8.1.0"
+        "window-size": "0.1.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
-          "dev": true,
-          "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true
         }
       }
@@ -31880,12 +31546,20 @@
       "dev": true,
       "requires": {
         "camelcase": "4.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
       }
     },
     "yauzl": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz",
-      "integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
       "dev": true,
       "requires": {
         "buffer-crc32": "0.2.13",
@@ -31913,6 +31587,45 @@
         "async": "2.6.0",
         "node-zopfli": "2.0.2",
         "webpack-sources": "1.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.5"
+          }
+        },
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+          "dev": true
+        },
+        "source-list-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
+          "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "webpack-sources": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
+          "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+          "dev": true,
+          "requires": {
+            "source-list-map": "2.0.0",
+            "source-map": "0.6.1"
+          }
+        }
       }
     }
   }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4249,6 +4249,12 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
+      "dev": true
+    },
     "cosmiconfig": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
@@ -6430,6 +6436,18 @@
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
+      }
+    },
+    "ecstatic": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-2.2.1.tgz",
+      "integrity": "sha512-ztE4WqheoWLh3wv+HQwy7dACnvNY620coWpa+XqY6R2cVWgaAT2lUISU1Uf7JpdLLJCURktJOaA9av2AOzsyYQ==",
+      "dev": true,
+      "requires": {
+        "he": "1.1.1",
+        "mime": "1.6.0",
+        "minimist": "1.2.0",
+        "url-join": "2.0.5"
       }
     },
     "ee-first": {
@@ -11149,6 +11167,28 @@
       "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
       "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM=",
       "dev": true
+    },
+    "http-server": {
+      "version": "github:johntron/http-server#2af9dee8ed4471d9bfc3b675ac5ae3cc420e711a",
+      "dev": true,
+      "requires": {
+        "colors": "1.0.3",
+        "corser": "2.0.1",
+        "ecstatic": "2.2.1",
+        "http-proxy": "1.16.2",
+        "opener": "1.4.3",
+        "optimist": "0.6.1",
+        "portfinder": "1.0.13",
+        "union": "0.4.6"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        }
+      }
     },
     "http-signature": {
       "version": "1.2.0",
@@ -20564,6 +20604,12 @@
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
+    "opener": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+      "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
+      "dev": true
+    },
     "opn": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
@@ -29409,6 +29455,23 @@
       "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
       "dev": true
     },
+    "union": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.4.6.tgz",
+      "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
+      "dev": true,
+      "requires": {
+        "qs": "2.3.3"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+          "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
+          "dev": true
+        }
+      }
+    },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -29626,6 +29689,12 @@
           "dev": true
         }
       }
+    },
+    "url-join": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
+      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
+      "dev": true
     },
     "url-parse": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "test": "NODE_PATH=node_modules jest --config=jest.config.js --no-cache",
     "test:watch": "npm test -- --watch",
     "testing": "NODE_ENV=testing webpack-dev-server --config ./webpack/webpack.dev.js --progress --colors --content-base ./build --host 0.0.0.0 --port $npm_package_config_port",
-    "integration-tests": "./scripts/ci/run-integration-tests",
+    "integration-tests": "PLUGINS_PATH=\"${npm_config_externalplugins}\" ./scripts/ci/run-integration-tests",
     "validate-build": "scripts/validate-build dist/*.js",
     "versions": "echo npm: $(npm --version) && echo node: $(node --version)",
     "tslint": "tslint -c tslint.json --project tsconfig.json"

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "test": "NODE_PATH=node_modules jest --config=jest.config.js --no-cache",
     "test:watch": "npm test -- --watch",
     "testing": "NODE_ENV=testing webpack-dev-server --config ./webpack/webpack.dev.js --progress --colors --content-base ./build --host 0.0.0.0 --port $npm_package_config_port",
+    "integration-tests": "./scripts/ci/run-integration-tests",
     "validate-build": "scripts/validate-build dist/*.js",
     "versions": "echo npm: $(npm --version) && echo node: $(node --version)",
     "tslint": "tslint -c tslint.json --project tsconfig.json"

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "jest-webpack-alias": "3.3.3",
     "jison-loader": "1.0.0",
     "json-loader": "0.5.4",
+    "junit-merge": "1.3.0",
     "less": "2.6.1",
     "less-loader": "4.0.5",
     "license-checker": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "test": "NODE_PATH=node_modules jest --config=jest.config.js --no-cache",
     "test:watch": "npm test -- --watch",
     "testing": "NODE_ENV=testing webpack-dev-server --config ./webpack/webpack.dev.js --progress --colors --content-base ./build --host 0.0.0.0 --port $npm_package_config_port",
-    "integration-tests": "PLUGINS_PATH=\"${npm_config_externalplugins}\" ./scripts/ci/run-integration-tests",
+    "integration-tests": "PLUGINS_PATH=\"${npm_config_externalplugins}\" ./scripts/run-integration-tests",
     "validate-build": "scripts/validate-build dist/*.js",
     "versions": "echo npm: $(npm --version) && echo node: $(node --version)",
     "tslint": "tslint -c tslint.json --project tsconfig.json"

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "gulp-connect": "3.2.2",
     "html-loader": "0.5.5",
     "html-webpack-plugin": "2.30.1",
+    "http-server": "github:johntron/http-server#proxy-secure-flag",
     "image-webpack-loader": "4.0.0",
     "jasmine-reporters": "2.1.1",
     "jest-cli": "22.4.0",

--- a/scripts/ci/run-integration-tests
+++ b/scripts/ci/run-integration-tests
@@ -28,6 +28,8 @@ STOP_ON_FAIL=${STOP_ON_FAIL:-1}
 # Values: 0, 1
 SUPPRESS_OUTPUT=${SUPPRESS_OUTPUT:-0}
 
+CLEANUP_TESTS=${CLEANUP_TESTS:-0}
+
 PROXY_PORT=${PROXY_PORT:-4200}
 PROXY_PID=0
 
@@ -35,7 +37,6 @@ PROJECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )"
 CYPRESS_FOLDER="cypress"
 TESTS_FOLDER="tests"
 
-PLUGINS_FOLDER="external_plugins"
 PLUGINS_PATH=${PLUGINS_PATH:-''}
 
 
@@ -98,9 +99,7 @@ function runTestFile {
 function setup_plugins {
   if [ -n "${PLUGINS_PATH}" ]; then
     echo "==> Setup external plugins…"
-    rm -rf ${PROJECT_ROOT}/${TESTS_FOLDER}/${PLUGINS_FOLDER}/
-    mkdir ${PROJECT_ROOT}/${TESTS_FOLDER}/${PLUGINS_FOLDER}/
-    rsync -aH ${PROJECT_ROOT}/${PLUGINS_PATH}/${TESTS_FOLDER}/ ${PROJECT_ROOT}/${TESTS_FOLDER}/${PLUGINS_FOLDER}/
+    rsync -aH ${PROJECT_ROOT}/${PLUGINS_PATH}/${TESTS_FOLDER}/ ${PROJECT_ROOT}/${TESTS_FOLDER}/
     echo "===> done."
   else
     echo "==> No Plugins configured."
@@ -110,9 +109,18 @@ function setup_plugins {
 # removes copied plugins files…
 function teardown_plugins {
   if [ -n "${PLUGINS_PATH}" ]; then
-    echo "==> Removing plugins folder…"
-    rm -r "${PROJECT_ROOT}/${TESTS_FOLDER}/${PLUGINS_FOLDER}/"
-    echo "===> done."
+    if [ ${CLEANUP_TESTS} -eq 0 ]; then
+      echo "==> Cleaning up ./${TESTS_FOLDER} folder"
+      rm -r ${PROJECT_ROOT}/${TESTS_FOLDER}
+      git checkout ${PROJECT_ROOT}/${TESTS_FOLDER}
+      echo "==> done."
+    else
+      echo ""
+      echo "==> !!! PLUGINS TESTS ARE STILL IN YOUR ./${TESTS_FOLDER} FOLDER, MAKE SURE TO CLEAN UP !!!"
+      echo "==> You can use 'rm -r ./${TESTS_FOLDER} && git checkout ./${TESTS_FOLDER}' to easily clean up."
+      echo "==> Or you can provide CLEANUP_TESTS=1 to this script in order to automatically clean up."
+      echo ""
+    fi
   fi
 }
 

--- a/scripts/ci/run-integration-tests
+++ b/scripts/ci/run-integration-tests
@@ -43,8 +43,17 @@ function runTestFile {
   exit 1
 }
 
-echo 'Running tests per file (./tests/*-cy.js)'
-find $PROJECT_ROOT/tests -type f -name '*-cy.js' | while read file; do runTestFile "$file"; done
+
+# Starting http-server & setting up trap
+http-server -sp 4200 dist&
+SERVER_PID=$!
+trap "kill $SERVER_PID" EXIT
+
+# pass in simple search strings for filenames here (find syntax)
+SEARCH=${1:-'*'}
+
+echo "Found these matching files ('./tests/${SEARCH}-cy.js')"
+find $PROJECT_ROOT/tests -type f -name ${SEARCH}"-cy.js" -print | tee /dev/tty | while read file; do runTestFile "$file"; done
 
 echo "Done running tests, merging the results now"
 junit-merge ./cypress/*-result.xml --out ./cypress/results.xml

--- a/scripts/ci/run-integration-tests
+++ b/scripts/ci/run-integration-tests
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+[ -n "${DEBUG}" ] && set -x
 
 # This script is a temporary solution to run the integration tests in a <= 1.GB
 # memory environment and with support for retries per test file. We should

--- a/scripts/ci/run-integration-tests
+++ b/scripts/ci/run-integration-tests
@@ -5,55 +5,183 @@
 # replace it with a test runner in the future, please see it more as a proof of
 # concept
 
-set -ex
+## Configuration
+#####################################################################
+
+# Search string passed to `find`
+# Values: String
+SEARCH=${1:-'*'}
+
+# Maximum number of retries
+# Values: n ∈ ℕ
+RETRIES=${RETRIES:-3}
+
+# Stop if file failed $RETRIES times? (turn this off, if you want
+# to test all tests locally but something keeps failing)
+# Values: 0, 1
+STOP_ON_FAIL=${STOP_ON_FAIL:-1}
+
+# Suppresses Cypress output on failures
+# Values: 0, 1
+SUPPRESS_OUTPUT=${SUPPRESS_OUTPUT:-0}
+
+PROXY_PORT=${PROXY_PORT:-4200}
+PROXY_PID=0
 
 PROJECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )"
-RETRIES=3
+CYPRESS_FOLDER="cypress"
+TESTS_FOLDER="tests"
 
+PLUGINS_FOLDER="external_plugins"
+PLUGINS_PATH=${PLUGINS_PATH:-''}
+
+
+
+## Functions
+#####################################################################
+
+# executes Cypress
+#
+# from callee:
+# FILE: file to test
+# OUTPUT_PATH: Directory where results are saved (e.g. "some/path/to/Testfile-cy.js-1")
 function executeCypress {
-  echo "=====> Executing cypress for $1"
-  local testResultPath
-  testResultPath="cypress/$(basename "$1")-result.xml"
-  npm run cypress -- -s "$1" --reporter junit --reporter-options "mochaFile=$testResultPath"
+  npm run --silent cypress -- \
+    --spec "${FILE}" \
+    --config "screenshotsFolder=${OUTPUT_PATH}/screenshots,videosFolder=${OUTPUT_PATH}/videos" \
+    --reporter junit \
+    --reporter-options "mochaFile=${OUTPUT_PATH}/result.xml"
 }
 
+# runs tests for matched file
+#
+# From callee:
+# RELATIVE_PATH: stripped down output from find command (e.g. "pages/Testfile-cy.js")
 function runTestFile {
-  echo "==> Running tests for $1"
-  i="0"
-  while [ $i -lt $RETRIES ]; do
-    i=$((i+1))
-    echo "===> Executing run $i"
-    local exit_code
+  echo ""
+  echo "==> Running Tests for ./${TESTS_FOLDER}/$RELATIVE_PATH"
+  local RUN=0
+  local EXIT_CODE=1
+  while [ $EXIT_CODE -ne 0 ] && [ $RUN -lt $RETRIES ]; do
+    RUN=$((RUN+1))
+    local OUTPUT_PATH="${PROJECT_ROOT}/${CYPRESS_FOLDER}/${RELATIVE_PATH}-${RUN}"
 
-    # We don't want to let an error in the block below to end the entire script
-    set +e # undo instant error flag
+    echo "===> Executing Cypress (${RUN}/${RETRIES})"
+    CYOUT="$(FILE="${PROJECT_ROOT}/tests/${RELATIVE_PATH}" RUN=${RUN} OUTPUT_PATH=${OUTPUT_PATH} executeCypress)"
+    EXIT_CODE=$?
 
-    executeCypress "$1"
-    exit_code=$?
-
-    set -e # redo flag
-    echo "==> $i run exit code: $exit_code"
-
-    if [ $exit_code -eq 0 ]; then
-      return 0
+    if [ $EXIT_CODE -eq 0 ]; then
+      echo "====> Successfully finished tests for ${RELATIVE_PATH}"
+    else
+      echo "====> Failures in tests for ${RELATIVE_PATH}"
+      [ $SUPPRESS_OUTPUT -eq 0 ] && echo "${CYOUT}"
     fi
   done
 
-  echo "==> Couldn't get a success in $RETRIES retries"
-  exit 1
+  if [ $EXIT_CODE -ne 0 ]; then
+    echo "===> Couldn't get a success in $RETRIES retries for $RELATIVE_PATH"
+  fi
+
+  if [ ${EXIT_CODE} -ne 0 ] && [ ${STOP_ON_FAIL} -eq 0 ]; then
+    echo "==> Continuing despite failures…"
+    return 0
+  fi
+
+  return $EXIT_CODE
 }
 
+# copies tests from plugins folder into project
+# this is necessary because Cypress doesnt allows external files to be tested…
+function setup_plugins {
+  if [ -n "${PLUGINS_PATH}" ]; then
+    echo "==> Setup external plugins…"
+    rm -rf ${PROJECT_ROOT}/${TESTS_FOLDER}/${PLUGINS_FOLDER}/
+    mkdir ${PROJECT_ROOT}/${TESTS_FOLDER}/${PLUGINS_FOLDER}/
+    rsync -aH ${PROJECT_ROOT}/${PLUGINS_PATH}/${TESTS_FOLDER}/ ${PROJECT_ROOT}/${TESTS_FOLDER}/${PLUGINS_FOLDER}/
+    echo "===> done."
+  else
+    echo "==> No Plugins configured."
+  fi
+}
 
-# Starting http-server & setting up trap
-http-server -sp 4200 dist&
-SERVER_PID=$!
-trap "kill $SERVER_PID" EXIT
+# removes copied plugins files…
+function teardown_plugins {
+  if [ -n "${PLUGINS_PATH}" ]; then
+    echo "==> Removing plugins folder…"
+    rm -r "${PROJECT_ROOT}/${TESTS_FOLDER}/${PLUGINS_FOLDER}/"
+    echo "===> done."
+  fi
+}
 
-# pass in simple search strings for filenames here (find syntax)
-SEARCH=${1:-'*'}
+# merges results from cypress runs into one file
+function teardown_merge {
+  if [ "$(find ${PROJECT_ROOT}/${CYPRESS_FOLDER}/ -type f -name result.xml | wc -l)" -ne 0 ]; then
+    echo "==> Merging results from ./${CYPRESS_FOLDER}/*/result.xml into ./${CYPRESS_FOLDER}/results.xml…"
+    junit-merge --out ${PROJECT_ROOT}/${CYPRESS_FOLDER}/results.xml $(find ${PROJECT_ROOT}/${CYPRESS_FOLDER}/ -type f -name result.xml)
+    echo "===> done."
+  else
+    echo "==> Nothing to merge."
+  fi
+}
 
-echo "Found these matching files ('./tests/${SEARCH}-cy.js')"
-find $PROJECT_ROOT/tests -type f -name ${SEARCH}"-cy.js" -print | tee /dev/tty | while read file; do runTestFile "$file"; done
+function teardown_proxy {
+  echo "==> Killing Proxy…"
+  kill $PROXY_PID
+  echo "===> done."
+}
 
-echo "Done running tests, merging the results now"
-junit-merge ./cypress/*-result.xml --out ./cypress/results.xml
+# sets up everything
+function setup {
+  echo ""
+  echo "=> Setup"
+
+  ## Setup proxy
+  if [ -n "$(lsof -i :${PROXY_PORT})" ]; then
+    echo "==> ERROR: Port ${PROXY_PORT} is already in use"
+    exit 1
+  fi
+  echo "==> Starting http-server…"
+  http-server -sp ${PROXY_PORT} dist&
+  PROXY_PID=$!
+  echo "===> done (PID: ${PROXY_PID})."
+
+  ## Setup plugins if configured
+  if [ -n "${PLUGINS_PATH}" ]; then
+    setup_plugins
+  fi
+
+  ## Remove old results
+  if [ -d "${PROJECT_ROOT}/${CYPRESS_FOLDER}" ]; then
+    echo "==> Directory ./${CYPRESS_FOLDER} already exists…"
+    rm -r "${PROJECT_ROOT}/${CYPRESS_FOLDER}"
+    echo "===> removed."
+  fi
+}
+
+# tears down everything…
+function teardown {
+  echo ""
+  echo "=> Teardown"
+  teardown_proxy
+  teardown_plugins
+  teardown_merge
+  echo "=> Bye."
+}
+
+# finds the files and runs the tests
+function run_tests {
+  echo ""
+  echo "=> Running Tests"
+  find "$PROJECT_ROOT/${TESTS_FOLDER}" -type f -name "${SEARCH}-cy.js" -print | \
+    while read FOUND_FILE
+    do
+      RELATIVE_PATH="$(echo ${FOUND_FILE} | sed s+${PROJECT_ROOT}/${TESTS_FOLDER}/++)" runTestFile || exit 1
+    done
+}
+
+## Programm
+#####################################################################
+
+setup
+trap teardown EXIT
+run_tests

--- a/scripts/ci/run-integration-tests
+++ b/scripts/ci/run-integration-tests
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # This script is a temporary solution to run the integration tests in a <= 1.GB
 # memory environment and with support for retries per test file. We should
 # replace it with a test runner in the future, please see it more as a proof of

--- a/scripts/ci/run-integration-tests
+++ b/scripts/ci/run-integration-tests
@@ -5,8 +5,7 @@
 # replace it with a test runner in the future, please see it more as a proof of
 # concept
 
-set -e
-shopt -s globstar # to allow ** in globs
+set -ex
 
 PROJECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )"
 RETRIES=3
@@ -44,10 +43,8 @@ function runTestFile {
   exit 1
 }
 
-
-for f in $PROJECT_ROOT/tests/**/*-cy.js; do
-  runTestFile "$f"
-done
+echo 'Running tests per file (./tests/*-cy.js)'
+find $PROJECT_ROOT/tests -type f -name '*-cy.js' | while read file; do runTestFile "$file"; done
 
 echo "Done running tests, merging the results now"
 junit-merge ./cypress/**/*-result.xml --out ./cypress/results.xml

--- a/scripts/ci/run-integration-tests
+++ b/scripts/ci/run-integration-tests
@@ -140,8 +140,12 @@ function setup {
     echo "==> ERROR: Port ${PROXY_PORT} is already in use"
     exit 1
   fi
-  echo "==> Starting http-server…"
-  http-server -sp ${PROXY_PORT} dist&
+  if [ ! -d ${PROJECT_ROOT}/dist ]; then
+    echo "==> ERROR: no dist folder! forgot npm run build?"
+    exit 1
+  fi
+  echo "==> Starting http-server, serving files from ./dist…"
+  http-server -sp ${PROXY_PORT} ${PROJECT_ROOT}/dist&
   PROXY_PID=$!
   echo "===> done (PID: ${PROXY_PID})."
 

--- a/scripts/ci/run-integration-tests
+++ b/scripts/ci/run-integration-tests
@@ -47,4 +47,4 @@ echo 'Running tests per file (./tests/*-cy.js)'
 find $PROJECT_ROOT/tests -type f -name '*-cy.js' | while read file; do runTestFile "$file"; done
 
 echo "Done running tests, merging the results now"
-junit-merge ./cypress/**/*-result.xml --out ./cypress/results.xml
+junit-merge ./cypress/*-result.xml --out ./cypress/results.xml

--- a/scripts/run-integration-tests
+++ b/scripts/run-integration-tests
@@ -110,16 +110,16 @@ function setup_plugins {
 function teardown_plugins {
   if [ -n "${PLUGINS_PATH}" ]; then
     if [ ${CLEANUP_TESTS} -eq 0 ]; then
-      echo "==> Cleaning up ./${TESTS_FOLDER} folder"
-      rm -r ${PROJECT_ROOT}/${TESTS_FOLDER}
-      git checkout ${PROJECT_ROOT}/${TESTS_FOLDER}
-      echo "==> done."
-    else
       echo ""
       echo "==> !!! PLUGINS TESTS ARE STILL IN YOUR ./${TESTS_FOLDER} FOLDER, MAKE SURE TO CLEAN UP !!!"
       echo "==> You can use 'rm -r ./${TESTS_FOLDER} && git checkout ./${TESTS_FOLDER}' to easily clean up."
       echo "==> Or you can provide CLEANUP_TESTS=1 to this script in order to automatically clean up."
       echo ""
+    else
+      echo "==> Cleaning up ./${TESTS_FOLDER} folder"
+      rm -r ${PROJECT_ROOT}/${TESTS_FOLDER}
+      git checkout ${PROJECT_ROOT}/${TESTS_FOLDER}
+      echo "==> done."
     fi
   fi
 }

--- a/scripts/run-integration-tests
+++ b/scripts/run-integration-tests
@@ -33,7 +33,7 @@ CLEANUP_TESTS=${CLEANUP_TESTS:-0}
 PROXY_PORT=${PROXY_PORT:-4200}
 PROXY_PID=0
 
-PROJECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )"
+PROJECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 CYPRESS_FOLDER="cypress"
 TESTS_FOLDER="tests"
 


### PR DESCRIPTION
Jenkins complained about `**` after its restart, this fixes the issue by replacing the globbing by `find`

also we moved `junit-merge` from the dockerfile to our package.json because it is part of the project - we want to make the `run-integration-tests` script our entrypoint also for local testing in a follow-up PR 👍 

---

I have decided to put a bit more effort into this to allow us to backport this ASAP to 1.11 👍 After we backported this we should be able to drasticly reduce `run integration tests` calls on 1.11 branch 🎉 

Also we are able to run single tests in an easy way with a command like this `npm run integration-tests -- Sidebar` 🎉 