### PR TITLE
DCOS-39153: add tabs to NodesPage

### DIFF
--- a/plugins/nodes/src/js/pages/NodesAgents.js
+++ b/plugins/nodes/src/js/pages/NodesAgents.js
@@ -10,7 +10,6 @@ import Config from "#SRC/js/config/Config";
 import DSLExpression from "#SRC/js/structs/DSLExpression";
 import DSLFilterList from "#SRC/js/structs/DSLFilterList";
 import EventTypes from "#SRC/js/constants/EventTypes";
-import FilterInputText from "#SRC/js/components/FilterInputText";
 import Icon from "#SRC/js/components/Icon";
 import InternalStorageMixin from "#SRC/js/mixins/InternalStorageMixin";
 import MesosSummaryStore from "#SRC/js/stores/MesosSummaryStore";
@@ -57,8 +56,8 @@ var DEFAULT_FILTER_OPTIONS = {
   filterExpression: new DSLExpression("")
 };
 
-var NodesOverview = React.createClass({
-  displayName: "NodesOverview",
+var NodesAgents = React.createClass({
+  displayName: "NodesAgents",
 
   mixins: [InternalStorageMixin, QueryParamsMixin, StoreMixin],
 
@@ -204,24 +203,10 @@ var NodesOverview = React.createClass({
     );
   },
 
-  getFilterInputText() {
-    var isVisible = this.props.location.pathname.endsWith("/nodes/");
-
-    if (!isVisible) {
-      return null;
-    }
-
-    return (
-      <FilterInputText
-        className="flush-bottom"
-        searchString={this.state.searchString}
-        handleFilterChange={this.handleSearchStringChange}
-      />
-    );
-  },
-
   getViewTypeRadioButtons(resetFilter) {
-    const isGridActive = /\/nodes\/grid\/?/i.test(this.props.location.pathname);
+    const isGridActive = /\/nodes\/agents\/grid\/?/i.test(
+      this.props.location.pathname
+    );
 
     var listClassSet = classNames("button button-outline", {
       active: !isGridActive
@@ -233,10 +218,14 @@ var NodesOverview = React.createClass({
 
     return (
       <div className="button-group flush-bottom">
-        <Link className={listClassSet} onClick={resetFilter} to="/nodes">
+        <Link className={listClassSet} onClick={resetFilter} to="/nodes/agents">
           List
         </Link>
-        <Link className={gridClassSet} onClick={resetFilter} to="/nodes/grid">
+        <Link
+          className={gridClassSet}
+          onClick={resetFilter}
+          to="/nodes/agents/grid"
+        >
           Grid
         </Link>
       </div>
@@ -256,11 +245,16 @@ var NodesOverview = React.createClass({
 
     return (
       <Page>
-        <Page.Header breadcrumbs={<NodeBreadcrumbs />} />
+        <Page.Header
+          breadcrumbs={<NodeBreadcrumbs />}
+          tabs={[
+            { label: "Agents", routePath: "/nodes/agents" },
+            { label: "Masters", routePath: "/nodes/masters" }
+          ]}
+        />
         <HostsPageContent
           byServiceFilter={byServiceFilter}
           filterButtonContent={this.getButtonContent}
-          filterInputText={this.getFilterInputText()}
           filterItemList={nodesHealth}
           filteredNodeCount={Math.min(
             nodesList.getItems().length,
@@ -320,4 +314,4 @@ var NodesOverview = React.createClass({
   }
 });
 
-module.exports = NodesOverview;
+module.exports = NodesAgents;

--- a/plugins/nodes/src/js/pages/NodesMasters.js
+++ b/plugins/nodes/src/js/pages/NodesMasters.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default class NodesMasters extends React.Component {
+  render() {
+    return null;
+  }
+}

--- a/plugins/nodes/src/js/routes/nodes.js
+++ b/plugins/nodes/src/js/routes/nodes.js
@@ -8,7 +8,8 @@ import NodeDetailPage from "../pages/nodes/NodeDetailPage";
 import NodeDetailTab from "../pages/nodes/NodeDetailTab";
 import NodeDetailTaskTab from "../pages/nodes/NodeDetailTaskTab";
 import NodesGridContainer from "../pages/nodes/nodes-grid/NodesGridContainer";
-import NodesOverview from "../pages/NodesOverview";
+import NodesAgents from "../pages/NodesAgents";
+import NodesMasters from "../pages/NodesMasters";
 import NodesPage from "../pages/NodesPage";
 import NodesTableContainer from "../pages/nodes/nodes-table/NodesTableContainer";
 import NodesTaskDetailPage from "../pages/nodes/NodesTaskDetailPage";
@@ -21,139 +22,163 @@ import TaskVolumeContainer from "../../../../services/src/js/containers/volume-d
 import NodesUnitsHealthDetailPage from "../pages/nodes/NodesUnitsHealthDetailPage";
 import VolumeTable from "../../../../services/src/js/components/VolumeTable";
 
-const nodesRoutes = {
-  type: Route,
-  path: "nodes",
-  component: NodesPage,
-  category: "resources",
-  isInSidebar: true,
-  children: [
-    {
-      type: Route,
-      component: NodesOverview,
-      children: [
-        {
-          type: IndexRoute,
-          component: NodesTableContainer
-        },
-        {
-          type: Route,
-          path: "grid",
-          component: NodesGridContainer
-        }
-      ]
-    },
-    {
-      type: Redirect,
-      from: "/nodes/:nodeID",
-      to: "/nodes/:nodeID/tasks"
-    },
-    {
-      type: Route,
-      path: ":nodeID",
-      component: NodeDetailPage,
-      children: [
-        {
-          type: Route,
-          title: "Tasks",
-          path: "tasks",
-          component: NodeDetailTaskTab
-        },
-        {
-          type: Redirect,
-          path: "/nodes/:nodeID/tasks/:taskID",
-          to: "/nodes/:nodeID/tasks/:taskID/details"
-        },
-        {
-          type: Route,
-          path: "health",
-          title: "Health",
-          component: NodeDetailHealthTab
-        },
-        {
-          type: Route,
-          path: "details",
-          title: "Details",
-          component: NodeDetailTab
-        }
-      ]
-    },
-    {
-      type: Route,
-      path: ":nodeID/tasks/:taskID",
-      component: NodesTaskDetailPage,
-      hideHeaderNavigation: true,
-      children: [
-        {
-          type: Route,
-          component: TaskDetailsTab,
-          hideHeaderNavigation: true,
-          title: "Details",
-          path: "details",
-          isTab: true
-        },
-        {
-          hideHeaderNavigation: true,
-          component: TaskFilesTab,
-          isTab: true,
-          path: "files",
-          title: "Files",
-          type: Route,
-          children: [
-            {
-              component: TaskFileBrowser,
-              fileViewerRoutePath:
-                "/nodes/:nodeID/tasks/:taskID/files/view(/:filePath(/:innerPath))",
-              hideHeaderNavigation: true,
-              type: IndexRoute
-            },
-            {
-              component: TaskFileViewer,
-              hideHeaderNavigation: true,
-              path: "view(/:filePath(/:innerPath))",
-              type: Route
-            }
-          ]
-        },
-        {
-          component: TaskLogsContainer,
-          hideHeaderNavigation: true,
-          isTab: true,
-          path: "logs",
-          title: "Logs",
-          type: Route,
-          children: [
-            {
-              path: ":filePath",
-              type: Route
-            }
-          ]
-        },
-        {
-          component: VolumeTable,
-          hideHeaderNavigation: true,
-          isTab: true,
-          path: "volumes",
-          title: "Volumes",
-          type: Route
-        }
-      ]
-    },
-    // This route needs to be rendered outside of the tabs that are rendered
-    // in the nodes-task-details route.
-    {
-      type: Route,
-      path: ":nodeID/tasks/:taskID/volumes/:volumeID",
-      component: TaskVolumeContainer
-    },
-    // This needs to be outside of the children array of node routes
-    // so that it can be responsible for rendering its own header.
-    {
-      type: Route,
-      path: ":nodeID/health/:unitNodeID/:unitID",
-      component: NodesUnitsHealthDetailPage
-    }
-  ]
-};
+const nodesRoutes = [
+  {
+    type: Redirect,
+    from: "/nodes",
+    to: "/nodes/agents/table"
+  },
+  {
+    type: Redirect,
+    from: "/nodes/grid",
+    to: "/nodes/agents/grid"
+  },
+  {
+    type: Route,
+    path: "nodes",
+    component: NodesPage,
+    category: "resources",
+    isInSidebar: true,
+    children: [
+      {
+        type: Redirect,
+        from: "/nodes/agents",
+        to: "/nodes/agents/table"
+      },
+      {
+        type: Route,
+        path: "agents",
+        component: NodesAgents,
+        children: [
+          {
+            type: Route,
+            component: NodesTableContainer,
+            path: "table"
+          },
+          {
+            type: Route,
+            component: NodesGridContainer,
+            path: "grid"
+          }
+        ]
+      },
+      {
+        type: Route,
+        path: "masters",
+        component: NodesMasters
+      },
+      {
+        type: Redirect,
+        from: "/nodes/:nodeID",
+        to: "/nodes/:nodeID/tasks"
+      },
+      {
+        type: Route,
+        path: ":nodeID",
+        component: NodeDetailPage,
+        children: [
+          {
+            type: Route,
+            title: "Tasks",
+            path: "tasks",
+            component: NodeDetailTaskTab
+          },
+          {
+            type: Redirect,
+            path: "/nodes/:nodeID/tasks/:taskID",
+            to: "/nodes/:nodeID/tasks/:taskID/details"
+          },
+          {
+            type: Route,
+            path: "health",
+            title: "Health",
+            component: NodeDetailHealthTab
+          },
+          {
+            type: Route,
+            path: "details",
+            title: "Details",
+            component: NodeDetailTab
+          }
+        ]
+      },
+      {
+        type: Route,
+        path: ":nodeID/tasks/:taskID",
+        component: NodesTaskDetailPage,
+        hideHeaderNavigation: true,
+        children: [
+          {
+            type: Route,
+            component: TaskDetailsTab,
+            hideHeaderNavigation: true,
+            title: "Details",
+            path: "details",
+            isTab: true
+          },
+          {
+            hideHeaderNavigation: true,
+            component: TaskFilesTab,
+            isTab: true,
+            path: "files",
+            title: "Files",
+            type: Route,
+            children: [
+              {
+                component: TaskFileBrowser,
+                fileViewerRoutePath:
+                  "/nodes/:nodeID/tasks/:taskID/files/view(/:filePath(/:innerPath))",
+                hideHeaderNavigation: true,
+                type: IndexRoute
+              },
+              {
+                component: TaskFileViewer,
+                hideHeaderNavigation: true,
+                path: "view(/:filePath(/:innerPath))",
+                type: Route
+              }
+            ]
+          },
+          {
+            component: TaskLogsContainer,
+            hideHeaderNavigation: true,
+            isTab: true,
+            path: "logs",
+            title: "Logs",
+            type: Route,
+            children: [
+              {
+                path: ":filePath",
+                type: Route
+              }
+            ]
+          },
+          {
+            component: VolumeTable,
+            hideHeaderNavigation: true,
+            isTab: true,
+            path: "volumes",
+            title: "Volumes",
+            type: Route
+          }
+        ]
+      },
+      // This route needs to be rendered outside of the tabs that are rendered
+      // in the nodes-task-details route.
+      {
+        type: Route,
+        path: ":nodeID/tasks/:taskID/volumes/:volumeID",
+        component: TaskVolumeContainer
+      },
+      // This needs to be outside of the children array of node routes
+      // so that it can be responsible for rendering its own header.
+      {
+        type: Route,
+        path: ":nodeID/health/:unitNodeID/:unitID",
+        component: NodesUnitsHealthDetailPage
+      }
+    ]
+  }
+];
 
 module.exports = nodesRoutes;


### PR DESCRIPTION
Closes DCOS-39153

## Testing

navigate to http://localhost:4200/#/nodes/agents to see tabs. Agents page should work as before. masters tab is filled by #3117 
<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->
