### PR TITLE
DCOS-40019: fix UI text flicker

### DIFF
--- a/src/styles/components/dropdown-menus/styles.less
+++ b/src/styles/components/dropdown-menus/styles.less
@@ -98,6 +98,7 @@
     // Overrides default Canvas styles.
     float: initial;
     left: initial;
+    text-rendering: optimizeLegibility;
     z-index: @z-index-dropdown;
   }
 

--- a/src/styles/components/header-bar/styles.less
+++ b/src/styles/components/header-bar/styles.less
@@ -9,8 +9,9 @@
     height: @header-bar-height;
     padding-left: @header-bar-horizontal-padding;
     padding-right: @header-bar-horizontal-padding;
+    text-rendering: optimizeLegibility;
     width: 100%;
-    z-index: 999;
+    z-index: 9999;
 
     span {
       line-height: @header-bar-height;

--- a/src/styles/layout/sidebar/styles.less
+++ b/src/styles/layout/sidebar/styles.less
@@ -15,6 +15,7 @@
     height: 100%;
     left: 0;
     position: relative;
+    text-rendering: optimizeLegibility;
     top: 0;
     transform: translateX(-100%);
     transition: transform 0.25s;


### PR DESCRIPTION
Chrome on macOS has had issues with macOS' native subpixel antialising for a long time, and it's especially problematic for light text on a dark background

## Testing
1. In the header bar, click either of the dropdowns in the top-right corner - the dropdown trigger text should no longer flicker.

2. Go to any view with a dropdown in the main content area - for example, Services has a filter dropdown in it's search input, and Nodes has a dropdown labeled "Filter by Service". The text in the sidebar should no longer flicker.

Try these on your laptop monitor as well as an external monitor if you have one.

## Trade-offs
`text-rendering: optimizeLegibility`
    - 👍 will prevent text quirks without affecting the perceived thickness of the type
    - ❓ will change the text rendering however each browser handles it
    - 👎 has performance concerns
`-webkit-font-smoothing: antialiased`
    - 👍 no (known) performance concerns
    - 👍 will _only_ affect webkit browsers/Chrome
    - 👎 will make text appear slightly lighter in weight, impacting readability. This looks good on my high-DPI Macbook Pro screen, but it looks very jagged and appears to be lower contrast on my external monitor

The performance issues with `text-rendering: optimizeLegibility` should not cause any trouble since we're only applying it to certain elements, and not using brute force by applying it to <body>

Here is a comparison:
`text-rendering: optimizeLegibility` (the solution I used for this PR):
![optimizelegibility](https://user-images.githubusercontent.com/2313998/44274501-496f2f80-a210-11e8-9a93-9d6ba2b47981.gif)

`-webkit-font-smoothing: antialiased`
![antialiased](https://user-images.githubusercontent.com/2313998/44274517-512ed400-a210-11e8-99f2-ce02e6ca605c.gif)

inheriting `text-rendering: geometricPrecision` from <body> (currently in master):
![geometricprecision](https://user-images.githubusercontent.com/2313998/44274610-93581580-a210-11e8-882b-cd10637fae16.gif)


## Dependencies
None

---

This PR fixes the issues described in the ticket, but I propose supporting an "inverted" context by doing something like adding a class we put on dark containers, then add styling like this:
```
    .inverted {
        text-rendering: optimizeLegibility;
    }

    @media screen and (-webkit-min-device-pixel-ratio: 2), screen and (min-resolution: 2dppx) {
        .inverted {
            -webkit-font-smoothing: antialiased;
            text-rendering: auto;
        }
    }
```