### PR TITLE
DCOS-39862: Add hover state and cursor styles to column header

### DIFF
--- a/packages/ui-kit-stage/SortableColumnHeader.tsx
+++ b/packages/ui-kit-stage/SortableColumnHeader.tsx
@@ -8,20 +8,50 @@ import { HeaderCell } from "@dcos/ui-kit";
 import { SortableColumnHeaderCellIcon } from "ui-kit-stage/SortableColumnHeaderCellIcon";
 
 type SortDirection = "ASC" | "DESC" | null;
-
-export function SortableColumnHeader({
-  sortHandler,
-  sortDirection,
-  columnContent
-}: {
+interface Props {
   sortHandler: () => void;
   sortDirection: SortDirection;
   columnContent: string | React.ReactNode;
-}) {
-  return (
-    <HeaderCell onClick={sortHandler}>
-      {columnContent}
-      <SortableColumnHeaderCellIcon sortDirection={sortDirection} />
-    </HeaderCell>
-  );
+}
+interface State {
+  hovered: boolean;
+}
+
+export class SortableColumnHeader extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    this.hoverStart = this.hoverStart.bind(this);
+    this.hoverEnd = this.hoverEnd.bind(this);
+    this.state = {
+      hovered: false
+    };
+  }
+
+  hoverStart() {
+    this.setState({ hovered: true });
+  }
+
+  hoverEnd() {
+    this.setState({ hovered: false });
+  }
+
+  render() {
+    const { sortHandler, sortDirection, columnContent } = this.props;
+
+    const displaySortDirection =
+      sortDirection === null && this.state.hovered ? "DESC" : sortDirection;
+
+    return (
+      <HeaderCell
+        onMouseEnter={this.hoverStart}
+        onMouseLeave={this.hoverEnd}
+        onClick={sortHandler}
+        style={{ cursor: "pointer" }}
+      >
+        {columnContent}
+        <SortableColumnHeaderCellIcon sortDirection={displaySortDirection} />
+      </HeaderCell>
+    );
+  }
 }


### PR DESCRIPTION
## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

Checkout the nodes page and take a look if the column header behaves the same as before (having the carret being displayed when hovering and the mouse being a pointer.


## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- Decided to add state because it is just little, contained and the easiest solution.

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

None