### PR TITLE
DCOS-21723: use metadata instead of calculation

### DIFF
--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import { routerShape } from "react-router";
 
-import { DCOS_CHANGE, MESOS_STATE_CHANGE } from "#SRC/js/constants/EventTypes";
+import { DCOS_CHANGE } from "#SRC/js/constants/EventTypes";
 import { reconstructPathFromRoutes } from "#SRC/js/utils/RouterUtil";
 import AppDispatcher from "#SRC/js/events/AppDispatcher";
 import ContainerUtil from "#SRC/js/utils/ContainerUtil";
@@ -11,7 +11,6 @@ import DSLExpression from "#SRC/js/structs/DSLExpression";
 import DSLFilterList from "#SRC/js/structs/DSLFilterList";
 import Icon from "#SRC/js/components/Icon";
 import Loader from "#SRC/js/components/Loader";
-import MesosStateStore from "#SRC/js/stores/MesosStateStore";
 import Page from "#SRC/js/components/Page";
 import RequestErrorMsg from "#SRC/js/components/RequestErrorMsg";
 import {
@@ -143,10 +142,6 @@ class ServicesContainer extends React.Component {
 
   componentDidMount() {
     DCOSStore.addChangeListener(DCOS_CHANGE, this.onStoreChange);
-
-    // Don't block the whole screen if Mesos state is not there
-    // Mesos state is needed to aggregate frameworks resources correctly
-    MesosStateStore.addChangeListener(MESOS_STATE_CHANGE, function() {});
 
     // Listen for server actions so we can update state immediately
     // on the completion of an API request.

--- a/plugins/services/src/js/structs/Framework.js
+++ b/plugins/services/src/js/structs/Framework.js
@@ -93,45 +93,10 @@ module.exports = class Framework extends Application {
   }
 
   getResources() {
-    // TODO: Circular reference workaround DCOS_OSS-783
-    const MesosStateStore = require("#SRC/js/stores/MesosStateStore");
-
-    const tasks = MesosStateStore.getTasksByService(this) || [];
-
-    const instances = this.getInstancesCount();
-    const {
-      cpus = 0,
-      mem = 0,
-      gpus = 0,
-      disk = 0
-    } = this.getSpec().getResources();
-
-    const frameworkResources = {
-      cpus: cpus * instances,
-      mem: mem * instances,
-      gpus: gpus * instances,
-      disk: disk * instances
-    };
-
-    // Aggregate all the child tasks resources
-    // resources of child frameworks won't be aggregated
-    return tasks
-      .filter(function(task) {
-        return task.state === "TASK_RUNNING" && !task.isStartedByMarathon;
-      })
-      .reduce(function(memo, task) {
-        const { cpus = 0, mem = 0, gpus = 0, disk = 0 } = task.resources;
-
-        return {
-          cpus: memo.cpus + cpus,
-          mem: memo.mem + mem,
-          gpus: memo.gpus + gpus,
-          disk: memo.disk + disk
-        };
-      }, frameworkResources);
-  }
-
-  getUsedResources() {
+    // There's an unfortunate naming issue in Mesos.
+    // used_resources is actually allocated resources
+    // the name can't be changed to keep backward compatibility.
+    // This is why `getResources` returns `used_resources`
     return (
       this.get("used_resources") || {
         cpus: 0,

--- a/plugins/services/src/js/structs/__tests__/Framework-test.js
+++ b/plugins/services/src/js/structs/__tests__/Framework-test.js
@@ -224,50 +224,12 @@ describe("Framework", function() {
   });
 
   describe("#getResources", function() {
-    it("aggregates child task resources properly", function() {
-      MesosStateStore.getTasksByService = function() {
-        return [
-          {
-            id: "/fake_1",
-            isStartedByMarathon: true,
-            state: "TASK_RUNNING",
-            resources: { cpus: 0.2, mem: 300, gpus: 0 }
-          },
-          {
-            id: "/fake_2",
-            state: "TASK_RUNNING",
-            resources: { cpus: 0.8, mem: 700, gpus: 0, disk: 1000 }
-          },
-          {
-            id: "/fake_2",
-            state: "TASK_FINISHED",
-            resources: { cpus: 0.8, mem: 700, gpus: 0, disk: 0 }
-          }
-        ];
-      };
-
-      const service = new Framework({
-        instances: 1,
-        cpus: 1,
-        mem: 1000
-      });
-
-      expect(service.getResources()).toEqual({
-        cpus: 1.8,
-        mem: 1700,
-        gpus: 0,
-        disk: 1000
-      });
-    });
-  });
-
-  describe("#getUsedResources", function() {
     it("returns empty obj when resources are falsey", function() {
-      const node = new Framework({
+      const service = new Framework({
         used_resources: null
       });
 
-      expect(node.getUsedResources()).toEqual({
+      expect(service.getResources()).toEqual({
         cpus: 0,
         mem: 0,
         gpus: 0,

--- a/src/js/stores/DCOSStore.js
+++ b/src/js/stores/DCOSStore.js
@@ -440,7 +440,7 @@ class DCOSStore extends EventEmitter {
       .getServiceList()
       .reduceItems(function(memo, framework) {
         if (framework instanceof Item) {
-          memo[framework.get("name")] = framework.get();
+          memo[`/${framework.get("name")}`] = framework.get();
         }
 
         return memo;
@@ -459,7 +459,7 @@ class DCOSStore extends EventEmitter {
       };
 
       if (item instanceof Framework) {
-        options = Object.assign(options, frameworks[item.getName()]);
+        options = Object.assign(options, frameworks[item.getId()]);
       }
 
       if (item instanceof Item) {

--- a/src/js/stores/__tests__/DCOSStore-test.js
+++ b/src/js/stores/__tests__/DCOSStore-test.js
@@ -609,6 +609,151 @@ describe("DCOSStore", function() {
     });
   });
 
+  describe("#buildServiceTree", function() {
+    it("merges data from Mesos correctly", function() {
+      MarathonStore.__setKeyResponse(
+        "groups",
+        new ServiceTree({
+          items: [
+            {
+              id: "/blip/cassandra",
+              backoffFactor: 1.15,
+              backoffSeconds: 1,
+              cmd: "",
+              cpus: 1,
+              disk: 0,
+              env: {},
+              executor: "",
+              fetch: [],
+              healthChecks: [
+                {
+                  gracePeriodSeconds: 900,
+                  intervalSeconds: 30,
+                  maxConsecutiveFailures: 0,
+                  path: "/v1/health",
+                  portIndex: 0,
+                  protocol: "MESOS_HTTP",
+                  ipProtocol: "IPv4",
+                  timeoutSeconds: 30,
+                  delaySeconds: 15
+                }
+              ],
+              instances: 1,
+              labels: {
+                DCOS_COMMONS_UNINSTALL: "true",
+                DCOS_PACKAGE_OPTIONS: "",
+                DCOS_SERVICE_SCHEME: "http",
+                DCOS_PACKAGE_SOURCE: "https://universe.mesosphere.com/repo",
+                DCOS_PACKAGE_METADATA: "",
+                DCOS_SERVICE_NAME: "blip/cassandra",
+                DCOS_PACKAGE_FRAMEWORK_NAME: "blip/cassandra",
+                DCOS_SERVICE_PORT_INDEX: "0",
+                DCOS_PACKAGE_DEFINITION: "",
+                DCOS_PACKAGE_VERSION: "2.1.2-3.0.15-beta",
+                DCOS_COMMONS_API_VERSION: "v1",
+                DCOS_PACKAGE_NAME: "beta-cassandra",
+                MARATHON_SINGLE_INSTANCE_APP: "true"
+              },
+              maxLaunchDelaySeconds: 3600,
+              mem: 1024,
+              gpus: 0,
+              networks: [{ mode: "host" }],
+              portDefinitions: [
+                {
+                  port: 10000,
+                  labels: { VIP_0: "/api.blip/cassandra:80" },
+                  name: "api",
+                  protocol: "tcp"
+                }
+              ],
+              requirePorts: false,
+              upgradeStrategy: {
+                maximumOverCapacity: 0,
+                minimumHealthCapacity: 0
+              },
+              user: "nobody",
+              version: "2018-07-09T15:19:39.984Z",
+              versionInfo: {
+                lastScalingAt: "2018-07-09T15:19:39.984Z",
+                lastConfigChangeAt: "2018-07-09T15:19:39.984Z"
+              },
+              killSelection: "YOUNGEST_FIRST",
+              unreachableStrategy: {
+                inactiveAfterSeconds: 0,
+                expungeAfterSeconds: 0
+              },
+              tasksStaged: 0,
+              tasksRunning: 1,
+              tasksHealthy: 1,
+              tasksUnhealthy: 0,
+              deployments: [],
+              tasks: [],
+              taskStats: {}
+            }
+          ]
+        })
+      );
+      DCOSStore.onMarathonGroupsChange();
+
+      MesosSummaryStore.__setKeyResponse(
+        "states",
+        new SummaryList({
+          items: [
+            new StateSummary({
+              snapshot: {
+                frameworks: [
+                  {
+                    id: "3f420e28-ebcf-4bdb-8521-05aafa296335-0003",
+                    name: "blip/cassandra",
+                    used_resources: {
+                      disk: 10496,
+                      mem: 4128,
+                      gpus: 0,
+                      cpus: 0.6,
+                      ports: "[7000-7001, 7199-7199, 9042-9042]"
+                    },
+                    offered_resources: { disk: 0, mem: 0, gpus: 0, cpus: 0 },
+                    capabilities: ["RESERVATION_REFINEMENT"],
+                    hostname: "",
+                    webui_url: "",
+                    active: true,
+                    connected: true,
+                    recovered: false,
+                    TASK_STAGING: 0,
+                    TASK_STARTING: 0,
+                    TASK_RUNNING: 1,
+                    TASK_KILLING: 0,
+                    TASK_FINISHED: 1,
+                    TASK_KILLED: 0,
+                    TASK_FAILED: 0,
+                    TASK_LOST: 0,
+                    TASK_ERROR: 0,
+                    TASK_UNREACHABLE: 0,
+                    slave_ids: ["3f420e28-ebcf-4bdb-8521-05aafa296335-S1"]
+                  }
+                ]
+              },
+              successful: true
+            })
+          ]
+        })
+      );
+      DCOSStore.onMesosSummaryChange();
+
+      const serviceTree = DCOSStore.buildServiceTree();
+
+      expect(
+        serviceTree.findItemById("/blip/cassandra").get("used_resources")
+      ).toEqual({
+        disk: 10496,
+        mem: 4128,
+        gpus: 0,
+        cpus: 0.6,
+        ports: "[7000-7001, 7199-7199, 9042-9042]"
+      });
+    });
+  });
+
   describe("#buildFlatServiceTree", function() {
     beforeEach(function() {
       this.filterProperties = {


### PR DESCRIPTION
**TL;DR** This PR removes all the resources aggregation logic and replaces it with the `used_resources` for Frameworks.

**Tell me more**
Looks like we've mistakenly assumed that allocated resources for Frameworks should be aggregated from their tasks as with Marathon Services. Turned out that there's a special metadata on the Framework protobuf that has `used_resources` information.

**Checklist**
- [x] Did you add a JIRA issue in a commit message or as part of the branch name?
- [x] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

Closes DCOS-21723