### PR TITLE
DCOS-21638 use the mediator api on repository settings

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3147,6 +3147,11 @@
         }
       }
     },
+    "change-emitter": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
+    },
     "charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
@@ -24644,6 +24649,61 @@
       "dev": true,
       "requires": {
         "resolve": "1.6.0"
+      }
+    },
+    "recompose": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
+      "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
+      "requires": {
+        "change-emitter": "0.1.6",
+        "fbjs": "0.8.16",
+        "hoist-non-react-statics": "2.5.0",
+        "symbol-observable": "1.2.0"
+      },
+      "dependencies": {
+        "asap": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        },
+        "fbjs": {
+          "version": "0.8.16",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+          "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.17"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
+          "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "promise": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+          "requires": {
+            "asap": "2.0.6"
+          }
+        }
       }
     },
     "redbox-react": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-transition-group": "1.2.1",
     "reactjs-components": "0.20.3",
     "reactjs-mixin": "0.0.2",
+    "recompose": "0.26.0",
     "redux": "3.3.1",
     "reflect-metadata": "0.1.10",
     "rxjs": "5.4.3",

--- a/src/js/components/RepositoriesTabUI.js
+++ b/src/js/components/RepositoriesTabUI.js
@@ -1,0 +1,116 @@
+import { Link } from "react-router";
+import React from "react";
+
+import AddRepositoryFormModal
+  from "#SRC/js/components/modals/AddRepositoryFormModal";
+import Breadcrumb from "#SRC/js/components/Breadcrumb";
+import BreadcrumbTextContent from "#SRC/js/components/BreadcrumbTextContent";
+import FilterBar from "#SRC/js/components/FilterBar";
+import FilterInputText from "#SRC/js/components/FilterInputText";
+import Loader from "#SRC/js/components/Loader";
+import Page from "#SRC/js/components/Page";
+import RepositoriesTable from "#SRC/js/components/RepositoriesTable";
+import RequestErrorMsg from "#SRC/js/components/RequestErrorMsg";
+
+const RepositoriesBreadcrumbs = addButton => {
+  const crumbs = [
+    <Breadcrumb key={-1} title="Repositories">
+      <BreadcrumbTextContent>
+        <Link to="/settings/repositories">Package Repositories</Link>
+      </BreadcrumbTextContent>
+    </Breadcrumb>
+  ];
+
+  return (
+    <Page.Header.Breadcrumbs
+      iconID="settings"
+      breadcrumbs={crumbs}
+      addButton={addButton}
+    />
+  );
+};
+
+const METHODS_TO_BIND = ["handleCloseAddRepository", "handleOpenAddRepository"];
+
+export default class RepositoriesTabUI extends React.Component {
+  constructor() {
+    super();
+
+    this.state = {
+      addRepositoryModalOpen: false
+    };
+
+    METHODS_TO_BIND.forEach(method => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  handleCloseAddRepository() {
+    this.setState({ addRepositoryModalOpen: false });
+  }
+
+  handleOpenAddRepository() {
+    this.setState({ addRepositoryModalOpen: true });
+  }
+
+  getContent() {
+    const { addRepositoryModalOpen } = this.state;
+
+    const { repositories, searchTerm, onSearch } = this.props;
+
+    return (
+      <div>
+        <FilterBar>
+          <FilterInputText
+            className="flush-bottom"
+            placeholder="Search"
+            searchString={searchTerm}
+            handleFilterChange={onSearch}
+          />
+        </FilterBar>
+        <RepositoriesTable repositories={repositories} filter={searchTerm} />
+        <AddRepositoryFormModal
+          numberOfRepositories={repositories.getItems().length}
+          open={addRepositoryModalOpen}
+          onClose={this.handleCloseAddRepository}
+        />
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <RepositoriesTabUI.Page addButton={this.handleOpenAddRepository}>
+        {this.getContent()}
+      </RepositoriesTabUI.Page>
+    );
+  }
+}
+
+RepositoriesTabUI.Loading = () => {
+  return (
+    <RepositoriesTabUI.Page>
+      <Loader />
+    </RepositoriesTabUI.Page>
+  );
+};
+
+RepositoriesTabUI.Error = () => {
+  return (
+    <RepositoriesTabUI.Page>
+      <RequestErrorMsg />
+    </RepositoriesTabUI.Page>
+  );
+};
+
+RepositoriesTabUI.Page = ({ addButton, children }) => {
+  return (
+    <Page>
+      <Page.Header
+        addButton={addButton}
+        breadcrumbs={<RepositoriesBreadcrumbs />}
+      />
+      {children}
+    </Page>
+  );
+};

--- a/src/js/pages/system/RepositoriesTab.js
+++ b/src/js/pages/system/RepositoriesTab.js
@@ -1,158 +1,31 @@
-import mixin from "reactjs-mixin";
-import { Link } from "react-router";
-/* eslint-disable no-unused-vars */
 import React from "react";
-/* eslint-enable no-unused-vars */
-import { StoreMixin } from "mesosphere-shared-reactjs";
+import { componentFromStream } from "recompose";
 
-import AddRepositoryFormModal
-  from "../../components/modals/AddRepositoryFormModal";
-import Breadcrumb from "../../components/Breadcrumb";
-import BreadcrumbTextContent from "../../components/BreadcrumbTextContent";
-import CosmosPackagesStore from "../../stores/CosmosPackagesStore";
-import FilterBar from "../../components/FilterBar";
-import FilterInputText from "../../components/FilterInputText";
-import Loader from "../../components/Loader";
-import Page from "../../components/Page";
-import RepositoriesTable from "../../components/RepositoriesTable";
-import RequestErrorMsg from "../../components/RequestErrorMsg";
+import RepositoriesTabUI from "#SRC/js/components/RepositoriesTabUI";
 
-const RepositoriesBreadcrumbs = addButton => {
-  const crumbs = [
-    <Breadcrumb key={-1} title="Repositories">
-      <BreadcrumbTextContent>
-        <Link to="/settings/repositories">Package Repositories</Link>
-      </BreadcrumbTextContent>
-    </Breadcrumb>
-  ];
+import {
+  packageSources$,
+  searchPackageSource$
+} from "#SRC/js/streams/CosmosPackagesStream";
 
-  return (
-    <Page.Header.Breadcrumbs
-      iconID="settings"
-      breadcrumbs={crumbs}
-      addButton={addButton}
-    />
-  );
+const onSearch = term => {
+  searchPackageSource$.next(term);
 };
 
-const METHODS_TO_BIND = [
-  "handleSearchStringChange",
-  "handleCloseAddRepository",
-  "handleOpenAddRepository"
-];
-
-class RepositoriesTab extends mixin(StoreMixin) {
-  constructor() {
-    super();
-
-    this.state = {
-      addRepositoryModalOpen: false,
-      hasError: false,
-      isLoading: true,
-      searchString: ""
-    };
-
-    this.store_listeners = [
-      {
-        name: "cosmosPackages",
-        events: ["repositoriesSuccess", "repositoriesError"],
-        suppressUpdate: true
-      }
-    ];
-
-    METHODS_TO_BIND.forEach(method => {
-      this[method] = this[method].bind(this);
-    });
-  }
-
-  componentDidMount() {
-    super.componentDidMount(...arguments);
-    CosmosPackagesStore.fetchRepositories();
-  }
-
-  handleCloseAddRepository() {
-    this.setState({ addRepositoryModalOpen: false });
-  }
-
-  handleOpenAddRepository() {
-    this.setState({ addRepositoryModalOpen: true });
-  }
-
-  onCosmosPackagesStoreRepositoriesError() {
-    this.setState({ hasError: true });
-  }
-
-  onCosmosPackagesStoreRepositoriesSuccess() {
-    this.setState({ hasError: false, isLoading: false });
-  }
-
-  handleSearchStringChange(searchString = "") {
-    this.setState({ searchString });
-  }
-
-  getErrorScreen() {
-    return <RequestErrorMsg />;
-  }
-
-  getLoadingScreen() {
-    return <Loader />;
-  }
-
-  getContent() {
-    const {
-      addRepositoryModalOpen,
-      hasError,
-      isLoading,
-      searchString
-    } = this.state;
-
-    if (hasError) {
-      return this.getErrorScreen();
-    }
-
-    if (isLoading) {
-      return this.getLoadingScreen();
-    }
-
-    const repositories = CosmosPackagesStore.getRepositories().filterItemsByText(
-      searchString
-    );
-
+const components$ = packageSources$
+  .map(data => {
     return (
-      <div>
-        <FilterBar>
-          <FilterInputText
-            className="flush-bottom"
-            placeholder="Search"
-            searchString={searchString}
-            handleFilterChange={this.handleSearchStringChange}
-          />
-        </FilterBar>
-        <RepositoriesTable repositories={repositories} filter={searchString} />
-        <AddRepositoryFormModal
-          numberOfRepositories={repositories.getItems().length}
-          open={addRepositoryModalOpen}
-          onClose={this.handleCloseAddRepository}
-        />
-      </div>
+      <RepositoriesTabUI
+        repositories={data.repositories}
+        searchTerm={data.searchTerm}
+        onSearch={onSearch}
+      />
     );
-  }
+  })
+  .startWith(<RepositoriesTabUI.Loading />)
+  .catch(_err => <RepositoriesTabUI.Error />);
 
-  render() {
-    return (
-      <Page>
-        <Page.Header
-          addButton={{
-            onItemSelect: this.handleOpenAddRepository,
-            label: "Add Repository"
-          }}
-          breadcrumbs={<RepositoriesBreadcrumbs />}
-        />
-        {this.getContent()}
-      </Page>
-    );
-  }
-}
+const RepositoriesTab = componentFromStream(() => components$);
 
 RepositoriesTab.routeConfig = {
   label: "Package Repositories",

--- a/src/js/streams/CosmosPackagesStream.js
+++ b/src/js/streams/CosmosPackagesStream.js
@@ -1,0 +1,28 @@
+// to be replaced with https://github.com/dcos/dcos-ui/pull/2840
+import { Observable, Subject } from "rxjs";
+
+import CosmosPackagesStore from "#SRC/js/stores/CosmosPackagesStore";
+
+const cosmosPackageWrapper$ = Observable.timer(1000, 2000)
+  .map(() => CosmosPackagesStore.fetchRepositories())
+  .map(() => CosmosPackagesStore.getRepositories())
+  .distinctUntilChanged();
+
+const searchPackageSource$ = new Subject();
+const search$ = searchPackageSource$
+  .merge(Observable.of(""))
+  .publishReplay(1)
+  .refCount();
+
+const packageSources$ = cosmosPackageWrapper$
+  .combineLatest(search$, (repositories, searchTerm) => {
+    return { repositories, searchTerm };
+  })
+  .map(({ repositories, searchTerm }) => {
+    return {
+      repositories: repositories.filterItemsByText(searchTerm),
+      searchTerm
+    };
+  });
+
+export { packageSources$, searchPackageSource$ };

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -28,7 +28,8 @@ module.exports = {
       ),
       "#PLUGINS": path.resolve(__dirname, "../plugins"),
       "#SRC": path.resolve(__dirname, "../src"),
-      "#TESTS": path.resolve(__dirname, "../tests")
+      "#TESTS": path.resolve(__dirname, "../tests"),
+      "#PACKAGES": path.resolve(__dirname, "../packages")
     },
     modules: [
       // include packages


### PR DESCRIPTION
This implements the mediator pattern for the Settings page using recompose + rxjs. In the end we had to implement 0 lines of code on the data-service 🎆 .

To test this just play with Settings > Package Repositories, add, remove and filter packages.

Come to me if you need valid repos to test, or just remove first and then you can add again.

- [x] adequate with the API here #2841 

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

