### PR TITLE
DCOS-38242: Bug / table FF collapsed table td

### DIFF
--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -103,9 +103,6 @@
 
     th,
     td {
-      // This property is necessary for table cells to respect the text-overflow
-      // property. http://stackoverflow.com/questions/9789723/css-text-overflow-in-a-table-cell
-      max-width: 0;
       overflow: hidden;
       text-overflow: ellipsis;
       vertical-align: middle;


### PR DESCRIPTION
Based on testing seems like the ellipsis will work
without setting max-width: 0; which caused firefox
to collapse and break the UI.

Closes DCOS-38242

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?
