### PR TITLE
DCOS-20689: introduce Sentry bug tracking SaaS

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -2,11 +2,13 @@
   "branch": "master",
   "tagFormat": "master+v${version}",
   "verifyConditions": ["@semantic-release/github"],
-  "prepare": [
+  "prepare": [],
+  "publish": [
     {
       "path": "@semantic-release/exec",
-      "cmd": "sed -i '' 's/0\\.0\\.0-dev\\+semantic-release/${nextRelease.version}/' dist/index.html",
-    }
-  ],
-  "publish": ["@semantic-release/github"],
+      "cmd": "./scripts/ci/upload-release v${nextRelease.version}",
+      "shell": "/bin/bash"
+    },
+    "@semantic-release/github"
+  ]
 }

--- a/.releaserc
+++ b/.releaserc
@@ -2,6 +2,11 @@
   "branch": "master",
   "tagFormat": "master+v${version}",
   "verifyConditions": ["@semantic-release/github"],
-  "prepare": [],
-  "publish": ["@semantic-release/github"]
+  "prepare": [
+    {
+      "path": "@semantic-release/exec",
+      "cmd": "sed -i '' 's/0\\.0\\.0-dev\\+semantic-release/${nextRelease.version}/' dist/index.html",
+    }
+  ],
+  "publish": ["@semantic-release/github"],
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,41 +80,12 @@ pipeline {
     stage("Semantic Release") {
       steps {
         withCredentials([
-          string(credentialsId: "d146870f-03b0-4f6a-ab70-1d09757a51fc", variable: "GH_TOKEN")
+          string(credentialsId: "d146870f-03b0-4f6a-ab70-1d09757a51fc", variable: "GH_TOKEN"), // semantic-release
+          string(credentialsId: "3f0dbb48-de33-431f-b91c-2366d2f0e1cf",variable: "AWS_ACCESS_KEY_ID"), // upload-build
+          string(credentialsId: "f585ec9a-3c38-4f67-8bdb-79e5d4761937",variable: "AWS_SECRET_ACCESS_KEY"), // upload-build
+          usernamePassword(credentialsId: "a7ac7f84-64ea-4483-8e66-bb204484e58f", passwordVariable: "GIT_PASSWORD", usernameVariable: "GIT_USER") // update-dcos-repo
         ]) {
           sh "npx semantic-release"
-        }
-      }
-    }
-
-    stage("Upload Release") {
-      when {
-        expression {
-          master_branches.contains(BRANCH_NAME)
-        }
-      }
-
-      steps {
-        withCredentials([
-            string(credentialsId: "3f0dbb48-de33-431f-b91c-2366d2f0e1cf",variable: "AWS_ACCESS_KEY_ID"),
-            string(credentialsId: "f585ec9a-3c38-4f67-8bdb-79e5d4761937",variable: "AWS_SECRET_ACCESS_KEY"),
-            usernamePassword(credentialsId: "a7ac7f84-64ea-4483-8e66-bb204484e58f", passwordVariable: "GIT_PASSWORD", usernameVariable: "GIT_USER")
-        ]) {
-          sh "git config --global user.email $GIT_USER@users.noreply.github.com"
-          sh "git config --global user.name 'MesosphereCI Robot'"
-          sh "git config credential.helper 'cache --timeout=300'"
-
-          sh "git fetch --tags"
-
-          sh "tar czf release.tar.gz dist"
-
-          sh "./scripts/ci/upload-release"
-        }
-      }
-
-      post {
-        always {
-          archiveArtifacts "buildinfo.json"
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,6 @@ pipeline {
       steps {
         sh "npm --unsafe-perm install"
         sh "npm run build"
-        sh "tar czf release.tar.gz dist"
       }
     }
 
@@ -106,6 +105,8 @@ pipeline {
           sh "git config credential.helper 'cache --timeout=300'"
 
           sh "git fetch --tags"
+
+          sh "tar czf release.tar.gz dist"
 
           sh "./scripts/ci/upload-release"
         }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1804,6 +1804,74 @@
       "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
       "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg=="
     },
+    "@semantic-release/exec": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-3.1.0.tgz",
+      "integrity": "sha512-m+opdWgZ7ro4j9BD4yL2UIRom3RznE3sbx2Wj8CSCOXoSJ97Ar8Ci8/ziR4QF1SJcKVlrUUhj+7TP5FgziSDgg==",
+      "dev": true,
+      "requires": {
+        "@semantic-release/error": "^2.1.0",
+        "debug": "^3.1.0",
+        "execa": "^0.10.0",
+        "lodash": "^4.17.4",
+        "parse-json": "^4.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        }
+      }
+    },
     "@semantic-release/github": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-5.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@commitlint/cli": "6.1.3",
     "@commitlint/config-conventional": "6.1.3",
     "@dcos/eslint-config": "0.3.0",
+    "@semantic-release/exec": "3.1.0",
     "@types/events": "1.2.0",
     "@types/jest": "22.2.3",
     "@types/prop-types": "15.5.3",

--- a/scripts/ci/upload-release
+++ b/scripts/ci/upload-release
@@ -32,8 +32,8 @@ PKG_TARGET=$(python -c "import sys, json; \
   dcosrc = json.load(open('$PROJECT_ROOT/.dcosrc')); \
   sys.stdout.write(str(dcosrc['base']));")
 
-# release version (after switching to semantic-release, we cant use package.json anymore)
-PKG_VERSION="$(git tag -l --sort=-version:refname | grep ${PKG_TARGET} | head -1 | cut -d'+' -f2)"
+# next release version (passed in by semantic-release)
+PKG_VERSION="${1}"
 
 # build release name for branch and file names
 # Examples:
@@ -47,6 +47,19 @@ DCOS_BRANCH="dcos-ui/${PKG_TARGET}+dcos-ui-latest"
 ## Create Assets & Generate Upload Data
 #####################################################################
 
+VERSION_PLACEHOLDER="0.0.0-dev+semantic-release"
+
+# first, replace placeholder in dist bundle and verify that it worked
+sed -i "" "s/${VERSION_PLACEHOLDER}/${PKG_TARGET}+${PKG_VERSION}/" ${PROJECT_ROOT}/dist/index.html
+if ! grep "${PKG_TARGET}+${PKG_VERSION}" ${PROJECT_ROOT}/dist/index.html; then
+  echo "Version injection into dist/index.html failed!"
+  exit 1
+fi
+
+# second, create tarball
+tar czf release.tar.gz dist
+
+# third, upload tarball
 # if this fails, there is already a release with this SHA -> stop.
 RELEASE_NAME="${RELEASE_NAME}" \
   ${SCRIPT_PATH}/utils/upload-build || exit 0

--- a/src/index.html
+++ b/src/index.html
@@ -31,6 +31,7 @@
   <link rel="apple-touch-icon-precomposed" sizes="76x76" href="./img/components/icons/favicon-apple-76x76.png">
   <link rel="apple-touch-icon-precomposed" sizes="120x120" href="./img/components/icons/favicon-apple-120x120.png">
   <link rel="apple-touch-icon-precomposed" sizes="152x152" href="./img/components/icons/favicon-apple-152x152.png">
+  <script type="text/javascript"> window.DCOS_UI_VERSION = "0.0.0-dev+semantic-release"; </script>
   <script type="text/javascript">(function () { var PAGE_LOADED_TIME = Date.now(); window.getPageLoadedTime = function () { return PAGE_LOADED_TIME; } })();</script>
 </head>
 

--- a/src/js/stores/MetadataStore.js
+++ b/src/js/stores/MetadataStore.js
@@ -116,6 +116,12 @@ class MetadataStore extends GetSetBaseStore {
     MetadataActions.fetchDCOSBuildInfo();
   }
 
+  get variant() {
+    const metadata = this.get("dcosMetadata");
+
+    return metadata && metadata["dcos-variant"];
+  }
+
   get version() {
     const metadata = this.get("dcosMetadata");
 

--- a/webpack/webpack.production.js
+++ b/webpack/webpack.production.js
@@ -24,7 +24,7 @@ module.exports = merge(common, {
     new ModuleConcatenationPlugin(),
     new DefinePlugin({
       "process.env.NODE_ENV": JSON.stringify("production"),
-      "process.env.version": packageInfo.version
+      "process.env.version": JSON.stringify(packageInfo.version)
     }),
     new UglifyJsPlugin({
       parallel: true,


### PR DESCRIPTION
Track errors with [Sentry](https://sentry.io)

Closes DCOS-20689

## Testing

- Enable `tracking` plugin in your Config.dev.ts
- Add an exception to any place in code
- Reach this place on the UI
- Verify that the error is reflected and all tags (environment, variant, version) are set.

## Trade-offs

We track two versions: DCOS and DCOS-UI. DCOS-UI version will be set as a `release` in Sentry where dcos version as a tag. I did this because we are going to be shipping UI as a package thus having the same UI release running on different DCOS versions. Plus I'm going to connect Sentry and Github to provide better dev experience.