### PR TITLE
fix(MesosStream): delay reconnections

### DIFF
--- a/src/js/core/MesosStream.js
+++ b/src/js/core/MesosStream.js
@@ -1,8 +1,11 @@
 import { stream } from "@dcos/mesos-client";
 import { ReplaySubject } from "rxjs/ReplaySubject";
+import { Observable } from "rxjs/Observable";
+
+const RECONNECTION_DELAY = 2000;
 
 export const MesosStreamType = Symbol("MesosStreamType");
 export default stream({ type: "SUBSCRIBE" }, "/mesos/api/v1?subscribe")
-  .repeat()
+  .repeatWhen(() => Observable.timer(RECONNECTION_DELAY))
   .multicast(() => new ReplaySubject())
   .refCount();


### PR DESCRIPTION
Delay reconnection attempts to reduce load on Mesos and improve the UI performance. Without this adjustment, the UI will attempt to re-connect immediately which results in a rather high number of connection attempts which leads to a high CPU load if Mesos is unable to establish the stream (XHR).

Closes DCOS-22303