### PR TITLE
[Backport 1.11 ] fix(tasknametextfilter): include id search in task text filter

### DIFF
--- a/plugins/services/src/js/filters/TaskNameTextFilter.js
+++ b/plugins/services/src/js/filters/TaskNameTextFilter.js
@@ -23,7 +23,10 @@ class TaskNameTextFilter extends DSLFilter {
    */
   filterApply(resultSet, filterType, filterArguments) {
     return resultSet.filterItems(task => {
-      return task.name.indexOf(filterArguments.text) !== -1;
+      return (
+        (task.id && task.id.includes(filterArguments.text)) ||
+        (task.name && task.name.includes(filterArguments.text))
+      );
     });
   }
 }

--- a/plugins/services/src/js/filters/__tests__/TaskNameTextFilter-test.js
+++ b/plugins/services/src/js/filters/__tests__/TaskNameTextFilter-test.js
@@ -7,12 +7,15 @@ describe("TaskNameTextFilter", function() {
   beforeEach(function() {
     this.mockItems = [
       {
+        id: "cassandra.d9a2318d",
         name: "cassandra"
       },
       {
+        id: "",
         name: "node-1-server__1"
       },
       {
+        id: "",
         name: "node-0-server__2"
       }
     ];
@@ -28,6 +31,24 @@ describe("TaskNameTextFilter", function() {
       this.mockItems[1],
       this.mockItems[2]
     ]);
+  });
+
+  it("matches parts of task id", function() {
+    const tasks = new List({ items: this.mockItems });
+    const expr = SearchDSL.parse("d9a23");
+
+    const filters = new DSLFilterList().add(new TaskNameTextFilter());
+
+    expect(expr.filter(filters, tasks).getItems()).toEqual([this.mockItems[0]]);
+  });
+
+  it("matches exact parts of task name", function() {
+    const tasks = new List({ items: this.mockItems });
+    const expr = SearchDSL.parse("d9a23");
+
+    const filters = new DSLFilterList().add(new TaskNameTextFilter());
+
+    expect(expr.filter(filters, tasks).getItems()).toEqual([this.mockItems[0]]);
   });
 
   it("matches exact parts of task name", function() {


### PR DESCRIPTION
BACKPORT Include ID search in task text filter.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
