### PR TITLE
DCOS-14972: Enable dot separated values in Cypress tests

### DIFF
--- a/system-tests/jobs/test-jobs-cy.js
+++ b/system-tests/jobs/test-jobs-cy.js
@@ -28,14 +28,11 @@ describe("Jobs", function() {
     cy.root()
       .getFormGroupInputFor("Job ID *")
       .type(`{selectall}${fullJobName}`);
-    //
-    // TODO: Due to a bug in cypress you cannot type values with dots
-    // Cypress will also sometimes hang when typing long strings with hyphens
-    // cy
-    //   .root()
-    //   .getFormGroupInputFor('CPUs')
-    //   .type('{selectall}0.1');
-    //
+
+    cy.root()
+      .getFormGroupInputFor("CPUs *")
+      .type("{selectall}0.1");
+
     cy.root()
       .getFormGroupInputFor("Mem (MiB) *")
       .type("{selectall}32");
@@ -108,13 +105,11 @@ describe("Jobs", function() {
     cy.root()
       .getFormGroupInputFor("Job ID *")
       .type(`{selectall}${fullJobName}`);
-    //
-    // TODO: Due to a bug in cypress you cannot type values with dots
-    // cy
-    //   .root()
-    //   .getFormGroupInputFor('CPUs')
-    //   .type('{selectall}0.5');
-    //
+
+    cy.root()
+      .getFormGroupInputFor("CPUs *")
+      .type("{selectall}0.5");
+
     cy.root()
       .getFormGroupInputFor("Mem (MiB) *")
       .type("{selectall}32");
@@ -157,13 +152,10 @@ describe("Jobs", function() {
     cy.root()
       .getFormGroupInputFor("Job ID *")
       .should("have.value", `${fullJobName}`);
-    //
-    // TODO: Due to a bug in cypress you cannot type values with dots
-    // cy
-    //   .root()
-    //   .getFormGroupInputFor('CPUs')
-    //   .type('{selectall}0.5');
-    //
+
+    cy.root()
+      .getFormGroupInputFor("CPUs *")
+      .type("{selectall}0.5");
     cy.root()
       .getFormGroupInputFor("Mem (MiB) *")
       .should("have.value", "32");

--- a/system-tests/services/test-apps-cy.js
+++ b/system-tests/services/test-apps-cy.js
@@ -41,12 +41,7 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .get('input[name=cpus]')
-      //   .type('{selectall}0.5');
-      //
+      cy.get("input[name=cpus]").type("{selectall}0.5");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}10");
@@ -96,10 +91,9 @@ describe("Services", function() {
         .getFormGroupInputFor("Service ID *")
         .should("have.value", `/${Cypress.env("TEST_UUID")}/${serviceName}`);
 
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .getFormGroupInputFor('CPUs *')
-      //   .contents('equal', '0.5');
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .contents("equal", "0.5");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -172,13 +166,9 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs *')
-      //   .type('{selectall}0.1');
-      //
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}10");
@@ -274,12 +264,7 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Container Image")
         .type("nginx");
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .get('input[name=cpus]')
-      //   .type('{selectall}0.5');
-      //
+      cy.get("input[name=cpus]").type("{selectall}0.5");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}32");
@@ -410,12 +395,7 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Container Image")
         .type("python:3");
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .get('input[name=cpus]')
-      //   .type('{selectall}0.5');
-      //
+      cy.get("input[name=cpus]").type("{selectall}0.5");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}32");
@@ -500,12 +480,7 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Container Image")
         .should("have.value", "python:3");
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .get('input[name=cpus]')
-      //   .type('{selectall}0.5');
-      //
+      cy.get("input[name=cpus]").type("{selectall}0.5");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .should("have.value", "32");
@@ -554,16 +529,9 @@ describe("Services", function() {
         .getFormGroupInputFor("Container Image")
         .type("python:3");
 
-      // Hack to allow entering decimals in number fields
-      cy.root()
-        .getFormGroupInputFor("CPUs *")
-        .invoke("attr", "type", "text");
       cy.root()
         .getFormGroupInputFor("CPUs *")
         .type("{selectall}0.5");
-      cy.root()
-        .getFormGroupInputFor("CPUs *")
-        .invoke("attr", "type", "number");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -695,16 +663,9 @@ describe("Services", function() {
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
 
-      // Hack to allow entering decimals in number fields
-      cy.root()
-        .getFormGroupInputFor("CPUs *")
-        .invoke("attr", "type", "text");
       cy.root()
         .getFormGroupInputFor("CPUs *")
         .type("{selectall}0.5");
-      cy.root()
-        .getFormGroupInputFor("CPUs *")
-        .invoke("attr", "type", "number");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -832,12 +793,8 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .get('input[name=cpus]')
-      //   .type('{selectall}0.5');
-      //
+      cy.get("input[name=cpus]").type("{selectall}0.5");
+
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}10");
@@ -956,12 +913,7 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .get('input[name=cpus]')
-      //   .type('{selectall}0.5');
-      //
+      cy.get("input[name=cpus]").type("{selectall}0.5");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}32");
@@ -1117,12 +1069,7 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .get('input[name=cpus]')
-      //   .type('{selectall}0.5');
-      //
+      cy.get("input[name=cpus]").type("{selectall}0.5");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}10");
@@ -1252,12 +1199,7 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .get('input[name=cpus]')
-      //   .type('{selectall}0.5');
-      //
+      cy.get("input[name=cpus]").type("{selectall}0.5");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}10");
@@ -1363,16 +1305,9 @@ describe("Services", function() {
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
 
-      // Hack to allow entering decimals in number fields
-      cy.root()
-        .getFormGroupInputFor("CPUs *")
-        .invoke("attr", "type", "text");
       cy.root()
         .getFormGroupInputFor("CPUs *")
         .type("{selectall}0.5");
-      cy.root()
-        .getFormGroupInputFor("CPUs *")
-        .invoke("attr", "type", "number");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -1444,16 +1379,9 @@ describe("Services", function() {
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
 
-      // Hack to allow entering decimals in number fields
-      cy.root()
-        .getFormGroupInputFor("CPUs *")
-        .invoke("attr", "type", "text");
       cy.root()
         .getFormGroupInputFor("CPUs *")
         .type("{selectall}0.5");
-      cy.root()
-        .getFormGroupInputFor("CPUs *")
-        .invoke("attr", "type", "number");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")

--- a/system-tests/services/test-pods-cy.js
+++ b/system-tests/services/test-pods-cy.js
@@ -30,11 +30,9 @@ describe("Services", function() {
         .contains("container-1")
         .click();
 
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs *')
-      //   .type('{selectall}0.1');
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -77,11 +75,9 @@ describe("Services", function() {
         .contains("container-1")
         .click();
 
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs *')
-      //   .type('{selectall}0.1');
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -117,13 +113,9 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Container Image")
         .type("nginx");
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs')
-      //   .type('{selectall}0.1');
-      //
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{backspace}{backspace}{backspace}{backspace}10");
@@ -159,13 +151,9 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Container Image")
         .type("nginx");
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs')
-      //   .type('{selectall}0.1');
-      //
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{backspace}{backspace}{backspace}{backspace}10");
@@ -216,13 +204,10 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Container Image")
         .should("have.value", "nginx");
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs')
-      //   .type('{selectall}0.1');
-      //
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
+
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .should("have.value", "10");
@@ -257,13 +242,10 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Container Image")
         .should("have.value", "nginx");
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs')
-      //   .type('{selectall}0.1');
-      //
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
+
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .should("have.value", "10");
@@ -288,11 +270,9 @@ describe("Services", function() {
         .contains("container-1")
         .click();
 
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs *')
-      //   .type('{selectall}0.5');
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.5");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -363,11 +343,9 @@ describe("Services", function() {
         .contains("container-1")
         .click();
 
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs *')
-      //   .type('{selectall}0.5');
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.5");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -533,11 +511,9 @@ describe("Services", function() {
         .contains("container-1")
         .click();
 
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs *')
-      //   .type('{selectall}0.5');
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.5");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -604,11 +580,9 @@ describe("Services", function() {
         .contains("container-1")
         .click();
 
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs *')
-      //   .type('{selectall}0.5');
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.5");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -654,11 +628,9 @@ describe("Services", function() {
         .contains("container-1")
         .click();
 
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs *')
-      //   .type('{selectall}0.1');
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -719,11 +691,9 @@ describe("Services", function() {
         .contains("container-1")
         .click();
 
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs *')
-      //   .type('{selectall}0.1');
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -760,11 +730,9 @@ describe("Services", function() {
         .contains("container-1")
         .click();
 
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs *')
-      //   .type('{selectall}0.1');
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -859,11 +827,9 @@ describe("Services", function() {
         .contains("container-1")
         .click();
 
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs *')
-      //   .type('{selectall}0.1');
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")

--- a/tests/pages/jobs/JobJSONEditor-cy.js
+++ b/tests/pages/jobs/JobJSONEditor-cy.js
@@ -26,13 +26,11 @@ describe("Job JSON Editor", function() {
     cy.root()
       .getFormGroupInputFor("Job ID *")
       .type(`{selectall}${fullJobName}`);
-    //
-    // TODO: Due to a bug in cypress you cannot type values with dots
-    // cy
-    //   .root()
-    //   .getFormGroupInputFor('CPUs')
-    //   .type('{selectall}0.1');
-    //
+
+    cy.root()
+      .getFormGroupInputFor("CPUs *")
+      .type("{selectall}0.1");
+
     cy.root()
       .getFormGroupInputFor("Mem (MiB) *")
       .type("{selectall}32");
@@ -58,7 +56,7 @@ describe("Job JSON Editor", function() {
           id: fullJobName,
           description: "",
           run: {
-            cpus: 1,
+            cpus: 0.1,
             mem: 32,
             disk: 0,
             cmd: cmdline
@@ -85,6 +83,11 @@ describe("Job JSON Editor", function() {
     cy.root()
       .getFormGroupInputFor("Job ID *")
       .type(`{selectall}${fullJobName}`);
+
+    cy.root()
+      .getFormGroupInputFor("CPUs *")
+      .type("{selectall}0.1");
+
     cy.root()
       .getFormGroupInputFor("Mem (MiB) *")
       .type("{selectall}32");
@@ -124,7 +127,7 @@ describe("Job JSON Editor", function() {
           id: fullJobName,
           description: "",
           run: {
-            cpus: 1,
+            cpus: 0.1,
             mem: 32,
             disk: 0,
             gpus: 1,

--- a/tests/pages/services/ServicePodReviewScreen-cy.js
+++ b/tests/pages/services/ServicePodReviewScreen-cy.js
@@ -30,11 +30,9 @@ describe("Services", function() {
         .contains("container-1")
         .click();
 
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs *')
-      //   .type('{selectall}0.1');
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -169,13 +167,9 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Container Image")
         .type("nginx");
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs')
-      //   .type('{selectall}0.1');
-      //
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{backspace}{backspace}{backspace}{backspace}10");
@@ -211,13 +205,9 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Container Image")
         .type("nginx");
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs')
-      //   .type('{selectall}0.1');
-      //
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{backspace}{backspace}{backspace}{backspace}10");
@@ -357,11 +347,9 @@ describe("Services", function() {
         .contains("container-1")
         .click();
 
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs *')
-      //   .type('{selectall}0.5');
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -564,6 +552,10 @@ describe("Services", function() {
         .click();
 
       cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
+
+      cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}10");
 
@@ -759,11 +751,9 @@ describe("Services", function() {
         .contains("container-1")
         .click();
 
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs *')
-      //   .type('{selectall}0.5');
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -945,11 +935,9 @@ describe("Services", function() {
         .contains("container-1")
         .click();
 
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs *')
-      //   .type('{selectall}0.1');
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -1124,6 +1112,10 @@ describe("Services", function() {
       cy.get(".menu-tabbed-item")
         .contains("container-1")
         .click();
+
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -1381,6 +1373,10 @@ describe("Services", function() {
         .click();
 
       cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
+
+      cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}10");
 
@@ -1596,6 +1592,9 @@ describe("Services", function() {
         .contains(containerName)
         .click();
 
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}10");

--- a/tests/pages/services/ServiceReviewScreen-cy.js
+++ b/tests/pages/services/ServiceReviewScreen-cy.js
@@ -36,12 +36,7 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .get('input[name=cpus]')
-      //   .type('{selectall}0.5');
-      //
+      cy.get("input[name=cpus]").type("{selectall}0.1");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}10");
@@ -115,13 +110,9 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .root()
-      //   .getFormGroupInputFor('CPUs *')
-      //   .type('{selectall}0.1');
-      //
+      cy.root()
+        .getFormGroupInputFor("CPUs *")
+        .type("{selectall}0.1");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}10");
@@ -237,12 +228,7 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Container Image")
         .type("nginx");
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .get('input[name=cpus]')
-      //   .type('{selectall}0.5');
-      //
+      cy.get("input[name=cpus]").type("{selectall}0.1");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}32");
@@ -380,12 +366,8 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Container Image")
         .type("python:3");
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .get('input[name=cpus]')
-      //   .type('{selectall}0.5');
-      //
+      cy.get("input[name=cpus]").type("{selectall}0.1");
+
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}32");
@@ -517,16 +499,9 @@ describe("Services", function() {
         .getFormGroupInputFor("Container Image")
         .type("python:3");
 
-      // Hack to allow entering decimals in number fields
-      cy.root()
-        .getFormGroupInputFor("CPUs *")
-        .invoke("attr", "type", "text");
       cy.root()
         .getFormGroupInputFor("CPUs *")
         .type("{selectall}0.5");
-      cy.root()
-        .getFormGroupInputFor("CPUs *")
-        .invoke("attr", "type", "number");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -656,16 +631,9 @@ describe("Services", function() {
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
 
-      // Hack to allow entering decimals in number fields
-      cy.root()
-        .getFormGroupInputFor("CPUs *")
-        .invoke("attr", "type", "text");
       cy.root()
         .getFormGroupInputFor("CPUs *")
         .type("{selectall}0.5");
-      cy.root()
-        .getFormGroupInputFor("CPUs *")
-        .invoke("attr", "type", "number");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -791,12 +759,7 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .get('input[name=cpus]')
-      //   .type('{selectall}0.5');
-      //
+      cy.get("input[name=cpus]").type("{selectall}0.1");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}10");
@@ -917,12 +880,7 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .get('input[name=cpus]')
-      //   .type('{selectall}0.5');
-      //
+      cy.get("input[name=cpus]").type("{selectall}0.1");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}32");
@@ -1082,12 +1040,7 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .get('input[name=cpus]')
-      //   .type('{selectall}0.5');
-      //
+      cy.get("input[name=cpus]").type("{selectall}0.1");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}10");
@@ -1213,12 +1166,7 @@ describe("Services", function() {
       cy.root()
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
-      //
-      // TODO: Due to a bug in cypress you cannot type values with dots
-      // cy
-      //   .get('input[name=cpus]')
-      //   .type('{selectall}0.5');
-      //
+      cy.get("input[name=cpus]").type("{selectall}0.1");
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
         .type("{selectall}10");
@@ -1328,16 +1276,9 @@ describe("Services", function() {
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
 
-      // Hack to allow entering decimals in number fields
-      cy.root()
-        .getFormGroupInputFor("CPUs *")
-        .invoke("attr", "type", "text");
       cy.root()
         .getFormGroupInputFor("CPUs *")
         .type("{selectall}0.5");
-      cy.root()
-        .getFormGroupInputFor("CPUs *")
-        .invoke("attr", "type", "number");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")
@@ -1521,16 +1462,9 @@ describe("Services", function() {
         .getFormGroupInputFor("Service ID *")
         .type(`{selectall}{rightarrow}${serviceName}`);
 
-      // Hack to allow entering decimals in number fields
-      cy.root()
-        .getFormGroupInputFor("CPUs *")
-        .invoke("attr", "type", "text");
       cy.root()
         .getFormGroupInputFor("CPUs *")
         .type("{selectall}0.5");
-      cy.root()
-        .getFormGroupInputFor("CPUs *")
-        .invoke("attr", "type", "number");
 
       cy.root()
         .getFormGroupInputFor("Memory (MiB) *")


### PR DESCRIPTION
All I did was enabling `TODO: Due to a bug in cypress you cannot type values with dots` everything else is prettier.

## Testing

CI should pass

Closes DCOS-14972