### PR TITLE
fix(MesosStateStore): add linearBackoff retry to the stream

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -325,6 +325,53 @@ follow these guidelines. Some of the most common ones to follow:
 For more on this topic, and examples we recommend 
 [Better Specs](http://www.betterspecs.org/).
 
+### Testing rxjs observables with marbles diagrams
+
+Before you begin please read the introduction on [what the marbles diagrams are](https://github.com/ReactiveX/rxjs/blob/5.4.2/doc/writing-marble-tests.md).
+Since there's no official helpers to write tests levereging the marbles diagrams we're using [rxjs-marbles](https://github.com/cartant/rxjs-marbles) library.
+
+The most important thing you should do is wrapping your usual test case function with `marble` function
+
+```js
+import { marbles } from "rxjs-marbles/jest";
+
+it("tests marbles", marble(function(m) {
+  // My test case
+}));
+```
+
+it will inject the Context conventionally named `m` that exposes the helpers API.
+
+#### Example of a marble test
+
+```js
+import { marbles } from "rxjs-marbles/jest";
+import { linearBackoff } from "../rxjsUtils";
+
+describe("linearBackoff", function() {
+  it(
+    "retries maxRetries times",
+    // To setup marbles test env pass your function wrapped with `marbels`
+    // it will inject Context as the first argument named `m` by convention
+    marbles(function(m) {
+      // with `m.bind` we bind all time dependent operators to a TestScheduler
+      // so that we can use mocked time intervals.
+      // But we also could create our own TestScheduler and use it instead.
+      m.bind();
+
+      const source = m.cold("1--2#");
+      const expected = m.cold("1--2--1--2----1--2------1--2#");
+
+      // In test env we don't want to wait for the real wall clock
+      // so we encode time intervals with a special helper `m.time`
+      const result = source.retryWhen(linearBackoff(3, m.time("--|")));
+
+      m.expect(result).toBeObservable(expected);
+    })
+  );
+});
+```
+
 ## Integration Testing
 
 At the integration level, we are interested in verifying that the composition of

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -67,9 +67,9 @@
       "resolved": "https://registry.npmjs.org/@dcos/http-service/-/http-service-0.2.1.tgz"
     },
     "@dcos/mesos-client": {
-      "version": "0.1.10",
-      "from": "@dcos/mesos-client@0.1.10",
-      "resolved": "https://registry.npmjs.org/@dcos/mesos-client/-/mesos-client-0.1.10.tgz"
+      "version": "0.2.0",
+      "from": "@dcos/mesos-client@0.2.0",
+      "resolved": "https://registry.npmjs.org/@dcos/mesos-client/-/mesos-client-0.2.0.tgz"
     },
     "@dcos/recordio": {
       "version": "0.1.6",
@@ -105,6 +105,11 @@
       "version": "4.14.87",
       "from": "@types/lodash@4.14.87",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.87.tgz"
+    },
+    "@types/lodash-es": {
+      "version": "4.17.0",
+      "from": "@types/lodash-es@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.0.tgz"
     },
     "@types/minimatch": {
       "version": "3.0.1",
@@ -9274,6 +9279,11 @@
       "version": "5.4.3",
       "from": "rxjs@5.4.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.3.tgz"
+    },
+    "rxjs-marbles": {
+      "version": "2.3.1",
+      "from": "rxjs-marbles@2.3.1",
+      "resolved": "https://registry.npmjs.org/rxjs-marbles/-/rxjs-marbles-2.3.1.tgz"
     },
     "safe-buffer": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@dcos/http-service": "0.2.1",
-    "@dcos/mesos-client": "0.1.10",
+    "@dcos/mesos-client": "0.2.0",
     "babel-polyfill": "6.23.0",
     "browser-info": "0.4.0",
     "classnames": "2.2.3",
@@ -129,6 +129,7 @@
     "raml-validator-loader": "0.1.10",
     "react-hot-loader": "1.3.1",
     "react-test-renderer": "15.4.1",
+    "rxjs-marbles": "2.3.1",
     "source-map-loader": "0.1.5",
     "string-replace-webpack-plugin": "0.0.3",
     "style-loader": "0.13.1",

--- a/src/js/utils/__tests__/rxjsUtils-test.js
+++ b/src/js/utils/__tests__/rxjsUtils-test.js
@@ -1,0 +1,27 @@
+import "rxjs/add/operator/retryWhen";
+import { marbles } from "rxjs-marbles/jest";
+
+import { linearBackoff } from "../rxjsUtils";
+
+describe("linearBackoff", function() {
+  it(
+    "retries maxRetries times",
+    // To setup marbles test env pass your function wrapped with `marbels`
+    // it will inject Context as the first argument named `m` by convention
+    marbles(function(m) {
+      // with `m.bind` we bind all time dependent operators to a TestScheduler
+      // so that we can use mocked time intervals.
+      // But we also could create our own TestScheduler and use it instead.
+      m.bind();
+
+      const source = m.cold("1--2#");
+      const expected = m.cold("1--2--1--2----1--2------1--2#");
+
+      // In test env we don't want to wait for the real wall clock
+      // so we encode time intervals with a special helper `m.time`
+      const result = source.retryWhen(linearBackoff(3, m.time("--|")));
+
+      m.expect(result).toBeObservable(expected);
+    })
+  );
+});

--- a/src/js/utils/rxjsUtils.js
+++ b/src/js/utils/rxjsUtils.js
@@ -1,0 +1,18 @@
+import { timer } from "rxjs/observable/timer";
+
+import "rxjs/add/operator/delayWhen";
+import "rxjs/add/operator/scan";
+
+/* eslint-disable import/prefer-default-export */
+export function linearBackoff(maxRetries = 5, delay = 1000, scheduler = null) {
+  return errors =>
+    errors
+      .scan((count, error) => {
+        if (count >= maxRetries) {
+          throw error;
+        }
+
+        return count + 1;
+      }, 0)
+      .delayWhen(val => timer(val * delay, null, scheduler));
+}


### PR DESCRIPTION
Adjust the `MesosStateStore` to use a linear backoff strategy when re-connecting to Mesos (`retry`), as this otherwise leads to a rather high CPU load and an unresponsive UI due to a rather high number of connection attempts.

Closes DCOS-22301