### PR TITLE
↩️ fix(MesosStateStore): adjust stream data handling

### DIFF
--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -106,7 +106,10 @@ class MesosStateStore extends GetSetBaseStore {
       .concat(eventTriggerStream)
       .debounceTime(Config.getRefreshRate() * 0.5)
       .retryWhen(linearBackoff(MAX_RETRIES, RETRY_DELAY))
-      .subscribe(this.onStreamData, this.onStreamError);
+      .subscribe(
+        () => Promise.resolve().then(this.onStreamData),
+        this.onStreamError
+      );
   }
 
   getLastMesosState() {


### PR DESCRIPTION
---
↩️  _This PR back-ports a fix to release/1.11 introduced with #2888._

---

Use `Promise.resolve().then()` to schedule a micro tasks and asynchronously  trigger `onStreamData` which is used to emit the `MESOS_STATE_CHANGE`. This change will mitigate issues in which errors in view components lead to stale data as the error propergation broke the stream.

N.B. `EventEmitter` is synchronous meaning that every delay in an event handler effects the `emit` execution time and errors propagate up to the `emit` call which sometimes leads to undesireable behavior.

Closes DCOS-22189