### PR TITLE
DCOS-39331: Add isPublic to node api

### DIFF
--- a/src/js/structs/Node.d.ts
+++ b/src/js/structs/Node.d.ts
@@ -13,4 +13,5 @@ export default class Node extends Item {
   getOutput: () => any;
   sumTaskTypesByState: (state: any) => any;
   getUsedResources: () => any;
+  isPublic: () => boolean;
 }

--- a/src/js/structs/Node.js
+++ b/src/js/structs/Node.js
@@ -94,6 +94,12 @@ class Node extends Item {
       }
     );
   }
+
+  isPublic() {
+    return (
+      findNestedPropertyInObject(this.get("attributes"), "public_ip") === "true"
+    );
+  }
 }
 
 module.exports = Node;

--- a/src/js/structs/__tests__/Node-test.js
+++ b/src/js/structs/__tests__/Node-test.js
@@ -155,4 +155,36 @@ describe("Node", function() {
       });
     });
   });
+
+  describe("#isPublic", function() {
+    const testCases = [
+      {
+        name: "returns true if attributes.public_ip is true",
+        expected: true,
+        value: { attributes: { public_ip: "true" } }
+      },
+      {
+        name: "returns false if attributes.public_ip is false",
+        expected: false,
+        value: { attributes: { public_ip: "false" } }
+      },
+      {
+        name: "returns false if attributes.public_ip is missing",
+        expected: false,
+        value: { attributes: {} }
+      },
+      {
+        name: "returns false if attributes is missing",
+        expected: false,
+        value: {}
+      }
+    ];
+
+    testCases.forEach(function(test) {
+      it(test.name, function() {
+        const node = new Node(test.value);
+        expect(node.isPublic()).toEqual(test.expected);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

- See the tests that we wrote and verify that they handle each edge case
- Read through [the docs](https://docs.mesosphere.com/1.11/overview/architecture/node-types/#public-agent-nodes) and see if we are misusing the API

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- We chose to not use the "public_agent" role, because of what we found [here](https://docs.mesosphere.com/1.11/overview/architecture/node-types/#public-agent-nodes)
> The Mesos agents on public agent nodes also have the public_ip:true agent attribute to assist in their discovery.
It seemed to us like this is more precise

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

None