### PR TITLE
    DCOS-40779: [Firefox] Form control icons overflow issue (for other components) backport 1.11

### DIFF
--- a/src/js/pages/system/UnitsHealthTab.js
+++ b/src/js/pages/system/UnitsHealthTab.js
@@ -188,7 +188,7 @@ class UnitsHealthTab extends mixin(StoreMixin) {
             />
             <FilterBar rightAlignLastNChildren={1}>
               <FilterInputText
-                className="flush-bottom health-tab"
+                className="flush-bottom"
                 searchString={searchString}
                 handleFilterChange={this.handleSearchStringChange}
               />

--- a/src/styles/components/form-elements/form-group/styles.less
+++ b/src/styles/components/form-elements/form-group/styles.less
@@ -35,16 +35,13 @@
         }
       }
     }
-  }
-
-  .health-tab {
 
     input {
       min-width: 0;
     }
 
-    .form-control-group-add-on:last-child {
-      font-size: 0;
+    .form-control-group-add-on .icon {
+      display: block;
     }
   }
 }


### PR DESCRIPTION
In 1.11 add min-width to the input to fix overflowing icons in Firefox.

Closes https://jira.mesosphere.com/browse/DCOS-40779

## Testing
1. Set up node to use version 4.4.7 and npm to use version 3.9.6
I recommend using a new copy of the dcos-ui repository.
Setting up node is easy: just use a node version manager (I used https://github.com/creationix/nvm) and run (if you are using nvm) `nvm install 4.4.7` in the directory. Setting up npm is a bit trickier - navigate to the nvm directory, for example `cd ~/.nvm/versions/node/v4.4.7/lib` and run `npm install npm@3.9.6`. Then run `npm install`.

https://stackoverflow.com/a/33575448

2. Verify that the icons are fixed for all input bars (see screenshots). If possible, verify that the icons look good in other browsers.

## Trade-offs
I added `{display: block}}` to the icons like Mike suggested.

## Dependencies
None

## Screenshots
These are all the places that I found:

### Jobs > (Create a job if needed)
![screenshot from 2018-08-24 13-44-07](https://user-images.githubusercontent.com/40791275/44581786-d2a1db80-a7a7-11e8-87af-a9be7245056d.png)

### Nodes > Node > Health
![screenshot from 2018-08-24 13-47-17](https://user-images.githubusercontent.com/40791275/44581788-d7ff2600-a7a7-11e8-8778-2b90df00550a.png)

### Services > Service > Logs
![screenshot from 2018-08-24 13-48-23](https://user-images.githubusercontent.com/40791275/44581792-dcc3da00-a7a7-11e8-925a-633819523614.png)

### Catalog
![screenshot from 2018-08-24 13-48-37](https://user-images.githubusercontent.com/40791275/44581800-e3525180-a7a7-11e8-9820-8422b74eeecb.png)

### Networking > Networks
![screenshot from 2018-08-24 13-48-54](https://user-images.githubusercontent.com/40791275/44581806-e8170580-a7a7-11e8-9002-a50f70c3ba7d.png)

### Components
![screenshot from 2018-08-24 13-49-48](https://user-images.githubusercontent.com/40791275/44581813-eea57d00-a7a7-11e8-9b3d-377539744c0b.png)

### Settings > Package Repositories
![screenshot from 2018-08-24 13-50-02](https://user-images.githubusercontent.com/40791275/44581835-ff55f300-a7a7-11e8-8af3-ec7af9649a9d.png)

### Organization > Users
![screenshot from 2018-08-24 13-50-21](https://user-images.githubusercontent.com/40791275/44581842-054bd400-a7a8-11e8-9f87-b2af8e66f9b8.png)
