### PR TITLE
DCOS-40673: prevent header bar from overlapping popup-like ui

### DIFF
--- a/src/styles/components/header-bar/styles.less
+++ b/src/styles/components/header-bar/styles.less
@@ -11,7 +11,7 @@
     padding-right: @header-bar-horizontal-padding;
     text-rendering: optimizeLegibility;
     width: 100%;
-    z-index: 9999;
+    z-index: 999;
 
     span {
       line-height: @header-bar-height;


### PR DESCRIPTION
A [recent change](https://github.com/dcos/dcos-ui/pull/3189/files#diff-3f89f538ab8c9b21839f9efa3f7d317fR14) to the header bar's z-index caused it to overlap UI such as modals and tooltips

Closes: DCOS-40673

## Testing
Go to the "Services" view
Hover the "+" button for adding a service
Click the "+" button to open the modal flow for adding a service
Ensure the header does not overlap the tooltip that appears on hover or the modal that appears on click

## Trade-offs
If you click too low on either of the dropdowns in the header, your cursor will be over the dropdown menu while it's animating in, causing the dropdown trigger to very briefly lose it's `:hover` style. If this is a blocker, I can continue to investigate a solution

## Dependencies
None

## Screenshots
**Before:**
![headeroverlap_before](https://user-images.githubusercontent.com/2313998/44417742-62dfe680-a544-11e8-8660-1aac7004cc1e.gif)

**After:**
![headeroverlap_after](https://user-images.githubusercontent.com/2313998/44417755-696e5e00-a544-11e8-9b58-2ab92c04985e.gif)
