### PR TITLE
DCOS-39960: Tasks column in the nodes table should be right aligned

### DIFF
--- a/plugins/nodes/src/js/columns/NodesTableTasksColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableTasksColumn.tsx
@@ -3,13 +3,13 @@ import sort from "array-sort";
 import Node from "#SRC/js/structs/Node";
 import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
-import { TextCell } from "@dcos/ui-kit";
+import { NumberCell } from "@dcos/ui-kit";
 
 export function tasksRenderer(data: Node): React.ReactNode {
   return (
-    <TextCell>
+    <NumberCell>
       <span>{(data.get("TASK_RUNNING") || "0").toString()}</span>
-    </TextCell>
+    </NumberCell>
   );
 }
 


### PR DESCRIPTION
Right-align the tasks column using the new NumberCell from the ui kit.

Closes DCOS-39960

## Testing

Go to `Nodes` tab. In `List` view see if the `Tasks` column is right-aligned.

## Trade-offs
I think it looks good, but we can also consider adding a 10-20% margin (see screenshots), what does everyone else think?

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2018-08-15 14-05-20](https://user-images.githubusercontent.com/40791275/44145912-f9ffa7de-a095-11e8-832f-9f4828e80dbb.png)


### After
![screenshot from 2018-08-15 14-06-30](https://user-images.githubusercontent.com/40791275/44145858-cae0433c-a095-11e8-9a43-5f0b73e6b557.png)

### After mock-up with 10% right margin
![screenshot from 2018-08-15 14-07-01](https://user-images.githubusercontent.com/40791275/44145867-cef1cc98-a095-11e8-8772-84e61dfecef0.png)

### After mock-up with 20% right margin
![screenshot from 2018-08-15 14-07-13](https://user-images.githubusercontent.com/40791275/44145870-d3ca96dc-a095-11e8-9da5-65981d9a848b.png)
