### PR TITLE
fix(ServiceStorageConfigSection): adjust getDefinition default

### DIFF
--- a/plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceStorageConfigSection.js
@@ -53,7 +53,7 @@ class ServiceStorageConfigSection extends ServiceConfigBaseSectionDisplay {
       appConfig.container.volumes == null
     ) {
       // sanity check
-      return null;
+      return super.getDefinition();
     }
 
     const volumes = appConfig.container.volumes;


### PR DESCRIPTION
Adjust the `ServiceStorageConfigSection.getDefinition` default to align the return a type with the superclass.

Closes DCOS-20949