### PR TITLE
ci: use local dcos-launch bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN set -x \
   && cd /dcos-ui \
   && npm install -g git://github.com/dcos-labs/http-server.git#proxy-secure-flag \
   # Install dcos-launch
-  && curl 'https://downloads.dcos.io/dcos-launch/bin/linux/dcos-launch' > /usr/local/bin/dcos-launch \
+  && pip install git+git://github.com/dcos/dcos-test-utils@5361c8623cd0751f9312cf79b66dde6f09da1e74\
+  && pip install git+git://github.com/dcos/dcos-launch.git@4a2515f4819f0a7efc051eb5ad2c5ceb34da5975 \
   && chmod +x /usr/local/bin/dcos-launch \
   # Ensure entrypoint is executable
   && chmod +x /usr/local/bin/dcos-ui-docker-entrypoint \


### PR DESCRIPTION
Adjust Dockerfile to use local docs-launch instead of installing it from
a remote location. This changes is a hot fix to workaround issues with
the latest dcos-launch release which broke out system tests.

## Testing

With this change our CI should be able to spin up a cluster for out system test again.

## Trade-offs

We need to revert this change once we've agreed on a release and integration process with the respective team to always integrate with latest release when possible.

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
