### PR TITLE
DCOS-38641 stop action

### DIFF
--- a/plugins/jobs/src/js/JobStopRun.js
+++ b/plugins/jobs/src/js/JobStopRun.js
@@ -1,0 +1,80 @@
+import * as React from "react";
+import { componentFromStream } from "data-service";
+import { stopJobRun } from "#SRC/js/events/MetronomeClient";
+import PropTypes from "prop-types";
+
+import { Subject } from "rxjs/Subject";
+import "rxjs/add/operator/map";
+import "rxjs/add/operator/switchMap";
+import "rxjs/add/operator/do";
+import "rxjs/add/operator/combineLatest";
+import "rxjs/add/operator/startWith";
+import "rxjs/add/operator/catch";
+
+import JobStopRunModal from "./components/JobStopRunModal";
+
+function executeStopRequest({ jobID, jobRun, onSuccess }) {
+  return stopJobRun(jobID, jobRun)
+    .mapTo({ done: true })
+    .do(_ => onSuccess())
+    .startWith({ done: false });
+}
+
+function stopEventHandler() {
+  const stopSubject$ = new Subject();
+  const stop$ = stopSubject$.switchMap(executeStopRequest).catch(error => {
+    return stop$.startWith({
+      errorMsg: error.response.message,
+      done: true
+    });
+  });
+
+  return {
+    stop$,
+    stopHandler: (jobID, jobRun, onSuccess) => {
+      stopSubject$.next({ jobID, jobRun, onSuccess });
+    }
+  };
+}
+
+export function stopSingleJobRun(stopHandler, jobId, jobRuns, onSuccess) {
+  // TODO DCOS-8763 introduce support for multiple job run ID
+  if (jobRuns.length === 1) {
+    stopHandler(jobId, jobRuns[0], onSuccess);
+  }
+}
+
+export const JobStopRun = componentFromStream(props$ => {
+  const { stop$, stopHandler } = stopEventHandler();
+  const stopRequestState$ = stop$.startWith({ done: null });
+
+  return props$
+    .combineLatest(stopRequestState$, (props, { done }) => {
+      return { ...props, done };
+    })
+    .map(({ jobID, jobRuns, onClose, onSuccess, open, done }) => {
+      function onSuccessHandler() {
+        stopSingleJobRun(stopHandler, jobID, jobRuns, onSuccess);
+      }
+
+      return (
+        <JobStopRunModal
+          jobID={jobID}
+          onClose={onClose}
+          onSuccess={onSuccessHandler}
+          open={open}
+          disabled={done === false}
+          selectedItems={jobRuns}
+        />
+      );
+    });
+});
+
+JobStopRun.propTypes = {
+  jobID: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSuccess: PropTypes.func,
+  open: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool.isRequired,
+  selectedItems: PropTypes.array.isRequired
+};

--- a/plugins/jobs/src/js/__tests__/JobStopRun-test.js
+++ b/plugins/jobs/src/js/__tests__/JobStopRun-test.js
@@ -1,0 +1,42 @@
+import { stopSingleJobRun } from "../JobStopRun";
+
+const handlerMock = jest.fn();
+const jobId = "echo";
+const job = { jobId };
+const onSuccess = () => {};
+
+describe("JobStopRun", function() {
+  beforeEach(function() {
+    handlerMock.mockReset();
+  });
+
+  describe("#singleJobDeletion", function() {
+    describe("triggers deletion", function() {
+      it("when there is a single jobRun", function() {
+        const jobRuns = [job];
+
+        stopSingleJobRun(handlerMock, jobId, jobRuns, onSuccess);
+
+        expect(handlerMock).toHaveBeenCalledWith(jobId, job, onSuccess);
+      });
+    });
+
+    describe("does not trigger deletion", function() {
+      it("when there is no JobRun", function() {
+        const jobRuns = [];
+
+        stopSingleJobRun(handlerMock, jobId, jobRuns, onSuccess);
+
+        expect(handlerMock).not.toHaveBeenCalled();
+      });
+
+      it("when there is more than one JobRun", function() {
+        const jobRuns = [job, job];
+
+        stopSingleJobRun(handlerMock, jobId, jobRuns, onSuccess);
+
+        expect(handlerMock).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/plugins/jobs/src/js/components/JobStopRunModal.js
+++ b/plugins/jobs/src/js/components/JobStopRunModal.js
@@ -1,55 +1,9 @@
 import { Confirm } from "reactjs-components";
-import mixin from "reactjs-mixin";
 import PropTypes from "prop-types";
 import React from "react";
-import { StoreMixin } from "mesosphere-shared-reactjs";
+import ModalHeading from "#SRC/js/components/modals/ModalHeading";
 
-import MetronomeStore from "../../stores/MetronomeStore";
-import ModalHeading from "../modals/ModalHeading";
-
-const METHODS_TO_BIND = ["handleButtonConfirm"];
-
-class JobStopRunModal extends mixin(StoreMixin) {
-  constructor() {
-    super(...arguments);
-
-    this.store_listeners = [
-      {
-        name: "metronome",
-        events: ["jobStopRunSuccess", "jobStopRunError"],
-        suppressUpdate: true
-      }
-    ];
-
-    this.state = {
-      pendingRequest: false
-    };
-
-    METHODS_TO_BIND.forEach(method => {
-      this[method] = this[method].bind(this);
-    });
-  }
-
-  handleButtonConfirm() {
-    const { selectedItems, jobID } = this.props;
-    // TODO DCOS-8763 introduce support for multiple job run IDs
-    if (selectedItems.length === 1) {
-      MetronomeStore.stopJobRun(jobID, selectedItems[0]);
-    }
-
-    this.setState({ pendingRequest: true });
-  }
-
-  onMetronomeStoreJobStopRunSuccess() {
-    this.setState({ pendingRequest: false });
-    this.props.onClose();
-    this.props.onSuccess();
-  }
-
-  onMetronomeStoreJobStopRunError() {
-    this.props.onClose();
-  }
-
+class JobStopRunModal extends React.Component {
   getContentHeader(selectedItems, selectedItemsLength) {
     let headerContent = ` ${selectedItemsLength} Job Runs`;
     if (selectedItemsLength === 1) {
@@ -98,7 +52,7 @@ class JobStopRunModal extends mixin(StoreMixin) {
     return (
       <Confirm
         closeByBackdropClick={true}
-        disabled={this.state.pendingRequest}
+        disabled={this.props.disabled}
         header={this.getContentHeader(selectedItems, selectedItemsLength)}
         open={open}
         onClose={onClose}
@@ -107,7 +61,7 @@ class JobStopRunModal extends mixin(StoreMixin) {
         leftButtonClassName="button button-primary-link"
         rightButtonText={rightButtonText}
         rightButtonClassName="button button-danger"
-        rightButtonCallback={this.handleButtonConfirm}
+        rightButtonCallback={this.props.onSuccess}
         showHeader={true}
       >
         {this.getModalContents()}
@@ -125,6 +79,7 @@ JobStopRunModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   onSuccess: PropTypes.func,
   open: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool.isRequired,
   selectedItems: PropTypes.array.isRequired
 };
 

--- a/src/js/pages/jobs/JobRunHistoryTable.js
+++ b/src/js/pages/jobs/JobRunHistoryTable.js
@@ -7,15 +7,15 @@ import moment from "moment";
 
 import JobStates from "#PLUGINS/jobs/src/js/constants/JobStates";
 import TaskStates from "#PLUGINS/services/src/js/constants/TaskStates";
+import { JobStopRun } from "#PLUGINS/jobs/src/js/JobStopRun";
 
-import CollapsingString from "#SRC/js/components/CollapsingString";
-import CheckboxTable from "#SRC/js/components/CheckboxTable";
-import ExpandingTable from "#SRC/js/components/ExpandingTable";
-import FilterBar from "#SRC/js/components/FilterBar";
-import FilterHeadline from "#SRC/js/components/FilterHeadline";
-import Icon from "#SRC/js/components/Icon";
-import JobStopRunModal from "#SRC/js/components/modals/JobStopRunModal";
-import TimeAgo from "#SRC/js/components/TimeAgo";
+import CollapsingString from "../../components/CollapsingString";
+import CheckboxTable from "../../components/CheckboxTable";
+import ExpandingTable from "../../components/ExpandingTable";
+import FilterBar from "../../components/FilterBar";
+import FilterHeadline from "../../components/FilterHeadline";
+import Icon from "../../components/Icon";
+import TimeAgo from "../../components/TimeAgo";
 
 const columnClasses = {
   checkbox: "job-run-history-table-column-checkbox",
@@ -236,9 +236,9 @@ class JobRunHistoryTable extends React.Component {
     const jobRuns = Object.keys(checkedItems);
 
     return (
-      <JobStopRunModal
+      <JobStopRun
         jobID={this.props.job.getId()}
-        selectedItems={jobRuns}
+        jobRuns={jobRuns}
         onClose={this.handleStopJobRunModalClose}
         onSuccess={this.handleStopJobRunSuccess}
         open={isStopRunModalShown}


### PR DESCRIPTION
**SCOPE**

- Extract the JobStopAction into the mediator pattern
- Minor changes to existing JobStopModal component

**HOW TO TEST**

Scenario 1: A job

Go to the Job History page, run a job, and then selected it on the list (via the checkbox), a Stop button appears, you can stop the job there.

**WHAT WAS TAKEN OUT OF SCOPE**

- Not using graphql yet.