### PR TITLE
DCOS-39889: SortDirection isnt resetted when changing sortColumn

### DIFF
--- a/plugins/nodes/src/js/components/NodesTable.tsx
+++ b/plugins/nodes/src/js/components/NodesTable.tsx
@@ -161,7 +161,9 @@ export default class NodesTable extends React.Component<
 
   handleSortClick(columnName: string): void {
     const toggledDirection =
-      this.state.sortDirection === "ASC" ? "DESC" : "ASC";
+      this.state.sortDirection === "ASC" || this.state.sortColumn !== columnName
+        ? "DESC"
+        : "ASC";
 
     this.setState(
       this.updateData(

--- a/plugins/nodes/src/js/components/__tests__/NodesTable-test.js
+++ b/plugins/nodes/src/js/components/__tests__/NodesTable-test.js
@@ -1,0 +1,6 @@
+/* eslint-disable no-unused-vars */
+const React = require("react");
+/* eslint-enable no-unused-vars */
+
+NodesTable = require("../NodesTable");
+SortableColumnHeader = require("../../../../../packages/ui-kit-stage/SortableColumnHeader");

--- a/plugins/nodes/src/js/components/__tests__/NodesTable-test.js
+++ b/plugins/nodes/src/js/components/__tests__/NodesTable-test.js
@@ -1,6 +1,0 @@
-/* eslint-disable no-unused-vars */
-const React = require("react");
-/* eslint-enable no-unused-vars */
-
-NodesTable = require("../NodesTable");
-SortableColumnHeader = require("../../../../../packages/ui-kit-stage/SortableColumnHeader");


### PR DESCRIPTION
When changing the sorted column, it always sorts by descending order.

related jira: https://jira.mesosphere.com/browse/DCOS-39889

## Testing
In `Nodes` tab, sort some column by descending order (the caret pointing down) 
![screenshot from 2018-08-07 16-14-11](https://user-images.githubusercontent.com/40791275/43777950-fbc0d4b0-9a5c-11e8-9962-bdf3a5b9b931.png)

and then click another column to sort it - the second column should also be sorted by descending order.
![screenshot from 2018-08-07 16-14-20](https://user-images.githubusercontent.com/40791275/43777958-0152c794-9a5d-11e8-8116-ea82f7a9bb40.png)


## Trade-offs
Decided for a concise check.

## Dependencies
None.