### PR TITLE
fix(NodesTable): add consistency to link

### DIFF
--- a/plugins/nodes/src/js/components/NodesTable.tsx
+++ b/plugins/nodes/src/js/components/NodesTable.tsx
@@ -188,7 +188,7 @@ export default class NodesTable extends React.Component<
     const { data, sortColumn, sortDirection } = this.state;
 
     return (
-      <div style={{ flexGrow: 1 }}>
+      <div className="table-wrapper">
         <Table data={data.slice()}>
           <Column
             header={

--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -1,3 +1,13 @@
+.table-wrapper {
+  flex-grow: 1;
+
+  .table-cell-link-primary {
+    color: @grey-dark;
+    font-weight: 600;
+    text-decoration: none;
+  }
+}
+
 & when (@table-enabled) {
 
   .table {


### PR DESCRIPTION
> I started to build a new component in the UI Kit called `Link` to wrap the `Link` component from React Router but because it's out of scope I returned to the original fix.

Fix link in NodesTable to add consistency
across tables.

Closes DCOS-39959

## Testing
1. `npm start`
2. Go to Nodes page and note the fix in the column name

**Before**
![screen shot 2018-08-06 at 3 38 23 pm](https://user-images.githubusercontent.com/549394/43744408-ceeea9fe-998e-11e8-8284-ce20e22d5ec0.png)

**After**
![screen shot 2018-08-06 at 3 34 46 pm](https://user-images.githubusercontent.com/549394/43744331-6c81224c-998e-11e8-80d0-38252715bcf0.png)
