### PR TITLE
DCOS-40897: show a blank version cell if service is not a framework

### DIFF
--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -400,7 +400,7 @@ class ServicesTable extends React.Component {
     const displayVersion =
       service && service instanceof Framework
         ? FrameworkUtil.extractBaseTechVersion(rawVersion)
-        : rawVersion;
+        : "";
 
     return <Tooltip content={rawVersion}>{displayVersion}</Tooltip>;
   }


### PR DESCRIPTION
## Testing
1. Add a service that is not a framework
2. Check the entry Services table - the cell in the "Version" column should be empty

## Trade-offs
Not that I can think of

## Dependencies
None

## Screenshots
Before:
![blankcell_before](https://user-images.githubusercontent.com/2313998/44600942-f154a200-a7a8-11e8-9f61-3c5c0ed07dd6.png)

After:
![blankcell_after](https://user-images.githubusercontent.com/2313998/44600951-f6b1ec80-a7a8-11e8-8cb7-ef0a17e166d3.png)

