### PR TITLE
fix(MesosStateStore): adjust stream data handling

### DIFF
--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -56,7 +56,7 @@ class MesosStateStore extends GetSetBaseStore {
     this.on(eventName, callback);
 
     if (this.shouldSubscribe()) {
-      this.subscribe();
+      Promise.resolve().then(() => this.subscribe());
     }
   }
 
@@ -99,7 +99,8 @@ class MesosStateStore extends GetSetBaseStore {
     // refresh limits to the UI. They are:
     //
     // MOST once every (Config.getRefreshRate() * 0.5) ms. due to debounceTime.
-    // LEAST once every tick of Config.getRefreshRate() ms in Observable.interval
+    // LEAST once every tick of Config.getRefreshRate() ms in
+    // Observable.interval
     //
     // TODO: https://jira.mesosphere.com/browse/DCOS-18277
     this.stream = waitStream


### PR DESCRIPTION
Use `Promise.resolve().then()` to trigger the stream subscription asynchronously on the same macrotask (by using a microtask). Events emitted by the strean, trigger `onStreamData` which is used to emit an event (using EventEmitter) called `MESOS_STATE_CHANGE`. This change will mitigate issues in which errors in view components lead to stale data because the error propagation broke the stream.

N.B. `EventEmitter` is synchronous meaning that every delay in an event handler effects the `emit` execution time and errors propagate up to the `emit` call which sometimes leads to undesireable behavior.

Closes DCOS-21784

**how to test?**
You want to test this against an enterprise cluster that does not have regions. An example of that cluster is the `nuc` cluster sitting on @fabs desk (sorry SF). On master, if you go to the Networking page on the said cluster, you will get an error. Once that error happens, the mesos stream is broken and if you go to Nodes > Grid, you won't be able to see any grid data. If you then switch to this branch, the data should come normally, event with the error happening.  I recommend you test other pages that rely on data coming from the mesos stream. 

Closes DCOS-21784