### PR TITLE
DCOS-40523: Enable empty env vars

### DIFF
--- a/plugins/services/src/js/components/modals/CreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModalForm.js
@@ -78,6 +78,34 @@ const CONSTANTLY_UNMUTED_ERRORS = [
   /^volumes\.[0-9]+\./
 ];
 
+function cleanConfig(config) {
+  const { labels = {}, env = {}, environment = {}, ...serviceConfig } = config;
+
+  let newServiceConfig = CreateServiceModalFormUtil.stripEmptyProperties(
+    serviceConfig
+  );
+  if (Object.keys(labels).length !== 0) {
+    newServiceConfig = {
+      labels,
+      ...newServiceConfig
+    };
+  }
+  if (Object.keys(env).length !== 0) {
+    newServiceConfig = {
+      env,
+      ...newServiceConfig
+    };
+  }
+  if (Object.keys(environment).length !== 0) {
+    newServiceConfig = {
+      environment,
+      ...newServiceConfig
+    };
+  }
+
+  return newServiceConfig;
+}
+
 class CreateServiceModalForm extends Component {
   constructor() {
     super(...arguments);
@@ -86,19 +114,9 @@ class CreateServiceModalForm extends Component {
     //       shouldComponentUpdate function, since we are trying to reduce
     //       the number of updates as much as possible.
     // In the Next line we are destructing the config to keep labels as it is and even keep labels with an empty value
-    const { labels = {}, ...serviceConfig } = ServiceUtil.getServiceJSON(
-      this.props.service
+    const newServiceConfig = cleanConfig(
+      ServiceUtil.getServiceJSON(this.props.service)
     );
-
-    let newServiceConfig = {
-      labels,
-      ...CreateServiceModalFormUtil.stripEmptyProperties(serviceConfig)
-    };
-    if (Object.keys(labels).length === 0) {
-      newServiceConfig = CreateServiceModalFormUtil.stripEmptyProperties(
-        serviceConfig
-      );
-    }
     this.state = Object.assign(
       {
         appConfig: null,
@@ -333,16 +351,7 @@ class CreateServiceModalForm extends Component {
     );
 
     // In the Next line we are destructing the config to keep labels as it is and even keep labels with an empty value
-    const { labels, ...config } = newConfig;
-
-    if (Object.keys(labels).length === 0) {
-      return CreateServiceModalFormUtil.stripEmptyProperties(config);
-    }
-
-    return {
-      labels,
-      ...CreateServiceModalFormUtil.stripEmptyProperties(config)
-    };
+    return cleanConfig(newConfig);
   }
 
   getErrors() {

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/EnvironmentVariables.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/EnvironmentVariables.js
@@ -22,7 +22,7 @@ module.exports = {
       if (joinedPath === "env") {
         switch (type) {
           case ADD_ITEM:
-            this.env.push({ key: null, value: null });
+            this.env.push({ key: null, value: "" });
             break;
           case REMOVE_ITEM:
             this.env = this.env.filter((item, index) => {
@@ -32,7 +32,7 @@ module.exports = {
         }
 
         return this.env.reduce((memo, item) => {
-          if (item.key != null && item.value != null) {
+          if (item.key != null) {
             memo[item.key] = item.value;
           }
 
@@ -50,7 +50,7 @@ module.exports = {
     }
 
     return this.env.reduce((memo, item) => {
-      if (item.key != null && item.value != null) {
+      if (item.key != null) {
         memo[item.key] = item.value;
       }
 
@@ -65,7 +65,7 @@ module.exports = {
 
     return Object.keys(state.env)
       .filter(function(key) {
-        return typeof state.env[key] === "string";
+        return state.env[key] == null || typeof state.env[key] === "string";
       })
       .reduce(function(memo, key, index) {
         /**
@@ -78,9 +78,11 @@ module.exports = {
          */
         memo.push(new Transaction(["env"], index, ADD_ITEM));
         memo.push(new Transaction(["env", index, "key"], key, SET));
-        memo.push(
-          new Transaction(["env", index, "value"], state.env[key], SET)
-        );
+        if (typeof state.env[key] === "string") {
+          memo.push(
+            new Transaction(["env", index, "value"], state.env[key], SET)
+          );
+        }
 
         return memo;
       }, []);

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/MultiContainerEnvironmentVariables.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/MultiContainerEnvironmentVariables.js
@@ -9,7 +9,10 @@ module.exports = {
 
     return Object.keys(state.environment)
       .filter(function(key) {
-        return typeof state.environment[key] === "string";
+        return (
+          state.environment[key] == null ||
+          typeof state.environment[key] === "string"
+        );
       })
       .reduce(function(memo, key, index) {
         /**
@@ -22,9 +25,15 @@ module.exports = {
          */
         memo.push(new Transaction(["env"], index, ADD_ITEM));
         memo.push(new Transaction(["env", index, "key"], key, SET));
-        memo.push(
-          new Transaction(["env", index, "value"], state.environment[key], SET)
-        );
+        if (typeof state.environment[key] === "string") {
+          memo.push(
+            new Transaction(
+              ["env", index, "value"],
+              state.environment[key],
+              SET
+            )
+          );
+        }
 
         return memo;
       }, []);

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/EnvironmentVariables-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/EnvironmentVariables-test.js
@@ -48,6 +48,16 @@ describe("Environment Variables", function() {
         batch.reduce(EnvironmentVariables.JSONReducer.bind({}), {})
       ).toEqual({ second: "value" });
     });
+
+    it("keeps environment variable with empty value", () => {
+      let batch = new Batch();
+      batch = batch.add(new Transaction(["env"], null, ADD_ITEM));
+      batch = batch.add(new Transaction(["env", 0, "key"], "first"));
+
+      expect(
+        batch.reduce(EnvironmentVariables.JSONReducer.bind({}), {})
+      ).toEqual({ first: "" });
+    });
   });
 
   describe("#JSONParser", function() {
@@ -62,6 +72,21 @@ describe("Environment Variables", function() {
         { type: ADD_ITEM, value: 0, path: ["env"] },
         { type: SET, value: "key", path: ["env", 0, "key"] },
         { type: SET, value: "value", path: ["env", 0, "value"] }
+      ]);
+    });
+
+    it("returns an array of transactions for empty env var", function() {
+      expect(EnvironmentVariables.JSONParser({ env: { key: null } })).toEqual([
+        { type: ADD_ITEM, value: 0, path: ["env"] },
+        { type: SET, value: "key", path: ["env", 0, "key"] }
+      ]);
+    });
+
+    it("returns an array of transactions for empty string env var", function() {
+      expect(EnvironmentVariables.JSONParser({ env: { key: "" } })).toEqual([
+        { type: ADD_ITEM, value: 0, path: ["env"] },
+        { type: SET, value: "key", path: ["env", 0, "key"] },
+        { type: SET, value: "", path: ["env", 0, "value"] }
       ]);
     });
 


### PR DESCRIPTION
---
↩️  _This PR back-ports a fix to release/1.0 introduced with https://github.com/dcos/dcos-ui/pull/3106._

---

This fixes the environment variables reducer to support empty values.

## Testing

Try to create a service with the following config:

```json
{
  "env": {
    "key": ""
  }
}
```