### PR TITLE
DCOS-40051: Write one system test for the Nodes Master Tab

### DIFF
--- a/system-tests/nodes/test-nodes.js
+++ b/system-tests/nodes/test-nodes.js
@@ -19,4 +19,19 @@ describe("Nodes", function() {
     cy.visitUrl("/nodes");
     cy.get(healthySelector).should("have.length", 2);
   });
+
+  it("shows leader in master tab", () => {
+    cy.visitUrl("/nodes");
+    cy.get(".menu-tabbed-item-label")
+      .contains("Masters")
+      .click();
+    cy.get(".configuration-map-section")
+      .first()
+      .find(".configuration-map-row.table-row .configuration-map-value")
+      .each(node => {
+        cy.wrap(node)
+          .get(".loader")
+          .should("not.exist");
+      });
+  });
 });


### PR DESCRIPTION
Add a system test for the Masters tab on the Nodes page to check that Leader info gets displayed.

Closes DCOS-40051

## Testing

Run the nodes system test and ensure that it passes (maybe a few times to ensure that it's not 'flaky').
To simulate no data, change line 39 in /plugins/nodes/src/js/data/MesosMasters.js to:

```
leader: mastersInitialState().leader
```

This will result in the component not getting the leader information and will get stuck with loader spinners beside IP and Port, Region, etc. Tests run with this change should NOT pass.

To run system tests against local code:

```
#!/bin/bash

set -ex

USER_AUTH_INFO="<your dcos-acs-info-cookie>"

npx cypress open --project './system-tests' --env CLUSTER_URL="http://127.0.0.1:4200",CLUSTER_AUTH_TOKEN="<your dcos-acs-auth-cookie>",CLUSTER_AUTH_INFO="$USER_AUTH_INFO",TEST_UUID='local-system-test' "$@"
```

## Trade-offs

This test checks ONLY the leaders section of the masters tab. Further, the test checks only that the information corresponding to IP and Port, etc, resolves and that the loaders go away.

Questions:

- Can we assume that the cluster that the system tests are running on will always be somewhat consistent? For example, will it always be in the same region? If so, I can make the test more specific to check whether the actual data is correct instead of just checking that it appears
- Do we need a test for the Non-leaders section as well? On the shared cluster, there are no non-leaders

## Dependencies

The configuration for this is the same as in [#3163](https://github.com/dcos/dcos-ui/pull/3163). There will be merge conflicts. 3163 should go in first.
