### PR TITLE
DCOS-39972: fix spacing between node dials and filter

### DIFF
--- a/plugins/nodes/src/js/components/NodesGridView.js
+++ b/plugins/nodes/src/js/components/NodesGridView.js
@@ -87,7 +87,7 @@ var NodesGridView = React.createClass({
     // Add 'Others' node to the list
     if (activeServiceIds.length > MAX_SERVICES_TO_SHOW) {
       var classNameOther =
-        "service-legend-color service-color-" + OTHER_SERVICES_COLOR;
+        `dot service-color-${OTHER_SERVICES_COLOR}`;
       items.push(
         <li key="other">
           <span className={classNameOther} />

--- a/src/styles/components/filter-bar/styles.less
+++ b/src/styles/components/filter-bar/styles.less
@@ -2,6 +2,7 @@
 
   .filter-bar {
     display: flex;
+    flex-shrink: 0;
     flex-wrap: wrap-reverse;
     width: 100%;
 

--- a/src/styles/components/header-bar/styles.less
+++ b/src/styles/components/header-bar/styles.less
@@ -5,7 +5,7 @@
     display: flex;
     flex-basis: auto;
     flex-grow: 0;
-    flex-shrink: 1;
+    flex-shrink: 0;
     height: @header-bar-height;
     padding-left: @header-bar-horizontal-padding;
     padding-right: @header-bar-horizontal-padding;

--- a/src/styles/components/nodes-grid-view/styles.less
+++ b/src/styles/components/nodes-grid-view/styles.less
@@ -4,6 +4,8 @@
   .nodes-grid {
     display: flex;
     flex-direction: row;
+    overflow-x: hidden;
+    overflow-y: auto;
     position: relative;
 
     .nodes-grid-legend {


### PR DESCRIPTION
* Fixes the spacing between node dials and filter row when the size of the screen is changed
* Fixes the header bar shrinking issue
* Adds a dot for "Other" in the side list
* Adds scrolling for the nodes grid view

Closes DCOS-39972

## Testing

* To see a large number of nodes, set the cluster to a soak cluster
* Verify that the aforementioned points are fixed/added