### PR TITLE
    DCOS-40495  Nodes Table Region Column shows "N/A (Local)"

### DIFF
--- a/plugins/nodes/src/js/columns/NodesTableRegionColumn.tsx
+++ b/plugins/nodes/src/js/columns/NodesTableRegionColumn.tsx
@@ -11,7 +11,9 @@ export function regionRenderer(
 ): React.ReactNode {
   const regionName =
     data.getRegionName() +
-    (masterRegion === data.getRegionName() ? " (Local)" : "");
+    (masterRegion === data.getRegionName() && masterRegion !== "N/A"
+      ? " (Local)"
+      : "");
 
   return (
     <TextCell>


### PR DESCRIPTION
Remove the (Local) addition when the local region is "N/A"

jira: https://jira.mesosphere.com/browse/DCOS-40495

## Testing
In `Nodes` tab, in `Region` column, if there is no local region, the name should be shown just as `N/A` instead of `N/A (Local)`.

Alternatively, to test it, try replacing the function `regionRenderer` in `/plugins/nodes/src/js/columns/NodesTableRegionColumn.tsx` the following way:
```
export function regionRenderer(
  masterRegion: string,
  data: Node
): React.ReactNode {
  data;
  masterRegion = "N/A";
  const regionString = "N/A";
  const regionName =
  regionString +
    (masterRegion === regionString && masterRegion !== "N/A"
      ? " (Local)"
      : "");

  return (
    <TextCell>
      <span title={regionName}>{regionName}</span>
    </TextCell>
  );
}
```

## Trade-offs
None that I am aware of.

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2018-08-17 15-17-05](https://user-images.githubusercontent.com/40791275/44267864-76cfd380-a238-11e8-861b-d8130a8a83dc.png)


### After
![screenshot from 2018-08-17 15-47-48](https://user-images.githubusercontent.com/40791275/44267870-79cac400-a238-11e8-8dc4-babc49e5dc91.png)
