### PR TITLE
 DCOS-40691: in Services table, region column to use Tooltip component

### DIFF
--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -255,7 +255,16 @@ class ServicesTable extends React.Component {
       regions.push("N/A");
     }
 
-    return <span title={regions.join(", ")}>{regions.join(", ")}</span>;
+    return (
+      <Tooltip
+        elementTag="span"
+        wrapperClassName="tooltip-wrapper tooltip-block-wrapper text-overflow"
+        wrapText={true}
+        content={regions.join(", ")}
+      >
+        {regions.join(", ")}
+      </Tooltip>
+    );
   }
 
   renderServiceActions(prop, service) {

--- a/plugins/services/src/js/containers/services/__tests__/__snapshots__/ServicesTable-test.js.snap
+++ b/plugins/services/src/js/containers/services/__tests__/__snapshots__/ServicesTable-test.js.snap
@@ -2,7 +2,9 @@
 
 exports[`ServicesTable #renderRegions renders with multiple regions 1`] = `
 <span
-  title="aws/eu-central-1, dc-east"
+  className="tooltip-wrapper tooltip-block-wrapper text-overflow"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   aws/eu-central-1, dc-east
 </span>
@@ -10,7 +12,9 @@ exports[`ServicesTable #renderRegions renders with multiple regions 1`] = `
 
 exports[`ServicesTable #renderRegions renders with no regions 1`] = `
 <span
-  title="N/A"
+  className="tooltip-wrapper tooltip-block-wrapper text-overflow"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   N/A
 </span>
@@ -18,7 +22,9 @@ exports[`ServicesTable #renderRegions renders with no regions 1`] = `
 
 exports[`ServicesTable #renderRegions renders with one region 1`] = `
 <span
-  title="aws/eu-central-1"
+  className="tooltip-wrapper tooltip-block-wrapper text-overflow"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   aws/eu-central-1
 </span>


### PR DESCRIPTION
In the first pass at adding the Regions table, we used a span element with a title attribute to show a native tooltip in order to side-step text wrapping issues we were seeing when using the Tooltip component

Closes: DCOS-40691

## Testing
- Hard-code an array of region names in the "renderRegions" method in `/plugins/services/src/js/containers/services/ServicesTable.js`
- Go to the Services view
- Hover the text in the cells of the "Region" column

The tooltip should be hovering in the center of the cell, and the tooltip content text should be wrapping, not  overflowing the tooltip bubble or being chopped off

## Trade-offs
Nothing I can think of

## Dependencies
None

## Screenshots
**Before** (in `feature/DCOS-39895-services-region-info`):
![tooltipconsistency_before](https://user-images.githubusercontent.com/2313998/44422944-ab060580-a552-11e8-805e-a8864761053d.gif)

**After:**
![tooltipconsistency_after](https://user-images.githubusercontent.com/2313998/44422126-53669a80-a550-11e8-8d97-a7a218c12708.gif)

