### PR TITLE
DCOS-38339: Address Memory Issues

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -52,9 +52,9 @@
       "resolved": "https://registry.npmjs.org/@dcos/connections/-/connections-0.1.0.tgz"
     },
     "@dcos/copychars": {
-      "version": "0.1.0",
-      "from": "@dcos/copychars@0.1.0",
-      "resolved": "https://registry.npmjs.org/@dcos/copychars/-/copychars-0.1.0.tgz"
+      "version": "0.1.2",
+      "from": "@dcos/copychars@0.1.2",
+      "resolved": "https://registry.npmjs.org/@dcos/copychars/-/copychars-0.1.2.tgz"
     },
     "@dcos/eslint-config": {
       "version": "0.2.0",
@@ -67,14 +67,14 @@
       "resolved": "https://registry.npmjs.org/@dcos/http-service/-/http-service-0.3.0.tgz"
     },
     "@dcos/mesos-client": {
-      "version": "0.2.1",
-      "from": "@dcos/mesos-client@0.2.1",
-      "resolved": "https://registry.npmjs.org/@dcos/mesos-client/-/mesos-client-0.2.1.tgz"
+      "version": "0.2.3",
+      "from": "@dcos/mesos-client@0.2.3",
+      "resolved": "https://registry.npmjs.org/@dcos/mesos-client/-/mesos-client-0.2.3.tgz"
     },
     "@dcos/recordio": {
-      "version": "0.1.6",
-      "from": "@dcos/recordio@0.1.6",
-      "resolved": "https://registry.npmjs.org/@dcos/recordio/-/recordio-0.1.6.tgz"
+      "version": "0.1.7",
+      "from": "@dcos/recordio@0.1.7",
+      "resolved": "https://registry.npmjs.org/@dcos/recordio/-/recordio-0.1.7.tgz"
     },
     "@types/blob-util": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@dcos/http-service": "0.3.0",
-    "@dcos/mesos-client": "0.2.1",
+    "@dcos/mesos-client": "0.2.3",
     "babel-polyfill": "6.23.0",
     "browser-info": "0.4.0",
     "classnames": "2.2.3",

--- a/src/js/core/MesosStream.js
+++ b/src/js/core/MesosStream.js
@@ -1,11 +1,10 @@
 import { stream } from "@dcos/mesos-client";
-import { ReplaySubject } from "rxjs/ReplaySubject";
 import { Observable } from "rxjs/Observable";
 
 const RECONNECTION_DELAY = 2000;
 
 export const MesosStreamType = Symbol("MesosStreamType");
-export default stream({ type: "SUBSCRIBE" }, "/mesos/api/v1?subscribe")
-  .repeatWhen(() => Observable.timer(RECONNECTION_DELAY))
-  .multicast(() => new ReplaySubject())
-  .refCount();
+export default stream(
+  { type: "SUBSCRIBE" },
+  "/mesos/api/v1?subscribe"
+).repeatWhen(() => Observable.timer(RECONNECTION_DELAY));


### PR DESCRIPTION
Update the mesos-client to 0.2.3 as this version great reduces the memory footprint and adjust `MesosStream` to stop multicasting the stream using the replay subject. This change allows the browser to garbage collect dependent/sliced strings created while processing the Mesos response.

_Please note that this is a temporary adjustment as it would result in multiple open connections if consumed by more than one component. We're going to revert this change once the `http-service`  to emit event objects instead of the response as well as changed the `mesos-client` to output parsed JSON._

**Testing**

* Checkout the code and verify that the number of open mesos subscribe connections is correct and the updates are flowing through. 
* Make memory snapshots in Firefox and Chrome and observer the Safari memory footprint while looking at a task page.


Closes DCOS-38339