### PR TITLE
DCOS-21798 & DCOS-21614:  Backport to 1.11 

### DIFF
--- a/plugins/services/src/js/components/HighOrderServiceConfiguration.js
+++ b/plugins/services/src/js/components/HighOrderServiceConfiguration.js
@@ -1,7 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
 
-import Framework from "#PLUGINS/services/src/js/structs/Framework";
 import Pod from "../structs/Pod";
 import PodConfigurationContainer
   from "../containers/pod-configuration/PodConfigurationContainer";
@@ -17,7 +16,10 @@ const HighOrderServiceConfiguration = function(props) {
     return <PodConfigurationContainer pod={service} />;
   }
 
-  if (service instanceof Framework) {
+  if (
+    service.getLabels().DCOS_PACKAGE_DEFINITION != null ||
+    service.getLabels().DCOS_PACKAGE_METADATA != null
+  ) {
     return <FrameworkConfigurationContainer service={service} />;
   }
 

--- a/plugins/services/src/js/components/modals/EditServiceModal.js
+++ b/plugins/services/src/js/components/modals/EditServiceModal.js
@@ -5,12 +5,17 @@ import EditFrameworkConfiguration
 import CreateServiceModal
   from "#PLUGINS/services/src/js/components/modals/CreateServiceModal";
 import DCOSStore from "#SRC/js/stores/DCOSStore";
+import FullScreenModal from "#SRC/js/components/modals/FullScreenModal";
 
 class EditServiceModal extends Component {
   render() {
     const { id = "/" } = this.props.params;
     const serviceID = decodeURIComponent(id);
     const service = DCOSStore.serviceTree.findItemById(serviceID);
+
+    if (!service) {
+      return <FullScreenModal open={true} />;
+    }
 
     if (
       service.getLabels().DCOS_PACKAGE_DEFINITION != null ||

--- a/plugins/services/src/js/components/modals/EditServiceModal.js
+++ b/plugins/services/src/js/components/modals/EditServiceModal.js
@@ -4,7 +4,6 @@ import EditFrameworkConfiguration
   from "#PLUGINS/services/src/js/pages/EditFrameworkConfiguration";
 import CreateServiceModal
   from "#PLUGINS/services/src/js/components/modals/CreateServiceModal";
-import Framework from "#PLUGINS/services/src/js/structs/Framework";
 import DCOSStore from "#SRC/js/stores/DCOSStore";
 
 class EditServiceModal extends Component {
@@ -13,7 +12,10 @@ class EditServiceModal extends Component {
     const serviceID = decodeURIComponent(id);
     const service = DCOSStore.serviceTree.findItemById(serviceID);
 
-    if (service instanceof Framework) {
+    if (
+      service.getLabels().DCOS_PACKAGE_DEFINITION != null ||
+      service.getLabels().DCOS_PACKAGE_METADATA != null
+    ) {
       return <EditFrameworkConfiguration {...this.props} />;
     }
 

--- a/plugins/services/src/js/components/modals/__tests__/EditServiceModal-test.js
+++ b/plugins/services/src/js/components/modals/__tests__/EditServiceModal-test.js
@@ -1,0 +1,56 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+jest.mock("#SRC/js/stores/DCOSStore");
+
+const DCOSStore = require("#SRC/js/stores/DCOSStore");
+const EditServiceModal = require("../EditServiceModal").default;
+
+describe("EditServiceModal", function() {
+  it("renders an empty modal if no service is found", function() {
+    DCOSStore.serviceTree = {
+      findItemById() {
+        return null;
+      }
+    };
+
+    const wrapper = shallow(
+      <EditServiceModal params={{ id: "/my-non-existant-service" }} />
+    );
+    expect(wrapper.type().name).toBe("FullScreenModal");
+  });
+
+  it("renders an edit modal if the service has been created", function() {
+    DCOSStore.serviceTree = {
+      findItemById() {
+        return {
+          getLabels() {
+            return { DCOS_PACKAGE_DEFINITION: "some-value" };
+          }
+        };
+      }
+    };
+
+    const wrapper = shallow(
+      <EditServiceModal params={{ id: "/my-created-service" }} />
+    );
+    expect(wrapper.type().name).toBe("EditFrameworkConfiguration");
+  });
+
+  it("renders a create modal if the service has not been created", function() {
+    DCOSStore.serviceTree = {
+      findItemById() {
+        return {
+          getLabels() {
+            return { DCOS_PACKAGE_DEFINITION: null };
+          }
+        };
+      }
+    };
+
+    const wrapper = shallow(
+      <EditServiceModal params={{ id: "/my-new-service" }} />
+    );
+    expect(wrapper.type().name).toBe("CreateServiceModal");
+  });
+});


### PR DESCRIPTION
[Backport to 1.11 of this PR](https://github.com/dcos/dcos-ui/pull/2871)

## How to test

1. Add a new service with this configuration:

```
{
  "id": "/do-not-delete-me",
  "version": "2018-03-22T11:28:46.456Z",
  "containers": [
    {
      "name": "container-1",
      "resources": {
        "cpus": 0.1,
        "mem": 128,
        "disk": 0
      },
      "image": {
        "kind": "DOCKER",
        "id": "nginx"
      },
      "endpoints": [
        {
          "name": "http",
          "containerPort": 80,
          "hostPort": 0,
          "protocol": [
            "tcp"
          ]
        }
      ],
      "volumeMounts": [
        {
          "name": "home",
          "mountPath": "/etc/log"
        }
      ]
    }
  ],
  "volumes": [
    {
      "name": "home",
      "persistent": {
        "type": "root",
        "size": 10,
        "constraints": []
      }
    }
  ],
  "networks": [
    {
      "name": "dcos",
      "mode": "container"
    }
  ],
  "scaling": {
    "instances": 1,
    "kind": "fixed"
  },
  "scheduling": {
    "placement": {
      "constraints": []
    }
  },
  "executorResources": {
    "cpus": 0.1,
    "mem": 32,
    "disk": 10
  },
  "fetch": []
}
```

2. Visit the edit page of this service
3. Reload the edit page of this service and see there is no error

## Context
We accessed getLabel on the service without checking if the service is
even there. Therefore reloading the edit page caused an error.

By checking for a service and rendering an empty modal otherwise
we make sure that we don't try to render before we have the data.

Rendering the create form in these cases lead to a mutation of the data,
which in return lead to the edit form never being rendered.
Rendering null if there is no service lead to a dark flickering for the
time before the service loads. An empty modal gives a nicer UX.

**Checklist**
- [X] Did you add a JIRA issue in a commit message or as part of the branch name?
- [X] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [X] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
