### PR TITLE
DCOS-21640: Wrap cosmos repository API with http-service

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -396,9 +396,9 @@
       }
     },
     "@dcos/http-service": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@dcos/http-service/-/http-service-0.2.1.tgz",
-      "integrity": "sha1-GbMJz2WavAT9FfMyrGp5wTBfGF8=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@dcos/http-service/-/http-service-0.3.0.tgz",
+      "integrity": "sha1-PxdCYN1Is927pZIxnJKhwWp6wKU=",
       "requires": {
         "@dcos/connection-manager": "0.2.1",
         "@dcos/connections": "0.1.0",
@@ -406,12 +406,12 @@
       }
     },
     "@dcos/mesos-client": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@dcos/mesos-client/-/mesos-client-0.2.0.tgz",
-      "integrity": "sha1-E28yDVjZXmzKDggi4696iq5npYw=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@dcos/mesos-client/-/mesos-client-0.2.1.tgz",
+      "integrity": "sha1-pmzskdUxLqpi89sDleo8xi+hH+E=",
       "requires": {
         "@dcos/copychars": "0.1.0",
-        "@dcos/http-service": "0.2.1",
+        "@dcos/http-service": "0.3.0",
         "@dcos/recordio": "0.1.6",
         "rxjs": "5.4.3"
       }
@@ -3675,7 +3675,7 @@
     },
     "compression": {
       "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
       "integrity": "sha1-sDuNhub4rSloPLqN+R3cb/x3s5U=",
       "dev": true,
       "requires": {
@@ -15110,7 +15110,8 @@
       "dependencies": {
         "JSONStream": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
           "dev": true,
           "requires": {
             "jsonparse": "1.3.1",
@@ -15119,49 +15120,58 @@
           "dependencies": {
             "jsonparse": {
               "version": "1.3.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
               "dev": true
             },
             "through": {
               "version": "2.3.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
               "dev": true
             }
           }
         },
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "ansicolors": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
           "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "bin-links": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.0.tgz",
+          "integrity": "sha512-3desjIEoSt86s+BRZlkLpBPPcHhr4vyUPL/+X1cQuE96NIlkELqnb4Yq+I5gZe47gHsZztA6cm38uMrT9+FWpA==",
           "dev": true,
           "requires": {
             "bluebird": "3.5.1",
@@ -15174,12 +15184,14 @@
         },
         "bluebird": {
           "version": "3.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
           "dev": true
         },
         "cacache": {
           "version": "10.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.1.tgz",
+          "integrity": "sha512-dRHYcs9LvG9cHgdPzjiI+/eS7e1xRhULrcyOx04RZQsszNJXU2SL9CyG60yLnge282Qq5nwTv+ieK2fH+WPZmA==",
           "dev": true,
           "requires": {
             "bluebird": "3.5.1",
@@ -15199,7 +15211,8 @@
           "dependencies": {
             "ssri": {
               "version": "5.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz",
+              "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "5.1.1"
@@ -15207,24 +15220,28 @@
             },
             "y18n": {
               "version": "3.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
               "dev": true
             }
           }
         },
         "call-limit": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.0.tgz",
+          "integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o=",
           "dev": true
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true
         },
         "cli-table2": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cli-table2/-/cli-table2-0.2.0.tgz",
+          "integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
           "dev": true,
           "requires": {
             "colors": "1.1.2",
@@ -15234,18 +15251,21 @@
           "dependencies": {
             "colors": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+              "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
               "dev": true,
               "optional": true
             },
             "lodash": {
               "version": "3.10.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
               "dev": true
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
@@ -15255,12 +15275,14 @@
               "dependencies": {
                 "code-point-at": {
                   "version": "1.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                   "dev": true
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
                   "requires": {
                     "number-is-nan": "1.0.1"
@@ -15268,14 +15290,16 @@
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                       "dev": true
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
                     "ansi-regex": "2.1.1"
@@ -15283,7 +15307,8 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                       "dev": true
                     }
                   }
@@ -15294,7 +15319,8 @@
         },
         "cmd-shim": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
+          "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -15303,7 +15329,8 @@
         },
         "columnify": {
           "version": "1.5.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "dev": true,
           "requires": {
             "strip-ansi": "3.0.1",
@@ -15312,7 +15339,8 @@
           "dependencies": {
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "2.1.1"
@@ -15320,14 +15348,16 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                   "dev": true
                 }
               }
             },
             "wcwidth": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+              "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
               "dev": true,
               "requires": {
                 "defaults": "1.0.3"
@@ -15335,7 +15365,8 @@
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+                  "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                   "dev": true,
                   "requires": {
                     "clone": "1.0.2"
@@ -15343,7 +15374,8 @@
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
                       "dev": true
                     }
                   }
@@ -15354,7 +15386,8 @@
         },
         "config-chain": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+          "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
           "dev": true,
           "requires": {
             "ini": "1.3.4",
@@ -15363,24 +15396,28 @@
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+              "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
               "dev": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
           "dev": true
         },
         "detect-indent": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
           "dev": true
         },
         "dezalgo": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
           "dev": true,
           "requires": {
             "asap": "2.0.5",
@@ -15389,24 +15426,28 @@
           "dependencies": {
             "asap": {
               "version": "2.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+              "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
               "dev": true
             }
           }
         },
         "editor": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
           "dev": true
         },
         "find-npm-prefix": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.1.tgz",
+          "integrity": "sha512-I9R7ZnsjlKRvXBJjA1PE4wAkSc24YChoomWdEPTZgeB4DHxf87OutNGV5McFj6WwPghH97nZRejH58XvY6ga6Q==",
           "dev": true
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+          "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -15416,7 +15457,8 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+          "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -15427,7 +15469,8 @@
         },
         "gentle-fs": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.0.1.tgz",
+          "integrity": "sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==",
           "dev": true,
           "requires": {
             "aproba": "1.2.0",
@@ -15442,7 +15485,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -15455,12 +15499,14 @@
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
                 "brace-expansion": "1.1.8"
@@ -15468,7 +15514,8 @@
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                   "dev": true,
                   "requires": {
                     "balanced-match": "1.0.0",
@@ -15477,12 +15524,14 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                       "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                       "dev": true
                     }
                   }
@@ -15491,39 +15540,46 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true
             }
           }
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
           "dev": true
         },
         "iferr": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+          "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -15532,17 +15588,20 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
           "dev": true
         },
         "init-package-json": {
           "version": "1.10.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.1.tgz",
+          "integrity": "sha1-zYc6FneWvvuZYSsodioLY5P9j2o=",
           "dev": true,
           "requires": {
             "glob": "7.1.2",
@@ -15557,7 +15616,8 @@
           "dependencies": {
             "npm-package-arg": {
               "version": "5.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
+              "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
               "dev": true,
               "requires": {
                 "hosted-git-info": "2.5.0",
@@ -15568,7 +15628,8 @@
             },
             "promzard": {
               "version": "0.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+              "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
               "dev": true,
               "requires": {
                 "read": "1.0.7"
@@ -15578,7 +15639,8 @@
         },
         "is-cidr": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-1.0.0.tgz",
+          "integrity": "sha1-+1qs9lklUxA1naMsrgPkDGocKvw=",
           "dev": true,
           "requires": {
             "cidr-regex": "1.0.6"
@@ -15586,19 +15648,22 @@
           "dependencies": {
             "cidr-regex": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-1.0.6.tgz",
+              "integrity": "sha1-dKv9YZ3zcLnVSrFEdVaOl91kwME=",
               "dev": true
             }
           }
         },
         "lazy-property": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
+          "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
           "dev": true
         },
         "libnpx": {
           "version": "9.7.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/libnpx/-/libnpx-9.7.1.tgz",
+          "integrity": "sha512-OktT775uhfL93SoUfERj4ilM3D7c0hyUyALX9oJ2D/yO4Msm5hbkOKHcrOVHXRcEX9ytstviYQAEygFIiDj2bQ==",
           "dev": true,
           "requires": {
             "dotenv": "4.0.0",
@@ -15613,12 +15678,14 @@
           "dependencies": {
             "dotenv": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+              "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
               "dev": true
             },
             "npm-package-arg": {
               "version": "5.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
+              "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
               "dev": true,
               "requires": {
                 "hosted-git-info": "2.5.0",
@@ -15629,12 +15696,14 @@
             },
             "y18n": {
               "version": "3.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
               "dev": true
             },
             "yargs": {
               "version": "8.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+              "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
               "dev": true,
               "requires": {
                 "camelcase": "4.1.0",
@@ -15654,12 +15723,14 @@
               "dependencies": {
                 "camelcase": {
                   "version": "4.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                  "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                   "dev": true
                 },
                 "cliui": {
                   "version": "3.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                  "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                   "dev": true,
                   "requires": {
                     "string-width": "1.0.2",
@@ -15669,7 +15740,8 @@
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
                       "requires": {
                         "code-point-at": "1.1.0",
@@ -15679,12 +15751,14 @@
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                           "dev": true
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "dev": true,
                           "requires": {
                             "number-is-nan": "1.0.1"
@@ -15692,7 +15766,8 @@
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                               "dev": true
                             }
                           }
@@ -15701,7 +15776,8 @@
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "dev": true,
                       "requires": {
                         "ansi-regex": "2.1.1"
@@ -15709,14 +15785,16 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.1.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                           "dev": true
                         }
                       }
                     },
                     "wrap-ansi": {
                       "version": "2.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+                      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
                       "dev": true,
                       "requires": {
                         "string-width": "1.0.2",
@@ -15727,17 +15805,20 @@
                 },
                 "decamelize": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                  "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
                   "dev": true
                 },
                 "get-caller-file": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+                  "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
                   "dev": true
                 },
                 "os-locale": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+                  "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                   "dev": true,
                   "requires": {
                     "execa": "0.7.0",
@@ -15747,7 +15828,8 @@
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+                      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                       "dev": true,
                       "requires": {
                         "cross-spawn": "5.1.0",
@@ -15761,7 +15843,8 @@
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                           "dev": true,
                           "requires": {
                             "lru-cache": "4.1.1",
@@ -15771,7 +15854,8 @@
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
                               "dev": true,
                               "requires": {
                                 "shebang-regex": "1.0.0"
@@ -15779,7 +15863,8 @@
                               "dependencies": {
                                 "shebang-regex": {
                                   "version": "1.0.0",
-                                  "bundled": true,
+                                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                                  "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
                                   "dev": true
                                 }
                               }
@@ -15788,17 +15873,20 @@
                         },
                         "get-stream": {
                           "version": "3.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                           "dev": true
                         },
                         "is-stream": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                           "dev": true
                         },
                         "npm-run-path": {
                           "version": "2.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+                          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
                           "dev": true,
                           "requires": {
                             "path-key": "2.0.1"
@@ -15806,31 +15894,36 @@
                           "dependencies": {
                             "path-key": {
                               "version": "2.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
                               "dev": true
                             }
                           }
                         },
                         "p-finally": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+                          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
                           "dev": true
                         },
                         "signal-exit": {
                           "version": "3.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                           "dev": true
                         },
                         "strip-eof": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
                           "dev": true
                         }
                       }
                     },
                     "lcid": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                       "dev": true,
                       "requires": {
                         "invert-kv": "1.0.0"
@@ -15838,14 +15931,16 @@
                       "dependencies": {
                         "invert-kv": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
                           "dev": true
                         }
                       }
                     },
                     "mem": {
                       "version": "1.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+                      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
                       "dev": true,
                       "requires": {
                         "mimic-fn": "1.1.0"
@@ -15853,7 +15948,8 @@
                       "dependencies": {
                         "mimic-fn": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+                          "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
                           "dev": true
                         }
                       }
@@ -15862,7 +15958,8 @@
                 },
                 "read-pkg-up": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+                  "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
                   "dev": true,
                   "requires": {
                     "find-up": "2.1.0",
@@ -15871,7 +15968,8 @@
                   "dependencies": {
                     "find-up": {
                       "version": "2.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                       "dev": true,
                       "requires": {
                         "locate-path": "2.0.0"
@@ -15879,7 +15977,8 @@
                       "dependencies": {
                         "locate-path": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
                           "dev": true,
                           "requires": {
                             "p-locate": "2.0.0",
@@ -15888,7 +15987,8 @@
                           "dependencies": {
                             "p-locate": {
                               "version": "2.0.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                              "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
                               "dev": true,
                               "requires": {
                                 "p-limit": "1.1.0"
@@ -15896,14 +15996,16 @@
                               "dependencies": {
                                 "p-limit": {
                                   "version": "1.1.0",
-                                  "bundled": true,
+                                  "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+                                  "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
                                   "dev": true
                                 }
                               }
                             },
                             "path-exists": {
                               "version": "3.0.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
                               "dev": true
                             }
                           }
@@ -15912,7 +16014,8 @@
                     },
                     "read-pkg": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+                      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
                       "dev": true,
                       "requires": {
                         "load-json-file": "2.0.0",
@@ -15922,7 +16025,8 @@
                       "dependencies": {
                         "load-json-file": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+                          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
                           "dev": true,
                           "requires": {
                             "graceful-fs": "4.1.11",
@@ -15933,7 +16037,8 @@
                           "dependencies": {
                             "parse-json": {
                               "version": "2.2.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                              "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                               "dev": true,
                               "requires": {
                                 "error-ex": "1.3.1"
@@ -15941,7 +16046,8 @@
                               "dependencies": {
                                 "error-ex": {
                                   "version": "1.3.1",
-                                  "bundled": true,
+                                  "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+                                  "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
                                   "dev": true,
                                   "requires": {
                                     "is-arrayish": "0.2.1"
@@ -15949,7 +16055,8 @@
                                   "dependencies": {
                                     "is-arrayish": {
                                       "version": "0.2.1",
-                                      "bundled": true,
+                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
                                       "dev": true
                                     }
                                   }
@@ -15958,19 +16065,22 @@
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                               "dev": true
                             },
                             "strip-bom": {
                               "version": "3.0.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
                               "dev": true
                             }
                           }
                         },
                         "path-type": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+                          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
                           "dev": true,
                           "requires": {
                             "pify": "2.3.0"
@@ -15978,7 +16088,8 @@
                           "dependencies": {
                             "pify": {
                               "version": "2.3.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                               "dev": true
                             }
                           }
@@ -15989,22 +16100,26 @@
                 },
                 "require-directory": {
                   "version": "2.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+                  "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
                   "dev": true
                 },
                 "require-main-filename": {
                   "version": "1.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+                  "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
                   "dev": true
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                   "dev": true
                 },
                 "string-width": {
                   "version": "2.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                  "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                   "dev": true,
                   "requires": {
                     "is-fullwidth-code-point": "2.0.0",
@@ -16013,19 +16128,22 @@
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                       "dev": true
                     }
                   }
                 },
                 "which-module": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                  "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
                   "dev": true
                 },
                 "yargs-parser": {
                   "version": "7.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+                  "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
                   "dev": true,
                   "requires": {
                     "camelcase": "4.1.0"
@@ -16037,17 +16155,20 @@
         },
         "lockfile": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
+          "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k=",
           "dev": true
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
           "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+          "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
           "dev": true,
           "requires": {
             "lodash._createset": "4.0.3",
@@ -16056,29 +16177,34 @@
           "dependencies": {
             "lodash._createset": {
               "version": "4.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+              "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
               "dev": true
             },
             "lodash._root": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+              "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
               "dev": true
             }
           }
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
           "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
           "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
           "dev": true,
           "requires": {
             "lodash._getnative": "3.9.1"
@@ -16086,37 +16212,44 @@
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
           "dev": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
           "dev": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
           "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+          "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
           "dev": true
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+          "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
           "dev": true
         },
         "lodash.without": {
           "version": "4.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+          "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -16125,24 +16258,28 @@
           "dependencies": {
             "pseudomap": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
               "dev": true
             },
             "yallist": {
               "version": "2.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
               "dev": true
             }
           }
         },
         "meant": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/meant/-/meant-1.0.1.tgz",
+          "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg==",
           "dev": true
         },
         "mississippi": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
+          "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
           "dev": true,
           "requires": {
             "concat-stream": "1.6.0",
@@ -16159,7 +16296,8 @@
           "dependencies": {
             "concat-stream": {
               "version": "1.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+              "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
               "dev": true,
               "requires": {
                 "inherits": "2.0.3",
@@ -16169,14 +16307,16 @@
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                   "dev": true
                 }
               }
             },
             "duplexify": {
               "version": "3.5.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+              "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
               "dev": true,
               "requires": {
                 "end-of-stream": "1.0.0",
@@ -16187,7 +16327,8 @@
               "dependencies": {
                 "end-of-stream": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                  "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
                   "dev": true,
                   "requires": {
                     "once": "1.3.3"
@@ -16195,7 +16336,8 @@
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                       "dev": true,
                       "requires": {
                         "wrappy": "1.0.2"
@@ -16205,14 +16347,16 @@
                 },
                 "stream-shift": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                   "dev": true
                 }
               }
             },
             "end-of-stream": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+              "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
               "dev": true,
               "requires": {
                 "once": "1.4.0"
@@ -16220,7 +16364,8 @@
             },
             "flush-write-stream": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+              "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
               "dev": true,
               "requires": {
                 "inherits": "2.0.3",
@@ -16229,7 +16374,8 @@
             },
             "from2": {
               "version": "2.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+              "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
               "dev": true,
               "requires": {
                 "inherits": "2.0.3",
@@ -16238,7 +16384,8 @@
             },
             "parallel-transform": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+              "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
               "dev": true,
               "requires": {
                 "cyclist": "0.2.2",
@@ -16248,14 +16395,16 @@
               "dependencies": {
                 "cyclist": {
                   "version": "0.2.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+                  "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
                   "dev": true
                 }
               }
             },
             "pump": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
+              "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
               "dev": true,
               "requires": {
                 "end-of-stream": "1.4.0",
@@ -16264,7 +16413,8 @@
             },
             "pumpify": {
               "version": "1.3.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
+              "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
               "dev": true,
               "requires": {
                 "duplexify": "3.5.0",
@@ -16274,7 +16424,8 @@
             },
             "stream-each": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.0.tgz",
+              "integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE=",
               "dev": true,
               "requires": {
                 "end-of-stream": "1.4.0",
@@ -16283,14 +16434,16 @@
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                   "dev": true
                 }
               }
             },
             "through2": {
               "version": "2.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+              "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
               "dev": true,
               "requires": {
                 "readable-stream": "2.3.3",
@@ -16299,7 +16452,8 @@
               "dependencies": {
                 "xtend": {
                   "version": "4.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
                   "dev": true
                 }
               }
@@ -16308,7 +16462,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -16316,14 +16471,16 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             }
           }
         },
         "move-concurrently": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+          "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
           "dev": true,
           "requires": {
             "aproba": "1.2.0",
@@ -16336,7 +16493,8 @@
           "dependencies": {
             "copy-concurrently": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+              "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
               "dev": true,
               "requires": {
                 "aproba": "1.2.0",
@@ -16349,7 +16507,8 @@
             },
             "run-queue": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+              "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
               "dev": true,
               "requires": {
                 "aproba": "1.2.0"
@@ -16359,7 +16518,8 @@
         },
         "node-gyp": {
           "version": "3.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+          "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
           "dev": true,
           "requires": {
             "fstream": "1.0.11",
@@ -16379,7 +16539,8 @@
           "dependencies": {
             "fstream": {
               "version": "1.0.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+              "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
               "dev": true,
               "requires": {
                 "graceful-fs": "4.1.11",
@@ -16390,7 +16551,8 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
                 "brace-expansion": "1.1.8"
@@ -16398,7 +16560,8 @@
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                   "dev": true,
                   "requires": {
                     "balanced-match": "1.0.0",
@@ -16407,12 +16570,14 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                       "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                       "dev": true
                     }
                   }
@@ -16421,7 +16586,8 @@
             },
             "nopt": {
               "version": "3.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
               "dev": true,
               "requires": {
                 "abbrev": "1.1.1"
@@ -16429,12 +16595,14 @@
             },
             "semver": {
               "version": "5.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
               "dev": true
             },
             "tar": {
               "version": "2.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "dev": true,
               "requires": {
                 "block-stream": "0.0.9",
@@ -16444,7 +16612,8 @@
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
                   "dev": true,
                   "requires": {
                     "inherits": "2.0.3"
@@ -16456,7 +16625,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "requires": {
             "abbrev": "1.1.1",
@@ -16465,7 +16635,8 @@
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
             "hosted-git-info": "2.5.0",
@@ -16476,7 +16647,8 @@
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
               "dev": true,
               "requires": {
                 "builtin-modules": "1.1.1"
@@ -16484,7 +16656,8 @@
               "dependencies": {
                 "builtin-modules": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                  "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
                   "dev": true
                 }
               }
@@ -16493,12 +16666,14 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
           "dev": true
         },
         "npm-install-checks": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
+          "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
           "dev": true,
           "requires": {
             "semver": "5.4.1"
@@ -16506,7 +16681,8 @@
         },
         "npm-lifecycle": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-2.0.0.tgz",
+          "integrity": "sha512-aE7H012O01GKXT9BWnsGMLVci+MOgkhpSwq02ok20aXcNHxFs7enfampNMkiOV1DJEU0LynzemwdjbtXahXKcw==",
           "dev": true,
           "requires": {
             "byline": "5.0.0",
@@ -16521,19 +16697,22 @@
           "dependencies": {
             "byline": {
               "version": "5.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+              "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
               "dev": true
             },
             "resolve-from": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+              "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
               "dev": true
             }
           }
         },
         "npm-package-arg": {
           "version": "6.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.0.0.tgz",
+          "integrity": "sha512-hwC7g81KLgRmchv9ol6f3Fx4Yyc9ARX5X5niDHVILgpuvf08JRIgOZcEfpFXli3BgESoTrkauqorXm6UbvSgSg==",
           "dev": true,
           "requires": {
             "hosted-git-info": "2.5.0",
@@ -16544,7 +16723,8 @@
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "dev": true,
           "requires": {
             "ignore-walk": "3.0.1",
@@ -16553,7 +16733,8 @@
           "dependencies": {
             "ignore-walk": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+              "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "dev": true,
               "requires": {
                 "minimatch": "3.0.4"
@@ -16561,7 +16742,8 @@
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "requires": {
                     "brace-expansion": "1.1.8"
@@ -16569,7 +16751,8 @@
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "dev": true,
                       "requires": {
                         "balanced-match": "1.0.0",
@@ -16578,12 +16761,14 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                           "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                           "dev": true
                         }
                       }
@@ -16594,14 +16779,16 @@
             },
             "npm-bundled": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+              "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
               "dev": true
             }
           }
         },
         "npm-profile": {
           "version": "2.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-2.0.5.tgz",
+          "integrity": "sha512-tLmpDUCV72f/1/oXoyb+VwsZjOlsanp34pZeIZS0mxDoQUOX4Ld1hgPeOqoX4XggE88m7W47DHET2v+qd6sihg==",
           "dev": true,
           "requires": {
             "aproba": "1.2.0",
@@ -16610,7 +16797,8 @@
           "dependencies": {
             "make-fetch-happen": {
               "version": "2.5.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.5.0.tgz",
+              "integrity": "sha512-JPD5R43T02wIkcxjcmZuR7D06nB20fMR8aC9VEyYsSBXvJa5hOR/QhCxKY+5SXhy3uU5OUY/r+A6r+fJ2mFndA==",
               "dev": true,
               "requires": {
                 "agentkeepalive": "3.3.0",
@@ -16628,7 +16816,8 @@
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.3.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.3.0.tgz",
+                  "integrity": "sha512-9yhcpXti2ZQE7bxuCsjjWNIZoQOd9sZ1ZBovHG0YeCRohFv73SLvcm73PC9T3olM4GyozaQb+4MGdQpcD8m7NQ==",
                   "dev": true,
                   "requires": {
                     "humanize-ms": "1.2.1"
@@ -16636,7 +16825,8 @@
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+                      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
                       "dev": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -16644,7 +16834,8 @@
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                           "dev": true
                         }
                       }
@@ -16653,7 +16844,8 @@
                 },
                 "cacache": {
                   "version": "9.3.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/cacache/-/cacache-9.3.0.tgz",
+                  "integrity": "sha512-Vbi8J1XfC8v+FbQ6QkOtKXsHpPnB0i9uMeYFJoj40EbdOsEqWB3DPpNjfsnYBkqOPYA8UvrqH6FZPpBP0zdN7g==",
                   "dev": true,
                   "requires": {
                     "bluebird": "3.5.1",
@@ -16673,19 +16865,22 @@
                   "dependencies": {
                     "y18n": {
                       "version": "3.2.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
                       "dev": true
                     }
                   }
                 },
                 "http-cache-semantics": {
                   "version": "3.8.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.0.tgz",
+                  "integrity": "sha512-HGQFfBdru2fj/dwPn1oLx1fy6QMPeTAD1yzKcxD4l5biw+5QVaui/ehCqxaitoKJC/vHMLKv3Yd+nTlxboOJig==",
                   "dev": true
                 },
                 "http-proxy-agent": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.0.0.tgz",
+                  "integrity": "sha1-RkgqLwUjpNYIJVFwn0acs+SoX/Q=",
                   "dev": true,
                   "requires": {
                     "agent-base": "4.1.1",
@@ -16694,7 +16889,8 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.1.tgz",
+                      "integrity": "sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==",
                       "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -16702,7 +16898,8 @@
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
                             "es6-promise": "4.1.1"
@@ -16710,7 +16907,8 @@
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                               "dev": true
                             }
                           }
@@ -16719,7 +16917,8 @@
                     },
                     "debug": {
                       "version": "2.6.9",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                       "dev": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -16727,7 +16926,8 @@
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                           "dev": true
                         }
                       }
@@ -16736,7 +16936,8 @@
                 },
                 "https-proxy-agent": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.0.tgz",
+                  "integrity": "sha512-/DTVSUCbRc6AiyOV4DBRvPDpKKCJh4qQJNaCgypX0T41quD9hp/PB5iUyx/60XobuMPQa9ce1jNV9UOUq6PnTg==",
                   "dev": true,
                   "requires": {
                     "agent-base": "4.1.1",
@@ -16745,7 +16946,8 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.1.tgz",
+                      "integrity": "sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==",
                       "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -16753,7 +16955,8 @@
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
                             "es6-promise": "4.1.1"
@@ -16761,7 +16964,8 @@
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                               "dev": true
                             }
                           }
@@ -16770,7 +16974,8 @@
                     },
                     "debug": {
                       "version": "2.6.9",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                       "dev": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -16778,7 +16983,8 @@
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                           "dev": true
                         }
                       }
@@ -16787,7 +16993,8 @@
                 },
                 "node-fetch-npm": {
                   "version": "2.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+                  "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
                   "dev": true,
                   "requires": {
                     "encoding": "0.1.12",
@@ -16797,7 +17004,8 @@
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                       "dev": true,
                       "requires": {
                         "iconv-lite": "0.4.19"
@@ -16805,21 +17013,24 @@
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.19",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+                          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
                           "dev": true
                         }
                       }
                     },
                     "json-parse-better-errors": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+                      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
                       "dev": true
                     }
                   }
                 },
                 "promise-retry": {
                   "version": "1.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+                  "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
                   "dev": true,
                   "requires": {
                     "err-code": "1.1.2",
@@ -16828,14 +17039,16 @@
                   "dependencies": {
                     "err-code": {
                       "version": "1.1.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+                      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
                       "dev": true
                     }
                   }
                 },
                 "socks-proxy-agent": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
+                  "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
                   "dev": true,
                   "requires": {
                     "agent-base": "4.1.1",
@@ -16844,7 +17057,8 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.1.tgz",
+                      "integrity": "sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==",
                       "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -16852,7 +17066,8 @@
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
                             "es6-promise": "4.1.1"
@@ -16860,7 +17075,8 @@
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                               "dev": true
                             }
                           }
@@ -16869,7 +17085,8 @@
                     },
                     "socks": {
                       "version": "1.1.10",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+                      "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
                       "dev": true,
                       "requires": {
                         "ip": "1.1.5",
@@ -16878,12 +17095,14 @@
                       "dependencies": {
                         "ip": {
                           "version": "1.1.5",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+                          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
                           "dev": true
                         },
                         "smart-buffer": {
                           "version": "1.1.15",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+                          "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
                           "dev": true
                         }
                       }
@@ -16892,7 +17111,8 @@
                 },
                 "ssri": {
                   "version": "4.1.6",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
+                  "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
                   "dev": true,
                   "requires": {
                     "safe-buffer": "5.1.1"
@@ -16904,7 +17124,8 @@
         },
         "npm-registry-client": {
           "version": "8.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.5.0.tgz",
+          "integrity": "sha512-Nkcw24bfECKFNt0FLDQ+PjVqSlKxMggcboXiUBIvjbCnA15xjRO4kCwRDluGNXZjHFLx/vPjN4+ESXyVjpXLbQ==",
           "dev": true,
           "requires": {
             "concat-stream": "1.6.0",
@@ -16922,7 +17143,8 @@
           "dependencies": {
             "concat-stream": {
               "version": "1.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+              "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
               "dev": true,
               "requires": {
                 "inherits": "2.0.3",
@@ -16932,14 +17154,16 @@
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
                   "dev": true
                 }
               }
             },
             "npm-package-arg": {
               "version": "5.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
+              "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
               "dev": true,
               "requires": {
                 "hosted-git-info": "2.5.0",
@@ -16950,7 +17174,8 @@
             },
             "ssri": {
               "version": "4.1.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
+              "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
               "dev": true,
               "requires": {
                 "safe-buffer": "5.1.1"
@@ -16960,12 +17185,14 @@
         },
         "npm-user-validate": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.0.tgz",
+          "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
           "dev": true
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
@@ -16976,7 +17203,8 @@
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+              "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
               "dev": true,
               "requires": {
                 "delegates": "1.0.0",
@@ -16985,19 +17213,22 @@
               "dependencies": {
                 "delegates": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+                  "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                   "dev": true
                 }
               }
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true
             },
             "gauge": {
               "version": "2.7.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "requires": {
                 "aproba": "1.2.0",
@@ -17012,17 +17243,20 @@
               "dependencies": {
                 "object-assign": {
                   "version": "4.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                   "dev": true
                 },
                 "signal-exit": {
                   "version": "3.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                  "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                   "dev": true
                 },
                 "string-width": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
                   "requires": {
                     "code-point-at": "1.1.0",
@@ -17032,12 +17266,14 @@
                   "dependencies": {
                     "code-point-at": {
                       "version": "1.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                       "dev": true
                     },
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                       "dev": true,
                       "requires": {
                         "number-is-nan": "1.0.1"
@@ -17045,7 +17281,8 @@
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                           "dev": true
                         }
                       }
@@ -17054,7 +17291,8 @@
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
                     "ansi-regex": "2.1.1"
@@ -17062,14 +17300,16 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                       "dev": true
                     }
                   }
                 },
                 "wide-align": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+                  "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
                   "dev": true,
                   "requires": {
                     "string-width": "1.0.2"
@@ -17079,14 +17319,16 @@
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true
             }
           }
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -17094,12 +17336,14 @@
         },
         "opener": {
           "version": "1.4.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+          "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
           "dev": true
         },
         "osenv": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
           "requires": {
             "os-homedir": "1.0.2",
@@ -17108,19 +17352,22 @@
           "dependencies": {
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true
             }
           }
         },
         "pacote": {
           "version": "7.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pacote/-/pacote-7.0.2.tgz",
+          "integrity": "sha512-cTiugiG2ujDcqDtYtJ3doDrS6E3eU0bhuYAHhMTWgBezrhoqTEjc0axSBpbjw4QQkNT5AGRF15Mj2tF2HuBz7w==",
           "dev": true,
           "requires": {
             "bluebird": "3.5.1",
@@ -17149,12 +17396,14 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "dev": true
             },
             "make-fetch-happen": {
               "version": "2.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.6.0.tgz",
+              "integrity": "sha512-FFq0lNI0ax+n9IWzWpH8A4JdgYiAp2DDYIZ3rsaav8JDe8I+72CzK6PQW/oom15YDZpV5bYW/9INd6nIJ2ZfZw==",
               "dev": true,
               "requires": {
                 "agentkeepalive": "3.3.0",
@@ -17172,7 +17421,8 @@
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.3.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.3.0.tgz",
+                  "integrity": "sha512-9yhcpXti2ZQE7bxuCsjjWNIZoQOd9sZ1ZBovHG0YeCRohFv73SLvcm73PC9T3olM4GyozaQb+4MGdQpcD8m7NQ==",
                   "dev": true,
                   "requires": {
                     "humanize-ms": "1.2.1"
@@ -17180,7 +17430,8 @@
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+                      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
                       "dev": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -17188,7 +17439,8 @@
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                           "dev": true
                         }
                       }
@@ -17197,12 +17449,14 @@
                 },
                 "http-cache-semantics": {
                   "version": "3.8.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.0.tgz",
+                  "integrity": "sha512-HGQFfBdru2fj/dwPn1oLx1fy6QMPeTAD1yzKcxD4l5biw+5QVaui/ehCqxaitoKJC/vHMLKv3Yd+nTlxboOJig==",
                   "dev": true
                 },
                 "http-proxy-agent": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.0.0.tgz",
+                  "integrity": "sha1-RkgqLwUjpNYIJVFwn0acs+SoX/Q=",
                   "dev": true,
                   "requires": {
                     "agent-base": "4.1.2",
@@ -17211,7 +17465,8 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
+                      "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
                       "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -17219,7 +17474,8 @@
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
                             "es6-promise": "4.1.1"
@@ -17227,7 +17483,8 @@
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                               "dev": true
                             }
                           }
@@ -17236,7 +17493,8 @@
                     },
                     "debug": {
                       "version": "2.6.9",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                       "dev": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -17244,7 +17502,8 @@
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                           "dev": true
                         }
                       }
@@ -17253,7 +17512,8 @@
                 },
                 "https-proxy-agent": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.0.tgz",
+                  "integrity": "sha512-/DTVSUCbRc6AiyOV4DBRvPDpKKCJh4qQJNaCgypX0T41quD9hp/PB5iUyx/60XobuMPQa9ce1jNV9UOUq6PnTg==",
                   "dev": true,
                   "requires": {
                     "agent-base": "4.1.2",
@@ -17262,7 +17522,8 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
+                      "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
                       "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -17270,7 +17531,8 @@
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
                             "es6-promise": "4.1.1"
@@ -17278,7 +17540,8 @@
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                               "dev": true
                             }
                           }
@@ -17287,7 +17550,8 @@
                     },
                     "debug": {
                       "version": "2.6.9",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                       "dev": true,
                       "requires": {
                         "ms": "2.0.0"
@@ -17295,7 +17559,8 @@
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                           "dev": true
                         }
                       }
@@ -17304,7 +17569,8 @@
                 },
                 "node-fetch-npm": {
                   "version": "2.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+                  "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
                   "dev": true,
                   "requires": {
                     "encoding": "0.1.12",
@@ -17314,7 +17580,8 @@
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                       "dev": true,
                       "requires": {
                         "iconv-lite": "0.4.19"
@@ -17322,21 +17589,24 @@
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.19",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+                          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
                           "dev": true
                         }
                       }
                     },
                     "json-parse-better-errors": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+                      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
                       "dev": true
                     }
                   }
                 },
                 "socks-proxy-agent": {
                   "version": "3.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
+                  "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
                   "dev": true,
                   "requires": {
                     "agent-base": "4.1.2",
@@ -17345,7 +17615,8 @@
                   "dependencies": {
                     "agent-base": {
                       "version": "4.1.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
+                      "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
                       "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
@@ -17353,7 +17624,8 @@
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
                             "es6-promise": "4.1.1"
@@ -17361,7 +17633,8 @@
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+                              "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
                               "dev": true
                             }
                           }
@@ -17370,7 +17643,8 @@
                     },
                     "socks": {
                       "version": "1.1.10",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+                      "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
                       "dev": true,
                       "requires": {
                         "ip": "1.1.5",
@@ -17379,12 +17653,14 @@
                       "dependencies": {
                         "ip": {
                           "version": "1.1.5",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+                          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
                           "dev": true
                         },
                         "smart-buffer": {
                           "version": "1.1.15",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+                          "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
                           "dev": true
                         }
                       }
@@ -17395,7 +17671,8 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
                 "brace-expansion": "1.1.8"
@@ -17403,7 +17680,8 @@
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                   "dev": true,
                   "requires": {
                     "balanced-match": "1.0.0",
@@ -17412,12 +17690,14 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                       "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                       "dev": true
                     }
                   }
@@ -17426,7 +17706,8 @@
             },
             "npm-pick-manifest": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-2.1.0.tgz",
+              "integrity": "sha512-q9zLP8cTr8xKPmMZN3naxp1k/NxVFsjxN6uWuO1tiw9gxg7wZWQ/b5UTfzD0ANw2q1lQxdLKTeCCksq+bPSgbQ==",
               "dev": true,
               "requires": {
                 "npm-package-arg": "6.0.0",
@@ -17435,7 +17716,8 @@
             },
             "promise-retry": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+              "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
               "dev": true,
               "requires": {
                 "err-code": "1.1.2",
@@ -17444,14 +17726,16 @@
               "dependencies": {
                 "err-code": {
                   "version": "1.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+                  "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
                   "dev": true
                 }
               }
             },
             "protoduck": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-4.0.0.tgz",
+              "integrity": "sha1-/kh02MeRM2bP2erRJFOiLNNlf44=",
               "dev": true,
               "requires": {
                 "genfun": "4.0.1"
@@ -17459,7 +17743,8 @@
               "dependencies": {
                 "genfun": {
                   "version": "4.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/genfun/-/genfun-4.0.1.tgz",
+                  "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E=",
                   "dev": true
                 }
               }
@@ -17468,22 +17753,26 @@
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
           "dev": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+          "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
           "dev": true
         },
         "qrcode-terminal": {
           "version": "0.11.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.11.0.tgz",
+          "integrity": "sha1-/8bCii/Av7RwUrR+I/T0RqX7254=",
           "dev": true
         },
         "query-string": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.0.1.tgz",
+          "integrity": "sha512-aM+MkQClojlNiKkO09tiN2Fv8jM/L7GWIjG2liWeKljlOdOPNWr+bW3KQ+w5V/uKprpezC7fAsAMsJtJ+2rLKA==",
           "dev": true,
           "requires": {
             "decode-uri-component": "0.2.0",
@@ -17493,29 +17782,34 @@
           "dependencies": {
             "decode-uri-component": {
               "version": "0.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+              "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
               "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true
             },
             "strict-uri-encode": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+              "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
               "dev": true
             }
           }
         },
         "qw": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/qw/-/qw-1.0.1.tgz",
+          "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
           "dev": true
         },
         "read": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "dev": true,
           "requires": {
             "mute-stream": "0.0.7"
@@ -17523,14 +17817,16 @@
           "dependencies": {
             "mute-stream": {
               "version": "0.0.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+              "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
               "dev": true
             }
           }
         },
         "read-cmd-shim": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
+          "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11"
@@ -17538,7 +17834,8 @@
         },
         "read-installed": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
@@ -17552,14 +17849,16 @@
           "dependencies": {
             "util-extend": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+              "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
               "dev": true
             }
           }
         },
         "read-package-json": {
           "version": "2.0.12",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.12.tgz",
+          "integrity": "sha512-m7/I0+tP6D34EVvSlzCtuVA4D/dHL6OpLcn2e4XVP5X57pCKGUy1JjRSBVKHWpB+vUU91sL85h84qX0MdXzBSw==",
           "dev": true,
           "requires": {
             "glob": "7.1.2",
@@ -17571,19 +17870,22 @@
           "dependencies": {
             "json-parse-better-errors": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+              "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
               "dev": true
             },
             "slash": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+              "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
               "dev": true
             }
           }
         },
         "read-package-tree": {
           "version": "5.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.6.tgz",
+          "integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg==",
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
@@ -17595,7 +17897,8 @@
         },
         "readable-stream": {
           "version": "2.3.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -17609,22 +17912,26 @@
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
               "dev": true
             },
             "string_decoder": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
               "dev": true,
               "requires": {
                 "safe-buffer": "5.1.1"
@@ -17632,14 +17939,16 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true
             }
           }
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+          "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
@@ -17650,7 +17959,8 @@
         },
         "request": {
           "version": "2.83.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
           "dev": true,
           "requires": {
             "aws-sign2": "0.7.0",
@@ -17679,22 +17989,26 @@
           "dependencies": {
             "aws-sign2": {
               "version": "0.7.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+              "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
               "dev": true
             },
             "aws4": {
               "version": "1.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+              "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
               "dev": true
             },
             "caseless": {
               "version": "0.12.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
               "dev": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
               "dev": true,
               "requires": {
                 "delayed-stream": "1.0.0"
@@ -17702,24 +18016,28 @@
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
                   "dev": true
                 }
               }
             },
             "extend": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
               "dev": true
             },
             "forever-agent": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
               "dev": true
             },
             "form-data": {
               "version": "2.3.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+              "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
               "dev": true,
               "requires": {
                 "asynckit": "0.4.0",
@@ -17729,14 +18047,16 @@
               "dependencies": {
                 "asynckit": {
                   "version": "0.4.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                  "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
                   "dev": true
                 }
               }
             },
             "har-validator": {
               "version": "5.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+              "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
               "dev": true,
               "requires": {
                 "ajv": "5.2.3",
@@ -17745,7 +18065,8 @@
               "dependencies": {
                 "ajv": {
                   "version": "5.2.3",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+                  "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
                   "dev": true,
                   "requires": {
                     "co": "4.6.0",
@@ -17756,22 +18077,26 @@
                   "dependencies": {
                     "co": {
                       "version": "4.6.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
                       "dev": true
                     },
                     "fast-deep-equal": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+                      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
                       "dev": true
                     },
                     "json-schema-traverse": {
                       "version": "0.3.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+                      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
                       "dev": true
                     },
                     "json-stable-stringify": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                       "dev": true,
                       "requires": {
                         "jsonify": "0.0.0"
@@ -17779,7 +18104,8 @@
                       "dependencies": {
                         "jsonify": {
                           "version": "0.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
                           "dev": true
                         }
                       }
@@ -17788,14 +18114,16 @@
                 },
                 "har-schema": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+                  "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
                   "dev": true
                 }
               }
             },
             "hawk": {
               "version": "6.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+              "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
               "dev": true,
               "requires": {
                 "boom": "4.3.1",
@@ -17806,7 +18134,8 @@
               "dependencies": {
                 "boom": {
                   "version": "4.3.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+                  "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
                   "dev": true,
                   "requires": {
                     "hoek": "4.2.0"
@@ -17814,7 +18143,8 @@
                 },
                 "cryptiles": {
                   "version": "3.1.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+                  "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
                   "dev": true,
                   "requires": {
                     "boom": "5.2.0"
@@ -17822,7 +18152,8 @@
                   "dependencies": {
                     "boom": {
                       "version": "5.2.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                      "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                       "dev": true,
                       "requires": {
                         "hoek": "4.2.0"
@@ -17832,12 +18163,14 @@
                 },
                 "hoek": {
                   "version": "4.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+                  "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
                   "dev": true
                 },
                 "sntp": {
                   "version": "2.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
+                  "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
                   "dev": true,
                   "requires": {
                     "hoek": "4.2.0"
@@ -17847,7 +18180,8 @@
             },
             "http-signature": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+              "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
               "dev": true,
               "requires": {
                 "assert-plus": "1.0.0",
@@ -17857,12 +18191,14 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "dev": true
                 },
                 "jsprim": {
                   "version": "1.4.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+                  "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
                   "dev": true,
                   "requires": {
                     "assert-plus": "1.0.0",
@@ -17873,17 +18209,20 @@
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.3.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+                      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
                       "dev": true
                     },
                     "json-schema": {
                       "version": "0.2.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
                       "dev": true
                     },
                     "verror": {
                       "version": "1.10.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+                      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
                       "dev": true,
                       "requires": {
                         "assert-plus": "1.0.0",
@@ -17893,7 +18232,8 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                           "dev": true
                         }
                       }
@@ -17902,7 +18242,8 @@
                 },
                 "sshpk": {
                   "version": "1.13.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+                  "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
                   "dev": true,
                   "requires": {
                     "asn1": "0.2.3",
@@ -17917,12 +18258,14 @@
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
                       "dev": true
                     },
                     "bcrypt-pbkdf": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
                       "dev": true,
                       "optional": true,
                       "requires": {
@@ -17931,7 +18274,8 @@
                     },
                     "dashdash": {
                       "version": "1.14.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                       "dev": true,
                       "requires": {
                         "assert-plus": "1.0.0"
@@ -17939,7 +18283,8 @@
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                       "dev": true,
                       "optional": true,
                       "requires": {
@@ -17948,7 +18293,8 @@
                     },
                     "getpass": {
                       "version": "0.1.7",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                       "dev": true,
                       "requires": {
                         "assert-plus": "1.0.0"
@@ -17956,13 +18302,15 @@
                     },
                     "jsbn": {
                       "version": "0.1.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                       "dev": true,
                       "optional": true
                     },
                     "tweetnacl": {
                       "version": "0.14.5",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                       "dev": true,
                       "optional": true
                     }
@@ -17972,22 +18320,26 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
               "dev": true
             },
             "isstream": {
               "version": "0.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
               "dev": true
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
               "dev": true
             },
             "mime-types": {
               "version": "2.1.17",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+              "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
               "dev": true,
               "requires": {
                 "mime-db": "1.30.0"
@@ -17995,34 +18347,40 @@
               "dependencies": {
                 "mime-db": {
                   "version": "1.30.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+                  "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
                   "dev": true
                 }
               }
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
               "dev": true
             },
             "performance-now": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+              "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
               "dev": true
             },
             "qs": {
               "version": "6.5.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+              "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
               "dev": true
             },
             "stringstream": {
               "version": "0.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
               "dev": true
             },
             "tough-cookie": {
               "version": "2.3.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+              "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
               "dev": true,
               "requires": {
                 "punycode": "1.4.1"
@@ -18030,14 +18388,16 @@
               "dependencies": {
                 "punycode": {
                   "version": "1.4.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                  "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
                   "dev": true
                 }
               }
             },
             "tunnel-agent": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
               "dev": true,
               "requires": {
                 "safe-buffer": "5.1.1"
@@ -18047,12 +18407,14 @@
         },
         "retry": {
           "version": "0.10.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+          "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
           "dev": true
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -18060,17 +18422,20 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "semver": {
           "version": "5.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         },
         "sha": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
+          "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -18079,17 +18444,20 @@
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "sorted-object": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
+          "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
           "dev": true
         },
         "sorted-union-stream": {
           "version": "2.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
+          "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
           "dev": true,
           "requires": {
             "from2": "1.3.0",
@@ -18098,7 +18466,8 @@
           "dependencies": {
             "from2": {
               "version": "1.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
+              "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
               "dev": true,
               "requires": {
                 "inherits": "2.0.3",
@@ -18107,7 +18476,8 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                   "dev": true,
                   "requires": {
                     "core-util-is": "1.0.2",
@@ -18118,17 +18488,20 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                       "dev": true
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
                       "dev": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                       "dev": true
                     }
                   }
@@ -18137,7 +18510,8 @@
             },
             "stream-iterate": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
+              "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
               "dev": true,
               "requires": {
                 "readable-stream": "2.3.3",
@@ -18146,7 +18520,8 @@
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
                   "dev": true
                 }
               }
@@ -18155,7 +18530,8 @@
         },
         "ssri": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz",
+          "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -18163,7 +18539,8 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
@@ -18171,14 +18548,16 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             }
           }
         },
         "tar": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.0.2.tgz",
+          "integrity": "sha512-4lWN4uAEWzw8aHyBUx9HWXvH3vIFEhOyvN22HfBzWpE07HaTBXM8ttSeCQpswRo5On4q3nmmYmk7Tomn0uhUaw==",
           "dev": true,
           "requires": {
             "chownr": "1.0.1",
@@ -18190,7 +18569,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.1.tgz",
+              "integrity": "sha512-u1aUllxPJUI07cOqzR7reGmQxmCqlH88uIIsf6XZFEWgw7gXKpJdR+5R9Y3KEDmWYkdIz9wXZs3C0jOPxejk/Q==",
               "dev": true,
               "requires": {
                 "yallist": "3.0.2"
@@ -18198,7 +18578,8 @@
             },
             "minizlib": {
               "version": "1.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.0.4.tgz",
+              "integrity": "sha512-sN4U9tIJtBRwKbwgFh9qJfrPIQ/GGTRr1MGqkgOeMTLy8/lM0FcWU//FqlnZ3Vb7gJ+Mxh3FOg1EklibdajbaQ==",
               "dev": true,
               "requires": {
                 "minipass": "2.2.1"
@@ -18206,29 +18587,34 @@
             },
             "yallist": {
               "version": "3.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+              "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
               "dev": true
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
           "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
           "dev": true
         },
         "unique-filename": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+          "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
           "dev": true,
           "requires": {
             "unique-slug": "2.0.0"
@@ -18236,7 +18622,8 @@
           "dependencies": {
             "unique-slug": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+              "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
               "dev": true,
               "requires": {
                 "imurmurhash": "0.1.4"
@@ -18246,12 +18633,14 @@
         },
         "unpipe": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
           "dev": true
         },
         "update-notifier": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
+          "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
           "dev": true,
           "requires": {
             "boxen": "1.2.1",
@@ -18267,7 +18656,8 @@
           "dependencies": {
             "boxen": {
               "version": "1.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.1.tgz",
+              "integrity": "sha1-DxHn/jRO25OXl3/BPt5/ZNlWSB0=",
               "dev": true,
               "requires": {
                 "ansi-align": "2.0.0",
@@ -18281,7 +18671,8 @@
               "dependencies": {
                 "ansi-align": {
                   "version": "2.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+                  "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
                   "dev": true,
                   "requires": {
                     "string-width": "2.1.1"
@@ -18289,17 +18680,20 @@
                 },
                 "camelcase": {
                   "version": "4.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                  "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                   "dev": true
                 },
                 "cli-boxes": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+                  "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
                   "dev": true
                 },
                 "string-width": {
                   "version": "2.1.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                  "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                   "dev": true,
                   "requires": {
                     "is-fullwidth-code-point": "2.0.0",
@@ -18308,14 +18702,16 @@
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                       "dev": true
                     }
                   }
                 },
                 "term-size": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+                  "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
                   "dev": true,
                   "requires": {
                     "execa": "0.7.0"
@@ -18323,7 +18719,8 @@
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+                      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                       "dev": true,
                       "requires": {
                         "cross-spawn": "5.1.0",
@@ -18337,7 +18734,8 @@
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                           "dev": true,
                           "requires": {
                             "lru-cache": "4.1.1",
@@ -18347,7 +18745,8 @@
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
                               "dev": true,
                               "requires": {
                                 "shebang-regex": "1.0.0"
@@ -18355,7 +18754,8 @@
                               "dependencies": {
                                 "shebang-regex": {
                                   "version": "1.0.0",
-                                  "bundled": true,
+                                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                                  "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
                                   "dev": true
                                 }
                               }
@@ -18364,17 +18764,20 @@
                         },
                         "get-stream": {
                           "version": "3.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                           "dev": true
                         },
                         "is-stream": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                           "dev": true
                         },
                         "npm-run-path": {
                           "version": "2.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+                          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
                           "dev": true,
                           "requires": {
                             "path-key": "2.0.1"
@@ -18382,24 +18785,28 @@
                           "dependencies": {
                             "path-key": {
                               "version": "2.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
                               "dev": true
                             }
                           }
                         },
                         "p-finally": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+                          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
                           "dev": true
                         },
                         "signal-exit": {
                           "version": "3.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+                          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                           "dev": true
                         },
                         "strip-eof": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+                          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
                           "dev": true
                         }
                       }
@@ -18408,7 +18815,8 @@
                 },
                 "widest-line": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+                  "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
                   "dev": true,
                   "requires": {
                     "string-width": "1.0.2"
@@ -18416,7 +18824,8 @@
                   "dependencies": {
                     "string-width": {
                       "version": "1.0.2",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
                       "requires": {
                         "code-point-at": "1.1.0",
@@ -18426,12 +18835,14 @@
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                           "dev": true
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "dev": true,
                           "requires": {
                             "number-is-nan": "1.0.1"
@@ -18439,14 +18850,16 @@
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                               "dev": true
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                           "dev": true,
                           "requires": {
                             "ansi-regex": "2.1.1"
@@ -18454,7 +18867,8 @@
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                               "dev": true
                             }
                           }
@@ -18467,7 +18881,8 @@
             },
             "chalk": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+              "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
               "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
@@ -18477,7 +18892,8 @@
               "dependencies": {
                 "ansi-styles": {
                   "version": "3.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                  "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                   "dev": true,
                   "requires": {
                     "color-convert": "1.9.0"
@@ -18485,7 +18901,8 @@
                   "dependencies": {
                     "color-convert": {
                       "version": "1.9.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+                      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
                       "dev": true,
                       "requires": {
                         "color-name": "1.1.3"
@@ -18493,7 +18910,8 @@
                       "dependencies": {
                         "color-name": {
                           "version": "1.1.3",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
                           "dev": true
                         }
                       }
@@ -18502,12 +18920,14 @@
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
                   "dev": true
                 },
                 "supports-color": {
                   "version": "4.4.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+                  "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                   "dev": true,
                   "requires": {
                     "has-flag": "2.0.0"
@@ -18515,7 +18935,8 @@
                   "dependencies": {
                     "has-flag": {
                       "version": "2.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
                       "dev": true
                     }
                   }
@@ -18524,7 +18945,8 @@
             },
             "configstore": {
               "version": "3.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
+              "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
               "dev": true,
               "requires": {
                 "dot-prop": "4.2.0",
@@ -18537,7 +18959,8 @@
               "dependencies": {
                 "dot-prop": {
                   "version": "4.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+                  "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
                   "dev": true,
                   "requires": {
                     "is-obj": "1.0.1"
@@ -18545,14 +18968,16 @@
                   "dependencies": {
                     "is-obj": {
                       "version": "1.0.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+                      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
                       "dev": true
                     }
                   }
                 },
                 "make-dir": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+                  "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
                   "dev": true,
                   "requires": {
                     "pify": "2.3.0"
@@ -18560,14 +18985,16 @@
                   "dependencies": {
                     "pify": {
                       "version": "2.3.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                       "dev": true
                     }
                   }
                 },
                 "unique-string": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+                  "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
                   "dev": true,
                   "requires": {
                     "crypto-random-string": "1.0.0"
@@ -18575,7 +19002,8 @@
                   "dependencies": {
                     "crypto-random-string": {
                       "version": "1.0.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+                      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
                       "dev": true
                     }
                   }
@@ -18584,12 +19012,14 @@
             },
             "import-lazy": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+              "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
               "dev": true
             },
             "is-installed-globally": {
               "version": "0.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+              "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
               "dev": true,
               "requires": {
                 "global-dirs": "0.1.0",
@@ -18598,7 +19028,8 @@
               "dependencies": {
                 "global-dirs": {
                   "version": "0.1.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.0.tgz",
+                  "integrity": "sha1-ENNAOeDfBCcuJizyQiT3IJQ0308=",
                   "dev": true,
                   "requires": {
                     "ini": "1.3.4"
@@ -18606,7 +19037,8 @@
                 },
                 "is-path-inside": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+                  "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
                   "dev": true,
                   "requires": {
                     "path-is-inside": "1.0.2"
@@ -18616,12 +19048,14 @@
             },
             "is-npm": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+              "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
               "dev": true
             },
             "latest-version": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+              "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
               "dev": true,
               "requires": {
                 "package-json": "4.0.1"
@@ -18629,7 +19063,8 @@
               "dependencies": {
                 "package-json": {
                   "version": "4.0.1",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+                  "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
                   "dev": true,
                   "requires": {
                     "got": "6.7.1",
@@ -18640,7 +19075,8 @@
                   "dependencies": {
                     "got": {
                       "version": "6.7.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+                      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
                       "dev": true,
                       "requires": {
                         "create-error-class": "3.0.2",
@@ -18658,7 +19094,8 @@
                       "dependencies": {
                         "create-error-class": {
                           "version": "3.0.2",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+                          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
                           "dev": true,
                           "requires": {
                             "capture-stack-trace": "1.0.0"
@@ -18666,54 +19103,64 @@
                           "dependencies": {
                             "capture-stack-trace": {
                               "version": "1.0.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+                              "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
                               "dev": true
                             }
                           }
                         },
                         "duplexer3": {
                           "version": "0.1.4",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+                          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
                           "dev": true
                         },
                         "get-stream": {
                           "version": "3.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                           "dev": true
                         },
                         "is-redirect": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+                          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
                           "dev": true
                         },
                         "is-retry-allowed": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+                          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
                           "dev": true
                         },
                         "is-stream": {
                           "version": "1.1.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                           "dev": true
                         },
                         "lowercase-keys": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+                          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
                           "dev": true
                         },
                         "timed-out": {
                           "version": "4.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+                          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
                           "dev": true
                         },
                         "unzip-response": {
                           "version": "2.0.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+                          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
                           "dev": true
                         },
                         "url-parse-lax": {
                           "version": "1.0.0",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+                          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
                           "dev": true,
                           "requires": {
                             "prepend-http": "1.0.4"
@@ -18721,7 +19168,8 @@
                           "dependencies": {
                             "prepend-http": {
                               "version": "1.0.4",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+                              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
                               "dev": true
                             }
                           }
@@ -18730,7 +19178,8 @@
                     },
                     "registry-auth-token": {
                       "version": "3.3.1",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
+                      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
                       "dev": true,
                       "requires": {
                         "rc": "1.2.1",
@@ -18739,7 +19188,8 @@
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                           "dev": true,
                           "requires": {
                             "deep-extend": "0.4.2",
@@ -18750,17 +19200,20 @@
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+                              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
                               "dev": true
                             },
                             "minimist": {
                               "version": "1.2.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                               "dev": true
                             },
                             "strip-json-comments": {
                               "version": "2.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                               "dev": true
                             }
                           }
@@ -18769,7 +19222,8 @@
                     },
                     "registry-url": {
                       "version": "3.1.0",
-                      "bundled": true,
+                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+                      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
                       "dev": true,
                       "requires": {
                         "rc": "1.2.1"
@@ -18777,7 +19231,8 @@
                       "dependencies": {
                         "rc": {
                           "version": "1.2.1",
-                          "bundled": true,
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
                           "dev": true,
                           "requires": {
                             "deep-extend": "0.4.2",
@@ -18788,17 +19243,20 @@
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+                              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
                               "dev": true
                             },
                             "minimist": {
                               "version": "1.2.0",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                               "dev": true
                             },
                             "strip-json-comments": {
                               "version": "2.0.1",
-                              "bundled": true,
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                               "dev": true
                             }
                           }
@@ -18811,7 +19269,8 @@
             },
             "semver-diff": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+              "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
               "dev": true,
               "requires": {
                 "semver": "5.4.1"
@@ -18819,19 +19278,22 @@
             },
             "xdg-basedir": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+              "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
               "dev": true
             }
           }
         },
         "uuid": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "dev": true,
           "requires": {
             "spdx-correct": "1.0.2",
@@ -18840,7 +19302,8 @@
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
               "dev": true,
               "requires": {
                 "spdx-license-ids": "1.2.2"
@@ -18848,21 +19311,24 @@
               "dependencies": {
                 "spdx-license-ids": {
                   "version": "1.2.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                  "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
                   "dev": true
                 }
               }
             },
             "spdx-expression-parse": {
               "version": "1.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+              "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
               "dev": true
             }
           }
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "dev": true,
           "requires": {
             "builtins": "1.0.3"
@@ -18870,14 +19336,16 @@
           "dependencies": {
             "builtins": {
               "version": "1.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+              "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
               "dev": true
             }
           }
         },
         "which": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
             "isexe": "2.0.0"
@@ -18885,14 +19353,16 @@
           "dependencies": {
             "isexe": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
               "dev": true
             }
           }
         },
         "worker-farm": {
           "version": "1.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.1.tgz",
+          "integrity": "sha512-T5NH6Wqsd8MwGD4AK8BBllUy6LmHaqjEOyo/YIUEegZui6/v5Bqde//3jwyE3PGiGYMmWi06exFBi5LNhhPFNw==",
           "dev": true,
           "requires": {
             "errno": "0.1.4",
@@ -18901,7 +19371,8 @@
           "dependencies": {
             "errno": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+              "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
               "dev": true,
               "requires": {
                 "prr": "0.0.0"
@@ -18909,26 +19380,30 @@
               "dependencies": {
                 "prr": {
                   "version": "0.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+                  "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
                   "dev": true
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
               "dev": true
             }
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
+          "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -19265,7 +19740,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "externalplugins": ""
   },
   "dependencies": {
-    "@dcos/http-service": "0.2.1",
-    "@dcos/mesos-client": "0.2.0",
+    "@dcos/http-service": "0.3.0",
+    "@dcos/mesos-client": "0.2.1",
     "babel-polyfill": "6.23.0",
     "browser-info": "0.4.0",
     "classnames": "2.2.3",

--- a/plugins/catalog/src/js/repositories/__tests__/repositoriesStream-test.js
+++ b/plugins/catalog/src/js/repositories/__tests__/repositoriesStream-test.js
@@ -1,0 +1,82 @@
+import * as httpService from "@dcos/http-service";
+import Rx from "rxjs";
+import Config from "#SRC/js/config/Config";
+import {
+  fetchRepositories,
+  addRepository,
+  deleteRepository
+} from "../repositoriesStream";
+
+jest.mock("@dcos/http-service");
+
+describe("#fetchRepositories", function() {
+  it("makes the call with correct arguments", function(done) {
+    const spy = jest
+      .spyOn(httpService, "request")
+      .mockReturnValueOnce(Rx.Observable.of(""));
+
+    fetchRepositories().subscribe(function() {
+      done();
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      Config.cosmosAPIPrefix + "/repository/list",
+      {
+        method: "POST",
+        body: "{}",
+        headers: {
+          Accept: "application/vnd.dcos.package.repository.list-response+json;charset=utf-8;version=v1",
+          "Content-Type": "application/vnd.dcos.package.repository.list-request+json;charset=utf-8;version=v1"
+        }
+      }
+    );
+  });
+});
+
+describe("#addRepository", function() {
+  it("makes the call with correct arguments", function(done) {
+    const spy = jest
+      .spyOn(httpService, "request")
+      .mockReturnValueOnce(Rx.Observable.of(""));
+
+    addRepository("bar", "foo", 1).subscribe(function() {
+      done();
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      Config.cosmosAPIPrefix + "/repository/add",
+      {
+        method: "POST",
+        body: JSON.stringify({ name: "bar", uri: "foo", index: 1 }),
+        headers: {
+          Accept: "application/vnd.dcos.package.repository.add-response+json;charset=utf-8;version=v1",
+          "Content-Type": "application/vnd.dcos.package.repository.add-request+json;charset=utf-8;version=v1"
+        }
+      }
+    );
+  });
+});
+
+describe("#deleteRepository", function() {
+  it("makes the call with correct arguments", function(done) {
+    const spy = jest
+      .spyOn(httpService, "request")
+      .mockReturnValueOnce(Rx.Observable.of(""));
+
+    deleteRepository("bar", "foo").subscribe(function() {
+      done();
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      Config.cosmosAPIPrefix + "/repository/delete",
+      {
+        method: "POST",
+        body: JSON.stringify({ name: "bar", uri: "foo" }),
+        headers: {
+          Accept: "application/vnd.dcos.package.repository.delete-response+json;charset=utf-8;version=v1",
+          "Content-Type": "application/vnd.dcos.package.repository.delete-request+json;charset=utf-8;version=v1"
+        }
+      }
+    );
+  });
+});

--- a/plugins/catalog/src/js/repositories/repositoriesStream.js
+++ b/plugins/catalog/src/js/repositories/repositoriesStream.js
@@ -1,0 +1,32 @@
+import { request } from "@dcos/http-service";
+import Config from "#SRC/js/config/Config";
+
+export const fetchRepositories = type =>
+  request(`${Config.rootUrl}${Config.cosmosAPIPrefix}/repository/list`, {
+    method: "POST",
+    body: JSON.stringify({ type }),
+    headers: {
+      Accept: "application/vnd.dcos.package.repository.list-response+json;charset=utf-8;version=v1",
+      "Content-Type": "application/vnd.dcos.package.repository.list-request+json;charset=utf-8;version=v1"
+    }
+  });
+
+export const addRepository = (name, uri, index) =>
+  request(`${Config.rootUrl}${Config.cosmosAPIPrefix}/repository/add`, {
+    method: "POST",
+    body: JSON.stringify({ name, uri, index }),
+    headers: {
+      Accept: "application/vnd.dcos.package.repository.add-response+json;charset=utf-8;version=v1",
+      "Content-Type": "application/vnd.dcos.package.repository.add-request+json;charset=utf-8;version=v1"
+    }
+  });
+
+export const deleteRepository = (name, uri) =>
+  request(`${Config.rootUrl}${Config.cosmosAPIPrefix}/repository/delete`, {
+    method: "POST",
+    body: JSON.stringify({ name, uri }),
+    headers: {
+      Accept: "application/vnd.dcos.package.repository.delete-response+json;charset=utf-8;version=v1",
+      "Content-Type": "application/vnd.dcos.package.repository.delete-request+json;charset=utf-8;version=v1"
+    }
+  });

--- a/src/js/events/CosmosPackagesActions.js
+++ b/src/js/events/CosmosPackagesActions.js
@@ -1,4 +1,6 @@
 import { RequestUtil } from "mesosphere-shared-reactjs";
+import * as repositoriesStream
+  from "#PLUGINS/catalog/src/js/repositories/repositoriesStream";
 
 import {
   REQUEST_COSMOS_PACKAGES_LIST_SUCCESS,
@@ -30,6 +32,14 @@ import Util from "../utils/Util";
 
 function getContentType({ action, actionType, entity, version }) {
   return `application/vnd.dcos.${entity}.${action}-${actionType}+json;charset=utf-8;version=${version}`;
+}
+
+function getErrorMessage(response = {}) {
+  if (typeof response === "string") {
+    return response;
+  }
+
+  return response.description || response.message || "An error has occurred.";
 }
 
 const CosmosPackagesActions = {
@@ -382,60 +392,25 @@ const CosmosPackagesActions = {
   },
 
   fetchRepositories(type) {
-    RequestUtil.json({
-      contentType: getContentType({
-        action: "repository.list",
-        actionType: "request",
-        entity: "package",
-        version: "v1"
-      }),
-      headers: {
-        Accept: getContentType({
-          action: "repository.list",
-          actionType: "response",
-          entity: "package",
-          version: "v1"
-        })
-      },
-      method: "POST",
-      url: `${Config.rootUrl}${Config.cosmosAPIPrefix}/repository/list`,
-      data: JSON.stringify({ type }),
-      success(response) {
+    repositoriesStream.fetchRepositories(type).subscribe(
+      function success(response) {
         AppDispatcher.handleServerAction({
           type: REQUEST_COSMOS_REPOSITORIES_LIST_SUCCESS,
           data: response.repositories
         });
       },
-      error(xhr) {
+      function error({ response }) {
         AppDispatcher.handleServerAction({
           type: REQUEST_COSMOS_REPOSITORIES_LIST_ERROR,
-          data: RequestUtil.getErrorFromXHR(xhr),
-          xhr
+          data: getErrorMessage(response)
         });
       }
-    });
+    );
   },
 
   addRepository(name, uri, index) {
-    RequestUtil.json({
-      contentType: getContentType({
-        action: "repository.add",
-        actionType: "request",
-        entity: "package",
-        version: "v1"
-      }),
-      headers: {
-        Accept: getContentType({
-          action: "repository.add",
-          actionType: "response",
-          entity: "package",
-          version: "v1"
-        })
-      },
-      method: "POST",
-      url: `${Config.rootUrl}${Config.cosmosAPIPrefix}/repository/add`,
-      data: JSON.stringify({ name, uri, index }),
-      success(response) {
+    repositoriesStream.addRepository(name, uri, index).subscribe(
+      function success(response) {
         AppDispatcher.handleServerAction({
           type: REQUEST_COSMOS_REPOSITORY_ADD_SUCCESS,
           data: response,
@@ -443,38 +418,20 @@ const CosmosPackagesActions = {
           uri
         });
       },
-      error(xhr) {
+      function error({ response }) {
         AppDispatcher.handleServerAction({
           type: REQUEST_COSMOS_REPOSITORY_ADD_ERROR,
-          data: RequestUtil.getErrorFromXHR(xhr),
+          data: getErrorMessage(response),
           name,
-          uri,
-          xhr
+          uri
         });
       }
-    });
+    );
   },
 
   deleteRepository(name, uri) {
-    RequestUtil.json({
-      contentType: getContentType({
-        action: "repository.delete",
-        actionType: "request",
-        entity: "package",
-        version: "v1"
-      }),
-      headers: {
-        Accept: getContentType({
-          action: "repository.delete",
-          actionType: "response",
-          entity: "package",
-          version: "v1"
-        })
-      },
-      method: "POST",
-      url: `${Config.rootUrl}${Config.cosmosAPIPrefix}/repository/delete`,
-      data: JSON.stringify({ name, uri }),
-      success(response) {
+    repositoriesStream.deleteRepository(name, uri).subscribe(
+      function success(response) {
         AppDispatcher.handleServerAction({
           type: REQUEST_COSMOS_REPOSITORY_DELETE_SUCCESS,
           data: response,
@@ -482,16 +439,15 @@ const CosmosPackagesActions = {
           uri
         });
       },
-      error(xhr) {
+      function error({ response }) {
         AppDispatcher.handleServerAction({
           type: REQUEST_COSMOS_REPOSITORY_DELETE_ERROR,
-          data: RequestUtil.getErrorFromXHR(xhr),
+          data: getErrorMessage(response),
           name,
-          uri,
-          xhr
+          uri
         });
       }
-    });
+    );
   }
 };
 

--- a/src/js/events/__tests__/CosmosPackagesActions-test.js
+++ b/src/js/events/__tests__/CosmosPackagesActions-test.js
@@ -1,3 +1,7 @@
+jest.mock("@dcos/http-service");
+
+const httpService = require("@dcos/http-service");
+const Rx = require("rxjs");
 const RequestUtil = require("mesosphere-shared-reactjs").RequestUtil;
 const ActionTypes = require("../../constants/ActionTypes");
 const AppDispatcher = require("../AppDispatcher");
@@ -840,266 +844,194 @@ describe("CosmosPackagesActions", function() {
   });
 
   describe("#fetchRepositories", function() {
-    beforeEach(function() {
-      spyOn(RequestUtil, "json");
-      CosmosPackagesActions.fetchRepositories({ foo: "bar" });
-      thisConfiguration = RequestUtil.json.calls.mostRecent().args[0];
-    });
+    it("dispatches the correct action when successful", function(done) {
+      httpService.request.mockReturnValueOnce(
+        Rx.Observable.of({ repositories: [{ bar: "baz" }] })
+      );
 
-    it("dispatches the correct action when successful", function() {
       var id = AppDispatcher.register(function(payload) {
         var action = payload.action;
         AppDispatcher.unregister(id);
         expect(action.type).toEqual(
           ActionTypes.REQUEST_COSMOS_REPOSITORIES_LIST_SUCCESS
         );
+        done();
       });
 
-      thisConfiguration.success({ repositories: [{ bar: "baz" }] });
+      CosmosPackagesActions.fetchRepositories();
     });
 
-    it("dispatches with the correct data when successful", function() {
+    it("dispatches with the correct data when successful", function(done) {
+      httpService.request.mockReturnValueOnce(
+        Rx.Observable.of({ repositories: [{ bar: "baz" }] })
+      );
+
       var id = AppDispatcher.register(function(payload) {
         var action = payload.action;
         AppDispatcher.unregister(id);
         expect(action.data).toEqual([{ bar: "baz" }]);
+        done();
       });
 
-      thisConfiguration.success({ repositories: [{ bar: "baz" }] });
+      CosmosPackagesActions.fetchRepositories();
     });
 
-    it("dispatches the correct action when unsuccessful", function() {
+    it("dispatches the correct action when unsuccessful", function(done) {
+      httpService.request.mockReturnValueOnce(
+        Rx.Observable.throw({ responseJSON: { description: "bar" } })
+      );
+
       var id = AppDispatcher.register(function(payload) {
         var action = payload.action;
         AppDispatcher.unregister(id);
         expect(action.type).toEqual(
           ActionTypes.REQUEST_COSMOS_REPOSITORIES_LIST_ERROR
         );
+        done();
       });
 
-      thisConfiguration.error({ responseJSON: { description: "bar" } });
+      CosmosPackagesActions.fetchRepositories();
     });
 
-    it("dispatches with the correct data when unsuccessful", function() {
+    it("dispatches with the correct data when unsuccessful", function(done) {
+      httpService.request.mockReturnValueOnce(
+        Rx.Observable.throw({ response: { description: "bar" } })
+      );
+
       var id = AppDispatcher.register(function(payload) {
         var action = payload.action;
         AppDispatcher.unregister(id);
         expect(action.data).toEqual("bar");
+        done();
       });
 
-      thisConfiguration.error({ responseJSON: { description: "bar" } });
-    });
-
-    it("dispatches the xhr when unsuccessful", function() {
-      var id = AppDispatcher.register(function(payload) {
-        var action = payload.action;
-        AppDispatcher.unregister(id);
-        expect(action.xhr).toEqual({
-          foo: "bar",
-          responseJSON: { description: "baz" }
-        });
-      });
-
-      thisConfiguration.error({
-        foo: "bar",
-        responseJSON: { description: "baz" }
-      });
-    });
-
-    it("calls #json from the RequestUtil", function() {
-      expect(RequestUtil.json).toHaveBeenCalled();
-    });
-
-    it("fetches data from the correct URL", function() {
-      expect(thisConfiguration.url).toEqual(
-        Config.cosmosAPIPrefix + "/repository/list"
-      );
-    });
-
-    it("sends a POST request", function() {
-      expect(thisConfiguration.method).toEqual("POST");
+      CosmosPackagesActions.fetchRepositories();
     });
   });
 
   describe("#addRepository", function() {
-    beforeEach(function() {
-      spyOn(RequestUtil, "json");
-      CosmosPackagesActions.addRepository("foo", "bar");
-      thisConfiguration = RequestUtil.json.calls.mostRecent().args[0];
-    });
+    it("dispatches the correct action when successful", function(done) {
+      httpService.request.mockReturnValueOnce(Rx.Observable.of({ bar: "baz" }));
 
-    it("dispatches the correct action when successful", function() {
       var id = AppDispatcher.register(function(payload) {
         var action = payload.action;
         AppDispatcher.unregister(id);
         expect(action.type).toEqual(
           ActionTypes.REQUEST_COSMOS_REPOSITORY_ADD_SUCCESS
         );
+        done();
       });
 
-      thisConfiguration.success({ bar: "baz" });
+      CosmosPackagesActions.addRepository("foo", "bar", 1);
     });
 
-    it("dispatches with the correct data when successful", function() {
+    it("dispatches with the correct data when successful", function(done) {
+      httpService.request.mockReturnValueOnce(Rx.Observable.of({ bar: "baz" }));
+
       var id = AppDispatcher.register(function(payload) {
         var action = payload.action;
         AppDispatcher.unregister(id);
         expect(action.data).toEqual({ bar: "baz" });
         expect(action.name).toEqual("foo");
         expect(action.uri).toEqual("bar");
+        done();
       });
 
-      thisConfiguration.success({ bar: "baz" });
+      CosmosPackagesActions.addRepository("foo", "bar", 1);
     });
 
-    it("dispatches the correct action when unsuccessful", function() {
+    it("dispatches the correct action when unsuccessful", function(done) {
+      httpService.request.mockReturnValueOnce(
+        Rx.Observable.throw({ responseJSON: { description: "bar" } })
+      );
       var id = AppDispatcher.register(function(payload) {
         var action = payload.action;
         AppDispatcher.unregister(id);
         expect(action.type).toEqual(
           ActionTypes.REQUEST_COSMOS_REPOSITORY_ADD_ERROR
         );
+        done();
       });
 
-      thisConfiguration.error({ responseJSON: { description: "bar" } });
+      CosmosPackagesActions.addRepository("foo", "bar", 1);
     });
 
-    it("dispatches with the correct data when unsuccessful", function() {
+    it("dispatches with the correct data when unsuccessful", function(done) {
+      httpService.request.mockReturnValueOnce(
+        Rx.Observable.throw({ response: { description: "bar" } })
+      );
+
       var id = AppDispatcher.register(function(payload) {
         var action = payload.action;
         AppDispatcher.unregister(id);
         expect(action.data).toEqual("bar");
+        done();
       });
 
-      thisConfiguration.error({ responseJSON: { description: "bar" } });
-    });
-
-    it("dispatches the xhr when unsuccessful", function() {
-      var id = AppDispatcher.register(function(payload) {
-        var action = payload.action;
-        AppDispatcher.unregister(id);
-        expect(action.xhr).toEqual({
-          foo: "bar",
-          responseJSON: { description: "baz" }
-        });
-      });
-
-      thisConfiguration.error({
-        foo: "bar",
-        responseJSON: { description: "baz" }
-      });
-    });
-
-    it("calls #json from the RequestUtil", function() {
-      expect(RequestUtil.json).toHaveBeenCalled();
-    });
-
-    it("fetches data from the correct URL", function() {
-      expect(thisConfiguration.url).toEqual(
-        Config.cosmosAPIPrefix + "/repository/add"
-      );
-    });
-
-    it("sends query in request body", function() {
-      expect(JSON.parse(thisConfiguration.data)).toEqual({
-        name: "foo",
-        uri: "bar"
-      });
-    });
-
-    it("sends a POST request", function() {
-      expect(thisConfiguration.method).toEqual("POST");
+      CosmosPackagesActions.addRepository("foo", "bar", 1);
     });
   });
 
   describe("#deleteRepository", function() {
-    beforeEach(function() {
-      spyOn(RequestUtil, "json");
-      CosmosPackagesActions.deleteRepository("foo", "bar");
-      thisConfiguration = RequestUtil.json.calls.mostRecent().args[0];
-    });
+    it("dispatches the correct action when successful", function(done) {
+      httpService.request.mockReturnValueOnce(Rx.Observable.of([""]));
 
-    it("dispatches the correct action when successful", function() {
       var id = AppDispatcher.register(function(payload) {
         var action = payload.action;
         AppDispatcher.unregister(id);
         expect(action.type).toEqual(
           ActionTypes.REQUEST_COSMOS_REPOSITORY_DELETE_SUCCESS
         );
+        done();
       });
 
-      thisConfiguration.success({ bar: "baz" });
+      CosmosPackagesActions.deleteRepository("foo", "bar");
     });
 
-    it("dispatches with the correct data when successful", function() {
+    it("dispatches with the correct data when successful", function(done) {
+      httpService.request.mockReturnValueOnce(Rx.Observable.of({ bar: "baz" }));
+
       var id = AppDispatcher.register(function(payload) {
         var action = payload.action;
         AppDispatcher.unregister(id);
         expect(action.data).toEqual({ bar: "baz" });
         expect(action.name).toEqual("foo");
         expect(action.uri).toEqual("bar");
+        done();
       });
 
-      thisConfiguration.success({ bar: "baz" });
+      CosmosPackagesActions.deleteRepository("foo", "bar");
     });
 
-    it("dispatches the correct action when unsuccessful", function() {
+    it("dispatches the correct action when unsuccessful", function(done) {
+      httpService.request.mockReturnValueOnce(
+        Rx.Observable.throw({ response: { description: "bar" } })
+      );
+
       var id = AppDispatcher.register(function(payload) {
         var action = payload.action;
         AppDispatcher.unregister(id);
         expect(action.type).toEqual(
           ActionTypes.REQUEST_COSMOS_REPOSITORY_DELETE_ERROR
         );
+        done();
       });
 
-      thisConfiguration.error({ responseJSON: { description: "bar" } });
+      CosmosPackagesActions.deleteRepository("foo", "bar");
     });
 
-    it("dispatches with the correct data when unsuccessful", function() {
+    it("dispatches with the correct data when unsuccessful", function(done) {
+      httpService.request.mockReturnValueOnce(
+        Rx.Observable.throw({ response: { description: "bar" } })
+      );
       var id = AppDispatcher.register(function(payload) {
         var action = payload.action;
         AppDispatcher.unregister(id);
         expect(action.data).toEqual("bar");
+        done();
       });
 
-      thisConfiguration.error({ responseJSON: { description: "bar" } });
-    });
-
-    it("dispatches the xhr when unsuccessful", function() {
-      var id = AppDispatcher.register(function(payload) {
-        var action = payload.action;
-        AppDispatcher.unregister(id);
-        expect(action.xhr).toEqual({
-          foo: "bar",
-          responseJSON: { description: "baz" }
-        });
-      });
-
-      thisConfiguration.error({
-        foo: "bar",
-        responseJSON: { description: "baz" }
-      });
-    });
-
-    it("calls #json from the RequestUtil", function() {
-      expect(RequestUtil.json).toHaveBeenCalled();
-    });
-
-    it("fetches data from the correct URL", function() {
-      expect(thisConfiguration.url).toEqual(
-        Config.cosmosAPIPrefix + "/repository/delete"
-      );
-    });
-
-    it("sends query in request body", function() {
-      expect(JSON.parse(thisConfiguration.data)).toEqual({
-        name: "foo",
-        uri: "bar"
-      });
-    });
-
-    it("sends a POST request", function() {
-      expect(thisConfiguration.method).toEqual("POST");
+      CosmosPackagesActions.deleteRepository("foo", "bar");
     });
   });
 });


### PR DESCRIPTION
This PR refactors Settings -> Package Repositories page APIs wrapping them with `http-service`. This is a stepping stone in the data-layer effort.

So listing/deleting/adding repository should just work. 

~Beware that verbose error messages will be broken! Therefore `hold merge`
There's an [issue](https://github.com/dcos-labs/http-service/issues/4) for that and a [JIRA](https://jira.mesosphere.com/browse/DCOS-21727)~

Closes DCOS-21640

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
