### PR TITLE
DCOS-37791: Connect to MesosStream on all pages

### DIFF
--- a/src/js/pages/Index.js
+++ b/src/js/pages/Index.js
@@ -9,6 +9,7 @@ import ConfigStore from "../stores/ConfigStore";
 import EventTypes from "../constants/EventTypes";
 import InternalStorageMixin from "../mixins/InternalStorageMixin";
 import MetadataStore from "../stores/MetadataStore";
+import MesosStateStore from "../stores/MesosStateStore";
 import Modals from "../components/Modals";
 import RequestErrorMsg from "../components/RequestErrorMsg";
 import ServerErrorModal from "../components/ServerErrorModal";
@@ -40,6 +41,10 @@ var Index = React.createClass({
   componentWillMount() {
     MetadataStore.init();
     SidebarStore.init();
+    MesosStateStore.addChangeListener(
+      EventTypes.MESOS_STATE_CHANGE,
+      this.onMesosStoreChange
+    );
 
     // We want to always request the summary endpoint. This will ensure that
     // our charts always have data to render.
@@ -80,6 +85,10 @@ var Index = React.createClass({
       EventTypes.CONFIG_ERROR,
       this.onConfigError
     );
+    MesosStateStore.removeChangeListener(
+      EventTypes.MESOS_STATE_CHANGE,
+      this.onMesosStoreChange
+    );
   },
 
   onSideBarChange() {
@@ -107,6 +116,8 @@ var Index = React.createClass({
       mesosSummaryErrorCount: this.state.mesosSummaryErrorCount + 1
     });
   },
+
+  onMesosStoreChange() {},
 
   getErrorScreen(showErrorScreen) {
     if (!showErrorScreen) {

--- a/tests/smoke-cy.js
+++ b/tests/smoke-cy.js
@@ -1,15 +1,15 @@
 describe("DC/OS UI [00j]", function() {
   beforeEach(function() {
-    cy
-      .configureCluster({
-        mesos: "1-task-healthy"
-      })
-      .visitUrl({ url: "/", identify: true, fakeAnalytics: true });
+    cy.configureCluster({
+      mesos: "1-task-healthy"
+    }).visitUrl({ url: "/", identify: true, fakeAnalytics: true });
   });
 
   context("Dashboard [00k]", function() {
     beforeEach(function() {
-      cy.get(".sidebar-menu-item").contains("Dashboard").click();
+      cy.get(".sidebar-menu-item")
+        .contains("Dashboard")
+        .click();
     });
 
     it("can change hash to dashboard page [00l]", function() {
@@ -17,13 +17,17 @@ describe("DC/OS UI [00j]", function() {
     });
 
     it("has eight panels [00m]", function() {
-      cy.get("#application").find(".panel").should("to.have.length", 8);
+      cy.get("#application")
+        .find(".panel")
+        .should("to.have.length", 8);
     });
   });
 
   xcontext("Services [00n]", function() {
     beforeEach(function() {
-      cy.get(".sidebar-menu-item").contains("Services").click();
+      cy.get(".sidebar-menu-item")
+        .contains("Services")
+        .click();
       cy.get("table tbody tr").as("tableRows");
     });
 
@@ -42,7 +46,9 @@ describe("DC/OS UI [00j]", function() {
 
   context("Nodes [00r]", function() {
     beforeEach(function() {
-      cy.get(".sidebar-menu-item").contains("Nodes").click();
+      cy.get(".sidebar-menu-item")
+        .contains("Nodes")
+        .click();
     });
 
     it("can change hash to nodes page [00s]", function() {
@@ -50,7 +56,9 @@ describe("DC/OS UI [00j]", function() {
     });
 
     it("displays one row on the table [00t]", function() {
-      cy.get("table tbody tr").should("to.have.length", 3).contains("dcos-01");
+      cy.get("table tbody tr")
+        .should("to.have.length", 6)
+        .contains("dcos-01");
     });
   });
 });


### PR DESCRIPTION
On a bigger clusters fetching state can take a while. With this fix we connect to the stream as soon as we can so that when a user opens a page that requires the data it's already there (or half way there at least)

## Testing

Remember that the UI doesn't connect to the stream on the Dashboard - now it will. Please keep in mind that even in the current version once we connect to the stream we never unsubscribe.

## Checklist
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

Closes DCOS-37791