### PR TITLE
DCOS-37420: adjust Framework struct to improve performance

### DIFF
--- a/plugins/services/src/js/structs/Framework.js
+++ b/plugins/services/src/js/structs/Framework.js
@@ -9,6 +9,21 @@ import Application from "./Application";
 import FrameworkSpec from "./FrameworkSpec";
 
 module.exports = class Framework extends Application {
+  constructor() {
+    super(...arguments);
+
+    // For performance reasons only one instance of the spec is created
+    // instead of creating a new instance every time a user calls `getSpec()`.
+    //
+    // State and other _useless_ information is removed to create a clean
+    // service spec.
+    //
+    // The variable is prefixed because `Item` will expose all the properties
+    // it gets as a properties of this object and we want to avoid any naming
+    // collisions.
+    this._spec = new FrameworkSpec(cleanServiceJSON(this.get()));
+  }
+
   getPackageName() {
     return this.getLabels().DCOS_PACKAGE_NAME;
   }
@@ -28,8 +43,11 @@ module.exports = class Framework extends Application {
     return ROUTE_ACCESS_PREFIX + (this.get("name") || "").replace(regexp, "");
   }
 
+  /**
+   * @override
+   */
   getSpec() {
-    return new FrameworkSpec(cleanServiceJSON(this.get()));
+    return this._spec;
   }
 
   getTasksSummary() {


### PR DESCRIPTION
Change the Framework speck to create only one instance of the spec instead of creating a new instance every time a user calls `getSpec()`. This should lower the load and improve the performance.

Backport of https://github.com/dcos/dcos-ui/pull/2672/commits/2372ea59526b9df101ed7cc05ecb5c8774fcdb33

Closes DCOS-37420

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?