### PR TITLE
DCOS-39712: Nodes Masters Tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 npm-debug.log
 node_modules/
 src/js/config/Config.dev.ts
+src/js/config/Config.dev.js
 serve
 tmp/
 *.orig

--- a/plugins/nodes/src/js/components/LeaderGrid.js
+++ b/plugins/nodes/src/js/components/LeaderGrid.js
@@ -58,7 +58,7 @@ export default function LeaderGrid({ master }) {
           />
 
           <ConfigurationRow
-            keyValue="version"
+            keyValue="started"
             title={<FormattedMessage id="COMMON.STARTED" />}
             value={timeFromNow(master.startTime)}
           />

--- a/plugins/nodes/src/js/components/LeaderGrid.js
+++ b/plugins/nodes/src/js/components/LeaderGrid.js
@@ -31,57 +31,45 @@ const ConfigurationRow = ({ keyValue, title, value }) => {
   );
 };
 
-export default class LeaderGrid extends React.Component {
-  getMesosDetails() {
-    const {
-      hostPort,
-      version,
-      electedTime,
-      startTime,
-      region
-    } = this.props.master;
+export default function LeaderGrid({ master }) {
+  return (
+    <div className="container">
+      <ConfigurationMap>
+        <ConfigurationMapHeading className="flush-top">
+          Leader
+        </ConfigurationMapHeading>
+        <ConfigurationMapSection>
+          <ConfigurationRow
+            keyValue="leader"
+            title="IP and Port"
+            value={master.hostPort}
+          />
 
-    return (
-      <ConfigurationMapSection>
-        <ConfigurationRow
-          keyValue="leader"
-          title="IP and Port"
-          value={hostPort}
-        />
+          <ConfigurationRow
+            keyValue="region"
+            title="Region"
+            value={master.region}
+          />
 
-        <ConfigurationRow keyValue="region" title="Region" value={region} />
+          <ConfigurationRow
+            keyValue="version"
+            title={<FormattedMessage id="COMMON.VERSION" />}
+            value={master.version}
+          />
 
-        <ConfigurationRow
-          keyValue="version"
-          title={<FormattedMessage id="COMMON.VERSION" />}
-          value={version}
-        />
+          <ConfigurationRow
+            keyValue="version"
+            title={<FormattedMessage id="COMMON.STARTED" />}
+            value={timeFromNow(master.startTime)}
+          />
 
-        <ConfigurationRow
-          keyValue="version"
-          title={<FormattedMessage id="COMMON.STARTED" />}
-          value={timeFromNow(startTime)}
-        />
-
-        <ConfigurationRow
-          keyValue="elected"
-          title={<FormattedMessage id="COMMON.ELECTED" />}
-          value={timeFromNow(electedTime)}
-        />
-      </ConfigurationMapSection>
-    );
-  }
-
-  render() {
-    return (
-      <div className="container">
-        <ConfigurationMap>
-          <ConfigurationMapHeading className="flush-top">
-            Leader
-          </ConfigurationMapHeading>
-          {this.getMesosDetails()}
-        </ConfigurationMap>
-      </div>
-    );
-  }
+          <ConfigurationRow
+            keyValue="elected"
+            title={<FormattedMessage id="COMMON.ELECTED" />}
+            value={timeFromNow(master.electedTime)}
+          />
+        </ConfigurationMapSection>
+      </ConfigurationMap>
+    </div>
+  );
 }

--- a/plugins/nodes/src/js/components/LeaderGrid.js
+++ b/plugins/nodes/src/js/components/LeaderGrid.js
@@ -31,7 +31,7 @@ const ConfigurationRow = ({ keyValue, title, value }) => {
   );
 };
 
-export default function LeaderGrid({ master }) {
+export default function LeaderGrid({ leader }) {
   return (
     <div className="container">
       <ConfigurationMap>
@@ -42,31 +42,31 @@ export default function LeaderGrid({ master }) {
           <ConfigurationRow
             keyValue="leader"
             title="IP and Port"
-            value={master.hostPort}
+            value={leader.hostPort}
           />
 
           <ConfigurationRow
             keyValue="region"
             title="Region"
-            value={master.region}
+            value={leader.region}
           />
 
           <ConfigurationRow
             keyValue="version"
             title={<FormattedMessage id="COMMON.VERSION" />}
-            value={master.version}
+            value={leader.version}
           />
 
           <ConfigurationRow
             keyValue="started"
             title={<FormattedMessage id="COMMON.STARTED" />}
-            value={timeFromNow(master.startTime)}
+            value={timeFromNow(leader.startTime)}
           />
 
           <ConfigurationRow
             keyValue="elected"
             title={<FormattedMessage id="COMMON.ELECTED" />}
-            value={timeFromNow(master.electedTime)}
+            value={timeFromNow(leader.electedTime)}
           />
         </ConfigurationMapSection>
       </ConfigurationMap>

--- a/plugins/nodes/src/js/components/LeaderGrid.js
+++ b/plugins/nodes/src/js/components/LeaderGrid.js
@@ -1,0 +1,87 @@
+import React from "react";
+import { FormattedMessage } from "react-intl";
+import moment from "moment";
+
+import ConfigurationMap from "#SRC/js/components/ConfigurationMap";
+import ConfigurationMapHeading from "#SRC/js/components/ConfigurationMapHeading";
+import ConfigurationMapLabel from "#SRC/js/components/ConfigurationMapLabel";
+import ConfigurationMapRow from "#SRC/js/components/ConfigurationMapRow";
+import ConfigurationMapSection from "#SRC/js/components/ConfigurationMapSection";
+import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
+import Loader from "#SRC/js/components/Loader";
+
+function timeFromNow(time) {
+  if (!time) {
+    return null;
+  }
+
+  return moment(time * 1000).fromNow();
+}
+
+const Loading = () => <Loader size="small" type="ballBeat" />;
+
+const ConfigurationRow = ({ keyValue, title, value }) => {
+  const loadedValue = value || <Loading />;
+
+  return (
+    <ConfigurationMapRow key={keyValue}>
+      <ConfigurationMapLabel>{title}</ConfigurationMapLabel>
+      <ConfigurationMapValue>{loadedValue}</ConfigurationMapValue>
+    </ConfigurationMapRow>
+  );
+};
+
+export default class LeaderGrid extends React.Component {
+  getMesosDetails() {
+    const {
+      hostPort,
+      version,
+      electedTime,
+      startTime,
+      region
+    } = this.props.master;
+
+    return (
+      <ConfigurationMapSection>
+        <ConfigurationRow
+          keyValue="leader"
+          title="IP and Port"
+          value={hostPort}
+        />
+
+        <ConfigurationRow keyValue="region" title="Region" value={region} />
+
+        <ConfigurationRow
+          keyValue="version"
+          title={<FormattedMessage id="COMMON.VERSION" />}
+          value={version}
+        />
+
+        <ConfigurationRow
+          keyValue="version"
+          title={<FormattedMessage id="COMMON.STARTED" />}
+          value={timeFromNow(startTime)}
+        />
+
+        <ConfigurationRow
+          keyValue="elected"
+          title={<FormattedMessage id="COMMON.ELECTED" />}
+          value={timeFromNow(electedTime)}
+        />
+      </ConfigurationMapSection>
+    );
+  }
+
+  render() {
+    return (
+      <div className="container">
+        <ConfigurationMap>
+          <ConfigurationMapHeading className="flush-top">
+            Leader
+          </ConfigurationMapHeading>
+          {this.getMesosDetails()}
+        </ConfigurationMap>
+      </div>
+    );
+  }
+}

--- a/plugins/nodes/src/js/components/NonLeadersGrid.js
+++ b/plugins/nodes/src/js/components/NonLeadersGrid.js
@@ -45,7 +45,9 @@ const NonLeaderList = ({ masters }) => {
 
   return (
     <ConfigurationMapSection>
-      {masters.map(master => <NonLeader key={master.host_ip} master={master} />)}
+      {masters.map(master => (
+        <NonLeader key={master.host_ip} master={master} />
+      ))}
     </ConfigurationMapSection>
   );
 };

--- a/plugins/nodes/src/js/components/NonLeadersGrid.js
+++ b/plugins/nodes/src/js/components/NonLeadersGrid.js
@@ -35,7 +35,7 @@ const NonLeader = ({ master }) => {
 };
 
 const EmptyLeaderList = () => {
-  return <div>There are no more known masters in this cluster</div>;
+  return <div>There are no more known masters in this cluster.</div>;
 };
 
 const NonLeaderList = ({ masters }) => {

--- a/plugins/nodes/src/js/components/NonLeadersGrid.js
+++ b/plugins/nodes/src/js/components/NonLeadersGrid.js
@@ -1,0 +1,71 @@
+import React from "react";
+
+import ConfigurationMap from "#SRC/js/components/ConfigurationMap";
+import ConfigurationMapHeading from "#SRC/js/components/ConfigurationMapHeading";
+import ConfigurationMapLabel from "#SRC/js/components/ConfigurationMapLabel";
+import ConfigurationMapRow from "#SRC/js/components/ConfigurationMapRow";
+import ConfigurationMapSection from "#SRC/js/components/ConfigurationMapSection";
+import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
+import Loader from "#SRC/js/components/Loader";
+import StringUtil from "../../../../../src/js/utils/StringUtil";
+
+const Loading = () => <Loader size="small" type="ballBeat" />;
+
+const ConfigurationRow = ({ keyValue, title, value }) => {
+  return (
+    <ConfigurationMapRow key={keyValue}>
+      <ConfigurationMapLabel>{title}</ConfigurationMapLabel>
+      <ConfigurationMapValue>
+        <span className={value.classNames}>
+          {StringUtil.capitalize(value.title)}
+        </span>
+      </ConfigurationMapValue>
+    </ConfigurationMapRow>
+  );
+};
+
+const NonLeader = ({ master }) => {
+  return (
+    <ConfigurationRow
+      keyValue={master.host_ip}
+      title={master.host_ip}
+      value={master.healthDescription}
+    />
+  );
+};
+
+const EmptyLeaderList = () => {
+  return <div>There are no more known masters in this cluster</div>;
+};
+
+const NonLeaderList = ({ masters }) => {
+  if (masters.length === 0) {
+    return <EmptyLeaderList />;
+  }
+
+  return (
+    <ConfigurationMapSection>
+      {masters.map(master => <NonLeader key={master.host_ip} master={master} />)}
+    </ConfigurationMapSection>
+  );
+};
+
+export default function NonLeaderGrid({ masters }) {
+  const hasMasters = Array.isArray(masters);
+  const content = hasMasters ? (
+    <NonLeaderList masters={masters} />
+  ) : (
+    <Loading />
+  );
+
+  return (
+    <div className="container">
+      <ConfigurationMap>
+        <ConfigurationMapHeading className="flush-top">
+          Non-Leaders
+        </ConfigurationMapHeading>
+        {content}
+      </ConfigurationMap>
+    </div>
+  );
+}

--- a/plugins/nodes/src/js/components/__tests__/LeaderGrid-test.js
+++ b/plugins/nodes/src/js/components/__tests__/LeaderGrid-test.js
@@ -13,10 +13,10 @@ const master = {
   region: "us-east-1"
 };
 
-const TestableLeaderGrid = ({ master }) => {
+const TestableLeaderGrid = ({ leader }) => {
   return (
     <IntlProvider locale="en" messages={enUS}>
-      <LeaderGrid master={master} />
+      <LeaderGrid leader={leader} />
     </IntlProvider>
   );
 };
@@ -32,7 +32,7 @@ describe("LeaderGrid", function() {
 
   it("renders with running status", function() {
     expect(
-      renderer.create(<TestableLeaderGrid master={master} />).toJSON()
+      renderer.create(<TestableLeaderGrid leader={master} />).toJSON()
     ).toMatchSnapshot();
   });
 });

--- a/plugins/nodes/src/js/components/__tests__/LeaderGrid-test.js
+++ b/plugins/nodes/src/js/components/__tests__/LeaderGrid-test.js
@@ -1,0 +1,38 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { IntlProvider } from "react-intl";
+import enUS from "#SRC/js/translations/en-US.json";
+
+import LeaderGrid from "../LeaderGrid";
+
+const master = {
+  hostPort: "127.1.2.3:8080",
+  version: "2.9.1",
+  electedTime: 1532340694.04573,
+  startTime: 1232340694.04573,
+  region: "us-east-1"
+};
+
+const TestableLeaderGrid = ({ master }) => {
+  return (
+    <IntlProvider locale="en" messages={enUS}>
+      <LeaderGrid master={master} />
+    </IntlProvider>
+  );
+};
+
+describe("LeaderGrid", function() {
+  beforeEach(function() {
+    Date.now = jest.fn(() => 1542340694);
+  });
+
+  afterEach(function() {
+    Date.now.mockRestore();
+  });
+
+  it("renders with running status", function() {
+    expect(
+      renderer.create(<TestableLeaderGrid master={master} />).toJSON()
+    ).toMatchSnapshot();
+  });
+});

--- a/plugins/nodes/src/js/components/__tests__/NonLeaderGrid-test.js
+++ b/plugins/nodes/src/js/components/__tests__/NonLeaderGrid-test.js
@@ -1,0 +1,61 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { IntlProvider } from "react-intl";
+import enUS from "#SRC/js/translations/en-US.json";
+
+import NonLeadersGrid from "../NonLeadersGrid";
+
+const masters = [
+  {
+    health: 0,
+    healthDescription: {
+      classNames: "text-success",
+      key: "HEALTHY",
+      sortingValue: 3,
+      title: "Healthy",
+      value: 0
+    },
+    host_ip: "172.31.10.48",
+    role: "master"
+  },
+  {
+    health: 0,
+    healthDescription: {
+      classNames: "text-success",
+      key: "HEALTHY",
+      sortingValue: 3,
+      title: "Healthy",
+      value: 0
+    },
+    host_ip: "172.31.10.49",
+    role: "master"
+  }
+];
+
+const TestableNonLeadersGrid = ({ masters }) => {
+  return (
+    <IntlProvider locale="en" messages={enUS}>
+      <NonLeadersGrid masters={masters} />
+    </IntlProvider>
+  );
+};
+
+describe("LeaderGrid", function() {
+  it("renders loading", function() {
+    expect(
+      renderer.create(<TestableNonLeadersGrid masters={undefined} />).toJSON()
+    ).toMatchSnapshot();
+  });
+
+  it("renders empty", function() {
+    expect(
+      renderer.create(<TestableNonLeadersGrid masters={[]} />).toJSON()
+    ).toMatchSnapshot();
+  });
+
+  it("renders masters", function() {
+    expect(
+      renderer.create(<TestableNonLeadersGrid masters={masters} />).toJSON()
+    ).toMatchSnapshot();
+  });
+});

--- a/plugins/nodes/src/js/components/__tests__/__snapshots__/LeaderGrid-test.js.snap
+++ b/plugins/nodes/src/js/components/__tests__/__snapshots__/LeaderGrid-test.js.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LeaderGrid renders with running status 1`] = `
+<div
+  className="container"
+>
+  <div
+    className="configuration-map"
+  >
+    <h1
+      className="detail-view-section-heading detail-view-section-heading-primary configuration-map-heading flush-top"
+    >
+      Leader
+    </h1>
+    <div
+      className="configuration-map-section"
+    >
+      <div
+        className="configuration-map-row table-row"
+      >
+        <div
+          className="configuration-map-label"
+        >
+          IP and Port
+        </div>
+        <div
+          className="configuration-map-value"
+        >
+          127.1.2.3:8080
+        </div>
+      </div>
+      <div
+        className="configuration-map-row table-row"
+      >
+        <div
+          className="configuration-map-label"
+        >
+          Region
+        </div>
+        <div
+          className="configuration-map-value"
+        >
+          us-east-1
+        </div>
+      </div>
+      <div
+        className="configuration-map-row table-row"
+      >
+        <div
+          className="configuration-map-label"
+        >
+          <span>
+            Version
+          </span>
+        </div>
+        <div
+          className="configuration-map-value"
+        >
+          2.9.1
+        </div>
+      </div>
+      <div
+        className="configuration-map-row table-row"
+      >
+        <div
+          className="configuration-map-label"
+        >
+          <span>
+            Started
+          </span>
+        </div>
+        <div
+          className="configuration-map-value"
+        >
+          in 39 years
+        </div>
+      </div>
+      <div
+        className="configuration-map-row table-row"
+      >
+        <div
+          className="configuration-map-label"
+        >
+          <span>
+            Elected
+          </span>
+        </div>
+        <div
+          className="configuration-map-value"
+        >
+          in 49 years
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/plugins/nodes/src/js/components/__tests__/__snapshots__/NonLeaderGrid-test.js.snap
+++ b/plugins/nodes/src/js/components/__tests__/__snapshots__/NonLeaderGrid-test.js.snap
@@ -13,7 +13,7 @@ exports[`LeaderGrid renders empty 1`] = `
       Non-Leaders
     </h1>
     <div>
-      There are no more known masters in this cluster
+      There are no more known masters in this cluster.
     </div>
   </div>
 </div>

--- a/plugins/nodes/src/js/components/__tests__/__snapshots__/NonLeaderGrid-test.js.snap
+++ b/plugins/nodes/src/js/components/__tests__/__snapshots__/NonLeaderGrid-test.js.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LeaderGrid renders empty 1`] = `
+<div
+  className="container"
+>
+  <div
+    className="configuration-map"
+  >
+    <h1
+      className="detail-view-section-heading detail-view-section-heading-primary configuration-map-heading flush-top"
+    >
+      Non-Leaders
+    </h1>
+    <div>
+      There are no more known masters in this cluster
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LeaderGrid renders loading 1`] = `
+<div
+  className="container"
+>
+  <div
+    className="configuration-map"
+  >
+    <h1
+      className="detail-view-section-heading detail-view-section-heading-primary configuration-map-heading flush-top"
+    >
+      Non-Leaders
+    </h1>
+    <div
+      className="loader horizontal-center"
+    >
+      <div
+        className="ball-beat loader--small"
+      >
+        <div
+          className="loader-element"
+        />
+        <div
+          className="loader-element"
+        />
+        <div
+          className="loader-element"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`LeaderGrid renders masters 1`] = `
+<div
+  className="container"
+>
+  <div
+    className="configuration-map"
+  >
+    <h1
+      className="detail-view-section-heading detail-view-section-heading-primary configuration-map-heading flush-top"
+    >
+      Non-Leaders
+    </h1>
+    <div
+      className="configuration-map-section"
+    >
+      <div
+        className="configuration-map-row table-row"
+      >
+        <div
+          className="configuration-map-label"
+        >
+          172.31.10.48
+        </div>
+        <div
+          className="configuration-map-value"
+        >
+          <span
+            className="text-success"
+          >
+            Healthy
+          </span>
+        </div>
+      </div>
+      <div
+        className="configuration-map-row table-row"
+      >
+        <div
+          className="configuration-map-label"
+        >
+          172.31.10.49
+        </div>
+        <div
+          className="configuration-map-value"
+        >
+          <span
+            className="text-success"
+          >
+            Healthy
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/plugins/nodes/src/js/data/MesosMasters.js
+++ b/plugins/nodes/src/js/data/MesosMasters.js
@@ -50,7 +50,7 @@ export default class MesosMasters extends React.Component {
 
     this.stream = Observable.interval(STORE_POLL_INTERVAL)
       .map(_ => {
-        return MesosStateStore.getLastMesosState();
+        return MesosStateStore.getMaster();
       })
       .map(mesosState => mesosState.master_info)
       .filter(master => !isEmptyObject(master))

--- a/plugins/nodes/src/js/data/MesosMasters.js
+++ b/plugins/nodes/src/js/data/MesosMasters.js
@@ -7,6 +7,7 @@ import "rxjs/add/operator/retry";
 import "rxjs/add/operator/filter";
 
 import MesosStateStore from "#SRC/js/stores/MesosStateStore";
+import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
 
 import LeaderGrid from "../components/LeaderGrid";
 
@@ -18,19 +19,11 @@ function hostPort(address) {
   return `${address.hostname}:${address.port}`;
 }
 
-function supportsRegion(master) {
-  return (
-    master.domain &&
-    master.domain.fault_domain &&
-    master.domain.fault_domain.region &&
-    master.domain.fault_domain.region.name
-  );
-}
-
 export function getRegion(master) {
-  return supportsRegion(master)
-    ? master.domain.fault_domain.region.name
-    : "N/A";
+  return (
+    findNestedPropertyInObject(master, "domain.fault_domain.region.name") ||
+    "N/A"
+  );
 }
 
 const STORE_POLL_INTERVAL = 2000;

--- a/plugins/nodes/src/js/data/MesosMasters.js
+++ b/plugins/nodes/src/js/data/MesosMasters.js
@@ -1,0 +1,83 @@
+import React from "react";
+import { Observable } from "rxjs/Observable";
+import "rxjs/add/observable/timer";
+import "rxjs/add/operator/do";
+import "rxjs/add/operator/map";
+import "rxjs/add/operator/retry";
+import "rxjs/add/operator/filter";
+
+import MesosStateStore from "#SRC/js/stores/MesosStateStore";
+
+import LeaderGrid from "../components/LeaderGrid";
+
+function isEmptyObject(obj) {
+  return Object.keys(obj).length === 0;
+}
+
+function hostPort(address) {
+  return `${address.hostname}:${address.port}`;
+}
+
+// ask how to fix better
+function supportsRegion(master) {
+  return (
+    master.domain &&
+    master.domain.fault_domain &&
+    master.domain.fault_domain.region &&
+    master.domain.fault_domain.region.name
+  );
+}
+
+function getRegion(master) {
+  return supportsRegion(master)
+    ? master.domain.fault_domain.region.name
+    : "N/A";
+}
+
+const STORE_POLL_INTERVAL = 2000;
+
+export default class MesosMasters extends React.Component {
+  constructor() {
+    super(...arguments);
+
+    this.state = {
+      hostPort: undefined,
+      version: undefined,
+      electedTime: undefined,
+      startTime: undefined,
+      region: undefined
+    };
+
+    this.stream = Observable.interval(STORE_POLL_INTERVAL)
+      .map(_ => {
+        return MesosStateStore.getLastMesosState();
+      })
+      .map(mesosState => mesosState.master_info)
+      .filter(master => !isEmptyObject(master))
+      .map(master => {
+        return {
+          hostPort: hostPort(master.address),
+          version: master.version,
+          electedTime: master.elected_time,
+          startTime: master.start_time,
+          region: getRegion(master)
+        };
+      });
+  }
+
+  componentDidMount() {
+    this.subscription = this.stream.subscribe(master => {
+      this.setState(master);
+    });
+  }
+
+  componentWillUnmount() {
+    this.subscription.unsubscribe();
+  }
+
+  render() {
+    const master = this.state;
+
+    return <LeaderGrid master={master} />;
+  }
+}

--- a/plugins/nodes/src/js/data/MesosMasters.js
+++ b/plugins/nodes/src/js/data/MesosMasters.js
@@ -28,11 +28,11 @@ function filterLeader(leader, masters) {
   return masters.filter(master => master.host_ip !== leader.hostIp);
 }
 
-function combineMasterData(leaderDataSource, mastersDataSource) {
+export function combineMasterData(leaderDataSource, mesosMastersHealth) {
   const mesosLeader$ = leaderDataSource().startWith(
     mastersInitialState().leader
   );
-  const mesosMasters$ = mastersDataSource().startWith(undefined);
+  const mesosMasters$ = mesosMastersHealth().startWith(undefined);
 
   return function() {
     return mesosLeader$.combineLatest(mesosMasters$, (leader, masters) => ({
@@ -43,7 +43,7 @@ function combineMasterData(leaderDataSource, mastersDataSource) {
 }
 
 // This is an attempt of the mediator pattern without componentFromStream
-export function connectComponent(initialState, stream) {
+export function connectMasterComponent(initialState, stream) {
   class MesosMasters extends React.Component {
     constructor() {
       super(...arguments);
@@ -62,7 +62,6 @@ export function connectComponent(initialState, stream) {
 
     render() {
       const { masters, leader } = this.state;
-      console.log(masters, leader);
 
       return (
         <div>
@@ -81,4 +80,4 @@ const mastersWithHealth = combineMasterData(
   mesosMastersHealth
 );
 
-export default connectComponent(mastersInitialState, mastersWithHealth);
+export default connectMasterComponent(mastersInitialState, mastersWithHealth);

--- a/plugins/nodes/src/js/data/MesosMastersHealth.js
+++ b/plugins/nodes/src/js/data/MesosMastersHealth.js
@@ -1,0 +1,47 @@
+import Config from "#SRC/js/config/Config";
+import UnitHealthUtil from "#SRC/js/utils/UnitHealthUtil";
+
+import { Observable } from "rxjs";
+import { request } from "@dcos/http-service";
+import "rxjs/add/observable/of";
+import "rxjs/add/observable/timer";
+
+import "rxjs/add/operator/catch";
+import "rxjs/add/operator/map";
+import "rxjs/add/operator/exhaustMap";
+import "rxjs/add/operator/publishReplay";
+
+function fetchUnit(unitID) {
+  const unitUrl = `${Config.rootUrl}${
+    Config.unitHealthAPIPrefix
+  }/units/${unitID}/nodes`;
+
+  return request(unitUrl)
+    .map(response => response.nodes)
+    .catch(_err => Observable.of([]));
+}
+
+function pollStream(interval, stream) {
+  return Observable.timer(0, interval).exhaustMap(() => stream);
+}
+
+export function replayStream(stream) {
+  return stream.publishReplay(1).refCount();
+}
+
+function withHealthDescription(masters) {
+  return masters.map(master =>
+    Object.assign({}, master, {
+      healthDescription: UnitHealthUtil.getHealth(parseInt(master.health, 10))
+    })
+  );
+}
+
+const HEALTH_POLL_INTERVAL = 30000;
+export function mesosMastersHealth() {
+  const request$ = fetchUnit("dcos-mesos-master.service").map(
+    withHealthDescription
+  );
+
+  return replayStream(pollStream(HEALTH_POLL_INTERVAL, request$));
+}

--- a/plugins/nodes/src/js/data/MesosMastersHealth.js
+++ b/plugins/nodes/src/js/data/MesosMastersHealth.js
@@ -37,11 +37,16 @@ function withHealthDescription(masters) {
   );
 }
 
+export function mesosMastersHealthQuery(source, interval) {
+  const request$ = source().map(withHealthDescription);
+
+  return replayStream(pollStream(interval, request$));
+}
+
 const HEALTH_POLL_INTERVAL = 30000;
 export function mesosMastersHealth() {
-  const request$ = fetchUnit("dcos-mesos-master.service").map(
-    withHealthDescription
+  return mesosMastersHealthQuery(
+    () => fetchUnit("dcos-mesos-master.service"),
+    HEALTH_POLL_INTERVAL
   );
-
-  return replayStream(pollStream(HEALTH_POLL_INTERVAL, request$));
 }

--- a/plugins/nodes/src/js/data/MesosMastersLeader.js
+++ b/plugins/nodes/src/js/data/MesosMastersLeader.js
@@ -1,0 +1,53 @@
+import { Observable } from "rxjs/Observable";
+import "rxjs/add/observable/timer";
+import "rxjs/add/operator/do";
+import "rxjs/add/operator/map";
+import "rxjs/add/operator/retry";
+import "rxjs/add/operator/filter";
+
+import MesosStateStore from "#SRC/js/stores/MesosStateStore";
+import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
+
+const STORE_POLL_INTERVAL = 2000;
+
+function isEmptyObject(obj) {
+  return Object.keys(obj).length === 0;
+}
+
+function hostPort(address) {
+  return `${address.hostname}:${address.port}`;
+}
+
+export function getRegion(master) {
+  return (
+    findNestedPropertyInObject(master, "domain.fault_domain.region.name") ||
+    "N/A"
+  );
+}
+
+export function mesosMasterLeaderQuery(
+  masterDataSource,
+  interval = STORE_POLL_INTERVAL
+) {
+  return Observable.timer(0, interval)
+    .map(_ => {
+      return masterDataSource();
+    })
+    .map(mesosState => mesosState.master_info)
+    .filter(master => !isEmptyObject(master))
+    .map(master => {
+      return {
+        hostPort: hostPort(master.address),
+        hostIp: findNestedPropertyInObject(master, "address.ip"),
+        version: master.version,
+        electedTime: master.elected_time,
+        startTime: master.start_time,
+        region: getRegion(master)
+      };
+    });
+}
+
+const masterDataSource = MesosStateStore.getMaster.bind(MesosStateStore);
+export function mesosMastersLeader() {
+  return mesosMasterLeaderQuery(masterDataSource, STORE_POLL_INTERVAL);
+}

--- a/plugins/nodes/src/js/data/MesosMastersLeader.js
+++ b/plugins/nodes/src/js/data/MesosMastersLeader.js
@@ -8,13 +8,11 @@ import "rxjs/add/operator/filter";
 import MesosStateStore from "#SRC/js/stores/MesosStateStore";
 import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
 
-const STORE_POLL_INTERVAL = 2000;
-
 function isEmptyObject(obj) {
   return Object.keys(obj).length === 0;
 }
 
-function hostPort(address) {
+function hostWithPort(address) {
   return `${address.hostname}:${address.port}`;
 }
 
@@ -25,19 +23,14 @@ export function getRegion(master) {
   );
 }
 
-export function mesosMasterLeaderQuery(
-  masterDataSource,
-  interval = STORE_POLL_INTERVAL
-) {
+export function mesosMasterLeaderQuery(masterDataSource, interval) {
   return Observable.timer(0, interval)
-    .map(_ => {
-      return masterDataSource();
-    })
+    .map(_ => masterDataSource())
     .map(mesosState => mesosState.master_info)
     .filter(master => !isEmptyObject(master))
     .map(master => {
       return {
-        hostPort: hostPort(master.address),
+        hostPort: hostWithPort(master.address),
         hostIp: findNestedPropertyInObject(master, "address.ip"),
         version: master.version,
         electedTime: master.elected_time,
@@ -47,6 +40,7 @@ export function mesosMasterLeaderQuery(
     });
 }
 
+const STORE_POLL_INTERVAL = 2000;
 const masterDataSource = MesosStateStore.getMaster.bind(MesosStateStore);
 export function mesosMastersLeader() {
   return mesosMasterLeaderQuery(masterDataSource, STORE_POLL_INTERVAL);

--- a/plugins/nodes/src/js/data/__tests__/MesosMasters-test.js
+++ b/plugins/nodes/src/js/data/__tests__/MesosMasters-test.js
@@ -1,0 +1,69 @@
+import { marbles } from "rxjs-marbles/jest";
+
+import { mesosMasterInfo, getRegion } from "../MesosMasters";
+
+function faultDomainData() {
+  return {
+    region: { name: "us-east-1" }
+  };
+}
+
+function masterData(faultDomain) {
+  return {
+    master_info: {
+      address: {
+        hostname: "127.0.0.1",
+        port: "8080"
+      },
+      start_time: 12345789.0,
+      elected_time: 12345789.0,
+      version: "1.2.2",
+      domain: {
+        fault_domain: faultDomain
+      }
+    }
+  };
+}
+
+describe("MesosMasters", function() {
+  describe("#mesosMasterInfo", function() {
+    it(
+      "emits correct master",
+      marbles(function(m) {
+        m.bind();
+
+        const expectedData = {
+          electedTime: 12345789,
+          hostPort: "127.0.0.1:8080",
+          region: "us-east-1",
+          startTime: 12345789,
+          version: "1.2.2"
+        };
+
+        const master$ = mesosMasterInfo(
+          () => masterData(faultDomainData()),
+          m.time("--|")
+        );
+        const expected$ = m.cold("a-(a|)", {
+          a: expectedData
+        });
+
+        m.expect(master$.take(2)).toBeObservable(expected$);
+      })
+    );
+  });
+
+  describe("#getRegion", function() {
+    it("retrieves region correctly", function() {
+      const master = masterData();
+
+      expect(getRegion(master)).toBe("N/A");
+    });
+
+    it("returns N/A for missing region", function() {
+      const master = masterData(faultDomainData());
+
+      expect(getRegion(master)).toBe("N/A");
+    });
+  });
+});

--- a/plugins/nodes/src/js/data/__tests__/MesosMasters-test.js
+++ b/plugins/nodes/src/js/data/__tests__/MesosMasters-test.js
@@ -1,4 +1,5 @@
 import { marbles } from "rxjs-marbles/jest";
+import "rxjs/add/operator/take";
 
 import { mesosMasterInfo, getRegion } from "../MesosMasters";
 
@@ -55,13 +56,13 @@ describe("MesosMasters", function() {
 
   describe("#getRegion", function() {
     it("retrieves region correctly", function() {
-      const master = masterData();
+      const master = masterData(faultDomainData()).master_info;
 
-      expect(getRegion(master)).toBe("N/A");
+      expect(getRegion(master)).toBe("us-east-1");
     });
 
     it("returns N/A for missing region", function() {
-      const master = masterData(faultDomainData());
+      const master = masterData().master_info;
 
       expect(getRegion(master)).toBe("N/A");
     });

--- a/plugins/nodes/src/js/data/__tests__/MesosMasters-test.js
+++ b/plugins/nodes/src/js/data/__tests__/MesosMasters-test.js
@@ -88,6 +88,14 @@ const TestableMasterComponent = ({ component }) => {
 };
 
 describe("LeaderGrid", function() {
+  beforeEach(function() {
+    Date.now = jest.fn(() => 1542340694);
+  });
+
+  afterEach(function() {
+    Date.now.mockRestore();
+  });
+
   it("renders with running status", function() {
     const initialState = mastersInitialState;
 

--- a/plugins/nodes/src/js/data/__tests__/MesosMasters-test.js
+++ b/plugins/nodes/src/js/data/__tests__/MesosMasters-test.js
@@ -1,0 +1,105 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import { IntlProvider } from "react-intl";
+import { Observable } from "rxjs/Observable";
+import enUS from "#SRC/js/translations/en-US.json";
+
+import { connectMasterComponent, combineMasterData } from "../MesosMasters";
+
+const leader = {
+  hostPort: "127.1.2.3:8080",
+  version: "2.9.1",
+  electedTime: 1532340694.04573,
+  startTime: 1232340694.04573,
+  region: "us-east-1"
+};
+
+const nonLeader = [
+  {
+    host_ip: "192.168.0.1",
+    health: 0,
+    role: "master",
+    healthDescription: {
+      classNames: "text-success",
+      key: "HEALTHY",
+      sortingValue: 3,
+      title: "Healthy",
+      value: 0
+    }
+  },
+  {
+    host_ip: "192.168.0.2",
+    health: 1,
+    role: "master",
+    healthDescription: {
+      classNames: "text-danger",
+      key: "UNHEALTHY",
+      sortingValue: 0,
+      title: "Unhealthy",
+      value: 1
+    }
+  },
+  {
+    host_ip: "192.168.0.3",
+    health: 2,
+    role: "master",
+    healthDescription: {
+      classNames: "text-warning",
+      key: "WAR",
+      sortingValue: 2,
+      title: "Warning",
+      value: 2
+    }
+  },
+  {
+    host_ip: "192.168.0.4",
+    health: 4,
+    role: "master",
+    healthDescription: {
+      classNames: "text-mute",
+      key: "NA",
+      sortingValue: 1,
+      title: "N/A",
+      value: 3
+    }
+  }
+];
+
+function mastersInitialState() {
+  return {
+    leader: {
+      hostPort: undefined,
+      hostIp: undefined,
+      version: undefined,
+      electedTime: undefined,
+      startTime: undefined,
+      region: undefined
+    },
+    masters: undefined
+  };
+}
+
+const TestableMasterComponent = ({ component }) => {
+  return (
+    <IntlProvider locale="en" messages={enUS}>
+      {component}
+    </IntlProvider>
+  );
+};
+
+describe("LeaderGrid", function() {
+  it("renders with running status", function() {
+    const initialState = mastersInitialState;
+
+    const leaderData = () => Observable.of(leader);
+    const healthData = () => Observable.of(nonLeader);
+    const combinedData = combineMasterData(leaderData, healthData);
+    const MasterNodesTab = connectMasterComponent(initialState, combinedData);
+
+    expect(
+      renderer
+        .create(<TestableMasterComponent component={<MasterNodesTab />} />)
+        .toJSON()
+    ).toMatchSnapshot();
+  });
+});

--- a/plugins/nodes/src/js/data/__tests__/MesosMastersHealth-test.js
+++ b/plugins/nodes/src/js/data/__tests__/MesosMastersHealth-test.js
@@ -1,0 +1,85 @@
+import { marbles } from "rxjs-marbles/jest";
+import { Observable } from "rxjs/Observable";
+import "rxjs/add/operator/take";
+import "rxjs/add/observable/of";
+
+import { mesosMastersHealthQuery } from "../MesosMastersHealth";
+
+const nonLeaders = [
+  { host_ip: "192.168.0.1", health: 0, role: "master" },
+  { host_ip: "192.168.0.2", health: 1, role: "master" },
+  { host_ip: "192.168.0.3", health: 2, role: "master" },
+  { host_ip: "192.168.0.4", health: 4, role: "master" }
+];
+
+const nonLeadersWithHealth = [
+  {
+    host_ip: "192.168.0.1",
+    health: 0,
+    role: "master",
+    healthDescription: {
+      classNames: "text-success",
+      key: "HEALTHY",
+      sortingValue: 3,
+      title: "Healthy",
+      value: 0
+    }
+  },
+  {
+    host_ip: "192.168.0.2",
+    health: 1,
+    role: "master",
+    healthDescription: {
+      classNames: "text-danger",
+      key: "UNHEALTHY",
+      sortingValue: 0,
+      title: "Unhealthy",
+      value: 1
+    }
+  },
+  {
+    host_ip: "192.168.0.3",
+    health: 2,
+    role: "master",
+    healthDescription: {
+      classNames: "text-warning",
+      key: "WAR",
+      sortingValue: 2,
+      title: "Warning",
+      value: 2
+    }
+  },
+  {
+    host_ip: "192.168.0.4",
+    health: 4,
+    role: "master",
+    healthDescription: {
+      classNames: "text-mute",
+      key: "NA",
+      sortingValue: 1,
+      title: "N/A",
+      value: 3
+    }
+  }
+];
+
+describe("MesosMastersHealth", function() {
+  describe("#mesosMasterInfo", function() {
+    it(
+      "emits correct master",
+      marbles(function(m) {
+        m.bind();
+
+        const master$ = mesosMastersHealthQuery(
+          () => Observable.of(nonLeaders),
+          m.time("--|")
+        );
+        const expected$ = m.cold("a-(a|)", {
+          a: nonLeadersWithHealth
+        });
+
+        m.expect(master$.take(2)).toBeObservable(expected$);
+      })
+    );
+  });
+});

--- a/plugins/nodes/src/js/data/__tests__/MesosMastersLeader-test.js
+++ b/plugins/nodes/src/js/data/__tests__/MesosMastersLeader-test.js
@@ -1,7 +1,7 @@
 import { marbles } from "rxjs-marbles/jest";
 import "rxjs/add/operator/take";
 
-import { mesosMasterInfo, getRegion } from "../MesosMasters";
+import { mesosMasterLeaderQuery, getRegion } from "../MesosMastersLeader";
 
 function faultDomainData() {
   return {
@@ -26,7 +26,7 @@ function masterData(faultDomain) {
   };
 }
 
-describe("MesosMasters", function() {
+describe("MesosMastersLeader", function() {
   describe("#mesosMasterInfo", function() {
     it(
       "emits correct master",
@@ -41,7 +41,7 @@ describe("MesosMasters", function() {
           version: "1.2.2"
         };
 
-        const master$ = mesosMasterInfo(
+        const master$ = mesosMasterLeaderQuery(
           () => masterData(faultDomainData()),
           m.time("--|")
         );

--- a/plugins/nodes/src/js/data/__tests__/__snapshots__/MesosMasters-test.js.snap
+++ b/plugins/nodes/src/js/data/__tests__/__snapshots__/MesosMasters-test.js.snap
@@ -73,7 +73,7 @@ exports[`LeaderGrid renders with running status 1`] = `
           <div
             className="configuration-map-value"
           >
-            10 years ago
+            in 39 years
           </div>
         </div>
         <div
@@ -89,7 +89,7 @@ exports[`LeaderGrid renders with running status 1`] = `
           <div
             className="configuration-map-value"
           >
-            18 days ago
+            in 49 years
           </div>
         </div>
       </div>

--- a/plugins/nodes/src/js/data/__tests__/__snapshots__/MesosMasters-test.js.snap
+++ b/plugins/nodes/src/js/data/__tests__/__snapshots__/MesosMasters-test.js.snap
@@ -1,0 +1,188 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LeaderGrid renders with running status 1`] = `
+<div>
+  <div
+    className="container"
+  >
+    <div
+      className="configuration-map"
+    >
+      <h1
+        className="detail-view-section-heading detail-view-section-heading-primary configuration-map-heading flush-top"
+      >
+        Leader
+      </h1>
+      <div
+        className="configuration-map-section"
+      >
+        <div
+          className="configuration-map-row table-row"
+        >
+          <div
+            className="configuration-map-label"
+          >
+            IP and Port
+          </div>
+          <div
+            className="configuration-map-value"
+          >
+            127.1.2.3:8080
+          </div>
+        </div>
+        <div
+          className="configuration-map-row table-row"
+        >
+          <div
+            className="configuration-map-label"
+          >
+            Region
+          </div>
+          <div
+            className="configuration-map-value"
+          >
+            us-east-1
+          </div>
+        </div>
+        <div
+          className="configuration-map-row table-row"
+        >
+          <div
+            className="configuration-map-label"
+          >
+            <span>
+              Version
+            </span>
+          </div>
+          <div
+            className="configuration-map-value"
+          >
+            2.9.1
+          </div>
+        </div>
+        <div
+          className="configuration-map-row table-row"
+        >
+          <div
+            className="configuration-map-label"
+          >
+            <span>
+              Started
+            </span>
+          </div>
+          <div
+            className="configuration-map-value"
+          >
+            10 years ago
+          </div>
+        </div>
+        <div
+          className="configuration-map-row table-row"
+        >
+          <div
+            className="configuration-map-label"
+          >
+            <span>
+              Elected
+            </span>
+          </div>
+          <div
+            className="configuration-map-value"
+          >
+            18 days ago
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="container"
+  >
+    <div
+      className="configuration-map"
+    >
+      <h1
+        className="detail-view-section-heading detail-view-section-heading-primary configuration-map-heading flush-top"
+      >
+        Non-Leaders
+      </h1>
+      <div
+        className="configuration-map-section"
+      >
+        <div
+          className="configuration-map-row table-row"
+        >
+          <div
+            className="configuration-map-label"
+          >
+            192.168.0.1
+          </div>
+          <div
+            className="configuration-map-value"
+          >
+            <span
+              className="text-success"
+            >
+              Healthy
+            </span>
+          </div>
+        </div>
+        <div
+          className="configuration-map-row table-row"
+        >
+          <div
+            className="configuration-map-label"
+          >
+            192.168.0.2
+          </div>
+          <div
+            className="configuration-map-value"
+          >
+            <span
+              className="text-danger"
+            >
+              Unhealthy
+            </span>
+          </div>
+        </div>
+        <div
+          className="configuration-map-row table-row"
+        >
+          <div
+            className="configuration-map-label"
+          >
+            192.168.0.3
+          </div>
+          <div
+            className="configuration-map-value"
+          >
+            <span
+              className="text-warning"
+            >
+              Warning
+            </span>
+          </div>
+        </div>
+        <div
+          className="configuration-map-row table-row"
+        >
+          <div
+            className="configuration-map-label"
+          >
+            192.168.0.4
+          </div>
+          <div
+            className="configuration-map-value"
+          >
+            <span
+              className="text-mute"
+            >
+              N/A
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/plugins/nodes/src/js/pages/NodesAgents.js
+++ b/plugins/nodes/src/js/pages/NodesAgents.js
@@ -10,7 +10,6 @@ import Config from "#SRC/js/config/Config";
 import DSLExpression from "#SRC/js/structs/DSLExpression";
 import DSLFilterList from "#SRC/js/structs/DSLFilterList";
 import EventTypes from "#SRC/js/constants/EventTypes";
-import FilterInputText from "#SRC/js/components/FilterInputText";
 import Icon from "#SRC/js/components/Icon";
 import InternalStorageMixin from "#SRC/js/mixins/InternalStorageMixin";
 import MesosSummaryStore from "#SRC/js/stores/MesosSummaryStore";
@@ -58,8 +57,8 @@ var DEFAULT_FILTER_OPTIONS = {
   filterExpression: new DSLExpression("")
 };
 
-var NodesOverview = React.createClass({
-  displayName: "NodesOverview",
+var NodesAgents = React.createClass({
+  displayName: "NodesAgents",
 
   mixins: [InternalStorageMixin, QueryParamsMixin, StoreMixin],
 
@@ -205,24 +204,10 @@ var NodesOverview = React.createClass({
     );
   },
 
-  getFilterInputText() {
-    var isVisible = this.props.location.pathname.endsWith("/nodes/");
-
-    if (!isVisible) {
-      return null;
-    }
-
-    return (
-      <FilterInputText
-        className="flush-bottom"
-        searchString={this.state.searchString}
-        handleFilterChange={this.handleSearchStringChange}
-      />
-    );
-  },
-
   getViewTypeRadioButtons(resetFilter) {
-    const isGridActive = /\/nodes\/grid\/?/i.test(this.props.location.pathname);
+    const isGridActive = /\/nodes\/agents\/grid\/?/i.test(
+      this.props.location.pathname
+    );
 
     var listClassSet = classNames("button button-outline", {
       active: !isGridActive
@@ -234,10 +219,14 @@ var NodesOverview = React.createClass({
 
     return (
       <div className="button-group flush-bottom">
-        <Link className={listClassSet} onClick={resetFilter} to="/nodes">
+        <Link className={listClassSet} onClick={resetFilter} to="/nodes/agents">
           List
         </Link>
-        <Link className={gridClassSet} onClick={resetFilter} to="/nodes/grid">
+        <Link
+          className={gridClassSet}
+          onClick={resetFilter}
+          to="/nodes/agents/grid"
+        >
           Grid
         </Link>
       </div>
@@ -263,11 +252,16 @@ var NodesOverview = React.createClass({
         dontScroll={isNodesTableContainer}
         flushBottom={isNodesTableContainer}
       >
-        <Page.Header breadcrumbs={<NodeBreadcrumbs />} />
+        <Page.Header
+          breadcrumbs={<NodeBreadcrumbs />}
+          tabs={[
+            { label: "Agents", routePath: "/nodes/agents" },
+            { label: "Masters", routePath: "/nodes/masters" }
+          ]}
+        />
         <HostsPageContent
           byServiceFilter={byServiceFilter}
           filterButtonContent={this.getButtonContent}
-          filterInputText={this.getFilterInputText()}
           filterItemList={nodesHealth}
           filteredNodeCount={Math.min(
             nodesList.getItems().length,
@@ -323,4 +317,4 @@ var NodesOverview = React.createClass({
   }
 });
 
-module.exports = NodesOverview;
+module.exports = NodesAgents;

--- a/plugins/nodes/src/js/pages/NodesMasters.js
+++ b/plugins/nodes/src/js/pages/NodesMasters.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default class NodesMasters extends React.Component {
+  render() {
+    return null;
+  }
+}

--- a/plugins/nodes/src/js/pages/NodesMasters.js
+++ b/plugins/nodes/src/js/pages/NodesMasters.js
@@ -4,15 +4,14 @@ import NodeBreadcrumbs from "../components/NodeBreadcrumbs";
 import MesosMasters from "../data/MesosMasters";
 
 const NodesMastersPage = ({ children }) => {
+  const tabs = [
+    { label: "Agents", routePath: "/nodes/agents" },
+    { label: "Masters", routePath: "/nodes/masters" }
+  ];
+
   return (
     <Page>
-      <Page.Header
-        breadcrumbs={<NodeBreadcrumbs />}
-        tabs={[
-          { label: "Agents", routePath: "/nodes/agents" },
-          { label: "Masters", routePath: "/nodes/masters" }
-        ]}
-      />
+      <Page.Header breadcrumbs={<NodeBreadcrumbs />} tabs={tabs} />
       {children}
     </Page>
   );

--- a/plugins/nodes/src/js/pages/NodesMasters.js
+++ b/plugins/nodes/src/js/pages/NodesMasters.js
@@ -1,7 +1,29 @@
 import React from "react";
+import Page from "#SRC/js/components/Page";
+import NodeBreadcrumbs from "../components/NodeBreadcrumbs";
+import MesosMasters from "../data/MesosMasters";
+
+const NodesMastersPage = ({ children }) => {
+  return (
+    <Page>
+      <Page.Header
+        breadcrumbs={<NodeBreadcrumbs />}
+        tabs={[
+          { label: "Agents", routePath: "/nodes/agents" },
+          { label: "Masters", routePath: "/nodes/masters" }
+        ]}
+      />
+      {children}
+    </Page>
+  );
+};
 
 export default class NodesMasters extends React.Component {
   render() {
-    return null;
+    return (
+      <NodesMastersPage>
+        <MesosMasters />
+      </NodesMastersPage>
+    );
   }
 }

--- a/plugins/nodes/src/js/routes/nodes.js
+++ b/plugins/nodes/src/js/routes/nodes.js
@@ -8,7 +8,8 @@ import NodeDetailPage from "../pages/nodes/NodeDetailPage";
 import NodeDetailTab from "../pages/nodes/NodeDetailTab";
 import NodeDetailTaskTab from "../pages/nodes/NodeDetailTaskTab";
 import NodesGridContainer from "../pages/nodes/nodes-grid/NodesGridContainer";
-import NodesOverview from "../pages/NodesOverview";
+import NodesAgents from "../pages/NodesAgents";
+import NodesMasters from "../pages/NodesMasters";
 import NodesPage from "../pages/NodesPage";
 import NodesTableContainer from "../pages/nodes/nodes-table/NodesTableContainer";
 import NodesTaskDetailPage from "../pages/nodes/NodesTaskDetailPage";
@@ -21,139 +22,163 @@ import TaskVolumeContainer from "../../../../services/src/js/containers/volume-d
 import NodesUnitsHealthDetailPage from "../pages/nodes/NodesUnitsHealthDetailPage";
 import VolumeTable from "../../../../services/src/js/components/VolumeTable";
 
-const nodesRoutes = {
-  type: Route,
-  path: "nodes",
-  component: NodesPage,
-  category: "resources",
-  isInSidebar: true,
-  children: [
-    {
-      type: Route,
-      component: NodesOverview,
-      children: [
-        {
-          type: IndexRoute,
-          component: NodesTableContainer
-        },
-        {
-          type: Route,
-          path: "grid",
-          component: NodesGridContainer
-        }
-      ]
-    },
-    {
-      type: Redirect,
-      from: "/nodes/:nodeID",
-      to: "/nodes/:nodeID/tasks"
-    },
-    {
-      type: Route,
-      path: ":nodeID",
-      component: NodeDetailPage,
-      children: [
-        {
-          type: Route,
-          title: "Tasks",
-          path: "tasks",
-          component: NodeDetailTaskTab
-        },
-        {
-          type: Redirect,
-          path: "/nodes/:nodeID/tasks/:taskID",
-          to: "/nodes/:nodeID/tasks/:taskID/details"
-        },
-        {
-          type: Route,
-          path: "health",
-          title: "Health",
-          component: NodeDetailHealthTab
-        },
-        {
-          type: Route,
-          path: "details",
-          title: "Details",
-          component: NodeDetailTab
-        }
-      ]
-    },
-    {
-      type: Route,
-      path: ":nodeID/tasks/:taskID",
-      component: NodesTaskDetailPage,
-      hideHeaderNavigation: true,
-      children: [
-        {
-          type: Route,
-          component: TaskDetailsTab,
-          hideHeaderNavigation: true,
-          title: "Details",
-          path: "details",
-          isTab: true
-        },
-        {
-          hideHeaderNavigation: true,
-          component: TaskFilesTab,
-          isTab: true,
-          path: "files",
-          title: "Files",
-          type: Route,
-          children: [
-            {
-              component: TaskFileBrowser,
-              fileViewerRoutePath:
-                "/nodes/:nodeID/tasks/:taskID/files/view(/:filePath(/:innerPath))",
-              hideHeaderNavigation: true,
-              type: IndexRoute
-            },
-            {
-              component: TaskFileViewer,
-              hideHeaderNavigation: true,
-              path: "view(/:filePath(/:innerPath))",
-              type: Route
-            }
-          ]
-        },
-        {
-          component: TaskLogsContainer,
-          hideHeaderNavigation: true,
-          isTab: true,
-          path: "logs",
-          title: "Logs",
-          type: Route,
-          children: [
-            {
-              path: ":filePath",
-              type: Route
-            }
-          ]
-        },
-        {
-          component: VolumeTable,
-          hideHeaderNavigation: true,
-          isTab: true,
-          path: "volumes",
-          title: "Volumes",
-          type: Route
-        }
-      ]
-    },
-    // This route needs to be rendered outside of the tabs that are rendered
-    // in the nodes-task-details route.
-    {
-      type: Route,
-      path: ":nodeID/tasks/:taskID/volumes/:volumeID",
-      component: TaskVolumeContainer
-    },
-    // This needs to be outside of the children array of node routes
-    // so that it can be responsible for rendering its own header.
-    {
-      type: Route,
-      path: ":nodeID/health/:unitNodeID/:unitID",
-      component: NodesUnitsHealthDetailPage
-    }
-  ]
-};
+const nodesRoutes = [
+  {
+    type: Redirect,
+    from: "/nodes",
+    to: "/nodes/agents/table"
+  },
+  {
+    type: Redirect,
+    from: "/nodes/grid",
+    to: "/nodes/agents/grid"
+  },
+  {
+    type: Route,
+    path: "nodes",
+    component: NodesPage,
+    category: "resources",
+    isInSidebar: true,
+    children: [
+      {
+        type: Redirect,
+        from: "/nodes/agents",
+        to: "/nodes/agents/table"
+      },
+      {
+        type: Route,
+        path: "agents",
+        component: NodesAgents,
+        children: [
+          {
+            type: Route,
+            component: NodesTableContainer,
+            path: "table"
+          },
+          {
+            type: Route,
+            component: NodesGridContainer,
+            path: "grid"
+          }
+        ]
+      },
+      {
+        type: Route,
+        path: "masters",
+        component: NodesMasters
+      },
+      {
+        type: Redirect,
+        from: "/nodes/:nodeID",
+        to: "/nodes/:nodeID/tasks"
+      },
+      {
+        type: Route,
+        path: ":nodeID",
+        component: NodeDetailPage,
+        children: [
+          {
+            type: Route,
+            title: "Tasks",
+            path: "tasks",
+            component: NodeDetailTaskTab
+          },
+          {
+            type: Redirect,
+            path: "/nodes/:nodeID/tasks/:taskID",
+            to: "/nodes/:nodeID/tasks/:taskID/details"
+          },
+          {
+            type: Route,
+            path: "health",
+            title: "Health",
+            component: NodeDetailHealthTab
+          },
+          {
+            type: Route,
+            path: "details",
+            title: "Details",
+            component: NodeDetailTab
+          }
+        ]
+      },
+      {
+        type: Route,
+        path: ":nodeID/tasks/:taskID",
+        component: NodesTaskDetailPage,
+        hideHeaderNavigation: true,
+        children: [
+          {
+            type: Route,
+            component: TaskDetailsTab,
+            hideHeaderNavigation: true,
+            title: "Details",
+            path: "details",
+            isTab: true
+          },
+          {
+            hideHeaderNavigation: true,
+            component: TaskFilesTab,
+            isTab: true,
+            path: "files",
+            title: "Files",
+            type: Route,
+            children: [
+              {
+                component: TaskFileBrowser,
+                fileViewerRoutePath:
+                  "/nodes/:nodeID/tasks/:taskID/files/view(/:filePath(/:innerPath))",
+                hideHeaderNavigation: true,
+                type: IndexRoute
+              },
+              {
+                component: TaskFileViewer,
+                hideHeaderNavigation: true,
+                path: "view(/:filePath(/:innerPath))",
+                type: Route
+              }
+            ]
+          },
+          {
+            component: TaskLogsContainer,
+            hideHeaderNavigation: true,
+            isTab: true,
+            path: "logs",
+            title: "Logs",
+            type: Route,
+            children: [
+              {
+                path: ":filePath",
+                type: Route
+              }
+            ]
+          },
+          {
+            component: VolumeTable,
+            hideHeaderNavigation: true,
+            isTab: true,
+            path: "volumes",
+            title: "Volumes",
+            type: Route
+          }
+        ]
+      },
+      // This route needs to be rendered outside of the tabs that are rendered
+      // in the nodes-task-details route.
+      {
+        type: Route,
+        path: ":nodeID/tasks/:taskID/volumes/:volumeID",
+        component: TaskVolumeContainer
+      },
+      // This needs to be outside of the children array of node routes
+      // so that it can be responsible for rendering its own header.
+      {
+        type: Route,
+        path: ":nodeID/health/:unitNodeID/:unitID",
+        component: NodesUnitsHealthDetailPage
+      }
+    ]
+  }
+];
 
 module.exports = nodesRoutes;

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -23,7 +23,12 @@ import * as mesosStreamParsers from "./MesosStream/parsers";
 const MAX_RETRIES = 5;
 const RETRY_DELAY = 500;
 const MAX_RETRY_DELAY = 5000;
-const METHODS_TO_BIND = ["setState", "onStreamData", "onStreamError"];
+const METHODS_TO_BIND = [
+  "setState",
+  "setMaster",
+  "onStreamData",
+  "onStreamError"
+];
 
 class MesosStateStore extends GetSetBaseStore {
   constructor() {
@@ -74,7 +79,14 @@ class MesosStateStore extends GetSetBaseStore {
     const getMasterRequest = request(
       { type: "GET_MASTER" },
       "/mesos/api/v1?get_master"
-    ).retryWhen(linearBackoff(RETRY_DELAY, MAX_RETRIES));
+    )
+      .retryWhen(linearBackoff(RETRY_DELAY, MAX_RETRIES))
+      .map(message =>
+        mesosStreamParsers.getMaster(this.getMaster(), JSON.parse(message))
+      )
+      .do(master => {
+        this.setMaster(master);
+      });
 
     const parsers = pipe(...Object.values(mesosStreamParsers));
     const dataStream = mesosStream
@@ -124,6 +136,15 @@ class MesosStateStore extends GetSetBaseStore {
         tasks: []
       },
       this.get("lastMesosState")
+    );
+  }
+
+  getMaster() {
+    return Object.assign(
+      {
+        master_info: {}
+      },
+      this.get("master")
     );
   }
 
@@ -249,6 +270,12 @@ class MesosStateStore extends GetSetBaseStore {
   setState(state) {
     this.set({
       lastMesosState: state
+    });
+  }
+
+  setMaster(master) {
+    this.set({
+      master
     });
   }
 

--- a/src/js/stores/MesosStateStore.js
+++ b/src/js/stores/MesosStateStore.js
@@ -81,10 +81,11 @@ class MesosStateStore extends GetSetBaseStore {
       "/mesos/api/v1?get_master"
     )
       .retryWhen(linearBackoff(RETRY_DELAY, MAX_RETRIES))
-      .map(message =>
-        mesosStreamParsers.getMaster(this.getMaster(), JSON.parse(message))
-      )
-      .do(master => {
+      .do(message => {
+        const master = mesosStreamParsers.getMaster(
+          this.getMaster(),
+          JSON.parse(message)
+        );
         this.setMaster(master);
       });
 

--- a/src/js/stores/MesosStream/parsers/__tests__/master-test.js
+++ b/src/js/stores/MesosStream/parsers/__tests__/master-test.js
@@ -1,0 +1,98 @@
+import getMaster from "../master";
+
+function masterMessage() {
+  return {
+    type: "GET_MASTER",
+    get_master: {
+      master_info: {
+        id: "f4b0e45f-9112-4254-bcad-225353006080",
+        ip: 537337772,
+        port: 5050,
+        pid: "master@172.31.7.32:5050",
+        hostname: "172.31.7.32",
+        version: "1.5.1",
+        address: { hostname: "172.31.7.32", ip: "172.31.7.32", port: 5050 },
+        domain: {
+          fault_domain: {
+            region: { name: "us-east-1" },
+            zone: { name: "us-east-1a" }
+          }
+        },
+        capabilities: [{ type: "AGENT_UPDATE" }]
+      },
+      start_time: 1532339115.87122,
+      elected_time: 1532340694.04573
+    }
+  };
+}
+
+describe("#getMaster", function() {
+  it("flattens elected_time", function() {
+    const newState = getMaster({}, masterMessage());
+
+    expect(newState.master_info.elected_time).toBe(1532340694.04573);
+  });
+
+  it("flattens start_time", function() {
+    const newState = getMaster({}, masterMessage());
+
+    expect(newState.master_info.start_time).toBe(1532339115.87122);
+  });
+
+  it("flattens copies the full master info", function() {
+    const newState = getMaster({}, masterMessage());
+
+    expect(newState.master_info).toEqual({
+      id: "f4b0e45f-9112-4254-bcad-225353006080",
+      ip: 537337772,
+      port: 5050,
+      pid: "master@172.31.7.32:5050",
+      hostname: "172.31.7.32",
+      version: "1.5.1",
+      address: { hostname: "172.31.7.32", ip: "172.31.7.32", port: 5050 },
+      domain: {
+        fault_domain: {
+          region: { name: "us-east-1" },
+          zone: { name: "us-east-1a" }
+        }
+      },
+      capabilities: [{ type: "AGENT_UPDATE" }],
+      start_time: 1532339115.87122,
+      elected_time: 1532340694.04573
+    });
+  });
+
+  it("ignores non master message", function() {
+    const message = masterMessage();
+    message.type = "GET_NODES";
+    const newState = getMaster({}, message);
+
+    expect(newState).toEqual({});
+  });
+
+  it("preserves state", function() {
+    const message = masterMessage();
+    const newState = getMaster({ something: "something" }, message);
+
+    expect(newState.something).toEqual("something");
+  });
+
+  it("copies state", function() {
+    const message = masterMessage();
+    const state = { something: "something" };
+    const newState = getMaster(state, message);
+
+    state.something = "something_else";
+
+    expect(newState.something).toEqual("something");
+  });
+
+  it("copies message", function() {
+    const message = masterMessage();
+    const newState = getMaster({}, message);
+
+    message.start_time = 0;
+
+    expect(newState.master_info.start_time).toEqual(1532339115.87122);
+  });
+});

--- a/src/js/stores/MesosStream/parsers/master.js
+++ b/src/js/stores/MesosStream/parsers/master.js
@@ -5,7 +5,11 @@ export default function getMaster(state, message) {
     return state;
   }
 
-  const { master_info } = message.get_master;
+  const { master_info, elected_time, start_time } = message.get_master;
+  const enhancedMasterInfo = Object.assign({}, master_info, {
+    elected_time,
+    start_time
+  });
 
-  return Object.assign({}, state, { master_info });
+  return Object.assign({}, state, { master_info: enhancedMasterInfo });
 }


### PR DESCRIPTION
This Feature branch introduces Agents and Masters tabs. In its first iteration it will only contain a list of Details for the current leader.

Resolves  http://jira.mesosphere.com/browse/DCOS-39712

## Pull Requests in this Branch
- https://github.com/dcos/dcos-ui/pull/3118
- https://github.com/dcos/dcos-ui/pull/3127
- https://github.com/dcos/dcos-ui/pull/3156

## Testing

Before merging this branch: Navigate through the application, make sure all links pointing to nodes are still working and that agents and masters tabs are also working as expected. 
<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

Due to lack of APIs, we decided not to implement a table yet, but go with a quick first implementation that only displays some data regarding the fcurrent leader. more info in JIRA.

**Update: 2018-08-14**: We'd like to merge this as-is and later add #3156 to master directly, reason is that there are some things I'd like to be discussed between @Fabs and @nLight and this branch already is in good shape, only thing thats missing is the "non leader list". everything else should be good to merge 👍 
/cc @orlandohohmeier 
<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

None
<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->
