### PR TITLE
DCOS-39265: Use Cell from UI Kit for the content of the tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@dcos/http-service": "0.3.0",
     "@dcos/mesos-client": "0.2.3",
     "@dcos/tslint-config": "0.1.0",
-    "@dcos/ui-kit": "1.2.3",
+    "@dcos/ui-kit": "1.3.0",
     "babel-polyfill": "6.23.0",
     "browser-info": "0.4.0",
     "classnames": "2.2.3",

--- a/plugins/nodes/src/js/columns/NodesTableCPUBarColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableCPUBarColumn.tsx
@@ -5,15 +5,18 @@ import Node from "#SRC/js/structs/Node";
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
 import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs";
 import ProgressBar from "#SRC/js/components/ProgressBar";
+import { Cell } from "@dcos/ui-kit";
 
 export function cpubarRenderer(data: Node): React.ReactNode {
   return (
-    <ProgressBar
-      data={[
-        { value: data.getUsageStats("cpus").percentage, className: "color-1" }
-      ]}
-      total={100}
-    />
+    <Cell>
+      <ProgressBar
+        data={[
+          { value: data.getUsageStats("cpus").percentage, className: "color-1" }
+        ]}
+        total={100}
+      />
+    </Cell>
   );
 }
 

--- a/plugins/nodes/src/js/columns/NodesTableCPUColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableCPUColumn.tsx
@@ -5,10 +5,16 @@ import Node from "#SRC/js/structs/Node";
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
 import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
+import { TextCell } from "@dcos/ui-kit";
 
 export function cpuRenderer(data: Node): React.ReactNode {
-  return `${data.getUsageStats("cpus").percentage}%`;
+  return (
+    <TextCell>
+      <span>{data.getUsageStats("cpus").percentage}%</span>
+    </TextCell>
+  );
 }
+
 export function cpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const sortedData = data.sort((a, b) =>
     compareValues(
@@ -20,6 +26,7 @@ export function cpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
   );
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
 }
+
 export function cpuSizer(args: WidthArgs): number {
   // TODO: DCOS-39147
   return Math.min(60, Math.max(60, args.width / args.totalColumns));

--- a/plugins/nodes/src/js/columns/NodesTableDiskBarColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableDiskBarColumn.tsx
@@ -4,15 +4,18 @@ import Node from "#SRC/js/structs/Node";
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
 import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs";
 import ProgressBar from "#SRC/js/components/ProgressBar";
+import { Cell } from "@dcos/ui-kit";
 
 export function diskbarRenderer(data: Node): React.ReactNode {
   return (
-    <ProgressBar
-      data={[
-        { value: data.getUsageStats("disk").percentage, className: "color-1" }
-      ]}
-      total={100}
-    />
+    <Cell>
+      <ProgressBar
+        data={[
+          { value: data.getUsageStats("disk").percentage, className: "color-1" }
+        ]}
+        total={100}
+      />
+    </Cell>
   );
 }
 

--- a/plugins/nodes/src/js/columns/NodesTableDiskColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableDiskColumn.tsx
@@ -5,9 +5,14 @@ import Node from "#SRC/js/structs/Node";
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
 import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
+import { TextCell } from "@dcos/ui-kit";
 
 export function diskRenderer(data: Node): React.ReactNode {
-  return <span>{data.getUsageStats("disk").percentage}%</span>;
+  return (
+    <TextCell>
+      <span>{data.getUsageStats("disk").percentage}%</span>
+    </TextCell>
+  );
 }
 
 export function diskSorter(data: Node[], sortDirection: SortDirection): Node[] {

--- a/plugins/nodes/src/js/columns/NodesTableGPUBarColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableGPUBarColumn.tsx
@@ -5,15 +5,18 @@ import Node from "#SRC/js/structs/Node";
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
 import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs";
 import ProgressBar from "#SRC/js/components/ProgressBar";
+import { Cell } from "@dcos/ui-kit";
 
 export function gpubarRenderer(data: Node): React.ReactNode {
   return (
-    <ProgressBar
-      data={[
-        { value: data.getUsageStats("gpus").percentage, className: "color-1" }
-      ]}
-      total={100}
-    />
+    <Cell>
+      <ProgressBar
+        data={[
+          { value: data.getUsageStats("gpus").percentage, className: "color-1" }
+        ]}
+        total={100}
+      />
+    </Cell>
   );
 }
 

--- a/plugins/nodes/src/js/columns/NodesTableGPUColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableGPUColumn.tsx
@@ -5,10 +5,16 @@ import Node from "#SRC/js/structs/Node";
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
 import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
+import { TextCell } from "@dcos/ui-kit";
 
 export function gpuRenderer(data: Node): React.ReactNode {
-  return `${data.getUsageStats("gpus").percentage}%`;
+  return (
+    <TextCell>
+      <span>{data.getUsageStats("gpus").percentage}%</span>
+    </TextCell>
+  );
 }
+
 export function gpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const sortedData = data.sort((a, b) =>
     compareValues(
@@ -20,6 +26,7 @@ export function gpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
   );
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
 }
+
 export function gpuSizer(args: WidthArgs): number {
   return Math.max(60, args.width / args.totalColumns);
 }

--- a/plugins/nodes/src/js/columns/NodesTableHealthColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableHealthColumn.tsx
@@ -5,10 +5,15 @@ import Node from "#SRC/js/structs/Node";
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
 import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
+import { TextCell } from "@dcos/ui-kit";
 
 export function healthRenderer(data: Node): React.ReactNode {
   const health = data.getHealth();
-  return <span className={health.classNames}>{health.title}</span>;
+  return (
+    <TextCell>
+      <span className={health.classNames}>{health.title}</span>
+    </TextCell>
+  );
 }
 
 export function healthSorter(

--- a/plugins/nodes/src/js/columns/NodesTableHostnameColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableHostnameColumn.tsx
@@ -8,6 +8,7 @@ import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import { Link } from "react-router";
 import { Tooltip } from "reactjs-components";
 import Icon from "#SRC/js/components/Icon";
+import { TextCell } from "@dcos/ui-kit";
 
 export function hostnameRenderer(data: Node): React.ReactNode {
   const nodeID = data.get("id");
@@ -15,26 +16,30 @@ export function hostnameRenderer(data: Node): React.ReactNode {
 
   if (!data.isActive()) {
     return (
-      <Link className="table-cell-link-primary" to={`/nodes/${nodeID}`}>
-        <span title={headline}>
-          <Tooltip anchor="start" content="Connection to node lost">
-            <Icon
-              className="icon-alert icon-margin-right"
-              color="neutral"
-              id="yield"
-              size="mini"
-            />
-            {headline}
-          </Tooltip>
-        </span>
-      </Link>
+      <TextCell>
+        <Link className="table-cell-link-primary" to={`/nodes/${nodeID}`}>
+          <span title={headline}>
+            <Tooltip anchor="start" content="Connection to node lost">
+              <Icon
+                className="icon-alert icon-margin-right"
+                color="neutral"
+                id="yield"
+                size="mini"
+              />
+              {headline}
+            </Tooltip>
+          </span>
+        </Link>
+      </TextCell>
     );
   }
 
   return (
-    <Link className="table-cell-link-primary" to={`/nodes/${nodeID}`}>
-      <span title={headline}>{headline}</span>
-    </Link>
+    <TextCell>
+      <Link className="table-cell-link-primary" to={`/nodes/${nodeID}`}>
+        <span title={headline}>{headline}</span>
+      </Link>
+    </TextCell>
   );
 }
 

--- a/plugins/nodes/src/js/columns/NodesTableMemBarColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableMemBarColumn.tsx
@@ -4,15 +4,18 @@ import Node from "#SRC/js/structs/Node";
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
 import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs";
 import ProgressBar from "#SRC/js/components/ProgressBar";
+import { Cell } from "@dcos/ui-kit";
 
 export function membarRenderer(data: Node): React.ReactNode {
   return (
-    <ProgressBar
-      data={[
-        { value: data.getUsageStats("mem").percentage, className: "color-1" }
-      ]}
-      total={100}
-    />
+    <Cell>
+      <ProgressBar
+        data={[
+          { value: data.getUsageStats("mem").percentage, className: "color-1" }
+        ]}
+        total={100}
+      />
+    </Cell>
   );
 }
 

--- a/plugins/nodes/src/js/columns/NodesTableMemColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableMemColumn.tsx
@@ -5,9 +5,14 @@ import Node from "#SRC/js/structs/Node";
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
 import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
+import { TextCell } from "@dcos/ui-kit";
 
 export function memRenderer(data: Node): React.ReactNode {
-  return <span>{data.getUsageStats("mem").percentage}%</span>;
+  return (
+    <TextCell>
+      <span>{data.getUsageStats("mem").percentage}%</span>
+    </TextCell>
+  );
 }
 
 export function memSorter(data: Node[], sortDirection: SortDirection): Node[] {

--- a/plugins/nodes/src/js/columns/NodesTableRegionColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableRegionColumn.tsx
@@ -5,19 +5,23 @@ import Node from "#SRC/js/structs/Node";
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
 import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
+import { TextCell } from "@dcos/ui-kit";
 
 export function regionRenderer(
   masterRegion: string,
   data: Node
 ): React.ReactNode {
-  const regionName = data.getRegionName();
+  const regionName =
+    data.getRegionName() +
+    (masterRegion === data.getRegionName() ? " (Local)" : "");
+
   return (
-    <span title={regionName}>
-      {regionName}
-      {masterRegion === regionName ? " (Local)" : null}
-    </span>
+    <TextCell>
+      <span title={regionName}>{regionName}</span>
+    </TextCell>
   );
 }
+
 export function regionSorter(
   data: Node[],
   sortDirection: SortDirection
@@ -32,6 +36,7 @@ export function regionSorter(
   );
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
 }
+
 export function regionSizer(args: WidthArgs): number {
   return Math.max(170, args.width / args.totalColumns);
 }

--- a/plugins/nodes/src/js/columns/NodesTableTasksColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableTasksColumn.tsx
@@ -5,9 +5,14 @@ import Node from "#SRC/js/structs/Node";
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
 import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
+import { TextCell } from "@dcos/ui-kit";
 
 export function tasksRenderer(data: Node): React.ReactNode {
-  return <span>{data.get("TASK_RUNNING").toString()}</span>;
+  return (
+    <TextCell>
+      <span>{data.get("TASK_RUNNING").toString()}</span>
+    </TextCell>
+  );
 }
 
 export function tasksSorter(

--- a/plugins/nodes/src/js/columns/NodesTableZoneColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableZoneColumn.tsx
@@ -5,10 +5,16 @@ import Node from "#SRC/js/structs/Node";
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
 import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
+import { TextCell } from "@dcos/ui-kit";
 
 export function zoneRenderer(data: Node): React.ReactNode {
-  return <span title={data.getZoneName()}>{data.getZoneName()}</span>;
+  return (
+    <TextCell>
+      <span title={data.getZoneName()}>{data.getZoneName()}</span>
+    </TextCell>
+  );
 }
+
 export function zoneSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const sortedData = data.sort((a, b) =>
     compareValues(
@@ -20,6 +26,7 @@ export function zoneSorter(data: Node[], sortDirection: SortDirection): Node[] {
   );
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
 }
+
 export function zoneSizer(args: WidthArgs): number {
   return Math.max(125, args.width / args.totalColumns);
 }

--- a/plugins/nodes/src/js/columns/__tests__/__snapshots__/NodesTableHealthColumn-test.js.snap
+++ b/plugins/nodes/src/js/columns/__tests__/__snapshots__/NodesTableHealthColumn-test.js.snap
@@ -1,33 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NodesTableHealthColumn renderer renders with health status 'Healthy' 1`] = `
-<span
-  className="text-success"
+<div
+  className="css-19m5nce"
 >
-  Healthy
-</span>
+  <span
+    className="text-success"
+  >
+    Healthy
+  </span>
+</div>
 `;
 
 exports[`NodesTableHealthColumn renderer renders with health status 'NA' 1`] = `
-<span
-  className="text-mute"
+<div
+  className="css-19m5nce"
 >
-  N/A
-</span>
+  <span
+    className="text-mute"
+  >
+    N/A
+  </span>
+</div>
 `;
 
 exports[`NodesTableHealthColumn renderer renders with health status 'Unhealthy' 1`] = `
-<span
-  className="text-danger"
+<div
+  className="css-19m5nce"
 >
-  Unhealthy
-</span>
+  <span
+    className="text-danger"
+  >
+    Unhealthy
+  </span>
+</div>
 `;
 
 exports[`NodesTableHealthColumn renderer renders with health status 'Warn' 1`] = `
-<span
-  className="text-warning"
+<div
+  className="css-19m5nce"
 >
-  Warning
-</span>
+  <span
+    className="text-warning"
+  >
+    Warning
+  </span>
+</div>
 `;


### PR DESCRIPTION
The Cell Component from @dcos/ui-kit was added to all columns in the new (refactored) table.
Closes DCOS-39265

## Testing

run npm install

In `NodesTableContainer.js`:
```diff
-import NodesTable from "../../../components/NodesTable";
+import NodesTable from "../../../components/NodesTable-new";
```

## Trade-offs

I have decided to add a `<span>` element inside the Cell for some files that didn't have it (for example NodesTableGPUColumn.tsx). Some other files already had such a `<span>` and I wanted to be consistent.

## Dependencies
None
