### PR TITLE
feat(FrameworkConfiguration): show name and version in config tab

### DIFF
--- a/plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.js
+++ b/plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.js
@@ -9,6 +9,7 @@ import FrameworkConfigurationReviewScreen
   from "#SRC/js/components/FrameworkConfigurationReviewScreen";
 import Loader from "#SRC/js/components/Loader";
 import CosmosPackagesStore from "#SRC/js/stores/CosmosPackagesStore";
+import StringUtil from "#SRC/js/utils/StringUtil";
 import { COSMOS_SERVICE_DESCRIBE_CHANGE } from "#SRC/js/constants/EventTypes";
 import { getDefaultFormState } from "react-jsonschema-form/lib/utils";
 
@@ -24,7 +25,8 @@ class FrameworkConfigurationContainer extends React.Component {
     const { service } = this.props;
 
     this.state = {
-      frameworkData: null
+      frameworkData: null,
+      packageDetails: null
     };
 
     METHODS_TO_BIND.forEach(method => {
@@ -59,7 +61,7 @@ class FrameworkConfigurationContainer extends React.Component {
       schema.definitions
     );
 
-    this.setState({ frameworkData });
+    this.setState({ frameworkData, packageDetails });
   }
 
   handleEditClick() {
@@ -72,16 +74,22 @@ class FrameworkConfigurationContainer extends React.Component {
   }
 
   render() {
-    const { frameworkData } = this.state;
+    const { frameworkData, packageDetails } = this.state;
 
     if (!frameworkData) {
       return <Loader />;
     }
 
+    const frameworkMeta =
+      StringUtil.capitalize(packageDetails.getName()) +
+      " " +
+      packageDetails.getVersion();
+
     return (
       <FrameworkConfigurationReviewScreen
         frameworkData={frameworkData}
         onEditClick={this.handleEditClick}
+        frameworkMeta={frameworkMeta}
       />
     );
   }

--- a/src/js/components/FrameworkConfigurationReviewScreen.js
+++ b/src/js/components/FrameworkConfigurationReviewScreen.js
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
+import { Dropdown, Tooltip } from "reactjs-components";
 
 import HashMapDisplay from "#SRC/js/components/HashMapDisplay";
 import Util from "#SRC/js/utils/Util";
@@ -36,8 +37,75 @@ class FrameworkConfigurationReviewScreen extends React.Component {
     return renderKeys;
   }
 
+  getVersionsDropdown() {
+    const { frameworkMeta } = this.props;
+
+    const versionItems = [
+      {
+        id: frameworkMeta,
+        html: (
+          <div className="button-split-content-wrapper">
+            <Icon
+              className="services-version-select-icon services-version-select-icon-selected button-split-content-item"
+              id="check"
+              size="mini"
+              color="neutral"
+            />
+            <Icon
+              className="services-version-select-icon button-split-content-item"
+              id="commit"
+              size="mini"
+              color="neutral"
+            />
+            <span
+              className="button-split-content-item text-overflow"
+              title={frameworkMeta}
+            >
+              <span className="badge-container">
+                <span className="badge-container-text">{frameworkMeta}</span>
+                <span className="badge">Active</span>
+              </span>
+            </span>
+          </div>
+        )
+      }
+    ];
+
+    return (
+      <Tooltip
+        content="Configuration version"
+        wrapperClassName="button button-transparent button-flush"
+      >
+        <Dropdown
+          buttonClassName="services-version-select-toggle dropdown-toggle button button-transparent button-split-content flush-left"
+          dropdownMenuClassName="services-version-select-menu dropdown-menu"
+          dropdownMenuListClassName="dropdown-menu-list"
+          dropdownMenuListItemClassName="clickable"
+          items={versionItems}
+          persistentID={frameworkMeta}
+          key="version-dropdown"
+          scrollContainer=".gm-scroll-view"
+          scrollContainerParentSelector=".gm-prevented"
+          transition={true}
+          transitionName="dropdown-menu"
+          wrapperClassName="services-version-select dropdown"
+        />
+      </Tooltip>
+    );
+  }
+
+  getVersionsActions() {
+    return (
+      <div className="pod flush-top flush-right flush-left">
+        <div className="button-collection">
+          {this.getVersionsDropdown()}
+        </div>
+      </div>
+    );
+  }
+
   render() {
-    const { frameworkData, title, onEditClick } = this.props;
+    const { frameworkData, title, onEditClick, frameworkMeta } = this.props;
 
     const fileName = "config.json";
     const configString = JSON.stringify(frameworkData, null, 2);
@@ -45,10 +113,11 @@ class FrameworkConfigurationReviewScreen extends React.Component {
     return (
       <div className="container">
         <div className="row">
-          <div className="column-4">
-            <h1 className="flush-top">{title}</h1>
+          <div className="column-6">
+            {title && <h1 className="flush-top">{title}</h1>}
+            {frameworkMeta && this.getVersionsActions()}
           </div>
-          <div className="column-8 text-align-right">
+          <div className="column-6 text-align-right">
             <button
               className="button button-primary-link button-inline-flex"
               onClick={onEditClick}
@@ -97,7 +166,8 @@ FrameworkConfigurationReviewScreen.defaultProps = {
 FrameworkConfigurationReviewScreen.propTypes = {
   onEditClick: PropTypes.func.isRequired,
   frameworkData: PropTypes.object.isRequired,
-  title: PropTypes.string
+  title: PropTypes.string,
+  frameworkMeta: PropTypes.string
 };
 
 module.exports = FrameworkConfigurationReviewScreen;


### PR DESCRIPTION
The cosmos `config.json` doesn't have the name and version for frameworks.
This change adds the name and version to the top of this page, so users can easily view
this information without clicking the package to edit.

<img width="1421" alt="image 2018-04-06 at 2 56 26 pm" src="https://user-images.githubusercontent.com/1527504/38439217-d122fad4-39aa-11e8-8263-f9fa8cd63260.png">

Closes DCOS-19913

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
