### PR TITLE
DCOS-40893: Nodes Table Region Column shows "N/A (Local)" backport 1.11

### DIFF
--- a/plugins/nodes/src/js/components/NodesTable.js
+++ b/plugins/nodes/src/js/components/NodesTable.js
@@ -32,7 +32,10 @@ class NodesTable extends PureComponent {
     return (
       <span title={node.getRegionName()}>
         {node.getRegionName()}
-        {this.props.masterRegion === node.getRegionName() ? " (Local)" : null}
+        {this.props.masterRegion === node.getRegionName() &&
+          this.props.masterRegion !== "N/A"
+          ? " (Local)"
+          : null}
       </span>
     );
   }


### PR DESCRIPTION
In 1.11 remove the (Local) addition when the local region is "N/A"

Closes https://jira.mesosphere.com/browse/DCOS-40893

## Testing
1. Set up node to use version 4.4.7 and npm to use version 3.9.6
I recommend using a new copy of the dcos-ui repository.
Setting up node is easy: just use a node version manager (I used https://github.com/creationix/nvm) and run (if you are using nvm) `nvm install 4.4.7` in the directory. Setting up npm is a bit trickier - navigate to the nvm directory, for example `cd ~/.nvm/versions/node/v4.4.7/lib` and run `npm install npm@3.9.6`. Then run `npm install`.

https://stackoverflow.com/a/33575448

2. In `Nodes` tab, in `Region` column, if there is no local region, the name should be shown just as `N/A` instead of `N/A (Local)`.

Alternatively, to test it, try replacing the function `renderRegion` in `/plugins/nodes/src/js/components/NodesTable.js` the following way:
```
  renderRegion(_prop, node) {
    const masterRegion = "N/A";
    const regionName = "N/A"
    return (
      <span title={regionName}>
        {regionName}
        {masterRegion === regionName &&
          masterRegion !== "N/A"
          ? " (Local)"
          : null}
      </span>
    );
  }

```

## Trade-offs
None that I am aware of.

## Dependencies
None.

## Screenshots

### Before
![screenshot from 2018-08-24 14-33-03](https://user-images.githubusercontent.com/40791275/44583687-03d1da00-a7af-11e8-9047-ccd0c0db4cdf.png)

### After
![screenshot from 2018-08-24 14-35-19](https://user-images.githubusercontent.com/40791275/44583692-09c7bb00-a7af-11e8-8c9e-1fded5ff4b3d.png)

