### PR TITLE
DCOS-20989: use CosmosPackagesStores icons for Services Page

### DIFF
--- a/plugins/services/src/js/pages/ServicesPage.js
+++ b/plugins/services/src/js/pages/ServicesPage.js
@@ -6,6 +6,8 @@ import Icon from "#SRC/js/components/Icon";
 import RouterUtil from "#SRC/js/utils/RouterUtil";
 import TabsMixin from "#SRC/js/mixins/TabsMixin";
 
+import CosmosPackagesStore from "#SRC/js/stores/CosmosPackagesStore";
+
 var ServicesPage = React.createClass({
   contextTypes: {
     router: routerShape
@@ -37,6 +39,10 @@ var ServicesPage = React.createClass({
       "/services/overview": "Services"
     };
     this.updateCurrentTab();
+  },
+
+  componentDidMount() {
+    CosmosPackagesStore.fetchAvailablePackages();
   },
 
   componentDidUpdate() {

--- a/plugins/services/src/js/stores/MarathonStore.js
+++ b/plugins/services/src/js/stores/MarathonStore.js
@@ -4,6 +4,7 @@ import { SERVER_ACTION } from "#SRC/js/constants/ActionTypes";
 import AppDispatcher from "#SRC/js/events/AppDispatcher";
 import CompositeState from "#SRC/js/structs/CompositeState";
 import Config from "#SRC/js/config/Config";
+import CosmosPackagesStore from "#SRC/js/stores/CosmosPackagesStore";
 import GetSetBaseStore from "#SRC/js/stores/GetSetBaseStore";
 import VisibilityStore from "#SRC/js/stores/VisibilityStore";
 
@@ -85,6 +86,9 @@ import {
 import Framework from "../structs/Framework";
 import ServiceImages from "../constants/ServiceImages";
 import ServiceTree from "../structs/ServiceTree";
+
+import FrameworkUtil from "../utils/FrameworkUtil";
+import ServiceValidatorUtil from "../utils/ServiceValidatorUtil";
 
 let requestInterval = null;
 let shouldEmbedLastUnusedOffers = false;
@@ -226,6 +230,7 @@ class MarathonStore extends GetSetBaseStore {
           this.emit(MARATHON_SERVICE_RESTART_SUCCESS);
           break;
         case REQUEST_MARATHON_GROUPS_SUCCESS:
+          this.injectGroupsWithPackageImages(action.data);
           this.processMarathonGroups(action.data);
           break;
         case REQUEST_MARATHON_DEPLOYMENTS_SUCCESS:
@@ -461,6 +466,16 @@ class MarathonStore extends GetSetBaseStore {
 
   getServiceFromName(name) {
     return this.get("apps")[name];
+  }
+
+  injectGroupsWithPackageImages(data) {
+    data.items.forEach(item => {
+      if (ServiceValidatorUtil.isFrameworkResponse(item)) {
+        item["images"] = FrameworkUtil.extractImageUrls(
+          CosmosPackagesStore.getPackageImages()[item.labels.DCOS_PACKAGE_NAME]
+        );
+      }
+    });
   }
 
   processMarathonInfoRequest(info) {

--- a/plugins/services/src/js/structs/Framework.js
+++ b/plugins/services/src/js/structs/Framework.js
@@ -5,6 +5,8 @@ import {
   ROUTE_ACCESS_PREFIX,
   FRAMEWORK_ID_VALID_CHARACTERS
 } from "../constants/FrameworkConstants";
+import FrameworkUtil from "../utils/FrameworkUtil";
+
 import Application from "./Application";
 import FrameworkSpec from "./FrameworkSpec";
 
@@ -16,6 +18,13 @@ module.exports = class Framework extends Application {
     // it gets as a properties of this object and we want to avoid any naming
     // collisions.
     this._spec = null;
+  }
+
+  /**
+   * @override
+   */
+  getImages() {
+    return FrameworkUtil.getServiceImages(this.get("images"));
   }
 
   getPackageName() {

--- a/plugins/services/src/js/utils/FrameworkUtil.js
+++ b/plugins/services/src/js/utils/FrameworkUtil.js
@@ -1,4 +1,5 @@
 import Util from "#SRC/js/utils/Util";
+import RouterUtil from "#SRC/js/utils/RouterUtil";
 
 import ServiceImages from "../constants/ServiceImages";
 
@@ -38,6 +39,25 @@ const FrameworkUtil = {
     } catch (error) {
       return {};
     }
+  },
+
+  /**
+   * Get service icon images from images object
+   * @param  {Object} packageImages containing urls for the different image sizes
+   * @return {Object}               containing urls from the extracted query string
+   * if all is not available in given object.
+   */
+  extractImageUrls(packageImages) {
+    const images = Object.assign({}, packageImages);
+
+    Object.keys(images).forEach(image => {
+      const queryString = images[image].substring(
+        images[image].lastIndexOf("?")
+      );
+      images[image] = RouterUtil.getQueryStringInUrl(queryString).url;
+    });
+
+    return images;
   },
 
   /**

--- a/src/js/events/CosmosPackagesActions.js
+++ b/src/js/events/CosmosPackagesActions.js
@@ -63,6 +63,8 @@ const CosmosPackagesActions = {
       data: JSON.stringify({ query }),
       success(response) {
         const packages = response.packages || [];
+        const packageImages = {};
+
         const data = packages.map(function(cosmosPackage) {
           if (!cosmosPackage.resource) {
             cosmosPackage.resource = {};
@@ -73,11 +75,14 @@ const CosmosPackagesActions = {
             delete cosmosPackage.images;
           }
 
+          packageImages[cosmosPackage.name] = cosmosPackage.resource.images;
+
           return cosmosPackage;
         });
+
         AppDispatcher.handleServerAction({
           type: REQUEST_COSMOS_PACKAGES_SEARCH_SUCCESS,
-          data,
+          data: { packages: data, images: packageImages },
           query
         });
       },

--- a/src/js/events/__tests__/CosmosPackagesActions-test.js
+++ b/src/js/events/__tests__/CosmosPackagesActions-test.js
@@ -34,7 +34,10 @@ describe("CosmosPackagesActions", function() {
       var id = AppDispatcher.register(function(payload) {
         var action = payload.action;
         AppDispatcher.unregister(id);
-        expect(action.data).toEqual([{ bar: "baz", resource: {} }]);
+        expect(action.data).toEqual({
+          images: { undefined },
+          packages: [{ bar: "baz", resource: {} }]
+        });
       });
 
       thisConfiguration.success({ packages: [{ bar: "baz" }] });

--- a/src/js/stores/CosmosPackagesStore.js
+++ b/src/js/stores/CosmosPackagesStore.js
@@ -65,6 +65,7 @@ class CosmosPackagesStore extends GetSetBaseStore {
     this.getSet_data = {
       availablePackages: [],
       packagesVersions: {},
+      packageImages: {},
       packageDetails: null,
       serviceDetails: null,
       packageVersions: null,
@@ -154,7 +155,8 @@ class CosmosPackagesStore extends GetSetBaseStore {
           );
           break;
         case REQUEST_COSMOS_PACKAGES_SEARCH_SUCCESS:
-          this.processAvailablePackagesSuccess(data, action.query);
+          this.processPackageImagesSuccess(data.images);
+          this.processAvailablePackagesSuccess(data.packages, action.query);
           break;
         case REQUEST_COSMOS_PACKAGES_SEARCH_ERROR:
           this.processAvailablePackagesError(data, action.query);
@@ -316,6 +318,10 @@ class CosmosPackagesStore extends GetSetBaseStore {
     return null;
   }
 
+  getPackageImages() {
+    return this.get("packageImages");
+  }
+
   getServiceDetails() {
     return this.get("serviceDetails");
   }
@@ -337,6 +343,10 @@ class CosmosPackagesStore extends GetSetBaseStore {
     this.set({ availablePackages: packages });
 
     this.emit(COSMOS_SEARCH_CHANGE, query);
+  }
+
+  processPackageImagesSuccess(packageImages) {
+    this.set({ packageImages });
   }
 
   processAvailablePackagesError(error, query) {

--- a/src/js/stores/__tests__/CosmosPackagesStore-test.js
+++ b/src/js/stores/__tests__/CosmosPackagesStore-test.js
@@ -69,13 +69,25 @@ describe("CosmosPackagesStore", function() {
       it("stores availablePackages when event is dispatched", function() {
         AppDispatcher.handleServerAction({
           type: ActionTypes.REQUEST_COSMOS_PACKAGES_SEARCH_SUCCESS,
-          data: [{ gid: "foo", bar: "baz" }],
+          data: { packages: [{ gid: "foo", bar: "baz" }] },
           query: "foo"
         });
 
         var availablePackages = CosmosPackagesStore.getAvailablePackages().getItems();
         expect(availablePackages[0].get("gid")).toEqual("foo");
         expect(availablePackages[0].get("bar")).toEqual("baz");
+      });
+
+      it("stores packageImages when event is dispatched", function() {
+        AppDispatcher.handleServerAction({
+          type: ActionTypes.REQUEST_COSMOS_PACKAGES_SEARCH_SUCCESS,
+          data: { images: { gid: "foo", bar: "baz" } },
+          query: "foo"
+        });
+
+        var packageImages = CosmosPackagesStore.getPackageImages();
+        expect(packageImages["gid"]).toEqual("foo");
+        expect(packageImages["bar"]).toEqual("baz");
       });
 
       it("dispatches the correct event upon success", function() {
@@ -86,7 +98,7 @@ describe("CosmosPackagesStore", function() {
         );
         AppDispatcher.handleServerAction({
           type: ActionTypes.REQUEST_COSMOS_PACKAGES_SEARCH_SUCCESS,
-          data: [{ gid: "foo", bar: "baz" }],
+          data: { packages: [{ gid: "foo", bar: "baz" }] },
           query: "foo"
         });
 

--- a/tests/_fixtures/marathon-1-task/groups-sdk-services.json
+++ b/tests/_fixtures/marathon-1-task/groups-sdk-services.json
@@ -1,17 +1,17 @@
 {
   "id": "/",
   "dependencies": [
-    
+
   ],
   "version": "2017-05-04T16:48:10.710Z",
   "apps": [
-    
+
   ],
   "groups": [
     {
       "id": "/services",
       "dependencies": [
-        
+
       ],
       "version": "2017-05-04T16:48:10.710Z",
       "apps": [
@@ -21,7 +21,7 @@
           "args": null,
           "user": null,
           "env": {
-            
+
           },
           "instances": 1,
           "cpus": 0.1,
@@ -29,13 +29,13 @@
           "disk": 0,
           "executor": "",
           "constraints": [
-            
+
           ],
           "uris": [
-            
+
           ],
           "storeUrls": [
-            
+
           ],
           "ports": [
             10000
@@ -46,10 +46,10 @@
           "maxLaunchDelaySeconds": 3600,
           "container": null,
           "healthChecks": [
-            
+
           ],
           "dependencies": [
-            
+
           ],
           "upgradeStrategy": {
             "minimumHealthCapacity": 1,
@@ -67,16 +67,16 @@
           "tasksHealthy": 0,
           "tasksUnhealthy": 0,
           "deployments": [
-            
+
           ]
         },
         {
-          "id": "/services/sleep",
+          "id": "/services/sdk-sleep-with-image",
           "cmd": "sleep 3000",
           "args": null,
           "user": null,
           "env": {
-            
+
           },
           "instances": 1,
           "cpus": 0.1,
@@ -84,13 +84,13 @@
           "disk": 0,
           "executor": "",
           "constraints": [
-            
+
           ],
           "uris": [
-            
+
           ],
           "storeUrls": [
-            
+
           ],
           "ports": [
             10000
@@ -101,17 +101,24 @@
           "maxLaunchDelaySeconds": 3600,
           "container": null,
           "healthChecks": [
-            
+
           ],
           "dependencies": [
-            
+
           ],
           "upgradeStrategy": {
             "minimumHealthCapacity": 1,
             "maximumOverCapacity": 1
           },
           "labels": {
-            
+            "DCOS_COMMONS_API_VERSION": "v1",
+            "DCOS_PACKAGE_NAME": "test",
+            "DCOS_PACKAGE_FRAMEWORK_NAME": "/services/sdk-sleep"
+          },
+          "images": {
+            "icon-small": "foo.png",
+            "icon-medium": "bar.png",
+            "icon-large": "baz.png"
           },
           "acceptedResourceRoles": null,
           "version": "2015-08-28T01:26:14.620Z",
@@ -120,21 +127,74 @@
           "tasksHealthy": 0,
           "tasksUnhealthy": 0,
           "deployments": [
-            
+
+          ]
+        },
+        {
+          "id": "/services/sleep",
+          "cmd": "sleep 3000",
+          "args": null,
+          "user": null,
+          "env": {
+
+          },
+          "instances": 1,
+          "cpus": 0.1,
+          "mem": 16,
+          "disk": 0,
+          "executor": "",
+          "constraints": [
+
+          ],
+          "uris": [
+
+          ],
+          "storeUrls": [
+
+          ],
+          "ports": [
+            10000
+          ],
+          "requirePorts": false,
+          "backoffSeconds": 1,
+          "backoffFactor": 1.15,
+          "maxLaunchDelaySeconds": 3600,
+          "container": null,
+          "healthChecks": [
+
+          ],
+          "dependencies": [
+
+          ],
+          "upgradeStrategy": {
+            "minimumHealthCapacity": 1,
+            "maximumOverCapacity": 1
+          },
+          "labels": {
+
+          },
+          "acceptedResourceRoles": null,
+          "version": "2015-08-28T01:26:14.620Z",
+          "tasksStaged": 0,
+          "tasksRunning": 1,
+          "tasksHealthy": 0,
+          "tasksUnhealthy": 0,
+          "deployments": [
+
           ]
         }
       ],
       "groups": [
-        
+
       ],
       "pods": [
-        
+
       ]
     },
     {
       "id": "/other",
       "dependencies": [
-        
+
       ],
       "version": "2017-05-04T16:48:10.710Z",
       "apps": [
@@ -144,7 +204,7 @@
           "args": null,
           "user": null,
           "env": {
-            
+
           },
           "instances": 1,
           "cpus": 0.1,
@@ -152,13 +212,13 @@
           "disk": 0,
           "executor": "",
           "constraints": [
-            
+
           ],
           "uris": [
-            
+
           ],
           "storeUrls": [
-            
+
           ],
           "ports": [
             10000
@@ -169,17 +229,17 @@
           "maxLaunchDelaySeconds": 3600,
           "container": null,
           "healthChecks": [
-            
+
           ],
           "dependencies": [
-            
+
           ],
           "upgradeStrategy": {
             "minimumHealthCapacity": 1,
             "maximumOverCapacity": 1
           },
           "labels": {
-            
+
           },
           "acceptedResourceRoles": null,
           "version": "2015-08-28T01:26:14.620Z",
@@ -188,19 +248,19 @@
           "tasksHealthy": 0,
           "tasksUnhealthy": 0,
           "deployments": [
-            
+
           ]
         }
       ],
       "groups": [
-        
+
       ],
       "pods": [
-        
+
       ]
     }
   ],
   "pods": [
-    
+
   ]
 }

--- a/tests/pages/services/ServiceTable-cy.js
+++ b/tests/pages/services/ServiceTable-cy.js
@@ -2,8 +2,7 @@ import { SERVER_RESPONSE_DELAY } from "../../_support/constants/Timeouts";
 
 describe("Service Table", function() {
   function openDropdown(serviceName) {
-    cy
-      .get(".service-table")
+    cy.get(".service-table")
       .contains(serviceName)
       .closest("tr")
       .find(".dropdown")
@@ -11,7 +10,9 @@ describe("Service Table", function() {
   }
 
   function clickDropdownAction(actionText) {
-    cy.get(".dropdown-menu-items").contains(actionText).click();
+    cy.get(".dropdown-menu-items")
+      .contains(actionText)
+      .click();
   }
 
   context("Destroy Action", function() {
@@ -49,14 +50,15 @@ describe("Service Table", function() {
     it("hides the stop option in the service action dropdown", function() {
       openDropdown("sleep");
 
-      cy.get(".dropdown-menu-items li").contains("Stop").should("not.exist");
+      cy.get(".dropdown-menu-items li")
+        .contains("Stop")
+        .should("not.exist");
     });
 
     it("shows the resume option in the service action dropdown", function() {
       openDropdown("sleep");
 
-      cy
-        .get(".dropdown-menu-items li")
+      cy.get(".dropdown-menu-items li")
         .contains("Resume")
         .should("not.have.class", "hidden");
     });
@@ -65,8 +67,7 @@ describe("Service Table", function() {
       openDropdown("sleep");
       clickDropdownAction("Resume");
 
-      cy
-        .get(".modal-header")
+      cy.get(".modal-header")
         .contains("Resume Service")
         .should("have.length", 1);
     });
@@ -102,8 +103,7 @@ describe("Service Table", function() {
       openDropdown("sleep");
       clickDropdownAction("Resume");
 
-      cy
-        .get(".modal-footer .button-primary")
+      cy.get(".modal-footer .button-primary")
         .click()
         .should("have.class", "disabled");
     });
@@ -136,9 +136,10 @@ describe("Service Table", function() {
       clickDropdownAction("Resume");
 
       cy.get(".modal-footer .button-primary").click();
-      cy
-        .get(".modal-body .text-danger")
-        .should("to.have.text", "App is locked by one or more deployments.");
+      cy.get(".modal-body .text-danger").should(
+        "to.have.text",
+        "App is locked by one or more deployments."
+      );
     });
 
     it("shows error message on not authorized", function() {
@@ -155,9 +156,10 @@ describe("Service Table", function() {
       clickDropdownAction("Resume");
 
       cy.get(".modal-footer .button-primary").click();
-      cy
-        .get(".modal-body .text-danger")
-        .should("to.have.text", "Not Authorized to perform this action!");
+      cy.get(".modal-body .text-danger").should(
+        "to.have.text",
+        "Not Authorized to perform this action!"
+      );
     });
 
     it("reenables button after faulty request", function() {
@@ -171,7 +173,9 @@ describe("Service Table", function() {
       openDropdown("sleep");
       clickDropdownAction("Resume");
 
-      cy.get(".modal-footer .button-primary").as("primaryButton").click();
+      cy.get(".modal-footer .button-primary")
+        .as("primaryButton")
+        .click();
       cy.get("@primaryButton").should("have.class", "disabled");
       cy.get("@primaryButton").should("not.have.class", "disabled");
     });
@@ -180,7 +184,9 @@ describe("Service Table", function() {
       openDropdown("sleep");
       clickDropdownAction("Resume");
 
-      cy.get(".modal-footer .button").contains("Cancel").click();
+      cy.get(".modal-footer .button")
+        .contains("Cancel")
+        .click();
       cy.get(".modal-body").should("to.have.length", 0);
     });
   });
@@ -199,15 +205,16 @@ describe("Service Table", function() {
       openDropdown("sdk-sleep");
       clickDropdownAction("Delete");
 
-      cy
-        .get(".modal-header")
+      cy.get(".modal-header")
         .contains("Delete Service")
         .should("to.have.length", 1);
 
       cy.get(".modal-body p").contains("sdk-sleep");
       cy.get(".modal .filter-input-text").should("exist");
 
-      cy.get(".modal button").contains("Cancel").click();
+      cy.get(".modal button")
+        .contains("Cancel")
+        .click();
 
       cy.get(".modal").should("not.exist");
     });
@@ -216,18 +223,17 @@ describe("Service Table", function() {
       openDropdown("sdk-sleep");
       clickDropdownAction("Scale");
 
-      cy
-        .get(".modal-header")
+      cy.get(".modal-header")
         .contains("Scale Service")
         .should("to.have.length", 1);
 
-      cy
-        .get(".modal pre")
-        .contains(
-          "dcos test --name=/services/sdk-sleep update start --options=options.json"
-        );
+      cy.get(".modal pre").contains(
+        "dcos test --name=/services/sdk-sleep update start --options=options.json"
+      );
 
-      cy.get(".modal button").contains("Close").click();
+      cy.get(".modal button")
+        .contains("Close")
+        .click();
 
       cy.get(".modal").should("not.exist");
     });
@@ -235,13 +241,17 @@ describe("Service Table", function() {
     it("restart does not exist", function() {
       openDropdown("sdk-sleep");
 
-      cy.get(".dropdown-menu-items").contains("restart").should("not.exist");
+      cy.get(".dropdown-menu-items")
+        .contains("restart")
+        .should("not.exist");
     });
 
     it("stop does not exist", function() {
       openDropdown("sdk-sleep");
 
-      cy.get(".dropdown-menu-items").contains("stop").should("not.exist");
+      cy.get(".dropdown-menu-items")
+        .contains("stop")
+        .should("not.exist");
     });
   });
 
@@ -259,19 +269,18 @@ describe("Service Table", function() {
       openDropdown("services");
       clickDropdownAction("Delete");
 
-      cy
-        .get(".modal-header")
+      cy.get(".modal-header")
         .contains("Delete Group")
         .should("to.have.length", 1);
 
-      cy
-        .get(".modal-body")
-        .contains(
-          "This group needs to be empty to delete it. Please delete any services in the group first."
-        );
+      cy.get(".modal-body").contains(
+        "This group needs to be empty to delete it. Please delete any services in the group first."
+      );
       cy.get(".modal .filter-input-text").should("not.exist");
 
-      cy.get(".modal button").contains("OK").click();
+      cy.get(".modal button")
+        .contains("OK")
+        .click();
 
       cy.get(".modal").should("not.exist");
     });
@@ -280,22 +289,21 @@ describe("Service Table", function() {
       openDropdown("services");
       clickDropdownAction("Scale");
 
-      cy
-        .get(".modal-header")
+      cy.get(".modal-header")
         .contains("Scale Group")
         .should("to.have.length", 1);
 
-      cy
-        .get(".modal pre")
-        .contains(
-          "dcos test --name=/services/sdk-sleep update start --options=options.json"
-        );
+      cy.get(".modal pre").contains(
+        "dcos test --name=/services/sdk-sleep update start --options=options.json"
+      );
 
-      cy
-        .get(".modal pre")
-        .contains("dcos marathon app update /services/sleep options.json");
+      cy.get(".modal pre").contains(
+        "dcos marathon app update /services/sleep options.json"
+      );
 
-      cy.get(".modal button").contains("Close").click();
+      cy.get(".modal button")
+        .contains("Close")
+        .click();
 
       cy.get(".modal").should("not.exist");
     });

--- a/tests/pages/services/ServiceTable-cy.js
+++ b/tests/pages/services/ServiceTable-cy.js
@@ -201,6 +201,21 @@ describe("Service Table", function() {
       cy.visitUrl({ url: "/services/overview/%2Fservices" });
     });
 
+    it("updates package icon", function() {
+      const imageUrl = "foo.png";
+      const serviceName = "sdk-sleep-with-image";
+
+      cy.get(".service-table")
+        .find(`.icon-image-container img[src="${imageUrl}"]`)
+        .should("exist");
+
+      cy.contains(serviceName).click();
+
+      cy.get(".breadcrumb")
+        .find(`.icon-image-container img[src="${imageUrl}"]`)
+        .should("exist");
+    });
+
     it("opens the destroy dialog", function() {
       openDropdown("sdk-sleep");
       clickDropdownAction("Delete");

--- a/tests/pages/services/ServicesFilter-cy.js
+++ b/tests/pages/services/ServicesFilter-cy.js
@@ -2,14 +2,15 @@
 function setFilter(param) {
   cy.visitUrl({ url: "/services/overview" });
   cy.get("[placeholder='Filter']").click();
-  cy.get("label").contains(param).click();
+  cy.get("label")
+    .contains(param)
+    .click();
 }
 
 function testFilterByStatus(param) {
   setFilter(param);
 
-  cy
-    .get(".service-table")
+  cy.get(".service-table")
     .getTableColumn("Status")
     .get(".status-bar-text")
     .contents()
@@ -89,8 +90,7 @@ describe("Services Filter", function() {
     it("filters Healthy services", function() {
       setFilter("Healthy");
 
-      cy
-        .get(".service-table")
+      cy.get(".service-table")
         .getTableColumn("Name")
         .get(".table-cell-link-primary")
         .contents()
@@ -102,8 +102,7 @@ describe("Services Filter", function() {
     it("filters Unhealthy services", function() {
       setFilter("Unhealthy");
 
-      cy
-        .get(".service-table")
+      cy.get(".service-table")
         .getTableColumn("Name")
         .get(".table-cell-link-primary")
         .contents()
@@ -113,8 +112,7 @@ describe("Services Filter", function() {
     it("filters N/A services", function() {
       setFilter("N/A");
 
-      cy
-        .get(".service-table")
+      cy.get(".service-table")
         .getTableColumn("Name")
         .get(".table-cell-link-primary")
         .contents()
@@ -134,13 +132,14 @@ describe("Services Filter", function() {
       it("filters SDK services", function() {
         setFilter("Catalog");
 
-        cy
-          .get(".service-table")
+        const serviceNames = ["sdk-sleep", "sdk-sleep-with-image"];
+
+        cy.get(".service-table")
           .getTableColumn("Name")
           .get(".table-cell-link-primary")
           .contents()
-          .each(function(v) {
-            expect(v).to.eq("sdk-sleep");
+          .each(function(v, index) {
+            expect(v).to.eq(serviceNames[index]);
           });
       });
     });
@@ -156,8 +155,7 @@ describe("Services Filter", function() {
       it("filters Pods", function() {
         setFilter("Pod");
 
-        cy
-          .get(".service-table")
+        cy.get(".service-table")
           .getTableColumn("Name")
           .get(".table-cell-link-primary")
           .contents()
@@ -178,8 +176,7 @@ describe("Services Filter", function() {
       it("filters services with Volumes", function() {
         setFilter("Volumes");
 
-        cy
-          .get(".service-table")
+        cy.get(".service-table")
           .getTableColumn("Name")
           .get(".table-cell-link-primary")
           .contents()


### PR DESCRIPTION
* Uses the existing CosmosPackagesStores to retrieve the specific package from the availablePackages.
* Fetch its icons and display on the Services Page.

Closes DCOS-20989

## Testing
* Deploy a package from the catalog
* Check that the icon appears for the framework in the services table
* Go to the framework details page and check that its icon is in the breadcrumbs

## Trade-offs

### Fetching Icons
* Decided to fetch all the icons for all packages at once instead of having to make a request per service to get the icons

### Making Requests
* Opted to use the existing mechanisms for fetching the available packages
* Opted for the simpler approach to update the packages when the services page is rendered instead of using the data layer