### PR TITLE
fix(MesosStateStore): adjust stream data handling

### DIFF
--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -107,7 +107,10 @@ class MesosStateStore extends GetSetBaseStore {
       .concat(eventTriggerStream)
       .sampleTime(Config.getRefreshRate() * 0.5)
       .retryWhen(linearBackoff(MAX_RETRIES, RETRY_DELAY))
-      .subscribe(this.onStreamData, this.onStreamError);
+      .subscribe(
+        () => Promise.resolve().then(this.onStreamData),
+        this.onStreamError
+      );
   }
 
   getLastMesosState() {


### PR DESCRIPTION
---
⚠️  _This branch includes changes that will be introduced with #2908. For a list of changes please see: https://github.com/dcos/dcos-ui/compare/orlandohohmeier/master/fix/DCOS-21928-adjust-dsl-input-change-handling...orlandohohmeier/master/fix/DCOS-21784-adjust-mesos-stream-data-handling_ 

---


Use `Promise.resolve().then()` to schedule a micro tasks and asynchronously  trigger `onStreamData` which is used to emit the `MESOS_STATE_CHANGE`. This change will mitigate issues in which errors in view components lead to stale data as the error propergation broke the stream.

N.B. `EventEmitter` is synchronous meaning that every delay in an event handler effects the `emit` execution time and errors propagate up to the `emit` call which sometimes leads to undesireable behavior.

## Testing

Throw an error in one of the `MESOS_STATE_CHANGE` handler – this error should have no effect on the stream.

```js
    // ServicesContainer (L:154)
    MesosStateStore.addChangeListener(MESOS_STATE_CHANGE, function() {
      throw new Error("Test");
    });
 ```

Closes DCOS-21784
