### PR TITLE
refactor(ServiceDebugContainer): check instance type

### DIFF
--- a/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
+++ b/plugins/services/src/js/containers/service-debug/ServiceDebugContainer.js
@@ -16,6 +16,7 @@ import DeclinedOffersTable from "../../components/DeclinedOffersTable";
 import MarathonStore from "../../stores/MarathonStore";
 import RecentOffersSummary from "../../components/RecentOffersSummary";
 import Service from "../../structs/Service";
+import Framework from "../../structs/Framework";
 import TaskStatsTable from "./TaskStatsTable";
 
 const METHODS_TO_BIND = ["handleJumpToRecentOffersClick"];
@@ -192,7 +193,7 @@ class ServiceDebugContainer extends React.Component {
   getRecentOfferSummaryIntroText() {
     const { service } = this.props;
 
-    if (this.isFramework(service)) {
+    if (service instanceof Framework) {
       const frameworkName = service.getPackageName();
 
       return this.getRecentOfferSummaryDisabledText(frameworkName);
@@ -246,7 +247,7 @@ class ServiceDebugContainer extends React.Component {
   getWaitingForResourcesNotice() {
     const { service } = this.props;
 
-    if (this.isFramework(service)) {
+    if (service instanceof Framework) {
       return null;
     }
 
@@ -285,12 +286,6 @@ class ServiceDebugContainer extends React.Component {
     }
   }
 
-  isFramework(service) {
-    const { labels = {} } = service;
-
-    return labels.DCOS_PACKAGE_FRAMEWORK_NAME != null;
-  }
-
   shouldShowDeclinedOfferSummary() {
     const { service } = this.props;
 
@@ -313,7 +308,7 @@ class ServiceDebugContainer extends React.Component {
     const { service } = this.props;
     const queue = service.getQueue();
 
-    return queue == null || this.isFramework(service);
+    return queue == null || service instanceof Framework;
   }
 
   render() {


### PR DESCRIPTION
After fixing #3092 @orlandohohmeier and I decided to propagate the check forward so that we don't regress in the code base in the way we're checking if a service is a Framework or not.

---

Service has already been wrapped into a Framework struct at this point. No need in re-checking its type via labels.

Closes DCOS-39663

## Testing

Deploy a Framework from the Catalog, check to see if Debug tab still works.