### PR TITLE
DCOS-21766: fix(ci): fix release file name

### DIFF
--- a/scripts/ci/upload-build
+++ b/scripts/ci/upload-build
@@ -14,9 +14,8 @@ fi
 
 PKG_BRANCH=$(echo ${BRANCH_NAME} | sed -E 's/([^/]*)$|./\1/g')
 
-# ex. master+dcos-ui-v1.12.0-rc.11.tar.gz
-# ex. master+dcos-ui-ee-v1.12.0-rc.11.tar.gz
-RELEASE_NAME="${PKG_BRANCH}+dcos-ui${PKG_VERSION}.tar.gz"
+# ex. dcos-ui-v1.12.0-rc.11.tar.gz
+RELEASE_NAME="dcos-ui${PKG_VERSION}.tar.gz"
 
 # tar dist
 cd "dist"


### PR DESCRIPTION
this PR fixes a small issue with our new jenkinsfile by changing our release file names from `tag+name-tag.tar.gz` to `name-tag.tar.gz`. Jenkins passes the tag name as `BRANCH_NAME` to the script which caused theses names 👍 