### PR TITLE
ci(system-tests): remove stale cluster info if it exists

### DIFF
--- a/system-tests/_scripts/launch-cluster.sh
+++ b/system-tests/_scripts/launch-cluster.sh
@@ -11,6 +11,8 @@ fi
 CLUSTER_CONFIG=/tmp/cluster-config.yaml
 CLUSTER_INFO=/tmp/cluster-info.json
 
+rm ${CLUSTER_INFO}
+
 # Create cluster config
 cat << EOF > ${CLUSTER_CONFIG}
 ---


### PR DESCRIPTION
system tests are not cleaning up properly, so if they fail once, all following runs will fail because cluster-info.json still exists…

## Testing

we need a CI run where system test fail and then succeed…
<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->
