### PR TITLE
DCOS-40158: remove left-padding for left filter bar

### DIFF
--- a/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
+++ b/plugins/nodes/src/js/pages/nodes-overview/HostsPageContent.js
@@ -140,7 +140,7 @@ class HostsPageContent extends React.Component {
     const { filterExpression, filters, defaultFilterData } = this.state;
 
     return (
-      <div className="column-12">
+      <div className="column-12 flush-left">
         <DSLFilterField
           filters={filters}
           formSections={[

--- a/plugins/services/src/js/containers/tasks/TasksView.js
+++ b/plugins/services/src/js/containers/tasks/TasksView.js
@@ -203,7 +203,7 @@ class TasksView extends mixin(SaveStateMixin) {
 
     const filterExpressionValue = filterExpression.value;
 
-    const hostClasses = classNames({
+    const hostClasses = classNames("flush-left", {
       "column-medium-5": !filterExpressionValue,
       "column-medium-12": filterExpressionValue
     });

--- a/src/styles/components/filter-bar/styles.less
+++ b/src/styles/components/filter-bar/styles.less
@@ -49,7 +49,14 @@
   }
 
   .filter-bar-item {
-    .property-variant(button-collection, padding-right, margin-horizontal, null, null);
+
+    .property-variant(
+      button-collection,
+      padding-right,
+      margin-horizontal,
+      null,
+      null
+    );
     flex: 0 0 auto;
     max-width: 100%;
     padding-bottom: @filter-bar-item-spacing-vertical;
@@ -82,7 +89,14 @@
     }
 
     .filter-bar-item {
-      .property-variant(button-collection, padding-right, margin-horizontal, null, screen-small);
+
+      .property-variant(
+        button-collection,
+        padding-right,
+        margin-horizontal,
+        null,
+        screen-small
+      );
       padding-bottom: @filter-bar-item-spacing-vertical-screen-small;
     }
   }
@@ -100,7 +114,13 @@
     }
 
     .filter-bar-item {
-      .property-variant(button-collection, padding-right, margin-horizontal, null, screen-medium);
+      .property-variant(
+        button-collection,
+        padding-right,
+        margin-horizontal,
+        null,
+        screen-medium
+      );
       padding-bottom: @filter-bar-item-spacing-vertical-screen-medium;
     }
   }
@@ -118,7 +138,14 @@
     }
 
     .filter-bar-item {
-      .property-variant(button-collection, padding-right, margin-horizontal, null, screen-large);
+
+      .property-variant(
+        button-collection,
+        padding-right,
+        margin-horizontal,
+        null,
+        screen-large
+      );
       padding-bottom: @filter-bar-item-spacing-vertical-screen-large;
     }
   }
@@ -136,7 +163,14 @@
     }
 
     .filter-bar-item {
-      .property-variant(button-collection, padding-right, margin-horizontal, null, screen-jumbo);
+
+      .property-variant(
+        button-collection,
+        padding-right,
+        margin-horizontal,
+        null,
+        screen-jumbo
+      );
       padding-bottom: @filter-bar-item-spacing-vertical-screen-jumbo;
     }
   }


### PR DESCRIPTION
Removes the left padding for left filter bar.

Closes DCOS-40158

## Testing

* Go to Nodes and Service Tasks page
* Filter bar should be aligned

## Result

### Before
![screen shot 2018-08-16 at 3 01 36 pm](https://user-images.githubusercontent.com/4956107/44237481-7a465a80-a165-11e8-92e2-d9a856745f3e.png)

### After
![screen shot 2018-08-16 at 3 01 41 pm](https://user-images.githubusercontent.com/4956107/44237487-7f0b0e80-a165-11e8-8bd9-78df24f8a896.png)
