### PR TITLE
DCOS-38126: List of Jobs resolver - Take 2

### DIFF
--- a/plugins/jobs/src/js/data/JobModel-test-from-fabs-copy.js
+++ b/plugins/jobs/src/js/data/JobModel-test-from-fabs-copy.js
@@ -1,0 +1,1663 @@
+import { Observable } from "rxjs";
+import { marbles } from "rxjs-marbles/jest";
+import { resolvers } from "../JobModel";
+
+const defaultJobDetailData = {
+  id: "testid",
+  description: "test description",
+  labels: {},
+  run: {
+    cpus: 0.01,
+    mem: 128,
+    disk: 0,
+    cmd: "sleep 10",
+    env: {},
+    placement: {
+      constraints: []
+    },
+    artifacts: [],
+    maxLaunchDelay: 3600,
+    volumes: [],
+    restart: {
+      policy: "NEVER"
+    },
+    secrets: {}
+  },
+  schedules: [],
+  activeRuns: [],
+  history: {
+    successCount: 3,
+    failureCount: 1,
+    lastSuccessAt: "2018-06-06T10:49:44.471+0000",
+    lastFailureAt: "2018-06-06T09:31:47.760+0000",
+    successfulFinishedRuns: [
+      {
+        id: "20180606104932xsDzH",
+        createdAt: "2018-06-06T10:49:32.336+0000",
+        finishedAt: "2018-06-06T10:49:44.471+0000"
+      },
+      {
+        id: "20180606104545rjSRE",
+        createdAt: "2018-06-06T10:45:45.890+0000",
+        finishedAt: "2018-06-06T10:45:57.236+0000"
+      },
+      {
+        id: "20180606100732E88WQ",
+        createdAt: "2018-06-06T10:07:32.972+0000",
+        finishedAt: "2018-06-06T10:07:44.265+0000"
+      }
+    ],
+    failedFinishedRuns: [
+      {
+        createdAt: "2018-06-06T09:31:46.254+0000",
+        finishedAt: "2018-06-06T09:31:47.760+0000",
+        id: "20180606093146gr5Pi"
+      }
+    ]
+  }
+};
+
+describe("JobModel Resolver", () => {
+  let jobsData, jobsList;
+  beforeEach(() => {
+    jobsData = {
+      a: {
+        ...defaultJobDetailData,
+        id: "a",
+        activeRuns: [
+          {
+            jobId: "1",
+            createdAt: "2018-06-12T16:25:35.593+0000",
+            completedAt: "2018-06-12T17:25:35.593+0000",
+            status: "FAILED"
+          }
+        ],
+        schedules: [
+          {
+            concurrencyPolicy: "ALLOW",
+            cron: "* * * * *",
+            enabled: true,
+            id: "default",
+            nextRunAt: "2018-06-13T08:39:00.000+0000",
+            startingDeadlineSeconds: 900,
+            timezone: "UTC"
+          }
+        ],
+        history: {
+          lastFailureAt: "2018-06-12T16:25:35.593+0000",
+          lastSuccessAt: null,
+          successCount: 0,
+          failureCount: 0,
+          successfulFinishedRuns: [],
+          failedFinishedRuns: []
+        }
+      },
+      b: {
+        ...defaultJobDetailData,
+        id: "b",
+        activeRuns: [
+          {
+            jobId: "1",
+            createdAt: "2018-06-12T16:25:35.593+0000",
+            completedAt: "2018-06-12T17:25:35.593+0000",
+            status: "COMPLETED"
+          }
+        ],
+        schedules: [
+          {
+            concurrencyPolicy: "ALLOW",
+            cron: "* * * * *",
+            enabled: false,
+            id: "default",
+            nextRunAt: "2018-06-13T08:39:00.000+0000",
+            startingDeadlineSeconds: 900,
+            timezone: "UTC"
+          }
+        ],
+        history: {
+          lastFailureAt: null,
+          lastSuccessAt: null,
+          successCount: 0,
+          failureCount: 0,
+          successfulFinishedRuns: [],
+          failedFinishedRuns: []
+        }
+      },
+      c: {
+        ...defaultJobDetailData,
+        id: "c",
+        activeRuns: [],
+        schedules: []
+      }
+    };
+
+    jobsList = Object.values(jobsData);
+  });
+
+  describe("jobs", () => {
+    it(
+      "returns a list of jobs",
+      marbles(m => {
+        m.bind();
+
+        const fetchJobs = () => m.cold("(j|)", { j: [defaultJobDetailData] });
+        const fetchJobDetail = _id =>
+          m.cold("(j|)", { j: defaultJobDetailData });
+        const resolverResult$ = resolvers({
+          fetchJobs,
+          fetchJobDetail,
+          pollingInterval: m.time("--|")
+        }).Query.jobs();
+
+        const expected$ = m.cold("(j|)", {
+          j: true
+        });
+
+        const result$ = resolverResult$
+          .take(1)
+          .map(jobs => Array.isArray(jobs));
+        m.expect(result$).toBeObservable(expected$);
+      })
+    );
+
+    it(
+      "polls the endpoint",
+      marbles(m => {
+        m.bind();
+        const fetchJobs = () => m.cold("(j|)", { j: [defaultJobDetailData] });
+        const fetchJobDetail = _id =>
+          m.cold("(j|)", { j: defaultJobDetailData });
+        const resolverResult$ = resolvers({
+          fetchJobs,
+          fetchJobDetail,
+          pollingInterval: m.time("--|")
+        }).Query.jobs();
+
+        const expected$ = m.cold("(j|)", {
+          j: ["testid"]
+        });
+
+        const result$ = resolverResult$
+          .take(1)
+          .map(jobs => jobs.map(job => job.id));
+        m.expect(result$).toBeObservable(expected$);
+      })
+    );
+
+    const oneJobsResponse = (
+      m,
+      filter = "",
+      sortBy = "ID",
+      sortDirection = "ASC"
+    ) => {
+      const fetchJobs = () => m.cold("(j|)", { j: jobsList });
+      const fetchJobDetail = id => m.cold("(j|)", { j: jobsData[id] });
+      const resolverResult$ = resolvers({
+        fetchJobs,
+        fetchJobDetail,
+        pollingInterval: m.time("--|")
+      }).Query.jobs({}, { sortBy, sortDirection, filter });
+
+      return resolverResult$.take(1).map(jobs => jobs);
+    };
+
+    describe("ordering", () => {
+      it(
+        "orders by ID",
+        marbles(m => {
+          m.bind();
+
+          const result$ = oneJobsResponse(m, null, "ID", "ASC").map(jobs =>
+            jobs.map(job => job.id)
+          );
+
+          const expected$ = m.cold("(j|)", {
+            j: ["a", "b", "c"]
+          });
+
+          m.expect(result$).toBeObservable(expected$);
+        })
+      );
+
+      it(
+        "orders by ID DESC",
+        marbles(m => {
+          m.bind();
+
+          const result$ = oneJobsResponse(m, null, "ID", "DESC").map(jobs =>
+            jobs.map(job => job.id)
+          );
+
+          const expected$ = m.cold("(j|)", {
+            j: ["c", "b", "a"]
+          });
+
+          m.expect(result$).toBeObservable(expected$);
+        })
+      );
+
+      it(
+        "orders by STATUS",
+        marbles(m => {
+          m.bind();
+
+          const result$ = oneJobsResponse(m, null, "STATUS", "ASC").map(jobs =>
+            jobs.map(job => job.scheduleStatus)
+          );
+
+          const expected$ = m.cold("(j|)", {
+            j: ["FAILED", "UNSCHEDULED", "COMPLETED"]
+          });
+
+          m.expect(result$).toBeObservable(expected$);
+        })
+      );
+
+      it(
+        "orders by LAST_RUN",
+        marbles(m => {
+          m.bind();
+
+          const result$ = oneJobsResponse(m, null, "LAST_RUN", "ASC").map(
+            jobs => jobs.map(job => job.lastRunStatus.status)
+          );
+
+          const expected$ = m.cold("(j|)", {
+            j: ["Failed", "N/A", "Success"]
+          });
+
+          m.expect(result$).toBeObservable(expected$);
+        })
+      );
+    });
+
+    describe("filter", () => {
+      it(
+        "filters by ID",
+        marbles(m => {
+          m.bind();
+
+          const result$ = oneJobsResponse(m, "b").map(jobs =>
+            jobs.map(job => job.id)
+          );
+
+          const expected$ = m.cold("(j|)", {
+            j: ["b"]
+          });
+
+          m.expect(result$).toBeObservable(expected$);
+        })
+      );
+    });
+
+    describe("details", () => {
+      it(
+        "it has the information from the job details query",
+        marbles(m => {
+          m.bind();
+
+          const jobListWithoutScheduleStatus = jobsList.map(job => ({
+            ...job,
+            schedules: []
+          }));
+
+          const fetchJobs = () =>
+            m.cold("(j|)", { j: jobListWithoutScheduleStatus });
+          const fetchJobDetail = id => m.cold("(j|)", { j: jobsData[id] });
+          const resolverResult$ = resolvers({
+            fetchJobs,
+            fetchJobDetail,
+            pollingInterval: m.time("--|")
+          }).Query.jobs({}, {});
+
+          const result$ = resolverResult$
+            .take(1)
+            .map(jobs => jobs.map(job => job.scheduleStatus));
+
+          const expected$ = m.cold("(j|)", {
+            j: ["FAILED", "COMPLETED", "UNSCHEDULED"]
+          });
+
+          m.expect(result$).toBeObservable(expected$);
+        })
+      );
+    });
+  });
+
+  describe("job", () => {
+    it(
+      "polls the endpoint",
+      marbles(m => {
+        m.bind();
+        const fetchJobDetail = id =>
+          m.cold("--x|", { x: { ...defaultJobDetailData, id } });
+        const result$ = resolvers({
+          fetchJobDetail,
+          pollingInterval: m.time("--|")
+        }).Query.job({}, { id: "foo" });
+
+        const expected$ = m.cold("--x-x-(x|)", {
+          x: "foo"
+        });
+
+        m.expect(result$.take(3).map(x => x.id)).toBeObservable(expected$);
+      })
+    );
+
+    it(
+      "returns plain job data (id, disk, description, cpus, command, mem)",
+      marbles(m => {
+        m.bind();
+        const result$ = resolvers({
+          fetchJobDetail: () => Observable.of(defaultJobDetailData),
+          pollingInterval: m.time("-|")
+        }).Query.job({}, { id: "foo" });
+
+        m.expect(
+          result$
+            .take(1)
+            .map(({ id, disk, description, cpus, command, mem }) => ({
+              id,
+              disk,
+              description,
+              cpus,
+              command,
+              mem
+            }))
+        ).toBeObservable(
+          m.cold("(x|)", {
+            x: {
+              id: "testid",
+              disk: 0,
+              description: "test description",
+              cpus: 0.01,
+              mem: 128,
+              command: "sleep 10"
+            }
+          })
+        );
+      })
+    );
+
+    it(
+      "returns the name",
+      marbles(m => {
+        m.bind();
+        const result$ = resolvers({
+          fetchJobDetail: () =>
+            Observable.of({ ...defaultJobDetailData, id: "foo.bar.baz" }),
+          pollingInterval: m.time("-|")
+        }).Query.job({}, { id: "foo" });
+
+        m.expect(result$.take(1).map(({ name }) => name)).toBeObservable(
+          m.cold("(x|)", {
+            x: "baz"
+          })
+        );
+      })
+    );
+
+    describe("scheduleStatus", () => {
+      it(
+        "returns the longest running job's status",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData,
+                activeRuns: [
+                  {
+                    status: "foo",
+                    createdAt: "1985-01-03t00:00:00z-1"
+                  },
+                  {
+                    status: "bar",
+                    createdAt: "1990-01-03t00:00:00z-1"
+                  }
+                ]
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(({ scheduleStatus }) => scheduleStatus)
+          ).toBeObservable(
+            m.cold("(x|)", {
+              x: "foo"
+            })
+          );
+        })
+      );
+
+      it(
+        "returns scheduled if there are no active runs and the schedule is enabled",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData,
+                id: "/foo",
+                activeRuns: [],
+                schedules: [
+                  {
+                    enabled: true
+                  }
+                ]
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(({ scheduleStatus }) => scheduleStatus)
+          ).toBeObservable(
+            m.cold("(x|)", {
+              x: "SCHEDULED"
+            })
+          );
+        })
+      );
+
+      it(
+        "returns scheduled if there are no active runs and the schedule is enabled",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData,
+                id: "/foo",
+                activeRuns: [],
+                scheduled: [
+                  {
+                    enabled: false
+                  }
+                ]
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(({ scheduleStatus }) => scheduleStatus)
+          ).toBeObservable(
+            m.cold("(x|)", {
+              x: "UNSCHEDULED"
+            })
+          );
+        })
+      );
+
+      it(
+        "returns unscheduled if there are no active runs and no schedule",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData,
+                id: "/foo",
+                activeRuns: []
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(({ scheduleStatus }) => scheduleStatus)
+          ).toBeObservable(
+            m.cold("(x|)", {
+              x: "UNSCHEDULED"
+            })
+          );
+        })
+      );
+    });
+
+    describe("activeRuns", () => {
+      describe("longestRunningActiveRun", () => {
+        it(
+          "returns null if no runs are there",
+          marbles(m => {
+            m.bind();
+            const result$ = resolvers({
+              fetchJobDetail: () =>
+                Observable.of({
+                  ...defaultJobDetailData,
+                  id: "/foo",
+                  activeRuns: []
+                }),
+              pollingInterval: m.time("-|")
+            }).Query.job({}, { id: "xyz" });
+
+            m.expect(
+              result$
+                .take(1)
+                .map(
+                  ({ activeRuns: { longestRunningActiveRun } }) =>
+                    longestRunningActiveRun
+                )
+            ).toBeObservable(
+              m.cold("(x|)", {
+                x: null
+              })
+            );
+          })
+        );
+
+        it(
+          "returns the longest running active run",
+          marbles(m => {
+            m.bind();
+            const result$ = resolvers({
+              fetchJobDetail: () =>
+                Observable.of({
+                  ...defaultJobDetailData,
+                  id: "/foo",
+                  activeRuns: [
+                    { jobId: "1", createdAt: "1990-01-03T00:00:00Z-1" },
+                    { jobId: "2", createdAt: "1985-01-03T00:00:00Z-1" },
+                    { jobId: "3", createdAt: "1995-01-03T00:00:00Z-1" }
+                  ]
+                }),
+              pollingInterval: m.time("-|")
+            }).Query.job({}, { id: "xyz" });
+
+            m.expect(
+              result$
+                .take(1)
+                .map(
+                  ({ activeRuns: { longestRunningActiveRun } }) =>
+                    longestRunningActiveRun.jobID
+                )
+            ).toBeObservable(
+              m.cold("(x|)", {
+                x: "2"
+              })
+            );
+          })
+        );
+
+        it(
+          "ignores runs without a createdAt field",
+          marbles(m => {
+            m.bind();
+            const result$ = resolvers({
+              fetchJobDetail: () =>
+                Observable.of({
+                  ...defaultJobDetailData,
+                  id: "/foo",
+                  activeRuns: [
+                    { jobId: "1", createdAt: "1990-01-03T00:00:00Z-1" },
+                    { jobId: "2", createdAt: null },
+                    { jobId: "3", createdAt: "1995-01-03T00:00:00Z-1" }
+                  ]
+                }),
+              pollingInterval: m.time("-|")
+            }).Query.job({}, { id: "xyz" });
+
+            m.expect(
+              result$
+                .take(1)
+                .map(
+                  ({ activeRuns: { longestRunningActiveRun } }) =>
+                    longestRunningActiveRun.jobID
+                )
+            ).toBeObservable(
+              m.cold("(x|)", {
+                x: "1"
+              })
+            );
+          })
+        );
+      });
+
+      describe("nodes", () => {
+        it(
+          "returns all active runs",
+          marbles(m => {
+            m.bind();
+            const result$ = resolvers({
+              fetchJobDetail: () =>
+                Observable.of({
+                  ...defaultJobDetailData,
+                  id: "/foo",
+                  activeRuns: [
+                    { jobId: "1", createdAt: "1990-01-03T00:00:00Z-1" },
+                    { jobId: "2", createdAt: null },
+                    { jobId: "3", createdAt: "1995-01-03T00:00:00Z-1" }
+                  ]
+                }),
+              pollingInterval: m.time("-|")
+            }).Query.job({}, { id: "xyz" });
+
+            m.expect(
+              result$.take(1).map(({ activeRuns: { nodes } }) => nodes.length)
+            ).toBeObservable(
+              m.cold("(x|)", {
+                x: 3
+              })
+            );
+          })
+        );
+
+        describe("JobRun", () => {
+          it(
+            "contains dates as integers",
+            marbles(m => {
+              m.bind();
+              const result$ = resolvers({
+                fetchJobDetail: () =>
+                  Observable.of({
+                    ...defaultJobDetailData,
+                    id: "/foo",
+                    activeRuns: [
+                      {
+                        jobId: "1",
+                        createdAt: "2018-06-12T16:25:35.593+0000",
+                        completedAt: "2018-06-12T17:25:35.593+0000",
+                        status: "ACTIVE",
+                        id: "20180612162535qXvcx"
+                      }
+                    ]
+                  }),
+                pollingInterval: m.time("-|")
+              }).Query.job({}, { id: "xyz" });
+
+              m.expect(
+                result$.take(1).map(({ activeRuns: { nodes } }) => ({
+                  dateCreated: nodes[0].dateCreated,
+                  dateFinished: nodes[0].dateFinished
+                }))
+              ).toBeObservable(
+                m.cold("(x|)", {
+                  x: {
+                    dateCreated: 1528820735593,
+                    dateFinished: 1528824335593
+                  }
+                })
+              );
+            })
+          );
+
+          it(
+            "contains a status",
+            marbles(m => {
+              m.bind();
+              const result$ = resolvers({
+                fetchJobDetail: () =>
+                  Observable.of({
+                    ...defaultJobDetailData,
+                    id: "/foo",
+                    activeRuns: [
+                      {
+                        jobId: "1",
+                        createdAt: "2018-06-12T16:25:35.593+0000",
+                        completedAt: "2018-06-12T17:25:35.593+0000",
+                        status: "ACTIVE",
+                        id: "20180612162535qXvcx"
+                      }
+                    ]
+                  }),
+                pollingInterval: m.time("-|")
+              }).Query.job({}, { id: "xyz" });
+
+              m.expect(
+                result$
+                  .take(1)
+                  .map(({ activeRuns: { nodes } }) => nodes[0].status)
+              ).toBeObservable(
+                m.cold("(x|)", {
+                  x: "ACTIVE"
+                })
+              );
+            })
+          );
+
+          describe("tasks", () => {
+            it(
+              "nodes contains all tasks",
+              marbles(m => {
+                m.bind();
+                const result$ = resolvers({
+                  fetchJobDetail: () =>
+                    Observable.of({
+                      ...defaultJobDetailData,
+                      id: "/foo",
+                      activeRuns: [
+                        {
+                          jobId: "1",
+                          createdAt: "2018-06-12T16:25:35.593+0000",
+                          completedAt: "2018-06-12T17:25:35.593+0000",
+                          status: "ACTIVE",
+                          id: "20180612162535qXvcx",
+                          tasks: [
+                            {
+                              id:
+                                "foo_20180613080833uHuVo.f76c008f-6ee0-11e8-90f4-a20d8c471282",
+                              startedAt: "2018-06-13T08:08:34.773+0000",
+                              status: "TASK_RUNNING"
+                            },
+                            {
+                              id:
+                                "foo_20180613080833uHuVo.f76c008f-6ee0-11e8-90f4-a20d8c471283",
+                              startedAt: "2018-06-13T08:09:34.773+0000",
+                              status: "TASK_STARTING"
+                            },
+                            {
+                              id:
+                                "foo_20180613080833uHuVo.f76c008f-6ee0-11e8-90f4-a20d8c471283",
+                              startedAt: "2018-06-12T08:09:34.773+0000",
+                              status: "TASK_RUNNING"
+                            },
+                            {
+                              id:
+                                "foo_20180613080833uHuVo.f76c008f-6ee0-11e8-90f4-a20d8c471283",
+                              startedAt: "2018-06-12T08:09:34.773+0000",
+                              status: "TASK_FINISHED"
+                            }
+                          ]
+                        }
+                      ]
+                    }),
+                  pollingInterval: m.time("-|")
+                }).Query.job({}, { id: "xyz" });
+
+                m.expect(
+                  result$
+                    .take(1)
+                    .map(
+                      ({ activeRuns: { nodes } }) => nodes[0].tasks.nodes.length
+                    )
+                ).toBeObservable(
+                  m.cold("(x|)", {
+                    x: 4
+                  })
+                );
+              })
+            );
+
+            describe("JobTask", () => {
+              it(
+                "contains the dates as numbers",
+                marbles(m => {
+                  m.bind();
+                  const result$ = resolvers({
+                    fetchJobDetail: () =>
+                      Observable.of({
+                        ...defaultJobDetailData,
+                        id: "/foo",
+                        activeRuns: [
+                          {
+                            jobId: "1",
+                            createdAt: "2018-06-12T16:25:35.593+0000",
+                            completedAt: "2018-06-12T17:25:35.593+0000",
+                            status: "ACTIVE",
+                            id: "20180612162535qXvcx",
+                            tasks: [
+                              {
+                                id:
+                                  "foo_20180613080833uHuVo.f76c008f-6ee0-11e8-90f4-a20d8c471282",
+                                createdAt: "2018-06-13T08:08:34.773+0000",
+                                status: "TASK_RUNNING"
+                              },
+                              {
+                                id:
+                                  "foo_20180613080833uHuVo.f76c008f-6ee0-11e8-90f4-a20d8c471283",
+                                createdAt: "2018-06-13T08:09:34.773+0000",
+                                status: "TASK_STARTING"
+                              },
+                              {
+                                id:
+                                  "foo_20180613080833uHuVo.f76c008f-6ee0-11e8-90f4-a20d8c471283",
+                                createdAt: "2018-06-12T08:09:34.773+0000",
+                                status: "TASK_RUNNING"
+                              },
+                              {
+                                id:
+                                  "foo_20180613080833uHuVo.f76c008f-6ee0-11e8-90f4-a20d8c471283",
+                                createdAt: "2018-06-12T08:09:34.773+0000",
+                                status: "TASK_FINISHED",
+                                finishedAt: "2018-06-13T08:10:15.367+0000"
+                              }
+                            ]
+                          }
+                        ]
+                      }),
+                    pollingInterval: m.time("-|")
+                  }).Query.job({}, { id: "xyz" });
+
+                  m.expect(
+                    result$.take(1).map(({ activeRuns: { nodes } }) => ({
+                      dateCompleted: nodes[0].tasks.nodes[3].dateCompleted,
+                      dateStarted: nodes[0].tasks.nodes[3].dateStarted
+                    }))
+                  ).toBeObservable(
+                    m.cold("(x|)", {
+                      x: {
+                        dateCompleted: 1528877415367,
+                        dateStarted: 1528790974773
+                      }
+                    })
+                  );
+                })
+              );
+
+              it(
+                "contains the taskId",
+                marbles(m => {
+                  m.bind();
+                  const result$ = resolvers({
+                    fetchJobDetail: () =>
+                      Observable.of({
+                        ...defaultJobDetailData,
+                        id: "/foo",
+                        activeRuns: [
+                          {
+                            jobId: "1",
+                            createdAt: "2018-06-12T16:25:35.593+0000",
+                            completedAt: "2018-06-12T17:25:35.593+0000",
+                            status: "ACTIVE",
+                            id: "20180612162535qXvcx",
+                            tasks: [
+                              {
+                                id:
+                                  "foo_20180613080833uHuVo.f76c008f-6ee0-11e8-90f4-a20d8c471282",
+                                createdAt: "2018-06-13T08:08:34.773+0000",
+                                status: "TASK_RUNNING"
+                              },
+                              {
+                                id:
+                                  "foo_20180613080833uHuVo.f76c008f-6ee0-11e8-90f4-a20d8c471283",
+                                createdAt: "2018-06-13T08:09:34.773+0000",
+                                status: "TASK_STARTING"
+                              },
+                              {
+                                id:
+                                  "foo_20180613080833uHuVo.f76c008f-6ee0-11e8-90f4-a20d8c471283",
+                                createdAt: "2018-06-12T08:09:34.773+0000",
+                                status: "TASK_RUNNING"
+                              },
+                              {
+                                id:
+                                  "foo_20180613080833uHuVo.f76c008f-6ee0-11e8-90f4-a20d8c471283",
+                                createdAt: "2018-06-12T08:09:34.773+0000",
+                                status: "TASK_FINISHED",
+                                finishedAt: "2018-06-13T08:10:15.367+0000"
+                              }
+                            ]
+                          }
+                        ]
+                      }),
+                    pollingInterval: m.time("-|")
+                  }).Query.job({}, { id: "xyz" });
+
+                  m.expect(
+                    result$
+                      .take(1)
+                      .map(
+                        ({ activeRuns: { nodes } }) =>
+                          nodes[0].tasks.nodes[0].taskId
+                      )
+                  ).toBeObservable(
+                    m.cold("(x|)", {
+                      x:
+                        "foo_20180613080833uHuVo.f76c008f-6ee0-11e8-90f4-a20d8c471282"
+                    })
+                  );
+                })
+              );
+
+              it(
+                "contains the status",
+                marbles(m => {
+                  m.bind();
+                  const result$ = resolvers({
+                    fetchJobDetail: () =>
+                      Observable.of({
+                        ...defaultJobDetailData,
+                        id: "/foo",
+                        activeRuns: [
+                          {
+                            jobId: "1",
+                            createdAt: "2018-06-12T16:25:35.593+0000",
+                            completedAt: "2018-06-12T17:25:35.593+0000",
+                            status: "ACTIVE",
+                            id: "20180612162535qXvcx",
+                            tasks: [
+                              {
+                                id:
+                                  "foo_20180613080833uHuVo.f76c008f-6ee0-11e8-90f4-a20d8c471282",
+                                createdAt: "2018-06-13T08:08:34.773+0000",
+                                status: "TASK_RUNNING"
+                              },
+                              {
+                                id:
+                                  "foo_20180613080833uHuVo.f76c008f-6ee0-11e8-90f4-a20d8c471283",
+                                createdAt: "2018-06-13T08:09:34.773+0000",
+                                status: "TASK_STARTING"
+                              },
+                              {
+                                id:
+                                  "foo_20180613080833uHuVo.f76c008f-6ee0-11e8-90f4-a20d8c471283",
+                                createdAt: "2018-06-12T08:09:34.773+0000",
+                                status: "TASK_RUNNING"
+                              },
+                              {
+                                id:
+                                  "foo_20180613080833uHuVo.f76c008f-6ee0-11e8-90f4-a20d8c471283",
+                                createdAt: "2018-06-12T08:09:34.773+0000",
+                                status: "TASK_FINISHED",
+                                finishedAt: "2018-06-13T08:10:15.367+0000"
+                              }
+                            ]
+                          }
+                        ]
+                      }),
+                    pollingInterval: m.time("-|")
+                  }).Query.job({}, { id: "xyz" });
+
+                  m.expect(
+                    result$
+                      .take(1)
+                      .map(
+                        ({ activeRuns: { nodes } }) =>
+                          nodes[0].tasks.nodes[0].status
+                      )
+                  ).toBeObservable(
+                    m.cold("(x|)", {
+                      x: "TASK_RUNNING"
+                    })
+                  );
+                })
+              );
+            });
+
+            describe("longestRunningTask", () => {
+              it(
+                "returns longest running",
+                marbles(m => {
+                  m.bind();
+                  const result$ = resolvers({
+                    fetchJobDetail: () =>
+                      Observable.of({
+                        ...defaultJobDetailData,
+                        id: "/foo",
+                        activeRuns: [
+                          {
+                            jobId: "1",
+                            createdAt: "2018-06-12T16:25:35.593+0000",
+                            completedAt: "2018-06-12T17:25:35.593+0000",
+                            status: "ACTIVE",
+                            id: "20180612162535qXvcx",
+                            tasks: [
+                              {
+                                id: "shortest-running",
+                                createdAt: "2018-06-13T08:08:34.773+0000",
+                                status: "TASK_RUNNING"
+                              },
+                              {
+                                id: "middle-running",
+                                createdAt: "2018-06-13T08:09:34.773+0000",
+                                status: "TASK_STARTING"
+                              },
+                              {
+                                id: "longest-running",
+                                createdAt: "2018-06-12T08:09:34.773+0000",
+                                status: "TASK_RUNNING"
+                              }
+                            ]
+                          }
+                        ]
+                      }),
+                    pollingInterval: m.time("-|")
+                  }).Query.job({}, { id: "xyz" });
+
+                  m.expect(
+                    result$
+                      .take(1)
+                      .map(
+                        ({ activeRuns: { nodes } }) =>
+                          nodes[0].tasks.longestRunningTask.taskId
+                      )
+                  ).toBeObservable(
+                    m.cold("(x|)", {
+                      x: "longest-running"
+                    })
+                  );
+                })
+              );
+
+              it(
+                "ignores createdAt",
+                marbles(m => {
+                  m.bind();
+                  const result$ = resolvers({
+                    fetchJobDetail: () =>
+                      Observable.of({
+                        ...defaultJobDetailData,
+                        id: "/foo",
+                        activeRuns: [
+                          {
+                            jobId: "1",
+                            createdAt: "2018-06-12T16:25:35.593+0000",
+                            completedAt: "2018-06-12T17:25:35.593+0000",
+                            status: "ACTIVE",
+                            id: "20180612162535qXvcx",
+                            tasks: [
+                              {
+                                id: "shortest-running",
+                                createdAt: "2018-06-13T08:08:34.773+0000",
+                                status: "TASK_RUNNING"
+                              },
+                              {
+                                id: "longest-running",
+                                createdAt: "2017-06-13T08:09:34.773+0000",
+                                status: "TASK_STARTING"
+                              },
+                              {
+                                id: "without-created-at",
+                                status: "TASK_RUNNING"
+                              }
+                            ]
+                          }
+                        ]
+                      }),
+                    pollingInterval: m.time("-|")
+                  }).Query.job({}, { id: "xyz" });
+
+                  m.expect(
+                    result$
+                      .take(1)
+                      .map(
+                        ({ activeRuns: { nodes } }) =>
+                          nodes[0].tasks.longestRunningTask.taskId
+                      )
+                  ).toBeObservable(
+                    m.cold("(x|)", {
+                      x: "longest-running"
+                    })
+                  );
+                })
+              );
+
+              it(
+                "returns null if there are no tasks",
+                marbles(m => {
+                  m.bind();
+                  const result$ = resolvers({
+                    fetchJobDetail: () =>
+                      Observable.of({
+                        ...defaultJobDetailData,
+                        id: "/foo",
+                        activeRuns: [
+                          {
+                            jobId: "1",
+                            createdAt: "2018-06-12T16:25:35.593+0000",
+                            completedAt: "2018-06-12T17:25:35.593+0000",
+                            status: "ACTIVE",
+                            id: "20180612162535qXvcx",
+                            tasks: []
+                          }
+                        ]
+                      }),
+                    pollingInterval: m.time("-|")
+                  }).Query.job({}, { id: "xyz" });
+
+                  m.expect(
+                    result$
+                      .take(1)
+                      .map(
+                        ({ activeRuns: { nodes } }) =>
+                          nodes[0].tasks.longestRunningTask
+                      )
+                  ).toBeObservable(
+                    m.cold("(x|)", {
+                      x: null
+                    })
+                  );
+                })
+              );
+            });
+          });
+        });
+      });
+    });
+
+    describe("jobRuns", () => {
+      it(
+        "contains all types of job runs",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData,
+                id: "/foo",
+                activeRuns: [
+                  {
+                    jobId: "1",
+                    createdAt: "2018-06-12T16:25:35.593+0000",
+                    completedAt: "2018-06-12T17:25:35.593+0000",
+                    status: "ACTIVE",
+                    id: "20180612162535qXvcx",
+                    tasks: []
+                  }
+                ],
+                history: {
+                  successfulFinishedRuns: [
+                    {
+                      id: "2",
+                      createdAt: "2018-06-12T16:25:35.593+0000",
+                      finishedAt: "2018-06-12T17:25:35.593+0000"
+                    }
+                  ],
+                  failedFinishedRuns: [
+                    {
+                      id: "3",
+                      createdAt: "2018-06-12T16:25:35.593+0000",
+                      finishedAt: "2018-06-12T17:25:35.593+0000"
+                    }
+                  ]
+                }
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$
+              .take(1)
+              .map(({ jobRuns: { nodes } }) => nodes.map(node => node.jobID))
+          ).toBeObservable(
+            m.cold("(x|)", {
+              x: ["1", "2", "3"]
+            })
+          );
+        })
+      );
+
+      it(
+        "contains same information for each type",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData,
+                id: "/foo",
+                activeRuns: [
+                  {
+                    jobId: "1",
+                    createdAt: "2018-06-12T16:25:35.593+0000",
+                    completedAt: "2018-06-12T17:25:35.593+0000",
+                    status: "ACTIVE",
+                    id: "20180612162535qXvcx",
+                    tasks: []
+                  }
+                ],
+                history: {
+                  successfulFinishedRuns: [
+                    {
+                      id: "2",
+                      createdAt: "2018-06-12T16:25:35.593+0000",
+                      finishedAt: "2018-06-12T17:25:35.593+0000"
+                    }
+                  ],
+                  failedFinishedRuns: [
+                    {
+                      id: "3",
+                      createdAt: "2018-06-12T16:25:35.593+0000",
+                      finishedAt: "2018-06-12T17:25:35.593+0000"
+                    }
+                  ]
+                }
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          const emptyTasks = {
+            longestRunningTask: null,
+            nodes: []
+          };
+
+          m.expect(
+            result$
+              .take(1)
+              .map(({ jobRuns: { nodes } }) => nodes.map(node => node))
+          ).toBeObservable(
+            m.cold("(x|)", {
+              x: [
+                {
+                  dateCreated: 1528820735593,
+                  dateFinished: 1528824335593,
+                  jobID: "1",
+                  status: "ACTIVE",
+                  tasks: emptyTasks
+                },
+                {
+                  dateCreated: 1528820735593,
+                  dateFinished: null,
+                  jobID: "2",
+                  status: "COMPLETED",
+                  tasks: emptyTasks
+                },
+                {
+                  dateCreated: 1528820735593,
+                  dateFinished: null,
+                  jobID: "3",
+                  status: "FAILED",
+                  tasks: emptyTasks
+                }
+              ]
+            })
+          );
+        })
+      );
+    });
+
+    describe("lastRunsSummary", () => {
+      it(
+        "contains default if job wasnt run yet",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData,
+                history: {
+                  failureCount: 0,
+                  lastFailureAt: null,
+                  lastSuccessAt: null,
+                  successCount: 0,
+                  successfulFinishedRuns: [],
+                  failedFinishedRuns: []
+                }
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(response => response.lastRunsSummary)
+          ).toBeObservable(
+            m.cold("(x|)", {
+              x: {
+                failureCount: 0,
+                lastFailureAt: null,
+                lastSuccessAt: null,
+                successCount: 0
+              }
+            })
+          );
+        })
+      );
+    });
+
+    describe("docker", () => {
+      it(
+        "is null if no docker information is provided",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData,
+                run: {
+                  ...defaultJobDetailData.run,
+                  docker: null
+                }
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(response => response.docker)
+          ).toBeObservable(m.cold("(x|)", { x: null }));
+        })
+      );
+
+      it(
+        "returns forcePullImage",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData,
+                run: {
+                  ...defaultJobDetailData.run,
+                  docker: {
+                    forcePullImage: true,
+                    image: "node:10"
+                  }
+                }
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(response => response.docker.forcePullImage)
+          ).toBeObservable(m.cold("(x|)", { x: true }));
+        })
+      );
+
+      it(
+        "returns image",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData,
+                run: {
+                  ...defaultJobDetailData.run,
+                  docker: {
+                    forcePullImage: true,
+                    image: "node:10"
+                  }
+                }
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(response => response.docker.image)
+          ).toBeObservable(m.cold("(x|)", { x: "node:10" }));
+        })
+      );
+    });
+
+    describe("json", () => {
+      it(
+        "returns json representation",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData,
+                id: "json-id"
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(response => JSON.parse(response.json).id)
+          ).toBeObservable(m.cold("(x|)", { x: "json-id" }));
+        })
+      );
+
+      it(
+        "removes blacklisted keys from JSON",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(response => JSON.parse(response.json).history)
+          ).toBeObservable(m.cold("(x|)", { x: undefined }));
+        })
+      );
+    });
+
+    it(
+      "returns labels as array of key and value",
+      marbles(m => {
+        m.bind();
+        const result$ = resolvers({
+          fetchJobDetail: () =>
+            Observable.of({
+              ...defaultJobDetailData,
+              labels: {
+                foo: "bar",
+                baz: "nice"
+              }
+            }),
+          pollingInterval: m.time("-|")
+        }).Query.job({}, { id: "xyz" });
+
+        m.expect(
+          result$.take(1).map(response => response.labels)
+        ).toBeObservable(
+          m.cold("(x|)", {
+            x: [{ key: "foo", value: "bar" }, { key: "baz", value: "nice" }]
+          })
+        );
+      })
+    );
+
+    describe("lastRunStatus", () => {
+      it(
+        "returns status of last run",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(({ lastRunStatus }) => lastRunStatus.status)
+          ).toBeObservable(
+            m.cold("(x|)", {
+              x: "Success"
+            })
+          );
+        })
+      );
+      it(
+        "returns time of last run",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(({ lastRunStatus }) => lastRunStatus.time)
+          ).toBeObservable(
+            m.cold("(x|)", {
+              x: 1528282184471
+            })
+          );
+        })
+      );
+
+      it(
+        "returns status N/A for new Job",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData,
+                history: {
+                  lastFailureAt: null,
+                  lastSuccessAt: null,
+                  successCount: 0,
+                  failureCount: 0,
+                  successfulFinishedRuns: [],
+                  failedFinishedRuns: []
+                }
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(({ lastRunStatus }) => lastRunStatus.status)
+          ).toBeObservable(
+            m.cold("(x|)", {
+              x: "N/A"
+            })
+          );
+        })
+      );
+
+      it(
+        "returns time null for new Job",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData,
+                history: {
+                  lastFailureAt: null,
+                  lastSuccessAt: null,
+                  successCount: 0,
+                  failureCount: 0,
+                  successfulFinishedRuns: [],
+                  failedFinishedRuns: []
+                }
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(({ lastRunStatus }) => lastRunStatus.time)
+          ).toBeObservable(
+            m.cold("(x|)", {
+              x: null
+            })
+          );
+        })
+      );
+
+      it(
+        "returns failed for job with only failed",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData,
+                history: {
+                  lastFailureAt: "2018-06-06T09:31:47.760+0000",
+                  lastSuccessAt: null,
+                  successCount: 0,
+                  failureCount: 1,
+                  successfulFinishedRuns: [],
+                  failedFinishedRuns: [
+                    {
+                      createdAt: "2018-06-06T09:31:46.254+0000",
+                      finishedAt: "2018-06-06T09:31:47.760+0000",
+                      id: "20180606093146gr5Pi"
+                    }
+                  ]
+                }
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(({ lastRunStatus }) => lastRunStatus.status)
+          ).toBeObservable(
+            m.cold("(x|)", {
+              x: "Failed"
+            })
+          );
+        })
+      );
+
+      it(
+        "returns Success for first failed then successful Job",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(({ lastRunStatus }) => lastRunStatus)
+          ).toBeObservable(
+            m.cold("(x|)", {
+              x: { status: "Success", time: 1528282184471 }
+            })
+          );
+        })
+      );
+    });
+
+    describe("schedules", () => {
+      it(
+        "contains empty array for schedules if response did",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(({ schedules }) => schedules)
+          ).toBeObservable(
+            m.cold("(x|)", {
+              x: { nodes: [] }
+            })
+          );
+        })
+      );
+
+      it(
+        "contains schedule if response did",
+        marbles(m => {
+          m.bind();
+          const result$ = resolvers({
+            fetchJobDetail: () =>
+              Observable.of({
+                ...defaultJobDetailData,
+                schedules: [
+                  {
+                    concurrencyPolicy: "ALLOW",
+                    cron: "* * * * *",
+                    enabled: false,
+                    id: "default",
+                    nextRunAt: "2018-06-13T08:39:00.000+0000",
+                    startingDeadlineSeconds: 900,
+                    timezone: "UTC"
+                  }
+                ]
+              }),
+            pollingInterval: m.time("-|")
+          }).Query.job({}, { id: "xyz" });
+
+          m.expect(
+            result$.take(1).map(({ schedules }) => schedules)
+          ).toBeObservable(
+            m.cold("(x|)", {
+              x: {
+                nodes: [
+                  {
+                    cron: "* * * * *",
+                    enabled: false,
+                    id: "default",
+                    startingDeadlineSeconds: 900,
+                    timezone: "UTC"
+                  }
+                ]
+              }
+            })
+          );
+        })
+      );
+    });
+  });
+});

--- a/plugins/jobs/src/js/data/JobModel.ts
+++ b/plugins/jobs/src/js/data/JobModel.ts
@@ -1,11 +1,15 @@
 import { makeExecutableSchema, IResolvers } from "graphql-tools";
 import { Observable } from "rxjs/Observable";
 import {
+  fetchJobs,
   fetchJobDetail,
+  JobResponse as MetronomeJobResponse,
   JobDetailResponse as MetronomeJobDetailResponse
 } from "#SRC/js/events/MetronomeClient";
 
 import Config from "#SRC/js/config/Config";
+import JobStatusInformation from "#PLUGINS/jobs/src/js/types/JobStatus";
+import JobRunStatusInformation from "#PLUGINS/jobs/src/js/types/JobRunStatus";
 import {
   JobConnection,
   JobConnectionSchema
@@ -22,6 +26,7 @@ export interface Query {
 }
 
 export interface ResolverArgs {
+  fetchJobs: () => Observable<MetronomeJobResponse[]>;
   fetchJobDetail: (id: string) => Observable<MetronomeJobDetailResponse>;
   pollingInterval: number;
 }
@@ -31,16 +36,13 @@ export interface GeneralArgs {
 }
 
 export interface JobsQueryArgs {
-  filter?: string | null;
-  sortBy?: SortOption | null;
-  sortDirection?: SortDirection | null;
+  filter?: string;
+  sortBy?: SortOption;
+  sortDirection?: SortDirection;
 }
 
 export interface JobQueryArgs {
   id: string;
-  filter?: string | null;
-  sortBy?: SortOption | null;
-  sortDirection?: SortDirection | null;
 }
 
 export type SortOption = "ID" | "STATUS" | "LAST_RUN";
@@ -79,6 +81,65 @@ function isJobQueryArg(arg: any): arg is JobQueryArgs {
   return arg.id !== undefined;
 }
 
+// Sort and filtering
+function sortJobs(
+  jobs: Job[],
+  sortBy: SortOption = "ID",
+  sortDirection: SortDirection = "ASC"
+): Job[] {
+  jobs.sort((a, b) => {
+    let result;
+
+    switch (sortBy) {
+      case "ID":
+        result = sortJobById(a, b);
+        break;
+      case "STATUS":
+        result = sortJobByStatus(a, b);
+        break;
+      case "LAST_RUN":
+        result = sortJobByLastRun(a, b);
+        break;
+      default:
+        result = 0;
+    }
+
+    const direction = sortDirection === "ASC" ? 1 : -1;
+    return result * direction;
+  });
+
+  return jobs;
+}
+
+function sortJobById(a: Job, b: Job): number {
+  return a.id.localeCompare(b.id);
+}
+
+function sortJobByStatus(a: Job, b: Job): number {
+  return (
+    JobStatusInformation[a.scheduleStatus].sortOrder -
+    JobStatusInformation[b.scheduleStatus].sortOrder
+  );
+}
+
+function sortJobByLastRun(a: Job, b: Job): number {
+  return (
+    JobRunStatusInformation[a.lastRunStatus.status].sortOrder -
+    JobRunStatusInformation[b.lastRunStatus.status].sortOrder
+  );
+}
+
+function filterJobs(
+  jobs: MetronomeJobResponse[],
+  filter: string | null
+): MetronomeJobResponse[] {
+  if (filter === null) {
+    return jobs;
+  }
+
+  return jobs.filter(({ id }) => id.includes(filter));
+}
+
 export const resolvers = ({
   fetchJobDetail,
   pollingInterval
@@ -86,10 +147,35 @@ export const resolvers = ({
   Query: {
     jobs(
       _obj = {},
-      _args: GeneralArgs = {},
+      args: GeneralArgs = {},
       _context = {}
     ): Observable<JobConnection | null> {
-      return Observable.of(null);
+      // TODO: type guard
+      const {
+        sortBy = "ID",
+        sortDirection = "ASC",
+        filter = null
+      } = args as JobsQueryArgs;
+
+      const pollingInterval$ = Observable.timer(0, pollingInterval);
+      const responses$ = pollingInterval$.switchMap(fetchJobs);
+      const totalCount$ = responses$.map(jobs => jobs.length);
+
+      return (
+        responses$
+          .map(jobs => filterJobs(jobs, filter))
+          //TODO We need to remove the N + 1 query
+          // https://jira.mesosphere.com/browse/DCOS-38201
+          .map(jobs => jobs.map(job => fetchJobDetail(job.id)))
+          .switchMap(obs => Observable.combineLatest(obs))
+          .map(requests => requests.map(JobTypeResolver))
+          .map(jobs => sortJobs(jobs, sortBy, sortDirection))
+          .combineLatest(totalCount$, (jobs, totalCount) => ({
+            filteredCount: jobs.length,
+            totalCount,
+            nodes: jobs
+          }))
+      );
     },
     job(_obj = {}, args: GeneralArgs, _context = {}): Observable<Job | null> {
       if (!isJobQueryArg(args)) {
@@ -109,6 +195,7 @@ export const resolvers = ({
 export default makeExecutableSchema({
   typeDefs,
   resolvers: resolvers({
+    fetchJobs,
     fetchJobDetail,
     pollingInterval: Config.getRefreshRate()
   })

--- a/plugins/jobs/src/js/data/__tests__/JobModel-test.js
+++ b/plugins/jobs/src/js/data/__tests__/JobModel-test.js
@@ -292,10 +292,6 @@ describe("JobModel Resolver", () => {
                   ({ activeRuns: { longestRunningActiveRun } }) =>
                     longestRunningActiveRun
                 )
-                .catch(e => {
-                  console.error(e);
-                  throw e;
-                })
             ).toBeObservable(
               m.cold("(x|)", {
                 x: null
@@ -495,10 +491,6 @@ describe("JobModel Resolver", () => {
                 result$
                   .take(1)
                   .map(({ activeRuns: { nodes } }) => nodes[0].status)
-                  .catch(e => {
-                    console.error(e);
-                    throw e;
-                  })
               ).toBeObservable(
                 m.cold("(x|)", {
                   x: "ACTIVE"

--- a/plugins/jobs/src/js/types/Job.ts
+++ b/plugins/jobs/src/js/types/Job.ts
@@ -34,6 +34,7 @@ import {
 } from "#PLUGINS/jobs/src/js/types/JobDocker";
 import { JobLabel, LabelSchema } from "#PLUGINS/jobs/src/js/types/JobLabel";
 import { cleanJobJSON } from "#SRC/js/utils/CleanJSONUtil";
+
 export interface Job {
   activeRuns: JobRunConnection;
   command: string;
@@ -84,25 +85,25 @@ type Job {
 
 export function JobTypeResolver(response: MetronomeJobDetailResponse): Job {
   return {
-    id: fieldResolvers.id(response),
-    description: fieldResolvers.description(response),
-    command: fieldResolvers.command(response),
-    disk: fieldResolvers.disk(response),
-    mem: fieldResolvers.mem(response),
-    cpus: fieldResolvers.cpus(response),
-    docker: fieldResolvers.docker(response),
-    json: fieldResolvers.json(response),
-    labels: fieldResolvers.labels(response),
-    lastRunStatus: fieldResolvers.lastRunStatus(response),
-    name: fieldResolvers.name(response),
-    jobRuns: fieldResolvers.jobRuns(response),
-    lastRunsSummary: fieldResolvers.lastRunsSummary(response),
-    scheduleStatus: fieldResolvers.scheduleStatus(response),
-    activeRuns: fieldResolvers.activeRuns(response),
-    schedules: fieldResolvers.schedules(response)
+    id: JobFieldResolvers.id(response),
+    description: JobFieldResolvers.description(response),
+    command: JobFieldResolvers.command(response),
+    disk: JobFieldResolvers.disk(response),
+    mem: JobFieldResolvers.mem(response),
+    cpus: JobFieldResolvers.cpus(response),
+    docker: JobFieldResolvers.docker(response),
+    json: JobFieldResolvers.json(response),
+    labels: JobFieldResolvers.labels(response),
+    lastRunStatus: JobFieldResolvers.lastRunStatus(response),
+    name: JobFieldResolvers.name(response),
+    jobRuns: JobFieldResolvers.jobRuns(response),
+    lastRunsSummary: JobFieldResolvers.lastRunsSummary(response),
+    scheduleStatus: JobFieldResolvers.scheduleStatus(response),
+    activeRuns: JobFieldResolvers.activeRuns(response),
+    schedules: JobFieldResolvers.schedules(response)
   };
 }
-export const fieldResolvers = {
+export const JobFieldResolvers = {
   id(job: MetronomeJobDetailResponse): string {
     return job.id;
   },

--- a/plugins/jobs/src/js/types/JobRunStatus.ts
+++ b/plugins/jobs/src/js/types/JobRunStatus.ts
@@ -7,3 +7,27 @@ enum JobRunStatus {
   Success
 }
 `;
+
+export interface JobRunStatusMap {
+  [state: string]: {
+    displayName: string;
+    sortOrder: number;
+  };
+}
+
+const statusMap: JobRunStatusMap = {
+  "N/A": {
+    displayName: "N/A",
+    sortOrder: 1
+  },
+  Success: {
+    displayName: "Success",
+    sortOrder: 2
+  },
+  Failed: {
+    displayName: "Failed",
+    sortOrder: 0
+  }
+};
+
+export default statusMap;

--- a/plugins/jobs/src/js/types/JobStatus.ts
+++ b/plugins/jobs/src/js/types/JobStatus.ts
@@ -20,3 +20,61 @@ enum JobStatus {
   UNSCHEDULED
 }
 `;
+
+/**
+ * Sort order is ordered by most important (lowest number, top of list)
+ * to least important (largest number, bottom of list)
+ */
+
+export interface JobStatusMap {
+  [state: string]: {
+    stateTypes: string[];
+    displayName: string;
+    sortOrder: number;
+  };
+}
+
+const states: JobStatusMap = {
+  INITIAL: {
+    stateTypes: ["active"],
+    displayName: "Starting",
+    sortOrder: 3
+  },
+  STARTING: {
+    stateTypes: ["active"],
+    displayName: "Starting",
+    sortOrder: 3
+  },
+  ACTIVE: {
+    stateTypes: ["active"],
+    displayName: "Running",
+    sortOrder: 4
+  },
+  FAILED: {
+    stateTypes: ["completed", "failure"],
+    displayName: "Failed",
+    sortOrder: 0
+  },
+  SUCCESS: {
+    stateTypes: ["success"],
+    displayName: "Success",
+    sortOrder: 6
+  },
+  COMPLETED: {
+    stateTypes: ["success"],
+    displayName: "Completed",
+    sortOrder: 5
+  },
+  SCHEDULED: {
+    stateTypes: [],
+    displayName: "Scheduled",
+    sortOrder: 2
+  },
+  UNSCHEDULED: {
+    stateTypes: [],
+    displayName: "Unscheduled",
+    sortOrder: 1
+  }
+};
+
+export default states;

--- a/plugins/jobs/src/js/types/JobTask.ts
+++ b/plugins/jobs/src/js/types/JobTask.ts
@@ -42,7 +42,6 @@ export const JobTaskFieldResolvers = {
     return task.finishedAt ? DateUtil.strToMs(task.finishedAt) : null;
   },
   status(task: MetronomeJobRunTask): JobTaskStatus {
-    // TODO: this should use JobTaskStatusTypeResolver…
     return task.status;
   },
   taskId(task: MetronomeJobRunTask): string {

--- a/src/js/events/MetronomeClient.ts
+++ b/src/js/events/MetronomeClient.ts
@@ -7,7 +7,7 @@ import Config from "../config/Config";
 // Add interface information: https://jira.mesosphere.com/browse/DCOS-37725
 export interface JobResponse {
   id: string;
-  labels?: object;
+  labels?: LabelResponse;
   run: {
     cpus: number;
     mem: number;
@@ -27,10 +27,15 @@ export interface JobResponse {
     successCount: number;
   };
 }
+
+interface LabelResponse {
+  [key: string]: string;
+}
+
 export interface JobDetailResponse {
   id: string;
   description: string;
-  labels: JobLabels;
+  labels: LabelResponse;
   run: {
     cpus: number;
     mem: number;


### PR DESCRIPTION
I failed when trying to rebase, this is my attempt.

**TODOs**

The only thing left is that we would need to "merge" both test files, so take the `describe("jobs", () => {...});` from `plugins/jobs/src/js/data/JobModel-test-from-fabs-copy.js` and merge it into `plugins/jobs/src/js/data/JobModel-test.js`.

After that the tests will be red, because Fabs assumption was that we will return an array of jobs. We will return a JobRunConnection instead (see implementation), so we would need to map the output of the result$ in these tests like `result$.map(result => result.nodes)` to make them green.

Once they are green we would need to test `totalCount` to deliver us the number of all jobs despite being filtered and `filteredCount` to return the number after filtering.


**Checklist**
- [X] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->
