### PR TITLE
DCOS-39067: add correct sort icon to table header icon component

### DIFF
--- a/packages/ui-kit-stage/SortableColumnHeaderCellIcon.tsx
+++ b/packages/ui-kit-stage/SortableColumnHeaderCellIcon.tsx
@@ -15,7 +15,9 @@ export function SortableColumnHeaderCellIcon({
   if (sortDirection === null) {
     return null;
   }
-  // TODO: DCOS-39067
-  const icon = sortDirection === "ASC" ? "↗️" : "↘️";
-  return <span>{icon}</span>;
+  return sortDirection === "ASC" ? (
+    <span className="caret caret--asc caret--visible" />
+  ) : (
+    <span className="caret caret--desc caret--visible" />
+  );
 }


### PR DESCRIPTION
💁‍♂️ JIRA Link: https://jira.mesosphere.com/browse/DCOS-39067

## Testing

In `NodesTableContainer.js`: 
```diff
-import NodesTable from "../../../components/NodesTable";
+import NodesTable from "../../../components/NodesTable-new";
```

## Trade-offs

Not directly related to this PR, but I noticed that there was a right-aligned icon in the old table. Did we drop this with the new table component? 🤔  /cc @weblancaster @leemunroe @lilysamimi 

There is a Bug with the Table, after you clicked on a header to change sorting, you need to resize your Browserwindow 😅 Bug is already fixed in UI Kit but we still need to fix another issue to create a new UI Kit Release

## Dependencies

None
