### PR TITLE
↩️ fix(MesosStateStore): adjust stream event sampling

### DIFF
--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -98,13 +98,14 @@ class MesosStateStore extends GetSetBaseStore {
     // Since we introduced the fake event above, we have to guarantee certain
     // refresh limits to the UI. They are:
     //
-    // MOST once every (Config.getRefreshRate() * 0.5) ms. due to debounceTime.
-    // LEAST once every tick of Config.getRefreshRate() ms in Observable.interval
+    // MOST once every (Config.getRefreshRate() * 0.5) ms. due to sampleTime.
+    // LEAST once every tick of Config.getRefreshRate() ms in
+    // Observable.interval
     //
     // TODO: https://jira.mesosphere.com/browse/DCOS-18277
     this.stream = waitStream
       .concat(eventTriggerStream)
-      .debounceTime(Config.getRefreshRate() * 0.5)
+      .sampleTime(Config.getRefreshRate() * 0.5)
       .retryWhen(linearBackoff(MAX_RETRIES, RETRY_DELAY))
       .subscribe(this.onStreamData, this.onStreamError);
   }


### PR DESCRIPTION
---
↩️  _This PR back-ports a fix to release/1.11 introduced with #2890._

---

Use `sampleTime` instead of `debounceTime` to reduce the frequency of events.
Debounce emits values from the source Observable only after a particular time span has passed *without* another source emission – which in case the source update frequency is higher than the `dueTime` would mean that we don't receive any updates. The `sampleTime` operator emits the last emitted value from the source Observable within time intervals.

Closes DCOS_OSS-2386
