### PR TITLE
refactor(nodes): make table always 100% wide

### DIFF
--- a/plugins/nodes/src/js/columns/NodesTableCPUBarColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableCPUBarColumn.tsx
@@ -20,7 +20,7 @@ export function cpubarRenderer(data: Node): React.ReactNode {
   );
 }
 
-export function cpubarSizer(args: WidthArgs): number {
+export function cpubarSizer(_args: WidthArgs): number {
   // TODO: DCOS-39147
-  return Math.min(60, Math.max(60, args.width / args.totalColumns));
+  return 60;
 }

--- a/plugins/nodes/src/js/columns/NodesTableCPUColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableCPUColumn.tsx
@@ -27,7 +27,7 @@ export function cpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
 }
 
-export function cpuSizer(args: WidthArgs): number {
+export function cpuSizer(_args: WidthArgs): number {
   // TODO: DCOS-39147
-  return Math.min(60, Math.max(60, args.width / args.totalColumns));
+  return 60;
 }

--- a/plugins/nodes/src/js/columns/NodesTableDiskBarColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableDiskBarColumn.tsx
@@ -19,7 +19,7 @@ export function diskbarRenderer(data: Node): React.ReactNode {
   );
 }
 
-export function diskbarSizer(args: WidthArgs): number {
+export function diskbarSizer(_args: WidthArgs): number {
   // TODO: DCOS-39147
-  return Math.min(60, Math.max(60, args.width / args.totalColumns));
+  return 60;
 }

--- a/plugins/nodes/src/js/columns/NodesTableDiskColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableDiskColumn.tsx
@@ -27,7 +27,7 @@ export function diskSorter(data: Node[], sortDirection: SortDirection): Node[] {
   );
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
 }
-export function diskSizer(args: WidthArgs): number {
+export function diskSizer(_args: WidthArgs): number {
   // TODO: DCOS-39147
-  return Math.min(60, Math.max(60, args.width / args.totalColumns));
+  return 60;
 }

--- a/plugins/nodes/src/js/columns/NodesTableGPUBarColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableGPUBarColumn.tsx
@@ -20,7 +20,7 @@ export function gpubarRenderer(data: Node): React.ReactNode {
   );
 }
 
-export function gpubarSizer(args: WidthArgs): number {
+export function gpubarSizer(_args: WidthArgs): number {
   // TODO: DCOS-39147
-  return Math.min(60, Math.max(60, args.width / args.totalColumns));
+  return 60;
 }

--- a/plugins/nodes/src/js/columns/NodesTableGPUColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableGPUColumn.tsx
@@ -4,8 +4,8 @@ import Node from "#SRC/js/structs/Node";
 // TODO: DCOS-39079
 // import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/packages/table/components/Column";
 import { IWidthArgs as WidthArgs } from "#PLUGINS/nodes/src/js/types/IWidthArgs";
-import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
-import { TextCell } from "@dcos/ui-kit";
+import { SortDirection } from "#PLUGINS/nodes/src/js/types/SortDirection";
+import { TextCell } from "@dcos/ui-kit/dist/packages";
 
 export function gpuRenderer(data: Node): React.ReactNode {
   return (
@@ -27,6 +27,6 @@ export function gpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
 }
 
-export function gpuSizer(args: WidthArgs): number {
-  return Math.max(60, args.width / args.totalColumns);
+export function gpuSizer(_args: WidthArgs): number {
+  return 60;
 }

--- a/plugins/nodes/src/js/columns/NodesTableHealthColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableHealthColumn.tsx
@@ -24,7 +24,7 @@ export function healthSorter(
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
 }
 
-export function healthSizer(args: WidthArgs): number {
+export function healthSizer(_args: WidthArgs): number {
   // TODO: DCOS-38827
-  return Math.max(100, args.width / args.totalColumns);
+  return 120;
 }

--- a/plugins/nodes/src/js/columns/NodesTableHostnameColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableHostnameColumn.tsx
@@ -59,6 +59,6 @@ export function hostnameSorter(
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
 }
 
-export function hostnameSizer(args: WidthArgs): number {
-  return Math.max(150, args.width / args.totalColumns);
+export function hostnameSizer(_args: WidthArgs): number {
+  return 150;
 }

--- a/plugins/nodes/src/js/columns/NodesTableMemBarColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableMemBarColumn.tsx
@@ -19,7 +19,7 @@ export function membarRenderer(data: Node): React.ReactNode {
   );
 }
 
-export function membarSizer(args: WidthArgs): number {
+export function membarSizer(_args: WidthArgs): number {
   // TODO: DCOS-39147
-  return Math.min(60, Math.max(60, args.width / args.totalColumns));
+  return 60;
 }

--- a/plugins/nodes/src/js/columns/NodesTableMemColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableMemColumn.tsx
@@ -28,7 +28,7 @@ export function memSorter(data: Node[], sortDirection: SortDirection): Node[] {
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
 }
 
-export function memSizer(args: WidthArgs): number {
+export function memSizer(_args: WidthArgs): number {
   // TODO: DCOS-39147
-  return Math.min(60, Math.max(60, args.width / args.totalColumns));
+  return 60;
 }

--- a/plugins/nodes/src/js/columns/NodesTableRegionColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableRegionColumn.tsx
@@ -37,6 +37,6 @@ export function regionSorter(
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
 }
 
-export function regionSizer(args: WidthArgs): number {
-  return Math.max(170, args.width / args.totalColumns);
+export function regionSizer(_args: WidthArgs): number {
+  return 200;
 }

--- a/plugins/nodes/src/js/columns/NodesTableTasksColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableTasksColumn.tsx
@@ -31,6 +31,6 @@ export function tasksSorter(
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
 }
 
-export function tasksSizer(args: WidthArgs): number {
-  return Math.max(100, args.width / args.totalColumns);
+export function tasksSizer(_args: WidthArgs): number {
+  return 80;
 }

--- a/plugins/nodes/src/js/columns/NodesTableZoneColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableZoneColumn.tsx
@@ -27,6 +27,6 @@ export function zoneSorter(data: Node[], sortDirection: SortDirection): Node[] {
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
 }
 
-export function zoneSizer(args: WidthArgs): number {
-  return Math.max(125, args.width / args.totalColumns);
+export function zoneSizer(_args: WidthArgs): number {
+  return 200;
 }

--- a/plugins/nodes/src/js/components/NodesTable-new.tsx
+++ b/plugins/nodes/src/js/components/NodesTable-new.tsx
@@ -1,64 +1,77 @@
 import * as React from "react";
-import { Table, Column } from "@dcos/ui-kit";
+import { Table, Column } from "@dcos/ui-kit/dist/packages";
 
 import NodesList from "#SRC/js/structs/NodesList";
 import Node from "#SRC/js/structs/Node";
 
 import { SortableColumnHeader } from "ui-kit-stage/SortableColumnHeader";
-import { SortDirection } from "../types/SortDirection";
+import { SortDirection } from "#PLUGINS/nodes/src/js/types/SortDirection";
 
 import {
   hostnameSorter,
   hostnameRenderer,
   hostnameSizer
-} from "../columns/NodesTableHostnameColumn";
+} from "#PLUGINS/nodes/src/js/columns/NodesTableHostnameColumn";
 import {
   regionSorter,
   regionRenderer,
   regionSizer
-} from "../columns/NodesTableRegionColumn";
+} from "#PLUGINS/nodes/src/js/columns/NodesTableRegionColumn";
 import {
   zoneSorter,
   zoneRenderer,
   zoneSizer
-} from "../columns/NodesTableZoneColumn";
+} from "#PLUGINS/nodes/src/js/columns/NodesTableZoneColumn";
 import {
   healthSorter,
   healthRenderer,
   healthSizer
-} from "../columns/NodesTableHealthColumn";
+} from "#PLUGINS/nodes/src/js/columns/NodesTableHealthColumn";
 import {
   tasksSorter,
   tasksRenderer,
   tasksSizer
-} from "../columns/NodesTableTasksColumn";
-import { cpubarRenderer, cpubarSizer } from "../columns/NodesTableCPUBarColumn";
+} from "#PLUGINS/nodes/src/js/columns/NodesTableTasksColumn";
+import {
+  cpubarRenderer,
+  cpubarSizer
+} from "#PLUGINS/nodes/src/js/columns/NodesTableCPUBarColumn";
 import {
   cpuSorter,
   cpuRenderer,
   cpuSizer
-} from "../columns/NodesTableCPUColumn";
-import { membarRenderer, membarSizer } from "../columns/NodesTableMemBarColumn";
+} from "#PLUGINS/nodes/src/js/columns/NodesTableCPUColumn";
+import {
+  membarRenderer,
+  membarSizer
+} from "#PLUGINS/nodes/src/js/columns/NodesTableMemBarColumn";
 import {
   memSorter,
   memRenderer,
   memSizer
-} from "../columns/NodesTableMemColumn";
+} from "#PLUGINS/nodes/src/js/columns/NodesTableMemColumn";
 import {
   diskbarRenderer,
   diskbarSizer
-} from "../columns/NodesTableDiskBarColumn";
+} from "#PLUGINS/nodes/src/js/columns/NodesTableDiskBarColumn";
 import {
   diskSorter,
   diskRenderer,
   diskSizer
-} from "../columns/NodesTableDiskColumn";
-import { gpubarSizer, gpubarRenderer } from "../columns/NodesTableGPUBarColumn";
+} from "#PLUGINS/nodes/src/js/columns/NodesTableDiskColumn";
+import {
+  gpubarSizer,
+  gpubarRenderer
+} from "#PLUGINS/nodes/src/js/columns/NodesTableGPUBarColumn";
 import {
   gpuSorter,
   gpuRenderer,
   gpuSizer
-} from "../columns/NodesTableGPUColumn";
+} from "#PLUGINS/nodes/src/js/columns/NodesTableGPUColumn";
+import {
+  spacingSizer,
+  spacingRenderer
+} from "#PLUGINS/nodes/src/js/columns/NodesTableSpacingColumn";
 
 interface NodesTableProps {
   hosts: NodesList;
@@ -312,6 +325,12 @@ export default class NodesTable extends React.Component<
           }
           cellRenderer={gpuRenderer}
           width={gpuSizer}
+        />
+
+        <Column
+          header={<span title="Spacing" />}
+          cellRenderer={spacingRenderer}
+          width={spacingSizer}
         />
       </Table>
     );


### PR DESCRIPTION
Closes https://jira.mesosphere.com/DCOS-39797

## Testing

Verify that the table is 100% wide and its contents are “left aligned”
<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

I did this together with @lilysamimi and we decided to stick to static width per column. in order to stretch the whole table, we added a new spacing column to prevent sizing issues with the last content column.
<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

None
<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->