### PR TITLE
Fix configuration ui for frameworks that are not cosmos apps (master) (do not merge)

### DIFF
--- a/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
+++ b/plugins/services/src/js/structs/__tests__/ServiceTree-test.js
@@ -24,7 +24,9 @@ describe("ServiceTree", function() {
           {
             id: "/group/beta",
             labels: {
-              DCOS_PACKAGE_FRAMEWORK_NAME: "beta"
+              DCOS_PACKAGE_FRAMEWORK_NAME: "beta",
+              DCOS_PACKAGE_NAME: "beta",
+              DCOS_PACKAGE_VERSION: "beta"
             }
           },
           {
@@ -126,7 +128,9 @@ describe("ServiceTree", function() {
           {
             id: "/group/beta",
             labels: {
-              DCOS_PACKAGE_FRAMEWORK_NAME: "beta"
+              DCOS_PACKAGE_FRAMEWORK_NAME: "beta",
+              DCOS_PACKAGE_NAME: "beta",
+              DCOS_PACKAGE_VERSION: "beta"
             }
           },
           {

--- a/plugins/services/src/js/utils/ServiceValidatorUtil.js
+++ b/plugins/services/src/js/utils/ServiceValidatorUtil.js
@@ -72,7 +72,7 @@ const ServiceValidatorUtil = {
     // Check the DCOS_PACKAGE_FRAMEWORK_NAME label to determine if the item
     // should be converted to an Application or Framework instance.
     // It is possible to DCOS_PACKAGE_FRAMEWORK_NAME without being a Cosmos package,
-    // for example, with Marathon-on-Marathon EE, which is intentionally 
+    // for example, with Marathon-on-Marathon EE, which is intentionally
     // not available as a Cosmos package.
     return (
       ServiceValidatorUtil.isApplicationResponse(data) &&

--- a/plugins/services/src/js/utils/ServiceValidatorUtil.js
+++ b/plugins/services/src/js/utils/ServiceValidatorUtil.js
@@ -71,6 +71,9 @@ const ServiceValidatorUtil = {
   isFrameworkResponse(data) {
     // Check the DCOS_PACKAGE_FRAMEWORK_NAME label to determine if the item
     // should be converted to an Application or Framework instance.
+    // It is possible to DCOS_PACKAGE_FRAMEWORK_NAME without being a Cosmos package,
+    // for example, with Marathon-on-Marathon EE, which is intentionally 
+    // not available as a Cosmos package.
     return (
       ServiceValidatorUtil.isApplicationResponse(data) &&
       data.labels &&

--- a/plugins/services/src/js/utils/ServiceValidatorUtil.js
+++ b/plugins/services/src/js/utils/ServiceValidatorUtil.js
@@ -74,7 +74,9 @@ const ServiceValidatorUtil = {
     return (
       ServiceValidatorUtil.isApplicationResponse(data) &&
       data.labels &&
-      data.labels.DCOS_PACKAGE_FRAMEWORK_NAME
+      data.labels.DCOS_PACKAGE_NAME &&
+      data.labels.DCOS_PACKAGE_FRAMEWORK_NAME &&
+      data.labels.DCOS_PACKAGE_VERSION
     );
   },
 

--- a/plugins/services/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceUtil-test.js
@@ -28,11 +28,29 @@ describe("ServiceUtil", function() {
         disk: null,
         instances: null,
         labels: {
-          DCOS_PACKAGE_FRAMEWORK_NAME: "Test Framework"
+          DCOS_PACKAGE_NAME: "Test Framework",
+          DCOS_PACKAGE_FRAMEWORK_NAME: "Test Framework",
+          DCOS_PACKAGE_VERSION: "1.0.0"
         }
       });
 
       expect(instance instanceof Framework).toBeTruthy();
+    });
+
+    it("creates Application with Framework label instances", function() {
+      const instance = ServiceUtil.createServiceFromResponse({
+        id: "/test",
+        cmd: "sleep 1000;",
+        cpus: null,
+        mem: null,
+        disk: null,
+        instances: null,
+        labels: {
+          DCOS_PACKAGE_FRAMEWORK_NAME: "Test Framework"
+        }
+      });
+
+      expect(instance instanceof Application).toBeTruthy();
     });
 
     it("creates Pod instances", function() {

--- a/plugins/services/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceUtil-test.js
@@ -46,7 +46,7 @@ describe("ServiceUtil", function() {
         disk: null,
         instances: null,
         labels: {
-          DCOS_PACKAGE_FRAMEWORK_NAME: "Test Framework"
+          DCOS_PACKAGE_FRAMEWORK_NAME: "FrameworkNotCosmos"
         }
       });
 

--- a/src/js/stores/__tests__/DCOSStore-test.js
+++ b/src/js/stores/__tests__/DCOSStore-test.js
@@ -208,7 +208,7 @@ describe("DCOSStore", function() {
               labels: {
                 DCOS_PACKAGE_NAME: "alpha",
                 DCOS_PACKAGE_FRAMEWORK_NAME: "alpha",
-                DCOS_PACKAGE_VERSION: "v1",
+                DCOS_PACKAGE_VERSION: "v1"
               }
             }
           ]
@@ -229,7 +229,7 @@ describe("DCOSStore", function() {
               labels: {
                 DCOS_PACKAGE_NAME: "alpha",
                 DCOS_PACKAGE_FRAMEWORK_NAME: "alpha",
-                DCOS_PACKAGE_VERSION: "v1",
+                DCOS_PACKAGE_VERSION: "v1"
               }
             }
           ]
@@ -245,7 +245,7 @@ describe("DCOSStore", function() {
               labels: {
                 DCOS_PACKAGE_NAME: "beta",
                 DCOS_PACKAGE_FRAMEWORK_NAME: "beta",
-                DCOS_PACKAGE_VERSION: "v1",
+                DCOS_PACKAGE_VERSION: "v1"
               }
             }
           ]
@@ -265,7 +265,7 @@ describe("DCOSStore", function() {
               labels: {
                 DCOS_PACKAGE_NAME: "alpha",
                 DCOS_PACKAGE_FRAMEWORK_NAME: "alpha",
-                DCOS_PACKAGE_VERSION: "v1",
+                DCOS_PACKAGE_VERSION: "v1"
               }
             }
           ]
@@ -287,7 +287,7 @@ describe("DCOSStore", function() {
               labels: {
                 DCOS_PACKAGE_NAME: "beta",
                 DCOS_PACKAGE_FRAMEWORK_NAME: "beta",
-                DCOS_PACKAGE_VERSION: "v1",
+                DCOS_PACKAGE_VERSION: "v1"
               }
             }
           ]
@@ -308,7 +308,7 @@ describe("DCOSStore", function() {
               labels: {
                 DCOS_PACKAGE_NAME: "alpha",
                 DCOS_PACKAGE_FRAMEWORK_NAME: "alpha",
-                DCOS_PACKAGE_VERSION: "v1",
+                DCOS_PACKAGE_VERSION: "v1"
               }
             }
           ]
@@ -523,7 +523,7 @@ describe("DCOSStore", function() {
               labels: {
                 DCOS_PACKAGE_NAME: "alpha",
                 DCOS_PACKAGE_FRAMEWORK_NAME: "alpha",
-                DCOS_PACKAGE_VERSION: "v1",
+                DCOS_PACKAGE_VERSION: "v1"
               }
             }
           ]

--- a/src/js/stores/__tests__/DCOSStore-test.js
+++ b/src/js/stores/__tests__/DCOSStore-test.js
@@ -205,7 +205,11 @@ describe("DCOSStore", function() {
           items: [
             {
               id: "/alpha",
-              labels: { DCOS_PACKAGE_FRAMEWORK_NAME: "alpha" }
+              labels: {
+                DCOS_PACKAGE_NAME: "alpha",
+                DCOS_PACKAGE_FRAMEWORK_NAME: "alpha",
+                DCOS_PACKAGE_VERSION: "v1",
+              }
             }
           ]
         })
@@ -222,7 +226,11 @@ describe("DCOSStore", function() {
           items: [
             {
               id: "/alpha",
-              labels: { DCOS_PACKAGE_FRAMEWORK_NAME: "alpha" }
+              labels: {
+                DCOS_PACKAGE_NAME: "alpha",
+                DCOS_PACKAGE_FRAMEWORK_NAME: "alpha",
+                DCOS_PACKAGE_VERSION: "v1",
+              }
             }
           ]
         })
@@ -234,7 +242,11 @@ describe("DCOSStore", function() {
           items: [
             {
               id: "/beta",
-              labels: { DCOS_PACKAGE_FRAMEWORK_NAME: "beta" }
+              labels: {
+                DCOS_PACKAGE_NAME: "beta",
+                DCOS_PACKAGE_FRAMEWORK_NAME: "beta",
+                DCOS_PACKAGE_VERSION: "v1",
+              }
             }
           ]
         })
@@ -250,7 +262,11 @@ describe("DCOSStore", function() {
           items: [
             {
               id: "/alpha",
-              labels: { DCOS_PACKAGE_FRAMEWORK_NAME: "alpha" }
+              labels: {
+                DCOS_PACKAGE_NAME: "alpha",
+                DCOS_PACKAGE_FRAMEWORK_NAME: "alpha",
+                DCOS_PACKAGE_VERSION: "v1",
+              }
             }
           ]
         })
@@ -268,7 +284,11 @@ describe("DCOSStore", function() {
           items: [
             {
               id: "/beta",
-              labels: { DCOS_PACKAGE_FRAMEWORK_NAME: "beta" }
+              labels: {
+                DCOS_PACKAGE_NAME: "beta",
+                DCOS_PACKAGE_FRAMEWORK_NAME: "beta",
+                DCOS_PACKAGE_VERSION: "v1",
+              }
             }
           ]
         })
@@ -285,7 +305,11 @@ describe("DCOSStore", function() {
           items: [
             {
               id: "/alpha",
-              labels: { DCOS_PACKAGE_FRAMEWORK_NAME: "alpha" }
+              labels: {
+                DCOS_PACKAGE_NAME: "alpha",
+                DCOS_PACKAGE_FRAMEWORK_NAME: "alpha",
+                DCOS_PACKAGE_VERSION: "v1",
+              }
             }
           ]
         })
@@ -496,7 +520,11 @@ describe("DCOSStore", function() {
           items: [
             {
               id: "/alpha",
-              labels: { DCOS_PACKAGE_FRAMEWORK_NAME: "alpha" }
+              labels: {
+                DCOS_PACKAGE_NAME: "alpha",
+                DCOS_PACKAGE_FRAMEWORK_NAME: "alpha",
+                DCOS_PACKAGE_VERSION: "v1",
+              }
             }
           ]
         })

--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -195,7 +195,11 @@ describe("MesosStateStore", function() {
       var tasks = MesosStateStore.getTasksByService(
         new Framework({
           id: "/spark",
-          labels: { DCOS_PACKAGE_FRAMEWORK_NAME: "spark" }
+          labels: {
+            DCOS_PACKAGE_NAME: "spark",
+            DCOS_PACKAGE_FRAMEWORK_NAME: "spark",
+            DCOS_PACKAGE_VERSION: "v1"
+          }
         })
       );
       expect(tasks).toEqual([
@@ -257,7 +261,11 @@ describe("MesosStateStore", function() {
       var tasks = MesosStateStore.getTasksByService(
         new Framework({
           id: "/spark",
-          labels: { DCOS_PACKAGE_FRAMEWORK_NAME: "spark" }
+          labels: {
+            DCOS_PACKAGE_NAME: "spark",
+            DCOS_PACKAGE_FRAMEWORK_NAME: "spark",
+            DCOS_PACKAGE_VERSION: "v1"
+          }
         })
       );
       expect(tasks).toEqual([]);
@@ -269,7 +277,9 @@ describe("MesosStateStore", function() {
           id: "/spark",
           labels: {
             DCOS_COMMONS_API_VERSION: 1,
-            DCOS_PACKAGE_FRAMEWORK_NAME: "spark"
+            DCOS_PACKAGE_NAME: "spark",
+            DCOS_PACKAGE_FRAMEWORK_NAME: "spark",
+            DCOS_PACKAGE_VERSION: "v1"
           }
         })
       );

--- a/src/js/utils/__tests__/MesosStateUtil-test.js
+++ b/src/js/utils/__tests__/MesosStateUtil-test.js
@@ -13,10 +13,11 @@ describe("MesosStateUtil", function() {
       const frameworks = [{ name: "foo", id: "foo_1" }];
       const fooFramework = new Framework({
         name: "foo",
-        labels: { 
+        labels: {
           DCOS_PACKAGE_FRAMEWORK_NAME: "foo",
           DCOS_PACKAGE_NAME: "foo",
-          DCOS_PACKAGE_NAME: "v1" }
+          DCOS_PACKAGE_VERSION: "v1"
+        }
       });
       const serviceTree = new ServiceTree({ items: [fooFramework] });
 

--- a/src/js/utils/__tests__/MesosStateUtil-test.js
+++ b/src/js/utils/__tests__/MesosStateUtil-test.js
@@ -13,7 +13,10 @@ describe("MesosStateUtil", function() {
       const frameworks = [{ name: "foo", id: "foo_1" }];
       const fooFramework = new Framework({
         name: "foo",
-        labels: { DCOS_PACKAGE_FRAMEWORK_NAME: "foo" }
+        labels: { 
+          DCOS_PACKAGE_FRAMEWORK_NAME: "foo",
+          DCOS_PACKAGE_NAME: "foo",
+          DCOS_PACKAGE_NAME: "v1" }
       });
       const serviceTree = new ServiceTree({ items: [fooFramework] });
 

--- a/tests/_fixtures/marathon-1-task/deleting/app.json
+++ b/tests/_fixtures/marathon-1-task/deleting/app.json
@@ -43,6 +43,7 @@
       "labels": {
         "DCOS_COMMONS_API_VERSION": "v1",
         "DCOS_PACKAGE_NAME": "test",
+        "DCOS_PACKAGE_VERSION": "v1",
         "DCOS_PACKAGE_FRAMEWORK_NAME": "/sdk-sleep"
       },
       "acceptedResourceRoles": null,

--- a/tests/_fixtures/marathon-1-task/deleting/groups.json
+++ b/tests/_fixtures/marathon-1-task/deleting/groups.json
@@ -43,6 +43,7 @@
       "labels": {
         "DCOS_COMMONS_API_VERSION": "v1",
         "DCOS_PACKAGE_NAME": "test",
+        "DCOS_PACKAGE_VERSION": "v1",
         "DCOS_PACKAGE_FRAMEWORK_NAME": "/sdk-sleep"
       },
       "acceptedResourceRoles": null,

--- a/tests/_fixtures/marathon-1-task/groups-sdk-services.json
+++ b/tests/_fixtures/marathon-1-task/groups-sdk-services.json
@@ -58,6 +58,7 @@
           "labels": {
             "DCOS_COMMONS_API_VERSION": "v1",
             "DCOS_PACKAGE_NAME": "test",
+            "DCOS_PACKAGE_VERSION": "v1",
             "DCOS_PACKAGE_FRAMEWORK_NAME": "/services/sdk-sleep"
           },
           "acceptedResourceRoles": null,


### PR DESCRIPTION
See [COPS-3203](https://jira.mesosphere.com/browse/COPS-3203)

If you have a Marathon app that is a framework (has `DCOS_PACKAGE_FRAMEWORK_NAME` to pick up child tasks) but is not a Cosmos app (doesn't have all other accompanying `DCOS_PACKAGE_X` labels), if you go to the DC/OS UI and try to view/edit configuration, you'll start getting 500s.

This PR makes the detection of a Cosmos app more explicit; rather than just checking for DCOS_PACKAGE_FRAMEWORK_NAME, it also checks for `DCOS_PACKAGE_NAME` and `DCOS_PACKAGE_VERSION`

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [?] Did you add new unit tests?
- [?] Did you add new integration tests?
- [x] If this is a regression, did you write a test to catch this in the future?

Modified existing test, added a new test.  Not sure if it's an integration or unit test, but it's similar format to the existing tests and should help with this in the future.