### PR TITLE
DCOS_OSS-2059 Update Config Headings

### DIFF
--- a/src/js/components/FrameworkConfiguration.js
+++ b/src/js/components/FrameworkConfiguration.js
@@ -255,7 +255,6 @@ class FrameworkConfiguration extends Component {
           {defaultConfigWarningMessage}
           <FrameworkConfigurationReviewScreen
             frameworkData={formData}
-            title={"Configuration"}
             onEditClick={this.handleEditConfigurationButtonClick}
           />
         </div>

--- a/src/js/components/FrameworkConfigurationReviewScreen.js
+++ b/src/js/components/FrameworkConfigurationReviewScreen.js
@@ -150,6 +150,7 @@ class FrameworkConfigurationReviewScreen extends React.Component {
         </div>
         <HashMapDisplay
           hash={frameworkData}
+          headingLevel={0}
           renderKeys={this.getHashMapRenderKeys(frameworkData)}
           headlineClassName={"text-capitalize"}
           emptyValue={EmptyStates.CONFIG_VALUE}

--- a/src/js/components/HashMapDisplay.js
+++ b/src/js/components/HashMapDisplay.js
@@ -47,7 +47,7 @@ class HashMapDisplay extends React.Component {
       ) {
         // Increase the heading level for each nested description list, making
         // ensuring we don't surpass heading level 6.
-        const nextHeadingLevel = Math.min(headingLevel, 6);
+        const nextHeadingLevel = Math.min(headingLevel + 1, 6);
 
         return (
           <HashMapDisplay

--- a/src/js/components/HashMapDisplay.js
+++ b/src/js/components/HashMapDisplay.js
@@ -47,7 +47,7 @@ class HashMapDisplay extends React.Component {
       ) {
         // Increase the heading level for each nested description list, making
         // ensuring we don't surpass heading level 6.
-        const nextHeadingLevel = Math.min(headingLevel + 1, 6);
+        const nextHeadingLevel = Math.min(headingLevel, 6);
 
         return (
           <HashMapDisplay


### PR DESCRIPTION
Problem: Configuration headings for SDK and Marathon apps are inconsistent. 

1. "Services" heading with underline

Marathon
![screen shot 2018-04-20 at 2 41 46 pm](https://user-images.githubusercontent.com/8737825/39098102-869de2c2-461a-11e8-8be8-d65d638d6c7a.png)

SDK
![image](https://user-images.githubusercontent.com/8737825/39724825-aef8929a-51fe-11e8-868d-e8310ecc7776.png)

2. "Configuration" label on review screen 

Marathon
<img width="1675" alt="screen shot 2018-04-22 at 10 49 09 am" src="https://user-images.githubusercontent.com/8737825/39098137-1474596e-461b-11e8-9598-c97232da444c.png">

SDK
![image](https://user-images.githubusercontent.com/8737825/39724846-bcd304c2-51fe-11e8-81de-03e4f828adf4.png)

Solution:

1. Made Services heading the same 
2. Got rid of the Configuration title on SDK confirmation page 

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?