### PR TITLE
fix(package): fix compression version

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "clean": "rm -rf dist",
     "shrinkwrap": "npm shrinkwrap --dev && ./node_modules/.bin/gulp fixShrinkwrap",
     "preinstall": "./scripts/pre-install",
-    "prebuild-assets": "./node_modules/.bin/gulp checkDependencies && npm install compression-webpack-plugin@latest",
+    "prebuild-assets": "./node_modules/.bin/gulp checkDependencies && npm install compression-webpack-plugin@0.4.0",
     "build-assets": "npm run clean && NODE_ENV=production webpack --config ./webpack/webpack.production.babel.js",
     "postbuild-assets": "rm -rf node_modules/compression-webpack-plugin",
     "build": "npm run lint && npm test && npm run build-assets && npm run validate-build",


### PR DESCRIPTION
The latest version of compression-webpack-plugin doesn't support webpack 1.x

I have specified the last version that supports webpack 1.x

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
