### PR TITLE
refactor(ci): change timeout behaviour

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
   }
 
   options {
-    timeout(time: 2, unit: "HOURS")
+    timeout(time: 5, unit: "HOURS")
     disableConcurrentBuilds()
   }
 
@@ -37,11 +37,13 @@ pipeline {
       }
     }
 
-    stage("Test") {
+    stage("Tests") {
       parallel {
         stage("Integration Test") {
           steps {
-            sh "npm run integration-tests"
+            timeout(time: 60, unit: 'MINUTES') {
+              sh "npm run integration-tests"
+            }
           }
 
           post {
@@ -51,6 +53,7 @@ pipeline {
             }
           }
         }
+
         stage("System Test") {
           steps {
             withCredentials([
@@ -62,7 +65,9 @@ pipeline {
               ]
             ]) {
               retry(3) {
-                sh "dcos-system-test-driver -j1 -v ./system-tests/driver-config/jenkins.sh"
+                timeout(time: 60, unit: 'MINUTES') {
+                  sh "dcos-system-test-driver -j1 -v ./system-tests/driver-config/jenkins.sh"
+                }
               }
             }
           }


### PR DESCRIPTION
Cypress kept dying and with retry mechanisms in place there is no need anymore for running tests in parallel.

## Testing

verify that jenkins isnt running stages in parallel anymore 😢

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

Ci will take longer now… but IMHO thats better than having killed runs 🤷‍♂️
<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->
