### PR TITLE
Fix configuration ui for frameworks that are not cosmos apps (1.11) (do not merge)

### DIFF
--- a/plugins/services/src/js/utils/ServiceValidatorUtil.js
+++ b/plugins/services/src/js/utils/ServiceValidatorUtil.js
@@ -72,7 +72,7 @@ const ServiceValidatorUtil = {
     // Check the DCOS_PACKAGE_FRAMEWORK_NAME label to determine if the item
     // should be converted to an Application or Framework instance.
     // It is possible to DCOS_PACKAGE_FRAMEWORK_NAME without being a Cosmos package,
-    // for example, with Marathon-on-Marathon EE, which is intentionally 
+    // for example, with Marathon-on-Marathon EE, which is intentionally
     // not available as a Cosmos package.
     return (
       ServiceValidatorUtil.isApplicationResponse(data) &&

--- a/plugins/services/src/js/utils/ServiceValidatorUtil.js
+++ b/plugins/services/src/js/utils/ServiceValidatorUtil.js
@@ -71,6 +71,9 @@ const ServiceValidatorUtil = {
   isFrameworkResponse(data) {
     // Check the DCOS_PACKAGE_FRAMEWORK_NAME label to determine if the item
     // should be converted to an Application or Framework instance.
+    // It is possible to DCOS_PACKAGE_FRAMEWORK_NAME without being a Cosmos package,
+    // for example, with Marathon-on-Marathon EE, which is intentionally 
+    // not available as a Cosmos package.
     return (
       ServiceValidatorUtil.isApplicationResponse(data) &&
       data.labels &&

--- a/plugins/services/src/js/utils/ServiceValidatorUtil.js
+++ b/plugins/services/src/js/utils/ServiceValidatorUtil.js
@@ -74,7 +74,9 @@ const ServiceValidatorUtil = {
     return (
       ServiceValidatorUtil.isApplicationResponse(data) &&
       data.labels &&
-      data.labels.DCOS_PACKAGE_FRAMEWORK_NAME
+      data.labels.DCOS_PACKAGE_NAME &&
+      data.labels.DCOS_PACKAGE_FRAMEWORK_NAME &&
+      data.labels.DCOS_PACKAGE_VERSION
     );
   },
 

--- a/plugins/services/src/js/utils/__tests__/ServiceUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/ServiceUtil-test.js
@@ -28,11 +28,29 @@ describe("ServiceUtil", function() {
         disk: null,
         instances: null,
         labels: {
-          DCOS_PACKAGE_FRAMEWORK_NAME: "Test Framework"
+          DCOS_PACKAGE_NAME: "Test Framework",
+          DCOS_PACKAGE_FRAMEWORK_NAME: "Test Framework",
+          DCOS_PACKAGE_VERSION: "1.0.0"
         }
       });
 
       expect(instance instanceof Framework).toBeTruthy();
+    });
+
+    it("creates Application with Framework label instances", function() {
+      const instance = ServiceUtil.createServiceFromResponse({
+        id: "/test",
+        cmd: "sleep 1000;",
+        cpus: null,
+        mem: null,
+        disk: null,
+        instances: null,
+        labels: {
+          DCOS_PACKAGE_FRAMEWORK_NAME: "Test Framework"
+        }
+      });
+
+      expect(instance instanceof Application).toBeTruthy();
     });
 
     it("creates Pod instances", function() {


### PR DESCRIPTION
See [COPS-3203](https://jira.mesosphere.com/browse/COPS-3203)

If you have a Marathon app that is a framework (has `DCOS_PACKAGE_FRAMEWORK_NAME` to pick up child tasks) but is not a Cosmos app (doesn't have all other accompanying `DCOS_PACKAGE_X` labels), if you go to the DC/OS UI and try to view/edit configuration, you'll start getting 500s.

This PR makes the detection of a Cosmos app more explicit; rather than just checking for DCOS_PACKAGE_FRAMEWORK_NAME, it also checks for `DCOS_PACKAGE_NAME` and `DCOS_PACKAGE_VERSION`

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [?] Did you add new unit tests?
- [?] Did you add new integration tests?
- [x] If this is a regression, did you write a test to catch this in the future?

Modified existing test, added a new test.  Not sure if it's an integration or unit test, but it's similar format to the existing tests and should help with this in the future.