### PR TITLE
fix(generate-changelog): add missig prefix

### DIFF
--- a/scripts/ci/generate-changelog
+++ b/scripts/ci/generate-changelog
@@ -2,7 +2,7 @@
 set -ex
 
 MAJOR_MINOR_MATCH=$(echo $TAG_NAME | grep -Eo "^v?(0|[1-9]\d*)\.(0|[1-9]\d*)")
-TAGS=($(git tag -l "$MAJOR_MINOR_MATCH*" --sort=-version:refname))
+TAGS=($(git tag -l "v$MAJOR_MINOR_MATCH*" --sort=-version:refname))
 PREVIOUS_TAG=${TAGS[1]}
 
 if [[ -z $PREVIOUS_TAG ]]


### PR DESCRIPTION
Our version tags start with a v like in v1.9.0, so the query needs to be adapted

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
