### PR TITLE
DCOS-22128 - fix(marathonUtil): fix parsePod function

### DIFF
--- a/plugins/services/src/js/utils/MarathonUtil.js
+++ b/plugins/services/src/js/utils/MarathonUtil.js
@@ -136,7 +136,7 @@ function parsePod(pod) {
 
     const mounts = pod.spec.containers.reduce(function(
       memo,
-      { name: containerName, volumeMounts }
+      { name: containerName, volumeMounts = [] }
     ) {
       if (volumeMounts.length > 0) {
         volumeMounts.forEach(function(volumeMount) {


### PR DESCRIPTION
This fixes the parsePod function in the case that a pod with a similar configuration as:
```
{
  "id": "/test",
  "containers": [
    {
      "name": "container-1",
      "resources": {
        "cpus": 0.1,
        "mem": 128,
        "disk": 0
      },
      "image": {
        "kind": "DOCKER",
        "id": "alpine"
      },
      "exec": {
        "command": {
          "shell": "sleep 1000"
        }
      },
      "volumeMounts": [
        {
          "name": "home",
          "mountPath": "/var/log"
        }
      ]
    },
    {
      "name": "container-2",
      "resources": {
        "cpus": 0.1,
        "mem": 128,
        "disk": 0
      },
      "image": {
        "kind": "DOCKER",
        "id": "alpine"
      },
      "exec": {
        "command": {
          "shell": "sleep 1500"
        }
      },
      "volumeMounts": []
    }
  ],
  "volumes": [
    {
      "name": "home"
    }
  ],
  "networks": [
    {
      "mode": "host"
    }
  ],
  "scaling": {
    "instances": 1,
    "kind": "fixed"
  },
  "scheduling": {
    "placement": {
      "constraints": []
    }
  },
  "executorResources": {
    "cpus": 0.1,
    "mem": 32,
    "disk": 10
  },
  "fetch": []
}
```
To test just deploy the previously mentioned configuration.

Close DCOS-22128