### PR TITLE
[1.10] DCOS-37555: prevent unnecessary updates in ServiceBreadcrumb

### DIFF
--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -1,19 +1,18 @@
-import ReactDOM from "react-dom";
-import React from "react";
-import { Link } from "react-router";
-
-import DCOSStore from "#SRC/js/stores/DCOSStore";
 import Breadcrumb from "#SRC/js/components/Breadcrumb";
 import BreadcrumbSupplementalContent
   from "#SRC/js/components/BreadcrumbSupplementalContent";
 import BreadcrumbTextContent from "#SRC/js/components/BreadcrumbTextContent";
 import PageHeaderBreadcrumbs from "#SRC/js/components/PageHeaderBreadcrumbs";
+import DCOSStore from "#SRC/js/stores/DCOSStore";
 import Util from "#SRC/js/utils/Util";
-
+import deepEqual from "deep-equal";
+import React from "react";
+import ReactDOM from "react-dom";
+import { Link } from "react-router";
+import ServiceTree from "../structs/ServiceTree";
 import HealthBar from "./HealthBar";
 import ServiceStatusWarningWithDebugInformation
   from "./ServiceStatusWarningWithDebugInstruction";
-import ServiceTree from "../structs/ServiceTree";
 
 // The breadcrumb's margin is hardcoded to avoid calling #getComputedStyle.
 const BREADCRUMB_CONTENT_MARGIN = 7;
@@ -41,6 +40,22 @@ class ServiceBreadcrumbs extends React.Component {
   componentDidMount() {
     this.checkBreadcrumbOverflow();
     global.addEventListener("resize", this.handleViewportResize);
+  }
+
+  shouldComponentUpdate(nextProps) {
+    const hasServiceIDChanged = this.props.serviceID !== nextProps.serviceID;
+    const hasTaskIDChanged = this.props.taskID !== nextProps.taskID;
+    const hasTaskNameChanged = this.props.taskName !== nextProps.taskName;
+    const hasExtraNotChanged =
+      this.props.extra === nextProps.extra ||
+      deepEqual(this.props.extra, nextProps.extra);
+
+    return (
+      hasServiceIDChanged ||
+      hasTaskIDChanged ||
+      hasTaskNameChanged ||
+      !hasExtraNotChanged
+    );
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
<details><summary><strong>fix: prevent service breadcrumb to update without changes</strong></summary><hr/>

This adds a `shouldComponentUpdate` function to the `ServiceBreadcrumb` component. This ensures the
component is only updated if any of the props has changed.

To test you can use the following service config:

```JSON
{
  "id": "/volumes",
  "containers": [
    {
      "name": "container-1",
      "resources": {
        "cpus": 0.1,
        "mem": 128,
        "disk": 0
      },
      "image": {
        "kind": "DOCKER",
        "id": "alpine"
      },
      "exec": {
        "command": {
          "shell": "sleep 1000;"
        }
      },
      "volumeMounts": [
        {
          "name": "home",
          "mountPath": "/var/home"
        },
        {
          "name": "nothome",
          "mountPath": "/var/nothome"
        }
      ]
    }
  ],
  "volumes": [
    {
      "name": "home",
      "persistent": {
        "type": "root",
        "size": 1,
        "constraints": []
      }
    },
    {
      "name": "nothome",
      "persistent": {
        "type": "root",
        "size": 1,
        "constraints": []
      }
    }
  ],
  "networks": [
    {
      "mode": "host"
    }
  ],
  "scaling": {
    "instances": 1,
    "kind": "fixed"
  },
  "scheduling": {
    "placement": {
      "constraints": []
    }
  },
  "executorResources": {
    "cpus": 0.1,
    "mem": 32,
    "disk": 10
  },
  "fetch": []
}
```

This is going to create a multi container application with multiple volumes. Then you should
navigate to the service detail page.
Check if you can navigate to the task detail page and back.
Check if you can visit the volume detail page.
Check if you can switch between the two volume detail pages.
  - Copy the URL of the first volume Detail page,
  - Visit the second one, go to the address bar paste the URL and hit enter.
  - After this you may use the browser history to go back and forth.

Close DCOS-22453
</details>

---
Commit:
87fa23929e0cf158cafb10dd1c36867720bee13c