### PR TITLE
DCOS-40646: add base tech version parsing to services table 

### DIFF
--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -33,6 +33,8 @@ import ServiceStatus from "../../constants/ServiceStatus";
 import ServiceActionLabels from "../../constants/ServiceActionLabels";
 import ServiceTableHeaderLabels from "../../constants/ServiceTableHeaderLabels";
 import ServiceTableUtil from "../../utils/ServiceTableUtil";
+import FrameworkUtil from "../../utils/FrameworkUtil";
+import Framework from "../../structs/Framework";
 import ServiceTree from "../../structs/ServiceTree";
 import ServiceStatusIcon from "../../components/ServiceStatusIcon";
 
@@ -394,9 +396,13 @@ class ServicesTable extends React.Component {
     if (!service.getVersion || service.getVersion === "") {
       return null;
     }
-    const version = service.getVersion();
+    const rawVersion = service.getVersion();
+    const displayVersion =
+      service && service instanceof Framework
+        ? FrameworkUtil.extractBaseTechVersion(rawVersion)
+        : rawVersion;
 
-    return <Tooltip content={version}>{version}</Tooltip>;
+    return <Tooltip content={rawVersion}>{displayVersion}</Tooltip>;
   }
 
   renderInstances(prop, service) {

--- a/plugins/services/src/js/utils/FrameworkUtil.js
+++ b/plugins/services/src/js/utils/FrameworkUtil.js
@@ -56,6 +56,26 @@ const FrameworkUtil = {
     }
 
     return images;
+  },
+
+  /**
+   * Tries to parse the given version string to display only the
+   * base tech version of packages
+   * @param {string} version Version to parse
+   * @returns {string} base tech version (if possible) or "N/A"
+   */
+  extractBaseTechVersion(version) {
+    if (!version) {
+      return "N/A";
+    }
+
+    const splitVersion = version.split("-");
+
+    if (splitVersion.length === 1) {
+      return splitVersion[0];
+    }
+
+    return splitVersion.slice(1).join("-");
   }
 };
 

--- a/plugins/services/src/js/utils/__tests__/FrameworkUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/FrameworkUtil-test.js
@@ -98,4 +98,28 @@ describe("FrameworkUtil", function() {
       });
     });
   });
+
+  describe("#extractBaseTechVersion", () => {
+    it("returns given version without dash", () => {
+      expect(FrameworkUtil.extractBaseTechVersion("1.2.3")).toEqual("1.2.3");
+    });
+    it("returns given base tech with 1 dash", () => {
+      expect(FrameworkUtil.extractBaseTechVersion("1.2.3-2.3.4")).toEqual(
+        "2.3.4"
+      );
+    });
+    it("returns given first and second base tech with 2 dashes", () => {
+      expect(
+        FrameworkUtil.extractBaseTechVersion("1.2.3-2.3.4e-lorem")
+      ).toEqual("2.3.4e-lorem");
+    });
+    it("returns given base tech and 'beta' suffix with 2 dashes", () => {
+      expect(FrameworkUtil.extractBaseTechVersion("1.2.3-2.3.4-beta")).toEqual(
+        "2.3.4-beta"
+      );
+    });
+    it("returns N/A on undefined version", () => {
+      expect(FrameworkUtil.extractBaseTechVersion()).toEqual("N/A");
+    });
+  });
 });


### PR DESCRIPTION
Closes [DCOS-40646](https://jira.mesosphere.com/browse/DCOS-40646)

## Testing

check various frameworks to see that version is displayed correctly (parsed in table, full in tooltip)
<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

Please see the linkes JIRA Issue for more details. I parsed all packages in the current universe and also shared the result in JIRA
<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

None
<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

Before:
<img width="994" alt="screen shot 2018-08-21 at 11 44 32" src="https://user-images.githubusercontent.com/530632/44394492-9ec07f00-a537-11e8-8acc-ef1c7bea1233.png">

After:
<img width="995" alt="screen shot 2018-08-21 at 11 43 57" src="https://user-images.githubusercontent.com/530632/44394509-a41dc980-a537-11e8-97db-a55d5b9260cf.png">
