### PR TITLE
DCOS-38822: NodesTable / CPU Columns

### DIFF
--- a/plugins/nodes/src/js/columns/NodesTableCPUBarColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableCPUBarColumn.tsx
@@ -4,12 +4,20 @@ import Node from "#SRC/js/structs/Node";
 // TODO: DCOS-39079
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
 import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs";
+import ProgressBar from "#SRC/js/components/ProgressBar";
 
 export function cpubarRenderer(data: Node): React.ReactNode {
-  // TODO: DCOS-38822
-  return <span>{data.get("used_resources").cpus.toString()}</span>;
+  return (
+    <ProgressBar
+      data={[
+        { value: data.getUsageStats("cpus").percentage, className: "color-1" }
+      ]}
+      total={100}
+    />
+  );
 }
+
 export function cpubarSizer(args: WidthArgs): number {
-  // TODO: DCOS-38822
-  return Math.max(100, args.width / args.totalColumns);
+  // TODO: DCOS-39147
+  return Math.min(60, Math.max(60, args.width / args.totalColumns));
 }

--- a/plugins/nodes/src/js/columns/NodesTableCPUColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableCPUColumn.tsx
@@ -7,12 +7,9 @@ import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs"
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 
 export function cpuRenderer(data: Node): React.ReactNode {
-  // TODO: DCOS-38822
-  return <span>{data.get("used_resources").cpus.toString()}</span>;
+  return `${data.getUsageStats("cpus").percentage}%`;
 }
 export function cpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
-  // TODO: DCOS-38822
-  // current implementation is a rough idea, not sure if it is the best one…
   const sortedData = data.sort((a, b) =>
     compareValues(
       a.get("used_resources").cpus.toString(),
@@ -24,6 +21,6 @@ export function cpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
 }
 export function cpuSizer(args: WidthArgs): number {
-  // TODO: DCOS-38822
-  return Math.max(100, args.width / args.totalColumns);
+  // TODO: DCOS-39147
+  return Math.min(60, Math.max(60, args.width / args.totalColumns));
 }

--- a/src/js/components/ProgressBar.d.ts
+++ b/src/js/components/ProgressBar.d.ts
@@ -1,0 +1,11 @@
+import { Component, ReactElement } from "react";
+
+interface ProgressBarProps {
+  className?: Array<string> | Object | string;
+  total: number;
+  data: Array<{
+    className?: Array<string> | Object | string;
+    value: number;
+  }>;
+}
+export default class ProgressBar extends Component<ProgressBarProps> {}


### PR DESCRIPTION
## Testing

Change this line in `NodesTableContainer.js`

```diff
-import NodesTable from "../../../components/NodesTable";
+import NodesTable from "../../../components/NodesTable-new";
```

After that please take a look at the nodes table and see if the health column looks right and sorts correctly

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- CPU percentage and resource bar are two different columns, once we have finished DCOS-39147, we can merge them and hide the bar on smaller screens

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

None