### PR TITLE
Close DCOS-38595: fix framework configuration form

### DIFF
--- a/src/js/components/FrameworkConfiguration.js
+++ b/src/js/components/FrameworkConfiguration.js
@@ -13,7 +13,9 @@ import UniversePackage from "#SRC/js/structs/UniversePackage";
 import Util from "#SRC/js/utils/Util";
 import StringUtil from "#SRC/js/utils/StringUtil";
 import CosmosErrorMessage from "#SRC/js/components/CosmosErrorMessage";
-import FrameworkConfigurationForm from "#SRC/js/components/FrameworkConfigurationForm";
+import FrameworkConfigurationForm, {
+  isValidFormData
+} from "#SRC/js/components/FrameworkConfigurationForm";
 import FrameworkConfigurationReviewScreen from "#SRC/js/components/FrameworkConfigurationReviewScreen";
 
 const METHODS_TO_BIND = [
@@ -43,6 +45,15 @@ class FrameworkConfiguration extends Component {
 
     METHODS_TO_BIND.forEach(method => {
       this[method] = this[method].bind(this);
+    });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { packageDetails, formData } = nextProps;
+    this.setState({
+      jsonEditorActive:
+        !isValidFormData(formData, packageDetails.getConfig()) ||
+        this.state.jsonEditorActive
     });
   }
 

--- a/src/js/components/__tests__/FrameworkConfigurationForm-test.js
+++ b/src/js/components/__tests__/FrameworkConfigurationForm-test.js
@@ -1,0 +1,47 @@
+import { isValidFormData } from "../FrameworkConfigurationForm";
+
+describe("#isValidFormData", () => {
+  it("returns true if valid formdata is provided", () => {
+    expect(isValidFormData({ a: "test" }, { properties: { a: true } })).toBe(
+      true
+    );
+  });
+
+  it("returns false if invalid formdata is provided", () => {
+    expect(isValidFormData({ b: "test" }, { properties: { a: true } })).toBe(
+      false
+    );
+  });
+
+  it("returns false if partily invalid formdata is provided", () => {
+    expect(
+      isValidFormData({ a: "test", b: "test" }, { properties: { a: true } })
+    ).toBe(false);
+  });
+
+  it("returns true if nested valid formdata is provided", () => {
+    expect(
+      isValidFormData(
+        { a: "test", b: { a: "test", b: "test" } },
+        { properties: { a: true, b: { properties: { a: true, b: true } } } }
+      )
+    ).toBe(true);
+  });
+
+  it("returns false if nested invalid formdata is provided", () => {
+    expect(
+      isValidFormData(
+        { a: "test", b: { a: "test", b: "test" } },
+        { properties: { a: true, b: { properties: { a: true } } } }
+      )
+    ).toBe(false);
+  });
+  it("returns true if empty formdata is provided", () => {
+    expect(
+      isValidFormData(
+        {},
+        { properties: { a: true, b: { properties: { a: true } } } }
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
This fixes FrameworkConfigurationForm to gracefully handle an invalid
`formData` and provide an error message.

![image](https://user-images.githubusercontent.com/156010/43154435-997a32e4-8f74-11e8-9796-7b08a99167e2.png)


Close DCOS-38595

## Testing

Please have a look at the issue it has all the information to set up the cluster with the breaking state.

## Trade-offs

The trade-off is that currently in case of an invalid solution you can't disable the json-editor in the edit form.

## Dependencies

This change has no dependencies.
