### PR TITLE
[1.10] DCOS-22145: Backport of "File UI breaks using the switch button"

### DIFF
--- a/plugins/services/src/js/pages/task-details/TaskFileViewer.js
+++ b/plugins/services/src/js/pages/task-details/TaskFileViewer.js
@@ -12,7 +12,22 @@ import SearchLog from "../../components/SearchLog";
 import TaskDirectory from "../../structs/TaskDirectory";
 import TaskDirectoryActions from "../../events/TaskDirectoryActions";
 
-class TaskFileViewer extends React.Component {
+export function getNewRoute(routePath, params, path) {
+  const hasFilePathParam = routePath.indexOf(":filePath") !== -1;
+  if (!hasFilePathParam && routePath.endsWith("/")) {
+    routePath += ":filePath";
+  }
+  if (!hasFilePathParam && !routePath.endsWith("/")) {
+    routePath += "/:filePath";
+  }
+
+  return formatPattern(
+    routePath,
+    Object.assign({}, params, { filePath: encodeURIComponent(path) })
+  );
+}
+
+export default class TaskFileViewer extends React.Component {
   constructor() {
     super(...arguments);
 
@@ -55,7 +70,7 @@ class TaskFileViewer extends React.Component {
     const { params, routes } = this.props;
     const routePath = RouterUtil.reconstructPathFromRoutes(routes);
 
-    this.context.router.push(this.getNewRoute(routePath, params, path));
+    this.context.router.push(getNewRoute(routePath, params, path));
   }
 
   getLogFiles() {
@@ -227,24 +242,3 @@ TaskFileViewer.propTypes = {
   selectedLogFile: React.PropTypes.object,
   task: React.PropTypes.object
 };
-
-TaskFileViewer.prototype.getNewRoute = function getNewRoute(
-  routePath,
-  params,
-  path
-) {
-  const hasFilePathParam = routePath.indexOf(":filePath") !== -1;
-  if (!hasFilePathParam && routePath.endsWith("/")) {
-    routePath += ":filePath";
-  }
-  if (!hasFilePathParam && !routePath.endsWith("/")) {
-    routePath += "/:filePath";
-  }
-
-  return formatPattern(
-    routePath,
-    Object.assign({}, params, { filePath: encodeURIComponent(path) })
-  );
-};
-
-module.exports = TaskFileViewer;

--- a/plugins/services/src/js/pages/task-details/TaskFileViewer.js
+++ b/plugins/services/src/js/pages/task-details/TaskFileViewer.js
@@ -46,27 +46,16 @@ class TaskFileViewer extends React.Component {
   }
 
   handleViewChange(currentFile) {
-    const { params, routes } = this.props;
     const path = currentFile.get("path");
     if (path === this.getSelectedFile().get("path")) {
       // File path didn't change, let's not try to update path
       return;
     }
 
-    let routePath = RouterUtil.reconstructPathFromRoutes(routes);
-    const hasFilePathParam = routePath.endsWith(":filePath");
-    if (!hasFilePathParam && routePath.endsWith("/")) {
-      routePath += ":filePath";
-    }
-    if (!hasFilePathParam && !routePath.endsWith("/")) {
-      routePath += "/:filePath";
-    }
-    this.context.router.push(
-      formatPattern(
-        routePath,
-        Object.assign({}, params, { filePath: encodeURIComponent(path) })
-      )
-    );
+    const { params, routes } = this.props;
+    const routePath = RouterUtil.reconstructPathFromRoutes(routes);
+
+    this.context.router.push(this.getNewRoute(routePath, params, path));
   }
 
   getLogFiles() {
@@ -237,6 +226,25 @@ TaskFileViewer.propTypes = {
   limitLogFiles: React.PropTypes.arrayOf(React.PropTypes.string),
   selectedLogFile: React.PropTypes.object,
   task: React.PropTypes.object
+};
+
+TaskFileViewer.prototype.getNewRoute = function getNewRoute(
+  routePath,
+  params,
+  path
+) {
+  const hasFilePathParam = routePath.endsWith(":filePath");
+  if (!hasFilePathParam && routePath.endsWith("/")) {
+    routePath += ":filePath";
+  }
+  if (!hasFilePathParam && !routePath.endsWith("/")) {
+    routePath += "/:filePath";
+  }
+
+  return formatPattern(
+    routePath,
+    Object.assign({}, params, { filePath: encodeURIComponent(path) })
+  );
 };
 
 module.exports = TaskFileViewer;

--- a/plugins/services/src/js/pages/task-details/TaskFileViewer.js
+++ b/plugins/services/src/js/pages/task-details/TaskFileViewer.js
@@ -233,7 +233,7 @@ TaskFileViewer.prototype.getNewRoute = function getNewRoute(
   params,
   path
 ) {
-  const hasFilePathParam = routePath.endsWith(":filePath");
+  const hasFilePathParam = routePath.indexOf(":filePath") !== -1;
   if (!hasFilePathParam && routePath.endsWith("/")) {
     routePath += ":filePath";
   }

--- a/plugins/services/src/js/pages/task-details/__tests__/TaskFileViewer-test.js
+++ b/plugins/services/src/js/pages/task-details/__tests__/TaskFileViewer-test.js
@@ -32,7 +32,7 @@ describe("TaskFileViewer", function() {
           "/var/lib/foo"
         )
       ).toBe(
-        "/services/detail/%2Fdata-services%2Fkafka/tasks/kafka-0-broker__d79a8dae-f0c4-48bd-a6c7-269856337fc9/files/view/%252Fvar%252Flib%252Ffoo/%252Fvar%252Flib%252Ffoo"
+        "/services/detail/%2Fdata-services%2Fkafka/tasks/kafka-0-broker__d79a8dae-f0c4-48bd-a6c7-269856337fc9/files/view/%252Fvar%252Flib%252Ffoo/"
       );
     });
 

--- a/plugins/services/src/js/pages/task-details/__tests__/TaskFileViewer-test.js
+++ b/plugins/services/src/js/pages/task-details/__tests__/TaskFileViewer-test.js
@@ -1,24 +1,14 @@
-const JestUtil = require("#SRC/js/utils/JestUtil");
+import React from "react";
+import ReactDOM from "react-dom";
 
-JestUtil.unMockStores(["TaskDirectoryStore", "MesosLogStore"]);
+import DirectoryItem from "../../../structs/DirectoryItem";
+import TaskDirectory from "../../../structs/TaskDirectory";
 
-const DirectoryItem = require("../../../structs/DirectoryItem");
-const TaskDirectory = require("../../../structs/TaskDirectory");
-/* eslint-disable no-unused-vars */
-const React = require("react");
-/* eslint-enable no-unused-vars */
-const ReactDOM = require("react-dom");
-
-const TaskDirectoryActions = require("../../../events/TaskDirectoryActions");
-const TaskFileViewer = require("../TaskFileViewer");
+import TaskDirectoryActions from "../../../events/TaskDirectoryActions";
+import TaskFileViewer, { getNewRoute } from "../TaskFileViewer";
 
 describe("TaskFileViewer", function() {
   describe("#getNewRoute", function() {
-    let getNewRoute;
-    beforeEach(function() {
-      getNewRoute = TaskFileViewer.prototype.getNewRoute;
-    });
-
     it("does not augment the path if there is a :filePath placeholder", function() {
       const params = {
         filePath: "%2Fvar%2Flib%2Fbar",

--- a/plugins/services/src/js/pages/task-details/__tests__/TaskFileViewer-test.js
+++ b/plugins/services/src/js/pages/task-details/__tests__/TaskFileViewer-test.js
@@ -13,27 +13,86 @@ const TaskDirectoryActions = require("../../../events/TaskDirectoryActions");
 const TaskFileViewer = require("../TaskFileViewer");
 
 describe("TaskFileViewer", function() {
-  beforeEach(function() {
-    this.container = global.document.createElement("div");
-    this.instance = ReactDOM.render(
-      <TaskFileViewer
-        directory={
-          new TaskDirectory({ items: [{ nlink: 1, path: "/stdout" }] })
-        }
-        params={{ filePath: "undefined" }}
-        selectedLogFile={new DirectoryItem({ nlink: 1, path: "/stdout" })}
-        task={{ slave_id: "foo" }}
-      />,
-      this.container
-    );
-  });
+  describe("#getNewRoute", function() {
+    let getNewRoute;
+    beforeEach(function() {
+      getNewRoute = TaskFileViewer.prototype.getNewRoute;
+    });
 
-  afterEach(function() {
-    ReactDOM.unmountComponentAtNode(this.container);
+    it("does not augment the path if there is a :filePath placeholder", function() {
+      const params = {
+        filePath: "%2Fvar%2Flib%2Fbar",
+        id: "/data-services/kafka",
+        taskID: "kafka-0-broker__d79a8dae-f0c4-48bd-a6c7-269856337fc9"
+      };
+      expect(
+        getNewRoute(
+          "/services/detail/:id/tasks/:taskID/files/view(/:filePath(/:innerPath))",
+          params,
+          "/var/lib/foo"
+        )
+      ).toBe(
+        "/services/detail/%2Fdata-services%2Fkafka/tasks/kafka-0-broker__d79a8dae-f0c4-48bd-a6c7-269856337fc9/files/view/%252Fvar%252Flib%252Ffoo/%252Fvar%252Flib%252Ffoo"
+      );
+    });
+
+    it("does augment the path without a / if there is no placeholder", function() {
+      const params = {
+        filePath: "%2Fvar%2Flib%2Fbar",
+        id: "/data-services/kafka",
+        taskID: "kafka-0-broker__d79a8dae-f0c4-48bd-a6c7-269856337fc9"
+      };
+      expect(
+        getNewRoute(
+          "/services/detail/:id/tasks/:taskID/files/view",
+          params,
+          "/var/lib/foo"
+        )
+      ).toBe(
+        "/services/detail/%2Fdata-services%2Fkafka/tasks/kafka-0-broker__d79a8dae-f0c4-48bd-a6c7-269856337fc9/files/view/%252Fvar%252Flib%252Ffoo"
+      );
+    });
+
+    it("does augment the path with a / if there is no placeholder and no /", function() {
+      it("does augment the path without a / if there is no placeholder", function() {
+        const params = {
+          filePath: "%2Fvar%2Flib%2Fbar",
+          id: "/data-services/kafka",
+          taskID: "kafka-0-broker__d79a8dae-f0c4-48bd-a6c7-269856337fc9"
+        };
+        expect(
+          getNewRoute(
+            "/services/detail/:id/tasks/:taskID/files/view/",
+            params,
+            "/var/lib/foo"
+          )
+        ).toBe(
+          "/services/detail/%2Fdata-services%2Fkafka/tasks/kafka-0-broker__d79a8dae-f0c4-48bd-a6c7-269856337fc9/files/view/%252Fvar%252Flib%252Ffoo"
+        );
+      });
+    });
   });
 
   describe("#render", function() {
-    it("should set button disabled when file is not found", function() {
+    beforeEach(function() {
+      this.container = global.document.createElement("div");
+      this.instance = ReactDOM.render(
+        <TaskFileViewer
+          directory={
+            new TaskDirectory({ items: [{ nlink: 1, path: "/stdout" }] })
+          }
+          params={{ filePath: "undefined" }}
+          selectedLogFile={new DirectoryItem({ nlink: 1, path: "/stdout" })}
+          task={{ slave_id: "foo" }}
+        />,
+        this.container
+      );
+    });
+
+    afterEach(function() {
+      ReactDOM.unmountComponentAtNode(this.container);
+    });
+    it("sets button disabled when file is not found", function() {
       this.instance = ReactDOM.render(
         <TaskFileViewer
           directory={new TaskDirectory({ items: [{ nlink: 1, path: "" }] })}


### PR DESCRIPTION
Backport of https://github.com/dcos/dcos-ui/pull/2790

## How to review

1. Launch a Service with a Task
2. View a file (e.g. Stdout)
3. Switch to other files, the UI should not break then

**Checklist**
- [X] Did you add a JIRA issue in a commit message or as part of the branch name?
- [X] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
