### PR TITLE
DCOS-39069: use headercell from ui-kit

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -992,9 +992,9 @@
       "integrity": "sha512-WcTnrk4lc6vwMWn+pOrcGk9tTy6it03dCfQtqE+fw9bQ2llqzfxnLO7Har+la4kkJVnyTPAt7Nvpb50sjzsQXA=="
     },
     "@dcos/ui-kit": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@dcos/ui-kit/-/ui-kit-1.1.1.tgz",
-      "integrity": "sha512-SNTq1ea9gDIC3SWhbvWgnQdooNYnWa6CsyD+4cdm4LXrXlyoae9/IXXbcFqTluXXYM31AIIp1oCUNxejaJE8lQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@dcos/ui-kit/-/ui-kit-1.2.3.tgz",
+      "integrity": "sha512-MaNepw+MLI7GF2Q4MfSHR5BO3FEAzljmoEIh1OKqi0IjY4m4DjBybJ5iH4CzyLRJnOYw4Xip+voVi52nbd/bVQ==",
       "requires": {
         "emotion": "9.2.4",
         "memoize-one": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@dcos/http-service": "0.3.0",
     "@dcos/mesos-client": "0.2.3",
     "@dcos/tslint-config": "0.1.0",
-    "@dcos/ui-kit": "1.1.1",
+    "@dcos/ui-kit": "1.2.3",
     "babel-polyfill": "6.23.0",
     "browser-info": "0.4.0",
     "classnames": "2.2.3",

--- a/packages/ui-kit-stage/SortableColumnHeader.tsx
+++ b/packages/ui-kit-stage/SortableColumnHeader.tsx
@@ -4,6 +4,7 @@
  * JIRA: https://jira.mesosphere.com/browse/DCOS-39076
  */
 import * as React from "react";
+import { HeaderCell } from "@dcos/ui-kit";
 import { SortableColumnHeaderCellIcon } from "ui-kit-stage/SortableColumnHeaderCellIcon";
 
 type SortDirection = "ASC" | "DESC" | null;
@@ -17,11 +18,10 @@ export function SortableColumnHeader({
   sortDirection: SortDirection;
   columnContent: string | React.ReactNode;
 }) {
-  // TODO: DCOS-39069
   return (
-    <span onClick={sortHandler}>
+    <HeaderCell onClick={sortHandler}>
       {columnContent}
       <SortableColumnHeaderCellIcon sortDirection={sortDirection} />
-    </span>
+    </HeaderCell>
   );
 }


### PR DESCRIPTION
## Testing

Change this line in `NodesTableContainer.js`

```diff
-import NodesTable from "../../../components/NodesTable";
+import NodesTable from "../../../components/NodesTable-new";
```

After that please take a look at the nodes table and see if the headlines of the table look correctly

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- The content spacing is a separate issue (DCOS-39265), therefore it looks a bit off


## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

None