### PR TITLE
DCOS-37735: fix scrolling

### DIFF
--- a/src/styles/components/scrollbar/styles.less
+++ b/src/styles/components/scrollbar/styles.less
@@ -34,7 +34,8 @@
     }
   }
 
-  .gm-prevented {
+  .gm-prevented,
+  .gm-scrollbar-container-fluid-view-width.gm-prevented {
     overflow: auto;
   }
 


### PR DESCRIPTION
2 issues were messing with our scrolling.

1) Gemini scrollbar for some reason would act differently in different browsers. For some browsers it would add a static width/height and enable the scroll in the .gm-scroll-view. For some other browsers it would enable the scroll by adding a .gm-prevented class in the gm-scrollbar-container-fluid-view-width.

2) For some other reason in the inline-bootstrap-css.js file the purify would add the .page-body {} class in the root of the page. So on the left we can see what happens when everything is on the same file. On the right we can see in production what happens when the purify script has run and has added the .page-body{} class in the root. Since it is in the root, it would override the .gm-prevented class.

<img width="1280" alt="screen shot 2018-06-14 at 2 33 44 pm" src="https://user-images.githubusercontent.com/180432/41441024-b15466f4-6fe5-11e8-9c8c-5a717c675958.png">

As a final solution. I just made the .gm-prevented a bit more strict. Most-likely gemini scrollbar had the static width/height behavior in the UI testing environment that is why the tests were passing. We have to dive very deep to see why gemini acts differently in different environments. So this simple solution would work for now.

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
