### PR TITLE
[1.11] Backport framework form fix.

### DIFF
--- a/src/js/components/FrameworkConfiguration.js
+++ b/src/js/components/FrameworkConfiguration.js
@@ -17,8 +17,9 @@ import UniversePackage from "#SRC/js/structs/UniversePackage";
 import Util from "#SRC/js/utils/Util";
 import StringUtil from "#SRC/js/utils/StringUtil";
 import CosmosErrorMessage from "#SRC/js/components/CosmosErrorMessage";
-import FrameworkConfigurationForm
-  from "#SRC/js/components/FrameworkConfigurationForm";
+import FrameworkConfigurationForm, {
+  isValidFormData
+} from "#SRC/js/components/FrameworkConfigurationForm";
 import FrameworkConfigurationReviewScreen
   from "#SRC/js/components/FrameworkConfigurationReviewScreen";
 
@@ -49,6 +50,16 @@ class FrameworkConfiguration extends Component {
 
     METHODS_TO_BIND.forEach(method => {
       this[method] = this[method].bind(this);
+    });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { packageDetails, formData } = nextProps;
+    this.setState({
+      jsonEditorActive: !isValidFormData(
+        formData,
+        packageDetails.getConfig()
+      ) || this.state.jsonEditorActive
     });
   }
 
@@ -350,7 +361,8 @@ class FrameworkConfiguration extends Component {
           showHeader={true}
         >
           <p>
-            Are you sure you want to leave this page? Any data you entered will be lost.
+            Are you sure you want to leave this page? Any data you entered will
+            be lost.
           </p>
         </Confirm>
       </FullScreenModal>

--- a/src/js/components/__tests__/FrameworkConfigurationForm-test.js
+++ b/src/js/components/__tests__/FrameworkConfigurationForm-test.js
@@ -1,0 +1,47 @@
+import { isValidFormData } from "../FrameworkConfigurationForm";
+
+describe("#isValidFormData", () => {
+  it("returns true if valid formdata is provided", () => {
+    expect(isValidFormData({ a: "test" }, { properties: { a: true } })).toBe(
+      true
+    );
+  });
+
+  it("returns false if invalid formdata is provided", () => {
+    expect(isValidFormData({ b: "test" }, { properties: { a: true } })).toBe(
+      false
+    );
+  });
+
+  it("returns false if partily invalid formdata is provided", () => {
+    expect(
+      isValidFormData({ a: "test", b: "test" }, { properties: { a: true } })
+    ).toBe(false);
+  });
+
+  it("returns true if nested valid formdata is provided", () => {
+    expect(
+      isValidFormData(
+        { a: "test", b: { a: "test", b: "test" } },
+        { properties: { a: true, b: { properties: { a: true, b: true } } } }
+      )
+    ).toBe(true);
+  });
+
+  it("returns false if nested invalid formdata is provided", () => {
+    expect(
+      isValidFormData(
+        { a: "test", b: { a: "test", b: "test" } },
+        { properties: { a: true, b: { properties: { a: true } } } }
+      )
+    ).toBe(false);
+  });
+  it("returns true if empty formdata is provided", () => {
+    expect(
+      isValidFormData(
+        {},
+        { properties: { a: true, b: { properties: { a: true } } } }
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
This fixes FrameworkConfigurationForm to gracefully handle a invalid
formdata and provide an Error message.

Close DCOS-38595

Backport form #3101 