### PR TITLE
DCOS-38850: use existing data to update the jobs overview UI instantly

### DIFF
--- a/plugins/jobs/src/js/data/__tests__/JobModel-test.js
+++ b/plugins/jobs/src/js/data/__tests__/JobModel-test.js
@@ -205,6 +205,39 @@ describe("JobModel Resolver", () => {
         })
       );
 
+      it(
+        "shares the subscription",
+        marbles(m => {
+          m.bind();
+          const fetchJobs = jest.fn(() =>
+            m.cold("(j|)", { j: [defaultJobDetailData] })
+          );
+          const fetchJobDetail = _id =>
+            m.cold("(j|)", { j: defaultJobDetailData });
+          const jobsQuery = resolvers({
+            fetchJobs,
+            fetchJobDetail,
+            pollingInterval: m.time("--|")
+          }).Query.jobs;
+
+          Observable.concat(
+            jobsQuery({}, { path: [] }).take(1),
+            jobsQuery({}, { path: [] }).take(1),
+            jobsQuery({}, { path: [] }).take(1),
+            jobsQuery({}, { path: [] }).take(1),
+            jobsQuery({}, { path: [] }).take(1),
+            jobsQuery({}, { path: [] }).take(1),
+            jobsQuery({}, { path: [] }).take(1),
+            jobsQuery({}, { path: [] }).take(1),
+            jobsQuery({}, { path: [] }).take(1),
+            jobsQuery({}, { path: [] }).take(1),
+            jobsQuery({}, { path: [] }).take(1)
+          ).subscribe(jest.fn(), jest.fn(), () => {
+            expect(fetchJobs).toHaveBeenCalledTimes(1);
+          });
+        })
+      );
+
       describe("ordering", () => {
         it(
           "orders by ID",


### PR DESCRIPTION
## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

Please visit the Jobs Overview page and try to use a lot of filters and sorting. You should see a nearly instantly UI.

![](https://dzwonsemrish7.cloudfront.net/items/1n3M36312B2p1K0U021R/Screen%20Recording%202018-07-16%20at%2012.57%20PM.gif?v=a61610e7)

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- There might be situations where we cancel network requests becasue of bad timing. To solve this we would need to have a `refCountWithDelay` function build in. This should be part of DCOS-38161.

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

None 🎉 