### PR TITLE
DCOS-40526: add region information getter to pod struct

### DIFF
--- a/plugins/services/src/js/structs/Pod.js
+++ b/plugins/services/src/js/structs/Pod.js
@@ -208,4 +208,26 @@ module.exports = class Pod extends Service {
   getVolumesData() {
     return new VolumeList({ items: this.get("volumeData") || [] });
   }
+
+  /**
+   * @override
+   */
+  getRegions() {
+    if (!this._regions) {
+      const regionCounts = this.getInstanceList()
+        .getItems()
+        .reduce((regions, instance) => {
+          const region = instance.getAgentRegion();
+          if (region !== "") {
+            regions[region] = regions[region] ? regions[region] + 1 : 1;
+          }
+
+          return regions;
+        }, {});
+
+      this._regions = Object.keys(regionCounts).sort();
+    }
+
+    return this._regions;
+  }
 };

--- a/plugins/services/src/js/structs/PodInstance.js
+++ b/plugins/services/src/js/structs/PodInstance.js
@@ -82,6 +82,14 @@ module.exports = class PodInstance extends Item {
     return new Date(this.get("lastChanged"));
   }
 
+  getAgentRegion() {
+    return this.get("agentRegion") || "";
+  }
+
+  getAgentZone() {
+    return this.get("agentZone") || "";
+  }
+
   getLastUpdated() {
     return new Date(this.get("lastUpdated"));
   }

--- a/plugins/services/src/js/structs/Service.js
+++ b/plugins/services/src/js/structs/Service.js
@@ -71,9 +71,7 @@ module.exports = class Service extends Item {
         {}
       );
 
-      this._regions = Object.keys(regionCounts).sort(
-        (a, b) => regionCounts[b] - regionCounts[a]
-      );
+      this._regions = Object.keys(regionCounts).sort();
     }
 
     return this._regions;

--- a/plugins/services/src/js/structs/__tests__/Pod-test.js
+++ b/plugins/services/src/js/structs/__tests__/Pod-test.js
@@ -74,6 +74,27 @@ describe("Pod", function() {
     });
   });
 
+  describe("#getRegions", function() {
+    it("returns empty array if nothing is set", function() {
+      const pod = new Pod();
+      expect(pod.getRegions()).toEqual([]);
+    });
+    it("returns correct region for one instance", function() {
+      const pod = new Pod({ instances: [{ agentRegion: "Region-1" }] });
+      expect(pod.getRegions()).toEqual(["Region-1"]);
+    });
+    it("returns correct region for multiple instance", function() {
+      const pod = new Pod({
+        instances: [
+          { agentRegion: "Region-1" },
+          { agentRegion: "Region-2" },
+          { agentRegion: "Region-1" }
+        ]
+      });
+      expect(pod.getRegions()).toEqual(["Region-1", "Region-2"]);
+    });
+  });
+
   describe("#getInstancesCount", function() {
     it("passes through from specs", function() {
       const pod = new Pod(PodFixture);

--- a/plugins/services/src/js/structs/__tests__/PodInstance-test.js
+++ b/plugins/services/src/js/structs/__tests__/PodInstance-test.js
@@ -52,6 +52,32 @@ describe("PodInstance", function() {
     });
   });
 
+  describe("#getAgentRegion", function() {
+    it("returns the correct value", function() {
+      const podInstance = new PodInstance({ agentRegion: "Region-a" });
+
+      expect(podInstance.getAgentRegion()).toEqual("Region-a");
+    });
+
+    it("returns the correct default value", function() {
+      const podInstance = new PodInstance();
+      expect(podInstance.getAgentRegion()).toEqual("");
+    });
+  });
+
+  describe("#getAgentZone", function() {
+    it("returns the correct value", function() {
+      const podInstance = new PodInstance({ agentZone: "Zone-a" });
+
+      expect(podInstance.getAgentZone()).toEqual("Zone-a");
+    });
+
+    it("returns the correct default value", function() {
+      const podInstance = new PodInstance();
+      expect(podInstance.getAgentZone()).toEqual("");
+    });
+  });
+
   describe("#getStatus", function() {
     it("returns FINISHED when all containers are FINISHED", function() {
       const podInstance = new PodInstance({


### PR DESCRIPTION
Closes DCOS-40526

## Testing

ui isnt implemented yet - `npm run test` it is.
<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

I decided to just duplicate the code instead of extracting something into a util. I dont think that extracting it would add much value.

Also, this is a fixup commit for the last one, we're on a feature branch here which I'll have to rebase anyway - it _should_ work. I'm aware that this messes up our JIRAs a bit because there is no commit closing DCOS-40526 - lets see 🤷‍♂️ 
<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->
