### PR TITLE
DCOS-39896: add region information getter to struct

### DIFF
--- a/plugins/services/src/js/structs/Service.js
+++ b/plugins/services/src/js/structs/Service.js
@@ -7,6 +7,10 @@ import ServiceSpec from "./ServiceSpec";
 import VolumeList from "./VolumeList";
 
 module.exports = class Service extends Item {
+  constructor() {
+    super(...arguments);
+    this._regions = undefined;
+  }
   getId() {
     return this.get("id") || "";
   }
@@ -52,6 +56,27 @@ module.exports = class Service extends Item {
 
   getServiceStatus() {
     return ServiceStatus.NA;
+  }
+
+  getRegions() {
+    if (!this._regions) {
+      const regionCounts = (this.get("tasks") || []).reduce(
+        (regions, { region }) => {
+          if (region) {
+            regions[region] = regions[region] ? regions[region] + 1 : 1;
+          }
+
+          return regions;
+        },
+        {}
+      );
+
+      this._regions = Object.keys(regionCounts).sort(
+        (a, b) => regionCounts[b] - regionCounts[a]
+      );
+    }
+
+    return this._regions;
   }
 
   getImages() {

--- a/plugins/services/src/js/structs/__tests__/Service-test.js
+++ b/plugins/services/src/js/structs/__tests__/Service-test.js
@@ -32,6 +32,26 @@ describe("Service", function() {
     });
   });
 
+  describe("#getRegions", function() {
+    it("returns default correct regions data", function() {
+      expect(
+        new Service({
+          tasks: [
+            { region: "a" },
+            { region: "b" },
+            { region: "a" },
+            { region: "a" },
+            { region: "b" },
+            {}
+          ]
+        }).getRegions()
+      ).toEqual(["a", "b"]);
+    });
+    it("returns empty array for service without tasks", function() {
+      expect(new Service({}).getRegions()).toEqual([]);
+    });
+  });
+
   describe("#getRunningInstancesCount", function() {
     it("returns the number of reported tasks", function() {
       const service = new Service({


### PR DESCRIPTION
## Testing

This PR only adds the getter to our struct - `npm test`
<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

I decided to sort the regions by taskcount and generate & store the array on first read
<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->
