### PR TITLE
fix: cluster dropdown extra margin

### DIFF
--- a/src/styles/components/user-account-dropdown/styles.less
+++ b/src/styles/components/user-account-dropdown/styles.less
@@ -84,6 +84,10 @@
       display: none;
     }
 
+    li:empty + .dropdown-menu-section-header {
+      margin-top: 0;
+    }
+
     &-public-ip {
 
       li& {


### PR DESCRIPTION
Remove extra margin on cluster dropdown

Closes DCOS-39963

## Testing

1. `npm start`
2. Create a non-admin user (instruction below)

**How to create a user without metadata access**
![jul-31-2018 17-55-40](https://user-images.githubusercontent.com/549394/43471382-25d3d760-94eb-11e8-9433-af7fdad36ef9.gif)

**Before:**
![screen shot 2018-08-01 at 10 48 43](https://user-images.githubusercontent.com/530632/43511394-8fa113b4-9578-11e8-9f8e-ded9fe0c0478.png)

**After**
![screen shot 2018-08-06 at 12 16 54 pm](https://user-images.githubusercontent.com/549394/43736675-524074d4-9973-11e8-98f9-f634ca8733d5.png)
