### PR TITLE
1.10 DCOS-39661: Check instance type instead of labels

### DIFF
--- a/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
+++ b/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
@@ -17,6 +17,7 @@ import DeclinedOffersTable from "../../components/DeclinedOffersTable";
 import MarathonStore from "../../stores/MarathonStore";
 import RecentOffersSummary from "../../components/RecentOffersSummary";
 import Service from "../../structs/Service";
+import Framework from "../../structs/Framework";
 import TaskStatsTable from "./TaskStatsTable";
 
 const METHODS_TO_BIND = ["handleJumpToRecentOffersClick"];
@@ -211,7 +212,7 @@ class ServiceDebugContainer extends React.Component {
   getRecentOfferSummaryIntroText() {
     const { service } = this.props;
 
-    if (this.isFramework(service)) {
+    if (service instanceof Framework) {
       const frameworkName = service.getPackageName();
 
       return this.getRecentOfferSummaryDisabledText(frameworkName);
@@ -265,7 +266,7 @@ class ServiceDebugContainer extends React.Component {
   getWaitingForResourcesNotice() {
     const { service } = this.props;
 
-    if (this.isFramework(service)) {
+    if (service instanceof Framework) {
       return null;
     }
 
@@ -303,12 +304,6 @@ class ServiceDebugContainer extends React.Component {
     }
   }
 
-  isFramework(service) {
-    const { labels = {} } = service;
-
-    return labels.DCOS_PACKAGE_FRAMEWORK_NAME != null;
-  }
-
   shouldShowDeclinedOfferSummary() {
     const { service } = this.props;
 
@@ -331,7 +326,7 @@ class ServiceDebugContainer extends React.Component {
     const { service } = this.props;
     const queue = service.getQueue();
 
-    return queue == null || this.isFramework(service);
+    return queue == null || service instanceof Framework;
   }
 
   render() {


### PR DESCRIPTION
After fixing #3092 @orlandohohmeier and I decided to propagate the check forward so that we don't regress in the code base in the way we're checking if a service is a Framework or not.

---

Service has already been wrapped into a Framework struct at this point. No need in re-checking its type via labels.

Closes DCOS-39661

## Testing

Deploy a Framework from the Catalog, check to see if Debug tab still works.