### PR TITLE
DCOS-21723: Include scheduler resources 

### DIFF
--- a/plugins/services/src/js/structs/Framework.js
+++ b/plugins/services/src/js/structs/Framework.js
@@ -97,13 +97,23 @@ module.exports = class Framework extends Application {
     // used_resources is actually allocated resources
     // the name can't be changed to keep backward compatibility.
     // This is why `getResources` returns `used_resources`
-    return (
-      this.get("used_resources") || {
-        cpus: 0,
-        mem: 0,
-        gpus: 0,
-        disk: 0
-      }
-    );
+    const allocatedFrameworkResources = this.get("used_resources") || {
+      cpus: 0,
+      mem: 0,
+      gpus: 0,
+      disk: 0
+    };
+
+    // Framework doesn't know how many resources its scheduler consumes.
+    // Scheduler is launched by Marathon not the Framework itself.
+    // So we should get this information separately from the Marathon spec
+    const schedulerResources = this.getSpec().getResources();
+
+    return {
+      cpus: allocatedFrameworkResources.cpus + schedulerResources.cpus,
+      mem: allocatedFrameworkResources.mem + schedulerResources.mem,
+      gpus: allocatedFrameworkResources.gpus + schedulerResources.gpus,
+      disk: allocatedFrameworkResources.disk + schedulerResources.disk
+    };
   }
 };

--- a/plugins/services/src/js/structs/__tests__/Framework-test.js
+++ b/plugins/services/src/js/structs/__tests__/Framework-test.js
@@ -141,6 +141,7 @@ describe("Framework", function() {
     });
 
     it("aggregates the right number of tasks", function() {
+      const getTasksByService = MesosStateStore.getTasksByService;
       MesosStateStore.getTasksByService = function() {
         return [
           {
@@ -201,6 +202,8 @@ describe("Framework", function() {
         tasksOverCapacity: 0,
         tasksUnknown: 0
       });
+
+      MesosStateStore.getTasksByService = getTasksByService;
     });
   });
 
@@ -224,16 +227,38 @@ describe("Framework", function() {
   });
 
   describe("#getResources", function() {
-    it("returns empty obj when resources are falsey", function() {
+    it("returns only scheduler resources when used_resources are empty", function() {
       const service = new Framework({
-        used_resources: null
+        used_resources: null,
+        cpus: 0.2,
+        mem: 300,
+        gpus: 1,
+        disk: 10
       });
 
       expect(service.getResources()).toEqual({
-        cpus: 0,
-        mem: 0,
-        gpus: 0,
-        disk: 0
+        cpus: 0.2,
+        mem: 300,
+        gpus: 1,
+        disk: 10
+      });
+    });
+
+    it("returns allocated resources + scheduler resources", function() {
+      const service = new Framework({
+        id: "/blip",
+        used_resources: { cpus: 1, mem: 1024, gpus: 0, disk: 10 },
+        cpus: 0.2,
+        mem: 300,
+        gpus: 1,
+        disk: 10
+      });
+
+      expect(service.getResources()).toEqual({
+        cpus: 1.2,
+        mem: 1324,
+        gpus: 1,
+        disk: 20
       });
     });
   });


### PR DESCRIPTION
After lengthy discussions with many parties we've decided to include scheduler resources into report. To make data more sensible from the stand point of *DCOS*. 

So now on the Services view for frameworks we show allocated resources + scheduler resources:
<img width="791" alt="screen shot 2018-07-11 at 16 15 49" src="https://user-images.githubusercontent.com/186223/42577968-d0bb47d8-8525-11e8-960c-e552d23580f5.png">

Which is now aligned with the way we display Framework Tasks:
<img width="787" alt="screen shot 2018-07-11 at 16 15 59" src="https://user-images.githubusercontent.com/186223/42578007-e755461a-8525-11e8-917a-5c0afd3cfe62.png">

💁‍♂️  DCOS is not Mesos. (Duh..)

In DCOS we have a concept of root Marathon that we don't really reflect on the DCOS UI.

This root Marathon runs all the pods, services as well as scheduler tasks for frameworks.

We display Pods and Services on the Services view on the top level, like the `blip` task on the screenshot, wheres in Mesos they go under the root Marathon.

We display frameworks on the top level as well as they would go under Marathon, `cassandra` and `hello-world`, but not as a _task_ but as a separate entity a Framework. Though on Mesos those frameworks go _not_ under the root Marathon, they go _along_ with the root Marathon. 

Here where the complication starts.

As we don't display scheduler task but rather a Framework on the Services view, we move scheduler task to the Tasks view, as it would be launched by the framework itself.

Cassandra task you see on the Tasks page is a scheduler that is started by the root Marathon. This is why when we request allocated resources for Cassandra from Mesos we don't get scheduler's resource. We should add scheduler's resources from the Marathon's spec.

But wait, `CPU: 1 + 0.5 != 1.6` still doesn't look right! Well, what can I say? _I just sum_ what Mesos and Marathon give me. From my conversations with the core team the extra `0.1` is used by the executor.

We even have this info, but can we really subtract it or render it at some place of the Tasks view? I don't know. Is it the part of the ticket? Definitely not.

<img width="372" alt="screen shot 2018-07-12 at 12 22 48" src="https://user-images.githubusercontent.com/186223/42627826-70ccc578-85ce-11e8-927a-4ebacd3b7b4b.png">
