### PR TITLE
[1.11] DCOS-39877: remove flickering filter bug

### DIFF
--- a/plugins/services/src/js/components/dsl/FuzzyTextDSLSection.js
+++ b/plugins/services/src/js/components/dsl/FuzzyTextDSLSection.js
@@ -45,10 +45,9 @@ class FuzzyTextDSLSection extends React.Component {
 
   handleTextChange(event) {
     const { onChange, expression } = this.props;
-    const { target } = event;
-    event.stopPropagation();
+    const { target: { value } } = event;
 
-    const value = target.value;
+    event.stopPropagation();
     this.setState({
       data: Object.assign({}, this.state.data, {
         text: value

--- a/src/js/components/DSLFormDropdownPanel.js
+++ b/src/js/components/DSLFormDropdownPanel.js
@@ -55,8 +55,7 @@ class DSLFormDropdownPanel extends React.Component {
    * @param {DSLExpression} expression - The new expression
    */
   handleChange(expression) {
-    this.setState({ expression });
-    this.props.onChange(expression);
+    this.setState({ expression }, () => this.props.onChange(expression));
   }
 
   /**

--- a/src/js/components/DSLFormDropdownPanel.js
+++ b/src/js/components/DSLFormDropdownPanel.js
@@ -56,6 +56,7 @@ class DSLFormDropdownPanel extends React.Component {
    */
   handleChange(expression) {
     this.setState({ expression });
+    this.props.onChange(expression);
   }
 
   /**

--- a/tests/pages/services/ServiceDetail-cy.js
+++ b/tests/pages/services/ServiceDetail-cy.js
@@ -89,6 +89,86 @@ describe("Service Detail Page", function() {
         cy.hash().should("match", /services\/detail\/%2Fsleep\/volumes.*/);
       });
     });
+
+    context("Filter Tasks", function() {
+      const DEFAULT_ROWS = 3; // Headline plus invisible rows
+      beforeEach(function() {
+        cy.visitUrl({
+          url: "/services/detail/%2Fsleep/tasks"
+        });
+      });
+
+      it("starts with no filters", function() {
+        cy.get(".table tr").should("to.have.length", DEFAULT_ROWS + 3);
+      });
+
+      it("can filter tasks by status", function() {
+        cy
+          .get('use[*|href$="#icon-system--caret-down"]')
+          .click({ force: true });
+
+        // Disable active
+        cy.contains("Active").click({ force: true });
+
+        // Enable completed
+        cy.contains("Completed").click({ force: true });
+
+        // Wait a moment to check it doesn't flip back
+        cy.wait(500);
+
+        // Apply filter
+        cy.contains("Apply").click({ force: true });
+
+        cy.get(".table tr.inactive").should("to.have.length", 22);
+      });
+
+      it("can filter tasks by name", function() {
+        cy
+          .get('use[*|href$="#icon-system--caret-down"]')
+          .click({ force: true });
+
+        // Disable active
+        cy.contains("Active").click({ force: true });
+
+        cy
+          .get(".dsl-form-group input[name='text']")
+          .type("sleep.7084272b-6b76-11e5-a953-08002719334c");
+
+        // Wait a moment to check it doesn't flip back
+        cy.wait(500);
+
+        // Apply filter
+        cy.contains("Apply").click({ force: true });
+
+        cy.get(".table tr").should("to.have.length", DEFAULT_ROWS + 1);
+      });
+
+      it("can filter tasks by zone", function() {
+        cy
+          .get('use[*|href$="#icon-system--caret-down"]')
+          .click({ force: true });
+
+        // Enable zone
+        cy.contains("ap-northeast-1a").click({ force: true });
+
+        // Wait a moment to check it doesn't flip back
+        cy.wait(500);
+
+        // Apply filter
+        cy.contains("Apply").click({ force: true });
+
+        cy.get(".table tr").should("to.have.length", DEFAULT_ROWS + 1);
+      });
+
+      it("can filter by typing a filter", function() {
+        cy
+          .get(".filter-input-text")
+          .focus()
+          .clear()
+          .type("region:ap-northeast-1");
+        cy.get(".table tr").should("to.have.length", DEFAULT_ROWS + 1);
+      });
+    });
   });
 
   context("SDK Services", function() {


### PR DESCRIPTION
## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

- Check the tasks page for a service and verify that the fuzzy search loses it's content if "apply" is not pressed directly
- Check this branch out and verify that the content of the fuzzy search is directly applied

### Before
![old](https://user-images.githubusercontent.com/1337046/43764369-90dce2c6-9a2d-11e8-92fe-90ced7c91d88.gif)

### After

![new](https://user-images.githubusercontent.com/1337046/43764378-99b9da7a-9a2d-11e8-8335-7206efe11c9e.gif)


## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- There might have been a way to fix the bug without applying the fuzzy search directly to the search, but this was inconsistent with the buttons already (they apply directly) I decided to fix forward here and change the behavior (from my point of view) to the benefit of the customer.
- Decided for integration tests as there were no tests at all for this area. I thought system tests might not be necessary as it's more of a UI-only problem.


## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

- [x] Would like to have a small nod from @AmrAbdelrazik, @lilysamimi or @leemunroe as we have a little behaviour change here