### PR TITLE
DCOS-21183: no duplicate names when adding containers to service

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/Containers.js
@@ -1,5 +1,6 @@
 import { SET, ADD_ITEM, REMOVE_ITEM } from "#SRC/js/constants/TransactionTypes";
 import { combineReducers, simpleReducer } from "#SRC/js/utils/ReducerUtil";
+import ContainerUtil from "#SRC/js/utils/ContainerUtil";
 import { DEFAULT_POD_CONTAINER } from "../../../constants/DefaultPod";
 import { FormReducer as endpointsFormReducer } from "./Endpoints";
 import { FormReducer as multiContainerArtifacts } from "./MultiContainerArtifacts";
@@ -37,7 +38,10 @@ module.exports = {
     if (joinedPath === "containers") {
       switch (type) {
         case ADD_ITEM:
-          const name = `container-${newState.length + 1}`;
+          const name = ContainerUtil.getNewContainerName(
+            newState.length,
+            newState
+          );
 
           newState.push(Object.assign({}, DEFAULT_POD_CONTAINER, { name }));
           this.cache.push({});

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
@@ -1,6 +1,7 @@
 import { SET, ADD_ITEM, REMOVE_ITEM } from "#SRC/js/constants/TransactionTypes";
 import { combineReducers, simpleFloatReducer } from "#SRC/js/utils/ReducerUtil";
 import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
+import ContainerUtil from "#SRC/js/utils/ContainerUtil";
 import { isEmpty } from "#SRC/js/utils/ValidatorUtil";
 import Transaction from "#SRC/js/structs/Transaction";
 import Networking from "#SRC/js/constants/Networking";
@@ -392,7 +393,10 @@ module.exports = {
     if (joinedPath === "containers") {
       switch (type) {
         case ADD_ITEM:
-          const name = `container-${newState.length + 1}`;
+          const name = ContainerUtil.getNewContainerName(
+            newState.length,
+            newState
+          );
 
           newState.push(Object.assign({}, DEFAULT_POD_CONTAINER, { name }));
           this.cache.push({});

--- a/src/js/utils/ContainerUtil.js
+++ b/src/js/utils/ContainerUtil.js
@@ -18,6 +18,19 @@ const ContainerUtil = {
    */
   adjustPendingActions(pendingActions, actionType, isPending) {
     return Object.assign({}, pendingActions, { [actionType]: isPending });
+  },
+
+  getNewContainerName(containerLength, newState) {
+    const name = `container-${containerLength + 1}`;
+    const matchingNames = newState.filter(item => {
+      return item.name === name;
+    });
+
+    if (matchingNames.length > 0) {
+      return this.getNewContainerName(++containerLength, newState);
+    } else {
+      return name;
+    }
   }
 };
 

--- a/src/js/utils/__tests__/ContainerUtil-test.js
+++ b/src/js/utils/__tests__/ContainerUtil-test.js
@@ -51,3 +51,24 @@ describe("#adjustPendingActions", function() {
     expect(pendingActions).toEqual({ foo: false, bar: false });
   });
 });
+
+describe("#getNewContainerName", function() {
+  const newState = [
+    { name: "container-1", resources: { cpus: 0.1, mem: 128, disk: "" } },
+    { name: "container-3", resources: { cpus: 0.1, mem: 128, disk: "" } }
+  ];
+  const newName = ContainerUtil.getNewContainerName(newState.length, newState);
+
+  it("does not return a duplicate name", function() {
+    const dupeNames = newState.filter(item => {
+      return item.name === newName;
+    });
+    expect(dupeNames.length).toBe(0);
+  });
+
+  it("increases container number", function() {
+    expect(parseInt(newName.split("-")[1], 10)).toBeGreaterThan(
+      newState.length
+    );
+  });
+});


### PR DESCRIPTION
## Testing
After navigating to the Services tab:
1. Tap the "plus" in the upper-right corner to add a new service
2. Select "Multi-container (Pod)"
3. Add two new containers, so you have "container-1", "container-2", and "container-3"
4. Delete "container-2"
5. Add another new container; it should be named "container-4". Before these changes, it would have a duplicate name, "container-3"

## Trade-offs
No

## Dependencies
Nothing

## Screenshots
**Before**
![containernamedupe_before](https://user-images.githubusercontent.com/2313998/44222826-c9838f80-a153-11e8-84a0-b7f5e34a4e3e.gif)

**After**
![containernamedupe_after](https://user-images.githubusercontent.com/2313998/44222118-93dda700-a151-11e8-815d-a83ca1defc26.gif)
