### PR TITLE
DCOS-40638: Backport form control overflow fix for Firefox

### DIFF
--- a/src/js/pages/system/UnitsHealthTab.js
+++ b/src/js/pages/system/UnitsHealthTab.js
@@ -188,7 +188,7 @@ class UnitsHealthTab extends mixin(StoreMixin) {
             />
             <FilterBar rightAlignLastNChildren={1}>
               <FilterInputText
-                className="flush-bottom"
+                className="flush-bottom health-tab"
                 searchString={searchString}
                 handleFilterChange={this.handleSearchStringChange}
               />

--- a/src/styles/components/form-elements/form-group/styles.less
+++ b/src/styles/components/form-elements/form-group/styles.less
@@ -36,6 +36,17 @@
       }
     }
   }
+
+  .health-tab {
+
+    input {
+      min-width: 0;
+    }
+
+    .form-control-group-add-on:last-child {
+      font-size: 0;
+    }
+  }
 }
 
 & when (@form-group-enabled) and (@layout-screen-small-enabled) {


### PR DESCRIPTION
Backport changes that fixed the form control icon overflow issues in Firefox for 1.11. This PR takes the approved changes from [#3186](https://github.com/dcos/dcos-ui/pull/3186) and adds them to the 1.11 branch.

Closes DCOS-40638

## Testing

In Firefox, go to the Components tab and start typing in the filter input. The icons to the left and right of the text should remain aligned. Try also in Chrome to make sure the behaviour remains as expected there as well. 

## Trade-offs

I noticed that the cancel (x) icon to the right of the filter text was aligned noticeably lower than in the screenshots for [#3186](https://github.com/dcos/dcos-ui/pull/3186). `font-size: 0` was added to align the icon within its container. I'm keen for feedback on this, and whether the new alignment is correct (maybe we do not need it at all).

## Comparison

Firefox before: 
<img width="937" alt="firefox-before" src="https://user-images.githubusercontent.com/19582796/44372232-d0820900-a497-11e8-9a15-70e3800dd6d6.png">

Firefox with icons fixed but without right icon alignment: 
<img width="936" alt="firefox-misaligned" src="https://user-images.githubusercontent.com/19582796/44372252-e55e9c80-a497-11e8-81a4-418423844df0.png">

Firefox with icons fixed and right icon aligned:
<img width="933" alt="firefox-aligned" src="https://user-images.githubusercontent.com/19582796/44372265-f3acb880-a497-11e8-880b-aa751c8408d6.png">

Chrome without right icon aligned: 
![chrome-before](https://user-images.githubusercontent.com/19582796/44372283-01fad480-a498-11e8-97e0-be568c3ea9b9.png)

Chrome with right icon aligned: 
![chrome-aligned](https://user-images.githubusercontent.com/19582796/44372298-1212b400-a498-11e8-898a-6801c72e8679.png)

