### PR TITLE
fix(ServiceDebugContainer): stop using deprecated label

### DIFF
--- a/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
+++ b/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
@@ -21,6 +21,7 @@ import DeclinedOffersUtil from "../../utils/DeclinedOffersUtil";
 import MarathonStore from "../../stores/MarathonStore";
 import RecentOffersSummary from "../../components/RecentOffersSummary";
 import Service from "../../structs/Service";
+import Framework from "../../structs/Framework";
 import TaskStatsTable from "./TaskStatsTable";
 import TimeAgo from "../../../../../../src/js/components/TimeAgo";
 
@@ -166,15 +167,8 @@ class ServiceDebugContainer extends React.Component {
     let mainContent = null;
     let offerCount = null;
 
-    if (this.isFramework(service)) {
-      const { labels = {} } = service;
-      const frameworkName = labels.DCOS_PACKAGE_FRAMEWORK_NAME;
-
-      if (frameworkName != null) {
-        introText = `Rejected offer analysis is not currently supported for ${frameworkName}.`;
-      } else {
-        introText = "Rejected offer analysis is not currently supported.";
-      }
+    if (service instanceof Framework) {
+      introText = `Rejected offer analysis is not currently supported for ${service.getName()}.`;
     } else if (
       !DeclinedOffersUtil.shouldDisplayDeclinedOffersWarning(service) ||
       queue.declinedOffers.summary == null
@@ -217,7 +211,7 @@ class ServiceDebugContainer extends React.Component {
   getDeclinedOffersTable() {
     const { service } = this.props;
 
-    if (this.isFramework(service)) {
+    if (service instanceof Framework) {
       return null;
     }
 
@@ -257,7 +251,7 @@ class ServiceDebugContainer extends React.Component {
   getWaitingForResourcesNotice() {
     const { service } = this.props;
 
-    if (this.isFramework(service)) {
+    if (service instanceof Framework) {
       return null;
     }
 
@@ -293,15 +287,6 @@ class ServiceDebugContainer extends React.Component {
     if (this.offerSummaryRef) {
       this.offerSummaryRef.scrollIntoView();
     }
-  }
-
-  isFramework(service) {
-    const { labels = {} } = service;
-
-    return (
-      labels.DCOS_PACKAGE_FRAMEWORK_NAME != null ||
-      labels.DCOS_PACKAGE_IS_FRAMEWORK != null
-    );
   }
 
   render() {


### PR DESCRIPTION
`DCOS_PACKAGE_IS_FRAMEWORK` has been [deprecated](https://jira.mesosphere.com/browse/DCOS-15283) and we haven't backported. Checking it causes false positives, i.e. detecting `marathon-lb` as it would be a framework. Switching to `service instanceof Framework` check fixes the issue.

Closes DCOS-22291

Co-authored-by: Orlando Hohmeier <orlando@mesosphere.com>

## Testing

Look into soak19 with `release/1.9` UI verify that `marathon-lb` doesn't show anything under `Recent Resource Offers` section on the Debug tab.

Verify that with the fix you see the offers and rejections.