### PR TITLE
fix(ci): add build script to fix latest builds

### DIFF
--- a/scripts/ci/utils/update-dcos-repo
+++ b/scripts/ci/utils/update-dcos-repo
@@ -60,6 +60,11 @@ else
     reset --hard "origin/${PKG_TARGET}"
 fi
 
+# this is an intermediate step we need until we actually bumped the new process to DC/OS
+echo 'cp -r "/pkg/src/dcos-ui" "$PKG_PATH"/usr/' > ${PROJECT_ROOT}/${DCOS_FOLDER}/packages/dcos-ui/build
+git -C "${PROJECT_ROOT}/${DCOS_FOLDER}" \
+  add "${PROJECT_ROOT}/${DCOS_FOLDER}/packages/dcos-ui/build"
+
 cp -f ${PROJECT_ROOT}/buildinfo.json ${PROJECT_ROOT}/${DCOS_FOLDER}/packages/dcos-ui/buildinfo.json
 git -C "${PROJECT_ROOT}/${DCOS_FOLDER}" \
   add "${PROJECT_ROOT}/${DCOS_FOLDER}/packages/dcos-ui/buildinfo.json"


### PR DESCRIPTION
this should fix our latest DC/OS builds. 

Please only merge if the **branch** build is green and you verified that the DCOS PR contains the build script and is building correctly: https://github.com/dcos/dcos/pull/2741