### PR TITLE
DCOS-37421: Adjust GetSetBaseStore to stop dispatching events on every change

### DIFF
--- a/src/js/stores/ConfigStore.js
+++ b/src/js/stores/ConfigStore.js
@@ -10,6 +10,7 @@ import {
 import AppDispatcher from "../events/AppDispatcher";
 import ConfigActions from "../events/ConfigActions";
 import {
+  APP_STORE_CHANGE,
   CLUSTER_CCID_ERROR,
   CLUSTER_CCID_SUCCESS,
   CONFIG_ERROR,
@@ -63,6 +64,17 @@ class ConfigStore extends GetSetBaseStore {
       }
 
       return true;
+    });
+  }
+
+  set(config) {
+    super.set(config);
+
+    // Dispatch new Store data
+    PluginSDK.dispatch({
+      type: APP_STORE_CHANGE,
+      storeID: this.storeID,
+      data: this.getSet_data
     });
   }
 

--- a/src/js/stores/GetSetBaseStore.js
+++ b/src/js/stores/GetSetBaseStore.js
@@ -1,7 +1,4 @@
-import PluginSDK from "PluginSDK";
-
 import BaseStore from "./BaseStore";
-import { APP_STORE_CHANGE } from "../constants/EventTypes";
 
 // TODO: DCOS-6404, remove getters and setters from stores
 class GetSetBaseStore extends BaseStore {
@@ -25,13 +22,6 @@ class GetSetBaseStore extends BaseStore {
     }
 
     Object.assign(this.getSet_data, data);
-
-    // Dispatch new Store data
-    PluginSDK.dispatch({
-      type: APP_STORE_CHANGE,
-      storeID: this.storeID,
-      data: this.getSet_data
-    });
   }
 }
 


### PR DESCRIPTION
Adjust the `GetSetBaseStore` to not dispatch `APP_STORE_CHANGE` event on every "set" operation.
This greatly reduces the number of events and resolves performance issues with our `AppReducer` by only dispatching events on config change.

Closes DCOS-37421