### PR TITLE
DCOS-22309: chore(package): backport integration-test script to 1.11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,34 +88,14 @@ pipeline {
 
     stage('Integration Test') {
       steps {
-        // Run a simple webserver serving the dist folder statically
-        // before we run the cypress tests
-        writeFile file: 'integration-tests.sh', text: [
-          'export PATH=`pwd`/node_modules/.bin:$PATH',
-          'http-server -p 4200 dist&',
-          'SERVER_PID=$!',
-          'npm run cypress -- --reporter junit --reporter-options \'mochaFile=cypress/results.xml\'',
-          'RET=$?',
-          'echo "cypress exit status: ${RET}"',
-          'sleep 10',
-          'echo "kill server"',
-          'kill $SERVER_PID',
-          'exit $RET'
-        ].join('\n')
-
         unstash 'dist'
-
-        ansiColor('xterm') {
-          retry(2) {
-            sh '''bash integration-tests.sh'''
-          }
-        }
+        sh "npm run integration-tests"
       }
 
       post {
         always {
           archiveArtifacts 'cypress/**/*'
-          junit 'cypress/*.xml'
+          junit 'cypress/results.xml'
         }
       }
     }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -121,6 +121,11 @@
       "from": "@types/mocha@2.2.44",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.44.tgz"
     },
+    "@types/node": {
+      "version": "9.6.6",
+      "from": "@types/node@*",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.6.tgz"
+    },
     "@types/sinon": {
       "version": "4.0.0",
       "from": "@types/sinon@4.0.0",
@@ -197,7 +202,7 @@
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "from": "ansi-escapes@>=1.1.0 <2.0.0",
+      "from": "ansi-escapes@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
     },
     "ansi-regex": {
@@ -207,7 +212,7 @@
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "from": "ansi-styles@>=2.1.0 <3.0.0",
+      "from": "ansi-styles@>=2.2.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
     },
     "ansicolors": {
@@ -322,7 +327,7 @@
     },
     "asn1": {
       "version": "0.2.3",
-      "from": "asn1@>=0.2.3 <0.3.0",
+      "from": "asn1@~0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
     },
     "asn1.js": {
@@ -347,7 +352,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "from": "async@>=1.5.2 <2.0.0",
+      "from": "async@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
     },
     "async-done": {
@@ -362,7 +367,7 @@
     },
     "async-each-series": {
       "version": "1.1.0",
-      "from": "async-each-series@>=1.0.0 <2.0.0",
+      "from": "async-each-series@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-1.1.0.tgz"
     },
     "asynckit": {
@@ -403,12 +408,18 @@
         "chokidar": {
           "version": "1.6.1",
           "from": "chokidar@>=1.6.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz"
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+          "dependencies": {}
         },
         "core-js": {
           "version": "2.4.1",
           "from": "core-js@^2.4.0",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+        },
+        "nan": {
+          "version": "2.10.0",
+          "from": "nan@>=2.9.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz"
         },
         "regenerator-runtime": {
           "version": "0.10.5",
@@ -1789,7 +1800,7 @@
     },
     "bser": {
       "version": "1.0.2",
-      "from": "bser@>=1.0.2 <2.0.0",
+      "from": "bser@1.0.2",
       "resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz"
     },
     "buffer": {
@@ -1816,7 +1827,7 @@
     },
     "buffer-xor": {
       "version": "1.0.3",
-      "from": "buffer-xor@>=1.0.2 <2.0.0",
+      "from": "buffer-xor@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
     },
     "builtin-modules": {
@@ -1928,6 +1939,33 @@
       "from": "check-more-types@2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz"
     },
+    "cheerio": {
+      "version": "1.0.0-rc.2",
+      "from": "cheerio@>=1.0.0-rc.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+      "dependencies": {
+        "domhandler": {
+          "version": "2.4.1",
+          "from": "domhandler@>=2.3.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz"
+        },
+        "htmlparser2": {
+          "version": "3.9.2",
+          "from": "htmlparser2@>=3.9.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz"
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "from": "lodash@^4.15.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+        },
+        "parse5": {
+          "version": "3.0.3",
+          "from": "parse5@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz"
+        }
+      }
+    },
     "chokidar": {
       "version": "1.5.0",
       "from": "chokidar@>=1.0.0 <2.0.0",
@@ -1994,7 +2032,7 @@
     },
     "cli-cursor": {
       "version": "1.0.2",
-      "from": "cli-cursor@>=1.0.1 <2.0.0",
+      "from": "cli-cursor@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
     },
     "cli-spinners": {
@@ -2043,7 +2081,7 @@
     },
     "clone": {
       "version": "1.0.2",
-      "from": "clone@>=1.0.0 <2.0.0",
+      "from": "clone@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
     },
     "clone-regexp": {
@@ -2130,7 +2168,7 @@
     },
     "colors": {
       "version": "1.1.2",
-      "from": "colors@>=1.1.2 <1.2.0",
+      "from": "colors@1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
     },
     "combined-stream": {
@@ -2140,7 +2178,7 @@
     },
     "commander": {
       "version": "2.9.0",
-      "from": "commander@>=2.8.1 <3.0.0",
+      "from": "commander@>=2.9.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
     },
     "common-tags": {
@@ -2274,10 +2312,275 @@
       "from": "content-type-parser@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz"
     },
+    "conventional-changelog": {
+      "version": "1.1.24",
+      "from": "conventional-changelog@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.24.tgz",
+      "dependencies": {
+        "conventional-changelog-angular": {
+          "version": "1.6.6",
+          "from": "conventional-changelog-angular@>=1.6.6 <2.0.0",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz"
+        },
+        "q": {
+          "version": "1.5.1",
+          "from": "q@>=1.5.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz"
+        }
+      }
+    },
     "conventional-changelog-angular": {
       "version": "1.3.0",
       "from": "conventional-changelog-angular@1.3.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.3.0.tgz"
+    },
+    "conventional-changelog-atom": {
+      "version": "0.2.8",
+      "from": "conventional-changelog-atom@>=0.2.8 <0.3.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.2.8.tgz",
+      "dependencies": {
+        "q": {
+          "version": "1.5.1",
+          "from": "q@^1.5.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz"
+        }
+      }
+    },
+    "conventional-changelog-codemirror": {
+      "version": "0.3.8",
+      "from": "conventional-changelog-codemirror@>=0.3.8 <0.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.8.tgz",
+      "dependencies": {
+        "q": {
+          "version": "1.5.1",
+          "from": "q@^1.5.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz"
+        }
+      }
+    },
+    "conventional-changelog-core": {
+      "version": "2.0.11",
+      "from": "conventional-changelog-core@>=2.0.11 <3.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-2.0.11.tgz",
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "from": "camelcase@^4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+        },
+        "camelcase-keys": {
+          "version": "4.2.0",
+          "from": "camelcase-keys@^4.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz"
+        },
+        "conventional-commits-parser": {
+          "version": "2.1.7",
+          "from": "conventional-commits-parser@>=2.1.7 <3.0.0",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz"
+        },
+        "dateformat": {
+          "version": "3.0.3",
+          "from": "dateformat@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz"
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "from": "error-ex@^1.3.1",
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "from": "find-up@^2.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz"
+        },
+        "git-raw-commits": {
+          "version": "1.3.6",
+          "from": "git-raw-commits@>=1.3.6 <2.0.0",
+          "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz"
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "from": "indent-string@^3.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz"
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "from": "inherits@>=2.0.3 <2.1.0",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+        },
+        "jsonparse": {
+          "version": "1.3.1",
+          "from": "jsonparse@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz"
+        },
+        "JSONStream": {
+          "version": "1.3.2",
+          "from": "JSONStream@>=1.0.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz"
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "from": "load-json-file@^4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz"
+        },
+        "lodash.template": {
+          "version": "4.4.0",
+          "from": "lodash.template@>=4.0.2 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz"
+        },
+        "lodash.templatesettings": {
+          "version": "4.1.0",
+          "from": "lodash.templatesettings@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz"
+        },
+        "map-obj": {
+          "version": "2.0.0",
+          "from": "map-obj@^2.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz"
+        },
+        "meow": {
+          "version": "4.0.1",
+          "from": "meow@^4.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+          "dependencies": {
+            "read-pkg": {
+              "version": "3.0.0",
+              "from": "read-pkg@^3.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz"
+            },
+            "read-pkg-up": {
+              "version": "3.0.0",
+              "from": "read-pkg-up@^3.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz"
+            }
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "from": "parse-json@^4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz"
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "from": "path-type@^3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz"
+        },
+        "pify": {
+          "version": "3.0.0",
+          "from": "pify@^3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "from": "process-nextick-args@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz"
+        },
+        "q": {
+          "version": "1.5.1",
+          "from": "q@^1.5.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz"
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "from": "readable-stream@>=2.1.5 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz"
+        },
+        "redent": {
+          "version": "2.0.0",
+          "from": "redent@^2.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz"
+        },
+        "split2": {
+          "version": "2.2.0",
+          "from": "split2@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+          "dependencies": {
+            "through2": {
+              "version": "2.0.3",
+              "from": "through2@>=2.0.2 <3.0.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "from": "string_decoder@>=1.1.1 <1.2.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "from": "strip-bom@^3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "from": "strip-indent@^2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz"
+        },
+        "trim-newlines": {
+          "version": "2.0.0",
+          "from": "trim-newlines@^2.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz"
+        }
+      }
+    },
+    "conventional-changelog-ember": {
+      "version": "0.3.12",
+      "from": "conventional-changelog-ember@>=0.3.12 <0.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.3.12.tgz",
+      "dependencies": {
+        "q": {
+          "version": "1.5.1",
+          "from": "q@^1.5.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz"
+        }
+      }
+    },
+    "conventional-changelog-eslint": {
+      "version": "1.0.9",
+      "from": "conventional-changelog-eslint@>=1.0.9 <2.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.9.tgz",
+      "dependencies": {
+        "q": {
+          "version": "1.5.1",
+          "from": "q@^1.5.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz"
+        }
+      }
+    },
+    "conventional-changelog-express": {
+      "version": "0.3.6",
+      "from": "conventional-changelog-express@>=0.3.6 <0.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.3.6.tgz",
+      "dependencies": {
+        "q": {
+          "version": "1.5.1",
+          "from": "q@^1.5.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz"
+        }
+      }
+    },
+    "conventional-changelog-jquery": {
+      "version": "0.1.0",
+      "from": "conventional-changelog-jquery@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz"
+    },
+    "conventional-changelog-jscs": {
+      "version": "0.1.0",
+      "from": "conventional-changelog-jscs@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz"
+    },
+    "conventional-changelog-jshint": {
+      "version": "0.3.8",
+      "from": "conventional-changelog-jshint@>=0.3.8 <0.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.8.tgz",
+      "dependencies": {
+        "q": {
+          "version": "1.5.1",
+          "from": "q@^1.5.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz"
+        }
+      }
     },
     "conventional-changelog-lint": {
       "version": "1.1.9",
@@ -2336,6 +2639,118 @@
       "from": "conventional-changelog-lint-config-angular@0.4.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-lint-config-angular/-/conventional-changelog-lint-config-angular-0.4.1.tgz"
     },
+    "conventional-changelog-preset-loader": {
+      "version": "1.1.8",
+      "from": "conventional-changelog-preset-loader@>=1.1.8 <2.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-1.1.8.tgz"
+    },
+    "conventional-changelog-writer": {
+      "version": "3.0.9",
+      "from": "conventional-changelog-writer@>=3.0.9 <4.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-3.0.9.tgz",
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "from": "camelcase@>=4.1.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+        },
+        "camelcase-keys": {
+          "version": "4.2.0",
+          "from": "camelcase-keys@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz"
+        },
+        "dateformat": {
+          "version": "3.0.3",
+          "from": "dateformat@^3.0.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz"
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "from": "error-ex@>=1.3.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "from": "find-up@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz"
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "from": "indent-string@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz"
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "from": "load-json-file@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz"
+        },
+        "map-obj": {
+          "version": "2.0.0",
+          "from": "map-obj@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz"
+        },
+        "meow": {
+          "version": "4.0.1",
+          "from": "meow@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz"
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "from": "parse-json@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz"
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "from": "path-type@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz"
+        },
+        "pify": {
+          "version": "3.0.0",
+          "from": "pify@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "from": "read-pkg@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz"
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "from": "read-pkg-up@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz"
+        },
+        "redent": {
+          "version": "2.0.0",
+          "from": "redent@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz"
+        },
+        "split": {
+          "version": "1.0.1",
+          "from": "split@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz"
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "from": "strip-bom@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "from": "strip-indent@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz"
+        },
+        "trim-newlines": {
+          "version": "2.0.0",
+          "from": "trim-newlines@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz"
+        }
+      }
+    },
+    "conventional-commits-filter": {
+      "version": "1.1.6",
+      "from": "conventional-commits-filter@>=1.1.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.1.6.tgz"
+    },
     "conventional-commits-parser": {
       "version": "1.3.0",
       "from": "conventional-commits-parser@1.3.0",
@@ -2380,6 +2795,176 @@
         }
       }
     },
+    "conventional-recommended-bump": {
+      "version": "1.2.1",
+      "from": "conventional-recommended-bump@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.2.1.tgz",
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "from": "camelcase@^4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+        },
+        "camelcase-keys": {
+          "version": "4.2.0",
+          "from": "camelcase-keys@^4.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz"
+        },
+        "conventional-commits-parser": {
+          "version": "2.1.7",
+          "from": "conventional-commits-parser@^2.1.1",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
+          "dependencies": {
+            "meow": {
+              "version": "4.0.1",
+              "from": "meow@^4.0.0",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz"
+            }
+          }
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "from": "error-ex@^1.3.1",
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "from": "find-up@^2.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz"
+        },
+        "git-raw-commits": {
+          "version": "1.3.6",
+          "from": "git-raw-commits@^1.3.0",
+          "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
+          "dependencies": {
+            "meow": {
+              "version": "4.0.1",
+              "from": "meow@^4.0.0",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz"
+            }
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "from": "indent-string@^3.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz"
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "from": "inherits@~2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+        },
+        "jsonparse": {
+          "version": "1.3.1",
+          "from": "jsonparse@^1.2.0",
+          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz"
+        },
+        "JSONStream": {
+          "version": "1.3.2",
+          "from": "JSONStream@^1.0.4",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz"
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "from": "load-json-file@^4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz"
+        },
+        "lodash.template": {
+          "version": "4.4.0",
+          "from": "lodash.template@^4.0.2",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz"
+        },
+        "lodash.templatesettings": {
+          "version": "4.1.0",
+          "from": "lodash.templatesettings@^4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz"
+        },
+        "map-obj": {
+          "version": "2.0.0",
+          "from": "map-obj@^2.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz"
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "object-assign@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "from": "parse-json@^4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz"
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "from": "path-type@^3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz"
+        },
+        "pify": {
+          "version": "3.0.0",
+          "from": "pify@^3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "from": "process-nextick-args@~2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz"
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "from": "read-pkg@^3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz"
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "from": "read-pkg-up@^3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz"
+        },
+        "redent": {
+          "version": "2.0.0",
+          "from": "redent@^2.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz"
+        },
+        "split2": {
+          "version": "2.2.0",
+          "from": "split2@^2.0.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+          "dependencies": {
+            "through2": {
+              "version": "2.0.3",
+              "from": "through2@^2.0.2",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.3.6",
+                  "from": "readable-stream@^2.1.5",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "from": "string_decoder@~1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "from": "strip-bom@^3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "from": "strip-indent@^2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz"
+        },
+        "trim-newlines": {
+          "version": "2.0.0",
+          "from": "trim-newlines@^2.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz"
+        }
+      }
+    },
     "convert-source-map": {
       "version": "1.2.0",
       "from": "convert-source-map@>=1.1.0 <2.0.0",
@@ -2417,6 +3002,11 @@
       "from": "core-util-is@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
+    "corser": {
+      "version": "2.0.1",
+      "from": "corser@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz"
+    },
     "cosmiconfig": {
       "version": "1.1.0",
       "from": "cosmiconfig@>=1.1.0 <2.0.0",
@@ -2453,6 +3043,23 @@
       "version": "1.1.4",
       "from": "create-hmac@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "from": "cross-spawn@>=5.0.1 <6.0.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "dependencies": {
+        "isexe": {
+          "version": "2.0.0",
+          "from": "isexe@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+        },
+        "which": {
+          "version": "1.3.0",
+          "from": "which@>=1.2.9 <2.0.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz"
+        }
+      }
     },
     "crypt": {
       "version": "0.0.1",
@@ -2872,7 +3479,7 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "from": "assert-plus@^1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
@@ -2904,7 +3511,7 @@
     },
     "debug": {
       "version": "2.2.0",
-      "from": "debug@>=2.1.1 <3.0.0",
+      "from": "debug@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
     },
     "debuglog": {
@@ -2916,6 +3523,11 @@
       "version": "1.2.0",
       "from": "decamelize@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+    },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "from": "decamelize-keys@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz"
     },
     "decompress": {
       "version": "3.0.0",
@@ -2939,7 +3551,7 @@
             },
             "through2": {
               "version": "0.6.5",
-              "from": "through2@>=0.6.0 <0.7.0",
+              "from": "through2@^0.6.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
             }
           }
@@ -3101,7 +3713,7 @@
     },
     "defaults": {
       "version": "1.0.3",
-      "from": "defaults@>=1.0.0 <2.0.0",
+      "from": "defaults@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz"
     },
     "define-properties": {
@@ -3128,7 +3740,7 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "from": "delayed-stream@>=1.0.0 <1.1.0",
+      "from": "delayed-stream@~1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
     },
     "delegate": {
@@ -3187,6 +3799,11 @@
       "version": "5.0.2",
       "from": "diffie-hellman@>=5.0.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz"
+    },
+    "discontinuous-range": {
+      "version": "1.0.0",
+      "from": "discontinuous-range@1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz"
     },
     "doctrine": {
       "version": "1.2.2",
@@ -3291,6 +3908,33 @@
       "from": "dot-prop@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz"
     },
+    "dotgitignore": {
+      "version": "1.0.3",
+      "from": "dotgitignore@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/dotgitignore/-/dotgitignore-1.0.3.tgz",
+      "dependencies": {
+        "balanced-match": {
+          "version": "1.0.0",
+          "from": "balanced-match@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "from": "brace-expansion@>=1.1.7 <2.0.0",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "from": "find-up@^2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "from": "minimatch@>=3.0.4 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+        }
+      }
+    },
     "download": {
       "version": "4.4.3",
       "from": "download@>=4.1.2 <5.0.0",
@@ -3313,7 +3957,7 @@
             },
             "through2": {
               "version": "0.6.5",
-              "from": "through2@>=0.6.0 <0.7.0",
+              "from": "through2@^0.6.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
             }
           }
@@ -3396,8 +4040,20 @@
     },
     "ecc-jsbn": {
       "version": "0.1.1",
-      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+      "from": "ecc-jsbn@~0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+    },
+    "ecstatic": {
+      "version": "2.2.1",
+      "from": "ecstatic@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-2.2.1.tgz",
+      "dependencies": {
+        "he": {
+          "version": "1.1.1",
+          "from": "he@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz"
+        }
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -3431,7 +4087,7 @@
     },
     "end-of-stream": {
       "version": "0.1.5",
-      "from": "end-of-stream@>=0.1.5 <0.2.0",
+      "from": "end-of-stream@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz"
     },
     "enhanced-resolve": {
@@ -3451,6 +4107,42 @@
       "from": "entities@>=1.1.1 <1.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
     },
+    "enzyme": {
+      "version": "3.3.0",
+      "from": "enzyme@3.3.0",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.3.0.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "from": "lodash@>=4.17.4 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+        }
+      }
+    },
+    "enzyme-adapter-react-15.4": {
+      "version": "1.0.5",
+      "from": "enzyme-adapter-react-15.4@1.0.5",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-15.4/-/enzyme-adapter-react-15.4-1.0.5.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "from": "lodash@^4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+        }
+      }
+    },
+    "enzyme-adapter-utils": {
+      "version": "1.3.0",
+      "from": "enzyme-adapter-utils@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.3.0.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "from": "lodash@^4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+        }
+      }
+    },
     "errno": {
       "version": "0.1.4",
       "from": "errno@>=0.1.1 <0.2.0-0",
@@ -3463,7 +4155,7 @@
     },
     "error-stack-parser": {
       "version": "1.3.6",
-      "from": "error-stack-parser@>=1.2.0 <2.0.0",
+      "from": "error-stack-parser@>=1.3.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz"
     },
     "errorhandler": {
@@ -3589,14 +4281,14 @@
         },
         "source-map": {
           "version": "0.2.0",
-          "from": "source-map@>=0.2.0 <0.3.0",
+          "from": "source-map@~0.2.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
         }
       }
     },
     "escope": {
       "version": "3.6.0",
-      "from": "escope@>=3.4.0 <4.0.0",
+      "from": "escope@>=3.6.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz"
     },
     "eslint": {
@@ -3663,7 +4355,7 @@
     },
     "eslint-config-airbnb": {
       "version": "10.0.1",
-      "from": "eslint-config-airbnb@10.0.1",
+      "from": "eslint-config-airbnb@>=10.0.1 <11.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-10.0.1.tgz"
     },
     "eslint-config-airbnb-base": {
@@ -3807,7 +4499,7 @@
     },
     "estraverse": {
       "version": "4.2.0",
-      "from": "estraverse@>=4.1.1 <5.0.0",
+      "from": "estraverse@>=4.2.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
     },
     "esutils": {
@@ -3842,7 +4534,7 @@
     },
     "eventsource": {
       "version": "0.1.6",
-      "from": "eventsource@>=0.1.3 <0.2.0",
+      "from": "eventsource@0.1.6",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz"
     },
     "evp_bytestokey": {
@@ -3864,6 +4556,18 @@
       "version": "0.2.0",
       "from": "exec-sh@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz"
+    },
+    "execa": {
+      "version": "0.7.0",
+      "from": "execa@>=0.7.0 <0.8.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "dependencies": {
+        "signal-exit": {
+          "version": "3.0.2",
+          "from": "signal-exit@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+        }
+      }
     },
     "execall": {
       "version": "1.0.0",
@@ -4204,7 +4908,7 @@
     },
     "flatten": {
       "version": "1.0.2",
-      "from": "flatten@1.0.2",
+      "from": "flatten@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
     },
     "flow-parser": {
@@ -4224,7 +4928,7 @@
     },
     "for-own": {
       "version": "0.1.4",
-      "from": "for-own@>=0.1.3 <0.2.0",
+      "from": "for-own@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz"
     },
     "foreach": {
@@ -4234,7 +4938,7 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "from": "forever-agent@>=0.6.1 <0.7.0",
+      "from": "forever-agent@~0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
     },
     "form-data": {
@@ -4261,6 +4965,11 @@
       "version": "0.1.3",
       "from": "from@>=0.0.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
+    },
+    "fs-access": {
+      "version": "1.0.1",
+      "from": "fs-access@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz"
     },
     "fs-extra": {
       "version": "0.26.7",
@@ -4309,6 +5018,18 @@
       "from": "function-bind@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
     },
+    "function.prototype.name": {
+      "version": "1.1.0",
+      "from": "function.prototype.name@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
+      "dependencies": {
+        "function-bind": {
+          "version": "1.1.1",
+          "from": "function-bind@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
+        }
+      }
+    },
     "gather-stream": {
       "version": "1.0.0",
       "from": "gather-stream@>=1.0.0 <2.0.0",
@@ -4333,12 +5054,12 @@
     },
     "gaze": {
       "version": "0.5.2",
-      "from": "gaze@>=0.5.1 <0.6.0",
+      "from": "gaze@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
     },
     "gemini-scrollbar": {
       "version": "1.3.2",
-      "from": "gemini-scrollbar@>=1.0.0 <2.0.0",
+      "from": "gemini-scrollbar@>=1.3.0 <1.4.0",
       "resolved": "https://registry.npmjs.org/gemini-scrollbar/-/gemini-scrollbar-1.3.2.tgz"
     },
     "generate-function": {
@@ -4356,6 +5077,11 @@
       "from": "get-caller-file@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
     },
+    "get-pkg-repo": {
+      "version": "1.4.0",
+      "from": "get-pkg-repo@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz"
+    },
     "get-proxy": {
       "version": "1.1.0",
       "from": "get-proxy@>=1.0.1 <2.0.0",
@@ -4365,6 +5091,11 @@
       "version": "4.0.1",
       "from": "get-stdin@>=4.0.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "from": "get-stream@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz"
     },
     "getos": {
       "version": "2.8.4",
@@ -4390,7 +5121,7 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "from": "assert-plus@^1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
@@ -4444,10 +5175,112 @@
         }
       }
     },
+    "git-remote-origin-url": {
+      "version": "2.0.0",
+      "from": "git-remote-origin-url@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz"
+    },
+    "git-semver-tags": {
+      "version": "1.3.6",
+      "from": "git-semver-tags@>=1.3.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.3.6.tgz",
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "from": "camelcase@^4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+        },
+        "camelcase-keys": {
+          "version": "4.2.0",
+          "from": "camelcase-keys@^4.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz"
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "from": "error-ex@^1.3.1",
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "from": "find-up@^2.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz"
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "from": "indent-string@^3.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz"
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "from": "load-json-file@^4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz"
+        },
+        "map-obj": {
+          "version": "2.0.0",
+          "from": "map-obj@^2.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz"
+        },
+        "meow": {
+          "version": "4.0.1",
+          "from": "meow@^4.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz"
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "from": "parse-json@^4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz"
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "from": "path-type@^3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz"
+        },
+        "pify": {
+          "version": "3.0.0",
+          "from": "pify@^3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "from": "read-pkg@^3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz"
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "from": "read-pkg-up@^3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz"
+        },
+        "redent": {
+          "version": "2.0.0",
+          "from": "redent@^2.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz"
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "from": "strip-bom@^3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "from": "strip-indent@^2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz"
+        },
+        "trim-newlines": {
+          "version": "2.0.0",
+          "from": "trim-newlines@^2.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz"
+        }
+      }
+    },
     "git-toplevel": {
       "version": "1.1.1",
       "from": "git-toplevel@1.1.1",
       "resolved": "https://registry.npmjs.org/git-toplevel/-/git-toplevel-1.1.1.tgz"
+    },
+    "gitconfiglocal": {
+      "version": "1.0.0",
+      "from": "gitconfiglocal@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz"
     },
     "github-url-from-git": {
       "version": "1.5.0",
@@ -4510,7 +5343,7 @@
     },
     "glob2base": {
       "version": "0.0.12",
-      "from": "glob2base@>=0.0.12 <0.0.13",
+      "from": "glob2base@>=0.0.11 <0.1.0",
       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz"
     },
     "global": {
@@ -4665,7 +5498,7 @@
     },
     "gulp-sourcemaps": {
       "version": "1.6.0",
-      "from": "gulp-sourcemaps@>=1.5.2 <2.0.0",
+      "from": "gulp-sourcemaps@1.6.0",
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "dependencies": {
         "vinyl": {
@@ -4778,7 +5611,7 @@
     },
     "handlebars": {
       "version": "4.0.5",
-      "from": "handlebars@>=4.0.1 <5.0.0",
+      "from": "handlebars@>=4.0.3 <5.0.0",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
       "dependencies": {
         "source-map": {
@@ -4797,6 +5630,11 @@
       "version": "2.0.6",
       "from": "har-validator@>=2.0.6 <2.1.0",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
+    },
+    "has": {
+      "version": "1.0.1",
+      "from": "has@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
     },
     "has-ansi": {
       "version": "2.0.0",
@@ -4818,6 +5656,11 @@
       "from": "has-own@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz"
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "from": "has-symbols@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz"
+    },
     "has-unicode": {
       "version": "2.0.1",
       "from": "has-unicode@>=2.0.0 <3.0.0",
@@ -4835,7 +5678,7 @@
     },
     "hawk": {
       "version": "3.1.3",
-      "from": "hawk@>=3.1.3 <3.2.0",
+      "from": "hawk@3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
     },
     "he": {
@@ -4964,6 +5807,18 @@
       "from": "http-response-object@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz"
     },
+    "http-server": {
+      "version": "0.10.0",
+      "from": "johntron/http-server#proxy-secure-flag",
+      "resolved": "git://github.com/johntron/http-server.git#2af9dee8ed4471d9bfc3b675ac5ae3cc420e711a",
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "from": "colors@1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+        }
+      }
+    },
     "http-signature": {
       "version": "1.1.1",
       "from": "http-signature@>=1.1.0 <1.2.0",
@@ -5031,7 +5886,7 @@
             },
             "through2": {
               "version": "0.6.5",
-              "from": "through2@>=0.6.0 <0.7.0",
+              "from": "through2@^0.6.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
             }
           }
@@ -5218,7 +6073,7 @@
     },
     "invariant": {
       "version": "2.2.1",
-      "from": "invariant@>=2.0.0 <3.0.0",
+      "from": "invariant@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz"
     },
     "inversify": {
@@ -5265,6 +6120,11 @@
       "version": "1.0.1",
       "from": "is-binary-path@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
+    },
+    "is-boolean-object": {
+      "version": "1.0.0",
+      "from": "is-boolean-object@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz"
     },
     "is-buffer": {
       "version": "1.1.3",
@@ -5371,6 +6231,11 @@
       "from": "is-number@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
     },
+    "is-number-object": {
+      "version": "1.0.3",
+      "from": "is-number-object@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz"
+    },
     "is-obj": {
       "version": "1.0.1",
       "from": "is-obj@>=1.0.0 <2.0.0",
@@ -5456,6 +6321,16 @@
       "from": "is-stream@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
+    "is-string": {
+      "version": "1.0.4",
+      "from": "is-string@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz"
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "from": "is-subset@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz"
+    },
     "is-supported-regexp-flag": {
       "version": "1.0.0",
       "from": "is-supported-regexp-flag@>=1.0.0 <2.0.0",
@@ -5483,7 +6358,7 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "from": "is-typedarray@>=1.0.0 <1.1.0",
+      "from": "is-typedarray@~1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
     },
     "is-upper-case": {
@@ -5513,7 +6388,7 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "from": "isarray@1.0.0",
+      "from": "isarray@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
     },
     "isexe": {
@@ -5533,7 +6408,7 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "from": "isstream@>=0.1.2 <0.2.0",
+      "from": "isstream@~0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "istanbul-api": {
@@ -6308,7 +7183,7 @@
     },
     "js-yaml": {
       "version": "3.6.1",
-      "from": "js-yaml@>=3.6.0 <3.7.0",
+      "from": "js-yaml@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "dependencies": {
         "esprima": {
@@ -6350,6 +7225,11 @@
       "from": "json-loader@0.5.4",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz"
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "from": "json-parse-better-errors@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz"
+    },
     "json-parse-helpfulerror": {
       "version": "1.0.3",
       "from": "json-parse-helpfulerror@>=1.0.2 <2.0.0",
@@ -6367,12 +7247,12 @@
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "from": "json-stable-stringify@>=1.0.0 <2.0.0",
+      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+      "from": "json-stringify-safe@~5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
     "json3": {
@@ -6471,6 +7351,23 @@
           "version": "4.1.1",
           "from": "object-assign@^4.1.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        }
+      }
+    },
+    "junit-merge": {
+      "version": "1.3.0",
+      "from": "junit-merge@1.3.0",
+      "resolved": "https://registry.npmjs.org/junit-merge/-/junit-merge-1.3.0.tgz",
+      "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "from": "commander@>=2.12.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz"
+        },
+        "fs-readdir-recursive": {
+          "version": "1.1.0",
+          "from": "fs-readdir-recursive@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz"
         }
       }
     },
@@ -6777,6 +7674,11 @@
       "from": "localStorage@1.0.3",
       "resolved": "https://registry.npmjs.org/localStorage/-/localStorage-1.0.3.tgz"
     },
+    "locate-path": {
+      "version": "2.0.0",
+      "from": "locate-path@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz"
+    },
     "lodash": {
       "version": "4.12.0",
       "from": "lodash@>=4.2.0 <5.0.0",
@@ -6974,6 +7876,11 @@
       "from": "lodash.findindex@>=4.3.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.findindex/-/lodash.findindex-4.6.0.tgz"
     },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "from": "lodash.flattendeep@>=4.4.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz"
+    },
     "lodash.get": {
       "version": "4.4.2",
       "from": "lodash.get@>=4.0.0 <5.0.0",
@@ -7136,6 +8043,11 @@
       "from": "lpad-align@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.0.tgz"
     },
+    "lru-cache": {
+      "version": "4.1.2",
+      "from": "lru-cache@>=4.0.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz"
+    },
     "lrucache": {
       "version": "0.2.0",
       "from": "lrucache@>=0.2.0 <0.3.0",
@@ -7193,6 +8105,11 @@
       "from": "media-typer@0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
     },
+    "mem": {
+      "version": "1.1.0",
+      "from": "mem@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz"
+    },
     "memory-fs": {
       "version": "0.3.0",
       "from": "memory-fs@>=0.3.0 <0.4.0",
@@ -7200,7 +8117,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "from": "meow@>=3.5.0 <4.0.0",
+      "from": "meow@3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "dependencies": {
         "object-assign": {
@@ -7227,7 +8144,7 @@
     },
     "mesosphere-react-typeahead": {
       "version": "0.8.3",
-      "from": "mesosphere-react-typeahead@latest",
+      "from": "mesosphere-react-typeahead@0.8.3",
       "resolved": "https://registry.npmjs.org/mesosphere-react-typeahead/-/mesosphere-react-typeahead-0.8.3.tgz",
       "dependencies": {
         "lodash": {
@@ -7249,7 +8166,7 @@
     },
     "methods": {
       "version": "1.1.2",
-      "from": "methods@>=1.1.1 <1.2.0",
+      "from": "methods@>=1.1.2 <1.2.0",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
     },
     "micromatch": {
@@ -7277,6 +8194,11 @@
       "from": "mime-types@>=2.1.7 <2.2.0",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz"
     },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "from": "mimic-fn@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz"
+    },
     "min-document": {
       "version": "2.18.0",
       "from": "min-document@>=2.6.1 <3.0.0",
@@ -7289,7 +8211,7 @@
     },
     "minimatch": {
       "version": "2.0.10",
-      "from": "minimatch@>=2.0.3 <3.0.0",
+      "from": "minimatch@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
     },
     "minimist": {
@@ -7297,9 +8219,14 @@
       "from": "minimist@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
     },
+    "minimist-options": {
+      "version": "3.0.2",
+      "from": "minimist-options@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz"
+    },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@>=0.5.1 <0.6.0",
+      "from": "mkdirp@^0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "dependencies": {
         "minimist": {
@@ -7308,6 +8235,11 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         }
       }
+    },
+    "modify-values": {
+      "version": "1.0.1",
+      "from": "modify-values@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz"
     },
     "moment": {
       "version": "2.21.0",
@@ -7404,6 +8336,28 @@
       "version": "1.0.0",
       "from": "ncname@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz"
+    },
+    "nearley": {
+      "version": "2.13.0",
+      "from": "nearley@>=2.7.10 <3.0.0",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.13.0.tgz",
+      "dependencies": {
+        "colors": {
+          "version": "0.5.1",
+          "from": "colors@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz"
+        },
+        "nomnom": {
+          "version": "1.6.2",
+          "from": "nomnom@>=1.6.2 <1.7.0",
+          "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz"
+        },
+        "underscore": {
+          "version": "1.4.4",
+          "from": "underscore@>=1.4.4 <1.5.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+        }
+      }
     },
     "negotiator": {
       "version": "0.5.3",
@@ -7582,7 +8536,7 @@
     },
     "normalize-package-data": {
       "version": "2.3.5",
-      "from": "normalize-package-data@>=2.3.4 <3.0.0",
+      "from": "normalize-package-data@>=2.3.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
     },
     "normalize-path": {
@@ -7612,6 +8566,11 @@
         }
       }
     },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "from": "npm-run-path@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz"
+    },
     "npmlog": {
       "version": "4.1.2",
       "from": "npmlog@>=4.0.2 <5.0.0",
@@ -7628,6 +8587,11 @@
       "version": "1.0.1",
       "from": "nth-check@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
+    },
+    "null-check": {
+      "version": "1.0.0",
+      "from": "null-check@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz"
     },
     "num2fraction": {
       "version": "1.2.2",
@@ -7646,7 +8610,7 @@
     },
     "oauth-sign": {
       "version": "0.8.2",
-      "from": "oauth-sign@>=0.8.1 <0.9.0",
+      "from": "oauth-sign@~0.8.1",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
     },
     "object-assign": {
@@ -7654,15 +8618,47 @@
       "from": "object-assign@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
     },
+    "object-inspect": {
+      "version": "1.5.0",
+      "from": "object-inspect@>=1.5.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.5.0.tgz"
+    },
+    "object-is": {
+      "version": "1.0.1",
+      "from": "object-is@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz"
+    },
     "object-keys": {
       "version": "1.0.11",
       "from": "object-keys@>=1.0.8 <2.0.0",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
     },
+    "object.assign": {
+      "version": "4.1.0",
+      "from": "object.assign@>=4.1.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "dependencies": {
+        "function-bind": {
+          "version": "1.1.1",
+          "from": "function-bind@^1.1.1",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
+        }
+      }
+    },
+    "object.entries": {
+      "version": "1.0.4",
+      "from": "object.entries@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz"
+    },
     "object.omit": {
       "version": "2.0.0",
       "from": "object.omit@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz"
+    },
+    "object.values": {
+      "version": "1.0.4",
+      "from": "object.values@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz"
     },
     "objektiv": {
       "version": "0.3.0",
@@ -7693,6 +8689,11 @@
       "version": "1.1.0",
       "from": "onetime@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+    },
+    "opener": {
+      "version": "1.4.3",
+      "from": "opener@>=1.4.0 <1.5.0",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz"
     },
     "optimist": {
       "version": "0.6.1",
@@ -7802,10 +8803,30 @@
         }
       }
     },
+    "p-finally": {
+      "version": "1.0.0",
+      "from": "p-finally@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz"
+    },
+    "p-limit": {
+      "version": "1.2.0",
+      "from": "p-limit@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz"
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "from": "p-locate@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz"
+    },
     "p-map": {
       "version": "1.2.0",
       "from": "p-map@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz"
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "from": "p-try@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz"
     },
     "pako": {
       "version": "0.2.9",
@@ -7821,6 +8842,11 @@
       "version": "5.0.0",
       "from": "parse-asn1@>=5.0.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz"
+    },
+    "parse-github-repo-url": {
+      "version": "1.4.1",
+      "from": "parse-github-repo-url@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz"
     },
     "parse-glob": {
       "version": "3.0.4",
@@ -7857,6 +8883,11 @@
       "from": "path-case@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz"
     },
+    "path-exists": {
+      "version": "3.0.0",
+      "from": "path-exists@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
+    },
     "path-is-absolute": {
       "version": "1.0.0",
       "from": "path-is-absolute@>=1.0.0 <2.0.0",
@@ -7866,6 +8897,11 @@
       "version": "1.0.2",
       "from": "path-is-inside@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "from": "path-key@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
     },
     "path-parse": {
       "version": "1.0.5",
@@ -8013,6 +9049,11 @@
       "from": "pngquant-bin@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/pngquant-bin/-/pngquant-bin-3.1.0.tgz"
     },
+    "portfinder": {
+      "version": "1.0.13",
+      "from": "portfinder@>=1.0.13 <2.0.0",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz"
+    },
     "pos": {
       "version": "0.4.2",
       "from": "pos@0.4.2",
@@ -8020,7 +9061,7 @@
     },
     "postcss": {
       "version": "5.0.21",
-      "from": "postcss@>=5.0.19 <6.0.0",
+      "from": "postcss@5.0.21",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.21.tgz",
       "dependencies": {
         "source-map": {
@@ -8338,7 +9379,7 @@
     },
     "progress": {
       "version": "1.1.8",
-      "from": "progress@>=1.1.8 <2.0.0",
+      "from": "progress@1.1.8",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
     },
     "promise": {
@@ -8388,6 +9429,11 @@
       "from": "prr@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "from": "pseudomap@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+    },
     "public-encrypt": {
       "version": "4.0.0",
       "from": "public-encrypt@>=4.0.0 <5.0.0",
@@ -8395,7 +9441,7 @@
     },
     "punycode": {
       "version": "1.4.1",
-      "from": "punycode@>=1.2.4 <2.0.0",
+      "from": "punycode@^1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
     },
     "purify-css": {
@@ -8462,6 +9508,28 @@
       "from": "querystringify@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.3.tgz"
     },
+    "quick-lru": {
+      "version": "1.1.0",
+      "from": "quick-lru@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz"
+    },
+    "raf": {
+      "version": "3.4.0",
+      "from": "raf@>=3.4.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
+      "dependencies": {
+        "performance-now": {
+          "version": "2.1.0",
+          "from": "performance-now@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz"
+        }
+      }
+    },
+    "railroad-diagrams": {
+      "version": "1.0.0",
+      "from": "railroad-diagrams@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz"
+    },
     "ramda": {
       "version": "0.24.1",
       "from": "ramda@0.24.1",
@@ -8505,6 +9573,11 @@
       "version": "0.1.10",
       "from": "raml-validator-loader@0.1.10",
       "resolved": "https://registry.npmjs.org/raml-validator-loader/-/raml-validator-loader-0.1.10.tgz"
+    },
+    "randexp": {
+      "version": "0.4.6",
+      "from": "randexp@0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz"
     },
     "random-bytes": {
       "version": "1.0.0",
@@ -8791,7 +9864,7 @@
     },
     "rechoir": {
       "version": "0.6.2",
-      "from": "rechoir@>=0.6.0 <0.7.0",
+      "from": "rechoir@>=0.6.2 <0.7.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
     },
     "redbox-react": {
@@ -8997,7 +10070,7 @@
     },
     "resolve": {
       "version": "1.1.7",
-      "from": "resolve@>=1.1.6 <2.0.0",
+      "from": "resolve@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
     },
     "resolve-from": {
@@ -9019,6 +10092,11 @@
       "version": "1.0.1",
       "from": "restore-cursor@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
+    },
+    "ret": {
+      "version": "0.1.15",
+      "from": "ret@>=0.1.10 <0.2.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz"
     },
     "rework": {
       "version": "1.0.1",
@@ -9059,6 +10137,11 @@
       "from": "rndm@1.2.0",
       "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz"
     },
+    "rst-selector-parser": {
+      "version": "2.2.3",
+      "from": "rst-selector-parser@>=2.2.3 <3.0.0",
+      "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz"
+    },
     "run-async": {
       "version": "0.1.0",
       "from": "run-async@>=0.1.0 <0.2.0",
@@ -9098,7 +10181,7 @@
     },
     "sax": {
       "version": "1.2.1",
-      "from": "sax@>=1.2.1 <1.3.0",
+      "from": "sax@>=1.1.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
     },
     "scmp": {
@@ -9189,7 +10272,7 @@
     },
     "set-immediate-shim": {
       "version": "1.0.1",
-      "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+      "from": "set-immediate-shim@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
     },
     "setimmediate": {
@@ -9201,6 +10284,16 @@
       "version": "2.4.5",
       "from": "sha.js@>=2.3.6 <3.0.0",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz"
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "from": "shebang-command@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz"
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "from": "shebang-regex@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
     },
     "shelljs": {
       "version": "0.7.7",
@@ -9387,7 +10480,7 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "from": "assert-plus@^1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
@@ -9401,6 +10494,117 @@
       "version": "0.3.1",
       "from": "stackframe@>=0.3.1 <0.4.0",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz"
+    },
+    "standard-version": {
+      "version": "4.3.0",
+      "from": "standard-version@latest",
+      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-4.3.0.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "from": "ansi-regex@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "from": "camelcase@^4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "from": "chalk@>=1.1.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "from": "cliui@>=3.2.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "from": "string-width@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+            }
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "from": "find-up@^2.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz"
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "from": "load-json-file@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz"
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "from": "os-locale@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz"
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "from": "path-type@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz"
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "from": "read-pkg@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz"
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "from": "read-pkg-up@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz"
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "from": "set-blocking@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "from": "string-width@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "from": "strip-ansi@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+            }
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "from": "strip-bom@^3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "from": "which-module@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz"
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "from": "yargs@>=8.0.1 <9.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz"
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "from": "yargs-parser@>=7.0.0 <8.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz"
+        }
+      }
     },
     "stat-mode": {
       "version": "0.2.1",
@@ -9542,7 +10746,7 @@
     },
     "stringstream": {
       "version": "0.0.5",
-      "from": "stringstream@>=0.0.4 <0.1.0",
+      "from": "stringstream@~0.0.4",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
     },
     "strip-ansi": {
@@ -9564,6 +10768,11 @@
       "version": "1.1.1",
       "from": "strip-dirs@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz"
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "from": "strip-eof@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz"
     },
     "strip-indent": {
       "version": "1.0.1",
@@ -9854,7 +11063,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.3.4 <2.4.0",
+      "from": "through@>=2.2.7 <3.0.0",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
@@ -10082,7 +11291,7 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "from": "typedarray@>=0.0.5 <0.1.0",
+      "from": "typedarray@>=0.0.6 <0.0.7",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "typescript": {
@@ -10136,6 +11345,18 @@
       "version": "1.8.3",
       "from": "underscore@>=1.8.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
+    },
+    "union": {
+      "version": "0.4.6",
+      "from": "union@>=0.4.3 <0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.4.6.tgz",
+      "dependencies": {
+        "qs": {
+          "version": "2.3.3",
+          "from": "qs@>=2.3.3 <2.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+        }
+      }
     },
     "uniq": {
       "version": "1.0.1",
@@ -10194,7 +11415,7 @@
     },
     "url": {
       "version": "0.11.0",
-      "from": "url@>=0.11.0 <0.12.0",
+      "from": "url@0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "dependencies": {
         "punycode": {
@@ -10203,6 +11424,11 @@
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
         }
       }
+    },
+    "url-join": {
+      "version": "2.0.5",
+      "from": "url-join@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz"
     },
     "url-parse": {
       "version": "1.1.1",
@@ -10669,6 +11895,11 @@
       "from": "xmlbuilder@>=4.1.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz"
     },
+    "xmldoc": {
+      "version": "1.1.0",
+      "from": "xmldoc@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-1.1.0.tgz"
+    },
     "xmldom": {
       "version": "0.1.22",
       "from": "xmldom@0.1.22",
@@ -10696,13 +11927,18 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <5.0.0",
+      "from": "xtend@>=4.0.1 <4.1.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "y18n": {
       "version": "3.2.1",
       "from": "y18n@>=3.2.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "from": "yallist@>=2.1.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
     },
     "yaml-ast-parser": {
       "version": "0.0.31",

--- a/package.json
+++ b/package.json
@@ -110,12 +110,14 @@
     "gulp-connect": "3.2.2",
     "html-loader": "0.4.3",
     "html-webpack-plugin": "2.16.0",
+    "http-server": "github:johntron/http-server#proxy-secure-flag",
     "image-webpack-loader": "1.7.0",
     "jasmine-reporters": "2.1.1",
     "jest-cli": "16.0.2",
     "jest-webpack-alias": "3.3.0",
     "jison-loader": "1.0.0",
     "json-loader": "0.5.4",
+    "junit-merge": "1.3.0",
     "less": "2.6.1",
     "less-loader": "2.2.3",
     "license-checker": "5.1.2",
@@ -168,7 +170,8 @@
     "test:watch": "npm test -- --watch",
     "testing": "NODE_ENV=testing webpack-dev-server --config ./webpack/webpack.dev.babel.js --progress --colors --content-base ./build --host 0.0.0.0 --port $npm_package_config_port",
     "validate-build": "scripts/validate-build dist/*.js",
-    "release": "standard-version --tag-prefix \"$(python -c \"import sys, json; dcosrc = json.load(open('.dcosrc')); sys.stdout.write(str(dcosrc['base']));\")+v\""
+    "release": "standard-version --tag-prefix \"$(python -c \"import sys, json; dcosrc = json.load(open('.dcosrc')); sys.stdout.write(str(dcosrc['base']));\")+v\"",
+    "integration-tests": "PLUGINS_PATH=\"${npm_config_externalplugins}\" ./scripts/run-integration-tests"
   },
   "jest-webpack-alias": {
     "configFile": "./webpack/webpack.test.js"

--- a/scripts/run-integration-tests
+++ b/scripts/run-integration-tests
@@ -1,0 +1,202 @@
+#!/bin/bash
+
+set -e
+[ -n "${DEBUG}" ] && set -x
+
+# This script is a temporary solution to run the integration tests in a <= 1.GB
+# memory environment and with support for retries per test file. We should
+# replace it with a test runner in the future, please see it more as a proof of
+# concept
+
+## Configuration
+#####################################################################
+
+# Search string passed to `find`
+# Values: String
+SEARCH=${1:-'*'}
+
+# Maximum number of retries
+# Values: n ∈ ℕ
+RETRIES=${RETRIES:-3}
+
+# Stop if file failed $RETRIES times? (turn this off, if you want
+# to test all tests locally but something keeps failing)
+# Values: 0, 1
+STOP_ON_FAIL=${STOP_ON_FAIL:-1}
+
+# Suppresses Cypress output on failures
+# Values: 0, 1
+SUPPRESS_OUTPUT=${SUPPRESS_OUTPUT:-0}
+
+CLEANUP_TESTS=${CLEANUP_TESTS:-0}
+
+PROXY_PORT=${PROXY_PORT:-4200}
+PROXY_PID=0
+
+PROJECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+CYPRESS_FOLDER="cypress"
+TESTS_FOLDER="tests"
+
+PLUGINS_PATH=${PLUGINS_PATH:-''}
+
+
+
+## Functions
+#####################################################################
+
+# executes Cypress
+#
+# from callee:
+# FILE: file to test
+# OUTPUT_PATH: Directory where results are saved (e.g. "some/path/to/Testfile-cy.js-1")
+function executeCypress {
+  npm run --silent cypress -- \
+    --spec "${FILE}" \
+    --config "screenshotsFolder=${OUTPUT_PATH}/screenshots,videosFolder=${OUTPUT_PATH}/videos" \
+    --reporter junit \
+    --reporter-options "mochaFile=${OUTPUT_PATH}/result.xml"
+}
+
+# runs tests for matched file
+#
+# From callee:
+# RELATIVE_PATH: stripped down output from find command (e.g. "pages/Testfile-cy.js")
+function runTestFile {
+  echo ""
+  echo "==> Running Tests for ./${TESTS_FOLDER}/$RELATIVE_PATH"
+  local RUN=0
+  local EXIT_CODE=1
+  while [ $EXIT_CODE -ne 0 ] && [ $RUN -lt $RETRIES ]; do
+    RUN=$((RUN+1))
+    local OUTPUT_PATH="${PROJECT_ROOT}/${CYPRESS_FOLDER}/${RELATIVE_PATH}-${RUN}"
+
+    echo "===> Executing Cypress (${RUN}/${RETRIES})"
+    CYOUT="$(FILE="${PROJECT_ROOT}/tests/${RELATIVE_PATH}" RUN=${RUN} OUTPUT_PATH=${OUTPUT_PATH} executeCypress)"
+    EXIT_CODE=$?
+
+    if [ $EXIT_CODE -eq 0 ]; then
+      echo "====> Successfully finished tests for ${RELATIVE_PATH}"
+    else
+      echo "====> Failures in tests for ${RELATIVE_PATH}"
+      [ $SUPPRESS_OUTPUT -eq 0 ] && echo "${CYOUT}"
+    fi
+  done
+
+  if [ $EXIT_CODE -ne 0 ]; then
+    echo "===> Couldn't get a success in $RETRIES retries for $RELATIVE_PATH"
+  fi
+
+  if [ ${EXIT_CODE} -ne 0 ] && [ ${STOP_ON_FAIL} -eq 0 ]; then
+    echo "==> Continuing despite failures…"
+    return 0
+  fi
+
+  return $EXIT_CODE
+}
+
+# copies tests from plugins folder into project
+# this is necessary because Cypress doesnt allows external files to be tested…
+function setup_plugins {
+  if [ -n "${PLUGINS_PATH}" ]; then
+    echo "==> Setup external plugins…"
+    rsync -aH ${PROJECT_ROOT}/${PLUGINS_PATH}/${TESTS_FOLDER}/ ${PROJECT_ROOT}/${TESTS_FOLDER}/
+    echo "===> done."
+  else
+    echo "==> No Plugins configured."
+  fi
+}
+
+# removes copied plugins files…
+function teardown_plugins {
+  if [ -n "${PLUGINS_PATH}" ]; then
+    if [ ${CLEANUP_TESTS} -eq 0 ]; then
+      echo ""
+      echo "==> !!! PLUGINS TESTS ARE STILL IN YOUR ./${TESTS_FOLDER} FOLDER, MAKE SURE TO CLEAN UP !!!"
+      echo "==> You can use 'rm -r ./${TESTS_FOLDER} && git checkout ./${TESTS_FOLDER}' to easily clean up."
+      echo "==> Or you can provide CLEANUP_TESTS=1 to this script in order to automatically clean up."
+      echo ""
+    else
+      echo "==> Cleaning up ./${TESTS_FOLDER} folder"
+      rm -r ${PROJECT_ROOT}/${TESTS_FOLDER}
+      git checkout ${PROJECT_ROOT}/${TESTS_FOLDER}
+      echo "==> done."
+    fi
+  fi
+}
+
+# merges results from cypress runs into one file
+function teardown_merge {
+  if [ "$(find ${PROJECT_ROOT}/${CYPRESS_FOLDER}/ -type f -name result.xml | wc -l)" -ne 0 ]; then
+    echo "==> Merging results from ./${CYPRESS_FOLDER}/*/result.xml into ./${CYPRESS_FOLDER}/results.xml…"
+    junit-merge --out ${PROJECT_ROOT}/${CYPRESS_FOLDER}/results.xml $(find ${PROJECT_ROOT}/${CYPRESS_FOLDER}/ -type f -name result.xml)
+    echo "===> done."
+  else
+    echo "==> Nothing to merge."
+  fi
+}
+
+function teardown_proxy {
+  echo "==> Killing Proxy…"
+  kill $PROXY_PID
+  echo "===> done."
+}
+
+# sets up everything
+function setup {
+  echo ""
+  echo "=> Setup"
+
+  ## Setup proxy
+  if [ -n "$(lsof -i :${PROXY_PORT})" ]; then
+    echo "==> ERROR: Port ${PROXY_PORT} is already in use"
+    exit 1
+  fi
+  if [ ! -d ${PROJECT_ROOT}/dist ]; then
+    echo "==> ERROR: no dist folder! forgot npm run build?"
+    exit 1
+  fi
+  echo "==> Starting http-server, serving files from ./dist…"
+  http-server -sp ${PROXY_PORT} ${PROJECT_ROOT}/dist&
+  PROXY_PID=$!
+  echo "===> done (PID: ${PROXY_PID})."
+
+  ## Setup plugins if configured
+  if [ -n "${PLUGINS_PATH}" ]; then
+    setup_plugins
+  fi
+
+  ## Remove old results
+  if [ -d "${PROJECT_ROOT}/${CYPRESS_FOLDER}" ]; then
+    echo "==> Directory ./${CYPRESS_FOLDER} already exists…"
+    rm -r "${PROJECT_ROOT}/${CYPRESS_FOLDER}"
+    echo "===> removed."
+  fi
+}
+
+# tears down everything…
+function teardown {
+  echo ""
+  echo "=> Teardown"
+  teardown_proxy
+  teardown_plugins
+  teardown_merge
+  echo "=> Bye."
+}
+
+# finds the files and runs the tests
+function run_tests {
+  echo ""
+  echo "=> Running Tests"
+  find "$PROJECT_ROOT/${TESTS_FOLDER}" -type f -name "${SEARCH}-cy.js" -print | \
+    while read FOUND_FILE
+    do
+      RELATIVE_PATH="$(echo ${FOUND_FILE} | sed s+${PROJECT_ROOT}/${TESTS_FOLDER}/++)" runTestFile || exit 1
+    done
+}
+
+## Programm
+#####################################################################
+
+setup
+trap teardown EXIT
+run_tests


### PR DESCRIPTION
this should help us to investigate and identify flaky tests on 1.11 🙇 