### PR TITLE
DCOS-38340: Address unbound memory use in Mesos Stream

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20,7 +20,7 @@
       "dev": true,
       "requires": {
         "@babel/types": "7.0.0-beta.51",
-        "lodash": "^4.17.5"
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "lodash": {
@@ -37,9 +37,9 @@
       "integrity": "sha512-X3Ur/A/lIbbP8W0pmwgqtDXIxhQmxPaiwY9SKP7kF9wvZfjZRwMvbJE92ozUhF3UDK3DCKaV7oGqmI1rP/zqWA==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
+        "chalk": "2.3.2",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -48,7 +48,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -57,9 +57,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -74,7 +74,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -85,9 +85,9 @@
       "integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.5",
-        "to-fast-properties": "^2.0.0"
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "2.0.0"
       },
       "dependencies": {
         "lodash": {
@@ -110,10 +110,10 @@
       "integrity": "sha1-RgbhOLBbQwNNyErxXaGOITkFhTc=",
       "dev": true,
       "requires": {
-        "@commitlint/format": "^6.1.3",
-        "@commitlint/lint": "^6.1.3",
-        "@commitlint/load": "^6.1.3",
-        "@commitlint/read": "^6.1.3",
+        "@commitlint/format": "6.1.3",
+        "@commitlint/lint": "6.1.3",
+        "@commitlint/load": "6.1.3",
+        "@commitlint/read": "6.1.3",
         "babel-polyfill": "6.26.0",
         "chalk": "2.3.1",
         "get-stdin": "5.0.1",
@@ -128,7 +128,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "babel-polyfill": {
@@ -137,9 +137,9 @@
           "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.26.0",
-            "core-js": "^2.5.0",
-            "regenerator-runtime": "^0.10.5"
+            "babel-runtime": "6.26.0",
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.10.5"
           }
         },
         "babel-runtime": {
@@ -148,8 +148,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
           },
           "dependencies": {
             "regenerator-runtime": {
@@ -166,9 +166,9 @@
           "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.0",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.2.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -183,7 +183,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -230,8 +230,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "regenerator-runtime": {
@@ -248,8 +248,8 @@
       "integrity": "sha1-QUuQSKmvVFh9qWIicXujMjR6veM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.23.0",
-        "chalk": "^2.0.1"
+        "babel-runtime": "6.23.0",
+        "chalk": "2.3.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -258,7 +258,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -267,9 +267,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -284,7 +284,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -304,10 +304,10 @@
       "integrity": "sha1-aneI6uOBrahz90IeMVWecgPKrfM=",
       "dev": true,
       "requires": {
-        "@commitlint/is-ignored": "^6.1.3",
-        "@commitlint/parse": "^6.1.3",
-        "@commitlint/rules": "^6.1.3",
-        "babel-runtime": "^6.23.0",
+        "@commitlint/is-ignored": "6.1.3",
+        "@commitlint/parse": "6.1.3",
+        "@commitlint/rules": "6.1.3",
+        "babel-runtime": "6.23.0",
         "lodash.topairs": "4.3.0"
       }
     },
@@ -317,10 +317,10 @@
       "integrity": "sha1-G+QHETl5WPMWz0BXepyHmhbwClQ=",
       "dev": true,
       "requires": {
-        "@commitlint/execute-rule": "^6.1.3",
-        "@commitlint/resolve-extends": "^6.1.3",
-        "babel-runtime": "^6.23.0",
-        "cosmiconfig": "^4.0.0",
+        "@commitlint/execute-rule": "6.1.3",
+        "@commitlint/resolve-extends": "6.1.3",
+        "babel-runtime": "6.23.0",
+        "cosmiconfig": "4.0.0",
         "lodash.merge": "4.6.1",
         "lodash.mergewith": "4.6.1",
         "lodash.pick": "4.4.0",
@@ -334,10 +334,10 @@
           "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
           "dev": true,
           "requires": {
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.9.0",
-            "parse-json": "^4.0.0",
-            "require-from-string": "^2.0.1"
+            "is-directory": "0.3.1",
+            "js-yaml": "3.11.0",
+            "parse-json": "4.0.0",
+            "require-from-string": "2.0.1"
           }
         },
         "esprima": {
@@ -352,8 +352,8 @@
           "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.10",
+            "esprima": "4.0.0"
           }
         },
         "parse-json": {
@@ -362,8 +362,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
           }
         },
         "require-from-string": {
@@ -392,8 +392,8 @@
       "integrity": "sha1-/x5NksJ81naBK7a512zYhTwNlAc=",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "^1.3.3",
-        "conventional-commits-parser": "^2.1.0"
+        "conventional-changelog-angular": "1.6.6",
+        "conventional-commits-parser": "2.1.5"
       },
       "dependencies": {
         "camelcase": {
@@ -408,9 +408,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "conventional-changelog-angular": {
@@ -419,8 +419,8 @@
           "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
           "dev": true,
           "requires": {
-            "compare-func": "^1.3.1",
-            "q": "^1.5.1"
+            "compare-func": "1.3.2",
+            "q": "1.5.1"
           }
         },
         "conventional-commits-parser": {
@@ -429,13 +429,13 @@
           "integrity": "sha512-jaAP61py+ISMF3/n3yIiIuY5h6mJlucOqawu5mLB1HaQADLvg/y5UB3pT7HSucZJan34lp7+7ylQPfbKEGmxrA==",
           "dev": true,
           "requires": {
-            "JSONStream": "^1.0.4",
-            "is-text-path": "^1.0.0",
-            "lodash": "^4.2.1",
-            "meow": "^4.0.0",
-            "split2": "^2.0.0",
-            "through2": "^2.0.0",
-            "trim-off-newlines": "^1.0.0"
+            "JSONStream": "1.3.2",
+            "is-text-path": "1.0.1",
+            "lodash": "4.17.5",
+            "meow": "4.0.0",
+            "split2": "2.2.0",
+            "through2": "2.0.3",
+            "trim-off-newlines": "1.0.1"
           }
         },
         "find-up": {
@@ -444,7 +444,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "indent-string": {
@@ -465,10 +465,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "lodash": {
@@ -489,15 +489,15 @@
           "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
           }
         },
         "parse-json": {
@@ -506,8 +506,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
           }
         },
         "path-type": {
@@ -516,7 +516,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -531,9 +531,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -542,8 +542,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "readable-stream": {
@@ -552,13 +552,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "redent": {
@@ -567,8 +567,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "string_decoder": {
@@ -577,7 +577,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-bom": {
@@ -598,8 +598,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         },
         "trim-newlines": {
@@ -616,10 +616,10 @@
       "integrity": "sha1-n52NtQ+/Z/MACSFlftbvrbjPnxo=",
       "dev": true,
       "requires": {
-        "@commitlint/top-level": "^6.1.3",
-        "@marionebl/sander": "^0.6.0",
-        "babel-runtime": "^6.23.0",
-        "git-raw-commits": "^1.3.0"
+        "@commitlint/top-level": "6.1.3",
+        "@marionebl/sander": "0.6.1",
+        "babel-runtime": "6.23.0",
+        "git-raw-commits": "1.3.4"
       },
       "dependencies": {
         "camelcase": {
@@ -634,9 +634,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "find-up": {
@@ -645,7 +645,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "git-raw-commits": {
@@ -654,11 +654,11 @@
           "integrity": "sha512-G3O+41xHbscpgL5nA0DUkbFVgaAz5rd57AMSIMew8p7C8SyFwZDyn08MoXHkTl9zcD0LmxsLFPxbqFY4YPbpPA==",
           "dev": true,
           "requires": {
-            "dargs": "^4.0.1",
-            "lodash.template": "^4.0.2",
-            "meow": "^4.0.0",
-            "split2": "^2.0.0",
-            "through2": "^2.0.0"
+            "dargs": "4.1.0",
+            "lodash.template": "4.4.0",
+            "meow": "4.0.0",
+            "split2": "2.2.0",
+            "through2": "2.0.3"
           }
         },
         "indent-string": {
@@ -679,10 +679,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "lodash.template": {
@@ -691,8 +691,8 @@
           "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~3.0.0",
-            "lodash.templatesettings": "^4.0.0"
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.templatesettings": "4.1.0"
           }
         },
         "lodash.templatesettings": {
@@ -701,7 +701,7 @@
           "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~3.0.0"
+            "lodash._reinterpolate": "3.0.0"
           }
         },
         "map-obj": {
@@ -716,15 +716,15 @@
           "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
           }
         },
         "parse-json": {
@@ -733,8 +733,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
           }
         },
         "path-type": {
@@ -743,7 +743,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -758,9 +758,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -769,8 +769,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "readable-stream": {
@@ -779,13 +779,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "redent": {
@@ -794,8 +794,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "string_decoder": {
@@ -804,7 +804,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-bom": {
@@ -825,8 +825,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         },
         "trim-newlines": {
@@ -846,9 +846,9 @@
         "babel-runtime": "6.26.0",
         "lodash.merge": "4.6.1",
         "lodash.omit": "4.5.0",
-        "require-uncached": "^1.0.3",
-        "resolve-from": "^4.0.0",
-        "resolve-global": "^0.1.0"
+        "require-uncached": "1.0.3",
+        "resolve-from": "4.0.0",
+        "resolve-global": "0.1.0"
       },
       "dependencies": {
         "babel-runtime": {
@@ -857,8 +857,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "regenerator-runtime": {
@@ -881,10 +881,10 @@
       "integrity": "sha1-NOvSYsA3DUgwnlFnmUJNMsM/mEs=",
       "dev": true,
       "requires": {
-        "@commitlint/ensure": "^6.1.3",
-        "@commitlint/message": "^6.1.3",
-        "@commitlint/to-lines": "^6.1.3",
-        "babel-runtime": "^6.23.0"
+        "@commitlint/ensure": "6.1.3",
+        "@commitlint/message": "6.1.3",
+        "@commitlint/to-lines": "6.1.3",
+        "babel-runtime": "6.23.0"
       }
     },
     "@commitlint/to-lines": {
@@ -899,7 +899,7 @@
       "integrity": "sha1-Em3LbeFnY0LGnNQiYUg/RHhUcpk=",
       "dev": true,
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "2.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -908,7 +908,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         }
       }
@@ -919,10 +919,10 @@
       "integrity": "sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "cli-cursor": "^1.0.2",
-        "date-fns": "^1.27.2",
-        "figures": "^1.7.0"
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
       }
     },
     "@cypress/xvfb": {
@@ -931,7 +931,7 @@
       "integrity": "sha512-EfRzw+wgI0Zdb4ZlhSvjh3q7I+oenqEYPXvr7oH/2RnzQqGDrPr7IU1Pi2yzGwoXmkNUQbo6qvntnItvQj0F4Q==",
       "dev": true,
       "requires": {
-        "lodash.once": "^4.1.1"
+        "lodash.once": "4.1.1"
       }
     },
     "@dcos/connection-manager": {
@@ -939,8 +939,8 @@
       "resolved": "https://registry.npmjs.org/@dcos/connection-manager/-/connection-manager-0.2.1.tgz",
       "integrity": "sha1-eTd/d/ILs/umrx2yZDiZlSxYG1o=",
       "requires": {
-        "@dcos/connections": "^0.1.0",
-        "immutable": "^3.8.2"
+        "@dcos/connections": "0.1.0",
+        "immutable": "3.8.2"
       }
     },
     "@dcos/connections": {
@@ -949,9 +949,9 @@
       "integrity": "sha1-ASdOJhv5u3RNl1rZU+s6Pu6JF7w="
     },
     "@dcos/copychars": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@dcos/copychars/-/copychars-0.1.0.tgz",
-      "integrity": "sha1-Iwu0cHMjCQuXh0IHQk4mDLpsMJ8="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@dcos/copychars/-/copychars-0.1.2.tgz",
+      "integrity": "sha1-wpx1n+btFAaJMktSfLTW+6txCQs="
     },
     "@dcos/eslint-config": {
       "version": "0.3.0",
@@ -959,7 +959,7 @@
       "integrity": "sha1-ojiUzXKjTm3F1XG/WsRLvfS6Yqo=",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb": "^10.0.1"
+        "eslint-config-airbnb": "10.0.1"
       }
     },
     "@dcos/http-service": {
@@ -973,22 +973,22 @@
       }
     },
     "@dcos/mesos-client": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@dcos/mesos-client/-/mesos-client-0.2.1.tgz",
-      "integrity": "sha1-pmzskdUxLqpi89sDleo8xi+hH+E=",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@dcos/mesos-client/-/mesos-client-0.2.3.tgz",
+      "integrity": "sha1-5aPMJJ1oQUkffV5gCMHL8QLv/Dg=",
       "requires": {
-        "@dcos/copychars": "0.1.0",
+        "@dcos/copychars": "0.1.2",
         "@dcos/http-service": "0.3.0",
-        "@dcos/recordio": "0.1.6",
+        "@dcos/recordio": "0.1.7",
         "rxjs": "5.4.3"
       }
     },
     "@dcos/recordio": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@dcos/recordio/-/recordio-0.1.6.tgz",
-      "integrity": "sha512-ej0oXW9T3Hpm25JY3ifuWalXGjASPQ3u6z4GokHwH5J5chziae8BkXtgisDsQFgz5C0CUG1wWjU+xGP9N8lD7w==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@dcos/recordio/-/recordio-0.1.7.tgz",
+      "integrity": "sha1-x3djPxoObyAMO3MyUWA66c5sTdM=",
       "requires": {
-        "@dcos/copychars": "^0.1.0"
+        "@dcos/copychars": "0.1.2"
       }
     },
     "@dcos/tslint-config": {
@@ -1022,13 +1022,13 @@
           "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
           "dev": true,
           "requires": {
-            "core-js": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.18"
           }
         },
         "object-assign": {
@@ -1043,10 +1043,10 @@
           "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
           "dev": true,
           "requires": {
-            "fbjs": "^0.8.16",
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.0"
+            "fbjs": "0.8.17",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
           }
         },
         "react-dom": {
@@ -1055,10 +1055,10 @@
           "integrity": "sha512-bbLd+HYpBEnYoNyxDe9XpSG2t9wypMohwQPvKw8Hov3nF7SJiJIgK56b46zHpBUpHb06a1iEuw7G3rbrsnNL6w==",
           "dev": true,
           "requires": {
-            "fbjs": "^0.8.16",
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.0"
+            "fbjs": "0.8.17",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
           }
         },
         "ua-parser-js": {
@@ -1075,12 +1075,12 @@
       "integrity": "sha1-NNeETrUy0Rdcj8cBdb63TQcb++s=",
       "dev": true,
       "requires": {
-        "@emotion/hash": "^0.6.3",
-        "@emotion/memoize": "^0.6.3",
-        "@emotion/serialize": "^0.8.3",
-        "convert-source-map": "^1.5.1",
-        "find-root": "^1.1.0",
-        "source-map": "^0.7.2"
+        "@emotion/hash": "0.6.3",
+        "@emotion/memoize": "0.6.3",
+        "@emotion/serialize": "0.8.3",
+        "convert-source-map": "1.5.1",
+        "find-root": "1.1.0",
+        "source-map": "0.7.3"
       },
       "dependencies": {
         "source-map": {
@@ -1103,7 +1103,7 @@
       "integrity": "sha1-sElW4tZVAn/ojGI0Zp/XBk+wccw=",
       "dev": true,
       "requires": {
-        "@emotion/memoize": "^0.6.3"
+        "@emotion/memoize": "0.6.3"
       }
     },
     "@emotion/memoize": {
@@ -1118,10 +1118,10 @@
       "integrity": "sha1-D61Vual/lSPmsf1vtvdLbLQcf4s=",
       "dev": true,
       "requires": {
-        "@emotion/hash": "^0.6.3",
-        "@emotion/memoize": "^0.6.3",
-        "@emotion/unitless": "^0.6.3",
-        "@emotion/utils": "^0.7.1"
+        "@emotion/hash": "0.6.3",
+        "@emotion/memoize": "0.6.3",
+        "@emotion/unitless": "0.6.3",
+        "@emotion/utils": "0.7.1"
       }
     },
     "@emotion/stylis": {
@@ -1148,9 +1148,9 @@
       "integrity": "sha1-GViWWHTyS8Ub5Ih1/rUNZC/EH3s=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.3",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.2"
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
       }
     },
     "@types/blob-util": {
@@ -1177,8 +1177,8 @@
       "integrity": "sha512-7aIt9QMRdxuagLLI48dPz96YJdhu64p6FCa6n4qkGN5DQLHnrIjZpD9bXCvV2G0NwgZ1FAmfP214dxc5zNCfgQ==",
       "dev": true,
       "requires": {
-        "@types/chai": "*",
-        "@types/jquery": "*"
+        "@types/chai": "4.0.8",
+        "@types/jquery": "3.2.16"
       }
     },
     "@types/events": {
@@ -1222,7 +1222,7 @@
       "integrity": "sha512-h8lkWQSgT4qjs9PcIhcL2nWubZeXRVzjZxYlRFmcX9BW1PIk5qRc0djtRWZqtM+GDDFhwBt0ztRu72D/YxIcEw==",
       "dev": true,
       "requires": {
-        "@types/lodash": "*"
+        "@types/lodash": "4.14.87"
       }
     },
     "@types/minimatch": {
@@ -1261,8 +1261,8 @@
       "integrity": "sha512-MAct634qnTaaeVXg134MQIuUY+yISPqs0BzgkbTZpSvztlCxlLtK7spC8k//l8oUMFlxNt0aUuqZvTOxdXp4/A==",
       "dev": true,
       "requires": {
-        "@types/history": "^2",
-        "@types/react": "*"
+        "@types/history": "2.0.49",
+        "@types/react": "15.0.39"
       }
     },
     "@types/recompose": {
@@ -1271,7 +1271,7 @@
       "integrity": "sha512-S5fkitL277yWCEHDzgb/3aJ4RySeqSC7L3Xo+7AlDk6+DAPpQAfF0iwgfjAqbP49JAjVCY+asPQxFPiw1+4CYg==",
       "dev": true,
       "requires": {
-        "@types/react": "*"
+        "@types/react": "15.0.39"
       }
     },
     "@types/sinon": {
@@ -1286,8 +1286,8 @@
       "integrity": "sha512-EkI/ZvJT4hglWo7Ipf9SX+J+R9htNOMjW8xiOhce7+0csqvgoF5IXqY5Ae1GqRgNtWCuaywR5HjVa1snkTqpOw==",
       "dev": true,
       "requires": {
-        "@types/chai": "*",
-        "@types/sinon": "*"
+        "@types/chai": "4.0.8",
+        "@types/sinon": "4.0.0"
       }
     },
     "JSONSelect": {
@@ -1302,8 +1302,8 @@
       "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
       "dev": true,
       "requires": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
       }
     },
     "JSV": {
@@ -1330,7 +1330,7 @@
       "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.6",
+        "mime-types": "2.1.18",
         "negotiator": "0.5.3"
       }
     },
@@ -1346,7 +1346,7 @@
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "dev": true,
       "requires": {
-        "acorn": "^4.0.3"
+        "acorn": "4.0.13"
       },
       "dependencies": {
         "acorn": {
@@ -1363,7 +1363,7 @@
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "^5.0.0"
+        "acorn": "5.5.3"
       }
     },
     "acorn-jsx": {
@@ -1372,7 +1372,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "^3.0.4"
+        "acorn": "3.3.0"
       },
       "dependencies": {
         "acorn": {
@@ -1388,8 +1388,8 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "requires": {
-        "co": "^4.6.0",
-        "json-stable-stringify": "^1.0.1"
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
       }
     },
     "ajv-keywords": {
@@ -1404,9 +1404,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       }
     },
     "alphanum-sort": {
@@ -1467,8 +1467,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "apollo-link": {
@@ -1477,8 +1477,8 @@
       "integrity": "sha512-Uk/BC09dm61DZRDSu52nGq0nFhq7mcBPTjy5EEH1eunJndtCaNXQhQz/BjkI2NdrfGI+B+i5he6YSoRBhYizdw==",
       "requires": {
         "@types/graphql": "0.12.6",
-        "apollo-utilities": "^1.0.0",
-        "zen-observable-ts": "^0.8.9"
+        "apollo-utilities": "1.0.12",
+        "zen-observable-ts": "0.8.9"
       }
     },
     "apollo-utilities": {
@@ -1492,7 +1492,7 @@
       "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
       "dev": true,
       "requires": {
-        "default-require-extensions": "^1.0.0"
+        "default-require-extensions": "1.0.0"
       }
     },
     "aproba": {
@@ -1507,7 +1507,7 @@
       "integrity": "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=",
       "dev": true,
       "requires": {
-        "file-type": "^3.1.0"
+        "file-type": "3.9.0"
       }
     },
     "archy": {
@@ -1522,7 +1522,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -1531,7 +1531,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.0.1"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-flatten": {
@@ -1593,8 +1593,8 @@
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0"
       }
     },
     "array-map": {
@@ -1621,7 +1621,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -1641,8 +1641,8 @@
       "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0"
       }
     },
     "arrify": {
@@ -1667,9 +1667,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
       }
     },
     "assert": {
@@ -1715,10 +1715,10 @@
       "resolved": "https://registry.npmjs.org/async-done/-/async-done-0.4.0.tgz",
       "integrity": "sha1-q4BT9fYikPi/xY83zZtzBwszB7k=",
       "requires": {
-        "end-of-stream": "^0.1.4",
-        "next-tick": "^0.2.2",
-        "once": "^1.3.0",
-        "stream-exhaust": "^1.0.0"
+        "end-of-stream": "0.1.5",
+        "next-tick": "0.2.2",
+        "once": "1.4.0",
+        "stream-exhaust": "1.0.2"
       }
     },
     "async-each": {
@@ -1756,12 +1756,12 @@
       "integrity": "sha1-3ncuH82gjc4OmSzs95JS1fAI42c=",
       "dev": true,
       "requires": {
-        "browserslist": "~1.3.1",
-        "caniuse-db": "^1.0.30000444",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "postcss": "^5.0.19",
-        "postcss-value-parser": "^3.2.3"
+        "browserslist": "1.3.6",
+        "caniuse-db": "1.0.30000815",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "postcss": {
@@ -1770,10 +1770,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -1782,7 +1782,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -1803,21 +1803,21 @@
       "integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.24.1",
-        "babel-polyfill": "^6.23.0",
-        "babel-register": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "chokidar": "^1.6.1",
-        "commander": "^2.8.1",
-        "convert-source-map": "^1.1.0",
-        "fs-readdir-recursive": "^1.0.0",
-        "glob": "^7.0.0",
-        "lodash": "^4.2.0",
-        "output-file-sync": "^1.1.0",
-        "path-is-absolute": "^1.0.0",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.0",
-        "v8flags": "^2.0.10"
+        "babel-core": "6.24.1",
+        "babel-polyfill": "6.23.0",
+        "babel-register": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "chokidar": "1.7.0",
+        "commander": "2.15.1",
+        "convert-source-map": "1.5.1",
+        "fs-readdir-recursive": "1.1.0",
+        "glob": "7.0.5",
+        "lodash": "4.17.5",
+        "output-file-sync": "1.1.2",
+        "path-is-absolute": "1.0.1",
+        "slash": "1.0.0",
+        "source-map": "0.5.7",
+        "v8flags": "2.1.1"
       },
       "dependencies": {
         "lodash": {
@@ -1834,9 +1834,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       }
     },
     "babel-core": {
@@ -1845,25 +1845,25 @@
       "integrity": "sha1-jEKFZNzh4fQfszfsNPTDsCK1rYM=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "babel-generator": "^6.24.1",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1",
-        "babylon": "^6.11.0",
-        "convert-source-map": "^1.1.0",
-        "debug": "^2.1.1",
-        "json5": "^0.5.0",
-        "lodash": "^4.2.0",
-        "minimatch": "^3.0.2",
-        "path-is-absolute": "^1.0.0",
-        "private": "^0.1.6",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.0"
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.1",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.5",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "lodash": {
@@ -1878,7 +1878,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -1889,14 +1889,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.5",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "babel-runtime": {
@@ -1905,8 +1905,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "lodash": {
@@ -1929,9 +1929,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-builder-react-jsx": {
@@ -1940,9 +1940,9 @@
       "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "esutils": "^2.0.2"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "esutils": "2.0.2"
       },
       "dependencies": {
         "babel-runtime": {
@@ -1951,8 +1951,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "regenerator-runtime": {
@@ -1969,10 +1969,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-define-map": {
@@ -1981,10 +1981,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "babel-runtime": {
@@ -1993,8 +1993,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "lodash": {
@@ -2017,9 +2017,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
@@ -2028,11 +2028,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-get-function-arity": {
@@ -2041,8 +2041,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-hoist-variables": {
@@ -2051,8 +2051,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -2061,8 +2061,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-regex": {
@@ -2071,9 +2071,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "babel-runtime": {
@@ -2082,8 +2082,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "lodash": {
@@ -2106,11 +2106,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-replace-supers": {
@@ -2119,12 +2119,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helpers": {
@@ -2133,8 +2133,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-jest": {
@@ -2143,8 +2143,8 @@
       "integrity": "sha512-rEdN/jevSuX0IQKcUqwqOGa0gDNis4jGY52Rq53aizfDGPwQYNJq+f9NCMT1HUhtUZhYSjvfGUfHQWBRT1/icA==",
       "dev": true,
       "requires": {
-        "babel-plugin-istanbul": "^4.1.5",
-        "babel-preset-jest": "^22.4.1"
+        "babel-plugin-istanbul": "4.1.5",
+        "babel-preset-jest": "22.4.1"
       },
       "dependencies": {
         "babel-preset-jest": {
@@ -2153,8 +2153,8 @@
           "integrity": "sha512-gW3+spyB8fkSAI9fX+41BQMwar5LjR+nyKa2QRvK22snxnI29+jJVAMfId+osucFJzJJvhlvzKWnfwX8Omodvg==",
           "dev": true,
           "requires": {
-            "babel-plugin-jest-hoist": "^22.4.1",
-            "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+            "babel-plugin-jest-hoist": "22.4.1",
+            "babel-plugin-syntax-object-rest-spread": "6.13.0"
           }
         }
       }
@@ -2165,9 +2165,9 @@
       "integrity": "sha512-PeN29YvOynPMvNk7QCzsHqxpmfXwKAC+uxkiSNFQsmXBBVltzEkVWmv/Ip3tx7yk149dQUwk497bTXNu+DZjLA==",
       "dev": true,
       "requires": {
-        "find-cache-dir": "^1.0.0",
-        "loader-utils": "^1.0.2",
-        "mkdirp": "^0.5.1"
+        "find-cache-dir": "1.0.0",
+        "loader-utils": "1.1.0",
+        "mkdirp": "0.5.1"
       },
       "dependencies": {
         "find-cache-dir": {
@@ -2176,9 +2176,9 @@
           "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
           "dev": true,
           "requires": {
-            "commondir": "^1.0.1",
-            "make-dir": "^1.0.0",
-            "pkg-dir": "^2.0.0"
+            "commondir": "1.0.1",
+            "make-dir": "1.2.0",
+            "pkg-dir": "2.0.0"
           }
         },
         "find-up": {
@@ -2187,7 +2187,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "loader-utils": {
@@ -2196,9 +2196,9 @@
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         },
         "pkg-dir": {
@@ -2207,7 +2207,7 @@
           "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
           "dev": true,
           "requires": {
-            "find-up": "^2.1.0"
+            "find-up": "2.1.0"
           }
         }
       }
@@ -2218,7 +2218,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -2227,7 +2227,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-emotion": {
@@ -2237,17 +2237,17 @@
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "7.0.0-beta.51",
-        "@emotion/babel-utils": "^0.6.4",
-        "@emotion/hash": "^0.6.2",
-        "@emotion/memoize": "^0.6.1",
-        "@emotion/stylis": "^0.6.10",
-        "babel-plugin-macros": "^2.0.0",
-        "babel-plugin-syntax-jsx": "^6.18.0",
-        "convert-source-map": "^1.5.0",
-        "find-root": "^1.1.0",
-        "mkdirp": "^0.5.1",
-        "source-map": "^0.5.7",
-        "touch": "^1.0.0"
+        "@emotion/babel-utils": "0.6.5",
+        "@emotion/hash": "0.6.3",
+        "@emotion/memoize": "0.6.3",
+        "@emotion/stylis": "0.6.10",
+        "babel-plugin-macros": "2.2.2",
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "find-root": "1.1.0",
+        "mkdirp": "0.5.1",
+        "source-map": "0.5.7",
+        "touch": "1.0.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -2256,9 +2256,9 @@
       "integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
       "dev": true,
       "requires": {
-        "find-up": "^2.1.0",
-        "istanbul-lib-instrument": "^1.7.5",
-        "test-exclude": "^4.1.1"
+        "find-up": "2.1.0",
+        "istanbul-lib-instrument": "1.10.1",
+        "test-exclude": "4.2.1"
       },
       "dependencies": {
         "find-up": {
@@ -2267,7 +2267,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         }
       }
@@ -2284,7 +2284,7 @@
       "integrity": "sha512-wq6DYqjNmSPskGyhOeRIbmuvLtsHTfc6ROtGqapTttIGL1RoQmM3V5N8aJiDxPaw3/fveIsVspF51E3V7qTOMQ==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "^4.0.0"
+        "cosmiconfig": "4.0.0"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -2293,10 +2293,10 @@
           "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
           "dev": true,
           "requires": {
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.9.0",
-            "parse-json": "^4.0.0",
-            "require-from-string": "^2.0.1"
+            "is-directory": "0.3.1",
+            "js-yaml": "3.12.0",
+            "parse-json": "4.0.0",
+            "require-from-string": "2.0.2"
           }
         },
         "esprima": {
@@ -2311,8 +2311,8 @@
           "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.10",
+            "esprima": "4.0.0"
           }
         },
         "parse-json": {
@@ -2321,8 +2321,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
           }
         },
         "require-from-string": {
@@ -2339,7 +2339,7 @@
       "integrity": "sha1-UVu/qZaJOYEULZCx+bFjXeKZUQk=",
       "dev": true,
       "requires": {
-        "lodash": "^4.6.1"
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "lodash": {
@@ -2398,9 +2398,9 @@
       "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-generators": "^6.5.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-generators": "6.13.0",
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-async-to-generator": {
@@ -2409,9 +2409,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -2420,7 +2420,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -2429,7 +2429,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -2438,11 +2438,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "babel-runtime": {
@@ -2451,8 +2451,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "lodash": {
@@ -2475,15 +2475,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "^6.24.1",
-        "babel-helper-function-name": "^6.24.1",
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -2492,8 +2492,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -2502,7 +2502,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -2511,8 +2511,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -2521,7 +2521,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -2530,9 +2530,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -2541,7 +2541,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -2550,9 +2550,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -2561,10 +2561,10 @@
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       },
       "dependencies": {
         "babel-runtime": {
@@ -2573,8 +2573,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "regenerator-runtime": {
@@ -2591,9 +2591,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -2602,9 +2602,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -2613,8 +2613,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -2623,12 +2623,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -2637,8 +2637,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -2647,7 +2647,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -2656,9 +2656,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -2667,7 +2667,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -2676,7 +2676,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -2685,9 +2685,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.23.0",
+        "regexpu-core": "2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -2696,9 +2696,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-flow-strip-types": {
@@ -2707,8 +2707,8 @@
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-flow": "^6.18.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-flow": "6.18.0",
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -2717,8 +2717,8 @@
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-        "babel-runtime": "^6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.26.0"
       },
       "dependencies": {
         "babel-runtime": {
@@ -2727,8 +2727,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "regenerator-runtime": {
@@ -2745,7 +2745,7 @@
       "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-react-jsx": {
@@ -2754,9 +2754,9 @@
       "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-react-jsx": "^6.24.1",
-        "babel-plugin-syntax-jsx": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-builder-react-jsx": "6.26.0",
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-react-jsx-source": {
@@ -2765,8 +2765,8 @@
       "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-jsx": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -2775,7 +2775,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.10.0"
+        "regenerator-transform": "0.10.1"
       }
     },
     "babel-plugin-transform-runtime": {
@@ -2784,7 +2784,7 @@
       "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -2793,8 +2793,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-polyfill": {
@@ -2802,9 +2802,9 @@
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
       "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.10.0"
+        "babel-runtime": "6.23.0",
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.10.5"
       }
     },
     "babel-preset-es2015": {
@@ -2813,30 +2813,30 @@
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-        "babel-plugin-transform-es2015-classes": "^6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-        "babel-plugin-transform-es2015-for-of": "^6.22.0",
-        "babel-plugin-transform-es2015-function-name": "^6.24.1",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-        "babel-plugin-transform-es2015-object-super": "^6.24.1",
-        "babel-plugin-transform-es2015-parameters": "^6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-        "babel-plugin-transform-regenerator": "^6.24.1"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0"
       }
     },
     "babel-preset-jest": {
@@ -2845,8 +2845,8 @@
       "integrity": "sha512-p61cPMGYlSgfNScn1yQuVnLguWE4bjhB/br4KQDMbYZG+v6ryE5Ch7TKukjA6mRuIQj1zhyou7Sbpqrh4/N6Pg==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^22.2.0",
-        "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+        "babel-plugin-jest-hoist": "22.4.1",
+        "babel-plugin-syntax-object-rest-spread": "6.13.0"
       }
     },
     "babel-preset-react": {
@@ -2855,12 +2855,12 @@
       "integrity": "sha1-0yiaoOMI29SLchD5l3EB8Pluvh8=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-flow": "^6.3.13",
-        "babel-plugin-syntax-jsx": "^6.3.13",
-        "babel-plugin-transform-flow-strip-types": "^6.3.13",
-        "babel-plugin-transform-react-display-name": "^6.3.13",
-        "babel-plugin-transform-react-jsx": "^6.3.13",
-        "babel-plugin-transform-react-jsx-source": "^6.3.13"
+        "babel-plugin-syntax-flow": "6.18.0",
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-plugin-transform-flow-strip-types": "6.22.0",
+        "babel-plugin-transform-react-display-name": "6.25.0",
+        "babel-plugin-transform-react-jsx": "6.24.1",
+        "babel-plugin-transform-react-jsx-source": "6.22.0"
       }
     },
     "babel-preset-react-hmre": {
@@ -2869,10 +2869,10 @@
       "integrity": "sha1-0hbmDLW41Mhz4Z7Q9U6v8UN7xJI=",
       "dev": true,
       "requires": {
-        "babel-plugin-react-transform": "^2.0.2",
-        "react-transform-catch-errors": "^1.0.2",
-        "react-transform-hmr": "^1.0.3",
-        "redbox-react": "^1.2.2"
+        "babel-plugin-react-transform": "2.0.2",
+        "react-transform-catch-errors": "1.0.2",
+        "react-transform-hmr": "1.0.4",
+        "redbox-react": "1.5.0"
       }
     },
     "babel-preset-stage-3": {
@@ -2881,11 +2881,11 @@
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-generator-functions": "^6.24.1",
-        "babel-plugin-transform-async-to-generator": "^6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
-        "babel-plugin-transform-object-rest-spread": "^6.22.0"
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-generator-functions": "6.24.1",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-object-rest-spread": "6.26.0"
       }
     },
     "babel-register": {
@@ -2894,13 +2894,13 @@
       "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "core-js": "^2.4.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.2.0",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.2"
+        "babel-core": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "core-js": "2.5.3",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.5",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
       },
       "dependencies": {
         "lodash": {
@@ -2916,8 +2916,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.10.0"
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.10.5"
       }
     },
     "babel-template": {
@@ -2926,11 +2926,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "babel-runtime": {
@@ -2939,8 +2939,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "lodash": {
@@ -2963,15 +2963,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "babel-runtime": {
@@ -2980,8 +2980,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "lodash": {
@@ -3004,10 +3004,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.5",
+        "to-fast-properties": "1.0.3"
       },
       "dependencies": {
         "babel-runtime": {
@@ -3016,8 +3016,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "lodash": {
@@ -3051,13 +3051,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -3066,7 +3066,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "isobject": {
@@ -3095,8 +3095,8 @@
       "integrity": "sha1-1k03XWinxkDZEuI1jRcNylu1RoE=",
       "dev": true,
       "requires": {
-        "concat-stream": "~1.4.7",
-        "meow": "~2.0.0"
+        "concat-stream": "1.4.11",
+        "meow": "2.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -3111,8 +3111,8 @@
           "integrity": "sha1-vRoRv5sxoc5JNJOpMN4aC69K1+w=",
           "dev": true,
           "requires": {
-            "camelcase": "^1.0.1",
-            "map-obj": "^1.0.0"
+            "camelcase": "1.2.1",
+            "map-obj": "1.0.1"
           }
         },
         "concat-stream": {
@@ -3121,9 +3121,9 @@
           "integrity": "sha512-X3JMh8+4je3U1cQpG87+f9lXHDrqcb2MVLg9L7o8b1UZ0DzhRrUpdn65ttzu10PpJPPI3MQNkis+oha6TSA9Mw==",
           "dev": true,
           "requires": {
-            "inherits": "~2.0.1",
-            "readable-stream": "~1.1.9",
-            "typedarray": "~0.0.5"
+            "inherits": "2.0.3",
+            "readable-stream": "1.1.14",
+            "typedarray": "0.0.6"
           }
         },
         "get-stdin": {
@@ -3138,9 +3138,9 @@
           "integrity": "sha1-25m8xYPrarux5I3LsZmamGBBy2s=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1",
-            "minimist": "^1.1.0",
-            "repeating": "^1.1.0"
+            "get-stdin": "4.0.1",
+            "minimist": "1.2.0",
+            "repeating": "1.1.3"
           }
         },
         "meow": {
@@ -3149,10 +3149,10 @@
           "integrity": "sha1-j1MKjs9dQNP0tN+Tw0cpAPuiqPE=",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^1.0.0",
-            "indent-string": "^1.1.0",
-            "minimist": "^1.1.0",
-            "object-assign": "^1.0.0"
+            "camelcase-keys": "1.0.0",
+            "indent-string": "1.2.2",
+            "minimist": "1.2.0",
+            "object-assign": "1.0.0"
           }
         },
         "object-assign": {
@@ -3167,7 +3167,7 @@
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
           "dev": true,
           "requires": {
-            "is-finite": "^1.0.0"
+            "is-finite": "1.0.2"
           }
         }
       }
@@ -3196,7 +3196,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "beeper": {
@@ -3216,13 +3216,13 @@
       "integrity": "sha1-EfjdYfcP/Por3KpbRvXo/t1CIcw=",
       "dev": true,
       "requires": {
-        "archive-type": "^3.0.1",
-        "decompress": "^3.0.0",
-        "download": "^4.1.2",
-        "exec-series": "^1.0.0",
-        "rimraf": "^2.2.6",
-        "tempfile": "^1.0.0",
-        "url-regex": "^3.0.0"
+        "archive-type": "3.2.0",
+        "decompress": "3.0.0",
+        "download": "4.4.3",
+        "exec-series": "1.0.3",
+        "rimraf": "2.6.2",
+        "tempfile": "1.1.1",
+        "url-regex": "3.2.0"
       }
     },
     "bin-check": {
@@ -3231,7 +3231,7 @@
       "integrity": "sha1-hvjm9CU4k99g3DFpV/WvAqywWTA=",
       "dev": true,
       "requires": {
-        "executable": "^1.0.0"
+        "executable": "1.1.0"
       }
     },
     "bin-version": {
@@ -3240,7 +3240,7 @@
       "integrity": "sha1-nrSY7m/Xb3q5p8FgQ2+JV5Q1144=",
       "dev": true,
       "requires": {
-        "find-versions": "^1.0.0"
+        "find-versions": "1.2.1"
       }
     },
     "bin-version-check": {
@@ -3249,10 +3249,10 @@
       "integrity": "sha1-5OXfKQuQaffRETJAMe/BP90RpbA=",
       "dev": true,
       "requires": {
-        "bin-version": "^1.0.0",
-        "minimist": "^1.1.0",
-        "semver": "^4.0.3",
-        "semver-truncate": "^1.0.0"
+        "bin-version": "1.0.4",
+        "minimist": "1.2.0",
+        "semver": "4.3.6",
+        "semver-truncate": "1.1.2"
       },
       "dependencies": {
         "semver": {
@@ -3269,12 +3269,12 @@
       "integrity": "sha1-Z9MwYmLksaXy+I7iNGT2plVneus=",
       "dev": true,
       "requires": {
-        "bin-check": "^2.0.0",
-        "bin-version-check": "^2.1.0",
-        "download": "^4.0.0",
-        "each-async": "^1.1.1",
-        "lazy-req": "^1.0.0",
-        "os-filter-obj": "^1.0.0"
+        "bin-check": "2.0.0",
+        "bin-version-check": "2.1.0",
+        "download": "4.4.3",
+        "each-async": "1.1.1",
+        "lazy-req": "1.1.0",
+        "os-filter-obj": "1.0.3"
       }
     },
     "binary-extensions": {
@@ -3289,7 +3289,7 @@
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.5"
+        "readable-stream": "2.3.5"
       },
       "dependencies": {
         "isarray": {
@@ -3304,13 +3304,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -3319,7 +3319,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -3348,15 +3348,15 @@
       "dev": true,
       "requires": {
         "bytes": "2.1.0",
-        "content-type": "~1.0.1",
-        "debug": "~2.2.0",
-        "depd": "~1.0.1",
-        "http-errors": "~1.3.1",
+        "content-type": "1.0.4",
+        "debug": "2.2.0",
+        "depd": "1.0.1",
+        "http-errors": "1.3.1",
         "iconv-lite": "0.4.11",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "4.0.0",
-        "raw-body": "~2.1.2",
-        "type-is": "~1.6.6"
+        "raw-body": "2.1.7",
+        "type-is": "1.6.16"
       },
       "dependencies": {
         "debug": {
@@ -3394,12 +3394,12 @@
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "dev": true,
       "requires": {
-        "array-flatten": "^2.1.0",
-        "deep-equal": "^1.0.1",
-        "dns-equal": "^1.0.0",
-        "dns-txt": "^2.0.2",
-        "multicast-dns": "^6.0.1",
-        "multicast-dns-service-types": "^1.1.0"
+        "array-flatten": "2.1.1",
+        "deep-equal": "1.0.1",
+        "dns-equal": "1.0.0",
+        "dns-txt": "2.0.2",
+        "multicast-dns": "6.2.3",
+        "multicast-dns-service-types": "1.1.0"
       },
       "dependencies": {
         "array-flatten": {
@@ -3421,7 +3421,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "requires": {
-        "hoek": "2.x.x"
+        "hoek": "2.16.3"
       }
     },
     "brace": {
@@ -3437,7 +3437,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -3447,9 +3447,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
       }
     },
     "brorand": {
@@ -3492,12 +3492,12 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "browserify-cipher": {
@@ -3506,9 +3506,9 @@
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
+        "browserify-aes": "1.2.0",
+        "browserify-des": "1.0.1",
+        "evp_bytestokey": "1.0.3"
       }
     },
     "browserify-des": {
@@ -3517,9 +3517,9 @@
       "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1"
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3"
       }
     },
     "browserify-rsa": {
@@ -3528,8 +3528,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "randombytes": "2.0.6"
       }
     },
     "browserify-sign": {
@@ -3538,13 +3538,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "elliptic": "6.4.0",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.1"
       }
     },
     "browserify-zlib": {
@@ -3553,7 +3553,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "~1.0.5"
+        "pako": "1.0.6"
       }
     },
     "browserslist": {
@@ -3562,7 +3562,7 @@
       "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
       "dev": true,
       "requires": {
-        "caniuse-db": "^1.0.30000525"
+        "caniuse-db": "1.0.30000815"
       }
     },
     "bser": {
@@ -3571,7 +3571,7 @@
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "dev": true,
       "requires": {
-        "node-int64": "^0.4.0"
+        "node-int64": "0.4.0"
       }
     },
     "buffer": {
@@ -3580,9 +3580,9 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "1.3.0",
+        "ieee754": "1.1.10",
+        "isarray": "1.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -3617,10 +3617,10 @@
       "integrity": "sha1-APFfruOreh3aLN5tkSG//dB7ImI=",
       "dev": true,
       "requires": {
-        "file-type": "^3.1.0",
-        "readable-stream": "^2.0.2",
-        "uuid": "^2.0.1",
-        "vinyl": "^1.0.0"
+        "file-type": "3.9.0",
+        "readable-stream": "2.3.5",
+        "uuid": "2.0.3",
+        "vinyl": "1.1.1"
       },
       "dependencies": {
         "isarray": {
@@ -3635,13 +3635,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -3650,7 +3650,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "uuid": {
@@ -3697,19 +3697,19 @@
       "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.5.1",
-        "chownr": "^1.0.1",
-        "glob": "^7.1.2",
-        "graceful-fs": "^4.1.11",
-        "lru-cache": "^4.1.1",
-        "mississippi": "^2.0.0",
-        "mkdirp": "^0.5.1",
-        "move-concurrently": "^1.0.1",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.2",
-        "ssri": "^5.2.4",
-        "unique-filename": "^1.1.0",
-        "y18n": "^4.0.0"
+        "bluebird": "3.5.1",
+        "chownr": "1.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lru-cache": "4.1.2",
+        "mississippi": "2.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "promise-inflight": "1.0.1",
+        "rimraf": "2.6.2",
+        "ssri": "5.3.0",
+        "unique-filename": "1.1.0",
+        "y18n": "4.0.0"
       },
       "dependencies": {
         "glob": {
@@ -3718,12 +3718,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "lru-cache": {
@@ -3732,8 +3732,8 @@
           "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
           "dev": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         },
         "minimatch": {
@@ -3742,7 +3742,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "y18n": {
@@ -3759,15 +3759,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -3784,7 +3784,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "^0.2.0"
+        "callsites": "0.2.0"
       }
     },
     "callsites": {
@@ -3799,8 +3799,8 @@
       "integrity": "sha1-Gsp8TRlTWaLOmVV5NDPG5VQlEfI=",
       "dev": true,
       "requires": {
-        "sentence-case": "^1.1.1",
-        "upper-case": "^1.1.1"
+        "sentence-case": "1.1.3",
+        "upper-case": "1.1.3"
       }
     },
     "camelcase": {
@@ -3815,8 +3815,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       }
     },
     "caniuse-api": {
@@ -3825,10 +3825,10 @@
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "dev": true,
       "requires": {
-        "browserslist": "^1.3.6",
-        "caniuse-db": "^1.0.30000529",
-        "lodash.memoize": "^4.1.2",
-        "lodash.uniq": "^4.5.0"
+        "browserslist": "1.3.6",
+        "caniuse-db": "1.0.30000815",
+        "lodash.memoize": "4.1.2",
+        "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
@@ -3854,10 +3854,10 @@
       "integrity": "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=",
       "dev": true,
       "requires": {
-        "get-proxy": "^1.0.1",
-        "is-obj": "^1.0.0",
-        "object-assign": "^3.0.0",
-        "tunnel-agent": "^0.4.0"
+        "get-proxy": "1.1.0",
+        "is-obj": "1.0.1",
+        "object-assign": "3.0.0",
+        "tunnel-agent": "0.4.3"
       },
       "dependencies": {
         "tunnel-agent": {
@@ -3874,8 +3874,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       }
     },
     "chain-function": {
@@ -3888,11 +3888,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "change-case": {
@@ -3901,22 +3901,22 @@
       "integrity": "sha1-LE/ePwY7tB0AzWjg1aCdthy+iU8=",
       "dev": true,
       "requires": {
-        "camel-case": "^1.1.1",
-        "constant-case": "^1.1.0",
-        "dot-case": "^1.1.0",
-        "is-lower-case": "^1.1.0",
-        "is-upper-case": "^1.1.0",
-        "lower-case": "^1.1.1",
-        "lower-case-first": "^1.0.0",
-        "param-case": "^1.1.0",
-        "pascal-case": "^1.1.0",
-        "path-case": "^1.1.0",
-        "sentence-case": "^1.1.1",
-        "snake-case": "^1.1.0",
-        "swap-case": "^1.1.0",
-        "title-case": "^1.1.0",
-        "upper-case": "^1.1.1",
-        "upper-case-first": "^1.1.0"
+        "camel-case": "1.2.2",
+        "constant-case": "1.1.2",
+        "dot-case": "1.1.2",
+        "is-lower-case": "1.1.3",
+        "is-upper-case": "1.1.2",
+        "lower-case": "1.1.4",
+        "lower-case-first": "1.0.2",
+        "param-case": "1.1.2",
+        "pascal-case": "1.1.2",
+        "path-case": "1.1.2",
+        "sentence-case": "1.1.3",
+        "snake-case": "1.1.2",
+        "swap-case": "1.1.2",
+        "title-case": "1.1.2",
+        "upper-case": "1.1.3",
+        "upper-case-first": "1.1.2"
       }
     },
     "change-emitter": {
@@ -3941,12 +3941,12 @@
       "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
       "dev": true,
       "requires": {
-        "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.0",
-        "entities": "~1.1.1",
-        "htmlparser2": "^3.9.1",
-        "lodash": "^4.15.0",
-        "parse5": "^3.0.1"
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.0",
+        "entities": "1.1.1",
+        "htmlparser2": "3.9.2",
+        "lodash": "4.17.5",
+        "parse5": "3.0.3"
       },
       "dependencies": {
         "domhandler": {
@@ -3955,7 +3955,7 @@
           "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
           "dev": true,
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "htmlparser2": {
@@ -3964,12 +3964,12 @@
           "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
           "dev": true,
           "requires": {
-            "domelementtype": "^1.3.0",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.2"
+            "domelementtype": "1.3.0",
+            "domhandler": "2.4.1",
+            "domutils": "1.5.1",
+            "entities": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.5"
           }
         },
         "isarray": {
@@ -3990,13 +3990,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -4005,7 +4005,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -4016,15 +4016,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.2.4",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
       }
     },
     "chownr": {
@@ -4045,8 +4045,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "circular-json": {
@@ -4070,7 +4070,7 @@
       "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3"
+        "chalk": "1.1.3"
       }
     },
     "class-utils": {
@@ -4079,10 +4079,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -4091,7 +4091,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -4100,7 +4100,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4109,7 +4109,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -4120,7 +4120,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4129,7 +4129,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -4140,9 +4140,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "isobject": {
@@ -4170,7 +4170,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^1.0.1"
+        "restore-cursor": "1.0.1"
       }
     },
     "cli-spinners": {
@@ -4186,7 +4186,7 @@
       "dev": true,
       "requires": {
         "slice-ansi": "0.0.4",
-        "string-width": "^1.0.1"
+        "string-width": "1.0.2"
       }
     },
     "cli-width": {
@@ -4200,9 +4200,9 @@
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.5.10.tgz",
       "integrity": "sha1-UFoeV7pr2O2Ke6vdZVBLMVDmmBA=",
       "requires": {
-        "good-listener": "^1.1.6",
-        "select": "^1.0.6",
-        "tiny-emitter": "^1.0.0"
+        "good-listener": "1.2.2",
+        "select": "1.1.2",
+        "tiny-emitter": "1.2.0"
       }
     },
     "cliui": {
@@ -4211,8 +4211,8 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -4235,8 +4235,8 @@
       "integrity": "sha1-6uCiQT9VwJQvgYwin+/OhF1/Oxw=",
       "dev": true,
       "requires": {
-        "is-regexp": "^1.0.0",
-        "is-supported-regexp-flag": "^1.0.0"
+        "is-regexp": "1.0.0",
+        "is-supported-regexp-flag": "1.0.0"
       }
     },
     "clone-stats": {
@@ -4249,7 +4249,7 @@
       "resolved": "https://registry.npmjs.org/cnvs/-/cnvs-1.1.14.tgz",
       "integrity": "sha1-ZimiTd0P+yLB46Zw0GG5DI6UBVU=",
       "requires": {
-        "gulp-watch-less": "^1.0.1"
+        "gulp-watch-less": "1.0.1"
       }
     },
     "co": {
@@ -4263,7 +4263,7 @@
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "dev": true,
       "requires": {
-        "q": "^1.1.2"
+        "q": "1.5.1"
       }
     },
     "code-point-at": {
@@ -4278,8 +4278,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color": {
@@ -4288,9 +4288,9 @@
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.2",
-        "color-convert": "^1.3.0",
-        "color-string": "^0.3.0"
+        "clone": "1.0.3",
+        "color-convert": "1.9.1",
+        "color-string": "0.3.0"
       }
     },
     "color-convert": {
@@ -4299,7 +4299,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-diff": {
@@ -4320,7 +4320,7 @@
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "dev": true,
       "requires": {
-        "color-name": "^1.0.0"
+        "color-name": "1.1.3"
       }
     },
     "color-support": {
@@ -4334,16 +4334,16 @@
       "integrity": "sha512-qYVKTg626qpDg4/eBnPXidEPXn5+krbYqHVfyyEFBWV5z3IF4p44HKY/eE2t1ohlcrlIkDgHmFJMfQ8qMLnSFw==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "color-diff": "^0.1.3",
-        "log-symbols": "^1.0.2",
-        "object-assign": "^4.0.1",
-        "pipetteur": "^2.0.0",
-        "plur": "^2.0.0",
-        "postcss": "^5.0.4",
-        "postcss-reporter": "^1.2.1",
-        "text-table": "^0.2.0",
-        "yargs": "^1.2.6"
+        "chalk": "1.1.3",
+        "color-diff": "0.1.7",
+        "log-symbols": "1.0.2",
+        "object-assign": "4.1.1",
+        "pipetteur": "2.0.3",
+        "plur": "2.1.2",
+        "postcss": "5.2.18",
+        "postcss-reporter": "1.4.1",
+        "text-table": "0.2.0",
+        "yargs": "1.3.3"
       },
       "dependencies": {
         "object-assign": {
@@ -4358,10 +4358,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -4370,7 +4370,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         },
         "yargs": {
@@ -4387,9 +4387,9 @@
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
       "dev": true,
       "requires": {
-        "color": "^0.11.0",
+        "color": "0.11.4",
         "css-color-names": "0.0.4",
-        "has": "^1.0.1"
+        "has": "1.0.1"
       }
     },
     "colors": {
@@ -4403,7 +4403,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -4418,7 +4418,7 @@
       "integrity": "sha1-EYe+Tz1M8MBCfUP3Tu8fc1AWFMA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.18.0"
+        "babel-runtime": "6.23.0"
       }
     },
     "commondir": {
@@ -4433,8 +4433,8 @@
       "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
       "dev": true,
       "requires": {
-        "array-ify": "^1.0.0",
-        "dot-prop": "^3.0.0"
+        "array-ify": "1.0.0",
+        "dot-prop": "3.0.0"
       }
     },
     "compare-versions": {
@@ -4455,7 +4455,7 @@
       "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
       "dev": true,
       "requires": {
-        "mime-db": ">= 1.33.0 < 2"
+        "mime-db": "1.33.0"
       }
     },
     "compression": {
@@ -4464,12 +4464,12 @@
       "integrity": "sha1-sDuNhub4rSloPLqN+R3cb/x3s5U=",
       "dev": true,
       "requires": {
-        "accepts": "~1.2.12",
+        "accepts": "1.2.13",
         "bytes": "2.1.0",
-        "compressible": "~2.0.5",
-        "debug": "~2.2.0",
-        "on-headers": "~1.0.0",
-        "vary": "~1.0.1"
+        "compressible": "2.0.13",
+        "debug": "2.2.0",
+        "on-headers": "1.0.1",
+        "vary": "1.0.1"
       },
       "dependencies": {
         "debug": {
@@ -4495,11 +4495,11 @@
       "integrity": "sha512-oNao3kC1JiQC781akjCgm7zu7K1pxDw9sd2oUUbW128cp2OpvOD4xm1s/WDuAdRsOl4m6rsTGAzcdILvA/7nFg==",
       "dev": true,
       "requires": {
-        "async": "^2.4.1",
-        "cacache": "^10.0.1",
-        "find-cache-dir": "^1.0.0",
-        "serialize-javascript": "^1.4.0",
-        "webpack-sources": "^1.0.1"
+        "async": "2.6.0",
+        "cacache": "10.0.4",
+        "find-cache-dir": "1.0.0",
+        "serialize-javascript": "1.4.0",
+        "webpack-sources": "1.1.0"
       },
       "dependencies": {
         "async": {
@@ -4508,7 +4508,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "4.17.5"
           }
         },
         "find-cache-dir": {
@@ -4517,9 +4517,9 @@
           "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
           "dev": true,
           "requires": {
-            "commondir": "^1.0.1",
-            "make-dir": "^1.0.0",
-            "pkg-dir": "^2.0.0"
+            "commondir": "1.0.1",
+            "make-dir": "1.2.0",
+            "pkg-dir": "2.0.0"
           }
         },
         "find-up": {
@@ -4528,7 +4528,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "lodash": {
@@ -4543,7 +4543,7 @@
           "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
           "dev": true,
           "requires": {
-            "find-up": "^2.1.0"
+            "find-up": "2.1.0"
           }
         },
         "source-list-map": {
@@ -4564,8 +4564,8 @@
           "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
           "dev": true,
           "requires": {
-            "source-list-map": "^2.0.0",
-            "source-map": "~0.6.1"
+            "source-list-map": "2.0.0",
+            "source-map": "0.6.1"
           }
         }
       }
@@ -4581,9 +4581,9 @@
       "integrity": "sha1-JhuPUYMB8dg042NCuf6gldJiCiY=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.5",
+        "typedarray": "0.0.6"
       },
       "dependencies": {
         "isarray": {
@@ -4598,13 +4598,13 @@
           "integrity": "sha1-tPhQA6k4y7bsvOKhJPsQEr0ag40=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -4613,7 +4613,7 @@
           "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -4624,8 +4624,8 @@
       "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
       "dev": true,
       "requires": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
+        "ini": "1.3.5",
+        "proto-list": "1.2.4"
       }
     },
     "connect": {
@@ -4635,36 +4635,36 @@
       "dev": true,
       "requires": {
         "basic-auth-connect": "1.0.0",
-        "body-parser": "~1.13.3",
+        "body-parser": "1.13.3",
         "bytes": "2.1.0",
-        "compression": "~1.5.2",
-        "connect-timeout": "~1.6.2",
-        "content-type": "~1.0.1",
+        "compression": "1.5.2",
+        "connect-timeout": "1.6.2",
+        "content-type": "1.0.4",
         "cookie": "0.1.3",
-        "cookie-parser": "~1.3.5",
+        "cookie-parser": "1.3.5",
         "cookie-signature": "1.0.6",
-        "csurf": "~1.8.3",
-        "debug": "~2.2.0",
-        "depd": "~1.0.1",
-        "errorhandler": "~1.4.2",
-        "express-session": "~1.11.3",
+        "csurf": "1.8.3",
+        "debug": "2.2.0",
+        "depd": "1.0.1",
+        "errorhandler": "1.4.3",
+        "express-session": "1.11.3",
         "finalhandler": "0.4.0",
         "fresh": "0.3.0",
-        "http-errors": "~1.3.1",
-        "method-override": "~2.3.5",
-        "morgan": "~1.6.1",
+        "http-errors": "1.3.1",
+        "method-override": "2.3.10",
+        "morgan": "1.6.1",
         "multiparty": "3.3.2",
-        "on-headers": "~1.0.0",
-        "parseurl": "~1.3.0",
+        "on-headers": "1.0.1",
+        "parseurl": "1.3.2",
         "pause": "0.1.0",
         "qs": "4.0.0",
-        "response-time": "~2.3.1",
-        "serve-favicon": "~2.3.0",
-        "serve-index": "~1.7.2",
-        "serve-static": "~1.10.0",
-        "type-is": "~1.6.6",
+        "response-time": "2.3.2",
+        "serve-favicon": "2.3.2",
+        "serve-index": "1.7.3",
+        "serve-static": "1.10.3",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.0",
-        "vhost": "~3.0.1"
+        "vhost": "3.0.2"
       },
       "dependencies": {
         "cookie": {
@@ -4708,10 +4708,10 @@
       "integrity": "sha1-3ppexh4zoStu2qt7XwYumMWZuI4=",
       "dev": true,
       "requires": {
-        "debug": "~2.2.0",
-        "http-errors": "~1.3.1",
+        "debug": "2.2.0",
+        "http-errors": "1.3.1",
         "ms": "0.7.1",
-        "on-headers": "~1.0.0"
+        "on-headers": "1.0.1"
       },
       "dependencies": {
         "debug": {
@@ -4743,7 +4743,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "^0.1.4"
+        "date-now": "0.1.4"
       }
     },
     "console-stream": {
@@ -4758,8 +4758,8 @@
       "integrity": "sha1-jsLKW6ND4Aqjjb9OIA/VrJB+/WM=",
       "dev": true,
       "requires": {
-        "snake-case": "^1.1.0",
-        "upper-case": "^1.1.1"
+        "snake-case": "1.1.2",
+        "upper-case": "1.1.3"
       }
     },
     "constants-browserify": {
@@ -4798,17 +4798,17 @@
       "integrity": "sha512-yCPXU/OXJmxgbvTQfIKXKwKa4KQTvlO0a4T/371Raz3bdxcHIGhQtHtdrNee4Z8nGLNfe54njHDblVG2JNFyjg==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "^1.6.6",
-        "conventional-changelog-atom": "^0.2.8",
-        "conventional-changelog-codemirror": "^0.3.8",
-        "conventional-changelog-core": "^2.0.10",
-        "conventional-changelog-ember": "^0.3.11",
-        "conventional-changelog-eslint": "^1.0.9",
-        "conventional-changelog-express": "^0.3.6",
-        "conventional-changelog-jquery": "^0.1.0",
-        "conventional-changelog-jscs": "^0.1.0",
-        "conventional-changelog-jshint": "^0.3.8",
-        "conventional-changelog-preset-loader": "^1.1.8"
+        "conventional-changelog-angular": "1.6.6",
+        "conventional-changelog-atom": "0.2.8",
+        "conventional-changelog-codemirror": "0.3.8",
+        "conventional-changelog-core": "2.0.10",
+        "conventional-changelog-ember": "0.3.11",
+        "conventional-changelog-eslint": "1.0.9",
+        "conventional-changelog-express": "0.3.6",
+        "conventional-changelog-jquery": "0.1.0",
+        "conventional-changelog-jscs": "0.1.0",
+        "conventional-changelog-jshint": "0.3.8",
+        "conventional-changelog-preset-loader": "1.1.8"
       },
       "dependencies": {
         "conventional-changelog-angular": {
@@ -4817,8 +4817,8 @@
           "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
           "dev": true,
           "requires": {
-            "compare-func": "^1.3.1",
-            "q": "^1.5.1"
+            "compare-func": "1.3.2",
+            "q": "1.5.1"
           }
         }
       }
@@ -4829,9 +4829,9 @@
       "integrity": "sha1-P2QYWXiqE6sJVMnkaniWn9WcaAE=",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
-        "github-url-from-git": "^1.4.0",
-        "q": "^1.4.1"
+        "compare-func": "1.3.2",
+        "github-url-from-git": "1.5.0",
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-atom": {
@@ -4840,7 +4840,7 @@
       "integrity": "sha512-8pPZqhMbrnltNBizjoDCb/Sz85KyUXNDQxuAEYAU5V/eHn0okMBVjqc8aHWYpHrytyZWvMGbayOlDv7i8kEf6g==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-codemirror": {
@@ -4849,7 +4849,7 @@
       "integrity": "sha512-3HFZKtBXTaUCHvz7ai6nk2+psRIkldDoNzCsom0egDtVmPsvvHZkzjynhdQyULfacRSsBTaiQ0ol6nBOL4dDiQ==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-core": {
@@ -4858,19 +4858,19 @@
       "integrity": "sha512-FP0NHXIbpvU+f5jk/qZdnodhFmlzKW8ENRHQIWT69oe7ffur9nFRVJZlnXnFBOzwHM9WIRbC15ZWh9HZN6t9Uw==",
       "dev": true,
       "requires": {
-        "conventional-changelog-writer": "^3.0.9",
-        "conventional-commits-parser": "^2.1.7",
-        "dateformat": "^3.0.0",
-        "get-pkg-repo": "^1.0.0",
-        "git-raw-commits": "^1.3.6",
-        "git-remote-origin-url": "^2.0.0",
-        "git-semver-tags": "^1.3.6",
-        "lodash": "^4.2.1",
-        "normalize-package-data": "^2.3.5",
-        "q": "^1.5.1",
-        "read-pkg": "^1.1.0",
-        "read-pkg-up": "^1.0.1",
-        "through2": "^2.0.0"
+        "conventional-changelog-writer": "3.0.9",
+        "conventional-commits-parser": "2.1.7",
+        "dateformat": "3.0.3",
+        "get-pkg-repo": "1.4.0",
+        "git-raw-commits": "1.3.6",
+        "git-remote-origin-url": "2.0.0",
+        "git-semver-tags": "1.3.6",
+        "lodash": "4.17.5",
+        "normalize-package-data": "2.4.0",
+        "q": "1.5.1",
+        "read-pkg": "1.1.0",
+        "read-pkg-up": "1.0.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "camelcase": {
@@ -4885,9 +4885,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "conventional-commits-parser": {
@@ -4896,13 +4896,13 @@
           "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
           "dev": true,
           "requires": {
-            "JSONStream": "^1.0.4",
-            "is-text-path": "^1.0.0",
-            "lodash": "^4.2.1",
-            "meow": "^4.0.0",
-            "split2": "^2.0.0",
-            "through2": "^2.0.0",
-            "trim-off-newlines": "^1.0.0"
+            "JSONStream": "1.3.2",
+            "is-text-path": "1.0.1",
+            "lodash": "4.17.5",
+            "meow": "4.0.0",
+            "split2": "2.2.0",
+            "through2": "2.0.3",
+            "trim-off-newlines": "1.0.1"
           }
         },
         "dateformat": {
@@ -4917,7 +4917,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "git-raw-commits": {
@@ -4926,11 +4926,11 @@
           "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
           "dev": true,
           "requires": {
-            "dargs": "^4.0.1",
-            "lodash.template": "^4.0.2",
-            "meow": "^4.0.0",
-            "split2": "^2.0.0",
-            "through2": "^2.0.0"
+            "dargs": "4.1.0",
+            "lodash.template": "4.4.0",
+            "meow": "4.0.0",
+            "split2": "2.2.0",
+            "through2": "2.0.3"
           }
         },
         "indent-string": {
@@ -4951,10 +4951,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "lodash": {
@@ -4969,8 +4969,8 @@
           "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~3.0.0",
-            "lodash.templatesettings": "^4.0.0"
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.templatesettings": "4.1.0"
           }
         },
         "lodash.templatesettings": {
@@ -4979,7 +4979,7 @@
           "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~3.0.0"
+            "lodash._reinterpolate": "3.0.0"
           }
         },
         "map-obj": {
@@ -4994,15 +4994,15 @@
           "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
           },
           "dependencies": {
             "read-pkg": {
@@ -5011,9 +5011,9 @@
               "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
               "dev": true,
               "requires": {
-                "load-json-file": "^4.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^3.0.0"
+                "load-json-file": "4.0.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "3.0.0"
               }
             },
             "read-pkg-up": {
@@ -5022,8 +5022,8 @@
               "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
               "dev": true,
               "requires": {
-                "find-up": "^2.0.0",
-                "read-pkg": "^3.0.0"
+                "find-up": "2.1.0",
+                "read-pkg": "3.0.0"
               }
             }
           }
@@ -5034,8 +5034,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
           }
         },
         "path-type": {
@@ -5044,7 +5044,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -5059,13 +5059,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "redent": {
@@ -5074,8 +5074,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "string_decoder": {
@@ -5084,7 +5084,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-bom": {
@@ -5105,8 +5105,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         },
         "trim-newlines": {
@@ -5123,7 +5123,7 @@
       "integrity": "sha512-ErjPPiDmTd/WPgj2bSp+CGsLtJiv7FbdPKjZXH2Cd5P7j44Rqf0V9SIAAYFTQNoPqmvcp+sIcr/vH52WzPJUbw==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-eslint": {
@@ -5132,7 +5132,7 @@
       "integrity": "sha512-h87nfVh2fdk9fJIvz26wCBsbDC/KxqCc5wSlNMZbXcARtbgNbNDIF7Y7ctokFdnxkzVdaHsbINkh548T9eBA7Q==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-express": {
@@ -5141,7 +5141,7 @@
       "integrity": "sha512-3iWVtBJZ9RnRnZveNDzOD8QRn6g6vUif0qVTWWyi5nUIAbuN1FfPVyKdAlJJfp5Im+dE8Kiy/d2SpaX/0X678Q==",
       "dev": true,
       "requires": {
-        "q": "^1.5.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-jquery": {
@@ -5150,7 +5150,7 @@
       "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
       "dev": true,
       "requires": {
-        "q": "^1.4.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-jscs": {
@@ -5159,7 +5159,7 @@
       "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
       "dev": true,
       "requires": {
-        "q": "^1.4.1"
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-jshint": {
@@ -5168,8 +5168,8 @@
       "integrity": "sha512-hn9QU4ZI/5V50wKPJNPGT4gEWgiBFpV6adieILW4MaUFynuDYOvQ71EMSj3EznJyKi/KzuXpc9dGmX8njZMjig==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
-        "q": "^1.5.1"
+        "compare-func": "1.3.2",
+        "q": "1.5.1"
       }
     },
     "conventional-changelog-lint": {
@@ -5201,9 +5201,9 @@
           "integrity": "sha1-3ko3EAYTniCZCqwL42fTmDMSBOc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.20.0",
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.10.0"
+            "babel-runtime": "6.23.0",
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.10.5"
           }
         },
         "lodash": {
@@ -5218,10 +5218,10 @@
           "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
           "dev": true,
           "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.4.2",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           }
         }
       }
@@ -5244,16 +5244,16 @@
       "integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
-        "conventional-commits-filter": "^1.1.6",
-        "dateformat": "^3.0.0",
-        "handlebars": "^4.0.2",
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.2.1",
-        "meow": "^4.0.0",
-        "semver": "^5.5.0",
-        "split": "^1.0.0",
-        "through2": "^2.0.0"
+        "compare-func": "1.3.2",
+        "conventional-commits-filter": "1.1.6",
+        "dateformat": "3.0.3",
+        "handlebars": "4.0.11",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.17.5",
+        "meow": "4.0.0",
+        "semver": "5.5.0",
+        "split": "1.0.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "camelcase": {
@@ -5268,9 +5268,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "dateformat": {
@@ -5285,7 +5285,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "indent-string": {
@@ -5306,10 +5306,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "lodash": {
@@ -5330,15 +5330,15 @@
           "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
           }
         },
         "parse-json": {
@@ -5347,8 +5347,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
           }
         },
         "path-type": {
@@ -5357,7 +5357,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -5372,9 +5372,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -5383,8 +5383,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "readable-stream": {
@@ -5393,13 +5393,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "redent": {
@@ -5408,8 +5408,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "split": {
@@ -5418,7 +5418,7 @@
           "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
           "dev": true,
           "requires": {
-            "through": "2"
+            "through": "2.3.8"
           }
         },
         "string_decoder": {
@@ -5427,7 +5427,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-bom": {
@@ -5448,8 +5448,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         },
         "trim-newlines": {
@@ -5466,8 +5466,8 @@
       "integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
       "dev": true,
       "requires": {
-        "is-subset": "^0.1.1",
-        "modify-values": "^1.0.0"
+        "is-subset": "0.1.1",
+        "modify-values": "1.0.1"
       }
     },
     "conventional-commits-parser": {
@@ -5476,13 +5476,13 @@
       "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
       "dev": true,
       "requires": {
-        "JSONStream": "^1.0.4",
-        "is-text-path": "^1.0.0",
-        "lodash": "^4.2.1",
-        "meow": "^3.3.0",
-        "split2": "^2.0.0",
-        "through2": "^2.0.0",
-        "trim-off-newlines": "^1.0.0"
+        "JSONStream": "1.3.2",
+        "is-text-path": "1.0.1",
+        "lodash": "4.17.5",
+        "meow": "3.7.0",
+        "split2": "2.2.0",
+        "through2": "2.0.3",
+        "trim-off-newlines": "1.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -5503,13 +5503,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -5518,7 +5518,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "through2": {
@@ -5527,8 +5527,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -5539,13 +5539,13 @@
       "integrity": "sha512-oJjG6DkRgtnr/t/VrPdzmf4XZv8c4xKVJrVT4zrSHd92KEL+EYxSbYoKq8lQ7U5yLMw7130wrcQTLRjM/T+d4w==",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.4.10",
-        "conventional-commits-filter": "^1.1.1",
-        "conventional-commits-parser": "^2.1.1",
-        "git-raw-commits": "^1.3.0",
-        "git-semver-tags": "^1.3.0",
-        "meow": "^3.3.0",
-        "object-assign": "^4.0.1"
+        "concat-stream": "1.6.1",
+        "conventional-commits-filter": "1.1.6",
+        "conventional-commits-parser": "2.1.7",
+        "git-raw-commits": "1.3.6",
+        "git-semver-tags": "1.3.6",
+        "meow": "3.7.0",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "camelcase": {
@@ -5560,9 +5560,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "conventional-commits-parser": {
@@ -5571,13 +5571,13 @@
           "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
           "dev": true,
           "requires": {
-            "JSONStream": "^1.0.4",
-            "is-text-path": "^1.0.0",
-            "lodash": "^4.2.1",
-            "meow": "^4.0.0",
-            "split2": "^2.0.0",
-            "through2": "^2.0.0",
-            "trim-off-newlines": "^1.0.0"
+            "JSONStream": "1.3.2",
+            "is-text-path": "1.0.1",
+            "lodash": "4.17.5",
+            "meow": "4.0.0",
+            "split2": "2.2.0",
+            "through2": "2.0.3",
+            "trim-off-newlines": "1.0.1"
           },
           "dependencies": {
             "meow": {
@@ -5586,15 +5586,15 @@
               "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
               "dev": true,
               "requires": {
-                "camelcase-keys": "^4.0.0",
-                "decamelize-keys": "^1.0.0",
-                "loud-rejection": "^1.0.0",
-                "minimist": "^1.1.3",
-                "minimist-options": "^3.0.1",
-                "normalize-package-data": "^2.3.4",
-                "read-pkg-up": "^3.0.0",
-                "redent": "^2.0.0",
-                "trim-newlines": "^2.0.0"
+                "camelcase-keys": "4.2.0",
+                "decamelize-keys": "1.1.0",
+                "loud-rejection": "1.6.0",
+                "minimist": "1.2.0",
+                "minimist-options": "3.0.2",
+                "normalize-package-data": "2.4.0",
+                "read-pkg-up": "3.0.0",
+                "redent": "2.0.0",
+                "trim-newlines": "2.0.0"
               }
             }
           }
@@ -5605,7 +5605,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "git-raw-commits": {
@@ -5614,11 +5614,11 @@
           "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
           "dev": true,
           "requires": {
-            "dargs": "^4.0.1",
-            "lodash.template": "^4.0.2",
-            "meow": "^4.0.0",
-            "split2": "^2.0.0",
-            "through2": "^2.0.0"
+            "dargs": "4.1.0",
+            "lodash.template": "4.4.0",
+            "meow": "4.0.0",
+            "split2": "2.2.0",
+            "through2": "2.0.3"
           },
           "dependencies": {
             "meow": {
@@ -5627,15 +5627,15 @@
               "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
               "dev": true,
               "requires": {
-                "camelcase-keys": "^4.0.0",
-                "decamelize-keys": "^1.0.0",
-                "loud-rejection": "^1.0.0",
-                "minimist": "^1.1.3",
-                "minimist-options": "^3.0.1",
-                "normalize-package-data": "^2.3.4",
-                "read-pkg-up": "^3.0.0",
-                "redent": "^2.0.0",
-                "trim-newlines": "^2.0.0"
+                "camelcase-keys": "4.2.0",
+                "decamelize-keys": "1.1.0",
+                "loud-rejection": "1.6.0",
+                "minimist": "1.2.0",
+                "minimist-options": "3.0.2",
+                "normalize-package-data": "2.4.0",
+                "read-pkg-up": "3.0.0",
+                "redent": "2.0.0",
+                "trim-newlines": "2.0.0"
               }
             }
           }
@@ -5658,10 +5658,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "lodash": {
@@ -5676,8 +5676,8 @@
           "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~3.0.0",
-            "lodash.templatesettings": "^4.0.0"
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.templatesettings": "4.1.0"
           }
         },
         "lodash.templatesettings": {
@@ -5686,7 +5686,7 @@
           "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~3.0.0"
+            "lodash._reinterpolate": "3.0.0"
           }
         },
         "map-obj": {
@@ -5707,8 +5707,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
           }
         },
         "path-type": {
@@ -5717,7 +5717,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -5732,9 +5732,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -5743,8 +5743,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "readable-stream": {
@@ -5753,13 +5753,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "redent": {
@@ -5768,8 +5768,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "string_decoder": {
@@ -5778,7 +5778,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-bom": {
@@ -5799,8 +5799,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         },
         "trim-newlines": {
@@ -5852,12 +5852,12 @@
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.1",
-        "fs-write-stream-atomic": "^1.0.8",
-        "iferr": "^0.1.5",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.0"
+        "aproba": "1.2.0",
+        "fs-write-stream-atomic": "1.0.10",
+        "iferr": "0.1.5",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "run-queue": "1.0.3"
       }
     },
     "copy-descriptor": {
@@ -5888,14 +5888,14 @@
       "integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "js-yaml": "^3.4.3",
-        "minimist": "^1.2.0",
-        "object-assign": "^4.0.1",
-        "os-homedir": "^1.0.1",
-        "parse-json": "^2.2.0",
-        "pinkie-promise": "^2.0.0",
-        "require-from-string": "^1.1.0"
+        "graceful-fs": "4.1.11",
+        "js-yaml": "3.7.0",
+        "minimist": "1.2.0",
+        "object-assign": "4.1.1",
+        "os-homedir": "1.0.2",
+        "parse-json": "2.2.0",
+        "pinkie-promise": "2.0.1",
+        "require-from-string": "1.2.1"
       },
       "dependencies": {
         "object-assign": {
@@ -5912,17 +5912,17 @@
       "integrity": "sha1-GFvgGFEdhycN7czCkxceN2VauI8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.9.2",
-        "chokidar": "^1.6.0",
-        "duplexer": "^0.1.1",
-        "glob": "^7.0.5",
-        "glob2base": "^0.0.12",
-        "minimatch": "^3.0.2",
-        "mkdirp": "^0.5.1",
-        "resolve": "^1.1.7",
-        "safe-buffer": "^5.0.1",
-        "shell-quote": "^1.6.1",
-        "subarg": "^1.0.0"
+        "babel-runtime": "6.23.0",
+        "chokidar": "1.7.0",
+        "duplexer": "0.1.1",
+        "glob": "7.0.5",
+        "glob2base": "0.0.12",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "resolve": "1.6.0",
+        "safe-buffer": "5.1.1",
+        "shell-quote": "1.6.1",
+        "subarg": "1.0.0"
       },
       "dependencies": {
         "minimatch": {
@@ -5931,7 +5931,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -5948,8 +5948,8 @@
       "integrity": "sha512-iZvCCg8XqHQZ1ioNBTzXS/cQSkqkqcPs8xSX4upNB+DAk9Ht3uzQf2J32uAHNCne8LDmKr29AgZrEs4oIrwLuQ==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.0"
       }
     },
     "create-emotion": {
@@ -5958,13 +5958,13 @@
       "integrity": "sha1-XbTwbZNgJeQ70xJFOj7pRuTV5ds=",
       "dev": true,
       "requires": {
-        "@emotion/hash": "^0.6.2",
-        "@emotion/memoize": "^0.6.1",
-        "@emotion/stylis": "^0.6.10",
-        "@emotion/unitless": "^0.6.2",
-        "csstype": "^2.5.2",
-        "stylis": "^3.5.0",
-        "stylis-rule-sheet": "^0.0.10"
+        "@emotion/hash": "0.6.3",
+        "@emotion/memoize": "0.6.3",
+        "@emotion/stylis": "0.6.10",
+        "@emotion/unitless": "0.6.3",
+        "csstype": "2.5.5",
+        "stylis": "3.5.1",
+        "stylis-rule-sheet": "0.0.10"
       }
     },
     "create-emotion-styled": {
@@ -5973,7 +5973,7 @@
       "integrity": "sha1-P1VTZXECM/DyaDHR7PC473YNSyo=",
       "dev": true,
       "requires": {
-        "@emotion/is-prop-valid": "^0.6.1"
+        "@emotion/is-prop-valid": "0.6.3"
       }
     },
     "create-error-class": {
@@ -5982,7 +5982,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "^1.0.0"
+        "capture-stack-trace": "1.0.0"
       }
     },
     "create-hash": {
@@ -5991,11 +5991,11 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "md5.js": "1.3.4",
+        "ripemd160": "2.0.2",
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -6004,12 +6004,12 @@
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.11"
       }
     },
     "create-react-class": {
@@ -6017,9 +6017,9 @@
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
       "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
       "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "asap": {
@@ -6037,13 +6037,13 @@
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
           "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
           "requires": {
-            "core-js": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.9"
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.17"
           }
         },
         "object-assign": {
@@ -6056,7 +6056,7 @@
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
           "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
           "requires": {
-            "asap": "~2.0.3"
+            "asap": "2.0.6"
           }
         }
       }
@@ -6067,9 +6067,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.2",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       },
       "dependencies": {
         "lru-cache": {
@@ -6078,8 +6078,8 @@
           "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
           "dev": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         }
       }
@@ -6094,7 +6094,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "requires": {
-        "boom": "2.x.x"
+        "boom": "2.10.1"
       }
     },
     "crypto-browserify": {
@@ -6103,17 +6103,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
+        "browserify-cipher": "1.0.1",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.1",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "diffie-hellman": "5.0.3",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.14",
+        "public-encrypt": "4.0.2",
+        "randombytes": "2.0.6",
+        "randomfill": "1.0.4"
       }
     },
     "csrf": {
@@ -6133,10 +6133,10 @@
       "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "source-map": "^0.1.38",
-        "source-map-resolve": "^0.3.0",
-        "urix": "^0.1.0"
+        "inherits": "2.0.3",
+        "source-map": "0.1.43",
+        "source-map-resolve": "0.3.1",
+        "urix": "0.1.0"
       },
       "dependencies": {
         "atob": {
@@ -6151,7 +6151,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         },
         "source-map-resolve": {
@@ -6160,10 +6160,10 @@
           "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
           "dev": true,
           "requires": {
-            "atob": "~1.1.0",
-            "resolve-url": "~0.2.1",
-            "source-map-url": "~0.3.0",
-            "urix": "~0.1.0"
+            "atob": "1.1.3",
+            "resolve-url": "0.2.1",
+            "source-map-url": "0.3.0",
+            "urix": "0.1.0"
           }
         },
         "source-map-url": {
@@ -6186,20 +6186,20 @@
       "integrity": "sha512-X1IJteKnW9Llmrd+lJ0f7QZHh9Arf+11S7iRcoT2+riig3BK0QaCaOtubAulMK6Itbo08W6d3l8sW21r+Jhp5Q==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "css-selector-tokenizer": "^0.7.0",
-        "cssnano": "^3.10.0",
-        "icss-utils": "^2.1.0",
-        "loader-utils": "^1.0.2",
-        "lodash.camelcase": "^4.3.0",
-        "object-assign": "^4.1.1",
-        "postcss": "^5.0.6",
-        "postcss-modules-extract-imports": "^1.2.0",
-        "postcss-modules-local-by-default": "^1.2.0",
-        "postcss-modules-scope": "^1.1.0",
-        "postcss-modules-values": "^1.3.0",
-        "postcss-value-parser": "^3.3.0",
-        "source-list-map": "^2.0.0"
+        "babel-code-frame": "6.26.0",
+        "css-selector-tokenizer": "0.7.0",
+        "cssnano": "3.10.0",
+        "icss-utils": "2.1.0",
+        "loader-utils": "1.1.0",
+        "lodash.camelcase": "4.3.0",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-modules-extract-imports": "1.2.0",
+        "postcss-modules-local-by-default": "1.2.0",
+        "postcss-modules-scope": "1.1.0",
+        "postcss-modules-values": "1.3.0",
+        "postcss-value-parser": "3.3.0",
+        "source-list-map": "2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6208,7 +6208,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "css-selector-tokenizer": {
@@ -6217,9 +6217,9 @@
           "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
           "dev": true,
           "requires": {
-            "cssesc": "^0.1.0",
-            "fastparse": "^1.1.1",
-            "regexpu-core": "^1.0.0"
+            "cssesc": "0.1.0",
+            "fastparse": "1.1.1",
+            "regexpu-core": "1.0.0"
           }
         },
         "loader-utils": {
@@ -6228,9 +6228,9 @@
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         },
         "lodash.camelcase": {
@@ -6251,10 +6251,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "postcss-modules-extract-imports": {
@@ -6263,7 +6263,7 @@
           "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
           "dev": true,
           "requires": {
-            "postcss": "^6.0.1"
+            "postcss": "6.0.21"
           },
           "dependencies": {
             "chalk": {
@@ -6272,9 +6272,9 @@
               "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.3.0"
               }
             },
             "has-flag": {
@@ -6289,9 +6289,9 @@
               "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
               "dev": true,
               "requires": {
-                "chalk": "^2.3.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^5.3.0"
+                "chalk": "2.3.2",
+                "source-map": "0.6.1",
+                "supports-color": "5.3.0"
               }
             },
             "source-map": {
@@ -6306,7 +6306,7 @@
               "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -6317,9 +6317,9 @@
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "dev": true,
           "requires": {
-            "regenerate": "^1.2.1",
-            "regjsgen": "^0.2.0",
-            "regjsparser": "^0.1.4"
+            "regenerate": "1.3.3",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
           }
         },
         "source-list-map": {
@@ -6334,7 +6334,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -6345,10 +6345,10 @@
       "integrity": "sha1-N4bnGYmD2WWibjGVfgkHjLt3BaI=",
       "dev": true,
       "requires": {
-        "css-tokenize": "^1.0.1",
+        "css-tokenize": "1.0.1",
         "duplexer2": "0.0.2",
-        "ldjson-stream": "^1.2.1",
-        "through2": "^0.6.3"
+        "ldjson-stream": "1.2.1",
+        "through2": "0.6.5"
       }
     },
     "css-select": {
@@ -6357,10 +6357,10 @@
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
-        "boolbase": "~1.0.0",
-        "css-what": "2.1",
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
         "domutils": "1.5.1",
-        "nth-check": "~1.0.1"
+        "nth-check": "1.0.1"
       }
     },
     "css-selector-parser": {
@@ -6375,8 +6375,8 @@
       "integrity": "sha1-RiXLHtohwUOFi3+B1oA8HSb8FL4=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^1.0.33"
+        "inherits": "2.0.3",
+        "readable-stream": "1.1.14"
       }
     },
     "css-what": {
@@ -6403,38 +6403,38 @@
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
       "dev": true,
       "requires": {
-        "autoprefixer": "^6.3.1",
-        "decamelize": "^1.1.2",
-        "defined": "^1.0.0",
-        "has": "^1.0.1",
-        "object-assign": "^4.0.1",
-        "postcss": "^5.0.14",
-        "postcss-calc": "^5.2.0",
-        "postcss-colormin": "^2.1.8",
-        "postcss-convert-values": "^2.3.4",
-        "postcss-discard-comments": "^2.0.4",
-        "postcss-discard-duplicates": "^2.0.1",
-        "postcss-discard-empty": "^2.0.1",
-        "postcss-discard-overridden": "^0.1.1",
-        "postcss-discard-unused": "^2.2.1",
-        "postcss-filter-plugins": "^2.0.0",
-        "postcss-merge-idents": "^2.1.5",
-        "postcss-merge-longhand": "^2.0.1",
-        "postcss-merge-rules": "^2.0.3",
-        "postcss-minify-font-values": "^1.0.2",
-        "postcss-minify-gradients": "^1.0.1",
-        "postcss-minify-params": "^1.0.4",
-        "postcss-minify-selectors": "^2.0.4",
-        "postcss-normalize-charset": "^1.1.0",
-        "postcss-normalize-url": "^3.0.7",
-        "postcss-ordered-values": "^2.1.0",
-        "postcss-reduce-idents": "^2.2.2",
-        "postcss-reduce-initial": "^1.0.0",
-        "postcss-reduce-transforms": "^1.0.3",
-        "postcss-svgo": "^2.1.1",
-        "postcss-unique-selectors": "^2.0.2",
-        "postcss-value-parser": "^3.2.3",
-        "postcss-zindex": "^2.0.1"
+        "autoprefixer": "6.3.6",
+        "decamelize": "1.2.0",
+        "defined": "1.0.0",
+        "has": "1.0.1",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-calc": "5.3.1",
+        "postcss-colormin": "2.2.2",
+        "postcss-convert-values": "2.6.1",
+        "postcss-discard-comments": "2.0.4",
+        "postcss-discard-duplicates": "2.1.0",
+        "postcss-discard-empty": "2.1.0",
+        "postcss-discard-overridden": "0.1.1",
+        "postcss-discard-unused": "2.2.3",
+        "postcss-filter-plugins": "2.0.2",
+        "postcss-merge-idents": "2.1.7",
+        "postcss-merge-longhand": "2.0.2",
+        "postcss-merge-rules": "2.1.2",
+        "postcss-minify-font-values": "1.0.5",
+        "postcss-minify-gradients": "1.0.5",
+        "postcss-minify-params": "1.2.2",
+        "postcss-minify-selectors": "2.1.1",
+        "postcss-normalize-charset": "1.1.1",
+        "postcss-normalize-url": "3.0.8",
+        "postcss-ordered-values": "2.2.3",
+        "postcss-reduce-idents": "2.4.0",
+        "postcss-reduce-initial": "1.0.1",
+        "postcss-reduce-transforms": "1.0.4",
+        "postcss-svgo": "2.1.6",
+        "postcss-unique-selectors": "2.0.2",
+        "postcss-value-parser": "3.3.0",
+        "postcss-zindex": "2.2.0"
       },
       "dependencies": {
         "object-assign": {
@@ -6449,10 +6449,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -6461,7 +6461,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -6472,8 +6472,8 @@
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
       "dev": true,
       "requires": {
-        "clap": "^1.0.9",
-        "source-map": "^0.5.3"
+        "clap": "1.2.3",
+        "source-map": "0.5.7"
       }
     },
     "cssom": {
@@ -6488,7 +6488,7 @@
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "dev": true,
       "requires": {
-        "cssom": "0.3.x"
+        "cssom": "0.3.2"
       }
     },
     "csstype": {
@@ -6505,8 +6505,8 @@
       "requires": {
         "cookie": "0.1.3",
         "cookie-signature": "1.0.6",
-        "csrf": "~3.0.0",
-        "http-errors": "~1.3.1"
+        "csrf": "3.0.6",
+        "http-errors": "1.3.1"
       },
       "dependencies": {
         "cookie": {
@@ -6523,7 +6523,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "cwebp-bin": {
@@ -6532,9 +6532,9 @@
       "integrity": "sha1-7it/YzPTQm+1K7QF+m8uyLYolPQ=",
       "dev": true,
       "requires": {
-        "bin-build": "^2.2.0",
-        "bin-wrapper": "^3.0.1",
-        "logalot": "^2.0.0"
+        "bin-build": "2.2.0",
+        "bin-wrapper": "3.0.2",
+        "logalot": "2.1.0"
       }
     },
     "cycle": {
@@ -6599,7 +6599,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "bluebird": {
@@ -6614,9 +6614,9 @@
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.1.0",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^4.0.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -6625,7 +6625,7 @@
               "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
               "dev": true,
               "requires": {
-                "has-flag": "^2.0.0"
+                "has-flag": "2.0.0"
               }
             }
           }
@@ -6651,12 +6651,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-flag": {
@@ -6677,7 +6677,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "request-progress": {
@@ -6686,7 +6686,7 @@
           "integrity": "sha1-ByHBBdipasayzossia4tXs/Pazo=",
           "dev": true,
           "requires": {
-            "throttleit": "~0.0.2"
+            "throttleit": "0.0.2"
           }
         },
         "supports-color": {
@@ -6695,7 +6695,7 @@
           "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         },
         "throttleit": {
@@ -6710,8 +6710,8 @@
           "integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=",
           "dev": true,
           "requires": {
-            "buffer-crc32": "~0.2.3",
-            "fd-slicer": "~1.0.1"
+            "buffer-crc32": "0.2.13",
+            "fd-slicer": "1.0.1"
           }
         }
       }
@@ -6722,7 +6722,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.41"
       }
     },
     "d3": {
@@ -6742,7 +6742,7 @@
       "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "dashdash": {
@@ -6750,7 +6750,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -6815,8 +6815,8 @@
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
+        "decamelize": "1.2.0",
+        "map-obj": "1.0.1"
       }
     },
     "decode-uri-component": {
@@ -6831,15 +6831,15 @@
       "integrity": "sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0=",
       "dev": true,
       "requires": {
-        "buffer-to-vinyl": "^1.0.0",
-        "concat-stream": "^1.4.6",
-        "decompress-tar": "^3.0.0",
-        "decompress-tarbz2": "^3.0.0",
-        "decompress-targz": "^3.0.0",
-        "decompress-unzip": "^3.0.0",
-        "stream-combiner2": "^1.1.1",
-        "vinyl-assign": "^1.0.1",
-        "vinyl-fs": "^2.2.0"
+        "buffer-to-vinyl": "1.1.0",
+        "concat-stream": "1.6.1",
+        "decompress-tar": "3.1.0",
+        "decompress-tarbz2": "3.1.0",
+        "decompress-targz": "3.1.0",
+        "decompress-unzip": "3.4.0",
+        "stream-combiner2": "1.1.1",
+        "vinyl-assign": "1.2.1",
+        "vinyl-fs": "2.4.4"
       },
       "dependencies": {
         "glob": {
@@ -6848,11 +6848,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "glob-parent": {
@@ -6861,8 +6861,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           }
         },
         "glob-stream": {
@@ -6871,14 +6871,14 @@
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
           "dev": true,
           "requires": {
-            "extend": "^3.0.0",
-            "glob": "^5.0.3",
-            "glob-parent": "^3.0.0",
-            "micromatch": "^2.3.7",
-            "ordered-read-streams": "^0.3.0",
-            "through2": "^0.6.0",
-            "to-absolute-glob": "^0.1.1",
-            "unique-stream": "^2.0.2"
+            "extend": "3.0.1",
+            "glob": "5.0.15",
+            "glob-parent": "3.1.0",
+            "micromatch": "2.3.11",
+            "ordered-read-streams": "0.3.0",
+            "through2": "0.6.5",
+            "to-absolute-glob": "0.1.1",
+            "unique-stream": "2.2.1"
           },
           "dependencies": {
             "isarray": {
@@ -6893,10 +6893,10 @@
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             },
             "string_decoder": {
@@ -6911,8 +6911,8 @@
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "dev": true,
               "requires": {
-                "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                "xtend": ">=4.0.0 <4.1.0-0"
+                "readable-stream": "1.0.34",
+                "xtend": "4.0.1"
               }
             }
           }
@@ -6929,7 +6929,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "isarray": {
@@ -6944,7 +6944,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "object-assign": {
@@ -6959,8 +6959,8 @@
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
           "dev": true,
           "requires": {
-            "is-stream": "^1.0.1",
-            "readable-stream": "^2.0.1"
+            "is-stream": "1.1.0",
+            "readable-stream": "2.3.5"
           }
         },
         "readable-stream": {
@@ -6969,13 +6969,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -6984,7 +6984,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-bom": {
@@ -6993,7 +6993,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "through2": {
@@ -7002,8 +7002,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         },
         "unique-stream": {
@@ -7012,8 +7012,8 @@
           "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
           "dev": true,
           "requires": {
-            "json-stable-stringify": "^1.0.0",
-            "through2-filter": "^2.0.0"
+            "json-stable-stringify": "1.0.1",
+            "through2-filter": "2.0.0"
           }
         },
         "vinyl-fs": {
@@ -7022,23 +7022,23 @@
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "dev": true,
           "requires": {
-            "duplexify": "^3.2.0",
-            "glob-stream": "^5.3.2",
-            "graceful-fs": "^4.0.0",
+            "duplexify": "3.5.4",
+            "glob-stream": "5.3.5",
+            "graceful-fs": "4.1.11",
             "gulp-sourcemaps": "1.6.0",
-            "is-valid-glob": "^0.3.0",
-            "lazystream": "^1.0.0",
-            "lodash.isequal": "^4.0.0",
-            "merge-stream": "^1.0.0",
-            "mkdirp": "^0.5.0",
-            "object-assign": "^4.0.0",
-            "readable-stream": "^2.0.4",
-            "strip-bom": "^2.0.0",
-            "strip-bom-stream": "^1.0.0",
-            "through2": "^2.0.0",
-            "through2-filter": "^2.0.0",
-            "vali-date": "^1.0.0",
-            "vinyl": "^1.0.0"
+            "is-valid-glob": "0.3.0",
+            "lazystream": "1.0.0",
+            "lodash.isequal": "4.5.0",
+            "merge-stream": "1.0.1",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "readable-stream": "2.3.5",
+            "strip-bom": "2.0.0",
+            "strip-bom-stream": "1.0.0",
+            "through2": "2.0.3",
+            "through2-filter": "2.0.0",
+            "vali-date": "1.0.0",
+            "vinyl": "1.1.1"
           }
         }
       }
@@ -7049,7 +7049,7 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.0"
       }
     },
     "decompress-tar": {
@@ -7058,12 +7058,12 @@
       "integrity": "sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY=",
       "dev": true,
       "requires": {
-        "is-tar": "^1.0.0",
-        "object-assign": "^2.0.0",
-        "strip-dirs": "^1.0.0",
-        "tar-stream": "^1.1.1",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.3"
+        "is-tar": "1.0.0",
+        "object-assign": "2.1.1",
+        "strip-dirs": "1.1.1",
+        "tar-stream": "1.5.5",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -7084,8 +7084,8 @@
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -7096,13 +7096,13 @@
       "integrity": "sha1-iyOTVoE1X58YnYclag+L3ZbZZm0=",
       "dev": true,
       "requires": {
-        "is-bzip2": "^1.0.0",
-        "object-assign": "^2.0.0",
-        "seek-bzip": "^1.0.3",
-        "strip-dirs": "^1.0.0",
-        "tar-stream": "^1.1.1",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.3"
+        "is-bzip2": "1.0.0",
+        "object-assign": "2.1.1",
+        "seek-bzip": "1.0.5",
+        "strip-dirs": "1.1.1",
+        "tar-stream": "1.5.5",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -7123,8 +7123,8 @@
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -7135,12 +7135,12 @@
       "integrity": "sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA=",
       "dev": true,
       "requires": {
-        "is-gzip": "^1.0.0",
-        "object-assign": "^2.0.0",
-        "strip-dirs": "^1.0.0",
-        "tar-stream": "^1.1.1",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.3"
+        "is-gzip": "1.0.0",
+        "object-assign": "2.1.1",
+        "strip-dirs": "1.1.1",
+        "tar-stream": "1.5.5",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -7161,8 +7161,8 @@
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -7173,13 +7173,13 @@
       "integrity": "sha1-YUdbQVIGa74/7hL51inRX+ZHjus=",
       "dev": true,
       "requires": {
-        "is-zip": "^1.0.0",
-        "read-all-stream": "^3.0.0",
-        "stat-mode": "^0.2.0",
-        "strip-dirs": "^1.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^1.0.0",
-        "yauzl": "^2.2.1"
+        "is-zip": "1.0.0",
+        "read-all-stream": "3.1.0",
+        "stat-mode": "0.2.2",
+        "strip-dirs": "1.1.1",
+        "through2": "2.0.3",
+        "vinyl": "1.1.1",
+        "yauzl": "2.9.1"
       },
       "dependencies": {
         "isarray": {
@@ -7194,13 +7194,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -7209,7 +7209,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "through2": {
@@ -7218,8 +7218,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -7247,7 +7247,7 @@
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
       "dev": true,
       "requires": {
-        "strip-bom": "^2.0.0"
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -7256,7 +7256,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -7267,7 +7267,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.2"
+        "clone": "1.0.3"
       }
     },
     "define-properties": {
@@ -7276,8 +7276,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
       }
     },
     "define-property": {
@@ -7286,8 +7286,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -7310,13 +7310,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "object-assign": {
@@ -7360,8 +7360,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
       }
     },
     "destroy": {
@@ -7382,7 +7382,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "detect-newline": {
@@ -7403,8 +7403,8 @@
       "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
       "dev": true,
       "requires": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
+        "asap": "2.0.6",
+        "wrappy": "1.0.2"
       }
     },
     "diff": {
@@ -7419,9 +7419,9 @@
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.0.6"
       }
     },
     "discontinuous-range": {
@@ -7442,8 +7442,8 @@
       "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "dev": true,
       "requires": {
-        "ip": "^1.1.0",
-        "safe-buffer": "^5.0.1"
+        "ip": "1.1.5",
+        "safe-buffer": "5.1.1"
       }
     },
     "dns-txt": {
@@ -7452,7 +7452,7 @@
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "dev": true,
       "requires": {
-        "buffer-indexof": "^1.0.0"
+        "buffer-indexof": "1.1.1"
       }
     },
     "doctrine": {
@@ -7461,8 +7461,8 @@
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "isarray": "^1.0.0"
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -7479,18 +7479,18 @@
       "integrity": "sha1-GJLRC2Gpo1at2/K2FJM+gfi7ODQ=",
       "dev": true,
       "requires": {
-        "browserslist": "^1.1.1",
-        "caniuse-db": "^1.0.30000187",
-        "css-rule-stream": "^1.1.0",
+        "browserslist": "1.3.6",
+        "caniuse-db": "1.0.30000815",
+        "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
-        "jsonfilter": "^1.1.2",
-        "ldjson-stream": "^1.2.1",
-        "lodash": "^4.0.0",
-        "multimatch": "^2.0.0",
-        "postcss": "^5.0.8",
-        "source-map": "^0.4.2",
-        "through2": "^0.6.3",
-        "yargs": "^3.5.4"
+        "jsonfilter": "1.1.2",
+        "ldjson-stream": "1.2.1",
+        "lodash": "4.17.5",
+        "multimatch": "2.1.0",
+        "postcss": "5.2.18",
+        "source-map": "0.4.4",
+        "through2": "0.6.5",
+        "yargs": "3.10.0"
       },
       "dependencies": {
         "lodash": {
@@ -7505,10 +7505,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           },
           "dependencies": {
             "source-map": {
@@ -7525,7 +7525,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         },
         "supports-color": {
@@ -7534,7 +7534,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -7545,7 +7545,7 @@
       "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
       "dev": true,
       "requires": {
-        "utila": "~0.3"
+        "utila": "0.3.3"
       },
       "dependencies": {
         "utila": {
@@ -7567,8 +7567,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -7603,7 +7603,7 @@
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
       "dev": true,
       "requires": {
-        "webidl-conversions": "^4.0.2"
+        "webidl-conversions": "4.0.2"
       }
     },
     "domhandler": {
@@ -7612,7 +7612,7 @@
       "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
       "dev": true,
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.0"
       }
     },
     "domutils": {
@@ -7621,8 +7621,8 @@
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
       }
     },
     "dot-case": {
@@ -7631,7 +7631,7 @@
       "integrity": "sha1-HnOCaQDeKNbeVIC8HeMdCEKwa+w=",
       "dev": true,
       "requires": {
-        "sentence-case": "^1.1.2"
+        "sentence-case": "1.1.3"
       }
     },
     "dot-prop": {
@@ -7640,7 +7640,7 @@
       "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
       "dev": true,
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "dotgitignore": {
@@ -7649,8 +7649,8 @@
       "integrity": "sha512-eu5XjSstm0WXQsARgo6kPjkINYZlOUW+z/KtAAIBjHa5mUpMPrxJytbPIndWz6GubBuuuH5ljtVcXKnVnH5q8w==",
       "dev": true,
       "requires": {
-        "find-up": "^2.1.0",
-        "minimatch": "^3.0.4"
+        "find-up": "2.1.0",
+        "minimatch": "3.0.4"
       },
       "dependencies": {
         "find-up": {
@@ -7659,7 +7659,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "minimatch": {
@@ -7668,7 +7668,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -7679,21 +7679,21 @@
       "integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
       "dev": true,
       "requires": {
-        "caw": "^1.0.1",
-        "concat-stream": "^1.4.7",
-        "each-async": "^1.0.0",
-        "filenamify": "^1.0.1",
-        "got": "^5.0.0",
-        "gulp-decompress": "^1.2.0",
-        "gulp-rename": "^1.2.0",
-        "is-url": "^1.2.0",
-        "object-assign": "^4.0.1",
-        "read-all-stream": "^3.0.0",
-        "readable-stream": "^2.0.2",
-        "stream-combiner2": "^1.1.1",
-        "vinyl": "^1.0.0",
-        "vinyl-fs": "^2.2.0",
-        "ware": "^1.2.0"
+        "caw": "1.2.0",
+        "concat-stream": "1.6.1",
+        "each-async": "1.1.1",
+        "filenamify": "1.2.1",
+        "got": "5.7.1",
+        "gulp-decompress": "1.2.0",
+        "gulp-rename": "1.2.2",
+        "is-url": "1.2.2",
+        "object-assign": "4.1.1",
+        "read-all-stream": "3.1.0",
+        "readable-stream": "2.3.5",
+        "stream-combiner2": "1.1.1",
+        "vinyl": "1.1.1",
+        "vinyl-fs": "2.4.4",
+        "ware": "1.3.0"
       },
       "dependencies": {
         "glob": {
@@ -7702,11 +7702,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "glob-parent": {
@@ -7715,8 +7715,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           }
         },
         "glob-stream": {
@@ -7725,14 +7725,14 @@
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
           "dev": true,
           "requires": {
-            "extend": "^3.0.0",
-            "glob": "^5.0.3",
-            "glob-parent": "^3.0.0",
-            "micromatch": "^2.3.7",
-            "ordered-read-streams": "^0.3.0",
-            "through2": "^0.6.0",
-            "to-absolute-glob": "^0.1.1",
-            "unique-stream": "^2.0.2"
+            "extend": "3.0.1",
+            "glob": "5.0.15",
+            "glob-parent": "3.1.0",
+            "micromatch": "2.3.11",
+            "ordered-read-streams": "0.3.0",
+            "through2": "0.6.5",
+            "to-absolute-glob": "0.1.1",
+            "unique-stream": "2.2.1"
           },
           "dependencies": {
             "isarray": {
@@ -7747,10 +7747,10 @@
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             },
             "string_decoder": {
@@ -7765,8 +7765,8 @@
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
               "dev": true,
               "requires": {
-                "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                "xtend": ">=4.0.0 <4.1.0-0"
+                "readable-stream": "1.0.34",
+                "xtend": "4.0.1"
               }
             }
           }
@@ -7783,7 +7783,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "isarray": {
@@ -7798,7 +7798,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "object-assign": {
@@ -7813,8 +7813,8 @@
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
           "dev": true,
           "requires": {
-            "is-stream": "^1.0.1",
-            "readable-stream": "^2.0.1"
+            "is-stream": "1.1.0",
+            "readable-stream": "2.3.5"
           }
         },
         "readable-stream": {
@@ -7823,13 +7823,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -7838,7 +7838,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-bom": {
@@ -7847,7 +7847,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "through2": {
@@ -7856,8 +7856,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         },
         "unique-stream": {
@@ -7866,8 +7866,8 @@
           "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
           "dev": true,
           "requires": {
-            "json-stable-stringify": "^1.0.0",
-            "through2-filter": "^2.0.0"
+            "json-stable-stringify": "1.0.1",
+            "through2-filter": "2.0.0"
           }
         },
         "vinyl-fs": {
@@ -7876,23 +7876,23 @@
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
           "dev": true,
           "requires": {
-            "duplexify": "^3.2.0",
-            "glob-stream": "^5.3.2",
-            "graceful-fs": "^4.0.0",
+            "duplexify": "3.5.4",
+            "glob-stream": "5.3.5",
+            "graceful-fs": "4.1.11",
             "gulp-sourcemaps": "1.6.0",
-            "is-valid-glob": "^0.3.0",
-            "lazystream": "^1.0.0",
-            "lodash.isequal": "^4.0.0",
-            "merge-stream": "^1.0.0",
-            "mkdirp": "^0.5.0",
-            "object-assign": "^4.0.0",
-            "readable-stream": "^2.0.4",
-            "strip-bom": "^2.0.0",
-            "strip-bom-stream": "^1.0.0",
-            "through2": "^2.0.0",
-            "through2-filter": "^2.0.0",
-            "vali-date": "^1.0.0",
-            "vinyl": "^1.0.0"
+            "is-valid-glob": "0.3.0",
+            "lazystream": "1.0.0",
+            "lodash.isequal": "4.5.0",
+            "merge-stream": "1.0.1",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "readable-stream": "2.3.5",
+            "strip-bom": "2.0.0",
+            "strip-bom-stream": "1.0.0",
+            "through2": "2.0.3",
+            "through2-filter": "2.0.0",
+            "vali-date": "1.0.0",
+            "vinyl": "1.1.1"
           }
         }
       }
@@ -7908,7 +7908,7 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "requires": {
-        "readable-stream": "~1.1.9"
+        "readable-stream": "1.1.14"
       }
     },
     "duplexer3": {
@@ -7923,10 +7923,10 @@
       "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.5",
+        "stream-shift": "1.0.0"
       },
       "dependencies": {
         "end-of-stream": {
@@ -7935,7 +7935,7 @@
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           }
         },
         "isarray": {
@@ -7950,13 +7950,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -7965,7 +7965,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -7976,8 +7976,8 @@
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
       "dev": true,
       "requires": {
-        "onetime": "^1.0.0",
-        "set-immediate-shim": "^1.0.0"
+        "onetime": "1.1.0",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "ebnf-parser": {
@@ -7992,7 +7992,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "ecstatic": {
@@ -8001,10 +8001,10 @@
       "integrity": "sha512-ztE4WqheoWLh3wv+HQwy7dACnvNY620coWpa+XqY6R2cVWgaAT2lUISU1Uf7JpdLLJCURktJOaA9av2AOzsyYQ==",
       "dev": true,
       "requires": {
-        "he": "^1.1.1",
-        "mime": "^1.2.11",
-        "minimist": "^1.1.0",
-        "url-join": "^2.0.2"
+        "he": "1.1.1",
+        "mime": "1.3.4",
+        "minimist": "1.2.0",
+        "url-join": "2.0.5"
       }
     },
     "ee-first": {
@@ -8031,13 +8031,13 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.3",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "emojis-list": {
@@ -8052,8 +8052,8 @@
       "integrity": "sha1-ATnnzBVLKEX0ua+qmW3U3hO7kOM=",
       "dev": true,
       "requires": {
-        "babel-plugin-emotion": "^9.2.4",
-        "create-emotion": "^9.2.4"
+        "babel-plugin-emotion": "9.2.5",
+        "create-emotion": "9.2.5"
       }
     },
     "encodeurl": {
@@ -8067,7 +8067,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "0.4.19"
       }
     },
     "end-of-stream": {
@@ -8075,7 +8075,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
       "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
       "requires": {
-        "once": "~1.3.0"
+        "once": "1.3.3"
       },
       "dependencies": {
         "once": {
@@ -8083,7 +8083,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         }
       }
@@ -8094,10 +8094,10 @@
       "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.4.0",
-        "object-assign": "^4.0.1",
-        "tapable": "^0.2.7"
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.4.1",
+        "object-assign": "4.1.1",
+        "tapable": "0.2.8"
       },
       "dependencies": {
         "object-assign": {
@@ -8120,22 +8120,22 @@
       "integrity": "sha512-l8csyPyLmtxskTz6pX9W8eDOyH1ckEtDttXk/vlFWCjv00SkjTjtoUrogqp4yEvMyneU9dUJoOLnqFoiHb8IHA==",
       "dev": true,
       "requires": {
-        "cheerio": "^1.0.0-rc.2",
-        "function.prototype.name": "^1.0.3",
-        "has": "^1.0.1",
-        "is-boolean-object": "^1.0.0",
-        "is-callable": "^1.1.3",
-        "is-number-object": "^1.0.3",
-        "is-string": "^1.0.4",
-        "is-subset": "^0.1.1",
-        "lodash": "^4.17.4",
-        "object-inspect": "^1.5.0",
-        "object-is": "^1.0.1",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.0.4",
-        "object.values": "^1.0.4",
-        "raf": "^3.4.0",
-        "rst-selector-parser": "^2.2.3"
+        "cheerio": "1.0.0-rc.2",
+        "function.prototype.name": "1.1.0",
+        "has": "1.0.1",
+        "is-boolean-object": "1.0.0",
+        "is-callable": "1.1.3",
+        "is-number-object": "1.0.3",
+        "is-string": "1.0.4",
+        "is-subset": "0.1.1",
+        "lodash": "4.17.5",
+        "object-inspect": "1.5.0",
+        "object-is": "1.0.1",
+        "object.assign": "4.1.0",
+        "object.entries": "1.0.4",
+        "object.values": "1.0.4",
+        "raf": "3.4.0",
+        "rst-selector-parser": "2.2.3"
       },
       "dependencies": {
         "lodash": {
@@ -8152,11 +8152,11 @@
       "integrity": "sha512-EM1shx5KbjddW4y2z/AvhKCfmhPdMNUdES0L7rHw1zF5cYWXBtfECNu+6bqYMK66Lgoz2iWHBmnYmQ2alIyaSA==",
       "dev": true,
       "requires": {
-        "enzyme-adapter-utils": "^1.1.0",
-        "lodash": "^4.17.4",
-        "object.assign": "^4.0.4",
-        "object.values": "^1.0.4",
-        "prop-types": "^15.5.10"
+        "enzyme-adapter-utils": "1.3.0",
+        "lodash": "4.17.5",
+        "object.assign": "4.1.0",
+        "object.values": "1.0.4",
+        "prop-types": "15.6.0"
       },
       "dependencies": {
         "lodash": {
@@ -8173,9 +8173,9 @@
       "integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.4",
-        "object.assign": "^4.0.4",
-        "prop-types": "^15.6.0"
+        "lodash": "4.17.5",
+        "object.assign": "4.1.0",
+        "prop-types": "15.6.0"
       },
       "dependencies": {
         "lodash": {
@@ -8191,7 +8191,7 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "error-ex": {
@@ -8200,7 +8200,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "error-stack-parser": {
@@ -8209,7 +8209,7 @@
       "integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
       "dev": true,
       "requires": {
-        "stackframe": "^0.3.1"
+        "stackframe": "0.3.1"
       }
     },
     "errorhandler": {
@@ -8218,8 +8218,8 @@
       "integrity": "sha1-t7cO2PNZ6duICS8tIMD4MUIK2D8=",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.0",
-        "escape-html": "~1.0.3"
+        "accepts": "1.3.5",
+        "escape-html": "1.0.3"
       },
       "dependencies": {
         "accepts": {
@@ -8228,7 +8228,7 @@
           "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
           "dev": true,
           "requires": {
-            "mime-types": "~2.1.18",
+            "mime-types": "2.1.18",
             "negotiator": "0.6.1"
           }
         },
@@ -8246,11 +8246,11 @@
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -8259,9 +8259,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.1",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "es5-ext": {
@@ -8270,9 +8270,9 @@
       "integrity": "sha1-urPpgtdQ8BEvDLnmq+1yxZ6zPrI=",
       "dev": true,
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       },
       "dependencies": {
         "next-tick": {
@@ -8289,9 +8289,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.41",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-map": {
@@ -8300,12 +8300,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-set": "~0.1.5",
-        "es6-symbol": "~3.1.1",
-        "event-emitter": "~0.3.5"
+        "d": "1.0.0",
+        "es5-ext": "0.10.41",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
       }
     },
     "es6-promise": {
@@ -8320,11 +8320,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
+        "d": "1.0.0",
+        "es5-ext": "0.10.41",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
-        "event-emitter": "~0.3.5"
+        "event-emitter": "0.3.5"
       }
     },
     "es6-symbol": {
@@ -8333,8 +8333,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.41"
       }
     },
     "es6-templates": {
@@ -8343,8 +8343,8 @@
       "integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
       "dev": true,
       "requires": {
-        "recast": "~0.11.12",
-        "through": "~2.3.6"
+        "recast": "0.11.23",
+        "through": "2.3.8"
       }
     },
     "es6-weak-map": {
@@ -8353,10 +8353,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.41",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "escape-html": {
@@ -8376,11 +8376,11 @@
       "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "dev": true,
       "requires": {
-        "esprima": "^3.1.3",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -8398,10 +8398,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "^0.1.3",
-        "es6-weak-map": "^2.0.1",
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
       }
     },
     "eslint": {
@@ -8410,40 +8410,40 @@
       "integrity": "sha1-vcxqbF/+CBYOe5PAZmlTYqkeMPI=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.16.0",
-        "chalk": "^1.1.3",
-        "concat-stream": "^1.4.6",
-        "debug": "^2.1.1",
-        "doctrine": "^1.2.2",
-        "escope": "^3.6.0",
-        "espree": "^3.4.0",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "glob": "^7.0.3",
-        "globals": "^9.14.0",
-        "ignore": "^3.2.0",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^0.12.0",
-        "is-my-json-valid": "^2.10.0",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.5.1",
-        "json-stable-stringify": "^1.0.0",
-        "levn": "^0.3.0",
-        "lodash": "^4.0.0",
-        "mkdirp": "^0.5.0",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.1",
-        "pluralize": "^1.2.1",
-        "progress": "^1.1.8",
-        "require-uncached": "^1.0.2",
-        "shelljs": "^0.7.5",
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "~2.0.1",
-        "table": "^3.7.8",
-        "text-table": "~0.2.0",
-        "user-home": "^2.0.0"
+        "babel-code-frame": "6.26.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.1",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
+        "escope": "3.6.0",
+        "espree": "3.5.4",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "glob": "7.0.5",
+        "globals": "9.18.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.17.2",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.7.0",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.5",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.7.8",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
       },
       "dependencies": {
         "lodash": {
@@ -8464,7 +8464,7 @@
           "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
           "dev": true,
           "requires": {
-            "os-homedir": "^1.0.0"
+            "os-homedir": "1.0.2"
           }
         }
       }
@@ -8475,7 +8475,7 @@
       "integrity": "sha1-pHAQhkbWxF4fY5oD8R1QShqkrtw=",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb-base": "^5.0.2"
+        "eslint-config-airbnb-base": "5.0.3"
       }
     },
     "eslint-config-airbnb-base": {
@@ -8490,9 +8490,9 @@
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
       "dev": true,
       "requires": {
-        "debug": "^2.2.0",
-        "object-assign": "^4.0.1",
-        "resolve": "^1.1.6"
+        "debug": "2.6.9",
+        "object-assign": "4.1.1",
+        "resolve": "1.6.0"
       },
       "dependencies": {
         "object-assign": {
@@ -8509,10 +8509,10 @@
       "integrity": "sha1-kUqPuTqWlQFA/5Aq0okJMOkBBGw=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.23.0",
+        "babel-runtime": "6.23.0",
         "browserslist": "1.7.5",
         "caniuse-db": "1.0.30000626",
-        "requireindex": "^1.1.0"
+        "requireindex": "1.2.0"
       },
       "dependencies": {
         "browserslist": {
@@ -8521,8 +8521,8 @@
           "integrity": "sha1-7KRxOJe1HkRCgyQfrPOYXeSanis=",
           "dev": true,
           "requires": {
-            "caniuse-db": "^1.0.30000624",
-            "electron-to-chromium": "^1.2.3"
+            "caniuse-db": "1.0.30000626",
+            "electron-to-chromium": "1.3.39"
           }
         },
         "caniuse-db": {
@@ -8539,7 +8539,7 @@
       "integrity": "sha1-9vizklEg7K83bGjWvGqdMN76aro=",
       "dev": true,
       "requires": {
-        "lodash.zipobject": "^4.1.3"
+        "lodash.zipobject": "4.1.3"
       }
     },
     "eslint-plugin-import": {
@@ -8548,20 +8548,20 @@
       "integrity": "sha1-DonthoOW0JEi4wft9ts3iBz93dc=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.1.1",
-        "contains-path": "^0.1.0",
-        "debug": "^2.2.0",
-        "doctrine": "1.2.x",
-        "es6-map": "^0.1.3",
-        "es6-set": "^0.1.4",
-        "eslint-import-resolver-node": "^0.2.0",
-        "lodash.cond": "^4.3.0",
-        "lodash.endswith": "^4.0.1",
-        "lodash.find": "^4.3.0",
-        "lodash.findindex": "^4.3.0",
-        "object-assign": "^4.0.1",
-        "pkg-dir": "^1.0.0",
-        "pkg-up": "^1.0.0"
+        "builtin-modules": "1.1.1",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
+        "doctrine": "1.2.3",
+        "es6-map": "0.1.5",
+        "es6-set": "0.1.5",
+        "eslint-import-resolver-node": "0.2.3",
+        "lodash.cond": "4.5.2",
+        "lodash.endswith": "4.2.1",
+        "lodash.find": "4.6.0",
+        "lodash.findindex": "4.6.0",
+        "object-assign": "4.1.1",
+        "pkg-dir": "1.0.0",
+        "pkg-up": "1.0.0"
       },
       "dependencies": {
         "doctrine": {
@@ -8570,8 +8570,8 @@
           "integrity": "sha1-auxrvWLPid1JjK5wwO2fSdqHOmo=",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
           }
         },
         "isarray": {
@@ -8594,9 +8594,9 @@
       "integrity": "sha1-dZUkuNcWHYSad6kXNaOXTdHPwys=",
       "dev": true,
       "requires": {
-        "damerau-levenshtein": "^1.0.0",
-        "jsx-ast-utils": "^1.0.0",
-        "object-assign": "^4.0.1"
+        "damerau-levenshtein": "1.0.4",
+        "jsx-ast-utils": "1.4.1",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "object-assign": {
@@ -8619,8 +8619,8 @@
       "integrity": "sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==",
       "dev": true,
       "requires": {
-        "fast-diff": "^1.1.1",
-        "jest-docblock": "^21.0.0"
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
       },
       "dependencies": {
         "jest-docblock": {
@@ -8637,9 +8637,9 @@
       "integrity": "sha1-VMLpkGt2+dEBQgML3DTp1oQKC7I=",
       "dev": true,
       "requires": {
-        "array.prototype.find": "^2.0.1",
-        "doctrine": "^1.2.2",
-        "jsx-ast-utils": "^1.3.4"
+        "array.prototype.find": "2.0.4",
+        "doctrine": "1.5.0",
+        "jsx-ast-utils": "1.4.1"
       }
     },
     "eslint-plugin-test-names": {
@@ -8648,7 +8648,7 @@
       "integrity": "sha1-6f24t7eN3jnfQ9EEipCqVy3/b9U=",
       "dev": true,
       "requires": {
-        "requireindex": "~1.1.0"
+        "requireindex": "1.1.0"
       },
       "dependencies": {
         "requireindex": {
@@ -8665,8 +8665,8 @@
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "^5.5.0",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "5.5.3",
+        "acorn-jsx": "3.0.1"
       }
     },
     "esprima": {
@@ -8681,7 +8681,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -8708,8 +8708,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.41"
       }
     },
     "event-stream": {
@@ -8718,13 +8718,13 @@
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
+        "map-stream": "0.1.0",
         "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
+        "split": "0.3.3",
+        "stream-combiner": "0.0.4",
+        "through": "2.3.8"
       }
     },
     "eventemitter3": {
@@ -8745,7 +8745,7 @@
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
       "dev": true,
       "requires": {
-        "original": ">=0.0.5"
+        "original": "1.0.0"
       }
     },
     "evp_bytestokey": {
@@ -8754,8 +8754,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.1"
       }
     },
     "exec-series": {
@@ -8764,8 +8764,8 @@
       "integrity": "sha1-bSV6m+rEgqhyx3g7yGFYOfx3FDo=",
       "dev": true,
       "requires": {
-        "async-each-series": "^1.1.0",
-        "object-assign": "^4.1.0"
+        "async-each-series": "1.1.0",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "object-assign": {
@@ -8782,7 +8782,7 @@
       "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
       "dev": true,
       "requires": {
-        "merge": "^1.1.3"
+        "merge": "1.2.0"
       }
     },
     "execa": {
@@ -8791,13 +8791,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "execall": {
@@ -8806,7 +8806,7 @@
       "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
       "dev": true,
       "requires": {
-        "clone-regexp": "^1.0.0"
+        "clone-regexp": "1.0.0"
       }
     },
     "executable": {
@@ -8815,7 +8815,7 @@
       "integrity": "sha1-h3mA6REvM5EGbaNyZd562ENKtNk=",
       "dev": true,
       "requires": {
-        "meow": "^3.1.0"
+        "meow": "3.7.0"
       }
     },
     "exit": {
@@ -8836,7 +8836,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -8845,7 +8845,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.3"
       }
     },
     "expand-tilde": {
@@ -8854,7 +8854,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "expect": {
@@ -8863,12 +8863,12 @@
       "integrity": "sha512-Fiy862jT3qc70hwIHwwCBNISmaqBrfWKKrtqyMJ6iwZr+6KXtcnHojZFtd63TPRvRl8EQTJ+YXYy2lK6/6u+Hw==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "jest-diff": "^22.4.0",
-        "jest-get-type": "^22.1.0",
-        "jest-matcher-utils": "^22.4.0",
-        "jest-message-util": "^22.4.0",
-        "jest-regex-util": "^22.1.0"
+        "ansi-styles": "3.2.1",
+        "jest-diff": "22.4.0",
+        "jest-get-type": "22.1.0",
+        "jest-matcher-utils": "22.4.0",
+        "jest-message-util": "22.4.0",
+        "jest-regex-util": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8877,7 +8877,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         }
       }
@@ -8888,36 +8888,36 @@
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.3",
+        "proxy-addr": "2.0.3",
         "qs": "6.5.1",
-        "range-parser": "~1.2.0",
+        "range-parser": "1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "accepts": {
@@ -8926,7 +8926,7 @@
           "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
           "dev": true,
           "requires": {
-            "mime-types": "~2.1.18",
+            "mime-types": "2.1.18",
             "negotiator": "0.6.1"
           }
         },
@@ -8937,15 +8937,15 @@
           "dev": true,
           "requires": {
             "bytes": "3.0.0",
-            "content-type": "~1.0.4",
+            "content-type": "1.0.4",
             "debug": "2.6.9",
-            "depd": "~1.1.1",
-            "http-errors": "~1.6.2",
+            "depd": "1.1.2",
+            "http-errors": "1.6.2",
             "iconv-lite": "0.4.19",
-            "on-finished": "~2.3.0",
+            "on-finished": "2.3.0",
             "qs": "6.5.1",
             "raw-body": "2.3.2",
-            "type-is": "~1.6.15"
+            "type-is": "1.6.16"
           }
         },
         "bytes": {
@@ -8979,12 +8979,12 @@
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "on-finished": "~2.3.0",
-            "parseurl": "~1.3.2",
-            "statuses": "~1.4.0",
-            "unpipe": "~1.0.0"
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.4.0",
+            "unpipe": "1.0.0"
           }
         },
         "fresh": {
@@ -9002,7 +9002,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": ">= 1.3.1 < 2"
+            "statuses": "1.4.0"
           },
           "dependencies": {
             "depd": {
@@ -9062,18 +9062,18 @@
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "depd": "~1.1.2",
-            "destroy": "~1.0.4",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "etag": "~1.8.1",
+            "depd": "1.1.2",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "~1.6.2",
+            "http-errors": "1.6.2",
             "mime": "1.4.1",
             "ms": "2.0.0",
-            "on-finished": "~2.3.0",
-            "range-parser": "~1.2.0",
-            "statuses": "~1.4.0"
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.4.0"
           }
         },
         "serve-static": {
@@ -9082,9 +9082,9 @@
           "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
           "dev": true,
           "requires": {
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "parseurl": "~1.3.2",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "parseurl": "1.3.2",
             "send": "0.16.2"
           }
         },
@@ -9111,11 +9111,11 @@
         "cookie": "0.1.3",
         "cookie-signature": "1.0.6",
         "crc": "3.3.0",
-        "debug": "~2.2.0",
-        "depd": "~1.0.1",
-        "on-headers": "~1.0.0",
-        "parseurl": "~1.3.0",
-        "uid-safe": "~2.0.0",
+        "debug": "2.2.0",
+        "depd": "1.0.1",
+        "on-headers": "1.0.1",
+        "parseurl": "1.3.2",
+        "uid-safe": "2.0.0",
         "utils-merge": "1.0.0"
       },
       "dependencies": {
@@ -9157,7 +9157,7 @@
       "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
       "dev": true,
       "requires": {
-        "mime-db": "^1.28.0"
+        "mime-db": "1.33.0"
       }
     },
     "ext-name": {
@@ -9166,8 +9166,8 @@
       "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
       "dev": true,
       "requires": {
-        "ext-list": "^2.0.0",
-        "sort-keys-length": "^1.0.0"
+        "ext-list": "2.2.2",
+        "sort-keys-length": "1.0.1"
       }
     },
     "extend": {
@@ -9181,8 +9181,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -9191,7 +9191,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -9202,7 +9202,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "extract-text-webpack-plugin": {
@@ -9211,10 +9211,10 @@
       "integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
       "dev": true,
       "requires": {
-        "async": "^2.4.1",
-        "loader-utils": "^1.1.0",
-        "schema-utils": "^0.3.0",
-        "webpack-sources": "^1.0.1"
+        "async": "2.6.0",
+        "loader-utils": "1.1.0",
+        "schema-utils": "0.3.0",
+        "webpack-sources": "1.1.0"
       },
       "dependencies": {
         "async": {
@@ -9223,7 +9223,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "4.17.5"
           }
         },
         "loader-utils": {
@@ -9232,9 +9232,9 @@
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         },
         "lodash": {
@@ -9261,8 +9261,8 @@
           "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
           "dev": true,
           "requires": {
-            "source-list-map": "^2.0.0",
-            "source-map": "~0.6.1"
+            "source-list-map": "2.0.0",
+            "source-map": "0.6.1"
           }
         }
       }
@@ -9285,9 +9285,9 @@
           "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.5",
+            "typedarray": "0.0.6"
           }
         },
         "isarray": {
@@ -9317,13 +9317,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -9332,7 +9332,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "yauzl": {
@@ -9341,7 +9341,7 @@
           "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
           "dev": true,
           "requires": {
-            "fd-slicer": "~1.0.1"
+            "fd-slicer": "1.0.1"
           }
         }
       }
@@ -9363,10 +9363,10 @@
       "integrity": "sha1-wY0k71CRF0pJfzGM0ksCaiXN2rQ=",
       "dev": true,
       "requires": {
-        "acorn": "^1.0.3",
-        "foreach": "^2.0.5",
+        "acorn": "1.2.2",
+        "foreach": "2.0.5",
         "isarray": "0.0.1",
-        "object-keys": "^1.0.6"
+        "object-keys": "1.0.11"
       },
       "dependencies": {
         "acorn": {
@@ -9382,9 +9382,9 @@
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
       "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "requires": {
-        "ansi-gray": "^0.1.1",
-        "color-support": "^1.1.3",
-        "time-stamp": "^1.0.0"
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
+        "time-stamp": "1.1.0"
       }
     },
     "fast-deep-equal": {
@@ -9428,7 +9428,7 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
-        "websocket-driver": ">=0.5.1"
+        "websocket-driver": "0.7.0"
       }
     },
     "fb-watchman": {
@@ -9437,7 +9437,7 @@
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "dev": true,
       "requires": {
-        "bser": "^2.0.0"
+        "bser": "2.0.0"
       }
     },
     "fbemitter": {
@@ -9445,7 +9445,7 @@
       "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz",
       "integrity": "sha1-Uj4U/a9SSIBbsC9i78M75wP1GGU=",
       "requires": {
-        "fbjs": "^0.8.4"
+        "fbjs": "0.8.16"
       },
       "dependencies": {
         "asap": {
@@ -9463,13 +9463,13 @@
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
           "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
           "requires": {
-            "core-js": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.9"
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.17"
           }
         },
         "object-assign": {
@@ -9482,7 +9482,7 @@
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
           "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
           "requires": {
-            "asap": "~2.0.3"
+            "asap": "2.0.6"
           }
         }
       }
@@ -9492,9 +9492,9 @@
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.1.0-alpha.7.tgz",
       "integrity": "sha1-rUMIuPIy+zxzYDNJ6nJdHpw5Mjw=",
       "requires": {
-        "core-js": "^1.0.0",
-        "promise": "^7.0.3",
-        "whatwg-fetch": "^0.9.0"
+        "core-js": "1.2.7",
+        "promise": "7.3.1",
+        "whatwg-fetch": "0.9.0"
       },
       "dependencies": {
         "asap": {
@@ -9512,7 +9512,7 @@
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
           "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
           "requires": {
-            "asap": "~2.0.3"
+            "asap": "2.0.6"
           }
         },
         "whatwg-fetch": {
@@ -9528,7 +9528,7 @@
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
-        "pend": "~1.2.0"
+        "pend": "1.2.0"
       }
     },
     "figures": {
@@ -9537,8 +9537,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "object-assign": {
@@ -9555,8 +9555,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "object-assign": {
@@ -9573,8 +9573,8 @@
       "integrity": "sha512-873ztuL+/hfvXbLDJ262PGO6XjERnybJu2gW1/5j8HUfxSiFJI9Hj/DhZ50ZGRUxBvuNiazb/cM2rh9pqrxP6Q==",
       "dev": true,
       "requires": {
-        "loader-utils": "^1.0.2",
-        "schema-utils": "^0.3.0"
+        "loader-utils": "1.1.0",
+        "schema-utils": "0.3.0"
       },
       "dependencies": {
         "loader-utils": {
@@ -9583,9 +9583,9 @@
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         }
       }
@@ -9614,9 +9614,9 @@
       "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
       "dev": true,
       "requires": {
-        "filename-reserved-regex": "^1.0.0",
-        "strip-outer": "^1.0.0",
-        "trim-repeated": "^1.0.0"
+        "filename-reserved-regex": "1.0.0",
+        "strip-outer": "1.0.0",
+        "trim-repeated": "1.0.0"
       }
     },
     "fileset": {
@@ -9625,8 +9625,8 @@
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.3",
-        "minimatch": "^3.0.3"
+        "glob": "7.0.5",
+        "minimatch": "3.0.4"
       },
       "dependencies": {
         "minimatch": {
@@ -9635,7 +9635,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -9646,11 +9646,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^1.1.3",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
       }
     },
     "finalhandler": {
@@ -9659,10 +9659,10 @@
       "integrity": "sha1-llpS2ejQXSuFdUhUH7ibU6JJfZs=",
       "dev": true,
       "requires": {
-        "debug": "~2.2.0",
+        "debug": "2.2.0",
         "escape-html": "1.0.2",
-        "on-finished": "~2.3.0",
-        "unpipe": "~1.0.0"
+        "on-finished": "2.3.0",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -9705,8 +9705,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "find-versions": {
@@ -9715,10 +9715,10 @@
       "integrity": "sha1-y96fEuOFdaCvG+G5osXV/Y8Ya2I=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "meow": "^3.5.0",
-        "semver-regex": "^1.0.0"
+        "array-uniq": "1.0.3",
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0",
+        "semver-regex": "1.0.0"
       },
       "dependencies": {
         "get-stdin": {
@@ -9735,10 +9735,10 @@
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^3.1.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
+        "detect-file": "1.0.0",
+        "is-glob": "3.1.0",
+        "micromatch": "3.1.9",
+        "resolve-dir": "1.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -9759,18 +9759,18 @@
           "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "kind-of": "^6.0.2",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "kind-of": "6.0.2",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -9779,7 +9779,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -9788,7 +9788,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -9799,13 +9799,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -9814,7 +9814,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -9823,7 +9823,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-descriptor": {
@@ -9832,9 +9832,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -9851,14 +9851,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -9867,7 +9867,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -9876,7 +9876,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -9887,10 +9887,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -9899,7 +9899,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -9910,7 +9910,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -9919,7 +9919,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -9930,7 +9930,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -9939,7 +9939,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -9956,7 +9956,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -9965,7 +9965,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -9974,7 +9974,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -9997,19 +9997,19 @@
           "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.1",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -10020,11 +10020,11 @@
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "is-plain-object": "^2.0.3",
-        "object.defaults": "^1.1.0",
-        "object.pick": "^1.2.0",
-        "parse-filepath": "^1.0.1"
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.3.0",
+        "parse-filepath": "1.0.2"
       }
     },
     "first-chunk-stream": {
@@ -10044,10 +10044,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
       }
     },
     "flatten": {
@@ -10062,8 +10062,8 @@
       "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.4"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.5"
       },
       "dependencies": {
         "isarray": {
@@ -10078,13 +10078,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -10093,7 +10093,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -10103,9 +10103,9 @@
       "resolved": "https://registry.npmjs.org/flux/-/flux-2.1.1.tgz",
       "integrity": "sha1-LGrGUtQzdIiWhInGWG86/yajjqQ=",
       "requires": {
-        "fbemitter": "^2.0.0",
+        "fbemitter": "2.1.1",
         "fbjs": "0.1.0-alpha.7",
-        "immutable": "^3.7.4"
+        "immutable": "3.8.2"
       }
     },
     "for-in": {
@@ -10120,7 +10120,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "foreach": {
@@ -10139,9 +10139,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.5",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
       }
     },
     "forwarded": {
@@ -10156,7 +10156,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "franc": {
@@ -10165,7 +10165,7 @@
       "integrity": "sha1-2ZOe3tS0hqz0ufM1kf6OaeVGRhY=",
       "dev": true,
       "requires": {
-        "trigram-utils": "^0.1.0"
+        "trigram-utils": "0.1.1"
       }
     },
     "fresh": {
@@ -10186,8 +10186,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.5"
       },
       "dependencies": {
         "isarray": {
@@ -10202,13 +10202,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -10217,7 +10217,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -10228,7 +10228,7 @@
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
-        "null-check": "^1.0.0"
+        "null-check": "1.0.0"
       }
     },
     "fs-extra": {
@@ -10237,9 +10237,9 @@
       "integrity": "sha1-f8DGyJV/mD9X8waiTlud3Y0N2IA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^3.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "3.0.1",
+        "universalify": "0.1.1"
       }
     },
     "fs-readdir-recursive": {
@@ -10254,10 +10254,10 @@
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "iferr": "^0.1.5",
-        "imurmurhash": "^0.1.4",
-        "readable-stream": "1 || 2"
+        "graceful-fs": "4.1.11",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "readable-stream": "1.1.14"
       }
     },
     "fs.realpath": {
@@ -10265,535 +10265,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.21",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": "^2.1.0"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "minipass": {
-          "version": "2.2.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.10.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.1.10",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -10807,9 +10278,9 @@
       "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "is-callable": "^1.1.3"
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.1",
+        "is-callable": "1.1.3"
       }
     },
     "gather-stream": {
@@ -10823,7 +10294,7 @@
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
       "requires": {
-        "globule": "~0.1.0"
+        "globule": "0.1.0"
       }
     },
     "gemini-scrollbar": {
@@ -10843,7 +10314,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "^1.0.0"
+        "is-property": "1.0.2"
       }
     },
     "get-caller-file": {
@@ -10858,11 +10329,11 @@
       "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "meow": "^3.3.0",
-        "normalize-package-data": "^2.3.0",
-        "parse-github-repo-url": "^1.3.0",
-        "through2": "^2.0.0"
+        "hosted-git-info": "2.6.0",
+        "meow": "3.7.0",
+        "normalize-package-data": "2.4.0",
+        "parse-github-repo-url": "1.4.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "isarray": {
@@ -10877,13 +10348,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -10892,7 +10363,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "through2": {
@@ -10901,8 +10372,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -10913,7 +10384,7 @@
       "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
       "dev": true,
       "requires": {
-        "rc": "^1.1.2"
+        "rc": "1.2.6"
       }
     },
     "get-stdin": {
@@ -10949,7 +10420,7 @@
           "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
           "dev": true,
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "4.17.5"
           }
         },
         "lodash": {
@@ -10965,7 +10436,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -10981,9 +10452,9 @@
       "integrity": "sha1-9Fy17RAWW2ZdySng6TKLbIId+js=",
       "dev": true,
       "requires": {
-        "bin-build": "^2.0.0",
-        "bin-wrapper": "^3.0.0",
-        "logalot": "^2.0.0"
+        "bin-build": "2.2.0",
+        "bin-wrapper": "3.0.2",
+        "logalot": "2.1.0"
       }
     },
     "git-raw-commits": {
@@ -10992,11 +10463,11 @@
       "integrity": "sha1-oS2Ekq66KIGALXAIJe2ByfOeby8=",
       "dev": true,
       "requires": {
-        "dargs": "^4.0.1",
-        "lodash.template": "^4.0.2",
-        "meow": "^3.3.0",
-        "split2": "^2.0.0",
-        "through2": "^2.0.0"
+        "dargs": "4.1.0",
+        "lodash.template": "4.4.0",
+        "meow": "3.7.0",
+        "split2": "2.2.0",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "isarray": {
@@ -11011,8 +10482,8 @@
           "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~3.0.0",
-            "lodash.templatesettings": "^4.0.0"
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.templatesettings": "4.1.0"
           }
         },
         "lodash.templatesettings": {
@@ -11021,7 +10492,7 @@
           "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~3.0.0"
+            "lodash._reinterpolate": "3.0.0"
           }
         },
         "readable-stream": {
@@ -11030,13 +10501,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -11045,7 +10516,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "through2": {
@@ -11054,8 +10525,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -11066,8 +10537,8 @@
       "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
       "dev": true,
       "requires": {
-        "gitconfiglocal": "^1.0.0",
-        "pify": "^2.3.0"
+        "gitconfiglocal": "1.0.0",
+        "pify": "2.3.0"
       }
     },
     "git-semver-tags": {
@@ -11076,8 +10547,8 @@
       "integrity": "sha512-2jHlJnln4D/ECk9FxGEBh3k44wgYdWjWDtMmJPaecjoRmxKo3Y1Lh8GMYuOPu04CHw86NTAODchYjC5pnpMQig==",
       "dev": true,
       "requires": {
-        "meow": "^4.0.0",
-        "semver": "^5.5.0"
+        "meow": "4.0.0",
+        "semver": "5.5.0"
       },
       "dependencies": {
         "camelcase": {
@@ -11092,9 +10563,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "find-up": {
@@ -11103,7 +10574,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "indent-string": {
@@ -11118,10 +10589,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           }
         },
         "map-obj": {
@@ -11136,15 +10607,15 @@
           "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist": "^1.1.3",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
           }
         },
         "parse-json": {
@@ -11153,8 +10624,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
           }
         },
         "path-type": {
@@ -11163,7 +10634,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -11178,9 +10649,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -11189,8 +10660,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "redent": {
@@ -11199,8 +10670,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "strip-bom": {
@@ -11229,8 +10700,8 @@
       "integrity": "sha1-04ecbKYSDIyxgMUoQglMDMnq2so=",
       "dev": true,
       "requires": {
-        "es6-promise": "^3.0.2",
-        "jq-trim": "^0.1.1"
+        "es6-promise": "3.3.1",
+        "jq-trim": "0.1.2"
       }
     },
     "gitconfiglocal": {
@@ -11239,7 +10710,7 @@
       "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
       "dev": true,
       "requires": {
-        "ini": "^1.3.2"
+        "ini": "1.3.5"
       }
     },
     "github-url-from-git": {
@@ -11254,12 +10725,12 @@
       "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.2",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       },
       "dependencies": {
         "minimatch": {
@@ -11268,7 +10739,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -11279,8 +10750,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -11289,7 +10760,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "glob-stream": {
@@ -11298,12 +10769,12 @@
       "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
       "dev": true,
       "requires": {
-        "glob": "^4.3.1",
-        "glob2base": "^0.0.12",
-        "minimatch": "^2.0.1",
-        "ordered-read-streams": "^0.1.0",
-        "through2": "^0.6.1",
-        "unique-stream": "^1.0.0"
+        "glob": "4.5.3",
+        "glob2base": "0.0.12",
+        "minimatch": "2.0.10",
+        "ordered-read-streams": "0.1.0",
+        "through2": "0.6.5",
+        "unique-stream": "1.0.0"
       },
       "dependencies": {
         "glob": {
@@ -11312,10 +10783,10 @@
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^2.0.1",
-            "once": "^1.3.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
           }
         },
         "minimatch": {
@@ -11324,7 +10795,7 @@
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.0.0"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -11335,7 +10806,7 @@
       "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
       "dev": true,
       "requires": {
-        "gaze": "^0.5.1"
+        "gaze": "0.5.2"
       }
     },
     "glob2base": {
@@ -11343,7 +10814,7 @@
       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
       "requires": {
-        "find-index": "^0.1.1"
+        "find-index": "0.1.1"
       }
     },
     "global": {
@@ -11352,8 +10823,8 @@
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "dev": true,
       "requires": {
-        "min-document": "^2.19.0",
-        "process": "~0.5.1"
+        "min-document": "2.19.0",
+        "process": "0.5.2"
       }
     },
     "global-dirs": {
@@ -11362,7 +10833,7 @@
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "^1.3.4"
+        "ini": "1.3.5"
       }
     },
     "global-modules": {
@@ -11371,9 +10842,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -11382,11 +10853,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.0"
       }
     },
     "globals": {
@@ -11401,12 +10872,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.0.5",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "object-assign": {
@@ -11428,9 +10899,9 @@
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "requires": {
-        "glob": "~3.1.21",
-        "lodash": "~1.0.1",
-        "minimatch": "~0.2.11"
+        "glob": "3.1.21",
+        "lodash": "1.0.2",
+        "minimatch": "0.2.14"
       },
       "dependencies": {
         "glob": {
@@ -11438,9 +10909,9 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "requires": {
-            "graceful-fs": "~1.2.0",
-            "inherits": "1",
-            "minimatch": "~0.2.11"
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
           }
         },
         "graceful-fs": {
@@ -11460,7 +10931,7 @@
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
       "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.0"
       }
     },
     "good-listener": {
@@ -11468,7 +10939,7 @@
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "requires": {
-        "delegate": "^3.1.2"
+        "delegate": "3.2.0"
       }
     },
     "got": {
@@ -11477,21 +10948,21 @@
       "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
       "dev": true,
       "requires": {
-        "create-error-class": "^3.0.1",
-        "duplexer2": "^0.1.4",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "node-status-codes": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "parse-json": "^2.1.0",
-        "pinkie-promise": "^2.0.0",
-        "read-all-stream": "^3.0.0",
-        "readable-stream": "^2.0.5",
-        "timed-out": "^3.0.0",
-        "unzip-response": "^1.0.2",
-        "url-parse-lax": "^1.0.0"
+        "create-error-class": "3.0.2",
+        "duplexer2": "0.1.4",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.0",
+        "node-status-codes": "1.0.0",
+        "object-assign": "4.1.1",
+        "parse-json": "2.2.0",
+        "pinkie-promise": "2.0.1",
+        "read-all-stream": "3.1.0",
+        "readable-stream": "2.3.5",
+        "timed-out": "3.1.3",
+        "unzip-response": "1.0.2",
+        "url-parse-lax": "1.0.0"
       },
       "dependencies": {
         "duplexer2": {
@@ -11500,7 +10971,7 @@
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.0.2"
+            "readable-stream": "2.3.5"
           }
         },
         "isarray": {
@@ -11521,13 +10992,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -11536,7 +11007,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -11544,7 +11015,8 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -11557,7 +11029,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
       "integrity": "sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==",
       "requires": {
-        "iterall": "^1.2.1"
+        "iterall": "1.2.2"
       }
     },
     "graphql-tag": {
@@ -11570,11 +11042,11 @@
       "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-2.23.1.tgz",
       "integrity": "sha512-f85OdRuPcHvMhNqiotvgtzpx7RlY2pZW9UnmBu6AcooKVipWVyy0um9q17f78BBI+1UzwAMsfU9S6R38UGMjTQ==",
       "requires": {
-        "apollo-link": "^1.2.1",
-        "apollo-utilities": "^1.0.1",
-        "deprecated-decorator": "^0.1.6",
-        "iterall": "^1.1.3",
-        "uuid": "^3.1.0"
+        "apollo-link": "1.2.2",
+        "apollo-utilities": "1.0.12",
+        "deprecated-decorator": "0.1.6",
+        "iterall": "1.2.2",
+        "uuid": "3.2.1"
       }
     },
     "growly": {
@@ -11589,19 +11061,19 @@
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "chalk": "^1.0.0",
-        "deprecated": "^0.0.1",
-        "gulp-util": "^3.0.0",
-        "interpret": "^1.0.0",
-        "liftoff": "^2.1.0",
-        "minimist": "^1.1.0",
-        "orchestrator": "^0.3.0",
-        "pretty-hrtime": "^1.0.0",
-        "semver": "^4.1.0",
-        "tildify": "^1.0.0",
-        "v8flags": "^2.0.2",
-        "vinyl-fs": "^0.3.0"
+        "archy": "1.0.0",
+        "chalk": "1.1.3",
+        "deprecated": "0.0.1",
+        "gulp-util": "3.0.8",
+        "interpret": "1.1.0",
+        "liftoff": "2.5.0",
+        "minimist": "1.2.0",
+        "orchestrator": "0.3.8",
+        "pretty-hrtime": "1.0.3",
+        "semver": "4.3.6",
+        "tildify": "1.2.0",
+        "v8flags": "2.1.1",
+        "vinyl-fs": "0.3.14"
       },
       "dependencies": {
         "semver": {
@@ -11617,8 +11089,8 @@
       "resolved": "https://registry.npmjs.org/gulp-batch/-/gulp-batch-1.0.1.tgz",
       "integrity": "sha1-2aahq7UEs6QUctnqJy1JGeEbD4Y=",
       "requires": {
-        "async-done": "^0.4.0",
-        "stream-array": "^0.1.3"
+        "async-done": "0.4.0",
+        "stream-array": "0.1.3"
       }
     },
     "gulp-connect": {
@@ -11627,12 +11099,12 @@
       "integrity": "sha1-FiXm5u5qHoRQ9ZZkiCAnnd/+2Gs=",
       "dev": true,
       "requires": {
-        "connect": "^2.30.0",
-        "connect-livereload": "^0.5.4",
-        "event-stream": "^3.3.2",
-        "gulp-util": "^3.0.6",
-        "http2": "^3.3.2",
-        "tiny-lr": "^0.2.1"
+        "connect": "2.30.2",
+        "connect-livereload": "0.5.4",
+        "event-stream": "3.3.4",
+        "gulp-util": "3.0.8",
+        "http2": "3.3.7",
+        "tiny-lr": "0.2.1"
       }
     },
     "gulp-decompress": {
@@ -11641,10 +11113,10 @@
       "integrity": "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=",
       "dev": true,
       "requires": {
-        "archive-type": "^3.0.0",
-        "decompress": "^3.0.0",
-        "gulp-util": "^3.0.1",
-        "readable-stream": "^2.0.2"
+        "archive-type": "3.2.0",
+        "decompress": "3.0.0",
+        "gulp-util": "3.0.8",
+        "readable-stream": "2.3.5"
       },
       "dependencies": {
         "isarray": {
@@ -11659,13 +11131,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -11674,7 +11146,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -11691,11 +11163,11 @@
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "dev": true,
       "requires": {
-        "convert-source-map": "^1.1.1",
-        "graceful-fs": "^4.1.2",
-        "strip-bom": "^2.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^1.0.0"
+        "convert-source-map": "1.5.1",
+        "graceful-fs": "4.1.11",
+        "strip-bom": "2.0.0",
+        "through2": "2.0.3",
+        "vinyl": "1.1.1"
       },
       "dependencies": {
         "isarray": {
@@ -11710,13 +11182,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -11725,7 +11197,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-bom": {
@@ -11734,7 +11206,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "through2": {
@@ -11743,8 +11215,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -11754,24 +11226,24 @@
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-uniq": "^1.0.2",
-        "beeper": "^1.0.0",
-        "chalk": "^1.0.0",
-        "dateformat": "^2.0.0",
-        "fancy-log": "^1.1.0",
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "lodash._reescape": "^3.0.0",
-        "lodash._reevaluate": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.template": "^3.0.0",
-        "minimist": "^1.1.0",
-        "multipipe": "^0.1.2",
-        "object-assign": "^3.0.0",
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.2",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
         "replace-ext": "0.0.1",
-        "through2": "^2.0.0",
-        "vinyl": "^0.5.0"
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
       },
       "dependencies": {
         "isarray": {
@@ -11784,13 +11256,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -11798,7 +11270,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "through2": {
@@ -11806,8 +11278,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         },
         "vinyl": {
@@ -11815,8 +11287,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.3",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -11827,14 +11299,14 @@
       "resolved": "https://registry.npmjs.org/gulp-watch/-/gulp-watch-1.2.1.tgz",
       "integrity": "sha1-QwNedgRs2P7TAzZcsJ4ECi4qoJs=",
       "requires": {
-        "gaze": "0.5.x",
-        "glob2base": "~0.0.11",
+        "gaze": "0.5.2",
+        "glob2base": "0.0.12",
         "gulp-batch": "1.0.1",
-        "gulp-util": "~3.0.0",
+        "gulp-util": "3.0.8",
         "path2glob": "0.0.2",
-        "readable-stream": "^1.0.31",
-        "vinyl": "^0.4.3",
-        "vinyl-file": "~1.1.0"
+        "readable-stream": "1.1.14",
+        "vinyl": "0.4.6",
+        "vinyl-file": "1.1.1"
       },
       "dependencies": {
         "clone": {
@@ -11847,8 +11319,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -11858,11 +11330,11 @@
       "resolved": "https://registry.npmjs.org/gulp-watch-less/-/gulp-watch-less-1.0.1.tgz",
       "integrity": "sha1-E5rjejiipZZCHuyXsr0L1Q4sscQ=",
       "requires": {
-        "gulp-util": "^3.0.0",
-        "gulp-watch": "^1.1.0",
-        "less": "~2.3.1",
-        "lodash.defaults": "^2.4.1",
-        "through2": "^0.6.1"
+        "gulp-util": "3.0.8",
+        "gulp-watch": "1.2.1",
+        "less": "2.3.1",
+        "lodash.defaults": "2.4.1",
+        "through2": "0.6.5"
       },
       "dependencies": {
         "asap": {
@@ -11877,7 +11349,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "optional": true,
           "requires": {
-            "natives": "^1.1.0"
+            "natives": "1.1.2"
           }
         },
         "image-size": {
@@ -11891,14 +11363,14 @@
           "resolved": "https://registry.npmjs.org/less/-/less-2.3.1.tgz",
           "integrity": "sha1-wQ7AgrLylQ9uHHUOTaFLzFQ+2EU=",
           "requires": {
-            "errno": "^0.1.1",
-            "graceful-fs": "^3.0.5",
-            "image-size": "~0.3.5",
-            "mime": "^1.2.11",
-            "mkdirp": "^0.5.0",
-            "promise": "^6.0.1",
-            "request": "^2.51.0",
-            "source-map": "^0.2.0"
+            "errno": "0.1.7",
+            "graceful-fs": "3.0.11",
+            "image-size": "0.3.5",
+            "mime": "1.3.4",
+            "mkdirp": "0.5.1",
+            "promise": "6.1.0",
+            "request": "2.81.0",
+            "source-map": "0.2.0"
           }
         },
         "promise": {
@@ -11907,7 +11379,7 @@
           "integrity": "sha1-LOcp9rlLRcJoka0GAsXJDgTG7vY=",
           "optional": true,
           "requires": {
-            "asap": "~1.0.0"
+            "asap": "1.0.0"
           }
         },
         "source-map": {
@@ -11916,7 +11388,7 @@
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "optional": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -11926,7 +11398,7 @@
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "requires": {
-        "glogg": "^1.0.0"
+        "glogg": "1.0.1"
       }
     },
     "handle-thing": {
@@ -11941,10 +11413,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "^1.4.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.6.4"
       },
       "dependencies": {
         "async": {
@@ -11959,7 +11431,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -11974,8 +11446,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
       "requires": {
-        "ajv": "^4.9.1",
-        "har-schema": "^1.0.5"
+        "ajv": "4.11.8",
+        "har-schema": "1.0.5"
       }
     },
     "has": {
@@ -11984,7 +11456,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -11992,7 +11464,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-flag": {
@@ -12006,7 +11478,7 @@
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.0"
       }
     },
     "has-symbol-support-x": {
@@ -12027,7 +11499,7 @@
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "^1.4.1"
+        "has-symbol-support-x": "1.4.2"
       }
     },
     "has-value": {
@@ -12036,9 +11508,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -12055,8 +11527,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -12065,7 +11537,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -12074,7 +11546,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -12085,7 +11557,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -12096,8 +11568,8 @@
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "hash.js": {
@@ -12106,8 +11578,8 @@
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
       }
     },
     "hasha": {
@@ -12116,8 +11588,8 @@
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "dev": true,
       "requires": {
-        "is-stream": "^1.0.1",
-        "pinkie-promise": "^2.0.0"
+        "is-stream": "1.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "hawk": {
@@ -12125,10 +11597,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "requires": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x",
-        "sntp": "1.x.x"
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
       }
     },
     "he": {
@@ -12142,10 +11614,10 @@
       "resolved": "https://registry.npmjs.org/history/-/history-2.1.2.tgz",
       "integrity": "sha1-SqLeiXoOSGfkU5hDvm7Nsphr/ew=",
       "requires": {
-        "deep-equal": "^1.0.0",
-        "invariant": "^2.0.0",
-        "query-string": "^3.0.0",
-        "warning": "^2.0.0"
+        "deep-equal": "1.0.1",
+        "invariant": "2.2.4",
+        "query-string": "3.0.3",
+        "warning": "2.1.0"
       },
       "dependencies": {
         "query-string": {
@@ -12153,7 +11625,7 @@
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.3.tgz",
           "integrity": "sha1-ri4UtNBQcdTpuetIc8NbDc1C5jg=",
           "requires": {
-            "strict-uri-encode": "^1.0.0"
+            "strict-uri-encode": "1.1.0"
           }
         },
         "warning": {
@@ -12161,7 +11633,7 @@
           "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
           "integrity": "sha1-ISINnGOvx3qMkhEeARr3Bc4MaQE=",
           "requires": {
-            "loose-envify": "^1.0.0"
+            "loose-envify": "1.3.1"
           }
         }
       }
@@ -12172,9 +11644,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "hoek": {
@@ -12193,8 +11665,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "homedir-polyfill": {
@@ -12203,7 +11675,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -12218,10 +11690,10 @@
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "obuf": "^1.0.0",
-        "readable-stream": "^2.0.1",
-        "wbuf": "^1.1.0"
+        "inherits": "2.0.3",
+        "obuf": "1.1.2",
+        "readable-stream": "2.3.5",
+        "wbuf": "1.7.3"
       },
       "dependencies": {
         "isarray": {
@@ -12236,13 +11708,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -12251,7 +11723,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -12268,7 +11740,7 @@
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "^1.0.1"
+        "whatwg-encoding": "1.0.3"
       }
     },
     "html-entities": {
@@ -12283,11 +11755,11 @@
       "integrity": "sha512-7hIW7YinOYUpo//kSYcPB6dCKoceKLmOwjEMmhIobHuWGDVl0Nwe4l68mdG/Ru0wcUxQjVMEoZpkalZ/SE7zog==",
       "dev": true,
       "requires": {
-        "es6-templates": "^0.2.3",
-        "fastparse": "^1.1.1",
-        "html-minifier": "^3.5.8",
-        "loader-utils": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "es6-templates": "0.2.3",
+        "fastparse": "1.1.1",
+        "html-minifier": "3.5.12",
+        "loader-utils": "1.1.0",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "camel-case": {
@@ -12296,8 +11768,8 @@
           "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
           "dev": true,
           "requires": {
-            "no-case": "^2.2.0",
-            "upper-case": "^1.1.1"
+            "no-case": "2.3.2",
+            "upper-case": "1.1.3"
           }
         },
         "clean-css": {
@@ -12306,7 +11778,7 @@
           "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
           "dev": true,
           "requires": {
-            "source-map": "0.5.x"
+            "source-map": "0.5.7"
           }
         },
         "he": {
@@ -12321,14 +11793,14 @@
           "integrity": "sha512-+N778qLf0RWBscD0TPGoYdeGNDZ0s76/0pQhY1/409EOudcENkm9IbSkk37RDyPdg/09GVHTKotU4ya93RF1Gg==",
           "dev": true,
           "requires": {
-            "camel-case": "3.0.x",
-            "clean-css": "4.1.x",
-            "commander": "2.15.x",
-            "he": "1.1.x",
-            "ncname": "1.0.x",
-            "param-case": "2.1.x",
-            "relateurl": "0.2.x",
-            "uglify-js": "3.3.x"
+            "camel-case": "3.0.0",
+            "clean-css": "4.1.11",
+            "commander": "2.15.1",
+            "he": "1.1.1",
+            "ncname": "1.0.0",
+            "param-case": "2.1.1",
+            "relateurl": "0.2.7",
+            "uglify-js": "3.3.16"
           }
         },
         "loader-utils": {
@@ -12337,9 +11809,9 @@
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         },
         "object-assign": {
@@ -12354,7 +11826,7 @@
           "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
           "dev": true,
           "requires": {
-            "no-case": "^2.2.0"
+            "no-case": "2.3.2"
           }
         },
         "uglify-js": {
@@ -12363,8 +11835,8 @@
           "integrity": "sha512-FMh5SRqJRGhv9BbaTffENIpDDQIoPDR8DBraunGORGhySArsXlw9++CN+BWzPBLpoI4RcSnpfGPnilTxWL3Vvg==",
           "dev": true,
           "requires": {
-            "commander": "~2.15.0",
-            "source-map": "~0.6.1"
+            "commander": "2.15.1",
+            "source-map": "0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -12389,12 +11861,12 @@
       "integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
       "dev": true,
       "requires": {
-        "bluebird": "^3.4.7",
-        "html-minifier": "^3.2.3",
-        "loader-utils": "^0.2.16",
-        "lodash": "^4.17.3",
-        "pretty-error": "^2.0.2",
-        "toposort": "^1.0.0"
+        "bluebird": "3.5.1",
+        "html-minifier": "3.5.12",
+        "loader-utils": "0.2.17",
+        "lodash": "4.17.5",
+        "pretty-error": "2.1.1",
+        "toposort": "1.0.6"
       },
       "dependencies": {
         "camel-case": {
@@ -12403,8 +11875,8 @@
           "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
           "dev": true,
           "requires": {
-            "no-case": "^2.2.0",
-            "upper-case": "^1.1.1"
+            "no-case": "2.3.2",
+            "upper-case": "1.1.3"
           }
         },
         "clean-css": {
@@ -12413,7 +11885,7 @@
           "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
           "dev": true,
           "requires": {
-            "source-map": "0.5.x"
+            "source-map": "0.5.7"
           }
         },
         "he": {
@@ -12428,14 +11900,14 @@
           "integrity": "sha512-+N778qLf0RWBscD0TPGoYdeGNDZ0s76/0pQhY1/409EOudcENkm9IbSkk37RDyPdg/09GVHTKotU4ya93RF1Gg==",
           "dev": true,
           "requires": {
-            "camel-case": "3.0.x",
-            "clean-css": "4.1.x",
-            "commander": "2.15.x",
-            "he": "1.1.x",
-            "ncname": "1.0.x",
-            "param-case": "2.1.x",
-            "relateurl": "0.2.x",
-            "uglify-js": "3.3.x"
+            "camel-case": "3.0.0",
+            "clean-css": "4.1.11",
+            "commander": "2.15.1",
+            "he": "1.1.1",
+            "ncname": "1.0.0",
+            "param-case": "2.1.1",
+            "relateurl": "0.2.7",
+            "uglify-js": "3.3.16"
           }
         },
         "lodash": {
@@ -12450,7 +11922,7 @@
           "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
           "dev": true,
           "requires": {
-            "no-case": "^2.2.0"
+            "no-case": "2.3.2"
           }
         },
         "toposort": {
@@ -12465,8 +11937,8 @@
           "integrity": "sha512-FMh5SRqJRGhv9BbaTffENIpDDQIoPDR8DBraunGORGhySArsXlw9++CN+BWzPBLpoI4RcSnpfGPnilTxWL3Vvg==",
           "dev": true,
           "requires": {
-            "commander": "~2.15.0",
-            "source-map": "~0.6.1"
+            "commander": "2.15.1",
+            "source-map": "0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -12485,10 +11957,10 @@
       "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
       "dev": true,
       "requires": {
-        "domelementtype": "1",
-        "domhandler": "2.1",
-        "domutils": "1.1",
-        "readable-stream": "1.0"
+        "domelementtype": "1.3.0",
+        "domhandler": "2.1.0",
+        "domutils": "1.1.6",
+        "readable-stream": "1.0.34"
       },
       "dependencies": {
         "domutils": {
@@ -12497,7 +11969,7 @@
           "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
           "dev": true,
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "readable-stream": {
@@ -12506,10 +11978,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         }
       }
@@ -12520,9 +11992,9 @@
       "integrity": "sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=",
       "dev": true,
       "requires": {
-        "caseless": "~0.11.0",
-        "concat-stream": "^1.4.6",
-        "http-response-object": "^1.0.0"
+        "caseless": "0.11.0",
+        "concat-stream": "1.6.1",
+        "http-response-object": "1.1.0"
       },
       "dependencies": {
         "caseless": {
@@ -12545,8 +12017,8 @@
       "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.1",
-        "statuses": "1"
+        "inherits": "2.0.3",
+        "statuses": "1.4.0"
       }
     },
     "http-parser-js": {
@@ -12561,8 +12033,8 @@
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
       "dev": true,
       "requires": {
-        "eventemitter3": "1.x.x",
-        "requires-port": "1.x.x"
+        "eventemitter3": "1.2.0",
+        "requires-port": "1.0.0"
       }
     },
     "http-proxy-middleware": {
@@ -12571,10 +12043,10 @@
       "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
       "dev": true,
       "requires": {
-        "http-proxy": "^1.16.2",
-        "is-glob": "^3.1.0",
-        "lodash": "^4.17.2",
-        "micromatch": "^2.3.11"
+        "http-proxy": "1.16.2",
+        "is-glob": "3.1.0",
+        "lodash": "4.17.5",
+        "micromatch": "2.3.11"
       },
       "dependencies": {
         "is-extglob": {
@@ -12589,7 +12061,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "lodash": {
@@ -12608,17 +12080,16 @@
     },
     "http-server": {
       "version": "github:johntron/http-server#2af9dee8ed4471d9bfc3b675ac5ae3cc420e711a",
-      "from": "github:johntron/http-server#proxy-secure-flag",
       "dev": true,
       "requires": {
         "colors": "1.0.3",
-        "corser": "~2.0.0",
-        "ecstatic": "^2.0.0",
-        "http-proxy": "^v1.11.1",
-        "opener": "~1.4.0",
-        "optimist": "0.6.x",
-        "portfinder": "^1.0.13",
-        "union": "~0.4.3"
+        "corser": "2.0.1",
+        "ecstatic": "2.2.1",
+        "http-proxy": "1.16.2",
+        "opener": "1.4.3",
+        "optimist": "0.6.1",
+        "portfinder": "1.0.13",
+        "union": "0.4.6"
       },
       "dependencies": {
         "colors": {
@@ -12634,9 +12105,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "requires": {
-        "assert-plus": "^0.2.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
       }
     },
     "http2": {
@@ -12669,7 +12140,7 @@
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.19"
       }
     },
     "ieee754": {
@@ -12703,15 +12174,15 @@
       "integrity": "sha512-CGaBiq7BOs3zHlFWf39+nowT2VlKrLySKjjdkBx8eLHdP8Uvv7zHTh1Z0lz7eAZhlBAxDPnGwiNt4r7m1NWaJQ==",
       "dev": true,
       "requires": {
-        "imagemin": "^5.2.2",
-        "imagemin-gifsicle": "^5.1.0",
-        "imagemin-mozjpeg": "^7.0.0",
-        "imagemin-optipng": "^5.2.1",
-        "imagemin-pngquant": "^5.0.0",
-        "imagemin-svgo": "^5.2.1",
-        "imagemin-webp": "^4.0.0",
-        "loader-utils": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "imagemin": "5.3.1",
+        "imagemin-gifsicle": "5.2.0",
+        "imagemin-mozjpeg": "7.0.0",
+        "imagemin-optipng": "5.2.1",
+        "imagemin-pngquant": "5.1.0",
+        "imagemin-svgo": "5.2.4",
+        "imagemin-webp": "4.1.0",
+        "loader-utils": "1.1.0",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "bin-build": {
@@ -12720,11 +12191,11 @@
           "integrity": "sha512-jcUOof71/TNAI2uM5uoUaDq2ePcVBQ3R/qhxAz1rX7UfvduAL/RXD3jXzvn8cVcDJdGVkiR1shal3OH0ImpuhA==",
           "dev": true,
           "requires": {
-            "decompress": "^4.0.0",
-            "download": "^6.2.2",
-            "execa": "^0.7.0",
-            "p-map-series": "^1.0.0",
-            "tempfile": "^2.0.0"
+            "decompress": "4.2.0",
+            "download": "6.2.5",
+            "execa": "0.7.0",
+            "p-map-series": "1.0.0",
+            "tempfile": "2.0.0"
           }
         },
         "caw": {
@@ -12733,10 +12204,10 @@
           "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
           "dev": true,
           "requires": {
-            "get-proxy": "^2.0.0",
-            "isurl": "^1.0.0-alpha5",
-            "tunnel-agent": "^0.6.0",
-            "url-to-options": "^1.0.1"
+            "get-proxy": "2.1.0",
+            "isurl": "1.0.0",
+            "tunnel-agent": "0.6.0",
+            "url-to-options": "1.0.1"
           }
         },
         "cross-spawn": {
@@ -12745,11 +12216,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "nice-try": "1.0.4",
+            "path-key": "2.0.1",
+            "semver": "5.5.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
           }
         },
         "decompress": {
@@ -12758,14 +12229,14 @@
           "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
           "dev": true,
           "requires": {
-            "decompress-tar": "^4.0.0",
-            "decompress-tarbz2": "^4.0.0",
-            "decompress-targz": "^4.0.0",
-            "decompress-unzip": "^4.0.1",
-            "graceful-fs": "^4.1.10",
-            "make-dir": "^1.0.0",
-            "pify": "^2.3.0",
-            "strip-dirs": "^2.0.0"
+            "decompress-tar": "4.1.1",
+            "decompress-tarbz2": "4.1.1",
+            "decompress-targz": "4.1.1",
+            "decompress-unzip": "4.0.1",
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.2.0",
+            "pify": "2.3.0",
+            "strip-dirs": "2.1.0"
           }
         },
         "decompress-tar": {
@@ -12774,9 +12245,9 @@
           "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
           "dev": true,
           "requires": {
-            "file-type": "^5.2.0",
-            "is-stream": "^1.1.0",
-            "tar-stream": "^1.5.2"
+            "file-type": "5.2.0",
+            "is-stream": "1.1.0",
+            "tar-stream": "1.5.5"
           },
           "dependencies": {
             "file-type": {
@@ -12793,11 +12264,11 @@
           "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
           "dev": true,
           "requires": {
-            "decompress-tar": "^4.1.0",
-            "file-type": "^6.1.0",
-            "is-stream": "^1.1.0",
-            "seek-bzip": "^1.0.5",
-            "unbzip2-stream": "^1.0.9"
+            "decompress-tar": "4.1.1",
+            "file-type": "6.2.0",
+            "is-stream": "1.1.0",
+            "seek-bzip": "1.0.5",
+            "unbzip2-stream": "1.2.5"
           },
           "dependencies": {
             "file-type": {
@@ -12814,9 +12285,9 @@
           "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
           "dev": true,
           "requires": {
-            "decompress-tar": "^4.1.1",
-            "file-type": "^5.2.0",
-            "is-stream": "^1.1.0"
+            "decompress-tar": "4.1.1",
+            "file-type": "5.2.0",
+            "is-stream": "1.1.0"
           },
           "dependencies": {
             "file-type": {
@@ -12833,10 +12304,10 @@
           "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
           "dev": true,
           "requires": {
-            "file-type": "^3.8.0",
-            "get-stream": "^2.2.0",
-            "pify": "^2.3.0",
-            "yauzl": "^2.4.2"
+            "file-type": "3.9.0",
+            "get-stream": "2.3.1",
+            "pify": "2.3.0",
+            "yauzl": "2.9.1"
           },
           "dependencies": {
             "file-type": {
@@ -12851,8 +12322,8 @@
               "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
               "dev": true,
               "requires": {
-                "object-assign": "^4.0.1",
-                "pinkie-promise": "^2.0.0"
+                "object-assign": "4.1.1",
+                "pinkie-promise": "2.0.1"
               }
             }
           }
@@ -12863,17 +12334,17 @@
           "integrity": "sha512-DpO9K1sXAST8Cpzb7kmEhogJxymyVUd5qz/vCOSyvwtp2Klj2XcDt5YUuasgxka44SxF0q5RriKIwJmQHG2AuA==",
           "dev": true,
           "requires": {
-            "caw": "^2.0.0",
-            "content-disposition": "^0.5.2",
-            "decompress": "^4.0.0",
-            "ext-name": "^5.0.0",
+            "caw": "2.0.1",
+            "content-disposition": "0.5.2",
+            "decompress": "4.2.0",
+            "ext-name": "5.0.0",
             "file-type": "5.2.0",
-            "filenamify": "^2.0.0",
-            "get-stream": "^3.0.0",
-            "got": "^7.0.0",
-            "make-dir": "^1.0.0",
-            "p-event": "^1.0.0",
-            "pify": "^3.0.0"
+            "filenamify": "2.0.0",
+            "get-stream": "3.0.0",
+            "got": "7.1.0",
+            "make-dir": "1.2.0",
+            "p-event": "1.3.0",
+            "pify": "3.0.0"
           },
           "dependencies": {
             "file-type": {
@@ -12896,11 +12367,11 @@
           "integrity": "sha512-wsiD+2Tp6BWHoVv3B+5Dcx6E7u5zky+hUwOHjuH2hKSLR3dvRmX8fk8UD8uqQixHs4Wk6eDmiegVrMPjKj7wpA==",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "p-finally": "^1.0.0",
-            "pify": "^3.0.0",
-            "rimraf": "^2.5.4",
-            "tempfile": "^2.0.0"
+            "execa": "0.7.0",
+            "p-finally": "1.0.0",
+            "pify": "3.0.0",
+            "rimraf": "2.6.2",
+            "tempfile": "2.0.0"
           },
           "dependencies": {
             "pify": {
@@ -12929,9 +12400,9 @@
           "integrity": "sha1-vRYiYsC26Uv7zc8Zo7uzdk94VpU=",
           "dev": true,
           "requires": {
-            "filename-reserved-regex": "^2.0.0",
-            "strip-outer": "^1.0.0",
-            "trim-repeated": "^1.0.0"
+            "filename-reserved-regex": "2.0.0",
+            "strip-outer": "1.0.0",
+            "trim-repeated": "1.0.0"
           }
         },
         "get-proxy": {
@@ -12940,7 +12411,7 @@
           "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
           "dev": true,
           "requires": {
-            "npm-conf": "^1.1.0"
+            "npm-conf": "1.1.3"
           }
         },
         "globby": {
@@ -12949,11 +12420,11 @@
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "array-union": "1.0.2",
+            "glob": "7.0.5",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "got": {
@@ -12962,20 +12433,20 @@
           "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
           "dev": true,
           "requires": {
-            "decompress-response": "^3.2.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-plain-obj": "^1.1.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "isurl": "^1.0.0-alpha5",
-            "lowercase-keys": "^1.0.0",
-            "p-cancelable": "^0.3.0",
-            "p-timeout": "^1.1.1",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "url-parse-lax": "^1.0.0",
-            "url-to-options": "^1.0.1"
+            "decompress-response": "3.3.0",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-plain-obj": "1.1.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "isurl": "1.0.0",
+            "lowercase-keys": "1.0.0",
+            "p-cancelable": "0.3.0",
+            "p-timeout": "1.2.1",
+            "safe-buffer": "5.1.1",
+            "timed-out": "4.0.1",
+            "url-parse-lax": "1.0.0",
+            "url-to-options": "1.0.1"
           }
         },
         "imagemin": {
@@ -12984,12 +12455,12 @@
           "integrity": "sha1-8Zwu7h5xumxlWMUV+fyWaAGJptQ=",
           "dev": true,
           "requires": {
-            "file-type": "^4.1.0",
-            "globby": "^6.1.0",
-            "make-dir": "^1.0.0",
-            "p-pipe": "^1.1.0",
-            "pify": "^2.3.0",
-            "replace-ext": "^1.0.0"
+            "file-type": "4.4.0",
+            "globby": "6.1.0",
+            "make-dir": "1.2.0",
+            "p-pipe": "1.2.0",
+            "pify": "2.3.0",
+            "replace-ext": "1.0.0"
           }
         },
         "imagemin-gifsicle": {
@@ -12998,9 +12469,9 @@
           "integrity": "sha512-K01m5QuPK+0en8oVhiOOAicF7KjrHlCZxS++mfLI2mV/Ksfq/Y9nCXCWDz6jRv13wwlqe5T7hXT+ji2DnLc2yQ==",
           "dev": true,
           "requires": {
-            "exec-buffer": "^3.0.0",
-            "gifsicle": "^3.0.0",
-            "is-gif": "^1.0.0"
+            "exec-buffer": "3.2.0",
+            "gifsicle": "3.0.4",
+            "is-gif": "1.0.0"
           }
         },
         "imagemin-optipng": {
@@ -13009,9 +12480,9 @@
           "integrity": "sha1-0i2kEsCfX/AKQzmWC5ioix2+hpU=",
           "dev": true,
           "requires": {
-            "exec-buffer": "^3.0.0",
-            "is-png": "^1.0.0",
-            "optipng-bin": "^3.0.0"
+            "exec-buffer": "3.2.0",
+            "is-png": "1.1.0",
+            "optipng-bin": "3.1.4"
           }
         },
         "imagemin-pngquant": {
@@ -13020,10 +12491,10 @@
           "integrity": "sha512-RtIUPbp8/HYX5EKY6p/L1NLKnkxNj37I92IFNsrptzBVql8FqBgPra9DO/eUgE4EWx+zq6ih4a/Y9YhF3pNM5A==",
           "dev": true,
           "requires": {
-            "execa": "^0.10.0",
-            "is-png": "^1.0.0",
-            "is-stream": "^1.1.0",
-            "pngquant-bin": "^4.0.0"
+            "execa": "0.10.0",
+            "is-png": "1.1.0",
+            "is-stream": "1.1.0",
+            "pngquant-bin": "4.0.0"
           },
           "dependencies": {
             "execa": {
@@ -13032,13 +12503,13 @@
               "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
               "dev": true,
               "requires": {
-                "cross-spawn": "^6.0.0",
-                "get-stream": "^3.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
+                "cross-spawn": "6.0.5",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
               }
             }
           }
@@ -13049,8 +12520,8 @@
           "integrity": "sha512-1bNZdlWVKdfxzu0xDD1pWjwK/G8FLcztUh/GWaI7xLgCFrn0j35o+uBbY7VcdY2AmKgiLYTXhrzrbkQk6xj8aA==",
           "dev": true,
           "requires": {
-            "is-svg": "^2.0.0",
-            "svgo": "^0.7.0"
+            "is-svg": "2.1.0",
+            "svgo": "0.7.2"
           }
         },
         "is-natural-number": {
@@ -13065,9 +12536,9 @@
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         },
         "object-assign": {
@@ -13082,10 +12553,10 @@
           "integrity": "sha512-jhjMp87bvaUeQOfNaPhSKx3tLCEwRaAycgDpIhMflgFr2+vYhw4ZrcK06eQeYg4OprXPanFljXLl5VuuAP2IHw==",
           "dev": true,
           "requires": {
-            "bin-build": "^3.0.0",
-            "bin-wrapper": "^3.0.0",
-            "execa": "^0.10.0",
-            "logalot": "^2.0.0"
+            "bin-build": "3.0.0",
+            "bin-wrapper": "3.0.2",
+            "execa": "0.10.0",
+            "logalot": "2.1.0"
           },
           "dependencies": {
             "execa": {
@@ -13094,13 +12565,13 @@
               "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
               "dev": true,
               "requires": {
-                "cross-spawn": "^6.0.0",
-                "get-stream": "^3.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
+                "cross-spawn": "6.0.5",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
               }
             }
           }
@@ -13117,7 +12588,7 @@
           "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
           "dev": true,
           "requires": {
-            "is-natural-number": "^4.0.1"
+            "is-natural-number": "4.0.1"
           }
         },
         "tempfile": {
@@ -13126,8 +12597,8 @@
           "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
           "dev": true,
           "requires": {
-            "temp-dir": "^1.0.0",
-            "uuid": "^3.0.1"
+            "temp-dir": "1.0.0",
+            "uuid": "3.2.1"
           }
         },
         "timed-out": {
@@ -13144,9 +12615,9 @@
       "integrity": "sha1-2SZHf8bvXzp2ikIi97LYCNPrpWg=",
       "dev": true,
       "requires": {
-        "execa": "^0.8.0",
-        "is-jpg": "^1.0.0",
-        "mozjpeg": "^5.0.0"
+        "execa": "0.8.0",
+        "is-jpg": "1.0.0",
+        "mozjpeg": "5.0.0"
       },
       "dependencies": {
         "execa": {
@@ -13155,13 +12626,13 @@
           "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
           "dev": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         }
       }
@@ -13172,9 +12643,9 @@
       "integrity": "sha1-7/0AFg2EVrlcveX9JsMtZLAxgGI=",
       "dev": true,
       "requires": {
-        "cwebp-bin": "^4.0.0",
-        "exec-buffer": "^3.0.0",
-        "is-cwebp-readable": "^2.0.1"
+        "cwebp-bin": "4.0.0",
+        "exec-buffer": "3.2.0",
+        "is-cwebp-readable": "2.0.1"
       },
       "dependencies": {
         "exec-buffer": {
@@ -13183,11 +12654,11 @@
           "integrity": "sha512-wsiD+2Tp6BWHoVv3B+5Dcx6E7u5zky+hUwOHjuH2hKSLR3dvRmX8fk8UD8uqQixHs4Wk6eDmiegVrMPjKj7wpA==",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "p-finally": "^1.0.0",
-            "pify": "^3.0.0",
-            "rimraf": "^2.5.4",
-            "tempfile": "^2.0.0"
+            "execa": "0.7.0",
+            "p-finally": "1.0.0",
+            "pify": "3.0.0",
+            "rimraf": "2.6.2",
+            "tempfile": "2.0.0"
           }
         },
         "pify": {
@@ -13202,8 +12673,8 @@
           "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
           "dev": true,
           "requires": {
-            "temp-dir": "^1.0.0",
-            "uuid": "^3.0.1"
+            "temp-dir": "1.0.0",
+            "uuid": "3.2.1"
           }
         }
       }
@@ -13219,8 +12690,8 @@
       "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "^2.0.0",
-        "resolve-cwd": "^2.0.0"
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -13229,7 +12700,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "pkg-dir": {
@@ -13238,7 +12709,7 @@
           "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
           "dev": true,
           "requires": {
-            "find-up": "^2.1.0"
+            "find-up": "2.1.0"
           }
         }
       }
@@ -13255,7 +12726,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "indexes-of": {
@@ -13275,8 +12746,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -13296,19 +12767,19 @@
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^1.1.0",
-        "ansi-regex": "^2.0.0",
-        "chalk": "^1.0.0",
-        "cli-cursor": "^1.0.1",
-        "cli-width": "^2.0.0",
-        "figures": "^1.3.5",
-        "lodash": "^4.3.0",
-        "readline2": "^1.0.1",
-        "run-async": "^0.1.0",
-        "rx-lite": "^3.1.2",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.0",
-        "through": "^2.3.6"
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.2.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.5",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
       },
       "dependencies": {
         "lodash": {
@@ -13325,7 +12796,7 @@
       "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
       "dev": true,
       "requires": {
-        "meow": "^3.3.0"
+        "meow": "3.7.0"
       }
     },
     "interpret": {
@@ -13370,7 +12841,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.3.1"
       }
     },
     "inversify": {
@@ -13414,8 +12885,8 @@
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "dev": true,
       "requires": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.2"
       }
     },
     "is-absolute-url": {
@@ -13428,14 +12899,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
       "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "dev": true,
       "requires": {
-        "kind-of": "^6.0.0"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
@@ -13451,7 +12924,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-boolean-object": {
@@ -13471,7 +12944,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-bzip2": {
@@ -13492,7 +12965,7 @@
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true,
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "1.1.3"
       }
     },
     "is-cwebp-readable": {
@@ -13501,7 +12974,7 @@
       "integrity": "sha1-r7k7DAq9CiUQEBauM66ort+SbSY=",
       "dev": true,
       "requires": {
-        "file-type": "^4.3.0"
+        "file-type": "4.4.0"
       },
       "dependencies": {
         "file-type": {
@@ -13516,14 +12989,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
       "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "dev": true,
       "requires": {
-        "kind-of": "^6.0.0"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
@@ -13537,16 +13012,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
       "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^1.0.0",
-        "is-data-descriptor": "^1.0.0",
-        "kind-of": "^6.0.2"
+        "is-accessor-descriptor": "1.0.0",
+        "is-data-descriptor": "1.0.0",
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
@@ -13568,7 +13045,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -13589,7 +13066,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -13598,7 +13075,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-generator-fn": {
@@ -13619,7 +13096,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "is-gzip": {
@@ -13634,8 +13111,8 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
+        "global-dirs": "0.1.1",
+        "is-path-inside": "1.0.1"
       }
     },
     "is-jpg": {
@@ -13650,7 +13127,7 @@
       "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.0"
+        "lower-case": "1.1.4"
       }
     },
     "is-my-ip-valid": {
@@ -13665,11 +13142,11 @@
       "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "dev": true,
       "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
       }
     },
     "is-natural-number": {
@@ -13684,7 +13161,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-number-object": {
@@ -13711,7 +13188,7 @@
       "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0"
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -13734,7 +13211,7 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -13743,7 +13220,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-obj": {
@@ -13758,7 +13235,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -13811,7 +13288,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.1"
       }
     },
     "is-regexp": {
@@ -13826,7 +13303,7 @@
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "dev": true,
       "requires": {
-        "is-unc-path": "^1.0.0"
+        "is-unc-path": "1.0.0"
       }
     },
     "is-resolvable": {
@@ -13870,7 +13347,7 @@
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
       "dev": true,
       "requires": {
-        "html-comment-regex": "^1.1.0"
+        "html-comment-regex": "1.1.1"
       }
     },
     "is-symbol": {
@@ -13891,7 +13368,7 @@
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
-        "text-extensions": "^1.0.0"
+        "text-extensions": "1.7.0"
       }
     },
     "is-typedarray": {
@@ -13905,7 +13382,7 @@
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "dev": true,
       "requires": {
-        "unc-path-regex": "^0.1.2"
+        "unc-path-regex": "0.1.2"
       }
     },
     "is-upper-case": {
@@ -13914,7 +13391,7 @@
       "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
       "dev": true,
       "requires": {
-        "upper-case": "^1.1.0"
+        "upper-case": "1.1.3"
       }
     },
     "is-url": {
@@ -13985,8 +13462,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
       }
     },
     "isstream": {
@@ -14000,18 +13477,18 @@
       "integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
       "dev": true,
       "requires": {
-        "async": "^2.1.4",
-        "compare-versions": "^3.1.0",
-        "fileset": "^2.0.2",
-        "istanbul-lib-coverage": "^1.2.0",
-        "istanbul-lib-hook": "^1.2.0",
-        "istanbul-lib-instrument": "^1.10.1",
-        "istanbul-lib-report": "^1.1.4",
-        "istanbul-lib-source-maps": "^1.2.4",
-        "istanbul-reports": "^1.3.0",
-        "js-yaml": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "once": "^1.4.0"
+        "async": "2.6.0",
+        "compare-versions": "3.1.0",
+        "fileset": "2.0.3",
+        "istanbul-lib-coverage": "1.2.0",
+        "istanbul-lib-hook": "1.2.0",
+        "istanbul-lib-instrument": "1.10.1",
+        "istanbul-lib-report": "1.1.4",
+        "istanbul-lib-source-maps": "1.2.4",
+        "istanbul-reports": "1.3.0",
+        "js-yaml": "3.7.0",
+        "mkdirp": "0.5.1",
+        "once": "1.4.0"
       },
       "dependencies": {
         "async": {
@@ -14020,7 +13497,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "4.17.5"
           }
         },
         "debug": {
@@ -14038,11 +13515,11 @@
           "integrity": "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
           "dev": true,
           "requires": {
-            "debug": "^3.1.0",
-            "istanbul-lib-coverage": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.6.1",
-            "source-map": "^0.5.3"
+            "debug": "3.1.0",
+            "istanbul-lib-coverage": "1.2.0",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "source-map": "0.5.7"
           }
         },
         "lodash": {
@@ -14065,7 +13542,7 @@
       "integrity": "sha512-p3En6/oGkFQV55Up8ZPC2oLxvgSxD8CzA0yBrhRZSh3pfv3OFj9aSGVC0yoerAi/O4u7jUVnOGVX1eVFM+0tmQ==",
       "dev": true,
       "requires": {
-        "append-transform": "^0.4.0"
+        "append-transform": "0.4.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -14074,13 +13551,13 @@
       "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
       "dev": true,
       "requires": {
-        "babel-generator": "^6.18.0",
-        "babel-template": "^6.16.0",
-        "babel-traverse": "^6.18.0",
-        "babel-types": "^6.18.0",
-        "babylon": "^6.18.0",
-        "istanbul-lib-coverage": "^1.2.0",
-        "semver": "^5.3.0"
+        "babel-generator": "6.26.1",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "istanbul-lib-coverage": "1.2.0",
+        "semver": "5.5.0"
       }
     },
     "istanbul-lib-report": {
@@ -14089,10 +13566,10 @@
       "integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "path-parse": "^1.0.5",
-        "supports-color": "^3.1.2"
+        "istanbul-lib-coverage": "1.2.0",
+        "mkdirp": "0.5.1",
+        "path-parse": "1.0.5",
+        "supports-color": "3.2.3"
       },
       "dependencies": {
         "supports-color": {
@@ -14101,7 +13578,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -14112,11 +13589,11 @@
       "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0",
-        "istanbul-lib-coverage": "^1.1.2",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.6.1",
-        "source-map": "^0.5.3"
+        "debug": "3.1.0",
+        "istanbul-lib-coverage": "1.2.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "debug": {
@@ -14136,7 +13613,7 @@
       "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.0.3"
+        "handlebars": "4.0.11"
       }
     },
     "isurl": {
@@ -14145,8 +13622,8 @@
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
       "requires": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
       }
     },
     "iterall": {
@@ -14160,7 +13637,7 @@
       "integrity": "sha1-CGRxjboRgIXnVH+fvZ3sHRSa6lc=",
       "dev": true,
       "requires": {
-        "mkdirp": "~0.3.5"
+        "mkdirp": "0.3.5"
       },
       "dependencies": {
         "mkdirp": {
@@ -14177,7 +13654,7 @@
       "integrity": "sha512-SzqOvoPMrXB0NPvDrSPeKETpoUNCtNDOsFbCzAGWxqWVvNyrIMLpUjVExT3u3LfdVrENlrNGCfh5YoFd8+ZeXg==",
       "dev": true,
       "requires": {
-        "throat": "^4.0.0"
+        "throat": "4.1.0"
       }
     },
     "jest-cli": {
@@ -14186,40 +13663,40 @@
       "integrity": "sha512-0JlBb/PvHGQZR2I9GZwsycHgWHhriBmvBWPaaPYUT186oiIIDY4ezDxFOFt2Ts0yNTRg3iY9mTyHsfWbT5VRWA==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.1",
-        "exit": "^0.1.2",
-        "glob": "^7.1.2",
-        "graceful-fs": "^4.1.11",
-        "import-local": "^1.0.0",
-        "is-ci": "^1.0.10",
-        "istanbul-api": "^1.1.14",
-        "istanbul-lib-coverage": "^1.1.1",
-        "istanbul-lib-instrument": "^1.8.0",
-        "istanbul-lib-source-maps": "^1.2.1",
-        "jest-changed-files": "^22.2.0",
-        "jest-config": "^22.4.0",
-        "jest-environment-jsdom": "^22.4.0",
-        "jest-get-type": "^22.1.0",
-        "jest-haste-map": "^22.4.0",
-        "jest-message-util": "^22.4.0",
-        "jest-regex-util": "^22.1.0",
-        "jest-resolve-dependencies": "^22.1.0",
-        "jest-runner": "^22.4.0",
-        "jest-runtime": "^22.4.0",
-        "jest-snapshot": "^22.4.0",
-        "jest-util": "^22.4.0",
-        "jest-validate": "^22.4.0",
-        "jest-worker": "^22.2.2",
-        "micromatch": "^2.3.11",
-        "node-notifier": "^5.2.1",
-        "realpath-native": "^1.0.0",
-        "rimraf": "^2.5.4",
-        "slash": "^1.0.0",
-        "string-length": "^2.0.0",
-        "strip-ansi": "^4.0.0",
-        "which": "^1.2.12",
-        "yargs": "^10.0.3"
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.3.2",
+        "exit": "0.1.2",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "import-local": "1.0.0",
+        "is-ci": "1.0.10",
+        "istanbul-api": "1.3.1",
+        "istanbul-lib-coverage": "1.2.0",
+        "istanbul-lib-instrument": "1.10.1",
+        "istanbul-lib-source-maps": "1.2.3",
+        "jest-changed-files": "22.2.0",
+        "jest-config": "22.4.2",
+        "jest-environment-jsdom": "22.4.1",
+        "jest-get-type": "22.1.0",
+        "jest-haste-map": "22.4.2",
+        "jest-message-util": "22.4.0",
+        "jest-regex-util": "22.1.0",
+        "jest-resolve-dependencies": "22.1.0",
+        "jest-runner": "22.4.2",
+        "jest-runtime": "22.4.2",
+        "jest-snapshot": "22.4.0",
+        "jest-util": "22.4.1",
+        "jest-validate": "22.4.2",
+        "jest-worker": "22.2.2",
+        "micromatch": "2.3.11",
+        "node-notifier": "5.2.1",
+        "realpath-native": "1.0.0",
+        "rimraf": "2.6.2",
+        "slash": "1.0.0",
+        "string-length": "2.0.0",
+        "strip-ansi": "4.0.0",
+        "which": "1.3.0",
+        "yargs": "10.1.2"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -14240,7 +13717,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -14249,9 +13726,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "cliui": {
@@ -14260,9 +13737,9 @@
           "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
           "dev": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           }
         },
         "find-up": {
@@ -14271,7 +13748,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "glob": {
@@ -14280,12 +13757,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-flag": {
@@ -14306,11 +13783,11 @@
           "integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.1",
-            "jest-config": "^22.4.2",
-            "jest-get-type": "^22.1.0",
-            "leven": "^2.1.0",
-            "pretty-format": "^22.4.0"
+            "chalk": "2.3.2",
+            "jest-config": "22.4.2",
+            "jest-get-type": "22.1.0",
+            "leven": "2.1.0",
+            "pretty-format": "22.4.0"
           }
         },
         "minimatch": {
@@ -14319,7 +13796,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "node-notifier": {
@@ -14328,10 +13805,10 @@
           "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
           "dev": true,
           "requires": {
-            "growly": "^1.3.0",
-            "semver": "^5.4.1",
-            "shellwords": "^0.1.1",
-            "which": "^1.3.0"
+            "growly": "1.3.0",
+            "semver": "5.5.0",
+            "shellwords": "0.1.1",
+            "which": "1.3.0"
           }
         },
         "os-locale": {
@@ -14340,9 +13817,9 @@
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "string-width": {
@@ -14351,8 +13828,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -14361,7 +13838,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -14370,7 +13847,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "which-module": {
@@ -14385,18 +13862,18 @@
           "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^8.1.0"
+            "cliui": "4.0.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "8.1.0"
           }
         }
       }
@@ -14407,17 +13884,17 @@
       "integrity": "sha512-oG31qYO73/3vj/Q8aM2RgzmHndTkz9nRk8ISybfuJqqbf0RW7OUjHVOZPLOUiwLWtz52Yq2HkjIblsyhbA7vrg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "glob": "^7.1.1",
-        "jest-environment-jsdom": "^22.4.1",
-        "jest-environment-node": "^22.4.1",
-        "jest-get-type": "^22.1.0",
-        "jest-jasmine2": "^22.4.2",
-        "jest-regex-util": "^22.1.0",
-        "jest-resolve": "^22.4.2",
-        "jest-util": "^22.4.1",
-        "jest-validate": "^22.4.2",
-        "pretty-format": "^22.4.0"
+        "chalk": "2.3.2",
+        "glob": "7.1.2",
+        "jest-environment-jsdom": "22.4.1",
+        "jest-environment-node": "22.4.1",
+        "jest-get-type": "22.1.0",
+        "jest-jasmine2": "22.4.2",
+        "jest-regex-util": "22.1.0",
+        "jest-resolve": "22.4.2",
+        "jest-util": "22.4.1",
+        "jest-validate": "22.4.2",
+        "pretty-format": "22.4.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14426,7 +13903,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -14435,9 +13912,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "glob": {
@@ -14446,12 +13923,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-flag": {
@@ -14466,11 +13943,11 @@
           "integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.1",
-            "jest-config": "^22.4.2",
-            "jest-get-type": "^22.1.0",
-            "leven": "^2.1.0",
-            "pretty-format": "^22.4.0"
+            "chalk": "2.3.2",
+            "jest-config": "22.4.2",
+            "jest-get-type": "22.1.0",
+            "leven": "2.1.0",
+            "pretty-format": "22.4.0"
           }
         },
         "minimatch": {
@@ -14479,7 +13956,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "supports-color": {
@@ -14488,7 +13965,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -14499,10 +13976,10 @@
       "integrity": "sha512-+/t20WmnkOkB8MOaGaPziI8zWKxquMvYw4Ub+wOzi7AUhmpFXz43buWSxVoZo4J5RnCozpGbX3/FssjJ5KV9Nw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "diff": "^3.2.0",
-        "jest-get-type": "^22.1.0",
-        "pretty-format": "^22.4.0"
+        "chalk": "2.3.2",
+        "diff": "3.5.0",
+        "jest-get-type": "22.1.0",
+        "pretty-format": "22.4.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14511,7 +13988,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -14520,9 +13997,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -14537,7 +14014,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -14548,7 +14025,7 @@
       "integrity": "sha512-lDY7GZ+/CJb02oULYLBDj7Hs5shBhVpDYpIm8LUyqw9X2J22QRsM19gmGQwIFqGSJmpc/LRrSYudeSrG510xlQ==",
       "dev": true,
       "requires": {
-        "detect-newline": "^2.1.0"
+        "detect-newline": "2.1.0"
       }
     },
     "jest-environment-jsdom": {
@@ -14557,9 +14034,9 @@
       "integrity": "sha512-x/JzAoH+dWPBnIMv5OQKiIR0TYf6UvbRjsIuDZ11yDFXkHKGJZg6jNnLAsokAm3cq9kUa2hH5BPUC9XU4n1ELQ==",
       "dev": true,
       "requires": {
-        "jest-mock": "^22.2.0",
-        "jest-util": "^22.4.1",
-        "jsdom": "^11.5.1"
+        "jest-mock": "22.2.0",
+        "jest-util": "22.4.1",
+        "jsdom": "11.6.2"
       }
     },
     "jest-environment-node": {
@@ -14568,8 +14045,8 @@
       "integrity": "sha512-wj9+zzfRgnUbm5VwFOCGgG1QmbucUyrjPKBKUJdLW8K5Ss5zrNc1k+v6feZhFg6sS3ZGnjgtIyklaxEARxu+LQ==",
       "dev": true,
       "requires": {
-        "jest-mock": "^22.2.0",
-        "jest-util": "^22.4.1"
+        "jest-mock": "22.2.0",
+        "jest-util": "22.4.1"
       }
     },
     "jest-get-type": {
@@ -14584,13 +14061,13 @@
       "integrity": "sha512-EdQADHGXRqHJYAr7q9B9YYHZnrlcMwhx1+DnIgc9uN05nCW3RvGCxJ91MqWXcC1AzatLoSv7SNd0qXMp2jKBDA==",
       "dev": true,
       "requires": {
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.1.11",
-        "jest-docblock": "^22.4.0",
-        "jest-serializer": "^22.4.0",
-        "jest-worker": "^22.2.2",
-        "micromatch": "^2.3.11",
-        "sane": "^2.0.0"
+        "fb-watchman": "2.0.0",
+        "graceful-fs": "4.1.11",
+        "jest-docblock": "22.4.0",
+        "jest-serializer": "22.4.0",
+        "jest-worker": "22.2.2",
+        "micromatch": "2.3.11",
+        "sane": "2.5.0"
       }
     },
     "jest-jasmine2": {
@@ -14599,17 +14076,17 @@
       "integrity": "sha512-KZaIHpXQ0AIlvQJFCU0uoXxtz5GG47X14r9upMe7VXE55UazoMZBFnQb9TX2HoYX2/AxJYnjHuvwKVCFqOrEtw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "co": "^4.6.0",
-        "expect": "^22.4.0",
-        "graceful-fs": "^4.1.11",
-        "is-generator-fn": "^1.0.0",
-        "jest-diff": "^22.4.0",
-        "jest-matcher-utils": "^22.4.0",
-        "jest-message-util": "^22.4.0",
-        "jest-snapshot": "^22.4.0",
-        "jest-util": "^22.4.1",
-        "source-map-support": "^0.5.0"
+        "chalk": "2.3.2",
+        "co": "4.6.0",
+        "expect": "22.4.0",
+        "graceful-fs": "4.1.11",
+        "is-generator-fn": "1.0.0",
+        "jest-diff": "22.4.0",
+        "jest-matcher-utils": "22.4.0",
+        "jest-message-util": "22.4.0",
+        "jest-snapshot": "22.4.0",
+        "jest-util": "22.4.1",
+        "source-map-support": "0.5.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14618,7 +14095,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -14627,9 +14104,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -14650,7 +14127,7 @@
           "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
           "dev": true,
           "requires": {
-            "source-map": "^0.6.0"
+            "source-map": "0.6.1"
           }
         },
         "supports-color": {
@@ -14659,7 +14136,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -14670,7 +14147,7 @@
       "integrity": "sha512-r3NEIVNh4X3fEeJtUIrKXWKhNokwUM2ILp5LD8w1KrEanPsFtZmYjmyZYjDTX2dXYr33TW65OvbRE3hWFAyq6g==",
       "dev": true,
       "requires": {
-        "pretty-format": "^22.4.0"
+        "pretty-format": "22.4.0"
       }
     },
     "jest-matcher-utils": {
@@ -14679,9 +14156,9 @@
       "integrity": "sha512-03m3issxUXpWMwDYTfmL8hRNewUB0yCRTeXPm+eq058rZxLHD9f5NtSSO98CWHqe4UyISIxd9Ao9iDVjHWd2qg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "jest-get-type": "^22.1.0",
-        "pretty-format": "^22.4.0"
+        "chalk": "2.3.2",
+        "jest-get-type": "22.1.0",
+        "pretty-format": "22.4.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14690,7 +14167,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -14699,9 +14176,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -14716,7 +14193,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -14727,11 +14204,11 @@
       "integrity": "sha512-eyCJB0T3hrlpFF2FqQoIB093OulP+1qvATQmD3IOgJgMGqPL6eYw8TbC5P/VCWPqKhGL51xvjIIhow5eZ2wHFw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0-beta.35",
-        "chalk": "^2.0.1",
-        "micromatch": "^2.3.11",
-        "slash": "^1.0.0",
-        "stack-utils": "^1.0.1"
+        "@babel/code-frame": "7.0.0-beta.42",
+        "chalk": "2.3.2",
+        "micromatch": "2.3.11",
+        "slash": "1.0.0",
+        "stack-utils": "1.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14740,7 +14217,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -14749,9 +14226,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -14766,7 +14243,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -14789,8 +14266,8 @@
       "integrity": "sha512-P1hSfcc2HJYT5t+WPu/11OfFMa7m8pBb2Gf2vm6W9OVs7YTXQ5RCC3nDqaYZQaTqxEM1ZZaTcQGcE6U2xMOsqQ==",
       "dev": true,
       "requires": {
-        "browser-resolve": "^1.11.2",
-        "chalk": "^2.0.1"
+        "browser-resolve": "1.11.2",
+        "chalk": "2.3.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14799,7 +14276,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -14808,9 +14285,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -14825,7 +14302,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -14836,7 +14313,7 @@
       "integrity": "sha512-76Ll61bD/Sus8wK8d+lw891EtiBJGJkWG8OuVDTEX0z3z2+jPujvQqSB2eQ+kCHyCsRwJ2PSjhn3UHqae/oEtA==",
       "dev": true,
       "requires": {
-        "jest-regex-util": "^22.1.0"
+        "jest-regex-util": "22.1.0"
       }
     },
     "jest-runner": {
@@ -14845,17 +14322,17 @@
       "integrity": "sha512-W4vwgiVQS0NyXt8hgpw7i0YUtsfoChiQcoHWBJeq2ocV4VF2osEZx8HYgpH5HfNe1Cb5LZeZWxX8Dr3hesbGFg==",
       "dev": true,
       "requires": {
-        "exit": "^0.1.2",
-        "jest-config": "^22.4.2",
-        "jest-docblock": "^22.4.0",
-        "jest-haste-map": "^22.4.2",
-        "jest-jasmine2": "^22.4.2",
-        "jest-leak-detector": "^22.4.0",
-        "jest-message-util": "^22.4.0",
-        "jest-runtime": "^22.4.2",
-        "jest-util": "^22.4.1",
-        "jest-worker": "^22.2.2",
-        "throat": "^4.0.0"
+        "exit": "0.1.2",
+        "jest-config": "22.4.2",
+        "jest-docblock": "22.4.0",
+        "jest-haste-map": "22.4.2",
+        "jest-jasmine2": "22.4.2",
+        "jest-leak-detector": "22.4.0",
+        "jest-message-util": "22.4.0",
+        "jest-runtime": "22.4.2",
+        "jest-util": "22.4.1",
+        "jest-worker": "22.2.2",
+        "throat": "4.1.0"
       }
     },
     "jest-runtime": {
@@ -14864,26 +14341,26 @@
       "integrity": "sha512-9/Fxbj99cqxI7o2nTNzevnI38eDBstkwve8ZeaAD/Kz0fbU3i3eRv2QPEmzbmyCyBvUWxCT7BzNLTzTqH1+pyA==",
       "dev": true,
       "requires": {
-        "babel-core": "^6.0.0",
-        "babel-jest": "^22.4.1",
-        "babel-plugin-istanbul": "^4.1.5",
-        "chalk": "^2.0.1",
-        "convert-source-map": "^1.4.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.1.11",
-        "jest-config": "^22.4.2",
-        "jest-haste-map": "^22.4.2",
-        "jest-regex-util": "^22.1.0",
-        "jest-resolve": "^22.4.2",
-        "jest-util": "^22.4.1",
-        "jest-validate": "^22.4.2",
-        "json-stable-stringify": "^1.0.1",
-        "micromatch": "^2.3.11",
-        "realpath-native": "^1.0.0",
-        "slash": "^1.0.0",
+        "babel-core": "6.24.1",
+        "babel-jest": "22.4.1",
+        "babel-plugin-istanbul": "4.1.5",
+        "chalk": "2.3.2",
+        "convert-source-map": "1.5.1",
+        "exit": "0.1.2",
+        "graceful-fs": "4.1.11",
+        "jest-config": "22.4.2",
+        "jest-haste-map": "22.4.2",
+        "jest-regex-util": "22.1.0",
+        "jest-resolve": "22.4.2",
+        "jest-util": "22.4.1",
+        "jest-validate": "22.4.2",
+        "json-stable-stringify": "1.0.1",
+        "micromatch": "2.3.11",
+        "realpath-native": "1.0.0",
+        "slash": "1.0.0",
         "strip-bom": "3.0.0",
-        "write-file-atomic": "^2.1.0",
-        "yargs": "^10.0.3"
+        "write-file-atomic": "2.3.0",
+        "yargs": "10.1.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -14898,7 +14375,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -14907,9 +14384,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "cliui": {
@@ -14918,9 +14395,9 @@
           "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
           "dev": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           }
         },
         "find-up": {
@@ -14929,7 +14406,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "has-flag": {
@@ -14950,11 +14427,11 @@
           "integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.1",
-            "jest-config": "^22.4.2",
-            "jest-get-type": "^22.1.0",
-            "leven": "^2.1.0",
-            "pretty-format": "^22.4.0"
+            "chalk": "2.3.2",
+            "jest-config": "22.4.2",
+            "jest-get-type": "22.1.0",
+            "leven": "2.1.0",
+            "pretty-format": "22.4.0"
           }
         },
         "os-locale": {
@@ -14963,9 +14440,9 @@
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "string-width": {
@@ -14974,8 +14451,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -14984,7 +14461,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "strip-bom": {
@@ -14999,7 +14476,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "which-module": {
@@ -15014,18 +14491,18 @@
           "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^8.1.0"
+            "cliui": "4.0.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "8.1.0"
           }
         }
       }
@@ -15042,12 +14519,12 @@
       "integrity": "sha512-6Zz4F9G1Nbr93kfm5h3A2+OkE+WGpgJlskYE4iSNN2uYfoTL5b9W6aB9Orpx+ueReHyqmy7HET7Z3EmYlL3hKw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "jest-diff": "^22.4.0",
-        "jest-matcher-utils": "^22.4.0",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "pretty-format": "^22.4.0"
+        "chalk": "2.3.2",
+        "jest-diff": "22.4.0",
+        "jest-matcher-utils": "22.4.0",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "pretty-format": "22.4.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15056,7 +14533,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -15065,9 +14542,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -15082,7 +14559,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -15093,13 +14570,13 @@
       "integrity": "sha512-9ySBdJY2qVWpg0OvZbGcFXE2NgwccpZVj384E9bx7brKFc7l5anpqah15mseWcz7FLDk7/N+LyYgqFme7Rez2Q==",
       "dev": true,
       "requires": {
-        "callsites": "^2.0.0",
-        "chalk": "^2.0.1",
-        "graceful-fs": "^4.1.11",
-        "is-ci": "^1.0.10",
-        "jest-message-util": "^22.4.0",
-        "mkdirp": "^0.5.1",
-        "source-map": "^0.6.0"
+        "callsites": "2.0.0",
+        "chalk": "2.3.2",
+        "graceful-fs": "4.1.11",
+        "is-ci": "1.0.10",
+        "jest-message-util": "22.4.0",
+        "mkdirp": "0.5.1",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -15108,7 +14585,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "callsites": {
@@ -15123,9 +14600,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -15146,7 +14623,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -15157,10 +14634,10 @@
       "integrity": "sha1-Le8FVFBrarzH0Z086lcpeoRNsxU=",
       "dev": true,
       "requires": {
-        "lodash": "^3.10.1",
-        "pkginfo": "^0.3.0",
-        "transform-jest-deps": "^2.2.0",
-        "unwin": "^1.0.1"
+        "lodash": "3.10.1",
+        "pkginfo": "0.3.1",
+        "transform-jest-deps": "2.2.1",
+        "unwin": "1.0.2"
       },
       "dependencies": {
         "lodash": {
@@ -15177,7 +14654,7 @@
       "integrity": "sha512-ZylDXjrFNt/OP6cUxwJFWwDgazP7hRjtCQbocFHyiwov+04Wm1x5PYzMGNJT53s4nwr0oo9ocYTImS09xOlUnw==",
       "dev": true,
       "requires": {
-        "merge-stream": "^1.0.1"
+        "merge-stream": "1.0.1"
       }
     },
     "jison": {
@@ -15189,10 +14666,10 @@
         "JSONSelect": "0.4.0",
         "cjson": "0.3.0",
         "ebnf-parser": "0.1.10",
-        "escodegen": "1.3.x",
-        "esprima": "1.1.x",
-        "jison-lex": "0.3.x",
-        "lex-parser": "~0.1.3",
+        "escodegen": "1.3.3",
+        "esprima": "1.1.1",
+        "jison-lex": "0.3.4",
+        "lex-parser": "0.1.4",
         "nomnom": "1.5.2"
       },
       "dependencies": {
@@ -15202,10 +14679,10 @@
           "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
           "dev": true,
           "requires": {
-            "esprima": "~1.1.1",
-            "estraverse": "~1.5.0",
-            "esutils": "~1.0.0",
-            "source-map": "~0.1.33"
+            "esprima": "1.1.1",
+            "estraverse": "1.5.1",
+            "esutils": "1.0.0",
+            "source-map": "0.1.43"
           }
         },
         "esprima": {
@@ -15233,7 +14710,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -15244,7 +14721,7 @@
       "integrity": "sha1-gcoo2E+ESZ36jFlNzePYo/Jux6U=",
       "dev": true,
       "requires": {
-        "lex-parser": "0.1.x",
+        "lex-parser": "0.1.4",
         "nomnom": "1.5.2"
       }
     },
@@ -15254,7 +14731,7 @@
       "integrity": "sha1-qR+OIiREJh7zzkMEawJQCeTv1yA=",
       "dev": true,
       "requires": {
-        "jison": "^0.4.15"
+        "jison": "0.4.18"
       }
     },
     "jq-trim": {
@@ -15280,8 +14757,8 @@
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^2.6.0"
+        "argparse": "1.0.10",
+        "esprima": "2.7.3"
       },
       "dependencies": {
         "esprima": {
@@ -15304,32 +14781,32 @@
       "integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
       "dev": true,
       "requires": {
-        "abab": "^1.0.4",
-        "acorn": "^5.3.0",
-        "acorn-globals": "^4.1.0",
-        "array-equal": "^1.0.0",
-        "browser-process-hrtime": "^0.1.2",
-        "content-type-parser": "^1.0.2",
-        "cssom": ">= 0.3.2 < 0.4.0",
-        "cssstyle": ">= 0.2.37 < 0.3.0",
-        "domexception": "^1.0.0",
-        "escodegen": "^1.9.0",
-        "html-encoding-sniffer": "^1.0.2",
-        "left-pad": "^1.2.0",
-        "nwmatcher": "^1.4.3",
+        "abab": "1.0.4",
+        "acorn": "5.5.3",
+        "acorn-globals": "4.1.0",
+        "array-equal": "1.0.0",
+        "browser-process-hrtime": "0.1.2",
+        "content-type-parser": "1.0.2",
+        "cssom": "0.3.2",
+        "cssstyle": "0.2.37",
+        "domexception": "1.0.1",
+        "escodegen": "1.9.1",
+        "html-encoding-sniffer": "1.0.2",
+        "left-pad": "1.2.0",
+        "nwmatcher": "1.4.4",
         "parse5": "4.0.0",
-        "pn": "^1.1.0",
-        "request": "^2.83.0",
-        "request-promise-native": "^1.0.5",
-        "sax": "^1.2.4",
-        "symbol-tree": "^3.2.2",
-        "tough-cookie": "^2.3.3",
-        "w3c-hr-time": "^1.0.1",
-        "webidl-conversions": "^4.0.2",
-        "whatwg-encoding": "^1.0.3",
-        "whatwg-url": "^6.4.0",
-        "ws": "^4.0.0",
-        "xml-name-validator": "^3.0.0"
+        "pn": "1.1.0",
+        "request": "2.85.0",
+        "request-promise-native": "1.0.5",
+        "sax": "1.2.4",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.3.4",
+        "w3c-hr-time": "1.0.1",
+        "webidl-conversions": "4.0.2",
+        "whatwg-encoding": "1.0.3",
+        "whatwg-url": "6.4.0",
+        "ws": "4.1.0",
+        "xml-name-validator": "3.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -15338,10 +14815,10 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "assert-plus": {
@@ -15362,7 +14839,7 @@
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "dev": true,
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "cryptiles": {
@@ -15371,7 +14848,7 @@
           "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
           "dev": true,
           "requires": {
-            "boom": "5.x.x"
+            "boom": "5.2.0"
           },
           "dependencies": {
             "boom": {
@@ -15380,7 +14857,7 @@
               "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
               "dev": true,
               "requires": {
-                "hoek": "4.x.x"
+                "hoek": "4.2.1"
               }
             }
           }
@@ -15391,9 +14868,9 @@
           "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "dev": true,
           "requires": {
-            "asynckit": "^0.4.0",
+            "asynckit": "0.4.0",
             "combined-stream": "1.0.6",
-            "mime-types": "^2.1.12"
+            "mime-types": "2.1.18"
           }
         },
         "har-schema": {
@@ -15408,8 +14885,8 @@
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "dev": true,
           "requires": {
-            "ajv": "^5.1.0",
-            "har-schema": "^2.0.0"
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
           }
         },
         "hawk": {
@@ -15418,10 +14895,10 @@
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
           "dev": true,
           "requires": {
-            "boom": "4.x.x",
-            "cryptiles": "3.x.x",
-            "hoek": "4.x.x",
-            "sntp": "2.x.x"
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.1",
+            "sntp": "2.1.0"
           }
         },
         "hoek": {
@@ -15436,9 +14913,9 @@
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.1"
           }
         },
         "parse5": {
@@ -15465,28 +14942,28 @@
           "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "hawk": "~6.0.2",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "stringstream": "~0.0.5",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
           }
         },
         "sntp": {
@@ -15495,7 +14972,7 @@
           "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
           "dev": true,
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         }
       }
@@ -15540,7 +15017,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -15566,7 +15043,7 @@
       "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "jsonfilter": {
@@ -15575,10 +15052,10 @@
       "integrity": "sha1-Ie987cdRk4E8dZMulqmL4gW6WhE=",
       "dev": true,
       "requires": {
-        "JSONStream": "^0.8.4",
-        "minimist": "^1.1.0",
-        "stream-combiner": "^0.2.1",
-        "through2": "^0.6.3"
+        "JSONStream": "0.8.4",
+        "minimist": "1.2.0",
+        "stream-combiner": "0.2.2",
+        "through2": "0.6.5"
       },
       "dependencies": {
         "JSONStream": {
@@ -15588,7 +15065,7 @@
           "dev": true,
           "requires": {
             "jsonparse": "0.0.5",
-            "through": ">=2.2.7 <3"
+            "through": "2.3.8"
           }
         },
         "jsonparse": {
@@ -15603,8 +15080,8 @@
           "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
           "dev": true,
           "requires": {
-            "duplexer": "~0.1.1",
-            "through": "~2.3.4"
+            "duplexer": "0.1.1",
+            "through": "2.3.8"
           }
         }
       }
@@ -15620,8 +15097,8 @@
       "integrity": "sha1-iKpGvCiaesk7tGyuLVihh6m7SUo=",
       "dev": true,
       "requires": {
-        "JSV": ">= 4.0.x",
-        "nomnom": ">= 1.5.x"
+        "JSV": "4.0.2",
+        "nomnom": "1.5.2"
       }
     },
     "jsonparse": {
@@ -15671,10 +15148,10 @@
       "integrity": "sha1-NSGkZskN1yfHj9CXGFECrj8EjVk=",
       "dev": true,
       "requires": {
-        "commander": "^2.12.2",
-        "fs-readdir-recursive": "^1.1.0",
-        "mkdirp": "^0.5.1",
-        "xmldoc": "^1.1.0"
+        "commander": "2.15.1",
+        "fs-readdir-recursive": "1.1.0",
+        "mkdirp": "0.5.1",
+        "xmldoc": "1.1.0"
       }
     },
     "kew": {
@@ -15695,15 +15172,16 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.9"
+        "graceful-fs": "4.1.11"
       }
     },
     "know-your-http-well": {
@@ -15712,7 +15190,7 @@
       "integrity": "sha1-E5IhCQtfl2JE6Xyq4RYUOYOdr+8=",
       "dev": true,
       "requires": {
-        "amdefine": "~0.0.4"
+        "amdefine": "0.0.8"
       },
       "dependencies": {
         "amdefine": {
@@ -15740,7 +15218,7 @@
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "requires": {
-        "package-json": "^4.0.0"
+        "package-json": "4.0.1"
       }
     },
     "lazy-ass": {
@@ -15767,7 +15245,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.5"
+        "readable-stream": "2.3.5"
       },
       "dependencies": {
         "isarray": {
@@ -15782,13 +15260,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -15797,7 +15275,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -15808,7 +15286,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "ldjson-stream": {
@@ -15817,8 +15295,8 @@
       "integrity": "sha1-kb7O2lrE7SsX5kn7d356v6AYnCs=",
       "dev": true,
       "requires": {
-        "split2": "^0.2.1",
-        "through2": "^0.6.1"
+        "split2": "0.2.1",
+        "through2": "0.6.5"
       },
       "dependencies": {
         "split2": {
@@ -15827,7 +15305,7 @@
           "integrity": "sha1-At2smtwD7Au3jBKC7Aecpuha6QA=",
           "dev": true,
           "requires": {
-            "through2": "~0.6.1"
+            "through2": "0.6.5"
           }
         }
       }
@@ -15844,14 +15322,14 @@
       "integrity": "sha1-ZY4B7JrDFJlZxrbfvPvAoXCv2no=",
       "dev": true,
       "requires": {
-        "errno": "^0.1.1",
-        "graceful-fs": "^4.1.2",
-        "image-size": "~0.4.0",
-        "mime": "^1.2.11",
-        "mkdirp": "^0.5.0",
-        "promise": "^7.1.1",
-        "request": "^2.51.0",
-        "source-map": "^0.5.3"
+        "errno": "0.1.7",
+        "graceful-fs": "4.1.11",
+        "image-size": "0.4.0",
+        "mime": "1.3.4",
+        "mkdirp": "0.5.1",
+        "promise": "7.3.1",
+        "request": "2.81.0",
+        "source-map": "0.5.7"
       }
     },
     "less-color-lighten": {
@@ -15865,9 +15343,9 @@
       "integrity": "sha1-rhVadAbKxqzSk9eFWH/P8PR4xN0=",
       "dev": true,
       "requires": {
-        "clone": "^2.1.1",
-        "loader-utils": "^1.1.0",
-        "pify": "^2.3.0"
+        "clone": "2.1.2",
+        "loader-utils": "1.1.0",
+        "pify": "2.3.0"
       },
       "dependencies": {
         "clone": {
@@ -15882,9 +15360,9 @@
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         }
       }
@@ -15901,8 +15379,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "lex-parser": {
@@ -15917,12 +15395,12 @@
       "integrity": "sha1-EHsCIRdHkMH+GZWHy22PoVVkybs=",
       "dev": true,
       "requires": {
-        "chalk": "~0.5.1",
-        "debug": "^2.2.0",
-        "mkdirp": "^0.3.5",
-        "nopt": "^2.2.0",
-        "read-installed": "~4.0.3",
-        "treeify": "^1.0.1"
+        "chalk": "0.5.1",
+        "debug": "2.6.9",
+        "mkdirp": "0.3.5",
+        "nopt": "2.2.1",
+        "read-installed": "4.0.3",
+        "treeify": "1.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -15943,11 +15421,11 @@
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^1.1.0",
-            "escape-string-regexp": "^1.0.0",
-            "has-ansi": "^0.1.0",
-            "strip-ansi": "^0.3.0",
-            "supports-color": "^0.2.0"
+            "ansi-styles": "1.1.0",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "0.1.0",
+            "strip-ansi": "0.3.0",
+            "supports-color": "0.2.0"
           }
         },
         "has-ansi": {
@@ -15956,7 +15434,7 @@
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.0"
+            "ansi-regex": "0.2.1"
           }
         },
         "mkdirp": {
@@ -15971,7 +15449,7 @@
           "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
           "dev": true,
           "requires": {
-            "abbrev": "1"
+            "abbrev": "1.1.1"
           }
         },
         "strip-ansi": {
@@ -15980,7 +15458,7 @@
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.1"
+            "ansi-regex": "0.2.1"
           }
         },
         "supports-color": {
@@ -15997,14 +15475,14 @@
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "dev": true,
       "requires": {
-        "extend": "^3.0.0",
-        "findup-sync": "^2.0.0",
-        "fined": "^1.0.1",
-        "flagged-respawn": "^1.0.0",
-        "is-plain-object": "^2.0.4",
-        "object.map": "^1.0.0",
-        "rechoir": "^0.6.2",
-        "resolve": "^1.1.7"
+        "extend": "3.0.1",
+        "findup-sync": "2.0.0",
+        "fined": "1.1.0",
+        "flagged-respawn": "1.0.0",
+        "is-plain-object": "2.0.4",
+        "object.map": "1.0.1",
+        "rechoir": "0.6.2",
+        "resolve": "1.6.0"
       }
     },
     "listr": {
@@ -16013,22 +15491,22 @@
       "integrity": "sha1-a84sD1YD+klYDqF81qAMwOX6RRo=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "cli-truncate": "^0.2.1",
-        "figures": "^1.7.0",
-        "indent-string": "^2.1.0",
-        "is-promise": "^2.1.0",
-        "is-stream": "^1.1.0",
-        "listr-silent-renderer": "^1.1.1",
-        "listr-update-renderer": "^0.2.0",
-        "listr-verbose-renderer": "^0.4.0",
-        "log-symbols": "^1.0.2",
-        "log-update": "^1.0.2",
-        "ora": "^0.2.3",
-        "p-map": "^1.1.1",
-        "rxjs": "^5.0.0-beta.11",
-        "stream-to-observable": "^0.1.0",
-        "strip-ansi": "^3.0.1"
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.2.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.4.3",
+        "stream-to-observable": "0.1.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "listr-silent-renderer": {
@@ -16043,14 +15521,14 @@
       "integrity": "sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "cli-truncate": "^0.2.1",
-        "elegant-spinner": "^1.0.1",
-        "figures": "^1.7.0",
-        "indent-string": "^3.0.0",
-        "log-symbols": "^1.0.2",
-        "log-update": "^1.0.2",
-        "strip-ansi": "^3.0.1"
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "indent-string": {
@@ -16067,10 +15545,10 @@
       "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "cli-cursor": "^1.0.2",
-        "date-fns": "^1.27.2",
-        "figures": "^1.7.0"
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
       }
     },
     "livereload-js": {
@@ -16085,11 +15563,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -16098,7 +15576,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -16115,10 +15593,10 @@
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
       "dev": true,
       "requires": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0",
-        "object-assign": "^4.0.1"
+        "big.js": "3.2.0",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "object-assign": {
@@ -16141,8 +15619,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -16175,10 +15653,10 @@
       "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
       "dev": true,
       "requires": {
-        "lodash._baseisequal": "^3.0.0",
-        "lodash._bindcallback": "^3.0.0",
-        "lodash.isarray": "^3.0.0",
-        "lodash.pairs": "^3.0.0"
+        "lodash._baseisequal": "3.0.7",
+        "lodash._bindcallback": "3.0.1",
+        "lodash.isarray": "3.0.4",
+        "lodash.pairs": "3.0.1"
       }
     },
     "lodash._basecopy": {
@@ -16192,7 +15670,7 @@
       "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
       "dev": true,
       "requires": {
-        "lodash.keys": "^3.0.0"
+        "lodash.keys": "3.1.2"
       }
     },
     "lodash._baseget": {
@@ -16207,9 +15685,9 @@
       "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
       "dev": true,
       "requires": {
-        "lodash.isarray": "^3.0.0",
-        "lodash.istypedarray": "^3.0.0",
-        "lodash.keys": "^3.0.0"
+        "lodash.isarray": "3.0.4",
+        "lodash.istypedarray": "3.0.6",
+        "lodash.keys": "3.1.2"
       }
     },
     "lodash._basetostring": {
@@ -16273,7 +15751,7 @@
       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
       "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
       "requires": {
-        "lodash._objecttypes": "~2.4.1"
+        "lodash._objecttypes": "2.4.1"
       }
     },
     "lodash._topath": {
@@ -16282,7 +15760,7 @@
       "integrity": "sha1-PsXiYGAU9MuX91X+aRTt2L/ADqw=",
       "dev": true,
       "requires": {
-        "lodash.isarray": "^3.0.0"
+        "lodash.isarray": "3.0.4"
       }
     },
     "lodash.assign": {
@@ -16302,8 +15780,8 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
       "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
       "requires": {
-        "lodash._objecttypes": "~2.4.1",
-        "lodash.keys": "~2.4.1"
+        "lodash._objecttypes": "2.4.1",
+        "lodash.keys": "2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -16311,9 +15789,9 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         }
       }
@@ -16329,7 +15807,7 @@
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "requires": {
-        "lodash._root": "^3.0.0"
+        "lodash._root": "3.0.1"
       }
     },
     "lodash.find": {
@@ -16376,7 +15854,7 @@
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
       "requires": {
-        "lodash._objecttypes": "~2.4.1"
+        "lodash._objecttypes": "2.4.1"
       }
     },
     "lodash.istypedarray": {
@@ -16396,9 +15874,9 @@
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "lodash.map": {
@@ -16407,11 +15885,11 @@
       "integrity": "sha1-tIOs0beGxce0ksSV97UmYim8AMI=",
       "dev": true,
       "requires": {
-        "lodash._arraymap": "^3.0.0",
-        "lodash._basecallback": "^3.0.0",
-        "lodash._baseeach": "^3.0.0",
-        "lodash.isarray": "^3.0.0",
-        "lodash.keys": "^3.0.0"
+        "lodash._arraymap": "3.0.0",
+        "lodash._basecallback": "3.3.1",
+        "lodash._baseeach": "3.0.4",
+        "lodash.isarray": "3.0.4",
+        "lodash.keys": "3.1.2"
       }
     },
     "lodash.memoize": {
@@ -16450,7 +15928,7 @@
       "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
       "dev": true,
       "requires": {
-        "lodash.keys": "^3.0.0"
+        "lodash.keys": "3.1.2"
       }
     },
     "lodash.pick": {
@@ -16465,10 +15943,10 @@
       "integrity": "sha1-s0fwN0wBafDusE1nLYnOyGMsIjE=",
       "dev": true,
       "requires": {
-        "lodash._baseget": "^3.0.0",
-        "lodash._topath": "^3.0.0",
-        "lodash.isarray": "^3.0.0",
-        "lodash.map": "^3.0.0"
+        "lodash._baseget": "3.7.2",
+        "lodash._topath": "3.8.1",
+        "lodash.isarray": "3.0.4",
+        "lodash.map": "3.1.4"
       }
     },
     "lodash.restparam": {
@@ -16499,15 +15977,15 @@
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash._basetostring": "^3.0.0",
-        "lodash._basevalues": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0",
-        "lodash.keys": "^3.0.0",
-        "lodash.restparam": "^3.0.0",
-        "lodash.templatesettings": "^3.0.0"
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
       }
     },
     "lodash.templatesettings": {
@@ -16515,8 +15993,8 @@
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
       }
     },
     "lodash.throttle": {
@@ -16559,7 +16037,7 @@
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0"
+        "chalk": "1.1.3"
       }
     },
     "log-update": {
@@ -16568,8 +16046,8 @@
       "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^1.0.0",
-        "cli-cursor": "^1.0.2"
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
       }
     },
     "logalot": {
@@ -16578,8 +16056,8 @@
       "integrity": "sha1-X46MkNME7fElMJUaVVSruMXj9VI=",
       "dev": true,
       "requires": {
-        "figures": "^1.3.5",
-        "squeak": "^1.0.0"
+        "figures": "1.7.0",
+        "squeak": "1.3.0"
       }
     },
     "loglevel": {
@@ -16605,7 +16083,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "loud-rejection": {
@@ -16614,8 +16092,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lower-case": {
@@ -16630,7 +16108,7 @@
       "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.2"
+        "lower-case": "1.1.4"
       }
     },
     "lowercase-keys": {
@@ -16645,10 +16123,10 @@
       "integrity": "sha1-IfYArBwwlcPG5JfuZyce4ISB/p4=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1",
-        "indent-string": "^2.1.0",
-        "longest": "^1.0.0",
-        "meow": "^3.3.0"
+        "get-stdin": "4.0.1",
+        "indent-string": "2.1.0",
+        "longest": "1.0.1",
+        "meow": "3.7.0"
       },
       "dependencies": {
         "get-stdin": {
@@ -16682,7 +16160,7 @@
       "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -16699,7 +16177,7 @@
       "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.1.0"
+        "kind-of": "3.2.2"
       }
     },
     "makeerror": {
@@ -16708,7 +16186,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.x"
+        "tmpl": "1.0.4"
       }
     },
     "map-cache": {
@@ -16735,7 +16213,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "marked": {
@@ -16755,9 +16233,9 @@
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.1.0.tgz",
       "integrity": "sha1-IuyS8zrJem703BbA9X+kbAHtE7s=",
       "requires": {
-        "charenc": "~0.0.1",
-        "crypt": "~0.0.1",
-        "is-buffer": "~1.1.1"
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "1.1.6"
       }
     },
     "md5.js": {
@@ -16766,8 +16244,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "media-typer": {
@@ -16782,7 +16260,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "memoize-one": {
@@ -16797,8 +16275,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
+        "errno": "0.1.7",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "isarray": {
@@ -16813,13 +16291,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -16828,7 +16306,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -16839,16 +16317,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       },
       "dependencies": {
         "object-assign": {
@@ -16877,7 +16355,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.5"
       },
       "dependencies": {
         "isarray": {
@@ -16892,13 +16370,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -16907,7 +16385,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -16917,11 +16395,11 @@
       "resolved": "https://registry.npmjs.org/mesosphere-react-typeahead/-/mesosphere-react-typeahead-0.8.3.tgz",
       "integrity": "sha1-SQHMO5xSdytbwWpYzz4bgDOUWKk=",
       "requires": {
-        "classnames": "^2.2.0",
-        "lodash": "^4.14.0",
-        "react-highlighter": "^0.3.3",
-        "react-input-autosize": "^1.1.0",
-        "react-onclickoutside": "^5.3.3"
+        "classnames": "2.2.3",
+        "lodash": "4.17.5",
+        "react-highlighter": "0.3.5",
+        "react-input-autosize": "1.2.0",
+        "react-onclickoutside": "5.11.1"
       },
       "dependencies": {
         "lodash": {
@@ -16936,7 +16414,7 @@
       "resolved": "https://registry.npmjs.org/mesosphere-shared-reactjs/-/mesosphere-shared-reactjs-0.0.24.tgz",
       "integrity": "sha1-OnSVlGERBoD4mW0Ot5zf2Bpy4lw=",
       "requires": {
-        "reqwest": "^2.0.5"
+        "reqwest": "2.0.5"
       }
     },
     "method-override": {
@@ -16946,9 +16424,9 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "methods": "~1.1.2",
-        "parseurl": "~1.3.2",
-        "vary": "~1.1.2"
+        "methods": "1.1.2",
+        "parseurl": "1.3.2",
+        "vary": "1.1.2"
       },
       "dependencies": {
         "vary": {
@@ -16971,19 +16449,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       }
     },
     "miller-rabin": {
@@ -16992,8 +16470,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
       }
     },
     "mime": {
@@ -17011,7 +16489,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.33.0"
       }
     },
     "mimic-fn": {
@@ -17032,7 +16510,7 @@
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "dev": true,
       "requires": {
-        "dom-walk": "^0.1.0"
+        "dom-walk": "0.1.1"
       }
     },
     "minimalistic-assert": {
@@ -17052,8 +16530,8 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
       "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
       "requires": {
-        "lru-cache": "2",
-        "sigmund": "~1.0.0"
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
       }
     },
     "minimist": {
@@ -17067,8 +16545,8 @@
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
+        "arrify": "1.0.1",
+        "is-plain-obj": "1.1.0"
       }
     },
     "mississippi": {
@@ -17077,16 +16555,16 @@
       "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.5.0",
-        "duplexify": "^3.4.2",
-        "end-of-stream": "^1.1.0",
-        "flush-write-stream": "^1.0.0",
-        "from2": "^2.1.0",
-        "parallel-transform": "^1.1.0",
-        "pump": "^2.0.1",
-        "pumpify": "^1.3.3",
-        "stream-each": "^1.1.0",
-        "through2": "^2.0.0"
+        "concat-stream": "1.6.1",
+        "duplexify": "3.5.4",
+        "end-of-stream": "1.4.1",
+        "flush-write-stream": "1.0.3",
+        "from2": "2.3.0",
+        "parallel-transform": "1.1.0",
+        "pump": "2.0.1",
+        "pumpify": "1.4.0",
+        "stream-each": "1.2.2",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "end-of-stream": {
@@ -17095,7 +16573,7 @@
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           }
         },
         "isarray": {
@@ -17110,13 +16588,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -17125,7 +16603,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "through2": {
@@ -17134,8 +16612,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -17146,8 +16624,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -17156,7 +16634,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -17199,11 +16677,11 @@
       "integrity": "sha1-X9gYOYxoGcuiinzWZk8pL+HAu/I=",
       "dev": true,
       "requires": {
-        "basic-auth": "~1.0.3",
-        "debug": "~2.2.0",
-        "depd": "~1.0.1",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.0.0"
+        "basic-auth": "1.0.4",
+        "debug": "2.2.0",
+        "depd": "1.0.1",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1"
       },
       "dependencies": {
         "debug": {
@@ -17229,12 +16707,12 @@
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.1",
-        "copy-concurrently": "^1.0.0",
-        "fs-write-stream-atomic": "^1.0.8",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.3"
+        "aproba": "1.2.0",
+        "copy-concurrently": "1.0.5",
+        "fs-write-stream-atomic": "1.0.10",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "run-queue": "1.0.3"
       }
     },
     "mozjpeg": {
@@ -17243,9 +16721,9 @@
       "integrity": "sha1-uGccSSRWijY94AP/L9OXq4P3UsU=",
       "dev": true,
       "requires": {
-        "bin-build": "^2.2.0",
-        "bin-wrapper": "^3.0.0",
-        "logalot": "^2.0.0"
+        "bin-build": "2.2.0",
+        "bin-wrapper": "3.0.2",
+        "logalot": "2.1.0"
       }
     },
     "ms": {
@@ -17260,8 +16738,8 @@
       "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
       "dev": true,
       "requires": {
-        "dns-packet": "^1.3.1",
-        "thunky": "^1.0.2"
+        "dns-packet": "1.3.1",
+        "thunky": "1.0.2"
       }
     },
     "multicast-dns-service-types": {
@@ -17276,10 +16754,10 @@
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4"
       },
       "dependencies": {
         "minimatch": {
@@ -17288,7 +16766,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -17299,8 +16777,8 @@
       "integrity": "sha1-Nd5oBNwZZD5SSfPT473GyM4wHT8=",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.1.9",
-        "stream-counter": "~0.2.0"
+        "readable-stream": "1.1.14",
+        "stream-counter": "0.2.0"
       }
     },
     "multipipe": {
@@ -17329,9 +16807,9 @@
       "integrity": "sha1-yLhSHZWN8KTydoAl22nHGe5O8c4=",
       "dev": true,
       "requires": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
+        "any-promise": "1.3.0",
+        "object-assign": "4.1.1",
+        "thenify-all": "1.6.0"
       },
       "dependencies": {
         "object-assign": {
@@ -17361,18 +16839,18 @@
       "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-odd": "^2.0.0",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -17412,7 +16890,7 @@
       "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
       "dev": true,
       "requires": {
-        "xml-char-classes": "^1.0.0"
+        "xml-char-classes": "1.0.0"
       }
     },
     "nearley": {
@@ -17421,10 +16899,10 @@
       "integrity": "sha512-ioYYogSaZhFlCpRizQgY3UT3G1qFXmHGY/5ozoFE3dMfiCRAeJfh+IPE3/eh9gCZvqLhPCWb4bLt7Bqzo+1mLQ==",
       "dev": true,
       "requires": {
-        "nomnom": "~1.6.2",
-        "railroad-diagrams": "^1.0.0",
+        "nomnom": "1.6.2",
+        "railroad-diagrams": "1.0.0",
         "randexp": "0.4.6",
-        "semver": "^5.4.1"
+        "semver": "5.5.0"
       },
       "dependencies": {
         "colors": {
@@ -17439,8 +16917,8 @@
           "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
           "dev": true,
           "requires": {
-            "colors": "0.5.x",
-            "underscore": "~1.4.4"
+            "colors": "0.5.1",
+            "underscore": "1.4.4"
           }
         },
         "underscore": {
@@ -17480,7 +16958,7 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.1"
+        "lower-case": "1.1.4"
       }
     },
     "node": {
@@ -17489,12 +16967,11 @@
       "integrity": "sha512-3/3EJFUgpaS9LpG6EbbdCKLzaXC5RmvBfRzzv/brvHauqoS9YIrxraAxrW2MkL5mviSGp5x9EHQxwFd9Fh8LnA==",
       "dev": true,
       "requires": {
-        "node-bin-setup": "^1.0.0"
+        "node-bin-setup": "1.0.6"
       },
       "dependencies": {
         "node-darwin-x64": {
-          "version": "8.9.4",
-          "resolved": "https://registry.npmjs.org/node-darwin-x64/-/node-darwin-x64-8.9.4.tgz",
+          "version": "https://registry.npmjs.org/node-darwin-x64/-/node-darwin-x64-8.9.4.tgz",
           "integrity": "sha512-dqVJO+C+UgPHfyZYSXGZ1y+IWVNKkSd/lRDnRzFwPaNvmUKblrti7LysmkQ5/H8CtY1v/BGzfD7j+uKhYGGozg=="
         }
       }
@@ -17510,8 +16987,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
       }
     },
     "node-forge": {
@@ -17532,28 +17009,28 @@
       "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "dev": true,
       "requires": {
-        "assert": "^1.1.1",
-        "browserify-zlib": "^0.2.0",
-        "buffer": "^4.3.0",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "^1.0.0",
-        "crypto-browserify": "^3.11.0",
-        "domain-browser": "^1.1.1",
-        "events": "^1.0.0",
-        "https-browserify": "^1.0.0",
-        "os-browserify": "^0.3.0",
+        "assert": "1.4.1",
+        "browserify-zlib": "0.2.0",
+        "buffer": "4.9.1",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.12.0",
+        "domain-browser": "1.2.0",
+        "events": "1.1.1",
+        "https-browserify": "1.0.0",
+        "os-browserify": "0.3.0",
         "path-browserify": "0.0.0",
-        "process": "^0.11.10",
-        "punycode": "^1.2.4",
-        "querystring-es3": "^0.2.0",
-        "readable-stream": "^2.3.3",
-        "stream-browserify": "^2.0.1",
-        "stream-http": "^2.7.2",
-        "string_decoder": "^1.0.0",
-        "timers-browserify": "^2.0.4",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.3.6",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.8.1",
+        "string_decoder": "1.1.1",
+        "timers-browserify": "2.0.10",
         "tty-browserify": "0.0.0",
-        "url": "^0.11.0",
-        "util": "^0.10.3",
+        "url": "0.11.0",
+        "util": "0.10.3",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -17575,13 +17052,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -17590,7 +17067,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -17607,8 +17084,8 @@
       "integrity": "sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=",
       "dev": true,
       "requires": {
-        "colors": "0.5.x",
-        "underscore": "1.1.x"
+        "colors": "0.5.1",
+        "underscore": "1.1.7"
       },
       "dependencies": {
         "colors": {
@@ -17625,7 +17102,7 @@
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
       "dev": true,
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -17634,10 +17111,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.6.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "normalize-path": {
@@ -17646,7 +17123,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "normalize-range": {
@@ -17667,10 +17144,10 @@
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
       "dev": true,
       "requires": {
-        "object-assign": "^4.0.1",
-        "prepend-http": "^1.0.0",
-        "query-string": "^4.1.0",
-        "sort-keys": "^1.0.0"
+        "object-assign": "4.1.1",
+        "prepend-http": "1.0.4",
+        "query-string": "4.1.0",
+        "sort-keys": "1.1.2"
       },
       "dependencies": {
         "object-assign": {
@@ -17687,112 +17164,112 @@
       "integrity": "sha512-mt839mCsI5hzdBJLf1iRBwt610P35iUfvqLVuL7VFdanUwRBAmGtbsjdGIuzegplR95xx+fTHE0vBMuMJp1sLQ==",
       "dev": true,
       "requires": {
-        "JSONStream": "~1.3.1",
-        "abbrev": "~1.1.1",
-        "ansi-regex": "~3.0.0",
-        "ansicolors": "~0.3.2",
-        "ansistyles": "~0.1.3",
-        "aproba": "~1.2.0",
-        "archy": "~1.0.0",
-        "bin-links": "^1.1.0",
-        "bluebird": "~3.5.1",
-        "cacache": "~10.0.1",
-        "call-limit": "~1.1.0",
-        "chownr": "~1.0.1",
-        "cli-table2": "~0.2.0",
-        "cmd-shim": "~2.0.2",
-        "columnify": "~1.5.4",
-        "config-chain": "~1.1.11",
-        "debuglog": "*",
-        "detect-indent": "~5.0.0",
-        "dezalgo": "~1.0.3",
-        "editor": "~1.0.0",
-        "find-npm-prefix": "~1.0.1",
-        "fs-vacuum": "~1.2.10",
-        "fs-write-stream-atomic": "~1.0.10",
-        "gentle-fs": "^2.0.1",
-        "glob": "~7.1.2",
-        "graceful-fs": "~4.1.11",
-        "has-unicode": "~2.0.1",
-        "hosted-git-info": "~2.5.0",
-        "iferr": "~0.1.5",
-        "imurmurhash": "*",
-        "inflight": "~1.0.6",
-        "inherits": "~2.0.3",
-        "ini": "~1.3.4",
-        "init-package-json": "~1.10.1",
-        "is-cidr": "~1.0.0",
-        "lazy-property": "~1.0.0",
-        "libnpx": "~9.7.1",
-        "lockfile": "~1.0.3",
-        "lodash._baseindexof": "*",
-        "lodash._baseuniq": "~4.6.0",
-        "lodash._bindcallback": "*",
-        "lodash._cacheindexof": "*",
-        "lodash._createcache": "*",
-        "lodash._getnative": "*",
-        "lodash.clonedeep": "~4.5.0",
-        "lodash.restparam": "*",
-        "lodash.union": "~4.6.0",
-        "lodash.uniq": "~4.5.0",
-        "lodash.without": "~4.4.0",
-        "lru-cache": "~4.1.1",
-        "meant": "~1.0.1",
-        "mississippi": "~1.3.0",
-        "mkdirp": "~0.5.1",
-        "move-concurrently": "^1.0.1",
-        "nopt": "~4.0.1",
-        "normalize-package-data": "~2.4.0",
-        "npm-cache-filename": "~1.0.2",
-        "npm-install-checks": "~3.0.0",
-        "npm-lifecycle": "~2.0.0",
-        "npm-package-arg": "~6.0.0",
-        "npm-packlist": "~1.1.10",
-        "npm-profile": "~2.0.5",
-        "npm-registry-client": "~8.5.0",
-        "npm-user-validate": "~1.0.0",
-        "npmlog": "~4.1.2",
-        "once": "~1.4.0",
-        "opener": "~1.4.3",
-        "osenv": "~0.1.4",
-        "pacote": "^7.0.2",
-        "path-is-inside": "~1.0.2",
-        "promise-inflight": "~1.0.1",
-        "qrcode-terminal": "~0.11.0",
-        "query-string": "~5.0.1",
-        "qw": "~1.0.1",
-        "read": "~1.0.7",
-        "read-cmd-shim": "~1.0.1",
-        "read-installed": "~4.0.3",
-        "read-package-json": "~2.0.12",
-        "read-package-tree": "~5.1.6",
-        "readable-stream": "~2.3.3",
-        "readdir-scoped-modules": "*",
-        "request": "~2.83.0",
-        "retry": "~0.10.1",
-        "rimraf": "~2.6.2",
-        "safe-buffer": "~5.1.1",
-        "semver": "~5.4.1",
-        "sha": "~2.0.1",
-        "slide": "~1.1.6",
-        "sorted-object": "~2.0.1",
-        "sorted-union-stream": "~2.1.3",
-        "ssri": "~5.0.0",
-        "strip-ansi": "~4.0.0",
-        "tar": "^4.0.2",
-        "text-table": "~0.2.0",
+        "JSONStream": "1.3.1",
+        "abbrev": "1.1.1",
+        "ansi-regex": "3.0.0",
+        "ansicolors": "0.3.2",
+        "ansistyles": "0.1.3",
+        "aproba": "1.2.0",
+        "archy": "1.0.0",
+        "bin-links": "1.1.0",
+        "bluebird": "3.5.1",
+        "cacache": "10.0.1",
+        "call-limit": "1.1.0",
+        "chownr": "1.0.1",
+        "cli-table2": "0.2.0",
+        "cmd-shim": "2.0.2",
+        "columnify": "1.5.4",
+        "config-chain": "1.1.11",
+        "debuglog": "1.0.1",
+        "detect-indent": "5.0.0",
+        "dezalgo": "1.0.3",
+        "editor": "1.0.0",
+        "find-npm-prefix": "1.0.1",
+        "fs-vacuum": "1.2.10",
+        "fs-write-stream-atomic": "1.0.10",
+        "gentle-fs": "2.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "has-unicode": "2.0.1",
+        "hosted-git-info": "2.5.0",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "ini": "1.3.4",
+        "init-package-json": "1.10.1",
+        "is-cidr": "1.0.0",
+        "lazy-property": "1.0.0",
+        "libnpx": "9.7.1",
+        "lockfile": "1.0.3",
+        "lodash._baseindexof": "3.1.0",
+        "lodash._baseuniq": "4.6.0",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2",
+        "lodash._getnative": "3.9.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.restparam": "3.6.1",
+        "lodash.union": "4.6.0",
+        "lodash.uniq": "4.5.0",
+        "lodash.without": "4.4.0",
+        "lru-cache": "4.1.1",
+        "meant": "1.0.1",
+        "mississippi": "1.3.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "nopt": "4.0.1",
+        "normalize-package-data": "2.4.0",
+        "npm-cache-filename": "1.0.2",
+        "npm-install-checks": "3.0.0",
+        "npm-lifecycle": "2.0.0",
+        "npm-package-arg": "6.0.0",
+        "npm-packlist": "1.1.10",
+        "npm-profile": "2.0.5",
+        "npm-registry-client": "8.5.0",
+        "npm-user-validate": "1.0.0",
+        "npmlog": "4.1.2",
+        "once": "1.4.0",
+        "opener": "1.4.3",
+        "osenv": "0.1.4",
+        "pacote": "7.0.2",
+        "path-is-inside": "1.0.2",
+        "promise-inflight": "1.0.1",
+        "qrcode-terminal": "0.11.0",
+        "query-string": "5.0.1",
+        "qw": "1.0.1",
+        "read": "1.0.7",
+        "read-cmd-shim": "1.0.1",
+        "read-installed": "4.0.3",
+        "read-package-json": "2.0.12",
+        "read-package-tree": "5.1.6",
+        "readable-stream": "2.3.3",
+        "readdir-scoped-modules": "1.0.2",
+        "request": "2.83.0",
+        "retry": "0.10.1",
+        "rimraf": "2.6.2",
+        "safe-buffer": "5.1.1",
+        "semver": "5.4.1",
+        "sha": "2.0.1",
+        "slide": "1.1.6",
+        "sorted-object": "2.0.1",
+        "sorted-union-stream": "2.1.3",
+        "ssri": "5.0.0",
+        "strip-ansi": "4.0.0",
+        "tar": "4.0.2",
+        "text-table": "0.2.0",
         "uid-number": "0.0.6",
-        "umask": "~1.1.0",
-        "unique-filename": "~1.1.0",
-        "unpipe": "~1.0.0",
-        "update-notifier": "~2.3.0",
-        "uuid": "~3.1.0",
-        "validate-npm-package-license": "*",
-        "validate-npm-package-name": "~3.0.0",
-        "which": "~1.3.0",
-        "worker-farm": "~1.5.1",
-        "wrappy": "~1.0.2",
-        "write-file-atomic": "~2.1.0"
+        "umask": "1.1.0",
+        "unique-filename": "1.1.0",
+        "unpipe": "1.0.0",
+        "update-notifier": "2.3.0",
+        "uuid": "3.1.0",
+        "validate-npm-package-license": "3.0.3",
+        "validate-npm-package-name": "3.0.0",
+        "which": "1.3.0",
+        "worker-farm": "1.5.4",
+        "wrappy": "1.0.2",
+        "write-file-atomic": "2.1.0"
       },
       "dependencies": {
         "JSONStream": {
@@ -17801,8 +17278,8 @@
           "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
           "dev": true,
           "requires": {
-            "jsonparse": "^1.2.0",
-            "through": ">=2.2.7 <3"
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
           },
           "dependencies": {
             "jsonparse": {
@@ -17861,12 +17338,12 @@
           "integrity": "sha512-3desjIEoSt86s+BRZlkLpBPPcHhr4vyUPL/+X1cQuE96NIlkELqnb4Yq+I5gZe47gHsZztA6cm38uMrT9+FWpA==",
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.0",
-            "cmd-shim": "^2.0.2",
-            "fs-write-stream-atomic": "^1.0.10",
-            "gentle-fs": "^2.0.0",
-            "graceful-fs": "^4.1.11",
-            "slide": "^1.1.6"
+            "bluebird": "3.5.1",
+            "cmd-shim": "2.0.2",
+            "fs-write-stream-atomic": "1.0.10",
+            "gentle-fs": "2.0.1",
+            "graceful-fs": "4.1.11",
+            "slide": "1.1.6"
           }
         },
         "bluebird": {
@@ -17881,19 +17358,19 @@
           "integrity": "sha512-dRHYcs9LvG9cHgdPzjiI+/eS7e1xRhULrcyOx04RZQsszNJXU2SL9CyG60yLnge282Qq5nwTv+ieK2fH+WPZmA==",
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.0",
-            "chownr": "^1.0.1",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "lru-cache": "^4.1.1",
-            "mississippi": "^1.3.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.1",
-            "ssri": "^5.0.0",
-            "unique-filename": "^1.1.0",
-            "y18n": "^3.2.1"
+            "bluebird": "3.5.1",
+            "chownr": "1.0.1",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "lru-cache": "4.1.1",
+            "mississippi": "1.3.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "promise-inflight": "1.0.1",
+            "rimraf": "2.6.2",
+            "ssri": "5.0.0",
+            "unique-filename": "1.1.0",
+            "y18n": "3.2.1"
           },
           "dependencies": {
             "ssri": {
@@ -17902,7 +17379,7 @@
               "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
               "dev": true,
               "requires": {
-                "safe-buffer": "^5.1.0"
+                "safe-buffer": "5.1.1"
               }
             },
             "y18n": {
@@ -17931,9 +17408,9 @@
           "integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
           "dev": true,
           "requires": {
-            "colors": "^1.1.2",
-            "lodash": "^3.10.1",
-            "string-width": "^1.0.1"
+            "colors": "1.1.2",
+            "lodash": "3.10.1",
+            "string-width": "1.0.2"
           },
           "dependencies": {
             "colors": {
@@ -17955,9 +17432,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               },
               "dependencies": {
                 "code-point-at": {
@@ -17972,7 +17449,7 @@
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
                   "requires": {
-                    "number-is-nan": "^1.0.0"
+                    "number-is-nan": "1.0.1"
                   },
                   "dependencies": {
                     "number-is-nan": {
@@ -17989,7 +17466,7 @@
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
-                    "ansi-regex": "^2.0.0"
+                    "ansi-regex": "2.1.1"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -18010,8 +17487,8 @@
           "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "mkdirp": "~0.5.0"
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1"
           }
         },
         "columnify": {
@@ -18020,8 +17497,8 @@
           "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "dev": true,
           "requires": {
-            "strip-ansi": "^3.0.0",
-            "wcwidth": "^1.0.0"
+            "strip-ansi": "3.0.1",
+            "wcwidth": "1.0.1"
           },
           "dependencies": {
             "strip-ansi": {
@@ -18030,7 +17507,7 @@
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -18047,7 +17524,7 @@
               "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
               "dev": true,
               "requires": {
-                "defaults": "^1.0.3"
+                "defaults": "1.0.3"
               },
               "dependencies": {
                 "defaults": {
@@ -18056,7 +17533,7 @@
                   "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
                   "dev": true,
                   "requires": {
-                    "clone": "^1.0.2"
+                    "clone": "1.0.2"
                   },
                   "dependencies": {
                     "clone": {
@@ -18077,8 +17554,8 @@
           "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
           "dev": true,
           "requires": {
-            "ini": "^1.3.4",
-            "proto-list": "~1.2.1"
+            "ini": "1.3.4",
+            "proto-list": "1.2.4"
           },
           "dependencies": {
             "proto-list": {
@@ -18107,8 +17584,8 @@
           "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
           "dev": true,
           "requires": {
-            "asap": "^2.0.0",
-            "wrappy": "1"
+            "asap": "2.0.5",
+            "wrappy": "1.0.2"
           },
           "dependencies": {
             "asap": {
@@ -18137,9 +17614,9 @@
           "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "path-is-inside": "^1.0.1",
-            "rimraf": "^2.5.2"
+            "graceful-fs": "4.1.11",
+            "path-is-inside": "1.0.2",
+            "rimraf": "2.6.2"
           }
         },
         "fs-write-stream-atomic": {
@@ -18148,10 +17625,10 @@
           "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "iferr": "^0.1.5",
-            "imurmurhash": "^0.1.4",
-            "readable-stream": "1 || 2"
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.3.3"
           }
         },
         "gentle-fs": {
@@ -18160,14 +17637,14 @@
           "integrity": "sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==",
           "dev": true,
           "requires": {
-            "aproba": "^1.1.2",
-            "fs-vacuum": "^1.2.10",
-            "graceful-fs": "^4.1.11",
-            "iferr": "^0.1.5",
-            "mkdirp": "^0.5.1",
-            "path-is-inside": "^1.0.2",
-            "read-cmd-shim": "^1.0.1",
-            "slide": "^1.1.6"
+            "aproba": "1.2.0",
+            "fs-vacuum": "1.2.10",
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "mkdirp": "0.5.1",
+            "path-is-inside": "1.0.2",
+            "read-cmd-shim": "1.0.1",
+            "slide": "1.1.6"
           }
         },
         "glob": {
@@ -18176,12 +17653,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           },
           "dependencies": {
             "fs.realpath": {
@@ -18196,7 +17673,7 @@
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.8"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -18205,7 +17682,7 @@
                   "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                   "dev": true,
                   "requires": {
-                    "balanced-match": "^1.0.0",
+                    "balanced-match": "1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -18269,8 +17746,8 @@
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -18291,14 +17768,14 @@
           "integrity": "sha1-zYc6FneWvvuZYSsodioLY5P9j2o=",
           "dev": true,
           "requires": {
-            "glob": "^7.1.1",
-            "npm-package-arg": "^4.0.0 || ^5.0.0",
-            "promzard": "^0.3.0",
-            "read": "~1.0.1",
-            "read-package-json": "1 || 2",
-            "semver": "2.x || 3.x || 4 || 5",
-            "validate-npm-package-license": "^3.0.1",
-            "validate-npm-package-name": "^3.0.0"
+            "glob": "7.1.2",
+            "npm-package-arg": "5.1.2",
+            "promzard": "0.3.0",
+            "read": "1.0.7",
+            "read-package-json": "2.0.12",
+            "semver": "5.4.1",
+            "validate-npm-package-license": "3.0.3",
+            "validate-npm-package-name": "3.0.0"
           },
           "dependencies": {
             "npm-package-arg": {
@@ -18307,10 +17784,10 @@
               "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
               "dev": true,
               "requires": {
-                "hosted-git-info": "^2.4.2",
-                "osenv": "^0.1.4",
-                "semver": "^5.1.0",
-                "validate-npm-package-name": "^3.0.0"
+                "hosted-git-info": "2.5.0",
+                "osenv": "0.1.4",
+                "semver": "5.4.1",
+                "validate-npm-package-name": "3.0.0"
               }
             },
             "promzard": {
@@ -18319,7 +17796,7 @@
               "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
               "dev": true,
               "requires": {
-                "read": "1"
+                "read": "1.0.7"
               }
             }
           }
@@ -18353,14 +17830,14 @@
           "integrity": "sha512-OktT775uhfL93SoUfERj4ilM3D7c0hyUyALX9oJ2D/yO4Msm5hbkOKHcrOVHXRcEX9ytstviYQAEygFIiDj2bQ==",
           "dev": true,
           "requires": {
-            "dotenv": "^4.0.0",
-            "npm-package-arg": "^5.1.2",
-            "rimraf": "^2.6.1",
-            "safe-buffer": "^5.1.0",
-            "update-notifier": "^2.2.0",
-            "which": "^1.2.14",
-            "y18n": "^3.2.1",
-            "yargs": "^8.0.2"
+            "dotenv": "4.0.0",
+            "npm-package-arg": "5.1.2",
+            "rimraf": "2.6.2",
+            "safe-buffer": "5.1.1",
+            "update-notifier": "2.3.0",
+            "which": "1.3.0",
+            "y18n": "3.2.1",
+            "yargs": "8.0.2"
           },
           "dependencies": {
             "dotenv": {
@@ -18375,10 +17852,10 @@
               "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
               "dev": true,
               "requires": {
-                "hosted-git-info": "^2.4.2",
-                "osenv": "^0.1.4",
-                "semver": "^5.1.0",
-                "validate-npm-package-name": "^3.0.0"
+                "hosted-git-info": "2.5.0",
+                "osenv": "0.1.4",
+                "semver": "5.4.1",
+                "validate-npm-package-name": "3.0.0"
               }
             },
             "y18n": {
@@ -18393,19 +17870,19 @@
               "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
               "dev": true,
               "requires": {
-                "camelcase": "^4.1.0",
-                "cliui": "^3.2.0",
-                "decamelize": "^1.1.1",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^2.0.0",
-                "read-pkg-up": "^2.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^7.0.0"
+                "camelcase": "4.1.0",
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "read-pkg-up": "2.0.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "7.0.0"
               },
               "dependencies": {
                 "camelcase": {
@@ -18420,9 +17897,9 @@
                   "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                   "dev": true,
                   "requires": {
-                    "string-width": "^1.0.1",
-                    "strip-ansi": "^3.0.1",
-                    "wrap-ansi": "^2.0.0"
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wrap-ansi": "2.1.0"
                   },
                   "dependencies": {
                     "string-width": {
@@ -18431,9 +17908,9 @@
                       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
                       "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                       },
                       "dependencies": {
                         "code-point-at": {
@@ -18448,7 +17925,7 @@
                           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "dev": true,
                           "requires": {
-                            "number-is-nan": "^1.0.0"
+                            "number-is-nan": "1.0.1"
                           },
                           "dependencies": {
                             "number-is-nan": {
@@ -18467,7 +17944,7 @@
                       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -18484,8 +17961,8 @@
                       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
                       "dev": true,
                       "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1"
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1"
                       }
                     }
                   }
@@ -18508,9 +17985,9 @@
                   "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                   "dev": true,
                   "requires": {
-                    "execa": "^0.7.0",
-                    "lcid": "^1.0.0",
-                    "mem": "^1.1.0"
+                    "execa": "0.7.0",
+                    "lcid": "1.0.0",
+                    "mem": "1.1.0"
                   },
                   "dependencies": {
                     "execa": {
@@ -18519,13 +17996,13 @@
                       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                       "dev": true,
                       "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
                       },
                       "dependencies": {
                         "cross-spawn": {
@@ -18534,9 +18011,9 @@
                           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                           "dev": true,
                           "requires": {
-                            "lru-cache": "^4.0.1",
-                            "shebang-command": "^1.2.0",
-                            "which": "^1.2.9"
+                            "lru-cache": "4.1.1",
+                            "shebang-command": "1.2.0",
+                            "which": "1.3.0"
                           },
                           "dependencies": {
                             "shebang-command": {
@@ -18545,7 +18022,7 @@
                               "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
                               "dev": true,
                               "requires": {
-                                "shebang-regex": "^1.0.0"
+                                "shebang-regex": "1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
@@ -18576,7 +18053,7 @@
                           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
                           "dev": true,
                           "requires": {
-                            "path-key": "^2.0.0"
+                            "path-key": "2.0.1"
                           },
                           "dependencies": {
                             "path-key": {
@@ -18613,7 +18090,7 @@
                       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                       "dev": true,
                       "requires": {
-                        "invert-kv": "^1.0.0"
+                        "invert-kv": "1.0.0"
                       },
                       "dependencies": {
                         "invert-kv": {
@@ -18630,7 +18107,7 @@
                       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
                       "dev": true,
                       "requires": {
-                        "mimic-fn": "^1.0.0"
+                        "mimic-fn": "1.1.0"
                       },
                       "dependencies": {
                         "mimic-fn": {
@@ -18649,8 +18126,8 @@
                   "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
                   "dev": true,
                   "requires": {
-                    "find-up": "^2.0.0",
-                    "read-pkg": "^2.0.0"
+                    "find-up": "2.1.0",
+                    "read-pkg": "2.0.0"
                   },
                   "dependencies": {
                     "find-up": {
@@ -18659,7 +18136,7 @@
                       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                       "dev": true,
                       "requires": {
-                        "locate-path": "^2.0.0"
+                        "locate-path": "2.0.0"
                       },
                       "dependencies": {
                         "locate-path": {
@@ -18668,8 +18145,8 @@
                           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
                           "dev": true,
                           "requires": {
-                            "p-locate": "^2.0.0",
-                            "path-exists": "^3.0.0"
+                            "p-locate": "2.0.0",
+                            "path-exists": "3.0.0"
                           },
                           "dependencies": {
                             "p-locate": {
@@ -18678,7 +18155,7 @@
                               "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
                               "dev": true,
                               "requires": {
-                                "p-limit": "^1.1.0"
+                                "p-limit": "1.1.0"
                               },
                               "dependencies": {
                                 "p-limit": {
@@ -18705,9 +18182,9 @@
                       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
                       "dev": true,
                       "requires": {
-                        "load-json-file": "^2.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^2.0.0"
+                        "load-json-file": "2.0.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "2.0.0"
                       },
                       "dependencies": {
                         "load-json-file": {
@@ -18716,10 +18193,10 @@
                           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
                           "dev": true,
                           "requires": {
-                            "graceful-fs": "^4.1.2",
-                            "parse-json": "^2.2.0",
-                            "pify": "^2.0.0",
-                            "strip-bom": "^3.0.0"
+                            "graceful-fs": "4.1.11",
+                            "parse-json": "2.2.0",
+                            "pify": "2.3.0",
+                            "strip-bom": "3.0.0"
                           },
                           "dependencies": {
                             "parse-json": {
@@ -18728,7 +18205,7 @@
                               "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                               "dev": true,
                               "requires": {
-                                "error-ex": "^1.2.0"
+                                "error-ex": "1.3.1"
                               },
                               "dependencies": {
                                 "error-ex": {
@@ -18737,7 +18214,7 @@
                                   "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
                                   "dev": true,
                                   "requires": {
-                                    "is-arrayish": "^0.2.1"
+                                    "is-arrayish": "0.2.1"
                                   },
                                   "dependencies": {
                                     "is-arrayish": {
@@ -18770,7 +18247,7 @@
                           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
                           "dev": true,
                           "requires": {
-                            "pify": "^2.0.0"
+                            "pify": "2.3.0"
                           },
                           "dependencies": {
                             "pify": {
@@ -18809,8 +18286,8 @@
                   "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                   "dev": true,
                   "requires": {
-                    "is-fullwidth-code-point": "^2.0.0",
-                    "strip-ansi": "^4.0.0"
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "4.0.0"
                   },
                   "dependencies": {
                     "is-fullwidth-code-point": {
@@ -18833,7 +18310,7 @@
                   "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
                   "dev": true,
                   "requires": {
-                    "camelcase": "^4.1.0"
+                    "camelcase": "4.1.0"
                   }
                 }
               }
@@ -18858,8 +18335,8 @@
           "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
           "dev": true,
           "requires": {
-            "lodash._createset": "~4.0.0",
-            "lodash._root": "~3.0.0"
+            "lodash._createset": "4.0.3",
+            "lodash._root": "3.0.1"
           },
           "dependencies": {
             "lodash._createset": {
@@ -18894,7 +18371,7 @@
           "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
           "dev": true,
           "requires": {
-            "lodash._getnative": "^3.0.0"
+            "lodash._getnative": "3.9.1"
           }
         },
         "lodash._getnative": {
@@ -18939,8 +18416,8 @@
           "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "dev": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           },
           "dependencies": {
             "pseudomap": {
@@ -18969,16 +18446,16 @@
           "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
           "dev": true,
           "requires": {
-            "concat-stream": "^1.5.0",
-            "duplexify": "^3.4.2",
-            "end-of-stream": "^1.1.0",
-            "flush-write-stream": "^1.0.0",
-            "from2": "^2.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^1.0.0",
-            "pumpify": "^1.3.3",
-            "stream-each": "^1.1.0",
-            "through2": "^2.0.0"
+            "concat-stream": "1.6.0",
+            "duplexify": "3.5.0",
+            "end-of-stream": "1.4.0",
+            "flush-write-stream": "1.0.2",
+            "from2": "2.3.0",
+            "parallel-transform": "1.1.0",
+            "pump": "1.0.2",
+            "pumpify": "1.3.5",
+            "stream-each": "1.2.0",
+            "through2": "2.0.3"
           },
           "dependencies": {
             "concat-stream": {
@@ -18987,9 +18464,9 @@
               "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
               "dev": true,
               "requires": {
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "typedarray": "0.0.6"
               },
               "dependencies": {
                 "typedarray": {
@@ -19007,9 +18484,9 @@
               "dev": true,
               "requires": {
                 "end-of-stream": "1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "stream-shift": "1.0.0"
               },
               "dependencies": {
                 "end-of-stream": {
@@ -19018,7 +18495,7 @@
                   "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
                   "dev": true,
                   "requires": {
-                    "once": "~1.3.0"
+                    "once": "1.3.3"
                   },
                   "dependencies": {
                     "once": {
@@ -19027,7 +18504,7 @@
                       "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                       "dev": true,
                       "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                       }
                     }
                   }
@@ -19046,7 +18523,7 @@
               "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
               "dev": true,
               "requires": {
-                "once": "^1.4.0"
+                "once": "1.4.0"
               }
             },
             "flush-write-stream": {
@@ -19055,8 +18532,8 @@
               "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
               "dev": true,
               "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.4"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
               }
             },
             "from2": {
@@ -19065,8 +18542,8 @@
               "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
               "dev": true,
               "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
               }
             },
             "parallel-transform": {
@@ -19075,9 +18552,9 @@
               "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
               "dev": true,
               "requires": {
-                "cyclist": "~0.2.2",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.1.5"
+                "cyclist": "0.2.2",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
               },
               "dependencies": {
                 "cyclist": {
@@ -19094,8 +18571,8 @@
               "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
               "dev": true,
               "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.0",
+                "once": "1.4.0"
               }
             },
             "pumpify": {
@@ -19104,9 +18581,9 @@
               "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
               "dev": true,
               "requires": {
-                "duplexify": "^3.1.2",
-                "inherits": "^2.0.1",
-                "pump": "^1.0.0"
+                "duplexify": "3.5.0",
+                "inherits": "2.0.3",
+                "pump": "1.0.2"
               }
             },
             "stream-each": {
@@ -19115,8 +18592,8 @@
               "integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE=",
               "dev": true,
               "requires": {
-                "end-of-stream": "^1.1.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.0",
+                "stream-shift": "1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -19133,8 +18610,8 @@
               "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
               "dev": true,
               "requires": {
-                "readable-stream": "^2.1.5",
-                "xtend": "~4.0.1"
+                "readable-stream": "2.3.3",
+                "xtend": "4.0.1"
               },
               "dependencies": {
                 "xtend": {
@@ -19170,12 +18647,12 @@
           "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
           "dev": true,
           "requires": {
-            "aproba": "^1.1.1",
-            "copy-concurrently": "^1.0.0",
-            "fs-write-stream-atomic": "^1.0.8",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.5.4",
-            "run-queue": "^1.0.3"
+            "aproba": "1.2.0",
+            "copy-concurrently": "1.0.5",
+            "fs-write-stream-atomic": "1.0.10",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "run-queue": "1.0.3"
           },
           "dependencies": {
             "copy-concurrently": {
@@ -19184,12 +18661,12 @@
               "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
               "dev": true,
               "requires": {
-                "aproba": "^1.1.1",
-                "fs-write-stream-atomic": "^1.0.8",
-                "iferr": "^0.1.5",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.0"
+                "aproba": "1.2.0",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
               }
             },
             "run-queue": {
@@ -19198,7 +18675,7 @@
               "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
               "dev": true,
               "requires": {
-                "aproba": "^1.1.1"
+                "aproba": "1.2.0"
               }
             }
           }
@@ -19209,19 +18686,19 @@
           "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
           "dev": true,
           "requires": {
-            "fstream": "^1.0.0",
-            "glob": "^7.0.3",
-            "graceful-fs": "^4.1.2",
-            "minimatch": "^3.0.2",
-            "mkdirp": "^0.5.0",
-            "nopt": "2 || 3",
-            "npmlog": "0 || 1 || 2 || 3 || 4",
-            "osenv": "0",
-            "request": "2",
-            "rimraf": "2",
-            "semver": "~5.3.0",
-            "tar": "^2.0.0",
-            "which": "1"
+            "fstream": "1.0.11",
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "4.1.2",
+            "osenv": "0.1.4",
+            "request": "2.83.0",
+            "rimraf": "2.6.2",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "which": "1.3.0"
           },
           "dependencies": {
             "fstream": {
@@ -19230,10 +18707,10 @@
               "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
               "dev": true,
               "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
               }
             },
             "minimatch": {
@@ -19242,7 +18719,7 @@
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.8"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -19251,7 +18728,7 @@
                   "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                   "dev": true,
                   "requires": {
-                    "balanced-match": "^1.0.0",
+                    "balanced-match": "1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -19277,7 +18754,7 @@
               "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
               "dev": true,
               "requires": {
-                "abbrev": "1"
+                "abbrev": "1.1.1"
               }
             },
             "semver": {
@@ -19292,9 +18769,9 @@
               "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "dev": true,
               "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
               },
               "dependencies": {
                 "block-stream": {
@@ -19303,7 +18780,7 @@
                   "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
                   "dev": true,
                   "requires": {
-                    "inherits": "~2.0.0"
+                    "inherits": "2.0.3"
                   }
                 }
               }
@@ -19316,8 +18793,8 @@
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.4"
           }
         },
         "normalize-package-data": {
@@ -19326,10 +18803,10 @@
           "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.4.1",
+            "validate-npm-package-license": "3.0.3"
           },
           "dependencies": {
             "is-builtin-module": {
@@ -19338,7 +18815,7 @@
               "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
               "dev": true,
               "requires": {
-                "builtin-modules": "^1.0.0"
+                "builtin-modules": "1.1.1"
               },
               "dependencies": {
                 "builtin-modules": {
@@ -19363,7 +18840,7 @@
           "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
           "dev": true,
           "requires": {
-            "semver": "^2.3.0 || 3.x || 4 || 5"
+            "semver": "5.4.1"
           }
         },
         "npm-lifecycle": {
@@ -19372,14 +18849,14 @@
           "integrity": "sha512-aE7H012O01GKXT9BWnsGMLVci+MOgkhpSwq02ok20aXcNHxFs7enfampNMkiOV1DJEU0LynzemwdjbtXahXKcw==",
           "dev": true,
           "requires": {
-            "byline": "^5.0.0",
-            "graceful-fs": "^4.1.11",
-            "node-gyp": "^3.6.2",
-            "resolve-from": "^4.0.0",
-            "slide": "^1.1.6",
+            "byline": "5.0.0",
+            "graceful-fs": "4.1.11",
+            "node-gyp": "3.6.2",
+            "resolve-from": "4.0.0",
+            "slide": "1.1.6",
             "uid-number": "0.0.6",
-            "umask": "^1.1.0",
-            "which": "^1.3.0"
+            "umask": "1.1.0",
+            "which": "1.3.0"
           },
           "dependencies": {
             "byline": {
@@ -19402,10 +18879,10 @@
           "integrity": "sha512-hwC7g81KLgRmchv9ol6f3Fx4Yyc9ARX5X5niDHVILgpuvf08JRIgOZcEfpFXli3BgESoTrkauqorXm6UbvSgSg==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "^2.5.0",
-            "osenv": "^0.1.4",
-            "semver": "^5.4.1",
-            "validate-npm-package-name": "^3.0.0"
+            "hosted-git-info": "2.5.0",
+            "osenv": "0.1.4",
+            "semver": "5.4.1",
+            "validate-npm-package-name": "3.0.0"
           }
         },
         "npm-packlist": {
@@ -19414,8 +18891,8 @@
           "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "dev": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           },
           "dependencies": {
             "ignore-walk": {
@@ -19424,7 +18901,7 @@
               "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
               "dev": true,
               "requires": {
-                "minimatch": "^3.0.4"
+                "minimatch": "3.0.4"
               },
               "dependencies": {
                 "minimatch": {
@@ -19433,7 +18910,7 @@
                   "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "^1.1.7"
+                    "brace-expansion": "1.1.8"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -19442,7 +18919,7 @@
                       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                       "dev": true,
                       "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -19478,8 +18955,8 @@
           "integrity": "sha512-tLmpDUCV72f/1/oXoyb+VwsZjOlsanp34pZeIZS0mxDoQUOX4Ld1hgPeOqoX4XggE88m7W47DHET2v+qd6sihg==",
           "dev": true,
           "requires": {
-            "aproba": "^1.1.2",
-            "make-fetch-happen": "^2.5.0"
+            "aproba": "1.2.0",
+            "make-fetch-happen": "2.5.0"
           },
           "dependencies": {
             "make-fetch-happen": {
@@ -19488,17 +18965,17 @@
               "integrity": "sha512-JPD5R43T02wIkcxjcmZuR7D06nB20fMR8aC9VEyYsSBXvJa5hOR/QhCxKY+5SXhy3uU5OUY/r+A6r+fJ2mFndA==",
               "dev": true,
               "requires": {
-                "agentkeepalive": "^3.3.0",
-                "cacache": "^9.2.9",
-                "http-cache-semantics": "^3.7.3",
-                "http-proxy-agent": "^2.0.0",
-                "https-proxy-agent": "^2.0.0",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^1.2.0",
-                "node-fetch-npm": "^2.0.1",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^3.0.0",
-                "ssri": "^4.1.6"
+                "agentkeepalive": "3.3.0",
+                "cacache": "9.3.0",
+                "http-cache-semantics": "3.8.0",
+                "http-proxy-agent": "2.0.0",
+                "https-proxy-agent": "2.1.0",
+                "lru-cache": "4.1.1",
+                "mississippi": "1.3.0",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "4.1.6"
               },
               "dependencies": {
                 "agentkeepalive": {
@@ -19507,7 +18984,7 @@
                   "integrity": "sha512-9yhcpXti2ZQE7bxuCsjjWNIZoQOd9sZ1ZBovHG0YeCRohFv73SLvcm73PC9T3olM4GyozaQb+4MGdQpcD8m7NQ==",
                   "dev": true,
                   "requires": {
-                    "humanize-ms": "^1.2.1"
+                    "humanize-ms": "1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
@@ -19516,7 +18993,7 @@
                       "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
                       "dev": true,
                       "requires": {
-                        "ms": "^2.0.0"
+                        "ms": "2.0.0"
                       },
                       "dependencies": {
                         "ms": {
@@ -19535,19 +19012,19 @@
                   "integrity": "sha512-Vbi8J1XfC8v+FbQ6QkOtKXsHpPnB0i9uMeYFJoj40EbdOsEqWB3DPpNjfsnYBkqOPYA8UvrqH6FZPpBP0zdN7g==",
                   "dev": true,
                   "requires": {
-                    "bluebird": "^3.5.0",
-                    "chownr": "^1.0.1",
-                    "glob": "^7.1.2",
-                    "graceful-fs": "^4.1.11",
-                    "lru-cache": "^4.1.1",
-                    "mississippi": "^1.3.0",
-                    "mkdirp": "^0.5.1",
-                    "move-concurrently": "^1.0.1",
-                    "promise-inflight": "^1.0.1",
-                    "rimraf": "^2.6.1",
-                    "ssri": "^4.1.6",
-                    "unique-filename": "^1.1.0",
-                    "y18n": "^3.2.1"
+                    "bluebird": "3.5.1",
+                    "chownr": "1.0.1",
+                    "glob": "7.1.2",
+                    "graceful-fs": "4.1.11",
+                    "lru-cache": "4.1.1",
+                    "mississippi": "1.3.0",
+                    "mkdirp": "0.5.1",
+                    "move-concurrently": "1.0.1",
+                    "promise-inflight": "1.0.1",
+                    "rimraf": "2.6.2",
+                    "ssri": "4.1.6",
+                    "unique-filename": "1.1.0",
+                    "y18n": "3.2.1"
                   },
                   "dependencies": {
                     "y18n": {
@@ -19570,8 +19047,8 @@
                   "integrity": "sha1-RkgqLwUjpNYIJVFwn0acs+SoX/Q=",
                   "dev": true,
                   "requires": {
-                    "agent-base": "4",
-                    "debug": "2"
+                    "agent-base": "4.1.1",
+                    "debug": "2.6.9"
                   },
                   "dependencies": {
                     "agent-base": {
@@ -19580,7 +19057,7 @@
                       "integrity": "sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==",
                       "dev": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
@@ -19589,7 +19066,7 @@
                           "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.1.1"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -19627,8 +19104,8 @@
                   "integrity": "sha512-/DTVSUCbRc6AiyOV4DBRvPDpKKCJh4qQJNaCgypX0T41quD9hp/PB5iUyx/60XobuMPQa9ce1jNV9UOUq6PnTg==",
                   "dev": true,
                   "requires": {
-                    "agent-base": "^4.1.0",
-                    "debug": "^2.4.1"
+                    "agent-base": "4.1.1",
+                    "debug": "2.6.9"
                   },
                   "dependencies": {
                     "agent-base": {
@@ -19637,7 +19114,7 @@
                       "integrity": "sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==",
                       "dev": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
@@ -19646,7 +19123,7 @@
                           "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.1.1"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -19684,9 +19161,9 @@
                   "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
                   "dev": true,
                   "requires": {
-                    "encoding": "^0.1.11",
-                    "json-parse-better-errors": "^1.0.0",
-                    "safe-buffer": "^5.1.1"
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.1",
+                    "safe-buffer": "5.1.1"
                   },
                   "dependencies": {
                     "encoding": {
@@ -19695,7 +19172,7 @@
                       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                       "dev": true,
                       "requires": {
-                        "iconv-lite": "~0.4.13"
+                        "iconv-lite": "0.4.19"
                       },
                       "dependencies": {
                         "iconv-lite": {
@@ -19720,8 +19197,8 @@
                   "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
                   "dev": true,
                   "requires": {
-                    "err-code": "^1.0.0",
-                    "retry": "^0.10.0"
+                    "err-code": "1.1.2",
+                    "retry": "0.10.1"
                   },
                   "dependencies": {
                     "err-code": {
@@ -19738,8 +19215,8 @@
                   "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
                   "dev": true,
                   "requires": {
-                    "agent-base": "^4.1.0",
-                    "socks": "^1.1.10"
+                    "agent-base": "4.1.1",
+                    "socks": "1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
@@ -19748,7 +19225,7 @@
                       "integrity": "sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==",
                       "dev": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
@@ -19757,7 +19234,7 @@
                           "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.1.1"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -19776,8 +19253,8 @@
                       "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
                       "dev": true,
                       "requires": {
-                        "ip": "^1.1.4",
-                        "smart-buffer": "^1.0.13"
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
                       },
                       "dependencies": {
                         "ip": {
@@ -19802,7 +19279,7 @@
                   "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
                   "dev": true,
                   "requires": {
-                    "safe-buffer": "^5.1.0"
+                    "safe-buffer": "5.1.1"
                   }
                 }
               }
@@ -19815,17 +19292,17 @@
           "integrity": "sha512-Nkcw24bfECKFNt0FLDQ+PjVqSlKxMggcboXiUBIvjbCnA15xjRO4kCwRDluGNXZjHFLx/vPjN4+ESXyVjpXLbQ==",
           "dev": true,
           "requires": {
-            "concat-stream": "^1.5.2",
-            "graceful-fs": "^4.1.6",
-            "normalize-package-data": "~1.0.1 || ^2.0.0",
-            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0",
-            "npmlog": "2 || ^3.1.0 || ^4.0.0",
-            "once": "^1.3.3",
-            "request": "^2.74.0",
-            "retry": "^0.10.0",
-            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
-            "slide": "^1.1.3",
-            "ssri": "^4.1.2"
+            "concat-stream": "1.6.0",
+            "graceful-fs": "4.1.11",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "5.1.2",
+            "npmlog": "4.1.2",
+            "once": "1.4.0",
+            "request": "2.83.0",
+            "retry": "0.10.1",
+            "semver": "5.4.1",
+            "slide": "1.1.6",
+            "ssri": "4.1.6"
           },
           "dependencies": {
             "concat-stream": {
@@ -19834,9 +19311,9 @@
               "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
               "dev": true,
               "requires": {
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "typedarray": "0.0.6"
               },
               "dependencies": {
                 "typedarray": {
@@ -19853,10 +19330,10 @@
               "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
               "dev": true,
               "requires": {
-                "hosted-git-info": "^2.4.2",
-                "osenv": "^0.1.4",
-                "semver": "^5.1.0",
-                "validate-npm-package-name": "^3.0.0"
+                "hosted-git-info": "2.5.0",
+                "osenv": "0.1.4",
+                "semver": "5.4.1",
+                "validate-npm-package-name": "3.0.0"
               }
             },
             "ssri": {
@@ -19865,7 +19342,7 @@
               "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
               "dev": true,
               "requires": {
-                "safe-buffer": "^5.1.0"
+                "safe-buffer": "5.1.1"
               }
             }
           }
@@ -19882,10 +19359,10 @@
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           },
           "dependencies": {
             "are-we-there-yet": {
@@ -19894,8 +19371,8 @@
               "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
               "dev": true,
               "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.3"
               },
               "dependencies": {
                 "delegates": {
@@ -19918,14 +19395,14 @@
               "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
               },
               "dependencies": {
                 "object-assign": {
@@ -19946,9 +19423,9 @@
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
                   "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
                   },
                   "dependencies": {
                     "code-point-at": {
@@ -19963,7 +19440,7 @@
                       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                       "dev": true,
                       "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                       },
                       "dependencies": {
                         "number-is-nan": {
@@ -19982,7 +19459,7 @@
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
-                    "ansi-regex": "^2.0.0"
+                    "ansi-regex": "2.1.1"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -19999,7 +19476,7 @@
                   "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
                   "dev": true,
                   "requires": {
-                    "string-width": "^1.0.2"
+                    "string-width": "1.0.2"
                   }
                 }
               }
@@ -20018,7 +19495,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "opener": {
@@ -20033,8 +19510,8 @@
           "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           },
           "dependencies": {
             "os-homedir": {
@@ -20057,28 +19534,28 @@
           "integrity": "sha512-cTiugiG2ujDcqDtYtJ3doDrS6E3eU0bhuYAHhMTWgBezrhoqTEjc0axSBpbjw4QQkNT5AGRF15Mj2tF2HuBz7w==",
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "cacache": "^10.0.1",
-            "get-stream": "^3.0.0",
-            "glob": "^7.1.2",
-            "lru-cache": "^4.1.1",
-            "make-fetch-happen": "^2.6.0",
-            "minimatch": "^3.0.4",
-            "mississippi": "^1.2.0",
-            "normalize-package-data": "^2.4.0",
-            "npm-package-arg": "^6.0.0",
-            "npm-packlist": "^1.1.10",
-            "npm-pick-manifest": "^2.1.0",
-            "osenv": "^0.1.4",
-            "promise-inflight": "^1.0.1",
-            "promise-retry": "^1.1.1",
-            "protoduck": "^4.0.0",
-            "safe-buffer": "^5.1.1",
-            "semver": "^5.4.1",
-            "ssri": "^5.0.0",
-            "tar": "^4.0.2",
-            "unique-filename": "^1.1.0",
-            "which": "^1.3.0"
+            "bluebird": "3.5.1",
+            "cacache": "10.0.1",
+            "get-stream": "3.0.0",
+            "glob": "7.1.2",
+            "lru-cache": "4.1.1",
+            "make-fetch-happen": "2.6.0",
+            "minimatch": "3.0.4",
+            "mississippi": "1.3.0",
+            "normalize-package-data": "2.4.0",
+            "npm-package-arg": "6.0.0",
+            "npm-packlist": "1.1.10",
+            "npm-pick-manifest": "2.1.0",
+            "osenv": "0.1.4",
+            "promise-inflight": "1.0.1",
+            "promise-retry": "1.1.1",
+            "protoduck": "4.0.0",
+            "safe-buffer": "5.1.1",
+            "semver": "5.4.1",
+            "ssri": "5.0.0",
+            "tar": "4.0.2",
+            "unique-filename": "1.1.0",
+            "which": "1.3.0"
           },
           "dependencies": {
             "get-stream": {
@@ -20093,17 +19570,17 @@
               "integrity": "sha512-FFq0lNI0ax+n9IWzWpH8A4JdgYiAp2DDYIZ3rsaav8JDe8I+72CzK6PQW/oom15YDZpV5bYW/9INd6nIJ2ZfZw==",
               "dev": true,
               "requires": {
-                "agentkeepalive": "^3.3.0",
-                "cacache": "^10.0.0",
-                "http-cache-semantics": "^3.8.0",
-                "http-proxy-agent": "^2.0.0",
-                "https-proxy-agent": "^2.1.0",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^1.2.0",
-                "node-fetch-npm": "^2.0.2",
-                "promise-retry": "^1.1.1",
-                "socks-proxy-agent": "^3.0.1",
-                "ssri": "^5.0.0"
+                "agentkeepalive": "3.3.0",
+                "cacache": "10.0.1",
+                "http-cache-semantics": "3.8.0",
+                "http-proxy-agent": "2.0.0",
+                "https-proxy-agent": "2.1.0",
+                "lru-cache": "4.1.1",
+                "mississippi": "1.3.0",
+                "node-fetch-npm": "2.0.2",
+                "promise-retry": "1.1.1",
+                "socks-proxy-agent": "3.0.1",
+                "ssri": "5.0.0"
               },
               "dependencies": {
                 "agentkeepalive": {
@@ -20112,7 +19589,7 @@
                   "integrity": "sha512-9yhcpXti2ZQE7bxuCsjjWNIZoQOd9sZ1ZBovHG0YeCRohFv73SLvcm73PC9T3olM4GyozaQb+4MGdQpcD8m7NQ==",
                   "dev": true,
                   "requires": {
-                    "humanize-ms": "^1.2.1"
+                    "humanize-ms": "1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
@@ -20121,7 +19598,7 @@
                       "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
                       "dev": true,
                       "requires": {
-                        "ms": "^2.0.0"
+                        "ms": "2.0.0"
                       },
                       "dependencies": {
                         "ms": {
@@ -20146,8 +19623,8 @@
                   "integrity": "sha1-RkgqLwUjpNYIJVFwn0acs+SoX/Q=",
                   "dev": true,
                   "requires": {
-                    "agent-base": "4",
-                    "debug": "2"
+                    "agent-base": "4.1.2",
+                    "debug": "2.6.9"
                   },
                   "dependencies": {
                     "agent-base": {
@@ -20156,7 +19633,7 @@
                       "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
                       "dev": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
@@ -20165,7 +19642,7 @@
                           "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.1.1"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -20203,8 +19680,8 @@
                   "integrity": "sha512-/DTVSUCbRc6AiyOV4DBRvPDpKKCJh4qQJNaCgypX0T41quD9hp/PB5iUyx/60XobuMPQa9ce1jNV9UOUq6PnTg==",
                   "dev": true,
                   "requires": {
-                    "agent-base": "^4.1.0",
-                    "debug": "^2.4.1"
+                    "agent-base": "4.1.2",
+                    "debug": "2.6.9"
                   },
                   "dependencies": {
                     "agent-base": {
@@ -20213,7 +19690,7 @@
                       "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
                       "dev": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
@@ -20222,7 +19699,7 @@
                           "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.1.1"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -20260,9 +19737,9 @@
                   "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
                   "dev": true,
                   "requires": {
-                    "encoding": "^0.1.11",
-                    "json-parse-better-errors": "^1.0.0",
-                    "safe-buffer": "^5.1.1"
+                    "encoding": "0.1.12",
+                    "json-parse-better-errors": "1.0.1",
+                    "safe-buffer": "5.1.1"
                   },
                   "dependencies": {
                     "encoding": {
@@ -20271,7 +19748,7 @@
                       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
                       "dev": true,
                       "requires": {
-                        "iconv-lite": "~0.4.13"
+                        "iconv-lite": "0.4.19"
                       },
                       "dependencies": {
                         "iconv-lite": {
@@ -20296,8 +19773,8 @@
                   "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
                   "dev": true,
                   "requires": {
-                    "agent-base": "^4.1.0",
-                    "socks": "^1.1.10"
+                    "agent-base": "4.1.2",
+                    "socks": "1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
@@ -20306,7 +19783,7 @@
                       "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
                       "dev": true,
                       "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
@@ -20315,7 +19792,7 @@
                           "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
                           "dev": true,
                           "requires": {
-                            "es6-promise": "^4.0.3"
+                            "es6-promise": "4.1.1"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -20334,8 +19811,8 @@
                       "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
                       "dev": true,
                       "requires": {
-                        "ip": "^1.1.4",
-                        "smart-buffer": "^1.0.13"
+                        "ip": "1.1.5",
+                        "smart-buffer": "1.1.15"
                       },
                       "dependencies": {
                         "ip": {
@@ -20362,7 +19839,7 @@
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.8"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -20371,7 +19848,7 @@
                   "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                   "dev": true,
                   "requires": {
-                    "balanced-match": "^1.0.0",
+                    "balanced-match": "1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -20397,8 +19874,8 @@
               "integrity": "sha512-q9zLP8cTr8xKPmMZN3naxp1k/NxVFsjxN6uWuO1tiw9gxg7wZWQ/b5UTfzD0ANw2q1lQxdLKTeCCksq+bPSgbQ==",
               "dev": true,
               "requires": {
-                "npm-package-arg": "^6.0.0",
-                "semver": "^5.4.1"
+                "npm-package-arg": "6.0.0",
+                "semver": "5.4.1"
               }
             },
             "promise-retry": {
@@ -20407,8 +19884,8 @@
               "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
               "dev": true,
               "requires": {
-                "err-code": "^1.0.0",
-                "retry": "^0.10.0"
+                "err-code": "1.1.2",
+                "retry": "0.10.1"
               },
               "dependencies": {
                 "err-code": {
@@ -20425,7 +19902,7 @@
               "integrity": "sha1-/kh02MeRM2bP2erRJFOiLNNlf44=",
               "dev": true,
               "requires": {
-                "genfun": "^4.0.1"
+                "genfun": "4.0.1"
               },
               "dependencies": {
                 "genfun": {
@@ -20462,9 +19939,9 @@
           "integrity": "sha512-aM+MkQClojlNiKkO09tiN2Fv8jM/L7GWIjG2liWeKljlOdOPNWr+bW3KQ+w5V/uKprpezC7fAsAMsJtJ+2rLKA==",
           "dev": true,
           "requires": {
-            "decode-uri-component": "^0.2.0",
-            "object-assign": "^4.1.0",
-            "strict-uri-encode": "^1.0.0"
+            "decode-uri-component": "0.2.0",
+            "object-assign": "4.1.1",
+            "strict-uri-encode": "1.1.0"
           },
           "dependencies": {
             "decode-uri-component": {
@@ -20499,7 +19976,7 @@
           "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "dev": true,
           "requires": {
-            "mute-stream": "~0.0.4"
+            "mute-stream": "0.0.7"
           },
           "dependencies": {
             "mute-stream": {
@@ -20516,7 +19993,7 @@
           "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2"
+            "graceful-fs": "4.1.11"
           }
         },
         "read-installed": {
@@ -20525,13 +20002,13 @@
           "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
           "dev": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "graceful-fs": "^4.1.2",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "slide": "~1.1.3",
-            "util-extend": "^1.0.1"
+            "debuglog": "1.0.1",
+            "graceful-fs": "4.1.11",
+            "read-package-json": "2.0.12",
+            "readdir-scoped-modules": "1.0.2",
+            "semver": "5.4.1",
+            "slide": "1.1.6",
+            "util-extend": "1.0.3"
           },
           "dependencies": {
             "util-extend": {
@@ -20548,11 +20025,11 @@
           "integrity": "sha512-m7/I0+tP6D34EVvSlzCtuVA4D/dHL6OpLcn2e4XVP5X57pCKGUy1JjRSBVKHWpB+vUU91sL85h84qX0MdXzBSw==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.1",
-            "graceful-fs": "^4.1.2",
-            "json-parse-better-errors": "^1.0.0",
-            "normalize-package-data": "^2.0.0",
-            "slash": "^1.0.0"
+            "glob": "7.1.2",
+            "graceful-fs": "4.1.11",
+            "json-parse-better-errors": "1.0.1",
+            "normalize-package-data": "2.4.0",
+            "slash": "1.0.0"
           },
           "dependencies": {
             "json-parse-better-errors": {
@@ -20575,11 +20052,11 @@
           "integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg==",
           "dev": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "once": "^1.3.0",
-            "read-package-json": "^2.0.0",
-            "readdir-scoped-modules": "^1.0.0"
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "once": "1.4.0",
+            "read-package-json": "2.0.12",
+            "readdir-scoped-modules": "1.0.2"
           }
         },
         "readable-stream": {
@@ -20588,13 +20065,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           },
           "dependencies": {
             "core-util-is": {
@@ -20621,7 +20098,7 @@
               "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
               "dev": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.1"
               }
             },
             "util-deprecate": {
@@ -20638,10 +20115,10 @@
           "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
           "dev": true,
           "requires": {
-            "debuglog": "^1.0.1",
-            "dezalgo": "^1.0.0",
-            "graceful-fs": "^4.1.2",
-            "once": "^1.3.0"
+            "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
+            "graceful-fs": "4.1.11",
+            "once": "1.4.0"
           }
         },
         "request": {
@@ -20650,28 +20127,28 @@
           "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "hawk": "~6.0.2",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "stringstream": "~0.0.5",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.1",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
           },
           "dependencies": {
             "aws-sign2": {
@@ -20698,7 +20175,7 @@
               "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
               "dev": true,
               "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
               },
               "dependencies": {
                 "delayed-stream": {
@@ -20727,9 +20204,9 @@
               "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
               "dev": true,
               "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.5",
-                "mime-types": "^2.1.12"
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.17"
               },
               "dependencies": {
                 "asynckit": {
@@ -20746,8 +20223,8 @@
               "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
               "dev": true,
               "requires": {
-                "ajv": "^5.1.0",
-                "har-schema": "^2.0.0"
+                "ajv": "5.2.3",
+                "har-schema": "2.0.0"
               },
               "dependencies": {
                 "ajv": {
@@ -20756,10 +20233,10 @@
                   "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
                   "dev": true,
                   "requires": {
-                    "co": "^4.6.0",
-                    "fast-deep-equal": "^1.0.0",
-                    "json-schema-traverse": "^0.3.0",
-                    "json-stable-stringify": "^1.0.1"
+                    "co": "4.6.0",
+                    "fast-deep-equal": "1.0.0",
+                    "json-schema-traverse": "0.3.1",
+                    "json-stable-stringify": "1.0.1"
                   },
                   "dependencies": {
                     "co": {
@@ -20786,7 +20263,7 @@
                       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                       "dev": true,
                       "requires": {
-                        "jsonify": "~0.0.0"
+                        "jsonify": "0.0.0"
                       },
                       "dependencies": {
                         "jsonify": {
@@ -20813,10 +20290,10 @@
               "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
               "dev": true,
               "requires": {
-                "boom": "4.x.x",
-                "cryptiles": "3.x.x",
-                "hoek": "4.x.x",
-                "sntp": "2.x.x"
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.0",
+                "sntp": "2.0.2"
               },
               "dependencies": {
                 "boom": {
@@ -20825,7 +20302,7 @@
                   "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
                   "dev": true,
                   "requires": {
-                    "hoek": "4.x.x"
+                    "hoek": "4.2.0"
                   }
                 },
                 "cryptiles": {
@@ -20834,7 +20311,7 @@
                   "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
                   "dev": true,
                   "requires": {
-                    "boom": "5.x.x"
+                    "boom": "5.2.0"
                   },
                   "dependencies": {
                     "boom": {
@@ -20843,7 +20320,7 @@
                       "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                       "dev": true,
                       "requires": {
-                        "hoek": "4.x.x"
+                        "hoek": "4.2.0"
                       }
                     }
                   }
@@ -20860,7 +20337,7 @@
                   "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
                   "dev": true,
                   "requires": {
-                    "hoek": "4.x.x"
+                    "hoek": "4.2.0"
                   }
                 }
               }
@@ -20871,9 +20348,9 @@
               "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
               "dev": true,
               "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
               },
               "dependencies": {
                 "assert-plus": {
@@ -20912,9 +20389,9 @@
                       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
                       "dev": true,
                       "requires": {
-                        "assert-plus": "^1.0.0",
+                        "assert-plus": "1.0.0",
                         "core-util-is": "1.0.2",
-                        "extsprintf": "^1.2.0"
+                        "extsprintf": "1.3.0"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -20933,14 +20410,14 @@
                   "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
                   "dev": true,
                   "requires": {
-                    "asn1": "~0.2.3",
-                    "assert-plus": "^1.0.0",
-                    "bcrypt-pbkdf": "^1.0.0",
-                    "dashdash": "^1.12.0",
-                    "ecc-jsbn": "~0.1.1",
-                    "getpass": "^0.1.1",
-                    "jsbn": "~0.1.0",
-                    "tweetnacl": "~0.14.0"
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.1",
+                    "dashdash": "1.14.1",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.7",
+                    "jsbn": "0.1.1",
+                    "tweetnacl": "0.14.5"
                   },
                   "dependencies": {
                     "asn1": {
@@ -20956,7 +20433,7 @@
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "tweetnacl": "^0.14.3"
+                        "tweetnacl": "0.14.5"
                       }
                     },
                     "dashdash": {
@@ -20965,7 +20442,7 @@
                       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                       "dev": true,
                       "requires": {
-                        "assert-plus": "^1.0.0"
+                        "assert-plus": "1.0.0"
                       }
                     },
                     "ecc-jsbn": {
@@ -20975,7 +20452,7 @@
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "~0.1.0"
+                        "jsbn": "0.1.1"
                       }
                     },
                     "getpass": {
@@ -20984,7 +20461,7 @@
                       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                       "dev": true,
                       "requires": {
-                        "assert-plus": "^1.0.0"
+                        "assert-plus": "1.0.0"
                       }
                     },
                     "jsbn": {
@@ -21029,7 +20506,7 @@
               "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
               "dev": true,
               "requires": {
-                "mime-db": "~1.30.0"
+                "mime-db": "1.30.0"
               },
               "dependencies": {
                 "mime-db": {
@@ -21070,7 +20547,7 @@
               "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
               "dev": true,
               "requires": {
-                "punycode": "^1.4.1"
+                "punycode": "1.4.1"
               },
               "dependencies": {
                 "punycode": {
@@ -21087,7 +20564,7 @@
               "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
               "dev": true,
               "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.1"
               }
             }
           }
@@ -21104,7 +20581,7 @@
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -21125,8 +20602,8 @@
           "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "readable-stream": "^2.0.2"
+            "graceful-fs": "4.1.11",
+            "readable-stream": "2.3.3"
           }
         },
         "slide": {
@@ -21147,8 +20624,8 @@
           "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
           "dev": true,
           "requires": {
-            "from2": "^1.3.0",
-            "stream-iterate": "^1.1.0"
+            "from2": "1.3.0",
+            "stream-iterate": "1.2.0"
           },
           "dependencies": {
             "from2": {
@@ -21157,8 +20634,8 @@
               "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
               "dev": true,
               "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "~1.1.10"
+                "inherits": "2.0.3",
+                "readable-stream": "1.1.14"
               },
               "dependencies": {
                 "readable-stream": {
@@ -21167,10 +20644,10 @@
                   "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.1",
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
                     "isarray": "0.0.1",
-                    "string_decoder": "~0.10.x"
+                    "string_decoder": "0.10.31"
                   },
                   "dependencies": {
                     "core-util-is": {
@@ -21201,8 +20678,8 @@
               "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
               "dev": true,
               "requires": {
-                "readable-stream": "^2.1.5",
-                "stream-shift": "^1.0.0"
+                "readable-stream": "2.3.3",
+                "stream-shift": "1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -21221,7 +20698,7 @@
           "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -21230,7 +20707,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -21247,11 +20724,11 @@
           "integrity": "sha512-4lWN4uAEWzw8aHyBUx9HWXvH3vIFEhOyvN22HfBzWpE07HaTBXM8ttSeCQpswRo5On4q3nmmYmk7Tomn0uhUaw==",
           "dev": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "minipass": "^2.2.1",
-            "minizlib": "^1.0.4",
-            "mkdirp": "^0.5.0",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "minipass": "2.2.1",
+            "minizlib": "1.0.4",
+            "mkdirp": "0.5.1",
+            "yallist": "3.0.2"
           },
           "dependencies": {
             "minipass": {
@@ -21260,7 +20737,7 @@
               "integrity": "sha512-u1aUllxPJUI07cOqzR7reGmQxmCqlH88uIIsf6XZFEWgw7gXKpJdR+5R9Y3KEDmWYkdIz9wXZs3C0jOPxejk/Q==",
               "dev": true,
               "requires": {
-                "yallist": "^3.0.0"
+                "yallist": "3.0.2"
               }
             },
             "minizlib": {
@@ -21269,7 +20746,7 @@
               "integrity": "sha512-sN4U9tIJtBRwKbwgFh9qJfrPIQ/GGTRr1MGqkgOeMTLy8/lM0FcWU//FqlnZ3Vb7gJ+Mxh3FOg1EklibdajbaQ==",
               "dev": true,
               "requires": {
-                "minipass": "^2.2.1"
+                "minipass": "2.2.1"
               }
             },
             "yallist": {
@@ -21304,7 +20781,7 @@
           "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
           "dev": true,
           "requires": {
-            "unique-slug": "^2.0.0"
+            "unique-slug": "2.0.0"
           },
           "dependencies": {
             "unique-slug": {
@@ -21313,7 +20790,7 @@
               "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
               "dev": true,
               "requires": {
-                "imurmurhash": "^0.1.4"
+                "imurmurhash": "0.1.4"
               }
             }
           }
@@ -21330,15 +20807,15 @@
           "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
           "dev": true,
           "requires": {
-            "boxen": "^1.2.1",
-            "chalk": "^2.0.1",
-            "configstore": "^3.0.0",
-            "import-lazy": "^2.1.0",
-            "is-installed-globally": "^0.1.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
+            "boxen": "1.2.1",
+            "chalk": "2.1.0",
+            "configstore": "3.1.1",
+            "import-lazy": "2.1.0",
+            "is-installed-globally": "0.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
           },
           "dependencies": {
             "boxen": {
@@ -21347,13 +20824,13 @@
               "integrity": "sha1-DxHn/jRO25OXl3/BPt5/ZNlWSB0=",
               "dev": true,
               "requires": {
-                "ansi-align": "^2.0.0",
-                "camelcase": "^4.0.0",
-                "chalk": "^2.0.1",
-                "cli-boxes": "^1.0.0",
-                "string-width": "^2.0.0",
-                "term-size": "^1.2.0",
-                "widest-line": "^1.0.0"
+                "ansi-align": "2.0.0",
+                "camelcase": "4.1.0",
+                "chalk": "2.1.0",
+                "cli-boxes": "1.0.0",
+                "string-width": "2.1.1",
+                "term-size": "1.2.0",
+                "widest-line": "1.0.0"
               },
               "dependencies": {
                 "ansi-align": {
@@ -21362,7 +20839,7 @@
                   "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
                   "dev": true,
                   "requires": {
-                    "string-width": "^2.0.0"
+                    "string-width": "2.1.1"
                   }
                 },
                 "camelcase": {
@@ -21383,8 +20860,8 @@
                   "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                   "dev": true,
                   "requires": {
-                    "is-fullwidth-code-point": "^2.0.0",
-                    "strip-ansi": "^4.0.0"
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "4.0.0"
                   },
                   "dependencies": {
                     "is-fullwidth-code-point": {
@@ -21401,7 +20878,7 @@
                   "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
                   "dev": true,
                   "requires": {
-                    "execa": "^0.7.0"
+                    "execa": "0.7.0"
                   },
                   "dependencies": {
                     "execa": {
@@ -21410,13 +20887,13 @@
                       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                       "dev": true,
                       "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
                       },
                       "dependencies": {
                         "cross-spawn": {
@@ -21425,9 +20902,9 @@
                           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                           "dev": true,
                           "requires": {
-                            "lru-cache": "^4.0.1",
-                            "shebang-command": "^1.2.0",
-                            "which": "^1.2.9"
+                            "lru-cache": "4.1.1",
+                            "shebang-command": "1.2.0",
+                            "which": "1.3.0"
                           },
                           "dependencies": {
                             "shebang-command": {
@@ -21436,7 +20913,7 @@
                               "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
                               "dev": true,
                               "requires": {
-                                "shebang-regex": "^1.0.0"
+                                "shebang-regex": "1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
@@ -21467,7 +20944,7 @@
                           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
                           "dev": true,
                           "requires": {
-                            "path-key": "^2.0.0"
+                            "path-key": "2.0.1"
                           },
                           "dependencies": {
                             "path-key": {
@@ -21506,7 +20983,7 @@
                   "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
                   "dev": true,
                   "requires": {
-                    "string-width": "^1.0.1"
+                    "string-width": "1.0.2"
                   },
                   "dependencies": {
                     "string-width": {
@@ -21515,9 +20992,9 @@
                       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
                       "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                       },
                       "dependencies": {
                         "code-point-at": {
@@ -21532,7 +21009,7 @@
                           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                           "dev": true,
                           "requires": {
-                            "number-is-nan": "^1.0.0"
+                            "number-is-nan": "1.0.1"
                           },
                           "dependencies": {
                             "number-is-nan": {
@@ -21549,7 +21026,7 @@
                           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                           "dev": true,
                           "requires": {
-                            "ansi-regex": "^2.0.0"
+                            "ansi-regex": "2.1.1"
                           },
                           "dependencies": {
                             "ansi-regex": {
@@ -21572,9 +21049,9 @@
               "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.1.0",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^4.0.0"
+                "ansi-styles": "3.2.0",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "4.4.0"
               },
               "dependencies": {
                 "ansi-styles": {
@@ -21583,7 +21060,7 @@
                   "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                   "dev": true,
                   "requires": {
-                    "color-convert": "^1.9.0"
+                    "color-convert": "1.9.0"
                   },
                   "dependencies": {
                     "color-convert": {
@@ -21592,7 +21069,7 @@
                       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
                       "dev": true,
                       "requires": {
-                        "color-name": "^1.1.1"
+                        "color-name": "1.1.3"
                       },
                       "dependencies": {
                         "color-name": {
@@ -21617,7 +21094,7 @@
                   "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                   "dev": true,
                   "requires": {
-                    "has-flag": "^2.0.0"
+                    "has-flag": "2.0.0"
                   },
                   "dependencies": {
                     "has-flag": {
@@ -21636,12 +21113,12 @@
               "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
               "dev": true,
               "requires": {
-                "dot-prop": "^4.1.0",
-                "graceful-fs": "^4.1.2",
-                "make-dir": "^1.0.0",
-                "unique-string": "^1.0.0",
-                "write-file-atomic": "^2.0.0",
-                "xdg-basedir": "^3.0.0"
+                "dot-prop": "4.2.0",
+                "graceful-fs": "4.1.11",
+                "make-dir": "1.0.0",
+                "unique-string": "1.0.0",
+                "write-file-atomic": "2.1.0",
+                "xdg-basedir": "3.0.0"
               },
               "dependencies": {
                 "dot-prop": {
@@ -21650,7 +21127,7 @@
                   "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
                   "dev": true,
                   "requires": {
-                    "is-obj": "^1.0.0"
+                    "is-obj": "1.0.1"
                   },
                   "dependencies": {
                     "is-obj": {
@@ -21667,7 +21144,7 @@
                   "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
                   "dev": true,
                   "requires": {
-                    "pify": "^2.3.0"
+                    "pify": "2.3.0"
                   },
                   "dependencies": {
                     "pify": {
@@ -21684,7 +21161,7 @@
                   "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
                   "dev": true,
                   "requires": {
-                    "crypto-random-string": "^1.0.0"
+                    "crypto-random-string": "1.0.0"
                   },
                   "dependencies": {
                     "crypto-random-string": {
@@ -21709,8 +21186,8 @@
               "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
               "dev": true,
               "requires": {
-                "global-dirs": "^0.1.0",
-                "is-path-inside": "^1.0.0"
+                "global-dirs": "0.1.0",
+                "is-path-inside": "1.0.0"
               },
               "dependencies": {
                 "global-dirs": {
@@ -21719,7 +21196,7 @@
                   "integrity": "sha1-ENNAOeDfBCcuJizyQiT3IJQ0308=",
                   "dev": true,
                   "requires": {
-                    "ini": "^1.3.4"
+                    "ini": "1.3.4"
                   }
                 },
                 "is-path-inside": {
@@ -21728,7 +21205,7 @@
                   "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
                   "dev": true,
                   "requires": {
-                    "path-is-inside": "^1.0.1"
+                    "path-is-inside": "1.0.2"
                   }
                 }
               }
@@ -21753,8 +21230,8 @@
           "integrity": "sha512-ITyClEvcfv0ozqJl1vmWFWhvI+OIrkbInYqkEPE50wFPXj8J9Gd3FYf8+CkZJXJJsQBYe+2DvmoK9Zhx5w8W+w==",
           "dev": true,
           "requires": {
-            "errno": "~0.1.7",
-            "xtend": "~4.0.1"
+            "errno": "0.1.7",
+            "xtend": "4.0.1"
           }
         },
         "wrappy": {
@@ -21769,9 +21246,9 @@
           "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
           }
         }
       }
@@ -21782,8 +21259,8 @@
       "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
       "dev": true,
       "requires": {
-        "config-chain": "^1.1.11",
-        "pify": "^3.0.0"
+        "config-chain": "1.1.11",
+        "pify": "3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -21800,7 +21277,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "nth-check": {
@@ -21809,7 +21286,7 @@
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "dev": true,
       "requires": {
-        "boolbase": "~1.0.0"
+        "boolbase": "1.0.0"
       }
     },
     "null-check": {
@@ -21852,9 +21329,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -21863,7 +21340,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -21872,7 +21349,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-data-descriptor": {
@@ -21881,7 +21358,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-descriptor": {
@@ -21890,9 +21367,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           },
           "dependencies": {
             "kind-of": {
@@ -21929,7 +21406,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -21946,10 +21423,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "object-keys": "1.0.11"
       }
     },
     "object.defaults": {
@@ -21958,10 +21435,10 @@
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "dev": true,
       "requires": {
-        "array-each": "^1.0.1",
-        "array-slice": "^1.0.0",
-        "for-own": "^1.0.0",
-        "isobject": "^3.0.0"
+        "array-each": "1.0.1",
+        "array-slice": "1.1.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -21970,7 +21447,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         },
         "isobject": {
@@ -21987,10 +21464,10 @@
       "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.6.1",
-        "function-bind": "^1.1.0",
-        "has": "^1.0.1"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.1"
       }
     },
     "object.getownpropertydescriptors": {
@@ -21999,8 +21476,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0"
       }
     },
     "object.map": {
@@ -22009,8 +21486,8 @@
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "dev": true,
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.0"
       },
       "dependencies": {
         "for-own": {
@@ -22019,7 +21496,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         }
       }
@@ -22030,8 +21507,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "object.pick": {
@@ -22040,7 +21517,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -22057,10 +21534,10 @@
       "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.6.1",
-        "function-bind": "^1.1.0",
-        "has": "^1.0.1"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.1"
       }
     },
     "objektiv": {
@@ -22094,7 +21571,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onecolor": {
@@ -22121,7 +21598,7 @@
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "dev": true,
       "requires": {
-        "is-wsl": "^1.1.0"
+        "is-wsl": "1.1.0"
       }
     },
     "optimist": {
@@ -22130,8 +21607,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
       },
       "dependencies": {
         "minimist": {
@@ -22154,12 +21631,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "optipng-bin": {
@@ -22168,9 +21645,9 @@
       "integrity": "sha1-ldNPLEiHBPb9cGBr/qDGWfHZXYQ=",
       "dev": true,
       "requires": {
-        "bin-build": "^2.0.0",
-        "bin-wrapper": "^3.0.0",
-        "logalot": "^2.0.0"
+        "bin-build": "2.2.0",
+        "bin-wrapper": "3.0.2",
+        "logalot": "2.1.0"
       }
     },
     "ora": {
@@ -22179,10 +21656,10 @@
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "cli-cursor": "^1.0.2",
-        "cli-spinners": "^0.1.2",
-        "object-assign": "^4.0.1"
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "object-assign": {
@@ -22199,9 +21676,9 @@
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
       "dev": true,
       "requires": {
-        "end-of-stream": "~0.1.5",
-        "sequencify": "~0.0.7",
-        "stream-consume": "~0.1.0"
+        "end-of-stream": "0.1.5",
+        "sequencify": "0.0.7",
+        "stream-consume": "0.1.1"
       }
     },
     "ordered-read-streams": {
@@ -22216,7 +21693,7 @@
       "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
       "dev": true,
       "requires": {
-        "url-parse": "1.0.x"
+        "url-parse": "1.0.5"
       },
       "dependencies": {
         "url-parse": {
@@ -22225,8 +21702,8 @@
           "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
           "dev": true,
           "requires": {
-            "querystringify": "0.0.x",
-            "requires-port": "1.0.x"
+            "querystringify": "0.0.4",
+            "requires-port": "1.0.0"
           }
         }
       }
@@ -22255,7 +21732,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "^1.0.0"
+        "lcid": "1.0.0"
       }
     },
     "os-tmpdir": {
@@ -22270,57 +21747,22 @@
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.4",
-        "mkdirp": "^0.5.1",
-        "object-assign": "^4.1.0"
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
-        "es6-promise": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
-        },
-        "fs-extra": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-          "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0"
-          }
-        },
         "graceful-fs": {
           "version": "4.1.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
-        },
-        "request-progress": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
-          "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
-          "requires": {
-            "throttleit": "^1.0.0"
-          }
-        },
-        "throttleit": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-          "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw="
         }
       }
     },
@@ -22336,7 +21778,7 @@
       "integrity": "sha1-jmtPT2XHK8W2/ii3XtqHT5akoIU=",
       "dev": true,
       "requires": {
-        "p-timeout": "^1.1.1"
+        "p-timeout": "1.2.1"
       }
     },
     "p-finally": {
@@ -22351,7 +21793,7 @@
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -22360,7 +21802,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.2.0"
       }
     },
     "p-map": {
@@ -22375,7 +21817,7 @@
       "integrity": "sha1-v5j+V1cFZYqeE1G++4WuTB8Hvco=",
       "dev": true,
       "requires": {
-        "p-reduce": "^1.0.0"
+        "p-reduce": "1.0.0"
       }
     },
     "p-pipe": {
@@ -22396,7 +21838,7 @@
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "dev": true,
       "requires": {
-        "p-finally": "^1.0.0"
+        "p-finally": "1.0.0"
       }
     },
     "p-try": {
@@ -22411,10 +21853,10 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0",
+        "semver": "5.5.0"
       },
       "dependencies": {
         "got": {
@@ -22423,17 +21865,17 @@
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
+            "create-error-class": "3.0.2",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.0",
+            "safe-buffer": "5.1.1",
+            "timed-out": "4.0.1",
+            "unzip-response": "2.0.1",
+            "url-parse-lax": "1.0.0"
           }
         },
         "timed-out": {
@@ -22462,9 +21904,9 @@
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "dev": true,
       "requires": {
-        "cyclist": "~0.2.2",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.1.5"
+        "cyclist": "0.2.2",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.5"
       },
       "dependencies": {
         "isarray": {
@@ -22479,13 +21921,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -22494,7 +21936,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -22505,7 +21947,7 @@
       "integrity": "sha1-3LCRpDwlm5Io8cNB57akTqC/l0M=",
       "dev": true,
       "requires": {
-        "sentence-case": "^1.1.2"
+        "sentence-case": "1.1.3"
       }
     },
     "parse-asn1": {
@@ -22514,11 +21956,11 @@
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3"
+        "asn1.js": "4.10.1",
+        "browserify-aes": "1.2.0",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.14"
       }
     },
     "parse-filepath": {
@@ -22527,9 +21969,9 @@
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "dev": true,
       "requires": {
-        "is-absolute": "^1.0.0",
-        "map-cache": "^0.2.0",
-        "path-root": "^0.1.1"
+        "is-absolute": "1.0.0",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
       }
     },
     "parse-github-repo-url": {
@@ -22544,10 +21986,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "parse-json": {
@@ -22556,7 +21998,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.1"
       }
     },
     "parse-passwd": {
@@ -22571,7 +22013,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "9.4.7"
       }
     },
     "parseurl": {
@@ -22586,8 +22028,8 @@
       "integrity": "sha1-Pl1kogBDgwp8STRMLXS0G+DJyZs=",
       "dev": true,
       "requires": {
-        "camel-case": "^1.1.1",
-        "upper-case-first": "^1.1.0"
+        "camel-case": "1.2.2",
+        "upper-case-first": "1.1.2"
       }
     },
     "pascalcase": {
@@ -22608,7 +22050,7 @@
       "integrity": "sha1-UM5roNO+090LXCqcRVNpdDRAlRQ=",
       "dev": true,
       "requires": {
-        "sentence-case": "^1.1.2"
+        "sentence-case": "1.1.3"
       }
     },
     "path-dirname": {
@@ -22623,7 +22065,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^2.0.0"
+        "pinkie-promise": "2.0.1"
       }
     },
     "path-is-absolute": {
@@ -22656,7 +22098,7 @@
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
-        "path-root-regex": "^0.1.0"
+        "path-root-regex": "0.1.2"
       }
     },
     "path-root-regex": {
@@ -22677,9 +22119,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "path2glob": {
@@ -22687,7 +22129,7 @@
       "resolved": "https://registry.npmjs.org/path2glob/-/path2glob-0.0.2.tgz",
       "integrity": "sha1-KejODRVAfCpQtjPvgFCy8pfARwI=",
       "requires": {
-        "glob": "^4.0.5"
+        "glob": "4.5.3"
       },
       "dependencies": {
         "glob": {
@@ -22695,10 +22137,10 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^2.0.1",
-            "once": "^1.3.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
           }
         },
         "minimatch": {
@@ -22706,7 +22148,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "requires": {
-            "brace-expansion": "^1.0.0"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -22723,7 +22165,7 @@
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
-        "through": "~2.3"
+        "through": "2.3.8"
       }
     },
     "pbkdf2": {
@@ -22732,11 +22174,11 @@
       "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
       "dev": true,
       "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.11"
       }
     },
     "pend": {
@@ -22756,15 +22198,15 @@
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "dev": true,
       "requires": {
-        "es6-promise": "^4.0.3",
-        "extract-zip": "^1.6.5",
-        "fs-extra": "^1.0.0",
-        "hasha": "^2.2.0",
-        "kew": "^0.7.0",
-        "progress": "^1.1.8",
-        "request": "^2.81.0",
-        "request-progress": "^2.0.1",
-        "which": "^1.2.10"
+        "es6-promise": "4.2.4",
+        "extract-zip": "1.6.6",
+        "fs-extra": "1.0.0",
+        "hasha": "2.2.0",
+        "kew": "0.7.0",
+        "progress": "1.1.8",
+        "request": "2.81.0",
+        "request-progress": "2.0.1",
+        "which": "1.3.0"
       },
       "dependencies": {
         "es6-promise": {
@@ -22779,9 +22221,9 @@
           "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1"
           }
         },
         "jsonfile": {
@@ -22790,7 +22232,7 @@
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.11"
           }
         }
       }
@@ -22813,7 +22255,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pipetteur": {
@@ -22822,8 +22264,8 @@
       "integrity": "sha1-GVV2CVno0aEcsqUOyD7sRwYz5J8=",
       "dev": true,
       "requires": {
-        "onecolor": "^3.0.4",
-        "synesthesia": "^1.0.1"
+        "onecolor": "3.0.5",
+        "synesthesia": "1.0.1"
       }
     },
     "pkg-dir": {
@@ -22832,7 +22274,7 @@
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0"
+        "find-up": "1.1.2"
       }
     },
     "pkg-up": {
@@ -22841,7 +22283,7 @@
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0"
+        "find-up": "1.1.2"
       }
     },
     "pkginfo": {
@@ -22856,7 +22298,7 @@
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "dev": true,
       "requires": {
-        "irregular-plurals": "^1.0.0"
+        "irregular-plurals": "1.4.0"
       }
     },
     "pluralize": {
@@ -22877,9 +22319,9 @@
       "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
       "dev": true,
       "requires": {
-        "async": "^1.5.2",
-        "debug": "^2.2.0",
-        "mkdirp": "0.5.x"
+        "async": "1.5.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1"
       },
       "dependencies": {
         "async": {
@@ -22908,9 +22350,9 @@
       "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.3.1",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.2.0"
+        "chalk": "2.3.2",
+        "source-map": "0.6.1",
+        "supports-color": "5.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -22919,7 +22361,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -22928,9 +22370,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -22951,7 +22393,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -22962,9 +22404,9 @@
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.2",
-        "postcss-message-helpers": "^2.0.0",
-        "reduce-css-calc": "^1.2.6"
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-css-calc": "1.3.0"
       },
       "dependencies": {
         "postcss": {
@@ -22973,10 +22415,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -22985,7 +22427,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -22996,9 +22438,9 @@
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
       "dev": true,
       "requires": {
-        "colormin": "^1.0.5",
-        "postcss": "^5.0.13",
-        "postcss-value-parser": "^3.2.3"
+        "colormin": "1.1.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "postcss": {
@@ -23007,10 +22449,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -23019,7 +22461,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23030,8 +22472,8 @@
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.11",
-        "postcss-value-parser": "^3.1.2"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "postcss": {
@@ -23040,10 +22482,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -23052,7 +22494,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23063,7 +22505,7 @@
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.14"
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "postcss": {
@@ -23072,10 +22514,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -23084,7 +22526,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23095,7 +22537,7 @@
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "postcss": {
@@ -23104,10 +22546,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -23116,7 +22558,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23127,7 +22569,7 @@
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.14"
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "postcss": {
@@ -23136,10 +22578,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -23148,7 +22590,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23159,7 +22601,7 @@
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.16"
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "postcss": {
@@ -23168,10 +22610,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -23180,7 +22622,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23191,8 +22633,8 @@
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.14",
-        "uniqs": "^2.0.0"
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
       },
       "dependencies": {
         "postcss": {
@@ -23201,10 +22643,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -23213,7 +22655,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23224,8 +22666,8 @@
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.4",
-        "uniqid": "^4.0.0"
+        "postcss": "5.2.18",
+        "uniqid": "4.1.1"
       },
       "dependencies": {
         "postcss": {
@@ -23234,10 +22676,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -23246,7 +22688,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23257,7 +22699,7 @@
       "integrity": "sha1-xjGwicbM5CK5oQ86lY0r7dOBkyQ=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.21"
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "postcss": {
@@ -23266,10 +22708,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -23278,7 +22720,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23289,10 +22731,10 @@
       "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
       "dev": true,
       "requires": {
-        "cosmiconfig": "^2.1.0",
-        "object-assign": "^4.1.0",
-        "postcss-load-options": "^1.2.0",
-        "postcss-load-plugins": "^2.3.0"
+        "cosmiconfig": "2.2.2",
+        "object-assign": "4.1.1",
+        "postcss-load-options": "1.2.0",
+        "postcss-load-plugins": "2.3.0"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -23301,13 +22743,13 @@
           "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
           "dev": true,
           "requires": {
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.4.3",
-            "minimist": "^1.2.0",
-            "object-assign": "^4.1.0",
-            "os-homedir": "^1.0.1",
-            "parse-json": "^2.2.0",
-            "require-from-string": "^1.1.0"
+            "is-directory": "0.3.1",
+            "js-yaml": "3.7.0",
+            "minimist": "1.2.0",
+            "object-assign": "4.1.1",
+            "os-homedir": "1.0.2",
+            "parse-json": "2.2.0",
+            "require-from-string": "1.2.1"
           }
         },
         "object-assign": {
@@ -23324,8 +22766,8 @@
       "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
       "dev": true,
       "requires": {
-        "cosmiconfig": "^2.1.0",
-        "object-assign": "^4.1.0"
+        "cosmiconfig": "2.2.2",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -23334,13 +22776,13 @@
           "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
           "dev": true,
           "requires": {
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.4.3",
-            "minimist": "^1.2.0",
-            "object-assign": "^4.1.0",
-            "os-homedir": "^1.0.1",
-            "parse-json": "^2.2.0",
-            "require-from-string": "^1.1.0"
+            "is-directory": "0.3.1",
+            "js-yaml": "3.7.0",
+            "minimist": "1.2.0",
+            "object-assign": "4.1.1",
+            "os-homedir": "1.0.2",
+            "parse-json": "2.2.0",
+            "require-from-string": "1.2.1"
           }
         },
         "object-assign": {
@@ -23357,8 +22799,8 @@
       "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
       "dev": true,
       "requires": {
-        "cosmiconfig": "^2.1.1",
-        "object-assign": "^4.1.0"
+        "cosmiconfig": "2.2.2",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -23367,13 +22809,13 @@
           "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
           "dev": true,
           "requires": {
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.4.3",
-            "minimist": "^1.2.0",
-            "object-assign": "^4.1.0",
-            "os-homedir": "^1.0.1",
-            "parse-json": "^2.2.0",
-            "require-from-string": "^1.1.0"
+            "is-directory": "0.3.1",
+            "js-yaml": "3.7.0",
+            "minimist": "1.2.0",
+            "object-assign": "4.1.1",
+            "os-homedir": "1.0.2",
+            "parse-json": "2.2.0",
+            "require-from-string": "1.2.1"
           }
         },
         "object-assign": {
@@ -23390,10 +22832,10 @@
       "integrity": "sha512-f0J/DWE/hyO9/LH0WHpXkny/ZZ238sSaG3p1SRBtVZnFWUtD7GXIEgHoBg8cnAeRbmEvUxHQptY46zWfwNYj/w==",
       "dev": true,
       "requires": {
-        "loader-utils": "^1.1.0",
-        "postcss": "^6.0.0",
-        "postcss-load-config": "^1.2.0",
-        "schema-utils": "^0.4.0"
+        "loader-utils": "1.1.0",
+        "postcss": "6.0.19",
+        "postcss-load-config": "1.2.0",
+        "schema-utils": "0.4.5"
       },
       "dependencies": {
         "ajv": {
@@ -23402,10 +22844,10 @@
           "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0",
-            "uri-js": "^3.0.2"
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "3.0.2"
           }
         },
         "ajv-keywords": {
@@ -23420,9 +22862,9 @@
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         },
         "schema-utils": {
@@ -23431,8 +22873,8 @@
           "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
           "dev": true,
           "requires": {
-            "ajv": "^6.1.0",
-            "ajv-keywords": "^3.1.0"
+            "ajv": "6.4.0",
+            "ajv-keywords": "3.1.0"
           }
         }
       }
@@ -23449,9 +22891,9 @@
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1",
-        "postcss": "^5.0.10",
-        "postcss-value-parser": "^3.1.1"
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "postcss": {
@@ -23460,10 +22902,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -23472,7 +22914,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23483,7 +22925,7 @@
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "postcss": {
@@ -23492,10 +22934,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -23504,7 +22946,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23515,11 +22957,11 @@
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
       "dev": true,
       "requires": {
-        "browserslist": "^1.5.2",
-        "caniuse-api": "^1.5.2",
-        "postcss": "^5.0.4",
-        "postcss-selector-parser": "^2.2.2",
-        "vendors": "^1.0.0"
+        "browserslist": "1.7.7",
+        "caniuse-api": "1.6.1",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3",
+        "vendors": "1.0.1"
       },
       "dependencies": {
         "browserslist": {
@@ -23528,8 +22970,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000815",
+            "electron-to-chromium": "1.3.39"
           }
         },
         "postcss": {
@@ -23538,10 +22980,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -23550,7 +22992,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23567,9 +23009,9 @@
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
       "dev": true,
       "requires": {
-        "object-assign": "^4.0.1",
-        "postcss": "^5.0.4",
-        "postcss-value-parser": "^3.0.2"
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "object-assign": {
@@ -23584,10 +23026,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -23596,7 +23038,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23607,8 +23049,8 @@
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.12",
-        "postcss-value-parser": "^3.3.0"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "postcss": {
@@ -23617,10 +23059,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -23629,7 +23071,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23640,10 +23082,10 @@
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
       "dev": true,
       "requires": {
-        "alphanum-sort": "^1.0.1",
-        "postcss": "^5.0.2",
-        "postcss-value-parser": "^3.0.2",
-        "uniqs": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "uniqs": "2.0.0"
       },
       "dependencies": {
         "postcss": {
@@ -23652,10 +23094,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -23664,7 +23106,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23675,10 +23117,10 @@
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
       "dev": true,
       "requires": {
-        "alphanum-sort": "^1.0.2",
-        "has": "^1.0.1",
-        "postcss": "^5.0.14",
-        "postcss-selector-parser": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3"
       },
       "dependencies": {
         "postcss": {
@@ -23687,10 +23129,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -23699,7 +23141,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23710,8 +23152,8 @@
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "dev": true,
       "requires": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "ansi-styles": {
@@ -23720,7 +23162,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -23729,9 +23171,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "css-selector-tokenizer": {
@@ -23740,9 +23182,9 @@
           "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
           "dev": true,
           "requires": {
-            "cssesc": "^0.1.0",
-            "fastparse": "^1.1.1",
-            "regexpu-core": "^1.0.0"
+            "cssesc": "0.1.0",
+            "fastparse": "1.1.1",
+            "regexpu-core": "1.0.0"
           }
         },
         "has-flag": {
@@ -23757,9 +23199,9 @@
           "integrity": "sha1-aGEH50OhLVUwy2hDjFkNWyv3LDw=",
           "dev": true,
           "requires": {
-            "chalk": "^2.3.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.3.0"
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
           }
         },
         "regexpu-core": {
@@ -23768,9 +23210,9 @@
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "dev": true,
           "requires": {
-            "regenerate": "^1.2.1",
-            "regjsgen": "^0.2.0",
-            "regjsparser": "^0.1.4"
+            "regenerate": "1.3.3",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
           }
         },
         "source-map": {
@@ -23785,7 +23227,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -23796,8 +23238,8 @@
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "dev": true,
       "requires": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "ansi-styles": {
@@ -23806,7 +23248,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -23815,9 +23257,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "css-selector-tokenizer": {
@@ -23826,9 +23268,9 @@
           "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
           "dev": true,
           "requires": {
-            "cssesc": "^0.1.0",
-            "fastparse": "^1.1.1",
-            "regexpu-core": "^1.0.0"
+            "cssesc": "0.1.0",
+            "fastparse": "1.1.1",
+            "regexpu-core": "1.0.0"
           }
         },
         "has-flag": {
@@ -23843,9 +23285,9 @@
           "integrity": "sha1-aGEH50OhLVUwy2hDjFkNWyv3LDw=",
           "dev": true,
           "requires": {
-            "chalk": "^2.3.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.3.0"
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
           }
         },
         "regexpu-core": {
@@ -23854,9 +23296,9 @@
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "dev": true,
           "requires": {
-            "regenerate": "^1.2.1",
-            "regjsgen": "^0.2.0",
-            "regjsparser": "^0.1.4"
+            "regenerate": "1.3.3",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
           }
         },
         "source-map": {
@@ -23871,7 +23313,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -23882,8 +23324,8 @@
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "dev": true,
       "requires": {
-        "icss-replace-symbols": "^1.1.0",
-        "postcss": "^6.0.1"
+        "icss-replace-symbols": "1.1.0",
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "ansi-styles": {
@@ -23892,7 +23334,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -23901,9 +23343,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "has-flag": {
@@ -23918,9 +23360,9 @@
           "integrity": "sha1-aGEH50OhLVUwy2hDjFkNWyv3LDw=",
           "dev": true,
           "requires": {
-            "chalk": "^2.3.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.3.0"
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
           }
         },
         "source-map": {
@@ -23935,7 +23377,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -23946,7 +23388,7 @@
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.5"
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "postcss": {
@@ -23955,10 +23397,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -23967,7 +23409,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -23978,10 +23420,10 @@
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
       "dev": true,
       "requires": {
-        "is-absolute-url": "^2.0.0",
-        "normalize-url": "^1.4.0",
-        "postcss": "^5.0.14",
-        "postcss-value-parser": "^3.2.3"
+        "is-absolute-url": "2.1.0",
+        "normalize-url": "1.9.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "postcss": {
@@ -23990,10 +23432,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -24002,7 +23444,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -24013,8 +23455,8 @@
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.4",
-        "postcss-value-parser": "^3.0.1"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "postcss": {
@@ -24023,10 +23465,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -24035,7 +23477,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -24046,8 +23488,8 @@
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.4",
-        "postcss-value-parser": "^3.0.2"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "postcss": {
@@ -24056,10 +23498,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -24068,7 +23510,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -24079,7 +23521,7 @@
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "postcss": {
@@ -24088,10 +23530,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -24100,7 +23542,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -24111,9 +23553,9 @@
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1",
-        "postcss": "^5.0.8",
-        "postcss-value-parser": "^3.0.1"
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "postcss": {
@@ -24122,10 +23564,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -24134,7 +23576,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -24145,10 +23587,10 @@
       "integrity": "sha1-wTbwpbFhkV83ndN2XGEHX357mvI=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "lodash": "^4.1.0",
-        "log-symbols": "^1.0.2",
-        "postcss": "^5.0.0"
+        "chalk": "1.1.3",
+        "lodash": "4.17.5",
+        "log-symbols": "1.0.2",
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "lodash": {
@@ -24163,10 +23605,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -24175,7 +23617,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -24192,7 +23634,7 @@
       "integrity": "sha1-bJoNsjUTMwRwdD+ykYY7uDP/zH4=",
       "dev": true,
       "requires": {
-        "postcss": "^5.1.2"
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "postcss": {
@@ -24201,10 +23643,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -24213,7 +23655,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -24224,9 +23666,9 @@
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
       "dev": true,
       "requires": {
-        "flatten": "^1.0.2",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
+        "flatten": "1.0.2",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
       }
     },
     "postcss-svgo": {
@@ -24235,10 +23677,10 @@
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
       "dev": true,
       "requires": {
-        "is-svg": "^2.0.0",
-        "postcss": "^5.0.14",
-        "postcss-value-parser": "^3.2.3",
-        "svgo": "^0.7.0"
+        "is-svg": "2.1.0",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "svgo": "0.7.2"
       },
       "dependencies": {
         "postcss": {
@@ -24247,10 +23689,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -24259,7 +23701,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -24270,9 +23712,9 @@
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
       "dev": true,
       "requires": {
-        "alphanum-sort": "^1.0.1",
-        "postcss": "^5.0.4",
-        "uniqs": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
       },
       "dependencies": {
         "postcss": {
@@ -24281,10 +23723,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -24293,7 +23735,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -24310,9 +23752,9 @@
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1",
-        "postcss": "^5.0.4",
-        "uniqs": "^2.0.0"
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
       },
       "dependencies": {
         "postcss": {
@@ -24321,10 +23763,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -24333,7 +23775,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -24368,8 +23810,8 @@
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "dev": true,
       "requires": {
-        "renderkid": "^2.0.1",
-        "utila": "~0.4"
+        "renderkid": "2.0.1",
+        "utila": "0.4.0"
       }
     },
     "pretty-format": {
@@ -24378,8 +23820,8 @@
       "integrity": "sha512-pvCxP2iODIIk9adXlo4S3GRj0BrJiil68kByAa1PrgG97c1tClh9dLMgp3Z6cHFZrclaABt0UH8PIhwHuFLqYA==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0",
-        "ansi-styles": "^3.2.0"
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -24394,7 +23836,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         }
       }
@@ -24410,8 +23852,8 @@
       "resolved": "https://registry.npmjs.org/prettycron/-/prettycron-0.10.0.tgz",
       "integrity": "sha1-EK8N+iC72fZZbX+1u4uFRsrFJ7s=",
       "requires": {
-        "later": "^1.1.6",
-        "moment": "^2.8.4"
+        "later": "1.2.0",
+        "moment": "2.21.0"
       }
     },
     "prettysize": {
@@ -24448,7 +23890,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "2.0.6"
       }
     },
     "promise-inflight": {
@@ -24468,9 +23910,9 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
       "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "requires": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "core-js": {
@@ -24483,13 +23925,13 @@
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
           "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
           "requires": {
-            "core-js": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.9"
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.17"
           }
         },
         "object-assign": {
@@ -24511,7 +23953,7 @@
       "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
       "dev": true,
       "requires": {
-        "forwarded": "~0.1.2",
+        "forwarded": "0.1.2",
         "ipaddr.js": "1.6.0"
       }
     },
@@ -24532,11 +23974,11 @@
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "parse-asn1": "5.1.1",
+        "randombytes": "2.0.6"
       }
     },
     "pump": {
@@ -24545,8 +23987,8 @@
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       },
       "dependencies": {
         "end-of-stream": {
@@ -24555,7 +23997,7 @@
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           }
         }
       }
@@ -24566,9 +24008,9 @@
       "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
       "dev": true,
       "requires": {
-        "duplexify": "^3.5.3",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
+        "duplexify": "3.5.4",
+        "inherits": "2.0.3",
+        "pump": "2.0.1"
       }
     },
     "punycode": {
@@ -24582,11 +24024,11 @@
       "integrity": "sha512-Vy4jRnV2w/kUjTyxzQOKbFkqwUe6RNLuZgIWR/IRQ8nCqRwiFgwC9XiO9+8poq5KL053uWAQnCSbsfihq77zPg==",
       "dev": true,
       "requires": {
-        "clean-css": "^4.0.12",
-        "glob": "^7.1.1",
-        "rework": "^1.0.1",
-        "uglify-js": "^3.0.6",
-        "yargs": "^8.0.1"
+        "clean-css": "4.1.11",
+        "glob": "7.1.2",
+        "rework": "1.0.1",
+        "uglify-js": "3.3.16",
+        "yargs": "8.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -24607,7 +24049,7 @@
           "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
           "dev": true,
           "requires": {
-            "source-map": "0.5.x"
+            "source-map": "0.5.7"
           }
         },
         "cliui": {
@@ -24616,9 +24058,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           },
           "dependencies": {
             "string-width": {
@@ -24627,9 +24069,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -24640,7 +24082,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "glob": {
@@ -24649,12 +24091,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "load-json-file": {
@@ -24663,10 +24105,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
           }
         },
         "minimatch": {
@@ -24675,7 +24117,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "os-locale": {
@@ -24684,9 +24126,9 @@
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "path-type": {
@@ -24695,7 +24137,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "^2.0.0"
+            "pify": "2.3.0"
           }
         },
         "read-pkg": {
@@ -24704,9 +24146,9 @@
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
           }
         },
         "read-pkg-up": {
@@ -24715,8 +24157,8 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
           }
         },
         "string-width": {
@@ -24725,8 +24167,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -24741,7 +24183,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -24758,8 +24200,8 @@
           "integrity": "sha512-FMh5SRqJRGhv9BbaTffENIpDDQIoPDR8DBraunGORGhySArsXlw9++CN+BWzPBLpoI4RcSnpfGPnilTxWL3Vvg==",
           "dev": true,
           "requires": {
-            "commander": "~2.15.0",
-            "source-map": "~0.6.1"
+            "commander": "2.15.1",
+            "source-map": "0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -24782,19 +24224,19 @@
           "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "read-pkg-up": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^7.0.0"
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
           }
         },
         "yargs-parser": {
@@ -24803,7 +24245,7 @@
           "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -24824,7 +24266,7 @@
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.1.0.tgz",
       "integrity": "sha1-oJInO87y3drUovDU4XlnAb6zWiM=",
       "requires": {
-        "strict-uri-encode": "^1.0.0"
+        "strict-uri-encode": "1.1.0"
       }
     },
     "querystring": {
@@ -24857,7 +24299,7 @@
       "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
       "dev": true,
       "requires": {
-        "performance-now": "^2.1.0"
+        "performance-now": "2.1.0"
       },
       "dependencies": {
         "performance-now": {
@@ -24886,33 +24328,33 @@
       "integrity": "sha1-+h+HgmvhsQI2CQKA6oD188M3ioA=",
       "dev": true,
       "requires": {
-        "base64url": "^1.0.6",
-        "change-case": "^2.3.1",
-        "concat-stream": "^1.5.1",
-        "http-response-object": "^1.1.0",
-        "invariant": "^2.0.0",
-        "json-schema-compatibility": "^1.1.0",
-        "json-stable-stringify": "^1.0.1",
-        "loophole": "^1.1.0",
-        "lrucache": "^0.2.0",
-        "marked": "^0.3.3",
-        "media-typer": "^0.3.0",
-        "mkdirp": "^0.5.0",
-        "pluralize": "^1.2.0",
-        "promise-polyfill": "^5.1.0",
-        "q": "^1.0.0",
+        "base64url": "1.0.6",
+        "change-case": "2.3.1",
+        "concat-stream": "1.6.1",
+        "http-response-object": "1.1.0",
+        "invariant": "2.2.4",
+        "json-schema-compatibility": "1.1.0",
+        "json-stable-stringify": "1.0.1",
+        "loophole": "1.1.0",
+        "lrucache": "0.2.0",
+        "marked": "0.3.12",
+        "media-typer": "0.3.0",
+        "mkdirp": "0.5.1",
+        "pluralize": "1.2.1",
+        "promise-polyfill": "5.2.1",
+        "q": "1.5.1",
         "raml-definition-system": "0.0.54",
-        "then-request": "^2.2.0",
+        "then-request": "2.2.0",
         "ts-model": "0.0.13",
         "ts-structure-parser": "0.0.12",
         "typescript-compiler": "1.4.1-2",
-        "underscore": "^1.8.3",
-        "wrench": "^1.5.8",
-        "xhr2": "^0.1.3",
-        "xmldom": "^0.1.22",
-        "xmlhttprequest": "^1.8.0",
+        "underscore": "1.8.3",
+        "wrench": "1.5.9",
+        "xhr2": "0.1.4",
+        "xmldom": "0.1.27",
+        "xmlhttprequest": "1.8.0",
         "yaml-ast-parser": "0.0.31",
-        "z-schema": "^3.16.1"
+        "z-schema": "3.19.1"
       },
       "dependencies": {
         "underscore": {
@@ -24929,10 +24371,10 @@
       "integrity": "sha1-euwv+KdO6ezmR8aYJaAX0rCLy+8=",
       "dev": true,
       "requires": {
-        "know-your-http-well": "^0.2.0",
+        "know-your-http-well": "0.2.0",
         "raml-typesystem": "0.0.60",
         "ts-structure-parser": "0.0.12",
-        "underscore": "^1.8.3"
+        "underscore": "1.8.3"
       },
       "dependencies": {
         "underscore": {
@@ -24950,7 +24392,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "z-schema": "^3.16.1"
+        "z-schema": "3.19.1"
       }
     },
     "raml-typesystem": {
@@ -24960,13 +24402,13 @@
       "dev": true,
       "requires": {
         "date-and-time": "0.3.0",
-        "json-schema-compatibility": "^1.1.0",
-        "lrucache": "^1.0.0",
+        "json-schema-compatibility": "1.1.0",
+        "lrucache": "1.0.3",
         "raml-json-validation": "0.0.11",
         "raml-xml-validation": "0.0.9",
-        "underscore": "^1.8.3",
-        "xml2js": "^0.4.16",
-        "xmldom": "^0.1.22"
+        "underscore": "1.8.3",
+        "xml2js": "0.4.19",
+        "xmldom": "0.1.27"
       },
       "dependencies": {
         "lrucache": {
@@ -24999,7 +24441,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "xmllint-jsparser": "^0.0.3"
+        "xmllint-jsparser": "0.0.3"
       }
     },
     "randexp": {
@@ -25009,7 +24451,7 @@
       "dev": true,
       "requires": {
         "discontinuous-range": "1.0.0",
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "random-bytes": {
@@ -25024,8 +24466,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -25034,7 +24476,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -25043,7 +24485,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -25054,7 +24496,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -25065,7 +24507,7 @@
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "randomfill": {
@@ -25074,8 +24516,8 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.1"
       }
     },
     "range-parser": {
@@ -25115,10 +24557,10 @@
       "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
       "dev": true,
       "requires": {
-        "deep-extend": "~0.4.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.4.2",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       }
     },
     "react": {
@@ -25126,9 +24568,9 @@
       "resolved": "https://registry.npmjs.org/react/-/react-15.4.1.tgz",
       "integrity": "sha1-SY6RhgJnejmDzQ/SBt/nADiaDdY=",
       "requires": {
-        "fbjs": "^0.8.4",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0"
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "core-js": {
@@ -25141,13 +24583,13 @@
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
           "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
           "requires": {
-            "core-js": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.9"
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.17"
           }
         },
         "object-assign": {
@@ -25162,8 +24604,8 @@
       "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-3.7.0.tgz",
       "integrity": "sha1-J0JG6ptAUSK3G+Iw9W1kfuUJHHc=",
       "requires": {
-        "brace": "^0.8.0",
-        "lodash.isequal": "^4.1.1"
+        "brace": "0.8.0",
+        "lodash.isequal": "4.5.0"
       }
     },
     "react-addons-pure-render-mixin": {
@@ -25188,9 +24630,9 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.4.1.tgz",
       "integrity": "sha1-1UyRMmGq7bF63CBBDQKdzBihNEo=",
       "requires": {
-        "fbjs": "^0.8.1",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0"
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "core-js": {
@@ -25203,13 +24645,13 @@
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
           "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
           "requires": {
-            "core-js": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.9"
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.17"
           }
         },
         "object-assign": {
@@ -25225,8 +24667,8 @@
       "integrity": "sha1-mOAPcM4spO4TkjRgEj52PkksATo=",
       "dev": true,
       "requires": {
-        "babel-plugin-emotion": "^9.2.4",
-        "create-emotion-styled": "^9.2.3"
+        "babel-plugin-emotion": "9.2.5",
+        "create-emotion-styled": "9.2.5"
       }
     },
     "react-gemini-scrollbar": {
@@ -25234,7 +24676,7 @@
       "resolved": "https://registry.npmjs.org/react-gemini-scrollbar/-/react-gemini-scrollbar-2.1.5.tgz",
       "integrity": "sha1-v//yPwOwuwnmM9jqZvQWCsNGgvU=",
       "requires": {
-        "gemini-scrollbar": "1.3.x"
+        "gemini-scrollbar": "1.3.2"
       }
     },
     "react-highlighter": {
@@ -25242,10 +24684,10 @@
       "resolved": "https://registry.npmjs.org/react-highlighter/-/react-highlighter-0.3.5.tgz",
       "integrity": "sha1-dlhGpkgxvhByMagsrT+U08VO30E=",
       "requires": {
-        "blacklist": "^1.1.2",
-        "create-react-class": "^15.5.2",
-        "escape-string-regexp": "^1.0.5",
-        "prop-types": "^15.5.8"
+        "blacklist": "1.1.4",
+        "create-react-class": "15.6.3",
+        "escape-string-regexp": "1.0.5",
+        "prop-types": "15.6.0"
       }
     },
     "react-hot-api": {
@@ -25260,8 +24702,8 @@
       "integrity": "sha1-yVZHrni3Pfzv9uxx/8sEGC/22vk=",
       "dev": true,
       "requires": {
-        "react-hot-api": "^0.4.5",
-        "source-map": "^0.4.4"
+        "react-hot-api": "0.4.7",
+        "source-map": "0.4.4"
       },
       "dependencies": {
         "source-map": {
@@ -25270,7 +24712,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -25280,8 +24722,8 @@
       "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-1.2.0.tgz",
       "integrity": "sha1-hyQQcRWfdCEjiXaR2meW7DO1fQU=",
       "requires": {
-        "create-react-class": "^15.5.2",
-        "prop-types": "^15.5.8"
+        "create-react-class": "15.6.3",
+        "prop-types": "15.6.0"
       }
     },
     "react-intl": {
@@ -25289,10 +24731,10 @@
       "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.2.3.tgz",
       "integrity": "sha1-juuwPN3DizN+0i+reAN6tTpZQnA=",
       "requires": {
-        "intl-format-cache": "^2.0.5",
-        "intl-messageformat": "^1.3.0",
-        "intl-relativeformat": "^1.3.0",
-        "invariant": "^2.1.1"
+        "intl-format-cache": "2.1.0",
+        "intl-messageformat": "1.3.0",
+        "intl-relativeformat": "1.3.0",
+        "invariant": "2.2.4"
       }
     },
     "react-jsonschema-form": {
@@ -25300,10 +24742,10 @@
       "resolved": "https://registry.npmjs.org/react-jsonschema-form/-/react-jsonschema-form-0.50.0.tgz",
       "integrity": "sha512-tvBL2sERUIG61U1Qzy3yvIOEi8mPG/4bPF9hVxZ1YB6o4nFgFQpV/1uvSW2OdxALweC/lwKlEN2gjTfaKMXvYg==",
       "requires": {
-        "jsonschema": "^1.2.0",
-        "lodash.topath": "^4.5.2",
-        "prop-types": "^15.5.8",
-        "setimmediate": "^1.0.5"
+        "jsonschema": "1.2.2",
+        "lodash.topath": "4.5.2",
+        "prop-types": "15.6.0",
+        "setimmediate": "1.0.5"
       }
     },
     "react-lifecycles-compat": {
@@ -25317,7 +24759,7 @@
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-5.11.1.tgz",
       "integrity": "sha1-ADFOUlZ89V+rqUyrus0RlhkHBiM=",
       "requires": {
-        "create-react-class": "^15.5.x"
+        "create-react-class": "15.6.3"
       }
     },
     "react-proxy": {
@@ -25326,8 +24768,8 @@
       "integrity": "sha1-nb/Z2SdSjDqp9ETkVYw3gwq4wmo=",
       "dev": true,
       "requires": {
-        "lodash": "^4.6.1",
-        "react-deep-force-update": "^1.0.0"
+        "lodash": "4.17.5",
+        "react-deep-force-update": "1.1.1"
       },
       "dependencies": {
         "lodash": {
@@ -25343,10 +24785,10 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.4.6.tgz",
       "integrity": "sha1-S50ymFMHoRCWot1hVhmABE/MYgk=",
       "requires": {
-        "hoist-non-react-statics": "^1.0.3",
-        "invariant": "^2.0.0",
-        "lodash": "^4.2.0",
-        "loose-envify": "^1.1.0"
+        "hoist-non-react-statics": "1.2.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.5",
+        "loose-envify": "1.3.1"
       },
       "dependencies": {
         "lodash": {
@@ -25361,11 +24803,11 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-2.8.1.tgz",
       "integrity": "sha1-c+lJH2zrMW0Pd5gpCBhj43juTtc=",
       "requires": {
-        "history": "^2.1.2",
-        "hoist-non-react-statics": "^1.2.0",
-        "invariant": "^2.2.1",
-        "loose-envify": "^1.2.0",
-        "warning": "^3.0.0"
+        "history": "2.1.2",
+        "hoist-non-react-statics": "1.2.0",
+        "invariant": "2.2.4",
+        "loose-envify": "1.3.1",
+        "warning": "3.0.0"
       }
     },
     "react-test-renderer": {
@@ -25386,8 +24828,8 @@
       "integrity": "sha1-4aQL0Krvxy6N/Xp82gmvhQZjl7s=",
       "dev": true,
       "requires": {
-        "global": "^4.3.0",
-        "react-proxy": "^1.1.7"
+        "global": "4.3.2",
+        "react-proxy": "1.1.8"
       }
     },
     "react-transition-group": {
@@ -25395,11 +24837,11 @@
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
       "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
       "requires": {
-        "chain-function": "^1.0.0",
-        "dom-helpers": "^3.2.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.5.6",
-        "warning": "^3.0.0"
+        "chain-function": "1.0.0",
+        "dom-helpers": "3.3.1",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.6.0",
+        "warning": "3.0.0"
       }
     },
     "react-virtualized": {
@@ -25408,12 +24850,12 @@
       "integrity": "sha512-2l6uFicZKZ3x4rdnS0W+1TfyLmPO/+hfZKsCtoChoSmH5aEezGLpSuHc7oplekNIOaEwChfCk30zjx+Zw6B8YQ==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "classnames": "^2.2.3",
-        "dom-helpers": "^2.4.0 || ^3.0.0",
-        "loose-envify": "^1.3.0",
-        "prop-types": "^15.6.0",
-        "react-lifecycles-compat": "^3.0.4"
+        "babel-runtime": "6.26.0",
+        "classnames": "2.2.3",
+        "dom-helpers": "3.3.1",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.6.0",
+        "react-lifecycles-compat": "3.0.4"
       },
       "dependencies": {
         "babel-runtime": {
@@ -25422,8 +24864,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "regenerator-runtime": {
@@ -25441,7 +24883,7 @@
       "requires": {
         "classnames": "2.2.3",
         "lodash.throttle": "4.1.1",
-        "prop-types": "^15.6.0"
+        "prop-types": "15.6.0"
       }
     },
     "reactjs-mixin": {
@@ -25455,8 +24897,8 @@
       "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^2.0.0",
-        "readable-stream": "^2.0.0"
+        "pinkie-promise": "2.0.1",
+        "readable-stream": "2.3.5"
       },
       "dependencies": {
         "isarray": {
@@ -25471,13 +24913,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -25486,7 +24928,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -25497,7 +24939,7 @@
       "integrity": "sha1-JezP86FTtoCa+ssj7hU4fbng7mE=",
       "dev": true,
       "requires": {
-        "gather-stream": "^1.0.0"
+        "gather-stream": "1.0.0"
       }
     },
     "read-installed": {
@@ -25506,13 +24948,13 @@
       "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
       "dev": true,
       "requires": {
-        "debuglog": "^1.0.1",
-        "graceful-fs": "^4.1.2",
-        "read-package-json": "^2.0.0",
-        "readdir-scoped-modules": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "slide": "~1.1.3",
-        "util-extend": "^1.0.1"
+        "debuglog": "1.0.1",
+        "graceful-fs": "4.1.11",
+        "read-package-json": "2.0.13",
+        "readdir-scoped-modules": "1.0.2",
+        "semver": "5.5.0",
+        "slide": "1.1.6",
+        "util-extend": "1.0.3"
       }
     },
     "read-package-json": {
@@ -25521,11 +24963,11 @@
       "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.1",
-        "graceful-fs": "^4.1.2",
-        "json-parse-better-errors": "^1.0.1",
-        "normalize-package-data": "^2.0.0",
-        "slash": "^1.0.0"
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "json-parse-better-errors": "1.0.1",
+        "normalize-package-data": "2.4.0",
+        "slash": "1.0.0"
       },
       "dependencies": {
         "glob": {
@@ -25534,12 +24976,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
@@ -25548,7 +24990,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         }
       }
@@ -25559,9 +25001,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
@@ -25570,8 +25012,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       }
     },
     "readable-stream": {
@@ -25579,10 +25021,10 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
         "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
+        "string_decoder": "0.10.31"
       }
     },
     "readdir-scoped-modules": {
@@ -25591,10 +25033,10 @@
       "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
       "dev": true,
       "requires": {
-        "debuglog": "^1.0.1",
-        "dezalgo": "^1.0.0",
-        "graceful-fs": "^4.1.2",
-        "once": "^1.3.0"
+        "debuglog": "1.0.1",
+        "dezalgo": "1.0.3",
+        "graceful-fs": "4.1.11",
+        "once": "1.4.0"
       }
     },
     "readdirp": {
@@ -25603,10 +25045,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.5",
+        "set-immediate-shim": "1.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -25621,7 +25063,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "readable-stream": {
@@ -25630,13 +25072,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -25645,7 +25087,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -25656,8 +25098,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -25667,7 +25109,7 @@
       "integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
       "dev": true,
       "requires": {
-        "util.promisify": "^1.0.0"
+        "util.promisify": "1.0.0"
       }
     },
     "recast": {
@@ -25677,9 +25119,9 @@
       "dev": true,
       "requires": {
         "ast-types": "0.9.6",
-        "esprima": "~3.1.0",
-        "private": "~0.1.5",
-        "source-map": "~0.5.0"
+        "esprima": "3.1.3",
+        "private": "0.1.8",
+        "source-map": "0.5.7"
       }
     },
     "rechoir": {
@@ -25688,7 +25130,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.6.0"
       }
     },
     "recompose": {
@@ -25696,10 +25138,10 @@
       "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
       "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
       "requires": {
-        "change-emitter": "^0.1.2",
-        "fbjs": "^0.8.1",
-        "hoist-non-react-statics": "^2.3.1",
-        "symbol-observable": "^1.0.4"
+        "change-emitter": "0.1.6",
+        "fbjs": "0.8.16",
+        "hoist-non-react-statics": "2.5.0",
+        "symbol-observable": "1.2.0"
       },
       "dependencies": {
         "core-js": {
@@ -25712,13 +25154,13 @@
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
           "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
           "requires": {
-            "core-js": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.9"
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.17"
           }
         },
         "hoist-non-react-statics": {
@@ -25739,10 +25181,10 @@
       "integrity": "sha512-mdxArOI3sF8K5Nay5NG+lv/VW516TbXjjd4h1wcV1Iy4IMDQPnCayjoQXBAycAFSME4nyXRUXCjHxsw2rYpVRw==",
       "dev": true,
       "requires": {
-        "error-stack-parser": "^1.3.6",
-        "object-assign": "^4.0.1",
-        "prop-types": "^15.5.4",
-        "sourcemapped-stacktrace": "^1.1.6"
+        "error-stack-parser": "1.3.6",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.0",
+        "sourcemapped-stacktrace": "1.1.8"
       },
       "dependencies": {
         "object-assign": {
@@ -25759,8 +25201,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       }
     },
     "reduce-css-calc": {
@@ -25769,9 +25211,9 @@
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "dev": true,
       "requires": {
-        "balanced-match": "^0.4.2",
-        "math-expression-evaluator": "^1.2.14",
-        "reduce-function-call": "^1.0.1"
+        "balanced-match": "0.4.2",
+        "math-expression-evaluator": "1.2.17",
+        "reduce-function-call": "1.0.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -25788,7 +25230,7 @@
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "dev": true,
       "requires": {
-        "balanced-match": "^0.4.2"
+        "balanced-match": "0.4.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -25804,9 +25246,9 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.3.1.tgz",
       "integrity": "sha1-cW34AEeG3q8ByTrjlshPwQQeQks=",
       "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
-        "loose-envify": "^1.1.0"
+        "lodash": "4.17.5",
+        "lodash-es": "4.17.7",
+        "loose-envify": "1.3.1"
       },
       "dependencies": {
         "lodash": {
@@ -25838,9 +25280,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.18.0",
-        "babel-types": "^6.19.0",
-        "private": "^0.1.6"
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.26.0",
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
@@ -25849,7 +25291,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -25858,8 +25300,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "regexpu-core": {
@@ -25868,9 +25310,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
+        "regenerate": "1.3.3",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
       }
     },
     "registry-auth-token": {
@@ -25879,8 +25321,8 @@
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
+        "rc": "1.2.6",
+        "safe-buffer": "5.1.1"
       }
     },
     "registry-url": {
@@ -25889,7 +25331,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "^1.0.1"
+        "rc": "1.2.6"
       }
     },
     "regjsgen": {
@@ -25904,7 +25346,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -25933,11 +25375,11 @@
       "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
       "dev": true,
       "requires": {
-        "css-select": "^1.1.0",
-        "dom-converter": "~0.1",
-        "htmlparser2": "~3.3.0",
-        "strip-ansi": "^3.0.0",
-        "utila": "~0.3"
+        "css-select": "1.2.0",
+        "dom-converter": "0.1.4",
+        "htmlparser2": "3.3.0",
+        "strip-ansi": "3.0.1",
+        "utila": "0.3.3"
       },
       "dependencies": {
         "utila": {
@@ -25966,7 +25408,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "replace-ext": {
@@ -25979,28 +25421,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
       "requires": {
-        "aws-sign2": "~0.6.0",
-        "aws4": "^1.2.1",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.0",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.1.1",
-        "har-validator": "~4.2.1",
-        "hawk": "~3.1.3",
-        "http-signature": "~1.1.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.7",
-        "oauth-sign": "~0.8.1",
-        "performance-now": "^0.2.0",
-        "qs": "~6.4.0",
-        "safe-buffer": "^5.0.1",
-        "stringstream": "~0.0.4",
-        "tough-cookie": "~2.3.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.0.0"
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "4.2.1",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "0.2.0",
+        "qs": "6.4.0",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
       }
     },
     "request-progress": {
@@ -26009,7 +25451,7 @@
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "dev": true,
       "requires": {
-        "throttleit": "^1.0.0"
+        "throttleit": "1.0.0"
       }
     },
     "request-promise-core": {
@@ -26018,7 +25460,7 @@
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "dev": true,
       "requires": {
-        "lodash": "^4.13.1"
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "lodash": {
@@ -26036,8 +25478,8 @@
       "dev": true,
       "requires": {
         "request-promise-core": "1.1.1",
-        "stealthy-require": "^1.1.0",
-        "tough-cookie": ">=2.3.3"
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.4"
       }
     },
     "require-directory": {
@@ -26064,8 +25506,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       }
     },
     "requireindex": {
@@ -26091,7 +25533,7 @@
       "integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "resolve-cwd": {
@@ -26100,7 +25542,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -26117,8 +25559,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       }
     },
     "resolve-from": {
@@ -26133,7 +25575,7 @@
       "integrity": "sha1-j7As/Vt9sgEY6IYxHxWvlb0V+9k=",
       "dev": true,
       "requires": {
-        "global-dirs": "^0.1.0"
+        "global-dirs": "0.1.1"
       }
     },
     "resolve-url": {
@@ -26148,8 +25590,8 @@
       "integrity": "sha1-/6cbq5UtYvfB1Jt0NDVfvGjf/Fo=",
       "dev": true,
       "requires": {
-        "depd": "~1.1.0",
-        "on-headers": "~1.0.1"
+        "depd": "1.1.2",
+        "on-headers": "1.0.1"
       },
       "dependencies": {
         "depd": {
@@ -26166,8 +25608,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
       }
     },
     "ret": {
@@ -26182,8 +25624,8 @@
       "integrity": "sha1-MIBqhBNCtUUQqkEQhQzUhTQUSqc=",
       "dev": true,
       "requires": {
-        "convert-source-map": "^0.3.3",
-        "css": "^2.0.0"
+        "convert-source-map": "0.3.5",
+        "css": "2.2.1"
       },
       "dependencies": {
         "convert-source-map": {
@@ -26200,7 +25642,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "rimraf": {
@@ -26209,7 +25651,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.0.5"
       }
     },
     "ripemd160": {
@@ -26218,8 +25660,8 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "rndm": {
@@ -26234,8 +25676,8 @@
       "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
       "dev": true,
       "requires": {
-        "lodash.flattendeep": "^4.4.0",
-        "nearley": "^2.7.10"
+        "lodash.flattendeep": "4.4.0",
+        "nearley": "2.13.0"
       }
     },
     "run-async": {
@@ -26244,7 +25686,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0"
+        "once": "1.4.0"
       }
     },
     "run-queue": {
@@ -26253,7 +25695,7 @@
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.1"
+        "aproba": "1.2.0"
       }
     },
     "rx-lite": {
@@ -26267,7 +25709,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.3.tgz",
       "integrity": "sha512-fSNi+y+P9ss+EZuV0GcIIqPUK07DEaMRUtLJvdcvMyFjc9dizuDjere+A4V7JrLGnm9iCc+nagV/4QdMTkqC4A==",
       "requires": {
-        "symbol-observable": "^1.0.1"
+        "symbol-observable": "1.2.0"
       }
     },
     "rxjs-marbles": {
@@ -26276,8 +25718,8 @@
       "integrity": "sha512-tGGYlAux+vSFQvXsUE2dgODm2LXYtKHFL+vmMryxmbroWHH0RSOsbPPflU8DDvUcq6st51wcNRzdCSALJHUMCw==",
       "dev": true,
       "requires": {
-        "@types/lodash-es": "^4.0.0",
-        "lodash-es": "^4.0.0"
+        "@types/lodash-es": "4.17.0",
+        "lodash-es": "4.17.7"
       }
     },
     "safe-buffer": {
@@ -26291,7 +25733,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "sane": {
@@ -26300,14 +25742,14 @@
       "integrity": "sha512-glfKd7YH4UCrh/7dD+UESsr8ylKWRE7UQPoXuz28FgmcF0ViJQhCTCCZHICRKxf8G8O1KdLEn20dcICK54c7ew==",
       "dev": true,
       "requires": {
-        "anymatch": "^2.0.0",
-        "exec-sh": "^0.2.0",
-        "fb-watchman": "^2.0.0",
-        "fsevents": "^1.1.1",
-        "micromatch": "^3.1.4",
-        "minimist": "^1.1.1",
-        "walker": "~1.0.5",
-        "watch": "~0.18.0"
+        "anymatch": "2.0.0",
+        "exec-sh": "0.2.1",
+        "fb-watchman": "2.0.0",
+        "fsevents": "1.2.4",
+        "micromatch": "3.1.9",
+        "minimist": "1.2.0",
+        "walker": "1.0.7",
+        "watch": "0.18.0"
       },
       "dependencies": {
         "anymatch": {
@@ -26316,8 +25758,8 @@
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
-            "micromatch": "^3.1.4",
-            "normalize-path": "^2.1.1"
+            "micromatch": "3.1.9",
+            "normalize-path": "2.1.1"
           }
         },
         "arr-diff": {
@@ -26338,18 +25780,18 @@
           "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "kind-of": "^6.0.2",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "kind-of": "6.0.2",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -26358,7 +25800,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -26367,7 +25809,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -26378,13 +25820,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -26393,7 +25835,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -26402,7 +25844,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-descriptor": {
@@ -26411,9 +25853,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -26430,14 +25872,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -26446,7 +25888,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -26455,7 +25897,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -26466,10 +25908,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -26478,7 +25920,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -26489,7 +25931,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -26498,7 +25940,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -26509,7 +25951,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -26518,7 +25960,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -26529,7 +25971,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -26538,7 +25980,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -26561,19 +26003,19 @@
           "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.1",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -26590,7 +26032,7 @@
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "dev": true,
       "requires": {
-        "ajv": "^5.0.0"
+        "ajv": "5.5.2"
       },
       "dependencies": {
         "ajv": {
@@ -26599,10 +26041,10 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         }
       }
@@ -26613,7 +26055,7 @@
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "dev": true,
       "requires": {
-        "commander": "~2.8.1"
+        "commander": "2.8.1"
       },
       "dependencies": {
         "commander": {
@@ -26622,7 +26064,7 @@
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
-            "graceful-readlink": ">= 1.0.0"
+            "graceful-readlink": "1.0.1"
           }
         }
       }
@@ -26658,7 +26100,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "^5.0.3"
+        "semver": "5.5.0"
       }
     },
     "semver-regex": {
@@ -26673,7 +26115,7 @@
       "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
       "dev": true,
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "5.5.0"
       }
     },
     "send": {
@@ -26682,18 +26124,18 @@
       "integrity": "sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=",
       "dev": true,
       "requires": {
-        "debug": "~2.2.0",
-        "depd": "~1.1.0",
-        "destroy": "~1.0.4",
-        "escape-html": "~1.0.3",
-        "etag": "~1.7.0",
+        "debug": "2.2.0",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "escape-html": "1.0.3",
+        "etag": "1.7.0",
         "fresh": "0.3.0",
-        "http-errors": "~1.3.1",
+        "http-errors": "1.3.1",
         "mime": "1.3.4",
         "ms": "0.7.1",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.0.3",
-        "statuses": "~1.2.1"
+        "on-finished": "2.3.0",
+        "range-parser": "1.0.3",
+        "statuses": "1.2.1"
       },
       "dependencies": {
         "debug": {
@@ -26731,7 +26173,7 @@
       "integrity": "sha1-gDSq/CFFdy06vhUJqkLJ4QQtwTk=",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.1"
+        "lower-case": "1.1.4"
       }
     },
     "sequencify": {
@@ -26752,10 +26194,10 @@
       "integrity": "sha1-3UGeJo3gEqtysxnTN/IQUBP5OB8=",
       "dev": true,
       "requires": {
-        "etag": "~1.7.0",
+        "etag": "1.7.0",
         "fresh": "0.3.0",
         "ms": "0.7.2",
-        "parseurl": "~1.3.1"
+        "parseurl": "1.3.2"
       },
       "dependencies": {
         "ms": {
@@ -26772,13 +26214,13 @@
       "integrity": "sha1-egV/xu4o3GP2RWbl+lexEahq7NI=",
       "dev": true,
       "requires": {
-        "accepts": "~1.2.13",
+        "accepts": "1.2.13",
         "batch": "0.5.3",
-        "debug": "~2.2.0",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.3.1",
-        "mime-types": "~2.1.9",
-        "parseurl": "~1.3.1"
+        "debug": "2.2.0",
+        "escape-html": "1.0.3",
+        "http-errors": "1.3.1",
+        "mime-types": "2.1.18",
+        "parseurl": "1.3.2"
       },
       "dependencies": {
         "debug": {
@@ -26804,8 +26246,8 @@
       "integrity": "sha1-zlpuzTEB/tXsCYJ9rCKpwpv7BTU=",
       "dev": true,
       "requires": {
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.1",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.13.2"
       }
     },
@@ -26827,10 +26269,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -26839,7 +26281,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -26861,8 +26303,8 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
       }
     },
     "shebang-command": {
@@ -26871,7 +26313,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -26886,10 +26328,10 @@
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "dev": true,
       "requires": {
-        "array-filter": "~0.0.0",
-        "array-map": "~0.0.0",
-        "array-reduce": "~0.0.0",
-        "jsonify": "~0.0.0"
+        "array-filter": "0.0.1",
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
+        "jsonify": "0.0.0"
       }
     },
     "shelljs": {
@@ -26898,9 +26340,9 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
+        "glob": "7.0.5",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
       }
     },
     "shellwords": {
@@ -26944,7 +26386,7 @@
       "integrity": "sha1-DC8l4wUVjZoY09l3BmGH/vilpmo=",
       "dev": true,
       "requires": {
-        "sentence-case": "^1.1.2"
+        "sentence-case": "1.1.3"
       }
     },
     "snapdragon": {
@@ -26953,14 +26395,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -26969,7 +26411,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -26978,7 +26420,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "is-accessor-descriptor": {
@@ -26987,7 +26429,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -26996,7 +26438,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -27007,7 +26449,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -27016,7 +26458,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -27027,9 +26469,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
@@ -27046,9 +26488,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -27057,7 +26499,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "isobject": {
@@ -27074,7 +26516,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       }
     },
     "sntp": {
@@ -27082,7 +26524,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "requires": {
-        "hoek": "2.x.x"
+        "hoek": "2.16.3"
       }
     },
     "sockjs": {
@@ -27091,8 +26533,8 @@
       "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
       "dev": true,
       "requires": {
-        "faye-websocket": "^0.10.0",
-        "uuid": "^3.0.1"
+        "faye-websocket": "0.10.0",
+        "uuid": "3.2.1"
       }
     },
     "sockjs-client": {
@@ -27101,12 +26543,12 @@
       "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
       "dev": true,
       "requires": {
-        "debug": "^2.6.6",
+        "debug": "2.6.9",
         "eventsource": "0.1.6",
-        "faye-websocket": "~0.11.0",
-        "inherits": "^2.0.1",
-        "json3": "^3.3.2",
-        "url-parse": "^1.1.8"
+        "faye-websocket": "0.11.1",
+        "inherits": "2.0.3",
+        "json3": "3.3.2",
+        "url-parse": "1.2.0"
       },
       "dependencies": {
         "faye-websocket": {
@@ -27115,7 +26557,7 @@
           "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
           "dev": true,
           "requires": {
-            "websocket-driver": ">=0.5.1"
+            "websocket-driver": "0.7.0"
           }
         }
       }
@@ -27126,7 +26568,7 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "^1.0.0"
+        "is-plain-obj": "1.1.0"
       }
     },
     "sort-keys-length": {
@@ -27135,7 +26577,7 @@
       "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
       "dev": true,
       "requires": {
-        "sort-keys": "^1.0.0"
+        "sort-keys": "1.1.2"
       }
     },
     "source-list-map": {
@@ -27156,9 +26598,9 @@
       "integrity": "sha1-DsbKWKoOYUY6KGc91MSei6Z9xxg=",
       "dev": true,
       "requires": {
-        "async": "^0.9.0",
-        "loader-utils": "~0.2.2",
-        "source-map": "~0.1.33"
+        "async": "0.9.2",
+        "loader-utils": "0.2.17",
+        "source-map": "0.1.43"
       },
       "dependencies": {
         "async": {
@@ -27173,7 +26615,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -27184,11 +26626,11 @@
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "dev": true,
       "requires": {
-        "atob": "^2.0.0",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.0.3",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -27197,7 +26639,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.7"
       }
     },
     "source-map-url": {
@@ -27234,8 +26676,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -27250,8 +26692,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -27266,12 +26708,12 @@
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "handle-thing": "^1.2.5",
-        "http-deceiver": "^1.2.7",
-        "safe-buffer": "^5.0.1",
-        "select-hose": "^2.0.0",
-        "spdy-transport": "^2.0.18"
+        "debug": "2.6.9",
+        "handle-thing": "1.2.5",
+        "http-deceiver": "1.2.7",
+        "safe-buffer": "5.1.1",
+        "select-hose": "2.0.0",
+        "spdy-transport": "2.1.0"
       }
     },
     "spdy-transport": {
@@ -27280,13 +26722,13 @@
       "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "detect-node": "^2.0.3",
-        "hpack.js": "^2.1.6",
-        "obuf": "^1.1.1",
-        "readable-stream": "^2.2.9",
-        "safe-buffer": "^5.0.1",
-        "wbuf": "^1.7.2"
+        "debug": "2.6.9",
+        "detect-node": "2.0.3",
+        "hpack.js": "2.1.6",
+        "obuf": "1.1.2",
+        "readable-stream": "2.3.5",
+        "safe-buffer": "5.1.1",
+        "wbuf": "1.7.3"
       },
       "dependencies": {
         "isarray": {
@@ -27301,13 +26743,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -27316,7 +26758,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -27333,7 +26775,7 @@
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "dev": true,
       "requires": {
-        "through": "2"
+        "through": "2.3.8"
       }
     },
     "split-string": {
@@ -27342,7 +26784,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "split2": {
@@ -27351,7 +26793,7 @@
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "dev": true,
       "requires": {
-        "through2": "^2.0.2"
+        "through2": "2.0.3"
       },
       "dependencies": {
         "isarray": {
@@ -27366,13 +26808,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -27381,7 +26823,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "through2": {
@@ -27390,8 +26832,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -27408,9 +26850,9 @@
       "integrity": "sha1-MwRQN7ZDiLVnZ0uEMiplIQc5FsM=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "console-stream": "^0.1.1",
-        "lpad-align": "^1.0.1"
+        "chalk": "1.1.3",
+        "console-stream": "0.1.1",
+        "lpad-align": "1.1.2"
       }
     },
     "sshpk": {
@@ -27418,14 +26860,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       },
       "dependencies": {
         "assert-plus": {
@@ -27441,7 +26883,7 @@
       "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.1.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "stack-trace": {
@@ -27468,14 +26910,14 @@
       "integrity": "sha512-2UJ2BIUNa7+41PH4FvYicSQED2LCt2RXjmNFis+JZlxZtwzNnGn4uuL8WBUqHoC9b+bJ0AHIAX/bilzm+pGPeA==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "conventional-changelog": "^1.1.0",
-        "conventional-recommended-bump": "^1.0.0",
-        "dotgitignore": "^1.0.3",
-        "figures": "^1.5.0",
-        "fs-access": "^1.0.0",
-        "semver": "^5.1.0",
-        "yargs": "^8.0.1"
+        "chalk": "1.1.3",
+        "conventional-changelog": "1.1.23",
+        "conventional-recommended-bump": "1.2.1",
+        "dotgitignore": "1.0.3",
+        "figures": "1.7.0",
+        "fs-access": "1.0.1",
+        "semver": "5.5.0",
+        "yargs": "8.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -27496,9 +26938,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           },
           "dependencies": {
             "string-width": {
@@ -27507,9 +26949,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -27520,7 +26962,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "load-json-file": {
@@ -27529,10 +26971,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
           }
         },
         "os-locale": {
@@ -27541,9 +26983,9 @@
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "path-type": {
@@ -27552,7 +26994,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "^2.0.0"
+            "pify": "2.3.0"
           }
         },
         "read-pkg": {
@@ -27561,9 +27003,9 @@
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
           }
         },
         "read-pkg-up": {
@@ -27572,8 +27014,8 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
           }
         },
         "string-width": {
@@ -27582,8 +27024,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -27598,7 +27040,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -27621,19 +27063,19 @@
           "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "read-pkg-up": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^7.0.0"
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
           }
         },
         "yargs-parser": {
@@ -27642,7 +27084,7 @@
           "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -27659,8 +27101,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -27669,7 +27111,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-accessor-descriptor": {
@@ -27678,7 +27120,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -27687,7 +27129,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -27698,7 +27140,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -27707,7 +27149,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -27718,9 +27160,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           }
         },
         "kind-of": {
@@ -27748,8 +27190,8 @@
       "resolved": "https://registry.npmjs.org/stream-array/-/stream-array-0.1.3.tgz",
       "integrity": "sha1-bjdOicmqoapImVHAcBHyRWEfyYs=",
       "requires": {
-        "fastqueue": "~0.1.0",
-        "readable-stream": "~1.1.0"
+        "fastqueue": "0.1.0",
+        "readable-stream": "1.1.14"
       }
     },
     "stream-browserify": {
@@ -27758,8 +27200,8 @@
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.5"
       },
       "dependencies": {
         "isarray": {
@@ -27774,13 +27216,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -27789,7 +27231,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -27800,7 +27242,7 @@
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1"
+        "duplexer": "0.1.1"
       }
     },
     "stream-combiner2": {
@@ -27809,8 +27251,8 @@
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "dev": true,
       "requires": {
-        "duplexer2": "~0.1.0",
-        "readable-stream": "^2.0.2"
+        "duplexer2": "0.1.4",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "duplexer2": {
@@ -27819,7 +27261,7 @@
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.0.2"
+            "readable-stream": "2.3.6"
           }
         },
         "isarray": {
@@ -27834,13 +27276,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -27849,7 +27291,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -27866,7 +27308,7 @@
       "integrity": "sha1-3tJmVWMZyLDiIoErnPOyb6fZR94=",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.1.8"
+        "readable-stream": "1.1.14"
       }
     },
     "stream-each": {
@@ -27875,8 +27317,8 @@
       "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "stream-shift": "1.0.0"
       },
       "dependencies": {
         "end-of-stream": {
@@ -27885,7 +27327,7 @@
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           }
         }
       }
@@ -27901,11 +27343,11 @@
       "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.3",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -27920,13 +27362,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -27935,7 +27377,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -27963,8 +27405,8 @@
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
       "requires": {
-        "astral-regex": "^1.0.0",
-        "strip-ansi": "^4.0.0"
+        "astral-regex": "1.0.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -27979,7 +27421,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -27990,11 +27432,11 @@
       "integrity": "sha1-gsZ0SM6pXsACob/P0vsBlc0SvSQ=",
       "dev": true,
       "requires": {
-        "async": "~0.2.10",
-        "css-loader": "^0.9.1",
-        "file-loader": "^0.8.1",
-        "loader-utils": "~0.2.3",
-        "style-loader": "^0.8.3"
+        "async": "0.2.10",
+        "css-loader": "0.9.1",
+        "file-loader": "0.8.5",
+        "loader-utils": "0.2.17",
+        "style-loader": "0.8.3"
       },
       "dependencies": {
         "css-loader": {
@@ -28003,9 +27445,9 @@
           "integrity": "sha1-LhqgDOfjDvLGp6SzAKCAp8l54Nw=",
           "dev": true,
           "requires": {
-            "csso": "1.3.x",
-            "loader-utils": "~0.2.2",
-            "source-map": "~0.1.38"
+            "csso": "1.3.12",
+            "loader-utils": "0.2.17",
+            "source-map": "0.1.43"
           }
         },
         "csso": {
@@ -28020,7 +27462,7 @@
           "integrity": "sha1-knXQMf54DyfUf19K8CvUNxPMFRs=",
           "dev": true,
           "requires": {
-            "loader-utils": "~0.2.5"
+            "loader-utils": "0.2.17"
           }
         },
         "source-map": {
@@ -28029,7 +27471,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         },
         "style-loader": {
@@ -28038,7 +27480,7 @@
           "integrity": "sha1-9Pkut9tjdodI8VBlzWcA9aHIU1c=",
           "dev": true,
           "requires": {
-            "loader-utils": "^0.2.5"
+            "loader-utils": "0.2.17"
           }
         }
       }
@@ -28049,9 +27491,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -28069,7 +27511,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -28077,8 +27519,8 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
       "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
       "requires": {
-        "first-chunk-stream": "^1.0.0",
-        "is-utf8": "^0.2.0"
+        "first-chunk-stream": "1.0.0",
+        "is-utf8": "0.2.1"
       }
     },
     "strip-bom-stream": {
@@ -28087,8 +27529,8 @@
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "^1.0.0",
-        "strip-bom": "^2.0.0"
+        "first-chunk-stream": "1.0.0",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -28097,7 +27539,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -28108,12 +27550,12 @@
       "integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "is-absolute": "^0.1.5",
-        "is-natural-number": "^2.0.0",
-        "minimist": "^1.1.0",
-        "sum-up": "^1.0.1"
+        "chalk": "1.1.3",
+        "get-stdin": "4.0.1",
+        "is-absolute": "0.1.7",
+        "is-natural-number": "2.1.1",
+        "minimist": "1.2.0",
+        "sum-up": "1.0.3"
       },
       "dependencies": {
         "get-stdin": {
@@ -28128,7 +27570,7 @@
           "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
           "dev": true,
           "requires": {
-            "is-relative": "^0.1.0"
+            "is-relative": "0.1.3"
           }
         },
         "is-relative": {
@@ -28151,7 +27593,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       },
       "dependencies": {
         "get-stdin": {
@@ -28174,7 +27616,7 @@
       "integrity": "sha1-qsC6YNLpDF1PJ1/Yhp/ZotMQ/7g=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.2"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "style-loader": {
@@ -28183,8 +27625,8 @@
       "integrity": "sha512-NtlwQOHQvUgEKuPs4JoUMQUkML8UNMxLbXM2JAZerIQVVVMgO5VVRjYQA8zzkpBu/X2OnTt+5ZKe8IbGk5TjRA==",
       "dev": true,
       "requires": {
-        "loader-utils": "^1.1.0",
-        "schema-utils": "^0.4.3"
+        "loader-utils": "1.1.0",
+        "schema-utils": "0.4.5"
       },
       "dependencies": {
         "ajv": {
@@ -28193,10 +27635,10 @@
           "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0",
-            "uri-js": "^3.0.2"
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "3.0.2"
           }
         },
         "ajv-keywords": {
@@ -28211,9 +27653,9 @@
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         },
         "schema-utils": {
@@ -28222,8 +27664,8 @@
           "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
           "dev": true,
           "requires": {
-            "ajv": "^6.1.0",
-            "ajv-keywords": "^3.1.0"
+            "ajv": "6.4.0",
+            "ajv-keywords": "3.1.0"
           }
         }
       }
@@ -28240,16 +27682,16 @@
       "integrity": "sha1-ZMg+BDimjJ7fRJ6MVSp9mrYAmws=",
       "dev": true,
       "requires": {
-        "browserslist": "^1.1.3",
-        "chalk": "^1.1.1",
-        "log-symbols": "^1.0.2",
-        "minimist": "^1.2.0",
-        "plur": "^2.1.2",
-        "postcss": "^5.0.18",
-        "postcss-reporter": "^1.3.3",
-        "postcss-selector-parser": "^2.0.0",
-        "read-file-stdin": "^0.2.1",
-        "text-table": "^0.2.0",
+        "browserslist": "1.3.6",
+        "chalk": "1.1.3",
+        "log-symbols": "1.0.2",
+        "minimist": "1.2.0",
+        "plur": "2.1.2",
+        "postcss": "5.2.18",
+        "postcss-reporter": "1.4.1",
+        "postcss-selector-parser": "2.2.3",
+        "read-file-stdin": "0.2.1",
+        "text-table": "0.2.0",
         "write-file-stdout": "0.0.2"
       },
       "dependencies": {
@@ -28259,10 +27701,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -28271,7 +27713,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -28282,40 +27724,40 @@
       "integrity": "sha1-Fueh8Byq2KUBLkC6YpZXa9XoRv4=",
       "dev": true,
       "requires": {
-        "autoprefixer": "^6.0.0",
-        "balanced-match": "^0.4.0",
-        "chalk": "^1.1.1",
-        "colorguard": "^1.2.0",
-        "cosmiconfig": "^1.1.0",
-        "doiuse": "^2.4.1",
-        "execall": "^1.0.0",
-        "get-stdin": "^5.0.0",
-        "globby": "^6.0.0",
-        "globjoin": "^0.1.4",
-        "html-tags": "^1.1.1",
-        "ignore": "^3.1.3",
-        "known-css-properties": "^0.0.4",
-        "lodash": "^4.0.0",
-        "log-symbols": "^1.0.2",
-        "meow": "^3.3.0",
-        "multimatch": "^2.1.0",
-        "normalize-selector": "^0.2.0",
-        "postcss": "^5.0.20",
-        "postcss-less": "^0.14.0",
-        "postcss-media-query-parser": "^0.2.0",
-        "postcss-reporter": "^1.3.0",
-        "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-scss": "^0.2.0",
-        "postcss-selector-parser": "^2.1.1",
-        "postcss-value-parser": "^3.1.1",
-        "resolve-from": "^2.0.0",
-        "specificity": "^0.2.1",
-        "string-width": "^1.0.1",
-        "style-search": "^0.1.0",
-        "stylehacks": "^2.3.0",
-        "sugarss": "^0.1.2",
-        "svg-tags": "^1.0.0",
-        "table": "^3.7.8"
+        "autoprefixer": "6.3.6",
+        "balanced-match": "0.4.2",
+        "chalk": "1.1.3",
+        "colorguard": "1.2.1",
+        "cosmiconfig": "1.1.0",
+        "doiuse": "2.6.0",
+        "execall": "1.0.0",
+        "get-stdin": "5.0.1",
+        "globby": "6.1.0",
+        "globjoin": "0.1.4",
+        "html-tags": "1.2.0",
+        "ignore": "3.3.7",
+        "known-css-properties": "0.0.4",
+        "lodash": "4.17.5",
+        "log-symbols": "1.0.2",
+        "meow": "3.7.0",
+        "multimatch": "2.1.0",
+        "normalize-selector": "0.2.0",
+        "postcss": "5.2.18",
+        "postcss-less": "0.14.0",
+        "postcss-media-query-parser": "0.2.3",
+        "postcss-reporter": "1.4.1",
+        "postcss-resolve-nested-selector": "0.1.1",
+        "postcss-scss": "0.2.1",
+        "postcss-selector-parser": "2.2.3",
+        "postcss-value-parser": "3.3.0",
+        "resolve-from": "2.0.0",
+        "specificity": "0.2.1",
+        "string-width": "1.0.2",
+        "style-search": "0.1.0",
+        "stylehacks": "2.3.2",
+        "sugarss": "0.1.6",
+        "svg-tags": "1.0.0",
+        "table": "3.8.3"
       },
       "dependencies": {
         "balanced-match": {
@@ -28330,11 +27772,11 @@
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "array-union": "1.0.2",
+            "glob": "7.0.5",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "lodash": {
@@ -28355,10 +27797,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "resolve-from": {
@@ -28373,7 +27815,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -28411,7 +27853,7 @@
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
-        "minimist": "^1.1.0"
+        "minimist": "1.2.0"
       }
     },
     "sugarss": {
@@ -28420,7 +27862,7 @@
       "integrity": "sha1-/jrA4eBygq7x3oSoC3I4b/Tn6jc=",
       "dev": true,
       "requires": {
-        "postcss": "^5.2.0"
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "postcss": {
@@ -28429,10 +27871,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.4.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "supports-color": {
@@ -28441,7 +27883,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -28452,7 +27894,7 @@
       "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0"
+        "chalk": "1.1.3"
       }
     },
     "supports-color": {
@@ -28466,24 +27908,24 @@
       "integrity": "sha1-tObKEICNjwP3F4lvq/I4NEjuIIY=",
       "dev": true,
       "requires": {
-        "async": "^2.0.0-rc.4",
-        "css-selector-parser": "^1.1.0",
-        "cssmin": "^0.4.3",
-        "cssom": "^0.3.0",
-        "glob": "^7.0.3",
-        "js-yaml": "^3.6.1",
-        "lodash": "^4.12.0",
-        "lodash.pluck": "^3.1.2",
-        "mkdirp": "^0.5.1",
-        "mustache": "^2.2.1",
-        "phantomjs-prebuilt": "^2.1.7",
-        "prettysize": "^0.0.3",
+        "async": "2.6.0",
+        "css-selector-parser": "1.3.0",
+        "cssmin": "0.4.3",
+        "cssom": "0.3.2",
+        "glob": "7.0.5",
+        "js-yaml": "3.7.0",
+        "lodash": "4.17.5",
+        "lodash.pluck": "3.1.2",
+        "mkdirp": "0.5.1",
+        "mustache": "2.3.0",
+        "phantomjs-prebuilt": "2.1.16",
+        "prettysize": "0.0.3",
         "svgo": "0.6.6",
-        "vinyl": "^1.1.0",
-        "winston": "^2.2.0",
+        "vinyl": "1.1.1",
+        "winston": "2.4.1",
         "xmldom": "0.1.22",
-        "xpath": "^0.0.23",
-        "yargs": "^4.7.0"
+        "xpath": "0.0.23",
+        "yargs": "4.8.1"
       },
       "dependencies": {
         "async": {
@@ -28492,7 +27934,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "4.17.5"
           }
         },
         "camelcase": {
@@ -28507,9 +27949,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           }
         },
         "csso": {
@@ -28518,8 +27960,8 @@
           "integrity": "sha1-F4tDpEYhIhwndWCG9THgL0KQDug=",
           "dev": true,
           "requires": {
-            "clap": "^1.0.9",
-            "source-map": "^0.5.3"
+            "clap": "1.2.3",
+            "source-map": "0.5.7"
           }
         },
         "esprima": {
@@ -28540,13 +27982,13 @@
           "integrity": "sha1-s0CIkDbyD5tEdUMHfQ9Vc+0ETAg=",
           "dev": true,
           "requires": {
-            "coa": "~1.0.1",
-            "colors": "~1.1.2",
-            "csso": "~2.0.0",
-            "js-yaml": "~3.6.0",
-            "mkdirp": "~0.5.1",
-            "sax": "~1.2.1",
-            "whet.extend": "~0.9.9"
+            "coa": "1.0.4",
+            "colors": "1.1.2",
+            "csso": "2.0.0",
+            "js-yaml": "3.6.1",
+            "mkdirp": "0.5.1",
+            "sax": "1.2.4",
+            "whet.extend": "0.9.9"
           },
           "dependencies": {
             "js-yaml": {
@@ -28555,8 +27997,8 @@
               "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
               "dev": true,
               "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^2.6.0"
+                "argparse": "1.0.10",
+                "esprima": "2.7.3"
               }
             }
           }
@@ -28579,20 +28021,20 @@
           "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
           "dev": true,
           "requires": {
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "lodash.assign": "^4.0.3",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.1",
-            "which-module": "^1.0.0",
-            "window-size": "^0.2.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^2.4.1"
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "lodash.assign": "4.2.0",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.1"
           }
         },
         "yargs-parser": {
@@ -28601,8 +28043,8 @@
           "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "lodash.assign": "^4.0.6"
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.2.0"
           }
         }
       }
@@ -28619,13 +28061,13 @@
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "dev": true,
       "requires": {
-        "coa": "~1.0.1",
-        "colors": "~1.1.2",
-        "csso": "~2.3.1",
-        "js-yaml": "~3.7.0",
-        "mkdirp": "~0.5.1",
-        "sax": "~1.2.1",
-        "whet.extend": "~0.9.9"
+        "coa": "1.0.4",
+        "colors": "1.1.2",
+        "csso": "2.3.2",
+        "js-yaml": "3.7.0",
+        "mkdirp": "0.5.1",
+        "sax": "1.2.4",
+        "whet.extend": "0.9.9"
       }
     },
     "swap-case": {
@@ -28634,8 +28076,8 @@
       "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.1",
-        "upper-case": "^1.1.1"
+        "lower-case": "1.1.4",
+        "upper-case": "1.1.3"
       }
     },
     "symbol-observable": {
@@ -28672,12 +28114,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "^4.7.0",
-        "ajv-keywords": "^1.0.0",
-        "chalk": "^1.1.1",
-        "lodash": "^4.0.0",
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.5",
         "slice-ansi": "0.0.4",
-        "string-width": "^2.0.0"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -28704,8 +28146,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -28714,7 +28156,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -28731,10 +28173,10 @@
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "dev": true,
       "requires": {
-        "bl": "^1.0.0",
-        "end-of-stream": "^1.0.0",
-        "readable-stream": "^2.0.0",
-        "xtend": "^4.0.0"
+        "bl": "1.2.1",
+        "end-of-stream": "1.4.1",
+        "readable-stream": "2.3.5",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "end-of-stream": {
@@ -28743,7 +28185,7 @@
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           }
         },
         "isarray": {
@@ -28758,13 +28200,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -28773,7 +28215,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -28790,8 +28232,8 @@
       "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "^1.0.0",
-        "uuid": "^2.0.1"
+        "os-tmpdir": "1.0.2",
+        "uuid": "2.0.3"
       },
       "dependencies": {
         "uuid": {
@@ -28808,11 +28250,11 @@
       "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "micromatch": "^3.1.8",
-        "object-assign": "^4.1.0",
-        "read-pkg-up": "^1.0.1",
-        "require-main-filename": "^1.0.1"
+        "arrify": "1.0.1",
+        "micromatch": "3.1.9",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "require-main-filename": "1.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -28833,18 +28275,18 @@
           "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "kind-of": "^6.0.2",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "kind-of": "6.0.2",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -28853,7 +28295,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -28862,7 +28304,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -28873,13 +28315,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -28888,7 +28330,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -28897,7 +28339,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-descriptor": {
@@ -28906,9 +28348,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -28925,14 +28367,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -28941,7 +28383,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -28950,7 +28392,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -28961,10 +28403,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -28973,7 +28415,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -28984,7 +28426,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -28993,7 +28435,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -29004,7 +28446,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -29013,7 +28455,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -29024,7 +28466,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -29033,7 +28475,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -29056,19 +28498,19 @@
           "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.1",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "object-assign": {
@@ -29097,12 +28539,12 @@
       "integrity": "sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=",
       "dev": true,
       "requires": {
-        "caseless": "~0.11.0",
-        "concat-stream": "^1.4.7",
-        "http-basic": "^2.5.1",
-        "http-response-object": "^1.1.0",
-        "promise": "^7.1.1",
-        "qs": "^6.1.0"
+        "caseless": "0.11.0",
+        "concat-stream": "1.6.1",
+        "http-basic": "2.5.1",
+        "http-response-object": "1.1.0",
+        "promise": "7.3.1",
+        "qs": "6.4.0"
       },
       "dependencies": {
         "caseless": {
@@ -29119,7 +28561,7 @@
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "dev": true,
       "requires": {
-        "any-promise": "^1.0.0"
+        "any-promise": "1.3.0"
       }
     },
     "thenify-all": {
@@ -29128,7 +28570,7 @@
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "dev": true,
       "requires": {
-        "thenify": ">= 3.1.0 < 4"
+        "thenify": "3.3.0"
       }
     },
     "throat": {
@@ -29154,8 +28596,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
       "requires": {
-        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-        "xtend": ">=4.0.0 <4.1.0-0"
+        "readable-stream": "1.0.34",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "readable-stream": {
@@ -29163,10 +28605,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         }
       }
@@ -29177,8 +28619,8 @@
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "dev": true,
       "requires": {
-        "through2": "~2.0.0",
-        "xtend": "~4.0.0"
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -29193,13 +28635,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -29208,7 +28650,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "through2": {
@@ -29217,8 +28659,8 @@
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.1.5",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.5",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -29235,7 +28677,7 @@
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "time-stamp": {
@@ -29255,7 +28697,7 @@
       "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "dev": true,
       "requires": {
-        "setimmediate": "^1.0.4"
+        "setimmediate": "1.0.5"
       }
     },
     "tiny-emitter": {
@@ -29269,12 +28711,12 @@
       "integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
       "dev": true,
       "requires": {
-        "body-parser": "~1.14.0",
-        "debug": "~2.2.0",
-        "faye-websocket": "~0.10.0",
-        "livereload-js": "^2.2.0",
-        "parseurl": "~1.3.0",
-        "qs": "~5.1.0"
+        "body-parser": "1.14.2",
+        "debug": "2.2.0",
+        "faye-websocket": "0.10.0",
+        "livereload-js": "2.3.0",
+        "parseurl": "1.3.2",
+        "qs": "5.1.0"
       },
       "dependencies": {
         "body-parser": {
@@ -29284,15 +28726,15 @@
           "dev": true,
           "requires": {
             "bytes": "2.2.0",
-            "content-type": "~1.0.1",
-            "debug": "~2.2.0",
-            "depd": "~1.1.0",
-            "http-errors": "~1.3.1",
+            "content-type": "1.0.4",
+            "debug": "2.2.0",
+            "depd": "1.1.2",
+            "http-errors": "1.3.1",
             "iconv-lite": "0.4.13",
-            "on-finished": "~2.3.0",
+            "on-finished": "2.3.0",
             "qs": "5.2.0",
-            "raw-body": "~2.1.5",
-            "type-is": "~1.6.10"
+            "raw-body": "2.1.7",
+            "type-is": "1.6.16"
           },
           "dependencies": {
             "qs": {
@@ -29350,8 +28792,8 @@
       "integrity": "sha1-+uSmrlRr+iLQg6DuqRCkDRLtT1o=",
       "dev": true,
       "requires": {
-        "sentence-case": "^1.1.1",
-        "upper-case": "^1.0.3"
+        "sentence-case": "1.1.3",
+        "upper-case": "1.1.3"
       }
     },
     "tmp": {
@@ -29360,7 +28802,7 @@
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "os-tmpdir": "1.0.2"
       }
     },
     "tmpl": {
@@ -29375,7 +28817,7 @@
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1"
+        "extend-shallow": "2.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -29384,7 +28826,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -29407,7 +28849,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "to-regex": {
@@ -29416,10 +28858,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -29428,8 +28870,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -29438,7 +28880,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         }
       }
@@ -29449,7 +28891,7 @@
       "integrity": "sha1-RJy+LbrlqMgDjjDXH6D/RklHxN4=",
       "dev": true,
       "requires": {
-        "nopt": "~1.0.10"
+        "nopt": "1.0.10"
       }
     },
     "tough-cookie": {
@@ -29457,7 +28899,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       }
     },
     "tr46": {
@@ -29466,7 +28908,7 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -29483,9 +28925,9 @@
       "integrity": "sha1-isvT66UU3BdwDI+223EU8vcqPnQ=",
       "dev": true,
       "requires": {
-        "acorn-jsx": "^2.0.0",
-        "falafel": "^1.2.0",
-        "lodash": "^3.10.1"
+        "acorn-jsx": "2.0.1",
+        "falafel": "1.2.0",
+        "lodash": "3.10.1"
       },
       "dependencies": {
         "acorn": {
@@ -29500,7 +28942,7 @@
           "integrity": "sha1-Dt+YeKWGa8piX1KVWh7Z59jFEX4=",
           "dev": true,
           "requires": {
-            "acorn": "^2.0.1"
+            "acorn": "2.7.0"
           }
         },
         "lodash": {
@@ -29523,7 +28965,7 @@
       "integrity": "sha1-ffigksmJf8Lgnawi9CPigyMXYuc=",
       "dev": true,
       "requires": {
-        "n-gram": "^0.1.0"
+        "n-gram": "0.1.2"
       }
     },
     "trim-newlines": {
@@ -29544,7 +28986,7 @@
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.2"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "trim-right": {
@@ -29559,17 +29001,17 @@
       "integrity": "sha512-kYQ6g1G1AU+bOO9rv+SSQXg4WTcni6Wx3AM48iHni0nP1vIuhdNRjKTE9Cxx36Ix/IOV7L85iKu07dgXJzH2pQ==",
       "dev": true,
       "requires": {
-        "babel-core": "^6.26.3",
-        "babel-plugin-istanbul": "^4.1.6",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
-        "babel-preset-jest": "^22.4.3",
-        "cpx": "^1.5.0",
+        "babel-core": "6.26.3",
+        "babel-plugin-istanbul": "4.1.6",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-preset-jest": "22.4.4",
+        "cpx": "1.5.0",
         "fs-extra": "6.0.0",
-        "jest-config": "^22.4.3",
-        "lodash": "^4.17.10",
-        "pkg-dir": "^2.0.0",
-        "source-map-support": "^0.5.5",
-        "yargs": "^11.0.0"
+        "jest-config": "22.4.4",
+        "lodash": "4.17.10",
+        "pkg-dir": "2.0.0",
+        "source-map-support": "0.5.6",
+        "yargs": "11.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -29584,7 +29026,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "babel-core": {
@@ -29593,25 +29035,25 @@
           "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
           "dev": true,
           "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-generator": "^6.26.0",
-            "babel-helpers": "^6.24.1",
-            "babel-messages": "^6.23.0",
-            "babel-register": "^6.26.0",
-            "babel-runtime": "^6.26.0",
-            "babel-template": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "convert-source-map": "^1.5.1",
-            "debug": "^2.6.9",
-            "json5": "^0.5.1",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.4",
-            "path-is-absolute": "^1.0.1",
-            "private": "^0.1.8",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.7"
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.1",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.5.1",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.10",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
           }
         },
         "babel-plugin-istanbul": {
@@ -29620,10 +29062,10 @@
           "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
           "dev": true,
           "requires": {
-            "babel-plugin-syntax-object-rest-spread": "^6.13.0",
-            "find-up": "^2.1.0",
-            "istanbul-lib-instrument": "^1.10.1",
-            "test-exclude": "^4.2.1"
+            "babel-plugin-syntax-object-rest-spread": "6.13.0",
+            "find-up": "2.1.0",
+            "istanbul-lib-instrument": "1.10.1",
+            "test-exclude": "4.2.1"
           }
         },
         "babel-plugin-jest-hoist": {
@@ -29638,10 +29080,10 @@
           "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
           "dev": true,
           "requires": {
-            "babel-plugin-transform-strict-mode": "^6.24.1",
-            "babel-runtime": "^6.26.0",
-            "babel-template": "^6.26.0",
-            "babel-types": "^6.26.0"
+            "babel-plugin-transform-strict-mode": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-preset-jest": {
@@ -29650,8 +29092,8 @@
           "integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
           "dev": true,
           "requires": {
-            "babel-plugin-jest-hoist": "^22.4.4",
-            "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+            "babel-plugin-jest-hoist": "22.4.4",
+            "babel-plugin-syntax-object-rest-spread": "6.13.0"
           }
         },
         "babel-register": {
@@ -29660,13 +29102,13 @@
           "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
           "dev": true,
           "requires": {
-            "babel-core": "^6.26.0",
-            "babel-runtime": "^6.26.0",
-            "core-js": "^2.5.0",
-            "home-or-tmp": "^2.0.0",
-            "lodash": "^4.17.4",
-            "mkdirp": "^0.5.1",
-            "source-map-support": "^0.4.15"
+            "babel-core": "6.26.3",
+            "babel-runtime": "6.26.0",
+            "core-js": "2.5.3",
+            "home-or-tmp": "2.0.0",
+            "lodash": "4.17.10",
+            "mkdirp": "0.5.1",
+            "source-map-support": "0.4.18"
           },
           "dependencies": {
             "source-map-support": {
@@ -29675,7 +29117,7 @@
               "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
               "dev": true,
               "requires": {
-                "source-map": "^0.5.6"
+                "source-map": "0.5.7"
               }
             }
           }
@@ -29686,8 +29128,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "camelcase": {
@@ -29702,9 +29144,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "cliui": {
@@ -29713,9 +29155,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           }
         },
         "find-up": {
@@ -29724,7 +29166,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "fs-extra": {
@@ -29733,9 +29175,9 @@
           "integrity": "sha512-lk2cUCo8QzbiEWEbt7Cw3m27WMiRG321xsssbcIpfMhpRjrlC08WBOVQqj1/nQYYNnPtyIhP1oqLO3QwT2tPCw==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
           }
         },
         "glob": {
@@ -29744,12 +29186,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-flag": {
@@ -29770,17 +29212,17 @@
           "integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.1",
-            "glob": "^7.1.1",
-            "jest-environment-jsdom": "^22.4.1",
-            "jest-environment-node": "^22.4.1",
-            "jest-get-type": "^22.1.0",
-            "jest-jasmine2": "^22.4.4",
-            "jest-regex-util": "^22.1.0",
-            "jest-resolve": "^22.4.2",
-            "jest-util": "^22.4.1",
-            "jest-validate": "^22.4.4",
-            "pretty-format": "^22.4.0"
+            "chalk": "2.4.1",
+            "glob": "7.1.2",
+            "jest-environment-jsdom": "22.4.1",
+            "jest-environment-node": "22.4.1",
+            "jest-get-type": "22.1.0",
+            "jest-jasmine2": "22.4.4",
+            "jest-regex-util": "22.1.0",
+            "jest-resolve": "22.4.2",
+            "jest-util": "22.4.1",
+            "jest-validate": "22.4.4",
+            "pretty-format": "22.4.0"
           }
         },
         "jest-jasmine2": {
@@ -29789,17 +29231,17 @@
           "integrity": "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.1",
-            "co": "^4.6.0",
-            "expect": "^22.4.0",
-            "graceful-fs": "^4.1.11",
-            "is-generator-fn": "^1.0.0",
-            "jest-diff": "^22.4.0",
-            "jest-matcher-utils": "^22.4.0",
-            "jest-message-util": "^22.4.0",
-            "jest-snapshot": "^22.4.0",
-            "jest-util": "^22.4.1",
-            "source-map-support": "^0.5.0"
+            "chalk": "2.4.1",
+            "co": "4.6.0",
+            "expect": "22.4.0",
+            "graceful-fs": "4.1.11",
+            "is-generator-fn": "1.0.0",
+            "jest-diff": "22.4.0",
+            "jest-matcher-utils": "22.4.0",
+            "jest-message-util": "22.4.0",
+            "jest-snapshot": "22.4.0",
+            "jest-util": "22.4.1",
+            "source-map-support": "0.5.6"
           }
         },
         "jest-validate": {
@@ -29808,11 +29250,11 @@
           "integrity": "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.1",
-            "jest-config": "^22.4.4",
-            "jest-get-type": "^22.1.0",
-            "leven": "^2.1.0",
-            "pretty-format": "^22.4.0"
+            "chalk": "2.4.1",
+            "jest-config": "22.4.4",
+            "jest-get-type": "22.1.0",
+            "leven": "2.1.0",
+            "pretty-format": "22.4.0"
           }
         },
         "jsonfile": {
@@ -29821,7 +29263,7 @@
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.11"
           }
         },
         "lodash": {
@@ -29836,7 +29278,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "os-locale": {
@@ -29845,9 +29287,9 @@
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "pkg-dir": {
@@ -29856,7 +29298,7 @@
           "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
           "dev": true,
           "requires": {
-            "find-up": "^2.1.0"
+            "find-up": "2.1.0"
           }
         },
         "regenerator-runtime": {
@@ -29871,8 +29313,8 @@
           "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
           "dev": true,
           "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
+            "buffer-from": "1.0.0",
+            "source-map": "0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -29889,8 +29331,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -29899,7 +29341,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -29908,7 +29350,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "which-module": {
@@ -29923,18 +29365,18 @@
           "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
           }
         },
         "yargs-parser": {
@@ -29943,7 +29385,7 @@
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -29954,11 +29396,11 @@
       "integrity": "sha512-JTia3kObhTk36wPFgy0RnkZReiusYx7Le9IhcUWRrCTcFcr6Dy1zGsFd3x8DG4gevlbN65knI8W50FfoykXcng==",
       "dev": true,
       "requires": {
-        "chalk": "^2.3.0",
-        "enhanced-resolve": "^3.0.0",
-        "loader-utils": "^1.0.2",
-        "micromatch": "^3.1.4",
-        "semver": "^5.0.1"
+        "chalk": "2.3.2",
+        "enhanced-resolve": "3.4.1",
+        "loader-utils": "1.1.0",
+        "micromatch": "3.1.10",
+        "semver": "5.5.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -29967,7 +29409,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "arr-diff": {
@@ -29988,18 +29430,18 @@
           "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "kind-of": "^6.0.2",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "kind-of": "6.0.2",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -30008,7 +29450,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -30017,7 +29459,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -30028,9 +29470,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "expand-brackets": {
@@ -30039,13 +29481,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -30054,7 +29496,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -30063,7 +29505,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-descriptor": {
@@ -30072,9 +29514,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -30091,14 +29533,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -30107,7 +29549,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -30116,7 +29558,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -30127,10 +29569,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -30139,7 +29581,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -30156,7 +29598,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -30165,7 +29607,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -30176,7 +29618,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -30185,7 +29627,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -30196,7 +29638,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -30205,7 +29647,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -30228,9 +29670,9 @@
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         },
         "micromatch": {
@@ -30239,19 +29681,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.1",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "supports-color": {
@@ -30260,7 +29702,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -30271,7 +29713,7 @@
       "integrity": "sha1-IlGGvFbeFRC+qf8rdbGfxhqnF4c=",
       "dev": true,
       "requires": {
-        "underscore": "^1.8.3"
+        "underscore": "1.8.3"
       },
       "dependencies": {
         "underscore": {
@@ -30289,7 +29731,7 @@
       "dev": true,
       "requires": {
         "typescript": "1.8.7",
-        "underscore": "^1.8.3"
+        "underscore": "1.8.3"
       },
       "dependencies": {
         "typescript": {
@@ -30318,18 +29760,18 @@
       "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^3.2.0",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.8.0",
-        "tsutils": "^2.12.1"
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.3.2",
+        "commander": "2.15.1",
+        "diff": "3.5.0",
+        "glob": "7.1.2",
+        "js-yaml": "3.7.0",
+        "minimatch": "3.0.4",
+        "resolve": "1.6.0",
+        "semver": "5.5.0",
+        "tslib": "1.9.0",
+        "tsutils": "2.26.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -30338,7 +29780,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -30347,9 +29789,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
           }
         },
         "glob": {
@@ -30358,12 +29800,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-flag": {
@@ -30378,7 +29820,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "supports-color": {
@@ -30387,7 +29829,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -30415,7 +29857,7 @@
           "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
           "dev": true,
           "requires": {
-            "esutils": "^1.1.6",
+            "esutils": "1.1.6",
             "isarray": "0.0.1"
           }
         },
@@ -30431,7 +29873,7 @@
           "integrity": "sha1-AWAXNymzvxOGKN0UoVN+AIUdgUo=",
           "dev": true,
           "requires": {
-            "tslib": "^1.7.1"
+            "tslib": "1.9.0"
           }
         }
       }
@@ -30442,8 +29884,8 @@
       "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
       "dev": true,
       "requires": {
-        "eslint-plugin-prettier": "^2.2.0",
-        "tslib": "^1.7.1"
+        "eslint-plugin-prettier": "2.6.0",
+        "tslib": "1.9.0"
       },
       "dependencies": {
         "eslint-plugin-prettier": {
@@ -30452,8 +29894,8 @@
           "integrity": "sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==",
           "dev": true,
           "requires": {
-            "fast-diff": "^1.1.1",
-            "jest-docblock": "^21.0.0"
+            "fast-diff": "1.1.2",
+            "jest-docblock": "21.2.0"
           }
         },
         "jest-docblock": {
@@ -30470,7 +29912,7 @@
       "integrity": "sha512-ndS/iOOGrasATcf5YU3JxoIwPGVykjrKhzmlVsRdT1xzl/RbNg9n627rtAGbCjkQepyiaQYgxWQT5G/qUpQCaA==",
       "dev": true,
       "requires": {
-        "tsutils": "^2.13.1"
+        "tsutils": "2.26.0"
       }
     },
     "tsscmp": {
@@ -30485,7 +29927,7 @@
       "integrity": "sha512-hXUttgxeaZ/uPP/dpeiWUHbP5h744mPrfN2YFFtcZzd7vBRPBP6Knr0Mt6Bd+5SntMn8/1r6IGFeYPDSBIIPpg==",
       "dev": true,
       "requires": {
-        "tslib": "^1.8.1"
+        "tslib": "1.9.0"
       }
     },
     "tty-browserify": {
@@ -30499,7 +29941,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "tv4": {
@@ -30519,7 +29961,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-is": {
@@ -30529,7 +29971,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.18"
       }
     },
     "typedarray": {
@@ -30561,8 +30003,8 @@
       "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
       "dev": true,
       "requires": {
-        "commander": "~2.13.0",
-        "source-map": "~0.6.1"
+        "commander": "2.13.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "commander": {
@@ -30586,10 +30028,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "async": "~0.2.6",
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "async": "0.2.10",
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       }
     },
     "uglify-to-browserify": {
@@ -30605,14 +30047,14 @@
       "integrity": "sha512-Bc2NeyTTSJAy2JuKaBpdvWyuySPSPHNcj70KFqu7FhfrfsjPo0Kta9jgAvPrQxnz86mOH1tk4n/I8wvZrXvetA==",
       "dev": true,
       "requires": {
-        "cacache": "^10.0.1",
-        "find-cache-dir": "^1.0.0",
-        "schema-utils": "^0.4.2",
-        "serialize-javascript": "^1.4.0",
-        "source-map": "^0.6.1",
-        "uglify-es": "^3.3.4",
-        "webpack-sources": "^1.1.0",
-        "worker-farm": "^1.5.2"
+        "cacache": "10.0.4",
+        "find-cache-dir": "1.0.0",
+        "schema-utils": "0.4.5",
+        "serialize-javascript": "1.4.0",
+        "source-map": "0.6.1",
+        "uglify-es": "3.3.9",
+        "webpack-sources": "1.1.0",
+        "worker-farm": "1.6.0"
       },
       "dependencies": {
         "ajv": {
@@ -30621,10 +30063,10 @@
           "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0",
-            "uri-js": "^3.0.2"
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1",
+            "uri-js": "3.0.2"
           }
         },
         "ajv-keywords": {
@@ -30639,9 +30081,9 @@
           "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
           "dev": true,
           "requires": {
-            "commondir": "^1.0.1",
-            "make-dir": "^1.0.0",
-            "pkg-dir": "^2.0.0"
+            "commondir": "1.0.1",
+            "make-dir": "1.2.0",
+            "pkg-dir": "2.0.0"
           }
         },
         "find-up": {
@@ -30650,7 +30092,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "pkg-dir": {
@@ -30659,7 +30101,7 @@
           "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
           "dev": true,
           "requires": {
-            "find-up": "^2.1.0"
+            "find-up": "2.1.0"
           }
         },
         "schema-utils": {
@@ -30668,8 +30110,8 @@
           "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
           "dev": true,
           "requires": {
-            "ajv": "^6.1.0",
-            "ajv-keywords": "^3.1.0"
+            "ajv": "6.4.0",
+            "ajv-keywords": "3.1.0"
           }
         },
         "source-list-map": {
@@ -30690,8 +30132,8 @@
           "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
           "dev": true,
           "requires": {
-            "source-list-map": "^2.0.0",
-            "source-map": "~0.6.1"
+            "source-list-map": "2.0.0",
+            "source-map": "0.6.1"
           }
         }
       }
@@ -30702,7 +30144,7 @@
       "integrity": "sha1-Otbzg2jG1MjHXsF2I/t5qh0HHYE=",
       "dev": true,
       "requires": {
-        "random-bytes": "~1.0.0"
+        "random-bytes": "1.0.0"
       }
     },
     "unbzip2-stream": {
@@ -30711,8 +30153,8 @@
       "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
       "dev": true,
       "requires": {
-        "buffer": "^3.0.1",
-        "through": "^2.3.6"
+        "buffer": "3.6.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "base64-js": {
@@ -30728,8 +30170,8 @@
           "dev": true,
           "requires": {
             "base64-js": "0.0.8",
-            "ieee754": "^1.1.4",
-            "isarray": "^1.0.0"
+            "ieee754": "1.1.10",
+            "isarray": "1.0.0"
           }
         },
         "isarray": {
@@ -30758,7 +30200,7 @@
       "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
       "dev": true,
       "requires": {
-        "qs": "~2.3.3"
+        "qs": "2.3.3"
       },
       "dependencies": {
         "qs": {
@@ -30775,10 +30217,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -30787,7 +30229,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -30796,10 +30238,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -30816,7 +30258,7 @@
       "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
       "dev": true,
       "requires": {
-        "macaddress": "^0.2.8"
+        "macaddress": "0.2.8"
       }
     },
     "uniqs": {
@@ -30831,7 +30273,7 @@
       "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
       "dev": true,
       "requires": {
-        "unique-slug": "^2.0.0"
+        "unique-slug": "2.0.0"
       }
     },
     "unique-slug": {
@@ -30840,7 +30282,7 @@
       "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
       "dev": true,
       "requires": {
-        "imurmurhash": "^0.1.4"
+        "imurmurhash": "0.1.4"
       }
     },
     "unique-stream": {
@@ -30867,8 +30309,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -30877,9 +30319,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -30943,7 +30385,7 @@
       "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
       "dev": true,
       "requires": {
-        "upper-case": "^1.1.1"
+        "upper-case": "1.1.3"
       }
     },
     "uri-js": {
@@ -30952,7 +30394,7 @@
       "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -30999,8 +30441,8 @@
       "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
       "dev": true,
       "requires": {
-        "querystringify": "~1.0.0",
-        "requires-port": "~1.0.0"
+        "querystringify": "1.0.0",
+        "requires-port": "1.0.0"
       },
       "dependencies": {
         "querystringify": {
@@ -31017,7 +30459,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "1.0.4"
       }
     },
     "url-regex": {
@@ -31026,7 +30468,7 @@
       "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
       "dev": true,
       "requires": {
-        "ip-regex": "^1.0.1"
+        "ip-regex": "1.0.3"
       }
     },
     "url-to-options": {
@@ -31041,7 +30483,7 @@
       "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.2"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -31092,8 +30534,8 @@
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
+        "define-properties": "1.1.2",
+        "object.getownpropertydescriptors": "2.0.3"
       }
     },
     "utila": {
@@ -31119,7 +30561,7 @@
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "dev": true,
       "requires": {
-        "user-home": "^1.1.1"
+        "user-home": "1.1.1"
       }
     },
     "vali-date": {
@@ -31134,8 +30576,8 @@
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "validate-npm-package-name": {
@@ -31144,7 +30586,7 @@
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "requires": {
-        "builtins": "^1.0.3"
+        "builtins": "1.0.3"
       }
     },
     "validator": {
@@ -31170,9 +30612,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -31194,8 +30636,8 @@
       "integrity": "sha1-eUCIfu8JOB6zYmrEwPmrU9S35FA=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.0",
-        "clone-stats": "^0.0.1",
+        "clone": "1.0.3",
+        "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       }
     },
@@ -31205,8 +30647,8 @@
       "integrity": "sha1-TRmIkbVRWRHXcajNnFSApGoHSkU=",
       "dev": true,
       "requires": {
-        "object-assign": "^4.0.1",
-        "readable-stream": "^2.0.0"
+        "object-assign": "4.1.1",
+        "readable-stream": "2.3.5"
       },
       "dependencies": {
         "isarray": {
@@ -31227,13 +30669,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -31242,7 +30684,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -31252,9 +30694,9 @@
       "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-1.1.1.tgz",
       "integrity": "sha1-gbZV8m5li9Logp8o1j+EfWhD1tA=",
       "requires": {
-        "graceful-fs": "^3.0.2",
-        "strip-bom": "^1.0.0",
-        "vinyl": "^0.4.3"
+        "graceful-fs": "3.0.11",
+        "strip-bom": "1.0.0",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -31267,7 +30709,7 @@
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "requires": {
-            "natives": "^1.1.0"
+            "natives": "1.1.2"
           }
         },
         "vinyl": {
@@ -31275,8 +30717,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -31287,14 +30729,14 @@
       "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
       "dev": true,
       "requires": {
-        "defaults": "^1.0.0",
-        "glob-stream": "^3.1.5",
-        "glob-watcher": "^0.0.6",
-        "graceful-fs": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "strip-bom": "^1.0.0",
-        "through2": "^0.6.1",
-        "vinyl": "^0.4.0"
+        "defaults": "1.0.3",
+        "glob-stream": "3.1.18",
+        "glob-watcher": "0.0.6",
+        "graceful-fs": "3.0.11",
+        "mkdirp": "0.5.1",
+        "strip-bom": "1.0.0",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "clone": {
@@ -31309,7 +30751,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "^1.1.0"
+            "natives": "1.1.2"
           }
         },
         "vinyl": {
@@ -31318,8 +30760,8 @@
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
           "dev": true,
           "requires": {
-            "clone": "^0.2.0",
-            "clone-stats": "^0.0.1"
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
@@ -31344,7 +30786,7 @@
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "dev": true,
       "requires": {
-        "browser-process-hrtime": "^0.1.2"
+        "browser-process-hrtime": "0.1.2"
       }
     },
     "walker": {
@@ -31353,7 +30795,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.x"
+        "makeerror": "1.0.11"
       }
     },
     "ware": {
@@ -31362,7 +30804,7 @@
       "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
       "dev": true,
       "requires": {
-        "wrap-fn": "^0.1.0"
+        "wrap-fn": "0.1.5"
       }
     },
     "warning": {
@@ -31370,7 +30812,7 @@
       "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
       "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.3.1"
       }
     },
     "watch": {
@@ -31379,8 +30821,8 @@
       "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
       "dev": true,
       "requires": {
-        "exec-sh": "^0.2.0",
-        "minimist": "^1.2.0"
+        "exec-sh": "0.2.1",
+        "minimist": "1.2.0"
       }
     },
     "watchpack": {
@@ -31389,9 +30831,9 @@
       "integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
       "dev": true,
       "requires": {
-        "chokidar": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "chokidar": "2.0.3",
+        "graceful-fs": "4.1.11",
+        "neo-async": "2.5.1"
       },
       "dependencies": {
         "anymatch": {
@@ -31400,8 +30842,8 @@
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
-            "micromatch": "^3.1.4",
-            "normalize-path": "^2.1.1"
+            "micromatch": "3.1.10",
+            "normalize-path": "2.1.1"
           }
         },
         "arr-diff": {
@@ -31422,33 +30864,25 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
             "extend-shallow": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -31459,18 +30893,18 @@
           "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
           "dev": true,
           "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.0",
-            "braces": "^2.3.0",
-            "fsevents": "^1.1.2",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.1",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "normalize-path": "^2.1.1",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.0.0",
-            "upath": "^1.0.0"
+            "anymatch": "2.0.0",
+            "async-each": "1.0.1",
+            "braces": "2.3.2",
+            "fsevents": "1.2.4",
+            "glob-parent": "3.1.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "4.0.0",
+            "normalize-path": "2.1.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0",
+            "upath": "1.0.4"
           }
         },
         "expand-brackets": {
@@ -31479,13 +30913,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -31494,7 +30928,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -31503,7 +30937,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-descriptor": {
@@ -31512,9 +30946,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -31531,14 +30965,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -31547,7 +30981,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -31556,7 +30990,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -31567,10 +31001,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -31579,7 +31013,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -31590,8 +31024,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           },
           "dependencies": {
             "is-glob": {
@@ -31600,7 +31034,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -31611,7 +31045,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -31620,7 +31054,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -31631,7 +31065,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -31640,7 +31074,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -31657,7 +31091,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -31666,7 +31100,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -31675,7 +31109,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -31698,19 +31132,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -31721,7 +31155,7 @@
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dev": true,
       "requires": {
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "1.0.0"
       }
     },
     "webidl-conversions": {
@@ -31736,28 +31170,28 @@
       "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
       "dev": true,
       "requires": {
-        "acorn": "^5.0.0",
-        "acorn-dynamic-import": "^2.0.0",
-        "ajv": "^5.1.5",
-        "ajv-keywords": "^2.0.0",
-        "async": "^2.1.2",
-        "enhanced-resolve": "^3.4.0",
-        "escope": "^3.6.0",
-        "interpret": "^1.0.0",
-        "json-loader": "^0.5.4",
-        "json5": "^0.5.1",
-        "loader-runner": "^2.3.0",
-        "loader-utils": "^1.1.0",
-        "memory-fs": "~0.4.1",
-        "mkdirp": "~0.5.0",
-        "node-libs-browser": "^2.0.0",
-        "source-map": "^0.5.3",
-        "supports-color": "^4.2.1",
-        "tapable": "^0.2.7",
-        "uglifyjs-webpack-plugin": "^0.4.6",
-        "watchpack": "^1.4.0",
-        "webpack-sources": "^1.0.1",
-        "yargs": "^8.0.2"
+        "acorn": "5.5.3",
+        "acorn-dynamic-import": "2.0.2",
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.1",
+        "async": "2.6.0",
+        "enhanced-resolve": "3.4.1",
+        "escope": "3.6.0",
+        "interpret": "1.1.0",
+        "json-loader": "0.5.4",
+        "json5": "0.5.1",
+        "loader-runner": "2.3.0",
+        "loader-utils": "1.1.0",
+        "memory-fs": "0.4.1",
+        "mkdirp": "0.5.1",
+        "node-libs-browser": "2.1.0",
+        "source-map": "0.5.7",
+        "supports-color": "4.5.0",
+        "tapable": "0.2.8",
+        "uglifyjs-webpack-plugin": "0.4.6",
+        "watchpack": "1.5.0",
+        "webpack-sources": "1.1.0",
+        "yargs": "8.0.2"
       },
       "dependencies": {
         "ajv": {
@@ -31766,10 +31200,10 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "ajv-keywords": {
@@ -31790,7 +31224,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "4.17.5"
           }
         },
         "camelcase": {
@@ -31805,7 +31239,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "has-flag": {
@@ -31820,10 +31254,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
           }
         },
         "loader-utils": {
@@ -31832,9 +31266,9 @@
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         },
         "lodash": {
@@ -31849,9 +31283,9 @@
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "path-type": {
@@ -31860,7 +31294,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "^2.0.0"
+            "pify": "2.3.0"
           }
         },
         "read-pkg": {
@@ -31869,9 +31303,9 @@
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
           }
         },
         "read-pkg-up": {
@@ -31880,8 +31314,8 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
           }
         },
         "string-width": {
@@ -31890,8 +31324,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -31906,7 +31340,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -31923,7 +31357,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         },
         "uglify-js": {
@@ -31932,9 +31366,9 @@
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
           },
           "dependencies": {
             "yargs": {
@@ -31943,9 +31377,9 @@
               "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "dev": true,
               "requires": {
-                "camelcase": "^1.0.2",
-                "cliui": "^2.1.0",
-                "decamelize": "^1.0.0",
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
                 "window-size": "0.1.0"
               }
             }
@@ -31957,9 +31391,9 @@
           "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
           "dev": true,
           "requires": {
-            "source-map": "^0.5.6",
-            "uglify-js": "^2.8.29",
-            "webpack-sources": "^1.0.1"
+            "source-map": "0.5.7",
+            "uglify-js": "2.8.29",
+            "webpack-sources": "1.1.0"
           }
         },
         "which-module": {
@@ -31974,19 +31408,19 @@
           "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "read-pkg-up": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^7.0.0"
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
           },
           "dependencies": {
             "camelcase": {
@@ -32001,9 +31435,9 @@
               "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
               "dev": true,
               "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
               },
               "dependencies": {
                 "string-width": {
@@ -32012,9 +31446,9 @@
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
                   "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
                   }
                 }
               }
@@ -32027,7 +31461,7 @@
           "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           },
           "dependencies": {
             "camelcase": {
@@ -32046,11 +31480,11 @@
       "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
       "dev": true,
       "requires": {
-        "memory-fs": "~0.4.1",
-        "mime": "^1.5.0",
-        "path-is-absolute": "^1.0.0",
-        "range-parser": "^1.0.3",
-        "time-stamp": "^2.0.0"
+        "memory-fs": "0.4.1",
+        "mime": "1.6.0",
+        "path-is-absolute": "1.0.1",
+        "range-parser": "1.0.3",
+        "time-stamp": "2.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -32065,8 +31499,8 @@
           "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
           "dev": true,
           "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
+            "errno": "0.1.7",
+            "readable-stream": "2.3.5"
           }
         },
         "mime": {
@@ -32081,13 +31515,13 @@
           "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -32096,7 +31530,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "time-stamp": {
@@ -32114,30 +31548,30 @@
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
-        "array-includes": "^3.0.3",
-        "bonjour": "^3.5.0",
-        "chokidar": "^2.0.0",
-        "compression": "^1.5.2",
-        "connect-history-api-fallback": "^1.3.0",
-        "debug": "^3.1.0",
-        "del": "^3.0.0",
-        "express": "^4.16.2",
-        "html-entities": "^1.2.0",
-        "http-proxy-middleware": "~0.17.4",
-        "import-local": "^1.0.0",
+        "array-includes": "3.0.3",
+        "bonjour": "3.5.0",
+        "chokidar": "2.0.3",
+        "compression": "1.5.2",
+        "connect-history-api-fallback": "1.5.0",
+        "debug": "3.1.0",
+        "del": "3.0.0",
+        "express": "4.16.3",
+        "html-entities": "1.2.1",
+        "http-proxy-middleware": "0.17.4",
+        "import-local": "1.0.0",
         "internal-ip": "1.2.0",
-        "ip": "^1.1.5",
-        "killable": "^1.0.0",
-        "loglevel": "^1.4.1",
-        "opn": "^5.1.0",
-        "portfinder": "^1.0.9",
-        "selfsigned": "^1.9.1",
-        "serve-index": "^1.7.2",
+        "ip": "1.1.5",
+        "killable": "1.0.0",
+        "loglevel": "1.6.1",
+        "opn": "5.3.0",
+        "portfinder": "1.0.13",
+        "selfsigned": "1.10.2",
+        "serve-index": "1.7.3",
         "sockjs": "0.3.19",
         "sockjs-client": "1.1.4",
-        "spdy": "^3.4.1",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^5.1.0",
+        "spdy": "3.4.7",
+        "strip-ansi": "3.0.1",
+        "supports-color": "5.3.0",
         "webpack-dev-middleware": "1.12.2",
         "yargs": "6.6.0"
       },
@@ -32148,8 +31582,8 @@
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
-            "micromatch": "^3.1.4",
-            "normalize-path": "^2.1.1"
+            "micromatch": "3.1.10",
+            "normalize-path": "2.1.1"
           }
         },
         "arr-diff": {
@@ -32170,18 +31604,18 @@
           "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "kind-of": "^6.0.2",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "kind-of": "6.0.2",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -32190,7 +31624,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -32199,7 +31633,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -32216,18 +31650,18 @@
           "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
           "dev": true,
           "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.0",
-            "braces": "^2.3.0",
-            "fsevents": "^1.1.2",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.1",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "normalize-path": "^2.1.1",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.0.0",
-            "upath": "^1.0.0"
+            "anymatch": "2.0.0",
+            "async-each": "1.0.1",
+            "braces": "2.3.1",
+            "fsevents": "1.2.4",
+            "glob-parent": "3.1.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "4.0.0",
+            "normalize-path": "2.1.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0",
+            "upath": "1.0.4"
           }
         },
         "cliui": {
@@ -32236,9 +31670,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           }
         },
         "connect-history-api-fallback": {
@@ -32262,12 +31696,12 @@
           "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
           "dev": true,
           "requires": {
-            "globby": "^6.1.0",
-            "is-path-cwd": "^1.0.0",
-            "is-path-in-cwd": "^1.0.0",
-            "p-map": "^1.1.1",
-            "pify": "^3.0.0",
-            "rimraf": "^2.2.8"
+            "globby": "6.1.0",
+            "is-path-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.0",
+            "p-map": "1.2.0",
+            "pify": "3.0.0",
+            "rimraf": "2.6.2"
           }
         },
         "expand-brackets": {
@@ -32276,13 +31710,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "debug": {
@@ -32300,7 +31734,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -32309,7 +31743,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-descriptor": {
@@ -32318,9 +31752,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -32337,14 +31771,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -32353,7 +31787,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -32362,7 +31796,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -32373,10 +31807,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -32385,7 +31819,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -32396,8 +31830,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           },
           "dependencies": {
             "is-glob": {
@@ -32406,7 +31840,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -32417,11 +31851,11 @@
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "array-union": "1.0.2",
+            "glob": "7.0.5",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           },
           "dependencies": {
             "pify": {
@@ -32444,7 +31878,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -32453,7 +31887,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -32464,7 +31898,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -32473,7 +31907,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -32490,7 +31924,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -32499,7 +31933,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -32508,7 +31942,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -32531,19 +31965,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.1",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "object-assign": {
@@ -32564,7 +31998,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "yargs": {
@@ -32573,19 +32007,19 @@
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^4.2.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
           }
         },
         "yargs-parser": {
@@ -32594,7 +32028,7 @@
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0"
+            "camelcase": "3.0.0"
           }
         }
       }
@@ -32605,7 +32039,7 @@
       "integrity": "sha512-geQsZ86YkXOVOjvPC5yv3JSNnL6/X3Kzh935AQ/gJNEYXEfJDQFu/sdFuktS9OW2JcH/SJec8TGfRdrpHshH7A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.4"
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "lodash": {
@@ -32622,9 +32056,9 @@
       "integrity": "sha1-z19rmhcR+Alpu8T3vRXUDqexh2E=",
       "dev": true,
       "requires": {
-        "node-notifier": "^5.1.2",
-        "object-assign": "^4.1.0",
-        "strip-ansi": "^3.0.1"
+        "node-notifier": "5.2.1",
+        "object-assign": "4.1.1",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "node-notifier": {
@@ -32633,10 +32067,10 @@
           "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
           "dev": true,
           "requires": {
-            "growly": "^1.3.0",
-            "semver": "^5.4.1",
-            "shellwords": "^0.1.1",
-            "which": "^1.3.0"
+            "growly": "1.3.0",
+            "semver": "5.5.0",
+            "shellwords": "0.1.1",
+            "which": "1.3.0"
           }
         },
         "object-assign": {
@@ -32653,8 +32087,8 @@
       "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
       "dev": true,
       "requires": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
+        "source-list-map": "2.0.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -32671,8 +32105,8 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": ">=0.4.0",
-        "websocket-extensions": ">=0.1.1"
+        "http-parser-js": "0.4.11",
+        "websocket-extensions": "0.1.3"
       }
     },
     "websocket-extensions": {
@@ -32701,9 +32135,9 @@
       "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.0",
-        "webidl-conversions": "^4.0.1"
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
       }
     },
     "whet.extend": {
@@ -32718,7 +32152,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -32739,12 +32173,12 @@
       "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
       "dev": true,
       "requires": {
-        "async": "~1.0.0",
-        "colors": "1.0.x",
-        "cycle": "1.0.x",
-        "eyes": "0.1.x",
-        "isstream": "0.1.x",
-        "stack-trace": "0.0.x"
+        "async": "1.0.0",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "stack-trace": "0.0.10"
       },
       "dependencies": {
         "async": {
@@ -32773,7 +32207,7 @@
       "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
       "dev": true,
       "requires": {
-        "errno": "~0.1.7"
+        "errno": "0.1.7"
       }
     },
     "wrap-ansi": {
@@ -32782,8 +32216,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       }
     },
     "wrap-fn": {
@@ -32820,7 +32254,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "write-file-atomic": {
@@ -32829,9 +32263,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "write-file-stdout": {
@@ -32846,8 +32280,8 @@
       "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
       "dev": true,
       "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0"
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.1"
       }
     },
     "xdg-basedir": {
@@ -32880,8 +32314,8 @@
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "dev": true,
       "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
       }
     },
     "xmlbuilder": {
@@ -32896,7 +32330,7 @@
       "integrity": "sha1-JckvCPJj80TayNCzI3CnAe6dDpM=",
       "dev": true,
       "requires": {
-        "sax": "^1.2.1"
+        "sax": "1.2.4"
       }
     },
     "xmldom": {
@@ -32953,9 +32387,9 @@
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
       "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
         "window-size": "0.1.0"
       },
       "dependencies": {
@@ -32973,7 +32407,7 @@
       "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
       "dev": true,
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "4.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -32990,8 +32424,8 @@
       "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.0.1"
+        "buffer-crc32": "0.2.13",
+        "fd-slicer": "1.0.1"
       }
     },
     "z-schema": {
@@ -33000,10 +32434,10 @@
       "integrity": "sha512-jPNzqmOu3+AGbb4krDODqo4QBzwUGDVzyfGyy1HtWaUnafltQotatSpxxWd6Mp0iSZOUwHU5sqKYi+U8HsHMkg==",
       "dev": true,
       "requires": {
-        "commander": "^2.7.1",
-        "lodash.get": "^4.0.0",
-        "lodash.isequal": "^4.0.0",
-        "validator": "^9.0.0"
+        "commander": "2.15.1",
+        "lodash.get": "4.4.2",
+        "lodash.isequal": "4.5.0",
+        "validator": "9.4.1"
       }
     },
     "zen-observable": {
@@ -33016,7 +32450,7 @@
       "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.9.tgz",
       "integrity": "sha512-KJz2O8FxbAdAU5CSc8qZ1K2WYEJb1HxS6XDRF+hOJ1rOYcg6eTMmS9xYHCXzqZZzKw6BbXWyF4UpwSsBQnHJeA==",
       "requires": {
-        "zen-observable": "^0.8.0"
+        "zen-observable": "0.8.8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@dcos/http-service": "0.3.0",
-    "@dcos/mesos-client": "0.2.1",
+    "@dcos/mesos-client": "0.2.3",
     "@dcos/tslint-config": "0.1.0",
     "babel-polyfill": "6.23.0",
     "browser-info": "0.4.0",

--- a/src/js/core/MesosStream.js
+++ b/src/js/core/MesosStream.js
@@ -1,11 +1,10 @@
 import { stream } from "@dcos/mesos-client";
-import { ReplaySubject } from "rxjs/ReplaySubject";
 import { Observable } from "rxjs/Observable";
 
 const RECONNECTION_DELAY = 2000;
 
 export const MesosStreamType = Symbol("MesosStreamType");
-export default stream({ type: "SUBSCRIBE" }, "/mesos/api/v1?subscribe")
-  .repeatWhen(() => Observable.timer(RECONNECTION_DELAY))
-  .multicast(() => new ReplaySubject())
-  .refCount();
+export default stream(
+  { type: "SUBSCRIBE" },
+  "/mesos/api/v1?subscribe"
+).repeatWhen(() => Observable.timer(RECONNECTION_DELAY));

--- a/tests/_fixtures/1-service-with-executor-task/summary.json
+++ b/tests/_fixtures/1-service-with-executor-task/summary.json
@@ -5,6 +5,16 @@
     {
       "id": "b3bd182c-c6d7-463e-8bf0-06cd5807df4e-S5",
       "pid": "slave(1)@10.0.1.108:5051",
+      "domain": {
+        "fault_domain": {
+          "region": {
+            "name": "eu-central-1"
+          },
+          "zone": {
+            "name": "eu-central-1b"
+          }
+        }
+      },
       "hostname": "10.0.1.108",
       "registered_time": 1456203145.01885,
       "resources": {


### PR DESCRIPTION
💁‍♂️ Forward port of #3048

> Update the mesos-client to 0.2.3 as this version great reduces the memory footprint and adjust `MesosStream` to stop multicasting the stream using the replay subject. This change allows the browser to garbage collect dependent/sliced strings created while processing the Mesos response.
> 
> _Please note that this is a temporary adjustment as it would result in multiple open connections if consumed by more than one component. We're going to revert this change once the `http-service`  to emit event objects instead of the response as well as changed the `mesos-client` to output parsed JSON._
> 
> **Testing**
> 
> * Checkout the code and verify that the number of open mesos subscribe connections is correct and the updates are flowing through. 
> * Make memory snapshots in Firefox and Chrome and observer the Safari memory footprint while looking at a task page.

Closes DCOS-38340