### PR TITLE
DCOS-39945: Re-add colors to NodesTable progress bars

### DIFF
--- a/plugins/nodes/src/js/columns/NodesTableCPUColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableCPUColumn.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import sort from "array-sort";
 import Node from "#SRC/js/structs/Node";
+import * as ResourcesUtil from "#SRC/js/utils/ResourcesUtil";
 import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import { Cell } from "@dcos/ui-kit";
@@ -15,7 +16,10 @@ export function cpuRenderer(data: Node): React.ReactNode {
     <Cell>
       <ProgressBar
         data={[
-          { value: data.getUsageStats("cpus").percentage, className: "color-1" }
+          {
+            value: data.getUsageStats("cpus").percentage,
+            className: `color-${ResourcesUtil.getResourceColor("cpus")}`
+          }
         ]}
         total={100}
       />

--- a/plugins/nodes/src/js/columns/NodesTableDiskColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableDiskColumn.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import sort from "array-sort";
 import Node from "#SRC/js/structs/Node";
+import * as ResourcesUtil from "#SRC/js/utils/ResourcesUtil";
 import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import { Cell } from "@dcos/ui-kit";
@@ -15,7 +16,10 @@ export function diskRenderer(data: Node): React.ReactNode {
     <Cell>
       <ProgressBar
         data={[
-          { value: data.getUsageStats("disk").percentage, className: "color-1" }
+          {
+            value: data.getUsageStats("disk").percentage,
+            className: `color-${ResourcesUtil.getResourceColor("disk")}`
+          }
         ]}
         total={100}
       />

--- a/plugins/nodes/src/js/columns/NodesTableGPUColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableGPUColumn.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import sort from "array-sort";
 import Node from "#SRC/js/structs/Node";
+import * as ResourcesUtil from "#SRC/js/utils/ResourcesUtil";
 import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import ProgressBar from "#SRC/js/components/ProgressBar";
@@ -15,7 +16,10 @@ export function gpuRenderer(data: Node): React.ReactNode {
     <Cell>
       <ProgressBar
         data={[
-          { value: data.getUsageStats("gpus").percentage, className: "color-1" }
+          {
+            value: data.getUsageStats("gpus").percentage,
+            className: `color-${ResourcesUtil.getResourceColor("gpus")}`
+          }
         ]}
         total={100}
       />

--- a/plugins/nodes/src/js/columns/NodesTableMemColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableMemColumn.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import sort from "array-sort";
 import Node from "#SRC/js/structs/Node";
+import * as ResourcesUtil from "#SRC/js/utils/ResourcesUtil";
 import { IWidthArgs as WidthArgs } from "@dcos/ui-kit/dist/packages/table/components/Column";
 import { SortDirection } from "plugins/nodes/src/js/types/SortDirection";
 import ProgressBar from "#SRC/js/components/ProgressBar";
@@ -15,7 +16,10 @@ export function memRenderer(data: Node): React.ReactNode {
     <Cell>
       <ProgressBar
         data={[
-          { value: data.getUsageStats("mem").percentage, className: "color-1" }
+          {
+            value: data.getUsageStats("mem").percentage,
+            className: `color-${ResourcesUtil.getResourceColor("mem")}`
+          }
         ]}
         total={100}
       />

--- a/src/js/utils/ResourcesUtil.d.ts
+++ b/src/js/utils/ResourcesUtil.d.ts
@@ -1,0 +1,3 @@
+export function getAvailableResources(excludeList: Array<object>): Array<object>;
+export function getResourceLabel(resource: string): string;
+export function getResourceColor(resource: string): number;

--- a/src/styles/components/status-bar/styles.less
+++ b/src/styles/components/status-bar/styles.less
@@ -64,12 +64,16 @@
       transition: width 600ms;
       width: 100%;
 
-      &.color-1 {
+      &.color-0 {
         background-color: @purple;
       }
 
+      &.color-1 {
+        background-color: @yellow;
+      }
+
       &.color-2 {
-        background-color: @pink;
+        background-color: @red;
       }
 
       &.color-3 {
@@ -91,15 +95,19 @@
 
       &.color-5,
       &.danger {
-        background-color: @red;
+        background-color: @orchid;
       }
 
       &.color-6,
       &.warning {
-        background-color: @yellow;
+        background-color: @pink;
       }
 
       &.color-7 {
+        background-color: @label-muted-color;
+      }
+
+      &.color-8 {
         background-color: @cyan;
       }
 


### PR DESCRIPTION
## Testing
- Go to the Nodes page
- See the new colors in the progress bars

If any bars are at 0%, manually add the bar markup:
```
<span class="bar color-{color id}" style="width: 25%;"></span>
```

I checked for other uses of `ProgressBar`, and they will not be affected by the style changes in `src/styles/components/status-bar/styles.less`

## Trade-offs
None that I can think of

## Dependencies
Nothing because the ticket for DCOS-39944 has already merged
