### PR TITLE
 DCOS_OSS-2397: shows filter default on task page loading

### DIFF
--- a/plugins/services/src/js/containers/tasks/TasksContainer.js
+++ b/plugins/services/src/js/containers/tasks/TasksContainer.js
@@ -164,6 +164,10 @@ class TasksContainer extends React.Component {
       newZones.length === zones.length &&
       newZones.every(zone => zones.indexOf(zone) !== -1)
     ) {
+      this.setState({
+        filterExpression: new DSLExpression(query)
+      });
+
       return;
     }
 

--- a/plugins/services/src/js/containers/tasks/__tests__/TasksContainer-test.js
+++ b/plugins/services/src/js/containers/tasks/__tests__/TasksContainer-test.js
@@ -1,0 +1,69 @@
+import TaskUtil from "#PLUGINS/services/src/js/utils/TaskUtil";
+import TasksContainer from "../TasksContainer";
+
+describe("TasksContainer", () => {
+  describe("propsToState", () => {
+    describe("filterExpression", () => {
+      const testCases = [
+        {
+          name: "no new regions and zones",
+          regions: [],
+          zones: [],
+          expectedQuery: "is:active"
+        },
+        {
+          name: "new region and zone",
+          regions: ["eu-central-1"],
+          zones: ["eu-central-1b"],
+          expectedQuery: "is:active"
+        },
+        {
+          name: "no new region with custom query",
+          regions: [],
+          zones: [],
+          query: "is:completed",
+          expectedQuery: "is:completed"
+        },
+        {
+          name: "new region with custom query",
+          regions: ["eu-central-1"],
+          zones: ["eu-central-1b"],
+          query: "is:completed",
+          expectedQuery: "is:completed"
+        }
+      ];
+
+      testCases.forEach(function({
+        name,
+        regions,
+        zones,
+        query,
+        expectedQuery
+      }) {
+        it(name, () => {
+          TaskUtil.getNode = jest.fn(({ region, zone }) => ({
+            getZoneName: jest.fn(() => zone),
+            getRegionName: jest.fn(() => region)
+          }));
+
+          const setState = jest.fn();
+          TasksContainer.prototype.propsToState.call(
+            {
+              state: { defaultFilterData: { zones: [], regions: [] } },
+              setState
+            },
+            {
+              location: { query: { q: query } },
+              tasks: zones.map((zone, i) => ({ zone, region: regions[i] }))
+            }
+          );
+
+          expect(setState).toHaveBeenCalled();
+          const filterExpression = setState.mock.calls[0][0].filterExpression;
+
+          expect(filterExpression.value).toBe(expectedQuery);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Not having new zones or regions prevented the state
of the component to be updated causing the default filter
to load with an empty value.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
