### PR TITLE
Add branch name to the slack message

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,7 +138,7 @@ pipeline {
         slackSend (
           channel: "#frontend-ci-status",
           color: "danger",
-          message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.RUN_DISPLAY_URL})",
+          message: "FAILED\nBranch: ${env.CHANGE_BRANCH}\nJob: <${env.RUN_DISPLAY_URL}|${env.JOB_NAME} [${env.BUILD_NUMBER}]>",
           teamDomain: "mesosphere",
           token: "${env.SLACK_TOKEN}",
         )
@@ -151,7 +151,7 @@ pipeline {
         slackSend (
           channel: "#frontend-ci-status",
           color: "warning",
-          message: "UNSTABLE: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.RUN_DISPLAY_URL})",
+          message: "UNSTABLE\nBranch: ${env.CHANGE_BRANCH}\nJob: <${env.RUN_DISPLAY_URL}|${env.JOB_NAME} [${env.BUILD_NUMBER}]>",
           teamDomain: "mesosphere",
           token: "${env.SLACK_TOKEN}",
         )


### PR DESCRIPTION
Problem: I can'e operate PR numbers, though our branch names are rather informative. This PR is an attempt to make `#frontend-ci-status` more helpful for me and maybe for everyone else.

## Testing

I'll re-run the PR couple of times to kick in flaky tests and see if slack message improves.

## Trade-offs

I decided not investing any time in a research whether we have PR title as an env var. I believe we should though. So I wen with a branch name for starters.