### PR TITLE
DCOS-40881: [Firefox] Form control icons overflow issue (for other components) backport 1.10

### DIFF
--- a/src/styles/components/form-elements/form-group/styles.less
+++ b/src/styles/components/form-elements/form-group/styles.less
@@ -35,6 +35,14 @@
         }
       }
     }
+
+    input {
+      min-width: 0;
+    }
+
+    .form-control-group-add-on .icon {
+      display: block;
+    }
   }
 }
 


### PR DESCRIPTION
In 1.10 add min-width to the input to fix overflowing icons in Firefox.

Closes https://jira.mesosphere.com/browse/DCOS-40881

## Testing
1. Set up node to use version 4.4.7 and npm to use version 3.9.6
I recommend using a new copy of the dcos-ui repository.
Setting up node is easy: just use a node version manager (I used https://github.com/creationix/nvm) and run (if you are using nvm) `nvm install 4.4.7` in the directory. Setting up npm is a bit trickier - navigate to the nvm directory, for example `cd ~/.nvm/versions/node/v4.4.7/lib` and run `npm install npm@3.9.6`.
Then run `npm install`.

https://stackoverflow.com/a/33575448

2. Verify that the icons are fixed for all input bars (see screenshots). If possible, verify that the icons look good in other browsers.

## Trade-offs
I added `display: block` to the icons like Mike suggested.

## Dependencies
None

## Screenshots
These are all the places that I found:

### Jobs > (Create a job if needed)
![screenshot from 2018-08-27 13-30-38](https://user-images.githubusercontent.com/40791275/44656492-b9946700-aa01-11e8-9146-4ea438024d9b.png)

### Nodes > Node > Health
![screenshot from 2018-08-27 13-31-04](https://user-images.githubusercontent.com/40791275/44656500-c0bb7500-aa01-11e8-8e79-debcfb0fc9cf.png)

### Services > Service > Logs
![screenshot from 2018-08-27 13-46-20](https://user-images.githubusercontent.com/40791275/44656505-c618bf80-aa01-11e8-8a93-c460a8250c63.png)

### Services > Service
![screenshot from 2018-08-27 13-33-49](https://user-images.githubusercontent.com/40791275/44656515-d4ff7200-aa01-11e8-8650-76ff42ab743f.png)

### Catalog
![screenshot from 2018-08-27 13-34-52](https://user-images.githubusercontent.com/40791275/44656527-e2b4f780-aa01-11e8-8259-9461159dc76f.png)

### Networking > Networks
![screenshot from 2018-08-27 13-34-24](https://user-images.githubusercontent.com/40791275/44656539-ea749c00-aa01-11e8-894c-51bb058f7f0a.png)

### Components
![screenshot from 2018-08-27 13-34-10](https://user-images.githubusercontent.com/40791275/44656550-f52f3100-aa01-11e8-8f2b-b44ced3e4658.png)

### Settings > Package Repositories
![screenshot from 2018-08-27 13-35-13](https://user-images.githubusercontent.com/40791275/44656557-00825c80-aa02-11e8-980a-6dee56c5eb6b.png)

### Organization > Users
![screenshot from 2018-08-27 13-35-55](https://user-images.githubusercontent.com/40791275/44656565-09732e00-aa02-11e8-830d-a7bd51cbf4d8.png)
