### PR TITLE
DCOS-22058: change package repositories ADD to the new data-layer patterns

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -27075,15 +27075,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
       "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs="
     },
-    "semver-diff": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "dev": true,
-      "requires": {
-        "semver": "5.5.0"
-      }
-    },
     "semver-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",

--- a/plugins/catalog/src/js/repositories/RepositoriesAdd.js
+++ b/plugins/catalog/src/js/repositories/RepositoriesAdd.js
@@ -1,0 +1,59 @@
+/* eslint-disable no-unused-vars */
+import React from "react";
+/* eslint-enable no-unused-vars */
+
+import { componentFromStream } from "data-service";
+
+import { Subject } from "rxjs/Subject";
+import "rxjs/add/operator/combineLatest";
+import "rxjs/add/operator/do";
+import "rxjs/observable/empty";
+
+import { Observable } from "rxjs/Observable";
+
+import { addRepository } from "./data/repositoriesStream";
+import AddRepositoryFormModal from "./components/AddRepositoryFormModal";
+
+// Imported from the Cosmos Store
+const getErrorMessage = (response = {}) => {
+  if (typeof response === "string") {
+    return response;
+  }
+
+  return response.description || response.message || "An error has occurred.";
+};
+
+const addRepositoryEvent$ = new Subject();
+const addRepository$ = addRepositoryEvent$
+  .switchMap(repository => {
+    return addRepository(
+      repository.name,
+      repository.uri,
+      repository.priority
+    ).do(() => {
+      repository.complete();
+    });
+  })
+  .catch(error => {
+    return Observable.of({
+      error: getErrorMessage(error.response),
+      pendingRequest: false
+    });
+  });
+
+const RepositoriesAdd = componentFromStream(props$ => {
+  return props$.combineLatest(addRepository$.startWith({}), (props, result) => {
+    return (
+      <AddRepositoryFormModal
+        numberOfRepositories={props.numberOfRepositories}
+        open={props.open}
+        addRepository={value =>
+          addRepository$.next({ complete: props.onClose, ...value })}
+        onClose={props.onClose}
+        errorMsg={result.error}
+      />
+    );
+  });
+});
+
+export default RepositoriesAdd;

--- a/plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.js
+++ b/plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.js
@@ -1,63 +1,25 @@
-import mixin from "reactjs-mixin";
 import PropTypes from "prop-types";
 /* eslint-disable no-unused-vars */
 import React from "react";
 /* eslint-enable no-unused-vars */
-import { StoreMixin } from "mesosphere-shared-reactjs";
 
-import CosmosPackagesStore from "../../stores/CosmosPackagesStore";
-import FormModal from "../FormModal";
-import ModalHeading from "../modals/ModalHeading";
-import ValidatorUtil from "../../utils/ValidatorUtil";
+import FormModal from "#SRC/js/components/FormModal";
+import ModalHeading from "#SRC/js/components/modals/ModalHeading";
+import ValidatorUtil from "#SRC/js/utils/ValidatorUtil";
 
-const METHODS_TO_BIND = [
-  "handleAddRepository",
-  "onCosmosPackagesStoreRepositoryAddError",
-  "onCosmosPackagesStoreRepositoryAddSuccess",
-  "resetState"
-];
+const METHODS_TO_BIND = ["handleAddRepository"];
 
-class AddRepositoryFormModal extends mixin(StoreMixin) {
+class AddRepositoryFormModal extends React.Component {
   constructor() {
     super();
-
-    this.state = {
-      disableButtons: false,
-      errorMsg: null
-    };
-
-    this.store_listeners = [
-      {
-        name: "cosmosPackages",
-        events: ["repositoryAddSuccess", "repositoryAddError"]
-      }
-    ];
 
     METHODS_TO_BIND.forEach(method => {
       this[method] = this[method].bind(this);
     });
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { props } = this;
-    if (props.open && !nextProps.open) {
-      // Closes, reset state
-      this.resetState();
-    }
-  }
-
-  onCosmosPackagesStoreRepositoryAddError(errorMsg) {
-    this.setState({ disableButtons: false, errorMsg });
-  }
-
-  onCosmosPackagesStoreRepositoryAddSuccess() {
-    CosmosPackagesStore.fetchRepositories();
-    this.props.onClose();
-  }
-
   handleAddRepository(model) {
-    CosmosPackagesStore.addRepository(model.name, model.uri, model.priority);
-    this.resetState();
+    this.props.addRepository(model);
   }
 
   getAddRepositoryFormDefinition() {
@@ -125,8 +87,7 @@ class AddRepositoryFormModal extends mixin(StoreMixin) {
     ];
   }
 
-  getErrorMessage() {
-    const { errorMsg } = this.state;
+  getErrorMessage(errorMsg) {
     if (!errorMsg) {
       return null;
     }
@@ -136,28 +97,23 @@ class AddRepositoryFormModal extends mixin(StoreMixin) {
     );
   }
 
-  resetState() {
-    this.setState({ errorMsg: null, disableButtons: false });
-  }
-
   render() {
-    const { props, state } = this;
+    const { props } = this;
 
     return (
       <FormModal
         definition={this.getAddRepositoryFormDefinition()}
-        disabled={state.disableButtons}
+        disabled={props.pendingRequest}
         buttonDefinition={this.getButtonDefinition()}
         modalProps={{
           header: <ModalHeading>Add Repository</ModalHeading>,
           showHeader: true
         }}
-        onChange={this.resetState}
-        onClose={props.onClose}
         onSubmit={this.handleAddRepository}
+        onClose={props.onClose}
         open={props.open}
       >
-        {this.getErrorMessage()}
+        {this.getErrorMessage(props.errorMsg)}
       </FormModal>
     );
   }
@@ -165,7 +121,8 @@ class AddRepositoryFormModal extends mixin(StoreMixin) {
 
 AddRepositoryFormModal.propTypes = {
   numberOfRepositories: PropTypes.number.isRequired,
-  open: PropTypes.bool
+  open: PropTypes.bool,
+  addRepository: PropTypes.func.isRequired
 };
 
 module.exports = AddRepositoryFormModal;

--- a/plugins/catalog/src/js/repositories/components/RepositoriesTabUI.js
+++ b/plugins/catalog/src/js/repositories/components/RepositoriesTabUI.js
@@ -1,13 +1,11 @@
 import React from "react";
 
-import AddRepositoryFormModal
-  from "#SRC/js/components/modals/AddRepositoryFormModal";
-
 import FilterBar from "#SRC/js/components/FilterBar";
 import FilterInputText from "#SRC/js/components/FilterInputText";
-import RepositoriesTable from "./RepositoriesTable";
 
 import RepositoriesPage from "./RepositoriesPage";
+import RepositoriesTable from "./RepositoriesTable";
+import RepositoriesAdd from "../RepositoriesAdd";
 
 const METHODS_TO_BIND = ["handleCloseAddRepository", "handleOpenAddRepository"];
 
@@ -48,7 +46,7 @@ export default class RepositoriesTabUI extends React.Component {
           />
         </FilterBar>
         <RepositoriesTable repositories={repositories} filter={searchTerm} />
-        <AddRepositoryFormModal
+        <RepositoriesAdd
           numberOfRepositories={repositories.getItems().length}
           open={addRepositoryModalOpen}
           onClose={this.handleCloseAddRepository}


### PR DESCRIPTION
~Depends on #2870, and then we can switch base to `feature/data-layer`. This was a split of that one to make it simpler.~

Moves add repositories away from mixings and flux stores by using the new data-layer patterns (streams and mediators). This is also done in a preparation to use graphql.

TESTING
Just open the Settings > Repositories and try to add, remove and filter packages.
 
AUTOMATED TESTING
No new tests were added since this is a refactor and rely on the current tests.

 **Checklist**
- [x] Explain how to test it
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
