### PR TITLE
DCOS-39877: apply changes in fuzzy search directly

### DIFF
--- a/plugins/services/src/js/components/dsl/FuzzyTextDSLSection.js
+++ b/plugins/services/src/js/components/dsl/FuzzyTextDSLSection.js
@@ -10,6 +10,10 @@ import FieldInput from "#SRC/js/components/form/FieldInput";
 import FieldLabel from "#SRC/js/components/form/FieldLabel";
 import FormGroup from "#SRC/js/components/form/FormGroup";
 
+import DSLFilterTypes from "#SRC/js/constants/DSLFilterTypes";
+import { FilterNode } from "#SRC/js/structs/DSLASTNodes";
+import DSLUpdateUtil from "#SRC/js/utils/DSLUpdateUtil";
+
 const EXPRESSION_PARTS = {
   text: DSLExpressionPart.fuzzy
 };
@@ -39,13 +43,40 @@ class FuzzyTextDSLSection extends React.Component {
   }
 
   handleTextChange(event) {
+    const { onChange, expression } = this.props;
     const { target } = event;
     event.stopPropagation();
+
+    const value = target.value;
     this.setState({
       data: Object.assign({}, this.state.data, {
-        text: target.value
+        text: value
       })
     });
+
+    // TODO: find better abstraction here (DCOS-40235)
+    const newFuzzyNodes = value
+      .replace(":", " ")
+      .split(" ")
+      .map(text => {
+        return new FilterNode(0, 0, DSLFilterTypes.FUZZY, { text });
+      });
+
+    const updateNode = EXPRESSION_PARTS["text"];
+    // The node(s) relevant to the property we are updating
+    const matchingNodes = DSLUtil.findNodesByFilter(expression.ast, updateNode);
+
+    // And replace the existing fuzzy nodes
+    const newExpression = DSLUpdateUtil.applyReplace(
+      expression,
+      matchingNodes,
+      newFuzzyNodes,
+      {
+        newCombiner: DSLCombinerTypes.AND
+      }
+    );
+
+    onChange(newExpression);
   }
 
   render() {

--- a/tests/pages/services/ServiceDetail-cy.js
+++ b/tests/pages/services/ServiceDetail-cy.js
@@ -29,8 +29,7 @@ describe("Service Detail Page", function() {
           url: "/services/detail/%2Fsleep"
         });
 
-        cy
-          .get(".menu-tabbed-item .active")
+        cy.get(".menu-tabbed-item .active")
           .contains("Tasks")
           .get(".table")
           .contains("sleep");
@@ -43,16 +42,18 @@ describe("Service Detail Page", function() {
           url: "/services/detail/%2Fsleep"
         });
 
-        cy.get(".menu-tabbed-item").contains("Configuration").click();
+        cy.get(".menu-tabbed-item")
+          .contains("Configuration")
+          .click();
 
-        cy
-          .get(".menu-tabbed-item .active")
+        cy.get(".menu-tabbed-item .active")
           .contains("Configuration")
           .get(".configuration-map");
 
-        cy
-          .hash()
-          .should("match", /services\/detail\/%2Fsleep\/configuration.*/);
+        cy.hash().should(
+          "match",
+          /services\/detail\/%2Fsleep\/configuration.*/
+        );
       });
 
       it("shows debug tab when clicked", function() {
@@ -60,10 +61,11 @@ describe("Service Detail Page", function() {
           url: "/services/detail/%2Fsleep"
         });
 
-        cy.get(".menu-tabbed-item").contains("Debug").click();
+        cy.get(".menu-tabbed-item")
+          .contains("Debug")
+          .click();
 
-        cy
-          .get(".menu-tabbed-item .active")
+        cy.get(".menu-tabbed-item .active")
           .contains("Debug")
           .get(".page-body-content")
           .contains("Last Changes");
@@ -76,17 +78,102 @@ describe("Service Detail Page", function() {
           url: "/services/detail/%2Fsleep"
         });
 
-        cy.get(".menu-tabbed-item").contains("Volumes").click();
+        cy.get(".menu-tabbed-item")
+          .contains("Volumes")
+          .click();
 
         cy.get(".menu-tabbed-item .active").contains("Volumes");
 
-        cy
-          .get(".table")
+        cy.get(".table")
           .contains("tr", "volume-1")
           .parents(".table")
           .contains("tr", "volume-2");
 
         cy.hash().should("match", /services\/detail\/%2Fsleep\/volumes.*/);
+      });
+    });
+
+    context("Filter Tasks", function() {
+      const DEFAULT_ROWS = 3; // Headline plus invisible rows
+      beforeEach(function() {
+        cy.configureCluster({
+          mesos: "1-task-healthy",
+          nodeHealth: true
+        });
+
+        cy.visitUrl({
+          url: "/services/detail/%2Fsleep/tasks"
+        });
+      });
+
+      it("starts with no filters", function() {
+        cy.get(".table tr").should("to.have.length", DEFAULT_ROWS + 3);
+      });
+
+      it("can filter tasks by status", function() {
+        cy.get('use[*|href$="#icon-system--funnel"]').click({
+          force: true
+        });
+
+        // Disable active
+        cy.contains("Active").click({ force: true });
+
+        // Enable completed
+        cy.contains("Completed").click({ force: true });
+
+        // Wait a moment to check it doesn't flip back
+        cy.wait(500);
+
+        // Apply filter
+        cy.contains("Apply").click({ force: true });
+
+        cy.get(".table tr.inactive").should("to.have.length", 22);
+      });
+
+      it("can filter tasks by name", function() {
+        cy.get('use[*|href$="#icon-system--funnel"]').click({
+          force: true
+        });
+
+        // Disable active
+        cy.contains("Active").click({ force: true });
+
+        cy.get(".dsl-form-group input[name='text']").type(
+          "sleep.7084272b-6b76-11e5-a953-08002719334c"
+        );
+
+        // Wait a moment to check it doesn't flip back
+        cy.wait(500);
+
+        // Apply filter
+        cy.contains("Apply").click({ force: true });
+
+        cy.get(".table tr").should("to.have.length", DEFAULT_ROWS + 1);
+      });
+
+      it("can filter tasks by zone", function() {
+        cy.get('use[*|href$="#icon-system--funnel"]').click({
+          force: true
+        });
+
+        // Enable zone
+        cy.contains("ap-northeast-1a").click({ force: true });
+
+        // Wait a moment to check it doesn't flip back
+        cy.wait(500);
+
+        // Apply filter
+        cy.contains("Apply").click({ force: true });
+
+        cy.get(".table tr").should("to.have.length", DEFAULT_ROWS + 1);
+      });
+
+      it("can filter by typing a filter", function() {
+        cy.get(".filter-input-text")
+          .focus()
+          .clear()
+          .type("region:ap-northeast-1");
+        cy.get(".table tr").should("to.have.length", DEFAULT_ROWS + 1);
       });
     });
   });
@@ -105,10 +192,11 @@ describe("Service Detail Page", function() {
     });
 
     it("edit config button opens the edit flow", function() {
-      cy.get(".container").contains("Edit Config").click();
+      cy.get(".container")
+        .contains("Edit Config")
+        .click();
 
-      cy
-        .location()
+      cy.location()
         .its("hash")
         .should("include", "#/services/detail/%2Fcassandra-healthy/edit");
     });


### PR DESCRIPTION
## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

- Check the tasks page for a service and verify that the fuzzy search loses it's content if "apply" is not pressed directly
- Check this branch out and verify that the content of the fuzzy search is directly applied


### Before
![old](https://user-images.githubusercontent.com/1337046/43764369-90dce2c6-9a2d-11e8-92fe-90ced7c91d88.gif)

### After

![new](https://user-images.githubusercontent.com/1337046/43764378-99b9da7a-9a2d-11e8-8335-7206efe11c9e.gif)

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- There might have been a way to fix the bug without applying the fuzzy search directly to the search, but this was inconsistent with the buttons already (they apply directly) I decided to fix forward here and change the behavior (from my point of view) to the benefit of the customer.
- Decided for integration tests as there were no tests at all for this area. I thought system tests might not be necessary as it's more of a UI-only problem.


## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

- [x] Would like to have a small nod from @AmrAbdelrazik, @lilysamimi or @leemunroe as we have a little behaviour change here