### PR TITLE
refactor(styles.less): center resource switch dropdown items properly

### DIFF
--- a/src/styles/components/resource-switch-dropdown/styles.less
+++ b/src/styles/components/resource-switch-dropdown/styles.less
@@ -43,7 +43,7 @@
       }
 
       > :not(.selected) {
-        margin-left: 21px;
+        margin: 0 auto;
       }
 
       &:hover {


### PR DESCRIPTION
* Remove the hacky method of centering for something proper :)

## Testing

* Check resource switch dropdown items are centered