### PR TITLE
DCOS-38825: GPU columns

### DIFF
--- a/plugins/nodes/src/js/columns/NodesTableGPUBarColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableGPUBarColumn.tsx
@@ -1,14 +1,23 @@
 import * as React from "react";
 import Node from "#SRC/js/structs/Node";
+
 // TODO: DCOS-39079
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
 import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs";
+import ProgressBar from "#SRC/js/components/ProgressBar";
 
 export function gpubarRenderer(data: Node): React.ReactNode {
-  // TODO: DCOS-38825
-  return <span>{data.get("used_resources").gpus.toString()}</span>;
+  return (
+    <ProgressBar
+      data={[
+        { value: data.getUsageStats("gpus").percentage, className: "color-1" }
+      ]}
+      total={100}
+    />
+  );
 }
+
 export function gpubarSizer(args: WidthArgs): number {
-  // TODO: DCOS-38825
-  return Math.max(100, args.width / args.totalColumns);
+  // TODO: DCOS-39147
+  return Math.min(60, Math.max(60, args.width / args.totalColumns));
 }

--- a/plugins/nodes/src/js/columns/NodesTableGPUColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableGPUColumn.tsx
@@ -7,12 +7,9 @@ import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs"
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 
 export function gpuRenderer(data: Node): React.ReactNode {
-  // TODO: DCOS-38825
-  return <span>{data.get("used_resources").gpus.toString()}</span>;
+  return `${data.getUsageStats("gpus").percentage}%`;
 }
 export function gpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
-  // TODO: DCOS-38825
-  // current implementation is a rough idea, not sure if it is the best one…
   const sortedData = data.sort((a, b) =>
     compareValues(
       a.get("used_resources").gpus.toString(),
@@ -24,6 +21,5 @@ export function gpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
 }
 export function gpuSizer(args: WidthArgs): number {
-  // TODO: DCOS-38825
-  return Math.max(100, args.width / args.totalColumns);
+  return Math.max(60, args.width / args.totalColumns);
 }


### PR DESCRIPTION
Progress bar for GPU column + minor tweaks to align with CPU cols.

Closes DCOS-38825

## Testing
`nodes/nodes-table/NodesTableContainer.js`

```diff
+import NodesTable from "../../../components/NodesTable-new";
-import NodesTable from "../../../components/NodesTable";
```