### PR TITLE
DCOS-19586 - (feat): volume table and volume detail for pods

### DIFF
--- a/plugins/services/src/js/components/PodVolumeTable.js
+++ b/plugins/services/src/js/components/PodVolumeTable.js
@@ -1,0 +1,204 @@
+import classNames from "classnames";
+import { Link } from "react-router";
+import PropTypes from "prop-types";
+import React from "react";
+import { Table } from "reactjs-components";
+
+import { reconstructPathFromRoutes } from "#SRC/js/utils/RouterUtil";
+import Volume from "../structs/Volume";
+import VolumeStatus from "../constants/VolumeStatus";
+import VolumeDefinitions from "../constants/VolumeDefinitions";
+
+const METHODS_TO_BIND = ["renderIDColumn"];
+
+class PodVolumeTable extends React.Component {
+  constructor() {
+    super();
+
+    METHODS_TO_BIND.forEach(method => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  getData(volumes) {
+    return volumes.map(function(volume) {
+      return {
+        id: volume.getId(),
+        host: volume.getHost(),
+        type: volume.getType(),
+        profile: volume.getProfile(),
+        name: volume.getContainerPath(),
+        size: volume.getSize(),
+        status: volume.getStatus()
+      };
+    });
+  }
+
+  getColGroup() {
+    return (
+      <colgroup>
+        <col style={{ width: "30%" }} />
+        <col style={{ width: "10%" }} />
+        <col style={{ width: "10%" }} />
+        <col style={{ width: "10%" }} />
+        <col style={{ width: "10%" }} />
+        <col style={{ width: "10%" }} />
+      </colgroup>
+    );
+  }
+
+  getColumnClassName(prop, sortBy, row) {
+    return classNames({
+      active: prop === sortBy.prop,
+      clickable: row == null,
+      "text-overflow": prop === "profile"
+    });
+  }
+
+  getColumnHeading(prop, order, sortBy) {
+    const caretClassNames = classNames("caret", {
+      [`caret--${order}`]: order != null,
+      "caret--visible": prop === sortBy.prop
+    });
+
+    const headingStrings = {
+      id: "ID",
+      host: "Host",
+      type: "Volume Type",
+      profile: "Volume Profile",
+      name: "Volume Name",
+      size: "Size",
+      status: "Status"
+    };
+
+    return (
+      <span>
+        {headingStrings[prop]}
+        <span className={caretClassNames} />
+      </span>
+    );
+  }
+
+  getColumns() {
+    return [
+      {
+        className: this.getColumnClassName,
+        heading: this.getColumnHeading,
+        prop: "id",
+        render: this.renderIDColumn,
+        sortable: true
+      },
+      {
+        className: this.getColumnClassName,
+        heading: this.getColumnHeading,
+        prop: "host",
+        sortable: true
+      },
+      {
+        className: this.getColumnClassName,
+        heading: this.getColumnHeading,
+        prop: "type",
+        sortable: true
+      },
+      {
+        className: this.getColumnClassName,
+        heading: this.getColumnHeading,
+        prop: "profile",
+        sortable: true
+      },
+      {
+        className: this.getColumnClassName,
+        heading: this.getColumnHeading,
+        prop: "name",
+        sortable: true
+      },
+      {
+        className: this.getColumnClassName,
+        heading: this.getColumnHeading,
+        prop: "size",
+        render: this.renderSizeColumn,
+        sortable: true
+      },
+      {
+        className: this.getColumnClassName,
+        heading: this.getColumnHeading,
+        prop: "status",
+        render: this.renderStatusColumn,
+        sortable: true
+      }
+    ];
+  }
+
+  renderIDColumn(prop, row) {
+    const id = row[prop];
+    const { nodeID, taskID } = this.props.params;
+    const volumeID = encodeURIComponent(id);
+    const serviceID = encodeURIComponent(this.props.params.id);
+    const currentroutePath = reconstructPathFromRoutes(this.props.routes);
+    let routePath = null;
+
+    if (currentroutePath === "/services/detail/:id/podvolumes") {
+      routePath = `/services/detail/${serviceID}/podvolumes/${volumeID}`;
+    } else if (
+      currentroutePath === "/services/detail/:id/tasks/:taskID/podvolumes"
+    ) {
+      routePath = `/services/detail/${serviceID}/tasks/${taskID}/podvolumes/${volumeID}`;
+    } else if (currentroutePath === "/nodes/:nodeID/tasks/:taskID/podvolumes") {
+      routePath = `/nodes/${nodeID}/tasks/${taskID}/podvolumes/${volumeID}`;
+    }
+
+    return <Link className="table-cell-link-primary" to={routePath}>{id}</Link>;
+  }
+
+  renderSizeColumn(prop, row) {
+    const { size } = row;
+    let unit = "MiB";
+
+    if (
+      row.type !== VolumeDefinitions.PERSISTENT.type &&
+      row.type !== VolumeDefinitions.DSS.type
+    ) {
+      unit = "GiB";
+    }
+
+    return (
+      <span>
+        {`${size} ${unit}`}
+      </span>
+    );
+  }
+
+  renderStatusColumn(prop, row) {
+    const value = row[prop];
+    const classes = classNames({
+      "text-danger": value === VolumeStatus.DETACHED,
+      "text-success": value === VolumeStatus.ATTACHED
+    });
+
+    return (
+      <span className={classes}>
+        {row[prop]}
+      </span>
+    );
+  }
+
+  render() {
+    return (
+      <Table
+        className="table table-flush table-borderless-outer table-borderless-inner-columns table-hover flush-bottom"
+        columns={this.getColumns()}
+        colGroup={this.getColGroup()}
+        data={this.getData(this.props.service.getVolumesData().getItems())}
+        sortBy={{ prop: "id", order: "asc" }}
+      />
+    );
+  }
+}
+
+PodVolumeTable.propTypes = {
+  volumes: PropTypes.arrayOf(PropTypes.instanceOf(Volume)),
+  params: PropTypes.object.isRequired,
+  routes: PropTypes.array.isRequired
+};
+
+export default PodVolumeTable;

--- a/plugins/services/src/js/containers/pod-detail/PodDetail.js
+++ b/plugins/services/src/js/containers/pod-detail/PodDetail.js
@@ -201,16 +201,31 @@ class PodDetail extends mixin(TabsMixin) {
     return actions;
   }
 
+  hasVolumes() {
+    return (
+      !!this.props.pod && this.props.pod.getVolumesData().getItems().length > 0
+    );
+  }
+
   getTabs() {
     const { pod: { id } } = this.props;
     const routePrefix = `/services/detail/${encodeURIComponent(id)}`;
 
-    return [
+    const tabs = [
       { label: "Tasks", routePath: `${routePrefix}/tasks` },
       { label: "Configuration", routePath: `${routePrefix}/configuration` },
       { label: "Debug", routePath: `${routePrefix}/debug` },
       { label: "Endpoints", routePath: `${routePrefix}/endpoints` }
     ];
+
+    if (this.hasVolumes()) {
+      tabs.push({
+        label: "Volumes",
+        routePath: `${routePrefix}/podvolumes`
+      });
+    }
+
+    return tabs;
   }
 
   render() {

--- a/plugins/services/src/js/containers/volume-detail/PodVolumeContainer.js
+++ b/plugins/services/src/js/containers/volume-detail/PodVolumeContainer.js
@@ -1,0 +1,84 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+import { DCOS_CHANGE } from "#SRC/js/constants/EventTypes";
+import DCOSStore from "#SRC/js/stores/DCOSStore";
+import Loader from "#SRC/js/components/Loader";
+
+import ServiceItemNotFound from "../../components/ServiceItemNotFound";
+import PodVolumeDetail from "./PodVolumeDetail";
+
+const METHODS_TO_BIND = ["onStoreChange"];
+
+class PodVolumeContainer extends React.Component {
+  constructor() {
+    super(...arguments);
+
+    this.state = {
+      isLoading: !DCOSStore.serviceDataReceived,
+      lastUpdate: 0
+    };
+
+    METHODS_TO_BIND.forEach(method => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  componentDidMount() {
+    DCOSStore.addChangeListener(DCOS_CHANGE, this.onStoreChange);
+  }
+
+  componentWillUnmount() {
+    DCOSStore.removeChangeListener(DCOS_CHANGE, this.onStoreChange);
+  }
+
+  onStoreChange() {
+    // Throttle updates from DCOSStore
+    if (
+      Date.now() - this.state.lastUpdate > 1000 ||
+      (DCOSStore.serviceDataReceived && this.state.isLoading)
+    ) {
+      this.setState({
+        isLoading: !DCOSStore.serviceDataReceived,
+        lastUpdate: Date.now()
+      });
+    }
+  }
+
+  render() {
+    const { id, volumeID } = this.props.params;
+    const serviceId = decodeURIComponent(id);
+    const service = DCOSStore.serviceTree.findItemById(serviceId);
+    const volumeId = decodeURIComponent(volumeID);
+
+    if (this.state.isLoading) {
+      return <Loader />;
+    }
+
+    if (!service) {
+      return (
+        <ServiceItemNotFound
+          message={`The service with the ID of "${id}" could not be found.`}
+        />
+      );
+    }
+
+    const volume = service.getVolumesData().findItem(volume => {
+      return volume.getId() === volumeId;
+    });
+
+    if (!volume) {
+      return (
+        <ServiceItemNotFound message={`Volume '${volumeId}' was not found.`} />
+      );
+    }
+
+    return <PodVolumeDetail service={service} volume={volume} />;
+  }
+}
+
+PodVolumeContainer.propTypes = {
+  params: PropTypes.object.isRequired
+};
+
+module.exports = PodVolumeContainer;

--- a/plugins/services/src/js/containers/volume-detail/PodVolumeDetail.js
+++ b/plugins/services/src/js/containers/volume-detail/PodVolumeDetail.js
@@ -1,0 +1,133 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+import { Link } from "react-router";
+
+import Breadcrumb from "#SRC/js/components/Breadcrumb";
+import BreadcrumbTextContent from "#SRC/js/components/BreadcrumbTextContent";
+import ConfigurationMap from "#SRC/js/components/ConfigurationMap";
+import ConfigurationMapLabel from "#SRC/js/components/ConfigurationMapLabel";
+import ConfigurationMapRow from "#SRC/js/components/ConfigurationMapRow";
+import ConfigurationMapSection
+  from "#SRC/js/components/ConfigurationMapSection";
+import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
+import DetailViewHeader from "#SRC/js/components/DetailViewHeader";
+import Page from "#SRC/js/components/Page";
+import ServiceBreadcrumbs from "../../components/ServiceBreadcrumbs";
+import VolumeStatus from "../../constants/VolumeStatus";
+
+class PodVolumeDetail extends React.Component {
+  getSizeLabel() {
+    if (this.props.volume.type === "External") {
+      return "Size (GiB)";
+    }
+
+    return "Size (MiB)";
+  }
+
+  renderSubHeader() {
+    const { volume } = this.props;
+
+    const status = volume.getStatus();
+    const classes = classNames({
+      "text-danger": status === VolumeStatus.DETACHED,
+      "text-success": status === VolumeStatus.ATTACHED
+    });
+
+    return <span className={classes}>{status}</span>;
+  }
+
+  render() {
+    const { service, volume } = this.props;
+
+    const serviceID = service.getId();
+    const encodedServiceId = encodeURIComponent(serviceID);
+    const volumeId = volume.getId();
+
+    const extraCrumbs = [
+      <Breadcrumb key={-1} title="Services">
+        <BreadcrumbTextContent>
+          <Link
+            to={`/services/detail/${encodedServiceId}/podvolumes/${escape(volumeId)}`}
+            key="volume"
+          >
+
+            {volumeId}
+          </Link>
+        </BreadcrumbTextContent>
+      </Breadcrumb>
+    ];
+
+    const breadcrumbs = (
+      <ServiceBreadcrumbs serviceID={serviceID} extra={extraCrumbs} />
+    );
+
+    return (
+      <Page>
+        <Page.Header breadcrumbs={breadcrumbs} />
+        <DetailViewHeader subTitle={this.renderSubHeader()} title={volumeId} />
+        <ConfigurationMap>
+          <ConfigurationMapSection>
+            {volume.getMounts().map(({ containerName, mountPath }) => (
+              <ConfigurationMapRow>
+                <ConfigurationMapLabel>
+                  {containerName} Path
+                </ConfigurationMapLabel>
+                <ConfigurationMapValue>
+                  {mountPath}
+                </ConfigurationMapValue>
+              </ConfigurationMapRow>
+            ))}
+            <ConfigurationMapRow>
+              <ConfigurationMapLabel>
+                {this.getSizeLabel()}
+              </ConfigurationMapLabel>
+              <ConfigurationMapValue>
+                {volume.getSize()}
+              </ConfigurationMapValue>
+            </ConfigurationMapRow>
+            <ConfigurationMapRow>
+              <ConfigurationMapLabel>
+                Application
+              </ConfigurationMapLabel>
+              <ConfigurationMapValue>
+                {serviceID}
+              </ConfigurationMapValue>
+            </ConfigurationMapRow>
+            <ConfigurationMapRow>
+              <ConfigurationMapLabel>
+                Profile Name
+              </ConfigurationMapLabel>
+              <ConfigurationMapValue>
+                {volume.getProfile()}
+              </ConfigurationMapValue>
+            </ConfigurationMapRow>
+            <ConfigurationMapRow>
+              <ConfigurationMapLabel>
+                Task ID
+              </ConfigurationMapLabel>
+              <ConfigurationMapValue>
+                {volume.getTaskID()}
+              </ConfigurationMapValue>
+            </ConfigurationMapRow>
+            <ConfigurationMapRow>
+              <ConfigurationMapLabel>
+                Host
+              </ConfigurationMapLabel>
+              <ConfigurationMapValue>
+                {volume.getHost()}
+              </ConfigurationMapValue>
+            </ConfigurationMapRow>
+          </ConfigurationMapSection>
+        </ConfigurationMap>
+      </Page>
+    );
+  }
+}
+
+PodVolumeDetail.propTypes = {
+  service: PropTypes.object.isRequired,
+  volume: PropTypes.object.isRequired
+};
+
+module.exports = PodVolumeDetail;

--- a/plugins/services/src/js/routes/services.js
+++ b/plugins/services/src/js/routes/services.js
@@ -19,12 +19,14 @@ import TaskLogsContainer from "../pages/task-details/TaskLogsContainer";
 import TaskVolumeContainer
   from "../containers/volume-detail/TaskVolumeContainer";
 import VolumeTable from "../components/VolumeTable";
+import PodVolumeTable from "../components/PodVolumeTable";
 import HighOrderServiceConfiguration
   from "../components/HighOrderServiceConfiguration";
 import HighOrderServiceDebug from "../components/HighOrderServiceDebug";
 import HighOrderServiceInstances from "../components/HighOrderServiceInstances";
 import ServiceConnectionContainer
   from "../components/ServiceConnectionContainer";
+import PodVolumeContainer from "../containers/volume-detail/PodVolumeContainer";
 
 const serviceRoutes = [
   {
@@ -98,6 +100,11 @@ const serviceRoutes = [
           },
           {
             type: Route,
+            path: "podvolumes/:volumeID",
+            component: PodVolumeContainer
+          },
+          {
+            type: Route,
             path: "configuration",
             title: "Configuration",
             component: HighOrderServiceConfiguration
@@ -113,6 +120,12 @@ const serviceRoutes = [
             path: "volumes",
             title: "Volumes",
             component: VolumeTable
+          },
+          {
+            type: Route,
+            path: "podvolumes",
+            title: "Volumes",
+            component: PodVolumeTable
           },
           {
             type: Route,
@@ -187,6 +200,14 @@ const serviceRoutes = [
                 hideHeaderNavigation: true,
                 isTab: true,
                 path: "volumes",
+                title: "Volumes",
+                type: Route
+              },
+              {
+                component: PodVolumeTable,
+                hideHeaderNavigation: true,
+                isTab: true,
+                path: "podvolumes",
                 title: "Volumes",
                 type: Route
               },

--- a/plugins/services/src/js/structs/Pod.js
+++ b/plugins/services/src/js/structs/Pod.js
@@ -6,6 +6,7 @@ import PodTerminationHistoryList from "./PodTerminationHistoryList";
 import Service from "./Service";
 import ServiceStatus from "../constants/ServiceStatus";
 import ServiceImages from "../constants/ServiceImages";
+import VolumeList from "./VolumeList";
 
 module.exports = class Pod extends Service {
   constructor() {
@@ -193,5 +194,9 @@ module.exports = class Pod extends Service {
     return new PodTerminationHistoryList({
       items: this.get("terminationHistory") || []
     });
+  }
+
+  getVolumesData() {
+    return new VolumeList({ items: this.get("volumeData") || [] });
   }
 };

--- a/plugins/services/src/js/structs/PodSpec.js
+++ b/plugins/services/src/js/structs/PodSpec.js
@@ -77,6 +77,9 @@ module.exports = class PodSpec extends ServiceSpec {
   getVolumes() {
     return this.get("volumes") || [];
   }
+  getVolumesData() {
+    return this.get("volumeData") || [];
+  }
 
   getUser() {
     return this.get("user") || "";

--- a/plugins/services/src/js/structs/Volume.js
+++ b/plugins/services/src/js/structs/Volume.js
@@ -38,6 +38,10 @@ class Volume extends Item {
   getType() {
     return this.get("type");
   }
+
+  getMounts() {
+    return this.get("mounts") || [];
+  }
 }
 
 module.exports = Volume;


### PR DESCRIPTION
This introduces a port of the volumes table from the single container applications to multi container applications.

To test deploy a Pod with a persistent volume (only these will / should show up in the table),

or just take the following JSON:
```JSON
{
  "id": "/pod-with-volume",
  "containers": [
    {
      "name": "container-1",
      "resources": {
        "cpus": 0.1,
        "mem": 128,
        "disk": 0
      },
      "image": {
        "kind": "DOCKER",
        "id": "nginx"
      },
      "endpoints": [
        {
          "name": "http",
          "containerPort": 80,
          "hostPort": 0,
          "protocol": [
            "tcp"
          ]
        }
      ],
      "volumeMounts": [
        {
          "name": "home",
          "mountPath": "/etc/log"
        }
      ]
    }
  ],
  "volumes": [
    {
      "name": "home",
      "persistent": {
        "type": "root",
        "size": 10,
        "constraints": []
      }
    }
  ],
  "networks": [
    {
      "name": "dcos",
      "mode": "container"
    }
  ],
  "scaling": {
    "instances": 1,
    "kind": "fixed"
  },
  "scheduling": {
    "placement": {
      "constraints": []
    }
  },
  "executorResources": {
    "cpus": 0.1,
    "mem": 32,
    "disk": 10
  },
  "fetch": []
}
```

![podvolumes mov](https://user-images.githubusercontent.com/156010/37827017-0274ec98-2e96-11e8-9cd7-0e058bc577da.gif)

Closes DCOS-19586 