### PR TITLE
DCOS-38900 - Fix build by removing type declaration.

### DIFF
--- a/plugins/jobs/src/js/JobsOverview.tsx
+++ b/plugins/jobs/src/js/JobsOverview.tsx
@@ -150,7 +150,7 @@ const JobsOverview = withRouter(
           filter$.next(filter);
         });
 
-      const jobs$: Observable<JobConnection> = combineLatest(path$, filter$)
+      const jobs$ = combineLatest(path$, filter$)
         .sampleTime(250)
         .switchMap(([path, filter]) => {
           // tslint:disable-next-line:no-console


### PR DESCRIPTION
Check out and build. If it builds without:

```
ERROR in /Users/ahoy/ship/dcos-ui/plugins/jobs/src/js/JobsOverview.tsx
[tsl] ERROR in /Users/fabs/ship/dcos-ui/plugins/jobs/src/js/JobsOverview.tsx(158,18)
      TS2352: Type 'Observable<any>' cannot be converted to type 'Observable<{ data: { jobs: JobConnection; }; }>'.

ERROR in /Users/ahoy/ship/dcos-ui/plugins/jobs/src/js/JobsOverview.tsx
[tsl] ERROR in /Users/fabs/ship/dcos-ui/plugins/jobs/src/js/JobsOverview.tsx(158,18)
      TS2352: Type 'Observable<any>' cannot be converted to type 'Observable<{ data: { jobs: JobConnection; }; }>'.
  Property 'buffer' is missing in type 'Observable<any>'.
```

Yay!