### PR TITLE
DCOS-39901: NodesTable height of container should fill remaining space

### DIFF
--- a/plugins/nodes/src/js/components/NodesTable.tsx
+++ b/plugins/nodes/src/js/components/NodesTable.tsx
@@ -188,151 +188,153 @@ export default class NodesTable extends React.Component<
     const { data, sortColumn, sortDirection } = this.state;
 
     return (
-      <Table data={data.slice()}>
-        <Column
-          header={
-            <SortableColumnHeader
-              columnContent="Name"
-              sortHandler={this.handleSortClick.bind(null, "hostname")}
-              sortDirection={sortColumn === "hostname" ? sortDirection : null}
-            />
-          }
-          cellRenderer={hostnameRenderer}
-          width={hostnameSizer}
-        />
+      <div style={{ flexGrow: 1 }}>
+        <Table data={data.slice()}>
+          <Column
+            header={
+              <SortableColumnHeader
+                columnContent="Name"
+                sortHandler={this.handleSortClick.bind(null, "hostname")}
+                sortDirection={sortColumn === "hostname" ? sortDirection : null}
+              />
+            }
+            cellRenderer={hostnameRenderer}
+            width={hostnameSizer}
+          />
 
-        <Column
-          header={
-            <SortableColumnHeader
-              columnContent="Type"
-              sortHandler={this.handleSortClick.bind(null, "type")}
-              sortDirection={sortColumn === "type" ? sortDirection : null}
-            />
-          }
-          cellRenderer={typeRenderer}
-          width={typeSizer}
-        />
+          <Column
+            header={
+              <SortableColumnHeader
+                columnContent="Type"
+                sortHandler={this.handleSortClick.bind(null, "type")}
+                sortDirection={sortColumn === "type" ? sortDirection : null}
+              />
+            }
+            cellRenderer={typeRenderer}
+            width={typeSizer}
+          />
 
-        <Column
-          header={
-            <SortableColumnHeader
-              columnContent="Region"
-              sortHandler={this.handleSortClick.bind(null, "region")}
-              sortDirection={sortColumn === "region" ? sortDirection : null}
-            />
-          }
-          cellRenderer={this.regionRenderer}
-          width={regionSizer}
-        />
+          <Column
+            header={
+              <SortableColumnHeader
+                columnContent="Region"
+                sortHandler={this.handleSortClick.bind(null, "region")}
+                sortDirection={sortColumn === "region" ? sortDirection : null}
+              />
+            }
+            cellRenderer={this.regionRenderer}
+            width={regionSizer}
+          />
 
-        <Column
-          header={
-            <SortableColumnHeader
-              columnContent="Zone"
-              sortHandler={this.handleSortClick.bind(null, "zone")}
-              sortDirection={sortColumn === "zone" ? sortDirection : null}
-            />
-          }
-          cellRenderer={zoneRenderer}
-          width={zoneSizer}
-        />
+          <Column
+            header={
+              <SortableColumnHeader
+                columnContent="Zone"
+                sortHandler={this.handleSortClick.bind(null, "zone")}
+                sortDirection={sortColumn === "zone" ? sortDirection : null}
+              />
+            }
+            cellRenderer={zoneRenderer}
+            width={zoneSizer}
+          />
 
-        <Column
-          header={
-            <SortableColumnHeader
-              columnContent="Health"
-              sortHandler={this.handleSortClick.bind(null, "health")}
-              sortDirection={sortColumn === "health" ? sortDirection : null}
-            />
-          }
-          cellRenderer={healthRenderer}
-          width={healthSizer}
-        />
+          <Column
+            header={
+              <SortableColumnHeader
+                columnContent="Health"
+                sortHandler={this.handleSortClick.bind(null, "health")}
+                sortDirection={sortColumn === "health" ? sortDirection : null}
+              />
+            }
+            cellRenderer={healthRenderer}
+            width={healthSizer}
+          />
 
-        <Column
-          header={
-            <SortableColumnHeader
-              columnContent="Tasks"
-              sortHandler={this.handleSortClick.bind(null, "tasks")}
-              sortDirection={sortColumn === "tasks" ? sortDirection : null}
-            />
-          }
-          cellRenderer={tasksRenderer}
-          width={tasksSizer}
-        />
+          <Column
+            header={
+              <SortableColumnHeader
+                columnContent="Tasks"
+                sortHandler={this.handleSortClick.bind(null, "tasks")}
+                sortDirection={sortColumn === "tasks" ? sortDirection : null}
+              />
+            }
+            cellRenderer={tasksRenderer}
+            width={tasksSizer}
+          />
 
-        <Column
-          header={<span title="CPUBar" />}
-          cellRenderer={cpubarRenderer}
-          width={cpubarSizer}
-        />
+          <Column
+            header={<span title="CPUBar" />}
+            cellRenderer={cpubarRenderer}
+            width={cpubarSizer}
+          />
 
-        <Column
-          header={
-            <SortableColumnHeader
-              columnContent="CPU"
-              sortHandler={this.handleSortClick.bind(null, "cpu")}
-              sortDirection={sortColumn === "cpu" ? sortDirection : null}
-            />
-          }
-          cellRenderer={cpuRenderer}
-          width={cpuSizer}
-        />
+          <Column
+            header={
+              <SortableColumnHeader
+                columnContent="CPU"
+                sortHandler={this.handleSortClick.bind(null, "cpu")}
+                sortDirection={sortColumn === "cpu" ? sortDirection : null}
+              />
+            }
+            cellRenderer={cpuRenderer}
+            width={cpuSizer}
+          />
 
-        <Column
-          header={<span title="MemBar" />}
-          cellRenderer={membarRenderer}
-          width={membarSizer}
-        />
+          <Column
+            header={<span title="MemBar" />}
+            cellRenderer={membarRenderer}
+            width={membarSizer}
+          />
 
-        <Column
-          header={
-            <SortableColumnHeader
-              columnContent="Mem"
-              sortHandler={this.handleSortClick.bind(null, "mem")}
-              sortDirection={sortColumn === "mem" ? sortDirection : null}
-            />
-          }
-          cellRenderer={memRenderer}
-          width={memSizer}
-        />
+          <Column
+            header={
+              <SortableColumnHeader
+                columnContent="Mem"
+                sortHandler={this.handleSortClick.bind(null, "mem")}
+                sortDirection={sortColumn === "mem" ? sortDirection : null}
+              />
+            }
+            cellRenderer={memRenderer}
+            width={memSizer}
+          />
 
-        <Column
-          header={<span title="DiskBar" />}
-          cellRenderer={diskbarRenderer}
-          width={diskbarSizer}
-        />
+          <Column
+            header={<span title="DiskBar" />}
+            cellRenderer={diskbarRenderer}
+            width={diskbarSizer}
+          />
 
-        <Column
-          header={
-            <SortableColumnHeader
-              columnContent="Disk"
-              sortHandler={this.handleSortClick.bind(null, "disk")}
-              sortDirection={sortColumn === "disk" ? sortDirection : null}
-            />
-          }
-          cellRenderer={diskRenderer}
-          width={diskSizer}
-        />
+          <Column
+            header={
+              <SortableColumnHeader
+                columnContent="Disk"
+                sortHandler={this.handleSortClick.bind(null, "disk")}
+                sortDirection={sortColumn === "disk" ? sortDirection : null}
+              />
+            }
+            cellRenderer={diskRenderer}
+            width={diskSizer}
+          />
 
-        <Column
-          header={<span title="GPUBar" />}
-          cellRenderer={gpubarRenderer}
-          width={gpubarSizer}
-        />
+          <Column
+            header={<span title="GPUBar" />}
+            cellRenderer={gpubarRenderer}
+            width={gpubarSizer}
+          />
 
-        <Column
-          header={
-            <SortableColumnHeader
-              columnContent="GPU"
-              sortHandler={this.handleSortClick.bind(null, "gpu")}
-              sortDirection={sortColumn === "gpu" ? sortDirection : null}
-            />
-          }
-          cellRenderer={gpuRenderer}
-          width={gpuSizer}
-        />
-      </Table>
+          <Column
+            header={
+              <SortableColumnHeader
+                columnContent="GPU"
+                sortHandler={this.handleSortClick.bind(null, "gpu")}
+                sortDirection={sortColumn === "gpu" ? sortDirection : null}
+              />
+            }
+            cellRenderer={gpuRenderer}
+            width={gpuSizer}
+          />
+        </Table>
+      </div>
     );
   }
 }

--- a/plugins/nodes/src/js/pages/NodesOverview.js
+++ b/plugins/nodes/src/js/pages/NodesOverview.js
@@ -255,7 +255,7 @@ var NodesOverview = React.createClass({
     const isFiltering = filterExpression && filterExpression.defined;
 
     return (
-      <Page>
+      <Page dontScroll>
         <Page.Header breadcrumbs={<NodeBreadcrumbs />} />
         <HostsPageContent
           byServiceFilter={byServiceFilter}

--- a/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
+++ b/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
@@ -201,7 +201,7 @@ class HostsPageContent extends React.Component {
     } = this.props;
 
     return (
-      <div>
+      <div className="flex-item-grow-1 flex flex-direction-top-to-bottom">
         <FilterHeadline
           currentLength={filteredNodeCount}
           isFiltering={isFiltering}


### PR DESCRIPTION
The NodesTable only showed two rows as this container was too small

Closes DCOS-39901

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

Run this branch against soak and see if the nodes table has the entire height of the leftover space of the screen and also if there are not two scroll bars


## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- We had to add a display: flex to one of the main gemini scrollbar components. If there is a different solution I am not aware of, please tell.

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->
None