### PR TITLE
DCOS-22414: do not wait for ee pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,7 +114,7 @@ pipeline {
         }
       }
       steps {
-        build job: "frontend/dcos-ui-ee-pipeline/" + env.BRANCH_NAME.replaceAll("/", "%2F")
+        build job: "frontend/dcos-ui-ee-pipeline/" + env.BRANCH_NAME.replaceAll("/", "%2F"), wait: false
       }
     }
   }


### PR DESCRIPTION
waiting for EE Pipeline occupies the executer for quote some time, we dont really need the feedback on OSS Pipeline, so there's no reason to wait…

<!--- Thank you for your contribution! Please provide enough information for others to best review your code. -->

<!-- Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it. -->

<!-- Description of motivation for making this change, what does it solve and steps needed to see change. -->

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
