### PR TITLE
DCOS-22443: guard host.framework_ids before accessing it

### DIFF
--- a/src/js/utils/MesosSummaryUtil.js
+++ b/src/js/utils/MesosSummaryUtil.js
@@ -47,8 +47,8 @@ const MesosSummaryUtil = {
   },
 
   filterHostsByService(hosts, frameworkId) {
-    return hosts.filter(function(host) {
-      return host.framework_ids.includes(frameworkId);
+    return hosts.filter(function({ framework_ids = [] }) {
+      return framework_ids.includes(frameworkId);
     });
   },
 


### PR DESCRIPTION
This should fix our NodePage flaky test… There was a Stacktrace all the time btw :(
https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/frontend%2Fdcos-ui-oss-pipeline/detail/PR-2930/5/tests/