### PR TITLE
DCOS-21235: [Firefox] Form control icons overflow issue

### DIFF
--- a/src/js/pages/system/UnitsHealthTab.js
+++ b/src/js/pages/system/UnitsHealthTab.js
@@ -191,7 +191,7 @@ class UnitsHealthTab extends mixin(StoreMixin) {
             />
             <FilterBar rightAlignLastNChildren={1}>
               <FilterInputText
-                className="flush-bottom"
+                className="flush-bottom health-tab"
                 searchString={searchString}
                 handleFilterChange={this.handleSearchStringChange}
               />

--- a/src/styles/components/form-elements/form-group/styles.less
+++ b/src/styles/components/form-elements/form-group/styles.less
@@ -36,6 +36,10 @@
       }
     }
   }
+
+  .health-tab input {
+    min-width: 0;
+  }
 }
 
 & when (@form-group-enabled) and (@layout-screen-small-enabled) {


### PR DESCRIPTION
Add width to the input to fix overflow after text is entered in Firefox.

Closes DCOS-21235

## Testing
In Firefox, in `Components` tab type something in the search bar. The magnifying glass and the cancel icon shouldn't move when something is typed (see screenshots).

Also, if possible, test this change in other browsers as well - I tested in Chrome to make sure it still works correctly.

## Trade-offs
I spend some time looking and wondering where to put my css change. If someone has better place in mind, please tell me.

## Dependencies
None.

## Screenshots
![screenshot from 2018-08-17 13-28-36](https://user-images.githubusercontent.com/40791275/44262693-a379f000-a224-11e8-8c4d-af5dfe8dbb92.png)
![screenshot from 2018-08-17 13-30-27](https://user-images.githubusercontent.com/40791275/44262694-a379f000-a224-11e8-8f97-3af4391c21e4.png)
![screenshot from 2018-08-17 13-30-53](https://user-images.githubusercontent.com/40791275/44262695-a379f000-a224-11e8-92aa-cf644338dfcf.png)

