### PR TITLE
[master] DCOS-37440: schedulerTasksMap with lookups

### DIFF
--- a/src/js/stores/__tests__/MesosStateStore-test.js
+++ b/src/js/stores/__tests__/MesosStateStore-test.js
@@ -543,6 +543,93 @@ describe("MesosStateStore", function() {
     });
   });
 
+  describe("#getSchedulerTasksMap", function() {
+    beforeEach(function() {
+      this.get = MesosStateStore.get;
+    });
+
+    afterEach(function() {
+      MesosStateStore.get = this.get;
+    });
+
+    it("returns scheduled tasks", function() {
+      MesosStateStore.get = function() {
+        return {
+          frameworks: [
+            {
+              id: "marathon-1",
+              name: "marathon",
+              active: true
+            }
+          ],
+          tasks: [
+            {
+              id: "foo",
+              framework_id: "marathon-1",
+              isSchedulerTask: true,
+              labels: [{ key: "DCOS_PACKAGE_FRAMEWORK_NAME", value: "foo" }]
+            },
+            {
+              id: "bar"
+            },
+            {
+              id: "baz",
+              framework_id: "marathon-1",
+              isSchedulerTask: true,
+              labels: [{ key: "DCOS_PACKAGE_FRAMEWORK_NAME", value: "baz" }]
+            }
+          ]
+        };
+      };
+
+      const schedulerTasksMap = MesosStateStore.getSchedulerTasksMap();
+      expect(schedulerTasksMap).toEqual({
+        foo: {
+          framework_id: "marathon-1",
+          isSchedulerTask: true,
+          labels: [
+            {
+              key: "DCOS_PACKAGE_FRAMEWORK_NAME",
+              value: "foo"
+            }
+          ]
+        },
+        baz: {
+          framework_id: "marathon-1",
+          isSchedulerTask: true,
+          labels: [
+            {
+              key: "DCOS_PACKAGE_FRAMEWORK_NAME",
+              value: "baz"
+            }
+          ]
+        }
+      });
+    });
+
+    it("returs plain tasks", function() {
+      MesosStateStore.get = function() {
+        return {
+          frameworks: [
+            {
+              id: "marathon-1",
+              name: "marathon",
+              active: true
+            }
+          ],
+          tasks: [
+            {
+              id: "bar"
+            }
+          ]
+        };
+      };
+
+      const schedulerTasksMap = MesosStateStore.getSchedulerTasksMap();
+      expect(schedulerTasksMap).toEqual({});
+    });
+  });
+
   describe("#getSchedulerTaskFromServiceName", function() {
     beforeEach(function() {
       thisGet = MesosStateStore.get;

--- a/src/js/utils/MesosStateUtil.js
+++ b/src/js/utils/MesosStateUtil.js
@@ -278,15 +278,15 @@ const MesosStateUtil = {
   /**
    * Assigns a property to task if it is a scheduler task.
    * @param  {Object} task
-   * @param  {Array} schedulerTasks Array of scheduler task
+   * @param  {Object} schedulerTasksMap Map of scheduler task
    * @return {Object} task
    */
-  assignSchedulerTaskField(task, schedulerTasks) {
-    if (schedulerTasks.some(({ id }) => task.id === id)) {
-      return Object.assign({}, task, { schedulerTask: true });
+  assignSchedulerTaskField(task, schedulerTasksMap) {
+    if (schedulerTasksMap[task.id] == null) {
+      return task;
     }
 
-    return task;
+    return { ...task, schedulerTask: true };
   },
 
   /**


### PR DESCRIPTION
Introduce a `schedulerTasksMap`  to improve lookups when assigning the scheduler task field. This change drastically improves the performance as
`assignSchedulerTaskField`  was using the `some` operator to check whether there is a matching scheduler task resulting in n*m iterations.

Closes DCOS-37437

**Checklist**
- [X] Did you add a JIRA issue in a commit message or as part of the branch name?
- [X] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
