### PR TITLE
DCOS-39797: refactor(nodes): make table always 100% wide

### DIFF
--- a/plugins/nodes/src/js/columns/NodesTableCPUBarColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableCPUBarColumn.tsx
@@ -17,7 +17,7 @@ export function cpubarRenderer(data: Node): React.ReactNode {
   );
 }
 
-export function cpubarSizer(args: WidthArgs): number {
+export function cpubarSizer(_args: WidthArgs): number {
   // TODO: DCOS-39147
-  return Math.min(60, Math.max(60, args.width / args.totalColumns));
+  return 80;
 }

--- a/plugins/nodes/src/js/columns/NodesTableCPUColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableCPUColumn.tsx
@@ -34,7 +34,7 @@ export function cpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
   return sort(data, comparators, { reverse });
 }
 
-export function cpuSizer(args: WidthArgs): number {
+export function cpuSizer(_args: WidthArgs): number {
   // TODO: DCOS-39147
-  return Math.min(60, Math.max(60, args.width / args.totalColumns));
+  return 80;
 }

--- a/plugins/nodes/src/js/columns/NodesTableDiskBarColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableDiskBarColumn.tsx
@@ -17,7 +17,7 @@ export function diskbarRenderer(data: Node): React.ReactNode {
   );
 }
 
-export function diskbarSizer(args: WidthArgs): number {
+export function diskbarSizer(_args: WidthArgs): number {
   // TODO: DCOS-39147
-  return Math.min(60, Math.max(60, args.width / args.totalColumns));
+  return 80;
 }

--- a/plugins/nodes/src/js/columns/NodesTableDiskColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableDiskColumn.tsx
@@ -35,5 +35,5 @@ export function diskSorter(data: Node[], sortDirection: SortDirection): Node[] {
 }
 export function diskSizer(_args: WidthArgs): number {
   // TODO: DCOS-39147
-  return 70;
+  return 80;
 }

--- a/plugins/nodes/src/js/columns/NodesTableGPUBarColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableGPUBarColumn.tsx
@@ -17,7 +17,7 @@ export function gpubarRenderer(data: Node): React.ReactNode {
   );
 }
 
-export function gpubarSizer(args: WidthArgs): number {
+export function gpubarSizer(_args: WidthArgs): number {
   // TODO: DCOS-39147
-  return Math.min(60, Math.max(60, args.width / args.totalColumns));
+  return 80;
 }

--- a/plugins/nodes/src/js/columns/NodesTableGPUColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableGPUColumn.tsx
@@ -35,6 +35,6 @@ export function gpuSorter(data: Node[], sortDirection: SortDirection): Node[] {
   return sort(data, comparators, { reverse });
 }
 
-export function gpuSizer(args: WidthArgs): number {
-  return Math.max(60, args.width / args.totalColumns);
+export function gpuSizer(_args: WidthArgs): number {
+  return 80;
 }

--- a/plugins/nodes/src/js/columns/NodesTableHealthColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableHealthColumn.tsx
@@ -22,7 +22,7 @@ export function healthSorter(
   return sortDirection === "ASC" ? sortedData : sortedData.reverse();
 }
 
-export function healthSizer(args: WidthArgs): number {
+export function healthSizer(_args: WidthArgs): number {
   // TODO: DCOS-38827
-  return Math.max(100, args.width / args.totalColumns);
+  return 120;
 }

--- a/plugins/nodes/src/js/columns/NodesTableHostnameColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableHostnameColumn.tsx
@@ -57,6 +57,6 @@ export function hostnameSorter(
   return sort(data, comparators, { reverse });
 }
 
-export function hostnameSizer(args: WidthArgs): number {
-  return Math.max(150, args.width / args.totalColumns);
+export function hostnameSizer(_args: WidthArgs): number {
+  return 150;
 }

--- a/plugins/nodes/src/js/columns/NodesTableMemBarColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableMemBarColumn.tsx
@@ -17,7 +17,7 @@ export function membarRenderer(data: Node): React.ReactNode {
   );
 }
 
-export function membarSizer(args: WidthArgs): number {
+export function membarSizer(_args: WidthArgs): number {
   // TODO: DCOS-39147
-  return Math.min(60, Math.max(60, args.width / args.totalColumns));
+  return 80;
 }

--- a/plugins/nodes/src/js/columns/NodesTableMemColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableMemColumn.tsx
@@ -36,5 +36,5 @@ export function memSorter(data: Node[], sortDirection: SortDirection): Node[] {
 
 export function memSizer(_args: WidthArgs): number {
   // TODO: DCOS-39147
-  return 70;
+  return 80;
 }

--- a/plugins/nodes/src/js/columns/NodesTableRegionColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableRegionColumn.tsx
@@ -43,6 +43,6 @@ export function regionSorter(
   return sort(data, comparators, { reverse });
 }
 
-export function regionSizer(args: WidthArgs): number {
-  return Math.max(170, args.width / args.totalColumns);
+export function regionSizer(_args: WidthArgs): number {
+  return 200;
 }

--- a/plugins/nodes/src/js/columns/NodesTableSpacingColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableSpacingColumn.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+import Node from "#SRC/js/structs/Node";
+
+import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
+
+export function spacingRenderer(_data: Node): React.ReactNode {
+  return null;
+}
+
+export function spacingSizer(args: WidthArgs): number {
+  // TODO: DCOS-39147
+  return Math.max(0, args.remainingWidth);
+}

--- a/plugins/nodes/src/js/columns/NodesTableTasksColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableTasksColumn.tsx
@@ -33,6 +33,6 @@ export function tasksSorter(
   return sort(data, comparators, { reverse });
 }
 
-export function tasksSizer(args: WidthArgs): number {
-  return Math.max(100, args.width / args.totalColumns);
+export function tasksSizer(_args: WidthArgs): number {
+  return 80;
 }

--- a/plugins/nodes/src/js/columns/NodesTableZoneColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableZoneColumn.tsx
@@ -34,6 +34,6 @@ export function zoneSorter(data: Node[], sortDirection: SortDirection): Node[] {
   return sort(data, comparators, { reverse });
 }
 
-export function zoneSizer(args: WidthArgs): number {
-  return Math.max(125, args.width / args.totalColumns);
+export function zoneSizer(_args: WidthArgs): number {
+  return 200;
 }

--- a/plugins/nodes/src/js/components/NodesTable.tsx
+++ b/plugins/nodes/src/js/components/NodesTable.tsx
@@ -64,6 +64,10 @@ import {
   gpuRenderer,
   gpuSizer
 } from "../columns/NodesTableGPUColumn";
+import {
+  spacingSizer,
+  spacingRenderer
+} from "../columns/NodesTableSpacingColumn";
 
 interface NodesTableProps {
   hosts: NodesList;
@@ -332,6 +336,12 @@ export default class NodesTable extends React.Component<
             }
             cellRenderer={gpuRenderer}
             width={gpuSizer}
+          />
+
+          <Column
+            header={<span title="Spacing" />}
+            cellRenderer={spacingRenderer}
+            width={spacingSizer}
           />
         </Table>
       </div>


### PR DESCRIPTION
This adds a new spacing column to strech the whole table to 100% width.

Adding a new column instead of just using the last one helps preventing sizing issues
when that last column hast left and right aligned content.

Closes https://jira.mesosphere.com/browse/DCOS-39797

## Testing

Resize window and verify that table always has 100% and content stays left.
<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

None
<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

None
<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->
