### PR TITLE
DCOS-22393: prevent concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ pipeline {
 
   options {
     timeout(time: 2, unit: "HOURS")
+    disableConcurrentBuilds()
   }
 
   stages {


### PR DESCRIPTION
After merging #2931 we're spamming jenkins with master builds 😅 
This should stop it.