### PR TITLE
fix(NestedServiceLinks): group link

### DIFF
--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -175,6 +175,7 @@ class ServicesTable extends React.Component {
     if (this.props.isFiltered) {
       return (
         <NestedServiceLinks
+          serviceLink={serviceLink}
           serviceID={id}
           className="service-breadcrumb"
           majorLinkClassName="service-breadcrumb-service-id"

--- a/src/js/components/NestedServiceLinks.js
+++ b/src/js/components/NestedServiceLinks.js
@@ -6,13 +6,13 @@ import React from "react";
 import Icon from "./Icon";
 
 class NestedServiceLinks extends React.Component {
-  getMinorLink(label, params, key, minorLinkClasses, minorLinkAnchorClasses) {
+  getMinorLink(label, id, key, minorLinkClasses, minorLinkAnchorClasses) {
     return (
       <div key={key} className="table-cell-value">
         <div className={minorLinkClasses}>
           <Link
             className={minorLinkAnchorClasses}
-            to={`/services/detail/${params.id}`}
+            to={`/services/overview/${id}`}
             title={label}
           >
             {label}
@@ -36,7 +36,7 @@ class NestedServiceLinks extends React.Component {
 
   getMinorLinks() {
     let componentKey = 0;
-    const { minorLinkClassName, minorLinkAnchorClassName, taskID } = this.props;
+    const { minorLinkClassName, minorLinkAnchorClassName } = this.props;
     const minorLinkClasses = classNames(
       "text-overflow service-link",
       minorLinkClassName
@@ -46,12 +46,8 @@ class NestedServiceLinks extends React.Component {
       minorLinkAnchorClassName
     );
     let nestedGroups = this.getServicePathParts();
-    let popCount = 1;
 
-    if (taskID != null) {
-      popCount = 0;
-    }
-    nestedGroups = nestedGroups.slice(0, nestedGroups.length - popCount);
+    nestedGroups = nestedGroups.slice(0, nestedGroups.length - 1);
 
     const links = nestedGroups.reduce((components, part, index) => {
       const id = encodeURIComponent(nestedGroups.slice(0, index + 1).join("/"));
@@ -59,7 +55,7 @@ class NestedServiceLinks extends React.Component {
       components.push(
         this.getMinorLink(
           part,
-          { id },
+          id,
           componentKey++,
           minorLinkClasses,
           minorLinkAnchorClasses
@@ -77,25 +73,16 @@ class NestedServiceLinks extends React.Component {
   }
 
   getMajorLink() {
-    let label;
-    const { majorLinkAnchorClassName, serviceID, taskID } = this.props;
-    let routePath;
+    const { majorLinkAnchorClassName, serviceLink } = this.props;
+    const label = this.getServicePathParts().pop();
 
     const anchorClasses = classNames(
       "table-cell-link-primary",
       majorLinkAnchorClassName
     );
 
-    if (taskID != null) {
-      label = taskID;
-      routePath = `/services/detail/${serviceID}/tasks/${taskID}`;
-    } else {
-      label = this.getServicePathParts().pop();
-      routePath = `/services/detail/${encodeURIComponent(serviceID)}`;
-    }
-
     return (
-      <Link className={anchorClasses} to={routePath} title={label}>
+      <Link className={anchorClasses} to={serviceLink} title={label}>
         <span className="text-overflow">
           {label}
         </span>
@@ -163,9 +150,7 @@ class NestedServiceLinks extends React.Component {
   }
 }
 
-NestedServiceLinks.defaultProps = {
-  taskID: null
-};
+NestedServiceLinks.defaultProps = {};
 
 const classPropType = PropTypes.oneOfType([
   PropTypes.array,
@@ -174,8 +159,8 @@ const classPropType = PropTypes.oneOfType([
 ]);
 
 NestedServiceLinks.propTypes = {
+  serviceLink: PropTypes.string.isRequired,
   serviceID: PropTypes.string.isRequired,
-  taskID: PropTypes.string,
   // Classes
   className: classPropType,
   majorLinkAnchorClassName: classPropType,

--- a/src/js/components/__tests__/NestedServiceLinks-test.js
+++ b/src/js/components/__tests__/NestedServiceLinks-test.js
@@ -1,0 +1,93 @@
+/* eslint-disable no-unused-vars */
+const React = require("react");
+const enzyme = require("enzyme");
+
+const NestedServiceLinks = require("../NestedServiceLinks");
+
+describe("NestedServiceLinks", function() {
+  const id = "foo";
+
+  describe("#Service", function() {
+    const serviceLink = `/services/detail/${id}`;
+    const component = enzyme.shallow(
+      <NestedServiceLinks
+        serviceLink={serviceLink}
+        serviceID={id}
+        className="service-breadcrumb"
+        majorLinkClassName="service-breadcrumb-service-id"
+        minorLinkWrapperClassName="service-breadcrumb-crumb"
+      />
+    );
+
+    it("major link navigates to detail", function() {
+      const result = component.find(".table-cell-link-primary").props().to;
+
+      expect(result).toEqual(serviceLink);
+    });
+
+    it("minor link navigates to services", function() {
+      const result = component.find(".table-cell-link-secondary").props().to;
+
+      expect(result).toEqual("/services");
+    });
+  });
+
+  describe("#Group", function() {
+    const groupServiceLink = `/services/overview/${id}`;
+    const component = enzyme.shallow(
+      <NestedServiceLinks
+        serviceLink={groupServiceLink}
+        serviceID={id}
+        className="service-breadcrumb"
+        majorLinkClassName="service-breadcrumb-service-id"
+        minorLinkWrapperClassName="service-breadcrumb-crumb"
+      />
+    );
+
+    it("major link navigates to overview", function() {
+      const result = component.find(".table-cell-link-primary").props().to;
+
+      expect(result).toEqual(groupServiceLink);
+    });
+
+    it("minor link navigates to services", function() {
+      const result = component.find(".table-cell-link-secondary").props().to;
+
+      expect(result).toEqual("/services");
+    });
+  });
+
+  describe("#Group multi level", function() {
+    const id = "group/foo";
+    const groupLevelLink = `/services/detail/${id}`;
+    const component = enzyme.shallow(
+      <NestedServiceLinks
+        serviceLink={groupLevelLink}
+        serviceID={id}
+        className="service-breadcrumb"
+        majorLinkClassName="service-breadcrumb-service-id"
+        minorLinkWrapperClassName="service-breadcrumb-crumb"
+      />
+    );
+
+    it("major link navigates to overview", function() {
+      const result = component.find(".table-cell-link-primary").props().to;
+
+      expect(result).toEqual(groupLevelLink);
+    });
+
+    it("first minor link navigates to services", function() {
+      const result = component.find(".table-cell-link-secondary");
+
+      expect(result.first().props().to).toEqual("/services");
+      expect(result.last().props().to).toEqual("/services/overview/group");
+    });
+
+    it("last minor link navigates to group", function() {
+      const result = component.find(".table-cell-link-secondary");
+
+      expect(result.first().props().to).toEqual("/services");
+      expect(result.last().props().to).toEqual("/services/overview/group");
+    });
+  });
+});


### PR DESCRIPTION
Fix group link when searching/filtering by name
on services.

Closes DCOS-28721

**Before**
![filter-group](https://user-images.githubusercontent.com/549394/40075556-6831e562-5831-11e8-8c1f-43e34a9ddfd9.gif)

**After**
![screen recording 2018-05-15 at 11 12 am](https://user-images.githubusercontent.com/549394/40075581-834b32a4-5831-11e8-802a-26f160c688f1.gif)


**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
