### PR TITLE
Backport(1.11): update moment

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7300,9 +7300,9 @@
       }
     },
     "moment": {
-      "version": "2.13.0",
-      "from": "moment@2.13.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
+      "version": "2.21.0",
+      "from": "moment@2.21.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz"
     },
     "morgan": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "md5": "2.1.0",
     "mesosphere-react-typeahead": "0.8.3",
     "mesosphere-shared-reactjs": "0.0.24",
-    "moment": "2.13.0",
+    "moment": "2.21.0",
     "objektiv": "0.3.0",
     "prettycron": "0.10.0",
     "prop-types": "15.6.0",

--- a/src/js/structs/__tests__/JobRunList-test.js
+++ b/src/js/structs/__tests__/JobRunList-test.js
@@ -1,6 +1,5 @@
-const moment = require("moment");
-
 const JobRunList = require("../JobRunList");
+const DateUtil = require("../../utils/DateUtil");
 
 describe("JobRunList", function() {
   describe("#getLongestRunningActiveRun", function() {
@@ -15,7 +14,7 @@ describe("JobRunList", function() {
 
       expect(
         activeRunList.getLongestRunningActiveRun().getDateCreated()
-      ).toEqual(moment("1985-01-03T00:00:00Z-1").valueOf());
+      ).toEqual(DateUtil.strToMs("1985-01-03T00:00:00Z-1"));
     });
 
     it("returns the longest running active run", function() {
@@ -29,7 +28,7 @@ describe("JobRunList", function() {
 
       expect(
         activeRunList.getLongestRunningActiveRun().getDateCreated()
-      ).toEqual(moment("1990-01-03T00:01:00Z-1").valueOf());
+      ).toEqual(DateUtil.strToMs("1990-01-03T00:01:00Z-1"));
     });
   });
 });

--- a/src/js/structs/__tests__/JobTaskList-test.js
+++ b/src/js/structs/__tests__/JobTaskList-test.js
@@ -1,6 +1,5 @@
-const moment = require("moment");
-
 const JobTaskList = require("../JobTaskList");
+const DateUtil = require("../../utils/DateUtil");
 
 describe("JobTaskList", function() {
   describe("#getLongestRunningTask", function() {
@@ -14,7 +13,7 @@ describe("JobTaskList", function() {
       });
 
       expect(activeRunList.getLongestRunningTask().getDateStarted()).toEqual(
-        moment("1985-01-03T00:00:00Z-1").valueOf()
+        DateUtil.strToMs("1985-01-03T00:00:00Z-1")
       );
     });
 
@@ -30,7 +29,7 @@ describe("JobTaskList", function() {
       });
 
       expect(activeRunList.getLongestRunningTask().getDateStarted()).toEqual(
-        moment("1990-01-03T00:00:00Z-1").valueOf()
+        DateUtil.strToMs("1990-01-03T00:00:00Z-1")
       );
     });
   });

--- a/src/js/utils/DateUtil.js
+++ b/src/js/utils/DateUtil.js
@@ -77,7 +77,9 @@ const DateUtil = {
       return null;
     }
 
-    return moment(str).valueOf();
+    return (
+      moment(str).valueOf() || moment(str, "YYYY-MM-DDTHH:mm:ssZ").valueOf()
+    );
   },
 
   getDuration(time, formatKey = "seconds") {


### PR DESCRIPTION
Backport of https://github.com/dcos/dcos-ui/pull/2843

The current version has a security vulnerability: CVE-2017-18214

Closes DCOS-21571

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
