### PR TITLE
fix(commitlint): adjust configuration

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,6 @@
 module.exports = {
-  extends: ["@commitlint/config-conventional"]
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "scope-case": [0]
+  }
 };


### PR DESCRIPTION
Disable `scope-case` rule to align the configuration with our contributing docs.