### PR TITLE
DCOS-39897: Add Region Column to Services Table

### DIFF
--- a/plugins/services/src/js/constants/ServiceTableHeaderLabels.js
+++ b/plugins/services/src/js/constants/ServiceTableHeaderLabels.js
@@ -6,7 +6,8 @@ var ServiceTableHeaderLabels = {
   name: "Name",
   status: "Status",
   version: "Version",
-  instances: "Instances"
+  instances: "Instances",
+  regions: "Region"
 };
 
 module.exports = ServiceTableHeaderLabels;

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -15,6 +15,7 @@ import ResourceTableUtil from "#SRC/js/utils/ResourceTableUtil";
 import TableUtil from "#SRC/js/utils/TableUtil";
 import Units from "#SRC/js/utils/Units";
 import { isSDKService } from "#SRC/js/utils/ServiceUtil";
+import CompositeState from "#SRC/js/structs/CompositeState";
 import ServiceStatusProgressBar from "../../components/ServiceStatusProgressBar";
 import Pod from "../../structs/Pod";
 import Service from "../../structs/Service";
@@ -44,6 +45,7 @@ const columnClasses = {
   name: "service-table-column-name",
   status: "service-table-column-status",
   version: "service-table-column-version",
+  regions: "service-table-column-regions",
   instances: "service-table-column-instances",
   cpus: "service-table-column-cpus",
   mem: "service-table-column-mem",
@@ -58,6 +60,7 @@ const METHODS_TO_BIND = [
   "handleActionDisabledModalOpen",
   "handleActionDisabledModalClose",
   "renderHeadline",
+  "renderRegions",
   "renderStats",
   "renderStatus",
   "renderServiceActions"
@@ -238,6 +241,21 @@ class ServicesTable extends React.Component {
         </span>
       </div>
     );
+  }
+
+  renderRegions(prop, service) {
+    const localRegion = CompositeState.getMasterNode().getRegionName();
+    let regions = service.getRegions();
+
+    regions = regions.map(
+      region => (region === localRegion ? region + " (Local)" : region)
+    );
+
+    if (regions.length === 0) {
+      regions.push("N/A");
+    }
+
+    return <span title={regions.join(", ")}>{regions.join(", ")}</span>;
   }
 
   renderServiceActions(prop, service) {
@@ -482,6 +500,15 @@ class ServicesTable extends React.Component {
       {
         className: this.getCellClasses,
         headerClassName: this.getCellClasses,
+        prop: "regions",
+        render: this.renderRegions,
+        sortable: true,
+        sortFunction: ServiceTableUtil.propCompareFunctionFactory,
+        heading
+      },
+      {
+        className: this.getCellClasses,
+        headerClassName: this.getCellClasses,
         prop: "instances",
         render: this.renderInstances,
         sortable: true,
@@ -543,6 +570,7 @@ class ServicesTable extends React.Component {
         <col className={columnClasses.name} />
         <col className={columnClasses.status} />
         <col className={columnClasses.version} />
+        <col className={columnClasses.regions} />
         <col className={columnClasses.instances} />
         <col className={columnClasses.cpus} />
         <col className={columnClasses.mem} />

--- a/plugins/services/src/js/containers/services/__tests__/ServicesTable-test.js
+++ b/plugins/services/src/js/containers/services/__tests__/ServicesTable-test.js
@@ -194,4 +194,39 @@ describe("ServicesTable", function() {
       expect(disksCell.text()).toEqual("0 B");
     });
   });
+
+  describe("#renderRegions", function() {
+    const renderRegions =
+      ServicesTable.WrappedComponent.prototype.renderRegions;
+    let mockService;
+    beforeEach(function() {
+      mockService = {
+        getRegions: jest.fn()
+      };
+    });
+
+    it("renders with no regions", function() {
+      mockService.getRegions.mockReturnValue([]);
+
+      expect(
+        renderer.create(renderRegions(null, mockService)).toJSON()
+      ).toMatchSnapshot();
+    });
+
+    it("renders with one region", function() {
+      mockService.getRegions.mockReturnValue(["aws/eu-central-1"]);
+
+      expect(
+        renderer.create(renderRegions(null, mockService)).toJSON()
+      ).toMatchSnapshot();
+    });
+
+    it("renders with multiple regions", function() {
+      mockService.getRegions.mockReturnValue(["aws/eu-central-1", "dc-east"]);
+
+      expect(
+        renderer.create(renderRegions(null, mockService)).toJSON()
+      ).toMatchSnapshot();
+    });
+  });
 });

--- a/plugins/services/src/js/containers/services/__tests__/__snapshots__/ServicesTable-test.js.snap
+++ b/plugins/services/src/js/containers/services/__tests__/__snapshots__/ServicesTable-test.js.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ServicesTable #renderRegions renders with multiple regions 1`] = `
+<span
+  title="aws/eu-central-1, dc-east"
+>
+  aws/eu-central-1, dc-east
+</span>
+`;
+
+exports[`ServicesTable #renderRegions renders with no regions 1`] = `
+<span
+  title="N/A"
+>
+  N/A
+</span>
+`;
+
+exports[`ServicesTable #renderRegions renders with one region 1`] = `
+<span
+  title="aws/eu-central-1"
+>
+  aws/eu-central-1
+</span>
+`;
+
 exports[`ServicesTable #renderStatus renders with deploying status 1`] = `
 <div
   className="flex"

--- a/plugins/services/src/js/structs/ServiceTree.js
+++ b/plugins/services/src/js/structs/ServiceTree.js
@@ -66,6 +66,10 @@ module.exports = class ServiceTree extends Tree {
     return null;
   }
 
+  getRegions() {
+    return [];
+  }
+
   getHealth() {
     return this.reduceItems(function(aggregatedHealth, item) {
       if (item instanceof Service) {

--- a/src/styles/components/service-table/styles.less
+++ b/src/styles/components/service-table/styles.less
@@ -41,6 +41,10 @@
         width: 115px;
       }
 
+      &-regions {
+        width: 115px;
+      }
+
       &-instances {
         width: 115px;
 
@@ -111,6 +115,10 @@
           width: 100px;
         }
 
+        &-regions {
+          width: 110px;
+        }
+
         &-actions {
           width: 30px;
         }
@@ -152,6 +160,10 @@
         &-status,
         &-version {
           width: 70px;
+        }
+
+        &-regions {
+          width: 80px;
         }
 
         &-actions {
@@ -201,6 +213,10 @@
           width: 78px;
         }
 
+        &-regions {
+          width: 88px;
+        }
+
         &-actions {
           width: 30px;
         }
@@ -231,6 +247,10 @@
 
         &-status {
           width: 115px;
+        }
+
+        &-regions {
+          width: 125px;
         }
 
         &-instances {


### PR DESCRIPTION
⚠️ this PR now also includes DCOS-39898 - it completely finishes the feature 👍 

---

## Testing
Go to `Services` Tab and make sure that the new `Region` column is displayed and it works correctly.

Run `npm run test /plugins/services/src/js/containers/services/__tests__` to vertify that the new tests that I added run successfully.

## Trade-offs
I've updated the tests as well as the snapshots.

The current behavior is that if the regions array is empty, the cell will display "N/A", if there is more than one region they will be shown separated with commas, for example "Region 1, Region 2" and if a region is the same as the local region, it will be shown as "Region (Local)"

For the width of the column for different screen sizes, check out `src/styles/components/service-table/styles.less`, the values I used are slightly larger than the values for the width of the status column in accordance with the jira mock-up:
![image](https://user-images.githubusercontent.com/40791275/44092968-aaba45d2-9fda-11e8-9f63-3d44c453a9b8.png)

I also named the column "Region" and not "Regions" in accordance with the mock-up, although I think that "Regions" can be considered as well, since it is possible to have more than one region.

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2018-08-14 15-54-25](https://user-images.githubusercontent.com/40791275/44092879-5abd5722-9fda-11e8-91c9-eec7e733f144.png)

### After
![screenshot from 2018-08-14 15-47-13](https://user-images.githubusercontent.com/40791275/44092886-60e951dc-9fda-11e8-921a-b627329f7885.png)


