### PR TITLE
DCOS-20689: remove space before value for sed -i flag

### DIFF
--- a/scripts/ci/upload-release
+++ b/scripts/ci/upload-release
@@ -50,7 +50,7 @@ DCOS_BRANCH="dcos-ui/${PKG_TARGET}+dcos-ui-latest"
 VERSION_PLACEHOLDER="0.0.0-dev+semantic-release"
 
 # first, replace placeholder in dist bundle and verify that it worked
-sed -i "" "s/${VERSION_PLACEHOLDER}/${PKG_TARGET}+${PKG_VERSION}/" ${PROJECT_ROOT}/dist/index.html
+sed -i'' "s/${VERSION_PLACEHOLDER}/${PKG_TARGET}+${PKG_VERSION}/" ${PROJECT_ROOT}/dist/index.html
 if ! grep "${PKG_TARGET}+${PKG_VERSION}" ${PROJECT_ROOT}/dist/index.html; then
   echo "Version injection into dist/index.html failed!"
   exit 1


### PR DESCRIPTION
turns out that `sed -i ''` is only supported on macOS, its `sed -i''` or `sed -i` on GNU sed…

## Testing

launch our `mesosphere/dcos-ui` docker container and try both variants of the command, `sed -i '' s/…/…/ dist/index.html` works on macOS, but fails on linux. the space is misinterpreted as "next argument" which means that the search expression is empty…

current error on master:
https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/frontend%2Fdcos-ui-oss-pipeline/detail/master/421/pipeline#step-86-log-110

reproduced and fixed commands in docker instance:
```
root@2566f4489bf9:/dcos-ui# sed -i '' s/0.0.0-dev+semantic-release/master+v2.15.0/ dist/index.html
sed: can't read s/0.0.0-dev+semantic-release/master+v2.15.0/: No such file or directory
root@2566f4489bf9:/dcos-ui# sed -i s/0.0.0-dev+semantic-release/master+v2.15.0/ dist/index.html
# no error \o/
root@2566f4489bf9:/dcos-ui# sed -i '.bak' s/0.0.0-dev+semantic-release/master+v2.15.0/ dist/index.html
sed: -e expression #1, char 1: unknown command: `.'
root@2566f4489bf9:/dcos-ui# sed -i'.bak' s/0.0.0-dev+semantic-release/master+v2.15.0/ dist/index.html
# no error \o/
root@2566f4489bf9:/dcos-ui# exit
```

Documentation: https://linux.die.net/man/1/sed
SO: https://stackoverflow.com/a/12696224
<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

~no macOS/Linux switch, that script is intended to run on CI. if we need to run it locally, we can change the line… (it will yell at us, because `sed -i` without a value is _not_ supported on macOS 🤦‍♂️)~ `sed -i''` works on macOS 👍 
<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
