### PR TITLE
DCOS-39720: enable service endpoints on ucr

### DIFF
--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -31,11 +31,9 @@ import SingleContainerPortMappings
 import {
   FormReducer as networks
 } from "../../reducers/serviceForm/FormReducers/Networks";
-import ContainerConstants from "../../constants/ContainerConstants";
 import ServiceConfigUtil from "../../utils/ServiceConfigUtil";
 
 const { BRIDGE, HOST, CONTAINER } = Networking.type;
-const { MESOS } = ContainerConstants.type;
 
 const METHODS_TO_BIND = ["onVirtualNetworksStoreSuccess"];
 
@@ -567,12 +565,6 @@ class NetworkingFormSection extends mixin(StoreMixin) {
   }
 
   getServiceEndpointsSection() {
-    const { container, networks } = this.props.data;
-    const networkType = findNestedPropertyInObject(networks, "0.mode");
-    const type = findNestedPropertyInObject(container, "type");
-    const isMesosRuntime = !type || type === MESOS;
-    const isVirtualNetwork = networkType && networkType.startsWith(CONTAINER);
-
     const serviceEndpointsDocsURI = MetadataStore.buildDocsURI(
       "/deploying-services/service-endpoints/"
     );
@@ -604,27 +596,6 @@ class NetworkingFormSection extends mixin(StoreMixin) {
         </FormGroupHeadingContent>
       </FormGroupHeading>
     );
-
-    // Mesos Runtime doesn't support Service Endpoints for the USER network
-    if (isMesosRuntime && isVirtualNetwork) {
-      const tooltipMessage = `Service Endpoints are not available in the ${ContainerConstants.labelMap[type]}`;
-
-      return (
-        <Tooltip
-          content={tooltipMessage}
-          maxWidth={500}
-          wrapperClassName="tooltip-wrapper tooltip-block-wrapper"
-          wrapText={true}
-        >
-          <h2 className="short-bottom muted" key="service-endpoints-header">
-            {heading}
-          </h2>
-          <p key="service-endpoints-description">
-            DC/OS can automatically generate a Service Address to connect to each of your load balanced endpoints.
-          </p>
-        </Tooltip>
-      );
-    }
 
     return (
       <div>

--- a/plugins/services/src/js/reducers/serviceForm/Container.js
+++ b/plugins/services/src/js/reducers/serviceForm/Container.js
@@ -133,14 +133,6 @@ const containerJSONReducer = combineReducers({
     // Store the change no matter what network type we have
     this.portDefinitions = PortMappingsReducer(this.portDefinitions, action);
 
-    // Mesos Runtime does not support portMappings for CONTAINER network
-    if (
-      this.containerType !== DOCKER &&
-      this.appState.networkType === CONTAINER
-    ) {
-      return null;
-    }
-
     // We only want portMappings for networks of type BRIDGE or CONTAINER
     if (
       this.appState.networkType !== BRIDGE &&

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -962,7 +962,7 @@ describe("Container", function() {
         });
       });
 
-      it("doesn't create portMappings when container.type is MESOS", function() {
+      it("creates portMappings when container.type is MESOS", function() {
         let batch = new Batch();
         batch = batch.add(new Transaction(["container", "type"], "MESOS", SET));
         batch = batch.add(
@@ -974,7 +974,16 @@ describe("Container", function() {
         );
 
         expect(batch.reduce(Container.JSONReducer.bind({}), {})).toEqual({
-          portMappings: null,
+          portMappings: [
+            {
+              containerPort: 0,
+              hostPort: 0,
+              labels: null,
+              name: null,
+              protocol: "tcp",
+              servicePort: null
+            }
+          ],
           type: "MESOS",
           volumes: []
         });


### PR DESCRIPTION
Enables Service endpoints on UCS for overlay networks: `dcos` and `dcos6`

Backport of #2800 

Closes DCOS-39720

## Testing

Try creating an app running UCR with `dcos` network and a service endpoint.