### PR TITLE
DCOS-38827: add health column

### DIFF
--- a/plugins/nodes/src/js/columns/NodesTableHealthColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableHealthColumn.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { compareValues } from "#PLUGINS/nodes/src/js/utils/compareValues";
+import UnitHealthUtil from "#SRC/js/utils/UnitHealthUtil";
 import Node from "#SRC/js/structs/Node";
 // TODO: DCOS-39079
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
@@ -7,25 +7,18 @@ import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs"
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 
 export function healthRenderer(data: Node): React.ReactNode {
-  // TODO: DCOS-38827
-  return <span>{data.getHealth().title.toString()}</span>;
+  const health = data.getHealth();
+  return <span className={health.classNames}>{health.title}</span>;
 }
+
 export function healthSorter(
   data: Node[],
   sortDirection: SortDirection
 ): Node[] {
-  // TODO: DCOS-38827
-  // current implementation is a rough idea, not sure if it is the best one…
-  const sortedData = data.sort((a, b) =>
-    compareValues(
-      a.getHealth().title.toLowerCase(),
-      b.getHealth().title.toLowerCase(),
-      a.getHostName().toLowerCase(),
-      b.getHostName().toLowerCase()
-    )
-  );
+  const sortedData = data.sort(UnitHealthUtil.getHealthSortFunction);
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
 }
+
 export function healthSizer(args: WidthArgs): number {
   // TODO: DCOS-38827
   return Math.max(100, args.width / args.totalColumns);

--- a/plugins/nodes/src/js/columns/__tests__/NodesTableHealthColumn-test.js
+++ b/plugins/nodes/src/js/columns/__tests__/NodesTableHealthColumn-test.js
@@ -1,0 +1,38 @@
+import TestRenderer from "react-test-renderer";
+import Node from "#SRC/js/structs/Node";
+import UnitHealthUtil from "#SRC/js/utils/UnitHealthUtil";
+
+import NA from "./fixtures/node-without-health.json";
+import Healthy from "./fixtures/node-healthy.json";
+import Unhealthy from "./fixtures/node-unhealthy.json";
+import Warn from "./fixtures/node-warn.json";
+
+import { healthRenderer, healthSorter } from "../NodesTableHealthColumn";
+
+describe("NodesTableHealthColumn", () => {
+  describe("renderer", () => {
+    const testCases = { NA, Healthy, Unhealthy, Warn };
+    for (const [statusName, data] of Object.entries(testCases)) {
+      it(`renders with health status '${statusName}'`, () => {
+        expect(
+          TestRenderer.create(healthRenderer(new Node(data))).toJSON()
+        ).toMatchSnapshot();
+      });
+    }
+  });
+
+  describe("sorter", () => {
+    it("calls the unit health sorter", () => {
+      const mockSort = jest.fn(() => ({
+        reverse: jest.fn()
+      }));
+      const arrayMock = {
+        sort: mockSort
+      };
+      healthSorter(arrayMock);
+      expect(mockSort).toHaveBeenCalledWith(
+        UnitHealthUtil.getHealthSortFunction
+      );
+    });
+  });
+});

--- a/plugins/nodes/src/js/columns/__tests__/__snapshots__/NodesTableHealthColumn-test.js.snap
+++ b/plugins/nodes/src/js/columns/__tests__/__snapshots__/NodesTableHealthColumn-test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NodesTableHealthColumn renderer renders with health status 'Healthy' 1`] = `
+<span
+  className="text-success"
+>
+  Healthy
+</span>
+`;
+
+exports[`NodesTableHealthColumn renderer renders with health status 'NA' 1`] = `
+<span
+  className="text-mute"
+>
+  N/A
+</span>
+`;
+
+exports[`NodesTableHealthColumn renderer renders with health status 'Unhealthy' 1`] = `
+<span
+  className="text-danger"
+>
+  Unhealthy
+</span>
+`;
+
+exports[`NodesTableHealthColumn renderer renders with health status 'Warn' 1`] = `
+<span
+  className="text-warning"
+>
+  Warning
+</span>
+`;

--- a/plugins/nodes/src/js/columns/__tests__/fixtures/node-healthy.json
+++ b/plugins/nodes/src/js/columns/__tests__/fixtures/node-healthy.json
@@ -1,0 +1,13 @@
+{
+  "domain": {
+    "fault_domain": {
+      "region": { "name": "us-west-2" },
+      "zone": { "name": "us-west-2a" }
+    }
+  },
+  "hostname": "10.0.4.93",
+  "id": "9fbe915f-c14a-452a-96cd-4e600bf7478a",
+  "pid": "master@10.0.4.93:5050",
+  "health": 0,
+  "port": 5050
+}

--- a/plugins/nodes/src/js/columns/__tests__/fixtures/node-unhealthy.json
+++ b/plugins/nodes/src/js/columns/__tests__/fixtures/node-unhealthy.json
@@ -1,0 +1,13 @@
+{
+  "domain": {
+    "fault_domain": {
+      "region": { "name": "us-west-2" },
+      "zone": { "name": "us-west-2a" }
+    }
+  },
+  "hostname": "10.0.4.93",
+  "id": "9fbe915f-c14a-452a-96cd-4e600bf7478a",
+  "pid": "master@10.0.4.93:5050",
+  "health": 1,
+  "port": 5050
+}

--- a/plugins/nodes/src/js/columns/__tests__/fixtures/node-warn.json
+++ b/plugins/nodes/src/js/columns/__tests__/fixtures/node-warn.json
@@ -1,0 +1,13 @@
+{
+  "domain": {
+    "fault_domain": {
+      "region": { "name": "us-west-2" },
+      "zone": { "name": "us-west-2a" }
+    }
+  },
+  "hostname": "10.0.4.93",
+  "id": "9fbe915f-c14a-452a-96cd-4e600bf7478a",
+  "pid": "master@10.0.4.93:5050",
+  "health": 2,
+  "port": 5050
+}

--- a/plugins/nodes/src/js/columns/__tests__/fixtures/node-without-health.json
+++ b/plugins/nodes/src/js/columns/__tests__/fixtures/node-without-health.json
@@ -1,0 +1,12 @@
+{
+  "domain": {
+    "fault_domain": {
+      "region": { "name": "us-west-2" },
+      "zone": { "name": "us-west-2a" }
+    }
+  },
+  "hostname": "10.0.4.93",
+  "id": "9fbe915f-c14a-452a-96cd-4e600bf7478a",
+  "pid": "master@10.0.4.93:5050",
+  "port": 5050
+}

--- a/src/js/utils/UnitHealthUtil.d.ts
+++ b/src/js/utils/UnitHealthUtil.d.ts
@@ -1,0 +1,4 @@
+export default class UnitHealthUtil {
+  static getHealthSortFunction(...args: any[]): any;
+  static getHealthSorting(): number;
+}


### PR DESCRIPTION
## Testing

Change this line in `NodesTableContainer.js`

```diff
-import NodesTable from "../../../components/NodesTable";
+import NodesTable from "../../../components/NodesTable-new";
```

After that please take a look at the nodes table and see if the health column looks right and sorts correctly

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- I decided not to move the sorting utils to typescript, because for me this would be out of scope
- I choose to use table driven tests because the test cases looked very similar to me

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

None