### PR TITLE
DCOS-20260: Include id search in task text filter

### DIFF
--- a/plugins/services/src/js/filters/TaskNameTextFilter.js
+++ b/plugins/services/src/js/filters/TaskNameTextFilter.js
@@ -23,7 +23,10 @@ class TaskNameTextFilter extends DSLFilter {
    */
   filterApply(resultSet, filterType, filterArguments) {
     return resultSet.filterItems(task => {
-      return task.name.indexOf(filterArguments.text) !== -1;
+      return (
+        (task.id && task.id.indexOf(filterArguments.text) !== -1) ||
+        (task.name && task.name.indexOf(filterArguments.text) !== -1)
+      );
     });
   }
 }

--- a/plugins/services/src/js/filters/__tests__/TaskNameTextFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/TaskNameTextFilter-test.js
@@ -9,12 +9,15 @@ describe("TaskNameTextFilter", function() {
   beforeEach(function() {
     thisMockItems = [
       {
+        id: "cassandra.d9a2318d",
         name: "cassandra"
       },
       {
+        id: "",
         name: "node-1-server__1"
       },
       {
+        id: "",
         name: "node-0-server__2"
       }
     ];
@@ -30,6 +33,15 @@ describe("TaskNameTextFilter", function() {
       thisMockItems[1],
       thisMockItems[2]
     ]);
+  });
+
+  it("matches parts of task id", function() {
+    const tasks = new List({ items: thisMockItems });
+    const expr = SearchDSL.parse("d9a23");
+
+    const filters = new DSLFilterList().add(new TaskNameTextFilter());
+
+    expect(expr.filter(filters, tasks).getItems()).toEqual([thisMockItems[0]]);
   });
 
   it("matches exact parts of task name", function() {


### PR DESCRIPTION
Include ID search in task text filter.

The neat new search does not work against the id field of the task table.

https://cl.ly/1c0l3H3x3236

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [x] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
