### PR TITLE
DCOS-40048: add toggle to date information on leader tab

### DIFF
--- a/plugins/nodes/src/js/components/LeaderGrid.js
+++ b/plugins/nodes/src/js/components/LeaderGrid.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { FormattedMessage } from "react-intl";
-import moment from "moment";
+import { ToggleContent } from "@dcos/ui-kit";
 
 import ConfigurationMap from "#SRC/js/components/ConfigurationMap";
 import ConfigurationMapHeading from "#SRC/js/components/ConfigurationMapHeading";
@@ -9,14 +9,7 @@ import ConfigurationMapRow from "#SRC/js/components/ConfigurationMapRow";
 import ConfigurationMapSection from "#SRC/js/components/ConfigurationMapSection";
 import ConfigurationMapValue from "#SRC/js/components/ConfigurationMapValue";
 import Loader from "#SRC/js/components/Loader";
-
-function timeFromNow(time) {
-  if (!time) {
-    return null;
-  }
-
-  return moment(time * 1000).fromNow();
-}
+import { msToRelativeTime, msToDateStr } from "#SRC/js/utils/DateUtil";
 
 const Loading = () => <Loader size="small" type="ballBeat" />;
 
@@ -60,13 +53,23 @@ export default function LeaderGrid({ leader }) {
           <ConfigurationRow
             keyValue="started"
             title={<FormattedMessage id="COMMON.STARTED" />}
-            value={timeFromNow(leader.startTime)}
+            value={
+              <ToggleContent
+                contentOn={msToRelativeTime(leader.startTime * 1000)}
+                contentOff={msToDateStr(leader.startTime * 1000)}
+              />
+            }
           />
 
           <ConfigurationRow
             keyValue="elected"
             title={<FormattedMessage id="COMMON.ELECTED" />}
-            value={timeFromNow(leader.electedTime)}
+            value={
+              <ToggleContent
+                contentOn={msToRelativeTime(leader.electedTime * 1000)}
+                contentOff={msToDateStr(leader.electedTime * 1000)}
+              />
+            }
           />
         </ConfigurationMapSection>
       </ConfigurationMap>

--- a/plugins/nodes/src/js/components/__tests__/__snapshots__/LeaderGrid-test.js.snap
+++ b/plugins/nodes/src/js/components/__tests__/__snapshots__/LeaderGrid-test.js.snap
@@ -72,7 +72,15 @@ exports[`LeaderGrid renders with running status 1`] = `
         <div
           className="configuration-map-value"
         >
-          in 39 years
+          <div
+            className="css-bfgqus"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={-1}
+          >
+            in 39 years
+          </div>
         </div>
       </div>
       <div
@@ -88,7 +96,15 @@ exports[`LeaderGrid renders with running status 1`] = `
         <div
           className="configuration-map-value"
         >
-          in 49 years
+          <div
+            className="css-bfgqus"
+            onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex={-1}
+          >
+            in 49 years
+          </div>
         </div>
       </div>
     </div>

--- a/plugins/nodes/src/js/data/__tests__/__snapshots__/MesosMasters-test.js.snap
+++ b/plugins/nodes/src/js/data/__tests__/__snapshots__/MesosMasters-test.js.snap
@@ -73,7 +73,15 @@ exports[`LeaderGrid renders with running status 1`] = `
           <div
             className="configuration-map-value"
           >
-            in 39 years
+            <div
+              className="css-bfgqus"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={-1}
+            >
+              in 39 years
+            </div>
           </div>
         </div>
         <div
@@ -89,7 +97,15 @@ exports[`LeaderGrid renders with running status 1`] = `
           <div
             className="configuration-map-value"
           >
-            in 49 years
+            <div
+              className="css-bfgqus"
+              onClick={[Function]}
+              onKeyPress={[Function]}
+              role="button"
+              tabIndex={-1}
+            >
+              in 49 years
+            </div>
           </div>
         </div>
       </div>

--- a/src/js/utils/DateUtil.js
+++ b/src/js/utils/DateUtil.js
@@ -40,7 +40,7 @@ const DateUtil = {
    * @return {String} time string with the format 'MM-DD-YYYY [at] h:mma'
    */
   msToDateStr(ms) {
-    return moment(ms).format("MM-DD-YYYY [at] h:mma");
+    return moment(ms).format("MMMM Do, YYYY h:mm a");
   },
 
   /**

--- a/src/js/utils/__tests__/DateUtil-test.js
+++ b/src/js/utils/__tests__/DateUtil-test.js
@@ -65,7 +65,7 @@ describe("DateUtil", function() {
 
       var result = DateUtil.msToDateStr(christmasValue);
 
-      expect(result).toEqual("12-25-2015 at 8:13am");
+      expect(result).toEqual("December 25th, 2015 8:13 am");
     });
 
     it("returns the correct string for PM", function() {
@@ -74,7 +74,7 @@ describe("DateUtil", function() {
 
       var result = DateUtil.msToDateStr(halloweenValue);
 
-      expect(result).toEqual("10-31-2015 at 8:30pm");
+      expect(result).toEqual("October 31st, 2015 8:30 pm");
     });
 
     it("can handle older dates", function() {
@@ -83,7 +83,7 @@ describe("DateUtil", function() {
 
       var result = DateUtil.msToDateStr(specialDayValue);
 
-      expect(result).toEqual("10-19-1993 at 11:29am");
+      expect(result).toEqual("October 19th, 1993 11:29 am");
     });
   });
 


### PR DESCRIPTION
JIRA: [DCOS-40048](https://jira.mesosphere.com/browse/DCOS-40048)

## Testing

Navigate to `/nodes/masters` and click on the text stating `X Something ago` - it should toggle to a Date. Verify that that Date is formatted correctly.
<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

* When using the `<ToggleContent />` component there is no dotted line, is this line supposed to be added in dcos-ui or should it be part of the `<ToggleContent />` component? 🤔 
* I decided to change the diplayed format of `DateUtil.msToDateStr` to our desired format, the function is only used on Nodes Details page and since we're on Master Detail here, I think it is good thing to have them aligned. 
<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

![screen recording 2018-08-28 at 04 15 pm](https://user-images.githubusercontent.com/530632/44728807-9343f980-aadd-11e8-9ac3-81c68a92f155.gif)
<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
