### PR TITLE
feat(NodesPage): add tabs to NodesPage

### DIFF
--- a/plugins/nodes/src/js/pages/NodesAgents.js
+++ b/plugins/nodes/src/js/pages/NodesAgents.js
@@ -204,7 +204,14 @@ var NodesOverview = React.createClass({
   },
 
   getViewTypeRadioButtons(resetFilter) {
-    const isGridActive = /\/nodes\/grid\/?/i.test(this.props.location.pathname);
+    const isGridActive = /\/nodes\/agents\/grid\/?/i.test(
+      this.props.location.pathname
+    );
+    // const activeView = this.props.location.pathname.includes("agents")
+    //   ? "agents"
+    //   : "masters";
+
+    console.log(this.props.location);
 
     var listClassSet = classNames("button button-outline", {
       active: !isGridActive
@@ -216,10 +223,14 @@ var NodesOverview = React.createClass({
 
     return (
       <div className="button-group flush-bottom">
-        <Link className={listClassSet} onClick={resetFilter} to="/nodes">
+        <Link className={listClassSet} onClick={resetFilter} to="/nodes/agents">
           List
         </Link>
-        <Link className={gridClassSet} onClick={resetFilter} to="/nodes/grid">
+        <Link
+          className={gridClassSet}
+          onClick={resetFilter}
+          to="/nodes/agents/grid"
+        >
           Grid
         </Link>
       </div>
@@ -239,7 +250,13 @@ var NodesOverview = React.createClass({
 
     return (
       <Page>
-        <Page.Header breadcrumbs={<NodeBreadcrumbs />} />
+        <Page.Header
+          breadcrumbs={<NodeBreadcrumbs />}
+          tabs={[
+            { label: "Agents", routePath: "/nodes/agents" },
+            { label: "Masters", routePath: "/nodes/masters" }
+          ]}
+        />
         <HostsPageContent
           byServiceFilter={byServiceFilter}
           filterButtonContent={this.getButtonContent}

--- a/plugins/nodes/src/js/pages/NodesMasters.tsx
+++ b/plugins/nodes/src/js/pages/NodesMasters.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default class NodesMasters extends React.Component {
+  render() {
+    return null;
+  }
+}

--- a/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
+++ b/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
@@ -159,7 +159,6 @@ class HostsPageContent extends React.Component {
     const {
       byServiceFilter,
       children,
-      filterInputText,
       filteredNodeCount,
       handleFilterChange,
       hosts,
@@ -194,7 +193,6 @@ class HostsPageContent extends React.Component {
           totalLength={totalNodeCount}
         />
         <FilterBar rightAlignLastNChildren={1}>
-          {filterInputText}
           {this.getFilterBar()}
           <div className="form-group flush-bottom">
             <FilterByService
@@ -220,7 +218,6 @@ class HostsPageContent extends React.Component {
 HostsPageContent.propTypes = {
   byServiceFilter: PropTypes.string,
   filterButtonContent: PropTypes.func,
-  filterInputText: PropTypes.node,
   filterItemList: PropTypes.array.isRequired,
   filteredNodeCount: PropTypes.number.isRequired,
   handleFilterChange: PropTypes.func.isRequired,

--- a/plugins/nodes/src/js/routes/nodes.js
+++ b/plugins/nodes/src/js/routes/nodes.js
@@ -9,6 +9,8 @@ import NodeDetailTab from "../pages/nodes/NodeDetailTab";
 import NodeDetailTaskTab from "../pages/nodes/NodeDetailTaskTab";
 import NodesGridContainer from "../pages/nodes/nodes-grid/NodesGridContainer";
 import NodesOverview from "../pages/NodesOverview";
+import NodesAgents from "../pages/NodesAgents";
+import NodesMasters from "../pages/NodesMasters";
 import NodesPage from "../pages/NodesPage";
 import NodesTableContainer from "../pages/nodes/nodes-table/NodesTableContainer";
 import NodesTaskDetailPage from "../pages/nodes/NodesTaskDetailPage";
@@ -21,139 +23,175 @@ import TaskVolumeContainer from "../../../../services/src/js/containers/volume-d
 import NodesUnitsHealthDetailPage from "../pages/nodes/NodesUnitsHealthDetailPage";
 import VolumeTable from "../../../../services/src/js/components/VolumeTable";
 
-const nodesRoutes = {
-  type: Route,
-  path: "nodes",
-  component: NodesPage,
-  category: "resources",
-  isInSidebar: true,
-  children: [
-    {
-      type: Route,
-      component: NodesOverview,
-      children: [
-        {
-          type: IndexRoute,
-          component: NodesTableContainer
-        },
-        {
-          type: Route,
-          path: "grid",
-          component: NodesGridContainer
-        }
-      ]
-    },
-    {
-      type: Redirect,
-      from: "/nodes/:nodeID",
-      to: "/nodes/:nodeID/tasks"
-    },
-    {
-      type: Route,
-      path: ":nodeID",
-      component: NodeDetailPage,
-      children: [
-        {
-          type: Route,
-          title: "Tasks",
-          path: "tasks",
-          component: NodeDetailTaskTab
-        },
-        {
-          type: Redirect,
-          path: "/nodes/:nodeID/tasks/:taskID",
-          to: "/nodes/:nodeID/tasks/:taskID/details"
-        },
-        {
-          type: Route,
-          path: "health",
-          title: "Health",
-          component: NodeDetailHealthTab
-        },
-        {
-          type: Route,
-          path: "details",
-          title: "Details",
-          component: NodeDetailTab
-        }
-      ]
-    },
-    {
-      type: Route,
-      path: ":nodeID/tasks/:taskID",
-      component: NodesTaskDetailPage,
-      hideHeaderNavigation: true,
-      children: [
-        {
-          type: Route,
-          component: TaskDetailsTab,
-          hideHeaderNavigation: true,
-          title: "Details",
-          path: "details",
-          isTab: true
-        },
-        {
-          hideHeaderNavigation: true,
-          component: TaskFilesTab,
-          isTab: true,
-          path: "files",
-          title: "Files",
-          type: Route,
-          children: [
-            {
-              component: TaskFileBrowser,
-              fileViewerRoutePath:
-                "/nodes/:nodeID/tasks/:taskID/files/view(/:filePath(/:innerPath))",
-              hideHeaderNavigation: true,
-              type: IndexRoute
-            },
-            {
-              component: TaskFileViewer,
-              hideHeaderNavigation: true,
-              path: "view(/:filePath(/:innerPath))",
-              type: Route
-            }
-          ]
-        },
-        {
-          component: TaskLogsContainer,
-          hideHeaderNavigation: true,
-          isTab: true,
-          path: "logs",
-          title: "Logs",
-          type: Route,
-          children: [
-            {
-              path: ":filePath",
-              type: Route
-            }
-          ]
-        },
-        {
-          component: VolumeTable,
-          hideHeaderNavigation: true,
-          isTab: true,
-          path: "volumes",
-          title: "Volumes",
-          type: Route
-        }
-      ]
-    },
-    // This route needs to be rendered outside of the tabs that are rendered
-    // in the nodes-task-details route.
-    {
-      type: Route,
-      path: ":nodeID/tasks/:taskID/volumes/:volumeID",
-      component: TaskVolumeContainer
-    },
-    // This needs to be outside of the children array of node routes
-    // so that it can be responsible for rendering its own header.
-    {
-      type: Route,
-      path: ":nodeID/health/:unitNodeID/:unitID",
-      component: NodesUnitsHealthDetailPage
-    }
-  ]
-};
+const nodesRoutes = [
+  // comment in to enable new:
+  // {
+  //   type: Redirect,
+  //   from: "/nodes",
+  //   to: "/nodes/agents/table"
+  // },
+  {
+    type: Route,
+    path: "nodes",
+    component: NodesPage,
+    category: "resources",
+    isInSidebar: true,
+    children: [
+      // old route object:
+      {
+        type: Route,
+        component: NodesOverview,
+        children: [
+          {
+            type: IndexRoute,
+            component: NodesTableContainer
+          },
+          {
+            type: Route,
+            path: "grid",
+            component: NodesGridContainer
+          }
+        ]
+      },
+      {
+        type: Redirect,
+        from: "/nodes/agents",
+        to: "/nodes/agents/table"
+      },
+      {
+        type: Route,
+        path: "agents",
+        component: NodesAgents,
+        children: [
+          {
+            type: Route,
+            component: NodesTableContainer,
+            path: "table"
+          },
+          {
+            type: Route,
+            component: NodesGridContainer,
+            path: "grid"
+          }
+        ]
+      },
+      {
+        type: Route,
+        path: "masters",
+        component: NodesMasters
+      },
+      {
+        type: Redirect,
+        from: "/nodes/:nodeID",
+        to: "/nodes/:nodeID/tasks"
+      },
+      {
+        type: Route,
+        path: ":nodeID",
+        component: NodeDetailPage,
+        children: [
+          {
+            type: Route,
+            title: "Tasks",
+            path: "tasks",
+            component: NodeDetailTaskTab
+          },
+          {
+            type: Redirect,
+            path: "/nodes/:nodeID/tasks/:taskID",
+            to: "/nodes/:nodeID/tasks/:taskID/details"
+          },
+          {
+            type: Route,
+            path: "health",
+            title: "Health",
+            component: NodeDetailHealthTab
+          },
+          {
+            type: Route,
+            path: "details",
+            title: "Details",
+            component: NodeDetailTab
+          }
+        ]
+      },
+      {
+        type: Route,
+        path: ":nodeID/tasks/:taskID",
+        component: NodesTaskDetailPage,
+        hideHeaderNavigation: true,
+        children: [
+          {
+            type: Route,
+            component: TaskDetailsTab,
+            hideHeaderNavigation: true,
+            title: "Details",
+            path: "details",
+            isTab: true
+          },
+          {
+            hideHeaderNavigation: true,
+            component: TaskFilesTab,
+            isTab: true,
+            path: "files",
+            title: "Files",
+            type: Route,
+            children: [
+              {
+                component: TaskFileBrowser,
+                fileViewerRoutePath:
+                  "/nodes/:nodeID/tasks/:taskID/files/view(/:filePath(/:innerPath))",
+                hideHeaderNavigation: true,
+                type: IndexRoute
+              },
+              {
+                component: TaskFileViewer,
+                hideHeaderNavigation: true,
+                path: "view(/:filePath(/:innerPath))",
+                type: Route
+              }
+            ]
+          },
+          {
+            component: TaskLogsContainer,
+            hideHeaderNavigation: true,
+            isTab: true,
+            path: "logs",
+            title: "Logs",
+            type: Route,
+            children: [
+              {
+                path: ":filePath",
+                type: Route
+              }
+            ]
+          },
+          {
+            component: VolumeTable,
+            hideHeaderNavigation: true,
+            isTab: true,
+            path: "volumes",
+            title: "Volumes",
+            type: Route
+          }
+        ]
+      },
+      // This route needs to be rendered outside of the tabs that are rendered
+      // in the nodes-task-details route.
+      {
+        type: Route,
+        path: ":nodeID/tasks/:taskID/volumes/:volumeID",
+        component: TaskVolumeContainer
+      },
+      // This needs to be outside of the children array of node routes
+      // so that it can be responsible for rendering its own header.
+      {
+        type: Route,
+        path: ":nodeID/health/:unitNodeID/:unitID",
+        component: NodesUnitsHealthDetailPage
+      }
+    ]
+  }
+];
 
 module.exports = nodesRoutes;


### PR DESCRIPTION
👨‍💻 paired with @weblancaster on this one

---

## Testing

checkout, start your local proxy and navigate to http://localhost:4200/#/nodes/agents/table?_k=x1ahzj
=> agents tab has to work exactly as before
=> masters tab is just an empty page for now, we need to clarify some thing here and will update that part later.

## Trade-offs

We decided to rename `NodesOverview` to `NodesAgents` and introduce a second `NodesMasters` component for "Masters" Tab. Currently this `NodesMasters` file is empty / broken. We need to clarify how to proceed there.

## Dependencies

None

---

🔖 JIRA: [DCOS-39153](https://jira.mesosphere.com/browse/DCOS-39153)