### PR TITLE
Revert "fix(MesosStateStore): adjust stream data handling"

### DIFF
--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -56,7 +56,7 @@ class MesosStateStore extends GetSetBaseStore {
     this.on(eventName, callback);
 
     if (this.shouldSubscribe()) {
-      Promise.resolve().then(() => this.subscribe());
+      this.subscribe();
     }
   }
 
@@ -99,8 +99,7 @@ class MesosStateStore extends GetSetBaseStore {
     // refresh limits to the UI. They are:
     //
     // MOST once every (Config.getRefreshRate() * 0.5) ms. due to debounceTime.
-    // LEAST once every tick of Config.getRefreshRate() ms in
-    // Observable.interval
+    // LEAST once every tick of Config.getRefreshRate() ms in Observable.interval
     //
     // TODO: https://jira.mesosphere.com/browse/DCOS-18277
     this.stream = waitStream


### PR DESCRIPTION
Reverts dcos/dcos-ui#2851 as the merged fix is not sufficient in preventing errors form propagating so that errors in `MESOS_STATE_CHANGE` handlers could still break the stream. 