### PR TITLE
DCOS-38399: Improve mesos backoff strategy

### DIFF
--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -21,7 +21,8 @@ import container from "../container";
 import * as mesosStreamParsers from "./MesosStream/parsers";
 
 const MAX_RETRIES = 5;
-const RETRY_DELAY = 5000;
+const RETRY_DELAY = 500;
+const MAX_RETRY_DELAY = 5000;
 const METHODS_TO_BIND = ["setState", "onStreamData", "onStreamError"];
 
 class MesosStateStore extends GetSetBaseStore {
@@ -106,7 +107,9 @@ class MesosStateStore extends GetSetBaseStore {
     this.stream = waitStream
       .concat(eventTriggerStream)
       .sampleTime(Config.getRefreshRate() * 0.5)
-      .retryWhen(linearBackoff(MAX_RETRIES, RETRY_DELAY))
+      .retryWhen(
+        linearBackoff(Number.MAX_SAFE_INTEGER, RETRY_DELAY, MAX_RETRY_DELAY)
+      )
       .subscribe(
         () => Promise.resolve().then(this.onStreamData),
         this.onStreamError

--- a/src/js/utils/__tests__/rxjsUtils-test.js
+++ b/src/js/utils/__tests__/rxjsUtils-test.js
@@ -15,12 +15,40 @@ describe("linearBackoff", function() {
       m.bind();
 
       const source = m.cold("1--2#");
-      const expected = m.cold("1--2--1--2----1--2------1--2#");
+      const expected = m.cold("1--2--1--2----1--2#");
 
       // In test env we don't want to wait for the real wall clock
       // so we encode time intervals with a special helper `m.time`
-      const result = source.retryWhen(linearBackoff(3, m.time("--|")));
+      const result = source.retryWhen(linearBackoff(2, m.time("--|")));
 
+      m.expect(result).toBeObservable(expected);
+    })
+  );
+
+  it(
+    "linearly grows the retry delay",
+    marbles(function(m) {
+      m.bind();
+
+      const source = m.cold("1--2#");
+      const expected = m.cold("1--2--1--2----1--2------1--2#");
+
+      const result = source.retryWhen(linearBackoff(3, m.time("--|")));
+      m.expect(result).toBeObservable(expected);
+    })
+  );
+
+  it(
+    "delays the retry no longer than max delay",
+    marbles(function(m) {
+      m.bind();
+
+      const source = m.cold("1--2#");
+      const expected = m.cold("1--2--1--2----1--2----1--2----1--2#");
+
+      const result = source.retryWhen(
+        linearBackoff(4, m.time("--|"), m.time("----|"))
+      );
       m.expect(result).toBeObservable(expected);
     })
   );

--- a/src/js/utils/rxjsUtils.js
+++ b/src/js/utils/rxjsUtils.js
@@ -4,7 +4,12 @@ import "rxjs/add/operator/delayWhen";
 import "rxjs/add/operator/scan";
 
 /* eslint-disable import/prefer-default-export */
-export function linearBackoff(maxRetries = 5, delay = 1000, scheduler = null) {
+export function linearBackoff(
+  maxRetries = 5,
+  delay = 1000,
+  maxDelay = Number.MAX_SAFE_INTEGER,
+  scheduler = null
+) {
   return errors =>
     errors
       .scan((count, error) => {
@@ -14,5 +19,7 @@ export function linearBackoff(maxRetries = 5, delay = 1000, scheduler = null) {
 
         return count + 1;
       }, 0)
-      .delayWhen(val => timer(val * delay, null, scheduler));
+      .delayWhen(val =>
+        timer(Math.min(val * delay, maxDelay), null, scheduler)
+      );
 }


### PR DESCRIPTION
Adjust the backoff strategy to allow _unlimitted_ retries, reduce the start delay and limit the delay to 5 seconds.

The adjusted strategy should make the Mesos data stream more resilient to connection issues and basically falls back to polling for changes in cases where chunked streaming doesn't work.

This change also improves the perceived performance as delaying the first retry longer than 500ms results in users thinking that nothing is happening at all.

Closes DCOS-38399