### PR TITLE
DCOS-39832 elected leader tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 npm-debug.log
 node_modules/
 src/js/config/Config.dev.ts
+src/js/config/Config.dev.js
 serve
 tmp/
 *.orig

--- a/plugins/nodes/src/js/components/LeaderGrid.js
+++ b/plugins/nodes/src/js/components/LeaderGrid.js
@@ -1,0 +1,87 @@
+import React from "react";
+import { FormattedMessage } from "react-intl";
+import moment from "moment";
+
+import ConfigurationMap from "#SRC/js/components/ConfigurationMap";
+import ConfigurationMapHeading from "#SRC/js/components/ConfigurationMapHeading";
+import ConfigurationMapLabel from "#SRC/js/components/ConfigurationMapLabel";
+import ConfigurationMapRow from "#SRC/js/components/ConfigurationMapRow";
+import ConfigurationMapSection from "#SRC/js/components/ConfigurationMapSection";
+import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
+import Loader from "#SRC/js/components/Loader";
+
+function timeFromNow(time) {
+  if (!time) {
+    return null;
+  }
+
+  return moment(time * 1000).fromNow();
+}
+
+const Loading = () => <Loader size="small" type="ballBeat" />;
+
+const ConfigurationRow = ({ keyValue, title, value }) => {
+  const loadedValue = value || <Loading />;
+
+  return (
+    <ConfigurationMapRow key={keyValue}>
+      <ConfigurationMapLabel>{title}</ConfigurationMapLabel>
+      <ConfigurationMapValue>{loadedValue}</ConfigurationMapValue>
+    </ConfigurationMapRow>
+  );
+};
+
+export default class LeaderGrid extends React.Component {
+  getMesosDetails() {
+    const {
+      hostPort,
+      version,
+      electedTime,
+      startTime,
+      region
+    } = this.props.master;
+
+    return (
+      <ConfigurationMapSection>
+        <ConfigurationRow
+          keyValue="leader"
+          title="IP and Port"
+          value={hostPort}
+        />
+
+        <ConfigurationRow keyValue="region" title="Region" value={region} />
+
+        <ConfigurationRow
+          keyValue="version"
+          title={<FormattedMessage id="COMMON.VERSION" />}
+          value={version}
+        />
+
+        <ConfigurationRow
+          keyValue="version"
+          title={<FormattedMessage id="COMMON.STARTED" />}
+          value={timeFromNow(startTime)}
+        />
+
+        <ConfigurationRow
+          keyValue="elected"
+          title={<FormattedMessage id="COMMON.ELECTED" />}
+          value={timeFromNow(electedTime)}
+        />
+      </ConfigurationMapSection>
+    );
+  }
+
+  render() {
+    return (
+      <div className="container">
+        <ConfigurationMap>
+          <ConfigurationMapHeading className="flush-top">
+            Leader
+          </ConfigurationMapHeading>
+          {this.getMesosDetails()}
+        </ConfigurationMap>
+      </div>
+    );
+  }
+}

--- a/plugins/nodes/src/js/components/__tests__/LeaderGrid-test.js
+++ b/plugins/nodes/src/js/components/__tests__/LeaderGrid-test.js
@@ -1,0 +1,38 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { IntlProvider } from "react-intl";
+import enUS from "#SRC/js/translations/en-US.json";
+
+import LeaderGrid from "../LeaderGrid";
+
+const master = {
+  hostPort: "127.1.2.3:8080",
+  version: "2.9.1",
+  electedTime: 1532340694.04573,
+  startTime: 1232340694.04573,
+  region: "us-east-1"
+};
+
+const TestableLeaderGrid = ({ master }) => {
+  return (
+    <IntlProvider locale="en" messages={enUS}>
+      <LeaderGrid master={master} />
+    </IntlProvider>
+  );
+};
+
+describe("LeaderGrid", function() {
+  beforeEach(function() {
+    Date.now = jest.fn(() => 1542340694);
+  });
+
+  afterEach(function() {
+    Date.now.mockRestore();
+  });
+
+  it("renders with running status", function() {
+    expect(
+      renderer.create(<TestableLeaderGrid master={master} />).toJSON()
+    ).toMatchSnapshot();
+  });
+});

--- a/plugins/nodes/src/js/components/__tests__/__snapshots__/LeaderGrid-test.js.snap
+++ b/plugins/nodes/src/js/components/__tests__/__snapshots__/LeaderGrid-test.js.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LeaderGrid renders with running status 1`] = `
+<div
+  className="container"
+>
+  <div
+    className="configuration-map"
+  >
+    <h1
+      className="detail-view-section-heading detail-view-section-heading-primary configuration-map-heading flush-top"
+    >
+      Leader
+    </h1>
+    <div
+      className="configuration-map-section"
+    >
+      <div
+        className="configuration-map-row table-row"
+      >
+        <div
+          className="configuration-map-label"
+        >
+          IP and Port
+        </div>
+        <div
+          className="configuration-map-value"
+        >
+          127.1.2.3:8080
+        </div>
+      </div>
+      <div
+        className="configuration-map-row table-row"
+      >
+        <div
+          className="configuration-map-label"
+        >
+          Region
+        </div>
+        <div
+          className="configuration-map-value"
+        >
+          us-east-1
+        </div>
+      </div>
+      <div
+        className="configuration-map-row table-row"
+      >
+        <div
+          className="configuration-map-label"
+        >
+          <span>
+            Version
+          </span>
+        </div>
+        <div
+          className="configuration-map-value"
+        >
+          2.9.1
+        </div>
+      </div>
+      <div
+        className="configuration-map-row table-row"
+      >
+        <div
+          className="configuration-map-label"
+        >
+          <span>
+            Started
+          </span>
+        </div>
+        <div
+          className="configuration-map-value"
+        >
+          in 39 years
+        </div>
+      </div>
+      <div
+        className="configuration-map-row table-row"
+      >
+        <div
+          className="configuration-map-label"
+        >
+          <span>
+            Elected
+          </span>
+        </div>
+        <div
+          className="configuration-map-value"
+        >
+          in 49 years
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/plugins/nodes/src/js/data/MesosMasters.js
+++ b/plugins/nodes/src/js/data/MesosMasters.js
@@ -50,7 +50,7 @@ export default class MesosMasters extends React.Component {
 
     this.stream = Observable.interval(STORE_POLL_INTERVAL)
       .map(_ => {
-        return MesosStateStore.getLastMesosState();
+        return MesosStateStore.getMaster();
       })
       .map(mesosState => mesosState.master_info)
       .filter(master => !isEmptyObject(master))

--- a/plugins/nodes/src/js/data/MesosMasters.js
+++ b/plugins/nodes/src/js/data/MesosMasters.js
@@ -1,0 +1,83 @@
+import React from "react";
+import { Observable } from "rxjs/Observable";
+import "rxjs/add/observable/timer";
+import "rxjs/add/operator/do";
+import "rxjs/add/operator/map";
+import "rxjs/add/operator/retry";
+import "rxjs/add/operator/filter";
+
+import MesosStateStore from "#SRC/js/stores/MesosStateStore";
+
+import LeaderGrid from "../components/LeaderGrid";
+
+function isEmptyObject(obj) {
+  return Object.keys(obj).length === 0;
+}
+
+function hostPort(address) {
+  return `${address.hostname}:${address.port}`;
+}
+
+// ask how to fix better
+function supportsRegion(master) {
+  return (
+    master.domain &&
+    master.domain.fault_domain &&
+    master.domain.fault_domain.region &&
+    master.domain.fault_domain.region.name
+  );
+}
+
+function getRegion(master) {
+  return supportsRegion(master)
+    ? master.domain.fault_domain.region.name
+    : "N/A";
+}
+
+const STORE_POLL_INTERVAL = 2000;
+
+export default class MesosMasters extends React.Component {
+  constructor() {
+    super(...arguments);
+
+    this.state = {
+      hostPort: undefined,
+      version: undefined,
+      electedTime: undefined,
+      startTime: undefined,
+      region: undefined
+    };
+
+    this.stream = Observable.interval(STORE_POLL_INTERVAL)
+      .map(_ => {
+        return MesosStateStore.getLastMesosState();
+      })
+      .map(mesosState => mesosState.master_info)
+      .filter(master => !isEmptyObject(master))
+      .map(master => {
+        return {
+          hostPort: hostPort(master.address),
+          version: master.version,
+          electedTime: master.elected_time,
+          startTime: master.start_time,
+          region: getRegion(master)
+        };
+      });
+  }
+
+  componentDidMount() {
+    this.subscription = this.stream.subscribe(master => {
+      this.setState(master);
+    });
+  }
+
+  componentWillUnmount() {
+    this.subscription.unsubscribe();
+  }
+
+  render() {
+    const master = this.state;
+
+    return <LeaderGrid master={master} />;
+  }
+}

--- a/plugins/nodes/src/js/data/__tests__/MesosMasters-test.js
+++ b/plugins/nodes/src/js/data/__tests__/MesosMasters-test.js
@@ -1,0 +1,69 @@
+import { marbles } from "rxjs-marbles/jest";
+
+import { mesosMasterInfo, getRegion } from "../MesosMasters";
+
+function faultDomainData() {
+  return {
+    region: { name: "us-east-1" }
+  };
+}
+
+function masterData(faultDomain) {
+  return {
+    master_info: {
+      address: {
+        hostname: "127.0.0.1",
+        port: "8080"
+      },
+      start_time: 12345789.0,
+      elected_time: 12345789.0,
+      version: "1.2.2",
+      domain: {
+        fault_domain: faultDomain
+      }
+    }
+  };
+}
+
+describe("MesosMasters", function() {
+  describe("#mesosMasterInfo", function() {
+    it(
+      "emits correct master",
+      marbles(function(m) {
+        m.bind();
+
+        const expectedData = {
+          electedTime: 12345789,
+          hostPort: "127.0.0.1:8080",
+          region: "us-east-1",
+          startTime: 12345789,
+          version: "1.2.2"
+        };
+
+        const master$ = mesosMasterInfo(
+          () => masterData(faultDomainData()),
+          m.time("--|")
+        );
+        const expected$ = m.cold("a-(a|)", {
+          a: expectedData
+        });
+
+        m.expect(master$.take(2)).toBeObservable(expected$);
+      })
+    );
+  });
+
+  describe("#getRegion", function() {
+    it("retrieves region correctly", function() {
+      const master = masterData();
+
+      expect(getRegion(master)).toBe("N/A");
+    });
+
+    it("returns N/A for missing region", function() {
+      const master = masterData(faultDomainData());
+
+      expect(getRegion(master)).toBe("N/A");
+    });
+  });
+});

--- a/plugins/nodes/src/js/pages/NodesMasters.js
+++ b/plugins/nodes/src/js/pages/NodesMasters.js
@@ -1,7 +1,29 @@
 import React from "react";
+import Page from "#SRC/js/components/Page";
+import NodeBreadcrumbs from "../components/NodeBreadcrumbs";
+import MesosMasters from "../data/MesosMasters";
+
+const NodesMastersPage = ({ children }) => {
+  return (
+    <Page>
+      <Page.Header
+        breadcrumbs={<NodeBreadcrumbs />}
+        tabs={[
+          { label: "Agents", routePath: "/nodes/agents" },
+          { label: "Masters", routePath: "/nodes/masters" }
+        ]}
+      />
+      {children}
+    </Page>
+  );
+};
 
 export default class NodesMasters extends React.Component {
   render() {
-    return null;
+    return (
+      <NodesMastersPage>
+        <MesosMasters />
+      </NodesMastersPage>
+    );
   }
 }

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -23,7 +23,12 @@ import * as mesosStreamParsers from "./MesosStream/parsers";
 const MAX_RETRIES = 5;
 const RETRY_DELAY = 500;
 const MAX_RETRY_DELAY = 5000;
-const METHODS_TO_BIND = ["setState", "onStreamData", "onStreamError"];
+const METHODS_TO_BIND = [
+  "setState",
+  "setMaster",
+  "onStreamData",
+  "onStreamError"
+];
 
 class MesosStateStore extends GetSetBaseStore {
   constructor() {
@@ -74,7 +79,14 @@ class MesosStateStore extends GetSetBaseStore {
     const getMasterRequest = request(
       { type: "GET_MASTER" },
       "/mesos/api/v1?get_master"
-    ).retryWhen(linearBackoff(RETRY_DELAY, MAX_RETRIES));
+    )
+      .retryWhen(linearBackoff(RETRY_DELAY, MAX_RETRIES))
+      .map(message =>
+        mesosStreamParsers.getMaster(this.getMaster(), JSON.parse(message))
+      )
+      .do(master => {
+        this.setMaster(master);
+      });
 
     const parsers = pipe(...Object.values(mesosStreamParsers));
     const dataStream = mesosStream
@@ -124,6 +136,15 @@ class MesosStateStore extends GetSetBaseStore {
         tasks: []
       },
       this.get("lastMesosState")
+    );
+  }
+
+  getMaster() {
+    return Object.assign(
+      {
+        master_info: {}
+      },
+      this.get("master")
     );
   }
 
@@ -249,6 +270,12 @@ class MesosStateStore extends GetSetBaseStore {
   setState(state) {
     this.set({
       lastMesosState: state
+    });
+  }
+
+  setMaster(master) {
+    this.set({
+      master
     });
   }
 

--- a/src/js/stores/MesosStream/parsers/__tests__/master-test.js
+++ b/src/js/stores/MesosStream/parsers/__tests__/master-test.js
@@ -1,0 +1,98 @@
+import getMaster from "../master";
+
+function masterMessage() {
+  return {
+    type: "GET_MASTER",
+    get_master: {
+      master_info: {
+        id: "f4b0e45f-9112-4254-bcad-225353006080",
+        ip: 537337772,
+        port: 5050,
+        pid: "master@172.31.7.32:5050",
+        hostname: "172.31.7.32",
+        version: "1.5.1",
+        address: { hostname: "172.31.7.32", ip: "172.31.7.32", port: 5050 },
+        domain: {
+          fault_domain: {
+            region: { name: "us-east-1" },
+            zone: { name: "us-east-1a" }
+          }
+        },
+        capabilities: [{ type: "AGENT_UPDATE" }]
+      },
+      start_time: 1532339115.87122,
+      elected_time: 1532340694.04573
+    }
+  };
+}
+
+describe("#getMaster", function() {
+  it("flattens elected_time", function() {
+    const newState = getMaster({}, masterMessage());
+
+    expect(newState.master_info.elected_time).toBe(1532340694.04573);
+  });
+
+  it("flattens start_time", function() {
+    const newState = getMaster({}, masterMessage());
+
+    expect(newState.master_info.start_time).toBe(1532339115.87122);
+  });
+
+  it("flattens copies the full master info", function() {
+    const newState = getMaster({}, masterMessage());
+
+    expect(newState.master_info).toEqual({
+      id: "f4b0e45f-9112-4254-bcad-225353006080",
+      ip: 537337772,
+      port: 5050,
+      pid: "master@172.31.7.32:5050",
+      hostname: "172.31.7.32",
+      version: "1.5.1",
+      address: { hostname: "172.31.7.32", ip: "172.31.7.32", port: 5050 },
+      domain: {
+        fault_domain: {
+          region: { name: "us-east-1" },
+          zone: { name: "us-east-1a" }
+        }
+      },
+      capabilities: [{ type: "AGENT_UPDATE" }],
+      start_time: 1532339115.87122,
+      elected_time: 1532340694.04573
+    });
+  });
+
+  it("ignores non master message", function() {
+    const message = masterMessage();
+    message.type = "GET_NODES";
+    const newState = getMaster({}, message);
+
+    expect(newState).toEqual({});
+  });
+
+  it("preserves state", function() {
+    const message = masterMessage();
+    const newState = getMaster({ something: "something" }, message);
+
+    expect(newState.something).toEqual("something");
+  });
+
+  it("copies state", function() {
+    const message = masterMessage();
+    const state = { something: "something" };
+    const newState = getMaster(state, message);
+
+    state.something = "something_else";
+
+    expect(newState.something).toEqual("something");
+  });
+
+  it("copies message", function() {
+    const message = masterMessage();
+    const newState = getMaster({}, message);
+
+    message.start_time = 0;
+
+    expect(newState.master_info.start_time).toEqual(1532339115.87122);
+  });
+});

--- a/src/js/stores/MesosStream/parsers/master.js
+++ b/src/js/stores/MesosStream/parsers/master.js
@@ -5,7 +5,11 @@ export default function getMaster(state, message) {
     return state;
   }
 
-  const { master_info } = message.get_master;
+  const { master_info, elected_time, start_time } = message.get_master;
+  const enhancedMasterInfo = Object.assign({}, master_info, {
+    elected_time,
+    start_time
+  });
 
-  return Object.assign({}, state, { master_info });
+  return Object.assign({}, state, { master_info: enhancedMasterInfo });
 }


### PR DESCRIPTION
## Testing

Launch a multi-master cluster. Look at the data it shows, go on the control panel for your cluster (AWS) and kill the machine that is, running.

Go to: http://localhost:4200/#/nodes/masters

## Trade-offs

**GET_MASTER quickfix** 
The state store only updates the MesosState once it
parsed the entire state, which means that we wait seconds
on a large cluster, before we are able to show a piece
of information, we get almost instantly (GET_MASTER).

**GET_MASTER parser elected and started**
I added code to the parser to add elected and started time to the master_info object. Not quite sure I like adding those there but do not have any better idea. I considered another structure like master_events with both. I also do not like to add them flatten to the mesos state we keep

**Toggle elected and started time**
We dont have this behaviour as a reusable component, so I will create a ticket (ticket here) to extract this component to the UI-kit, we can then use it later.

## Dependencies

Depends on #3118 for tabs