### PR TITLE
DCOS-39112: Fix comparison of numeric values in Nodes Table

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -992,9 +992,9 @@
       "integrity": "sha512-WcTnrk4lc6vwMWn+pOrcGk9tTy6it03dCfQtqE+fw9bQ2llqzfxnLO7Har+la4kkJVnyTPAt7Nvpb50sjzsQXA=="
     },
     "@dcos/ui-kit": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@dcos/ui-kit/-/ui-kit-1.2.3.tgz",
-      "integrity": "sha512-MaNepw+MLI7GF2Q4MfSHR5BO3FEAzljmoEIh1OKqi0IjY4m4DjBybJ5iH4CzyLRJnOYw4Xip+voVi52nbd/bVQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@dcos/ui-kit/-/ui-kit-1.3.0.tgz",
+      "integrity": "sha512-EcEPTTSQxVT2KHgJ8gM4y/yygKA3flRsOJcn2tziOF4ukLQaX0d5KfkGOJ+iGrmAFGZmWdDBNeJsyjl8/ABCPw==",
       "requires": {
         "emotion": "9.2.4",
         "memoize-one": "3.1.1",
@@ -7223,6 +7223,21 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "default-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
+      "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
+      "requires": {
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+        }
+      }
+    },
     "default-require-extensions": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
@@ -10909,8 +10924,7 @@
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-      "dev": true
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "getos": {
       "version": "2.8.4",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1592,6 +1592,23 @@
       "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
       "dev": true
     },
+    "array-sort": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
+      "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+      "requires": {
+        "default-compare": "1.0.0",
+        "get-value": "2.0.6",
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+        }
+      }
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@dcos/mesos-client": "0.2.3",
     "@dcos/tslint-config": "0.1.0",
     "@dcos/ui-kit": "1.3.0",
+    "array-sort": "1.0.0",
     "babel-polyfill": "6.23.0",
     "browser-info": "0.4.0",
     "classnames": "2.2.3",

--- a/plugins/nodes/src/js/columns/NodesTableCPUColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableCPUColumn.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { compareValues } from "#PLUGINS/nodes/src/js/utils/compareValues";
+import sort from "array-sort";
 import Node from "#SRC/js/structs/Node";
 // TODO: DCOS-39079
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
@@ -7,24 +7,33 @@ import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs"
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import { TextCell } from "@dcos/ui-kit";
 
+function getCpuUsage(data: Node): number {
+  return data.getUsageStats("cpus").percentage;
+}
+
 export function cpuRenderer(data: Node): React.ReactNode {
   return (
     <TextCell>
-      <span>{data.getUsageStats("cpus").percentage}%</span>
+      <span>{getCpuUsage(data)}%</span>
     </TextCell>
   );
 }
 
+function compareNodesByCpuUsage(a: Node, b: Node): number {
+  return getCpuUsage(a) - getCpuUsage(b);
+}
+
+function compareNodesByHostname(a: Node, b: Node): number {
+  return a
+    .getHostName()
+    .toLowerCase()
+    .localeCompare(b.getHostName().toLowerCase());
+}
+
+const comparators = [compareNodesByCpuUsage, compareNodesByHostname];
 export function cpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
-  const sortedData = data.sort((a, b) =>
-    compareValues(
-      a.get("used_resources").cpus.toString(),
-      b.get("used_resources").cpus.toString(),
-      a.getHostName().toLowerCase(),
-      b.getHostName().toLowerCase()
-    )
-  );
-  return sortDirection === "ASC" ? sortedData : sortedData.reverse();
+  const reverse = sortDirection !== "ASC";
+  return sort(data, comparators, { reverse });
 }
 
 export function cpuSizer(args: WidthArgs): number {

--- a/plugins/nodes/src/js/columns/NodesTableDiskColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableDiskColumn.tsx
@@ -35,7 +35,7 @@ export function diskSorter(data: Node[], sortDirection: SortDirection): Node[] {
   const reverse = sortDirection !== "ASC";
   return sort(data, comparators, { reverse });
 }
-export function diskSizer(args: WidthArgs): number {
+export function diskSizer(_args: WidthArgs): number {
   // TODO: DCOS-39147
-  return Math.min(60, Math.max(60, args.width / args.totalColumns));
+  return 70;
 }

--- a/plugins/nodes/src/js/columns/NodesTableDiskColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableDiskColumn.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { compareValues } from "#PLUGINS/nodes/src/js/utils/compareValues";
+import sort from "array-sort";
 import Node from "#SRC/js/structs/Node";
 // TODO: DCOS-39079
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
@@ -7,25 +7,33 @@ import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs"
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import { TextCell } from "@dcos/ui-kit";
 
+function getDiskUsage(data: Node) {
+  return data.getUsageStats("disk").percentage;
+}
+
 export function diskRenderer(data: Node): React.ReactNode {
   return (
     <TextCell>
-      <span>{data.getUsageStats("disk").percentage}%</span>
+      <span>{getDiskUsage(data)}%</span>
     </TextCell>
   );
 }
 
+function compareNodesByDiskUsage(a: Node, b: Node): number {
+  return getDiskUsage(a) - getDiskUsage(b);
+}
+
+function compareNodesByHostname(a: Node, b: Node): number {
+  return a
+    .getHostName()
+    .toLowerCase()
+    .localeCompare(b.getHostName().toLowerCase());
+}
+
+const comparators = [compareNodesByDiskUsage, compareNodesByHostname];
 export function diskSorter(data: Node[], sortDirection: SortDirection): Node[] {
-  // current implementation is a rough idea, not sure if it is the best one…
-  const sortedData = data.sort((a, b) =>
-    compareValues(
-      a.get("used_resources").disk.toString(),
-      b.get("used_resources").disk.toString(),
-      a.getHostName().toLowerCase(),
-      b.getHostName().toLowerCase()
-    )
-  );
-  return sortDirection === "ASC" ? sortedData : sortedData.reverse();
+  const reverse = sortDirection !== "ASC";
+  return sort(data, comparators, { reverse });
 }
 export function diskSizer(args: WidthArgs): number {
   // TODO: DCOS-39147

--- a/plugins/nodes/src/js/columns/NodesTableGPUColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableGPUColumn.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { compareValues } from "#PLUGINS/nodes/src/js/utils/compareValues";
+import sort from "array-sort";
 import Node from "#SRC/js/structs/Node";
 // TODO: DCOS-39079
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
@@ -7,24 +7,34 @@ import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs"
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import { TextCell } from "@dcos/ui-kit";
 
+function getGpuUsage(data: Node): number {
+  return data.getUsageStats("gpus").percentage;
+}
+
 export function gpuRenderer(data: Node): React.ReactNode {
   return (
     <TextCell>
-      <span>{data.getUsageStats("gpus").percentage}%</span>
+      <span>{getGpuUsage(data)}%</span>
     </TextCell>
   );
 }
 
+function compareNodesByGpuUsage(a: Node, b: Node): number {
+  return getGpuUsage(a) - getGpuUsage(b);
+}
+
+function compareNodesByHostname(a: Node, b: Node): number {
+  return a
+    .getHostName()
+    .toLowerCase()
+    .localeCompare(b.getHostName().toLowerCase());
+}
+
+const comparators = [compareNodesByGpuUsage, compareNodesByHostname];
+
 export function gpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
-  const sortedData = data.sort((a, b) =>
-    compareValues(
-      a.get("used_resources").gpus.toString(),
-      b.get("used_resources").gpus.toString(),
-      a.getHostName().toLowerCase(),
-      b.getHostName().toLowerCase()
-    )
-  );
-  return sortDirection === "ASC" ? sortedData : sortedData.reverse();
+  const reverse = sortDirection !== "ASC";
+  return sort(data, comparators, { reverse });
 }
 
 export function gpuSizer(args: WidthArgs): number {

--- a/plugins/nodes/src/js/columns/NodesTableHostnameColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableHostnameColumn.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { compareValues } from "#PLUGINS/nodes/src/js/utils/compareValues";
+import sort from "array-sort";
 import Node from "#SRC/js/structs/Node";
 // TODO: DCOS-39079
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
@@ -43,20 +43,20 @@ export function hostnameRenderer(data: Node): React.ReactNode {
   );
 }
 
+function compareNodesByHostname(a: Node, b: Node): number {
+  return a
+    .getHostName()
+    .toLowerCase()
+    .localeCompare(b.getHostName().toLowerCase());
+}
+
+const comparators = [compareNodesByHostname];
 export function hostnameSorter(
   data: Node[],
   sortDirection: SortDirection
 ): Node[] {
-  // current implementation is a rough idea, not sure if it is the best one…
-  const sortedData = data.sort((a, b) =>
-    compareValues(
-      a.getHostName().toLowerCase(),
-      b.getHostName().toLowerCase(),
-      a.getHostName().toLowerCase(),
-      b.getHostName().toLowerCase()
-    )
-  );
-  return sortDirection === "ASC" ? sortedData : sortedData.reverse();
+  const reverse = sortDirection !== "ASC";
+  return sort(data, comparators, { reverse });
 }
 
 export function hostnameSizer(args: WidthArgs): number {

--- a/plugins/nodes/src/js/columns/NodesTableMemColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableMemColumn.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { compareValues } from "#PLUGINS/nodes/src/js/utils/compareValues";
+import sort from "array-sort";
 import Node from "#SRC/js/structs/Node";
 // TODO: DCOS-39079
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
@@ -7,25 +7,33 @@ import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs"
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import { TextCell } from "@dcos/ui-kit";
 
+function getMemUsage(data: Node): number {
+  return data.getUsageStats("mem").percentage;
+}
+
 export function memRenderer(data: Node): React.ReactNode {
   return (
     <TextCell>
-      <span>{data.getUsageStats("mem").percentage}%</span>
+      <span>{getMemUsage(data)}%</span>
     </TextCell>
   );
 }
 
+function compareNodesByMemUsage(a: Node, b: Node): number {
+  return getMemUsage(a) - getMemUsage(b);
+}
+
+function compareNodesByHostname(a: Node, b: Node): number {
+  return a
+    .getHostName()
+    .toLowerCase()
+    .localeCompare(b.getHostName().toLowerCase());
+}
+
+const comparators = [compareNodesByMemUsage, compareNodesByHostname];
 export function memSorter(data: Node[], sortDirection: SortDirection): Node[] {
-  // current implementation is a rough idea, not sure if it is the best one…
-  const sortedData = data.sort((a, b) =>
-    compareValues(
-      a.get("used_resources").mem.toString(),
-      b.get("used_resources").mem.toString(),
-      a.getHostName().toLowerCase(),
-      b.getHostName().toLowerCase()
-    )
-  );
-  return sortDirection === "ASC" ? sortedData : sortedData.reverse();
+  const reverse = sortDirection !== "ASC";
+  return sort(data, comparators, { reverse });
 }
 
 export function memSizer(args: WidthArgs): number {

--- a/plugins/nodes/src/js/columns/NodesTableMemColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableMemColumn.tsx
@@ -36,7 +36,7 @@ export function memSorter(data: Node[], sortDirection: SortDirection): Node[] {
   return sort(data, comparators, { reverse });
 }
 
-export function memSizer(args: WidthArgs): number {
+export function memSizer(_args: WidthArgs): number {
   // TODO: DCOS-39147
-  return Math.min(60, Math.max(60, args.width / args.totalColumns));
+  return 70;
 }

--- a/plugins/nodes/src/js/columns/NodesTableRegionColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableRegionColumn.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { compareValues } from "#PLUGINS/nodes/src/js/utils/compareValues";
+import sort from "array-sort";
 import Node from "#SRC/js/structs/Node";
 // TODO: DCOS-39079
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
@@ -22,19 +22,27 @@ export function regionRenderer(
   );
 }
 
+function compareNodesByRegion(a: Node, b: Node): number {
+  return a
+    .getRegionName()
+    .toLowerCase()
+    .localeCompare(b.getRegionName().toLowerCase());
+}
+
+function compareNodesByHostname(a: Node, b: Node): number {
+  return a
+    .getHostName()
+    .toLowerCase()
+    .localeCompare(b.getHostName().toLowerCase());
+}
+
+const comparators = [compareNodesByRegion, compareNodesByHostname];
 export function regionSorter(
   data: Node[],
   sortDirection: SortDirection
 ): Node[] {
-  const sortedData = data.sort((a, b) =>
-    compareValues(
-      a.getRegionName().toLowerCase(),
-      b.getRegionName().toLowerCase(),
-      a.getHostName().toLowerCase(),
-      b.getHostName().toLowerCase()
-    )
-  );
-  return sortDirection === "ASC" ? sortedData : sortedData.reverse();
+  const reverse = sortDirection !== "ASC";
+  return sort(data, comparators, { reverse });
 }
 
 export function regionSizer(args: WidthArgs): number {

--- a/plugins/nodes/src/js/columns/NodesTableTasksColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableTasksColumn.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { compareValues } from "#PLUGINS/nodes/src/js/utils/compareValues";
+import sort from "array-sort";
 import Node from "#SRC/js/structs/Node";
 // TODO: DCOS-39079
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
@@ -15,20 +15,24 @@ export function tasksRenderer(data: Node): React.ReactNode {
   );
 }
 
+function compareNodesByTasks(a: Node, b: Node): number {
+  return a.get("TASK_RUNNING") - b.get("TASK_RUNNING");
+}
+
+function compareNodesByHostname(a: Node, b: Node): number {
+  return a
+    .getHostName()
+    .toLowerCase()
+    .localeCompare(b.getHostName().toLowerCase());
+}
+
+const comparators = [compareNodesByTasks, compareNodesByHostname];
 export function tasksSorter(
   data: Node[],
   sortDirection: SortDirection
 ): Node[] {
-  // current implementation is a rough idea, not sure if it is the best one…
-  const sortedData = data.sort((a, b) =>
-    compareValues(
-      a.get("TASK_RUNNING").toString(),
-      b.get("TASK_RUNNING").toString(),
-      a.getHostName().toLowerCase(),
-      b.getHostName().toLowerCase()
-    )
-  );
-  return sortDirection === "ASC" ? sortedData : sortedData.reverse();
+  const reverse = sortDirection !== "ASC";
+  return sort(data, comparators, { reverse });
 }
 
 export function tasksSizer(args: WidthArgs): number {

--- a/plugins/nodes/src/js/columns/NodesTableZoneColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableZoneColumn.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { compareValues } from "#PLUGINS/nodes/src/js/utils/compareValues";
+import sort from "array-sort";
 import Node from "#SRC/js/structs/Node";
 // TODO: DCOS-39079
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
@@ -15,16 +15,25 @@ export function zoneRenderer(data: Node): React.ReactNode {
   );
 }
 
+function compareNodesByZone(a: Node, b: Node): number {
+  return a
+    .getZoneName()
+    .toLowerCase()
+    .localeCompare(b.getZoneName().toLowerCase());
+}
+
+function compareNodesByHostname(a: Node, b: Node): number {
+  return a
+    .getHostName()
+    .toLowerCase()
+    .localeCompare(b.getHostName().toLowerCase());
+}
+
+const comparators = [compareNodesByZone, compareNodesByHostname];
+
 export function zoneSorter(data: Node[], sortDirection: SortDirection): Node[] {
-  const sortedData = data.sort((a, b) =>
-    compareValues(
-      a.getZoneName().toLowerCase(),
-      b.getZoneName().toLowerCase(),
-      a.getHostName().toLowerCase(),
-      b.getHostName().toLowerCase()
-    )
-  );
-  return sortDirection === "ASC" ? sortedData : sortedData.reverse();
+  const reverse = sortDirection !== "ASC";
+  return sort(data, comparators, { reverse });
 }
 
 export function zoneSizer(args: WidthArgs): number {

--- a/src/typings/array-sort.d.ts
+++ b/src/typings/array-sort.d.ts
@@ -1,0 +1,15 @@
+type Comparator<T> = (a: T, b: T) => number;
+type ComparisonArg<T> = string | Comparator<T>;
+type ComparisonArgs<T> = ComparisonArg<T> | Array<ComparisonArg<T>>;
+
+interface Options {
+  readonly reverse: boolean;
+}
+
+declare function arraySort<T>(
+  arr: Array<T>,
+  props: ComparisonArgs<T>,
+  options: Options
+): Array<T>;
+
+export default arraySort;


### PR DESCRIPTION
## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

Change this line in the `NodesTableContainer.js`:

```diff
-import NodesTable from "../../../components/NodesTable";
+import NodesTable from "../../../components/NodesTable-new";
```

Please take a look at the nodes table and see if all the sortings look correct (especially the ones with numbers, like mem, cpu, and disk. I also fixed that the carret should now be shown while sorting every column (except for the bars which are not sortable


## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- I decided to use an external library which provided the tiebreaker feature we want instead of writing something my own, because the contract it provided looked clear and it seems to solve the problem. Given the experience with my last try on designing an API for this problem I also wanted to cut discussions about the API and expected or unexpected behavior
- I introduced a comparators array in most columns, because I like to see the core of the sorting at one glance
- I did not refactor to DRY everything up, because I don't want to have anything disputable in this PR as it blocks quite a lot of efforts.

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

None