### PR TITLE
DCOS-37436: Adjust mesos state store

### DIFF
--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -245,6 +245,67 @@ describe("MesosStateStore", function() {
     });
   });
 
+  describe("#getSchedulerTasksMap", function() {
+    beforeEach(function() {
+      this.get = MesosStateStore.get;
+    });
+
+    afterEach(function() {
+      MesosStateStore.get = this.get;
+    });
+
+    it("should return scheduler tasks", function() {
+      MesosStateStore.get = function() {
+        return {
+          frameworks: [
+            {
+              name: "marathon",
+              tasks: [
+                {
+                  id: "foo",
+                  labels: [{ key: "DCOS_PACKAGE_FRAMEWORK_NAME", value: "foo" }]
+                },
+                {
+                  id: "bar"
+                },
+                {
+                  id: "baz",
+                  labels: [{ key: "DCOS_PACKAGE_FRAMEWORK_NAME", value: "baz" }]
+                }
+              ]
+            }
+          ]
+        };
+      };
+
+      const schedulerTasksMap = MesosStateStore.getSchedulerTasksMap();
+      expect(schedulerTasksMap).toEqual({
+        foo: { labels: [{ key: "DCOS_PACKAGE_FRAMEWORK_NAME", value: "foo" }] },
+        baz: { labels: [{ key: "DCOS_PACKAGE_FRAMEWORK_NAME", value: "baz" }] }
+      });
+    });
+
+    it("should not return plain tasks", function() {
+      MesosStateStore.get = function() {
+        return {
+          frameworks: [
+            {
+              name: "marathon",
+              tasks: [
+                {
+                  id: "foo"
+                }
+              ]
+            }
+          ]
+        };
+      };
+
+      const schedulerTasksMap = MesosStateStore.getSchedulerTasksMap();
+      expect(schedulerTasksMap).toEqual({});
+    });
+  });
+
   describe("#getSchedulerTaskFromServiceName", function() {
     beforeEach(function() {
       this.get = MesosStateStore.get;


### PR DESCRIPTION
Introduce a `schedulerTasksMap`  to improve lookups when assigning the scheduler task field. This change drastically improves the performance as `assignSchedulerTaskField`  was using the `some` operator to check whether there is a matching scheduler task resulting in n*m iterations.

Closes DCOS-37436

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
