### PR TITLE
DCOS-39900: Service Version on Services Table

### DIFF
--- a/plugins/services/src/js/constants/ServiceTableHeaderLabels.js
+++ b/plugins/services/src/js/constants/ServiceTableHeaderLabels.js
@@ -5,6 +5,7 @@ var ServiceTableHeaderLabels = {
   mem: "Mem",
   name: "Name",
   status: "Status",
+  version: "Version",
   instances: "Instances"
 };
 

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -43,6 +43,7 @@ const StatusMapping = {
 const columnClasses = {
   name: "service-table-column-name",
   status: "service-table-column-status",
+  version: "service-table-column-version",
   instances: "service-table-column-instances",
   cpus: "service-table-column-cpus",
   mem: "service-table-column-mem",
@@ -389,6 +390,15 @@ class ServicesTable extends React.Component {
     return <span>{Units.formatResource(prop, resource)}</span>;
   }
 
+  renderVersion(prop, service) {
+    if (!service.getVersion || service.getVersion === "") {
+      return null;
+    }
+    const version = service.getVersion();
+
+    return <Tooltip content={version}>{version}</Tooltip>;
+  }
+
   renderInstances(prop, service) {
     const instancesCount = service.getInstancesCount();
     const runningInstances = service.getRunningInstancesCount();
@@ -463,6 +473,15 @@ class ServicesTable extends React.Component {
       {
         className: this.getCellClasses,
         headerClassName: this.getCellClasses,
+        prop: "version",
+        render: this.renderVersion,
+        sortable: false,
+        sortFunction: ServiceTableUtil.propCompareFunctionFactory,
+        heading
+      },
+      {
+        className: this.getCellClasses,
+        headerClassName: this.getCellClasses,
         prop: "instances",
         render: this.renderInstances,
         sortable: true,
@@ -523,6 +542,7 @@ class ServicesTable extends React.Component {
       <colgroup>
         <col className={columnClasses.name} />
         <col className={columnClasses.status} />
+        <col className={columnClasses.version} />
         <col className={columnClasses.instances} />
         <col className={columnClasses.cpus} />
         <col className={columnClasses.mem} />

--- a/plugins/services/src/js/structs/Framework.js
+++ b/plugins/services/src/js/structs/Framework.js
@@ -22,6 +22,13 @@ module.exports = class Framework extends Application {
     return this.getLabels().DCOS_PACKAGE_NAME;
   }
 
+  /**
+   * @override
+   */
+  getVersion() {
+    return this.getLabels().DCOS_PACKAGE_VERSION;
+  }
+
   getFrameworkName() {
     return this.getLabels().DCOS_PACKAGE_FRAMEWORK_NAME;
   }

--- a/plugins/services/src/js/structs/Pod.js
+++ b/plugins/services/src/js/structs/Pod.js
@@ -205,6 +205,13 @@ module.exports = class Pod extends Service {
     );
   }
 
+  /**
+   * @override
+   */
+  getVersion() {
+    return this.getSpec().getVersion();
+  }
+
   getVolumesData() {
     return new VolumeList({ items: this.get("volumeData") || [] });
   }

--- a/plugins/services/src/js/structs/Service.js
+++ b/plugins/services/src/js/structs/Service.js
@@ -66,6 +66,10 @@ module.exports = class Service extends Item {
     return null;
   }
 
+  getVersion() {
+    return "";
+  }
+
   getInstancesCount() {
     return 0;
   }

--- a/plugins/services/src/js/structs/__tests__/Framework-test.js
+++ b/plugins/services/src/js/structs/__tests__/Framework-test.js
@@ -60,6 +60,27 @@ describe("Framework", function() {
     });
   });
 
+  describe("#getVersion", function() {
+    it("returns correct version", function() {
+      const service = new Framework({
+        id: "/test/framework",
+        labels: {
+          DCOS_PACKAGE_VERSION: "1"
+        }
+      });
+
+      expect(service.getVersion()).toEqual("1");
+    });
+
+    it("returns undefined if package version is undefined", function() {
+      const service = new Framework({
+        id: "/test/framework"
+      });
+
+      expect(service.getVersion()).toEqual(undefined);
+    });
+  });
+
   describe("#getFrameworkName", function() {
     it("returns correct name", function() {
       const service = new Framework({

--- a/plugins/services/src/js/structs/__tests__/Pod-test.js
+++ b/plugins/services/src/js/structs/__tests__/Pod-test.js
@@ -83,6 +83,18 @@ describe("Pod", function() {
     });
   });
 
+  describe("#getVersion", function() {
+    it("returns correct version", function() {
+      const pod = new Pod({
+        spec: {
+          version: "2016-03-22T10:46:07.354Z"
+        }
+      });
+
+      expect(pod.getVersion()).toEqual("2016-03-22T10:46:07.354Z");
+    });
+  });
+
   describe("#getLabels", function() {
     it("passes through from specs", function() {
       const pod = new Pod(PodFixture);

--- a/src/styles/components/service-table/styles.less
+++ b/src/styles/components/service-table/styles.less
@@ -37,6 +37,10 @@
         width: 115px;
       }
 
+      &-version {
+        width: 115px;
+      }
+
       &-instances {
         width: 115px;
 
@@ -88,7 +92,7 @@
       &-column {
 
         &-name {
-          width: 73px;
+          width: 100px;
         }
 
         &-instances {
@@ -102,7 +106,8 @@
           width: 60px;
         }
 
-        &-status {
+        &-status,
+        &-version {
           width: 100px;
         }
 
@@ -144,7 +149,8 @@
           }
         }
 
-        &-status {
+        &-status,
+        &-version {
           width: 70px;
         }
 


### PR DESCRIPTION
ℹ️ This is a Feature Branch, all code already go reviewed on its own, but please make sure that this branch also works as expected 👍 

--- 

## Testing

When this is done there are Package Version Information on Services Table, like this:
![screen shot 2018-08-16 at 17 34 57](https://user-images.githubusercontent.com/530632/44218795-c223ac80-a17a-11e8-9926-a16e6a5cec4a.png)

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

We decided to just plain display the full given version string, there is a feature request against packaging to add the base tech as dedicated field to the API - currently we do not have a reliable data source to take the information from :( 
<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->
