### PR TITLE
DCOS-20340: enlarge heading and wrap catalog screenshots

### DIFF
--- a/src/js/components/ImageViewer.js
+++ b/src/js/components/ImageViewer.js
@@ -67,9 +67,9 @@ class ImageViewer extends React.Component {
 
     return (
       <div className="pod pod-short flush-top flush-right flush-left">
-        <h5 className="flush-top">Media</h5>
+        <h2>Media</h2>
         <div className="media-object-spacing-wrapper media-object-offset">
-          <div className="media-object flex-box flex-box-wrap">
+          <div className="media-object media-object-wrap">
             {this.getImages(images)}
           </div>
         </div>


### PR DESCRIPTION
On a package catalog page:
* Enlarges the "Media" heading
* Wrapping for catalog screenshots

Closes DCOS-20340

## Testing
* Can't load images on local, so go to `PackageDetailTab.js` and replace:

```
<ImageViewer images={cosmosPackage.getScreenshots()} />
```

with (and add the Cluster URL below):

```
        <ImageViewer
          images={cosmosPackage
            .getScreenshots()
            .map(image =>
              image.replace(
                "https://localhost:4200",
                "<Cluster URL goes here>"
              )
            )}
        />
```

* Go to **weavescope** catalog page

## Result

### Before
![screen shot 2018-08-16 at 2 09 21 pm](https://user-images.githubusercontent.com/4956107/44235417-4287e480-a15e-11e8-97b8-9ed42be086dc.png)

### After
![screen shot 2018-08-16 at 2 10 36 pm](https://user-images.githubusercontent.com/4956107/44235420-49aef280-a15e-11e8-8b53-89291b30502a.png)