### PR TITLE
DCOS_OSS-3801: 1.11 / Support Docker Parameters in Jobs

### DIFF
--- a/src/js/schemas/JobSchema.js
+++ b/src/js/schemas/JobSchema.js
@@ -6,6 +6,7 @@ import Docker from "./job-schema/Docker";
 import General from "./job-schema/General";
 import Labels from "./job-schema/Labels";
 import Schedule from "./job-schema/Schedule";
+import Parameters from "./job-schema/Parameters";
 
 const JobSchema = {
   type: "object",
@@ -13,6 +14,7 @@ const JobSchema = {
     general: General,
     schedule: Schedule,
     docker: Docker,
+    docker_parameters: Parameters,
     labels: Labels
   },
   required: ["general"]

--- a/src/js/schemas/job-schema/Docker.js
+++ b/src/js/schemas/job-schema/Docker.js
@@ -1,7 +1,3 @@
-/* eslint-disable no-unused-vars */
-import React from "react";
-/* eslint-enable no-unused-vars */
-
 const General = {
   title: "Docker Container",
   description: "Configure your job settings",
@@ -13,6 +9,13 @@ const General = {
       type: "string",
       getter(job) {
         return job.getDocker().image;
+      }
+    },
+    privileged: {
+      type: "boolean",
+      description: "Run this docker image in privileged mode",
+      getter(job) {
+        return job.getDocker().privileged;
       }
     }
   },

--- a/src/js/schemas/job-schema/Parameters.js
+++ b/src/js/schemas/job-schema/Parameters.js
@@ -1,0 +1,29 @@
+const Parameters = {
+  type: "object",
+  title: "Docker Parameters",
+  description: "Add runtime parameters to a docker job run.",
+  properties: {
+    items: {
+      type: "array",
+      duplicable: true,
+      addLabel: "Add Parameter",
+      getter(job) {
+        return job.getParameters() || [];
+      },
+      itemShape: {
+        properties: {
+          key: {
+            title: "Parameter Name",
+            type: "string"
+          },
+          value: {
+            title: "Parameter Value",
+            type: "string"
+          }
+        }
+      }
+    }
+  }
+};
+
+module.exports = Parameters;

--- a/src/js/structs/Job.js
+++ b/src/js/structs/Job.js
@@ -8,6 +8,7 @@ import {
   DEFAULT_DISK,
   DEFAULT_MEM
 } from "../constants/JobResources";
+import { findNestedPropertyInObject } from "../utils/Util";
 
 module.exports = class Job extends Item {
   getActiveRuns() {
@@ -55,6 +56,12 @@ module.exports = class Job extends Item {
     return new JobRunList({
       items: [].concat(activeRuns, failedFinishedRuns, successfulFinishedRuns)
     });
+  }
+
+  getParameters() {
+    return (
+      findNestedPropertyInObject(this.get("run"), "docker.parameters") || []
+    );
   }
 
   getLabels() {

--- a/src/js/utils/JobUtil.js
+++ b/src/js/utils/JobUtil.js
@@ -47,6 +47,7 @@ const JobUtil = {
       },
       labels = {},
       docker,
+      docker_parameters,
       schedule
     } = formModel;
 
@@ -76,6 +77,11 @@ const JobUtil = {
 
     if (docker && docker.image) {
       Object.assign(spec.run, { docker });
+      if (docker_parameters != null && docker_parameters.items != null) {
+        spec.run.docker.parameters = docker_parameters.items;
+      } else {
+        spec.run.docker.parameters = [];
+      }
     }
 
     // Reset schedules
@@ -129,8 +135,12 @@ const JobUtil = {
     }
 
     const docker = job.getDocker();
+
     if (docker.image) {
       Object.assign(spec.run, { docker });
+
+      const parameters = job.getParameters();
+      spec.run.docker.parameters = parameters;
     }
 
     const [schedule] = job.getSchedules();

--- a/tests/pages/jobs/JobJSONEditor-cy.js
+++ b/tests/pages/jobs/JobJSONEditor-cy.js
@@ -97,7 +97,9 @@ describe("Job JSON Editor", function() {
           disk: 0,
           cmd: cmdline,
           docker: {
-            image: "python:3"
+            image: "python:3",
+            privileged: false,
+            parameters: []
           }
         },
         schedules: []


### PR DESCRIPTION
Support docker parameters in Metronome jobs.
This is based on @kensipe PR https://github.com/dcos/dcos-ui/pull/3037

Closes DCOS_OSS-3801

## Testing

Test job JSON that UI shouldn't change when you switch back and forward between JSON view and Form view.
```js
{
  "description": "Example Application",
  "id": "docker-param",
  "run": {
    "cmd": "sleep inf",
    "cpus": 0.2,
    "mem": 32,
    "docker": {
      "image": "ubuntu",
      "parameters": [
        {
          "key": "cap-drop",
          "value": "ALL"
        },
        {
          "key": "cap-add",
          "value": "SYSLOG"
        }
      ]
    }
  }
}
```