### PR TITLE
DCOS-37556: prevent unnecessary updates in ServiceBreadcrumb

### DIFF
--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -1,21 +1,20 @@
-import ReactDOM from "react-dom";
-import PropTypes from "prop-types";
-import React from "react";
-import { Link } from "react-router";
-
-import StringUtil from "#SRC/js/utils/StringUtil";
-import DCOSStore from "#SRC/js/stores/DCOSStore";
 import Breadcrumb from "#SRC/js/components/Breadcrumb";
 import BreadcrumbSupplementalContent
   from "#SRC/js/components/BreadcrumbSupplementalContent";
 import BreadcrumbTextContent from "#SRC/js/components/BreadcrumbTextContent";
 import PageHeaderBreadcrumbs from "#SRC/js/components/PageHeaderBreadcrumbs";
+import DCOSStore from "#SRC/js/stores/DCOSStore";
+import StringUtil from "#SRC/js/utils/StringUtil";
 import Util from "#SRC/js/utils/Util";
-
+import deepEqual from "deep-equal";
+import PropTypes from "prop-types";
+import React from "react";
+import ReactDOM from "react-dom";
+import { Link } from "react-router";
+import ServiceTree from "../structs/ServiceTree";
 import ServiceStatusProgressBar from "./ServiceStatusProgressBar";
 import ServiceStatusWarningWithDebugInformation
   from "./ServiceStatusWarningWithDebugInstruction";
-import ServiceTree from "../structs/ServiceTree";
 
 // The breadcrumb's margin is hardcoded to avoid calling #getComputedStyle.
 const BREADCRUMB_CONTENT_MARGIN = 7;
@@ -43,6 +42,22 @@ class ServiceBreadcrumbs extends React.Component {
   componentDidMount() {
     this.checkBreadcrumbOverflow();
     global.addEventListener("resize", this.handleViewportResize);
+  }
+
+  shouldComponentUpdate(nextProps) {
+    const hasServiceIDChanged = this.props.serviceID !== nextProps.serviceID;
+    const hasTaskIDChanged = this.props.taskID !== nextProps.taskID;
+    const hasTaskNameChanged = this.props.taskName !== nextProps.taskName;
+    const hasExtraNotChanged =
+      this.props.extra === nextProps.extra ||
+      deepEqual(this.props.extra, nextProps.extra);
+
+    return (
+      hasServiceIDChanged ||
+      hasTaskIDChanged ||
+      hasTaskNameChanged ||
+      !hasExtraNotChanged
+    );
   }
 
   componentDidUpdate() {

--- a/plugins/services/src/js/components/__tests__/ServiceBreadcrumbs-test.js
+++ b/plugins/services/src/js/components/__tests__/ServiceBreadcrumbs-test.js
@@ -1,5 +1,5 @@
+import { mount, shallow } from "enzyme";
 import React from "react";
-import { mount } from "enzyme";
 
 jest.mock("#SRC/js/stores/DCOSStore");
 
@@ -10,69 +10,172 @@ const PageHeaderBreadcrumbs = require("#SRC/js/components/PageHeaderBreadcrumbs"
 const Service = require("../../structs/Service");
 const ServiceTree = require("../../structs/ServiceTree");
 
-describe("ServiceBreadcrumbs instance", function() {
-  beforeEach(function() {
-    DCOSStore.serviceTree = {
-      findItemById() {
-        return new Service({ id: "/test" });
-      }
-    };
-  });
-
-  describe("extra breadcrumbs", function() {
-    it("does not render extra crumbs when there is none", function() {
-      const result = mount(<ServiceBreadcrumbs serviceID="/test" />);
-      expect(
-        result.find(PageHeaderBreadcrumbs).prop("breadcrumbs").length
-      ).toEqual(2);
-    });
-
-    it("renders extra crumbs", function() {
-      const result = mount(
-        <ServiceBreadcrumbs serviceID="/test" extra={[<a>Dummy</a>]} />
-      );
-
-      expect(
-        result.find(PageHeaderBreadcrumbs).prop("breadcrumbs").length
-      ).toEqual(3);
-      expect(
-        result.find(PageHeaderBreadcrumbs).prop("breadcrumbs")[2].props.children
-      ).toEqual("Dummy");
-    });
-  });
-
-  describe("route destination", function() {
-    it("provides overview route for a service that is a group", function() {
+describe("ServiceBreadcrumbs", function() {
+  describe("instance", function() {
+    beforeEach(function() {
       DCOSStore.serviceTree = {
         findItemById() {
-          return new ServiceTree({ id: "/foo", groups: [{ id: "/foo/bar" }] });
+          return new Service({ id: "/test" });
         }
       };
-      const instance = mount(<ServiceBreadcrumbs serviceID="/foo/bar" />);
-
-      const links = instance.find(Link);
-      expect(links.length).toEqual(4);
-      // Icon
-      expect(links.at(0).prop("to")).toEqual("/services");
-
-      // Actual of breadcrumbs
-      expect(links.at(1).prop("to")).toEqual("/services");
-      expect(links.at(2).prop("to")).toEqual("/services/overview/%2Ffoo");
-      expect(links.at(3).prop("to")).toEqual("/services/overview/%2Ffoo%2Fbar");
     });
 
-    it("provides detail route for a service that is not a group", function() {
-      const instance = mount(<ServiceBreadcrumbs serviceID="/foo" />);
+    describe("extra breadcrumbs", function() {
+      it("does not render extra crumbs when there is none", function() {
+        const result = mount(<ServiceBreadcrumbs serviceID="/test" />);
+        expect(
+          result.find(PageHeaderBreadcrumbs).prop("breadcrumbs").length
+        ).toEqual(2);
+      });
 
-      const links = instance.find(Link);
-      expect(links.length).toEqual(4);
-      // Icon
-      expect(links.at(0).prop("to")).toEqual("/services");
+      it("renders extra crumbs", function() {
+        const result = mount(
+          <ServiceBreadcrumbs serviceID="/test" extra={[<a>Dummy</a>]} />
+        );
 
-      // Actual of breadcrumbs
-      expect(links.at(1).prop("to")).toEqual("/services");
-      expect(links.at(2).prop("to")).toEqual("/services/detail/%2Ffoo");
-      expect(links.at(3).prop("to")).toEqual("/services/detail/%2Ffoo");
+        expect(
+          result.find(PageHeaderBreadcrumbs).prop("breadcrumbs").length
+        ).toEqual(3);
+        expect(
+          result.find(PageHeaderBreadcrumbs).prop("breadcrumbs")[2].props
+            .children
+        ).toEqual("Dummy");
+      });
+    });
+
+    describe("route destination", function() {
+      it("provides overview route for a service that is a group", function() {
+        DCOSStore.serviceTree = {
+          findItemById() {
+            return new ServiceTree({
+              id: "/foo",
+              groups: [{ id: "/foo/bar" }]
+            });
+          }
+        };
+        const instance = mount(<ServiceBreadcrumbs serviceID="/foo/bar" />);
+
+        const links = instance.find(Link);
+        expect(links.length).toEqual(4);
+        // Icon
+        expect(links.at(0).prop("to")).toEqual("/services");
+
+        // Actual of breadcrumbs
+        expect(links.at(1).prop("to")).toEqual("/services");
+        expect(links.at(2).prop("to")).toEqual("/services/overview/%2Ffoo");
+        expect(links.at(3).prop("to")).toEqual(
+          "/services/overview/%2Ffoo%2Fbar"
+        );
+      });
+
+      it("provides detail route for a service that is not a group", function() {
+        const instance = mount(<ServiceBreadcrumbs serviceID="/foo" />);
+
+        const links = instance.find(Link);
+        expect(links.length).toEqual(4);
+        // Icon
+        expect(links.at(0).prop("to")).toEqual("/services");
+
+        // Actual of breadcrumbs
+        expect(links.at(1).prop("to")).toEqual("/services");
+        expect(links.at(2).prop("to")).toEqual("/services/detail/%2Ffoo");
+        expect(links.at(3).prop("to")).toEqual("/services/detail/%2Ffoo");
+      });
+    });
+  });
+  describe("shouldComponentUpdate", function() {
+    it(`is updating serviceID`, function() {
+      const wrapper = shallow(
+        <ServiceBreadcrumbs {...{ serviceID: "/test" }} />
+      );
+      const componentDidUpdateSpy = jest.spyOn(
+        wrapper.instance(),
+        "componentDidUpdate"
+      );
+      wrapper.setProps({ serviceID: "/success" });
+      expect(componentDidUpdateSpy.mock.calls.length).toBe(1);
+    });
+
+    it(`is not updating on same serviceID`, function() {
+      const wrapper = shallow(
+        <ServiceBreadcrumbs {...{ serviceID: "/same" }} />
+      );
+      const componentDidUpdateSpy = jest.spyOn(
+        wrapper.instance(),
+        "componentDidUpdate"
+      );
+      wrapper.setProps({ serviceID: "/same" });
+      expect(componentDidUpdateSpy.mock.calls.length).toBe(0);
+    });
+
+    it(`is updating taskName`, function() {
+      const wrapper = shallow(
+        <ServiceBreadcrumbs
+          {...{ serviceID: "/service", taskID: "1234", taskName: "test" }}
+        />
+      );
+      const componentDidUpdateSpy = jest.spyOn(
+        wrapper.instance(),
+        "componentDidUpdate"
+      );
+      wrapper.setProps({
+        serviceID: "/service",
+        taskID: "1234",
+        taskName: "success"
+      });
+      expect(componentDidUpdateSpy.mock.calls.length).toBe(1);
+    });
+
+    it(`is updating not updating for same taskName`, function() {
+      const wrapper = shallow(
+        <ServiceBreadcrumbs
+          {...{ serviceID: "/service", taskID: "1234", taskName: "test" }}
+        />
+      );
+      const componentDidUpdateSpy = jest.spyOn(
+        wrapper.instance(),
+        "componentDidUpdate"
+      );
+      wrapper.setProps({
+        serviceID: "/service",
+        taskID: "1234",
+        taskName: "test"
+      });
+      expect(componentDidUpdateSpy.mock.calls.length).toBe(0);
+    });
+
+    it(`is updating extras`, function() {
+      const wrapper = shallow(
+        <ServiceBreadcrumbs
+          {...{ serviceID: "/service", extra: <span>test</span> }}
+        />
+      );
+      const componentDidUpdateSpy = jest.spyOn(
+        wrapper.instance(),
+        "componentDidUpdate"
+      );
+      wrapper.setProps({
+        serviceID: "/service",
+        extra: <span>changed</span>
+      });
+      expect(componentDidUpdateSpy.mock.calls.length).toBe(1);
+    });
+
+    it(`is updating not updating for same taskName`, function() {
+      const wrapper = shallow(
+        <ServiceBreadcrumbs
+          {...{ serviceID: "/service", extra: <span>same</span> }}
+        />
+      );
+      const componentDidUpdateSpy = jest.spyOn(
+        wrapper.instance(),
+        "componentDidUpdate"
+      );
+      wrapper.setProps({
+        serviceID: "/service",
+        extra: <span>same</span>
+      });
+      expect(componentDidUpdateSpy.mock.calls.length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
<details><summary><strong>fix: prevent service breadcrumb to update without changes</strong></summary><hr/>

This adds a `shouldComponentUpdate` function to the `ServiceBreadcrumb` component. This ensures the
component is only updated if any of the props has changed.

To test you can use the following service config:

```JSON
{
  "id": "/volumes",
  "containers": [
    {
      "name": "container-1",
      "resources": {
        "cpus": 0.1,
        "mem": 128,
        "disk": 0
      },
      "image": {
        "kind": "DOCKER",
        "id": "alpine"
      },
      "exec": {
        "command": {
          "shell": "sleep 1000;"
        }
      },
      "volumeMounts": [
        {
          "name": "home",
          "mountPath": "/var/home"
        },
        {
          "name": "nothome",
          "mountPath": "/var/nothome"
        }
      ]
    }
  ],
  "volumes": [
    {
      "name": "home",
      "persistent": {
        "type": "root",
        "size": 1,
        "constraints": []
      }
    },
    {
      "name": "nothome",
      "persistent": {
        "type": "root",
        "size": 1,
        "constraints": []
      }
    }
  ],
  "networks": [
    {
      "mode": "host"
    }
  ],
  "scaling": {
    "instances": 1,
    "kind": "fixed"
  },
  "scheduling": {
    "placement": {
      "constraints": []
    }
  },
  "executorResources": {
    "cpus": 0.1,
    "mem": 32,
    "disk": 10
  },
  "fetch": []
}
```

This is going to create a multi container application with multiple volumes. Then you should
navigate to the service detail page.
Check if you can navigate to the task detail page and back.
Check if you can visit the volume detail page.
Check if you can switch between the two volume detail pages.
  - Copy the URL of the first volume Detail page,
  - Visit the second one, go to the address bar paste the URL and hit enter.
  - After this you may use the browser history to go back and forth.

Close DCOS-22453
</details>

---
Commit:
6922ed07c4a4a5044263227ace2bf3673b2cb25c

Testwise from https://github.com/dcos/dcos-ui/pull/2962/files#diff-90b25207bf60e5708a7ba1ffdec09510R86 to the bottom is interesting this is new code the rest is moved. I created a separate `describe` block since the old one had a before each So I thought it made sense to create a separate block.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?