### PR TITLE
chore: double quote paths so that it allows spaces

### DIFF
--- a/scripts/ci/upload-release
+++ b/scripts/ci/upload-release
@@ -25,7 +25,7 @@ set -x
 SCRIPT_PATH="$(cd $(dirname "$0")/$(dirname "$(readlink "$0")") && pwd)"
 
 # project root for this file
-PROJECT_ROOT="$( cd "$( echo ${SCRIPT_PATH} | sed s+/scripts/ci++)" && pwd )"
+PROJECT_ROOT="$( cd "$( echo "${SCRIPT_PATH}" | sed s+/scripts/ci++)" && pwd )"
 
 # get correct DC/OS target (=base branch!) from .dcosrc file
 PKG_TARGET=$(python -c "import sys, json; \
@@ -51,7 +51,7 @@ VERSION_PLACEHOLDER="0.0.0-dev+semantic-release"
 
 # first, replace placeholder in dist bundle and verify that it worked
 sed -i'' "s/${VERSION_PLACEHOLDER}/${PKG_TARGET}+${PKG_VERSION}/" ${PROJECT_ROOT}/dist/index.html
-if ! grep "${PKG_TARGET}+${PKG_VERSION}" ${PROJECT_ROOT}/dist/index.html; then
+if ! grep "${PKG_TARGET}+${PKG_VERSION}" "${PROJECT_ROOT}/dist/index.html"; then
   echo "Version injection into dist/index.html failed!"
   exit 1
 fi
@@ -62,7 +62,7 @@ tar czf release.tar.gz dist
 # third, upload tarball
 # if this fails, there is already a release with this SHA -> stop.
 RELEASE_NAME="${RELEASE_NAME}" \
-  ${SCRIPT_PATH}/utils/upload-build || exit 0
+  "${SCRIPT_PATH}/utils/upload-build" || exit 0
 
 ## Update Latest DC/OS PR
 #####################################################################
@@ -72,4 +72,4 @@ DCOS_BRANCH=${DCOS_BRANCH} \
   DCOS_UPSTREAM="dcos/dcos" \
   PKG_TARGET=${PKG_TARGET} \
   PKG_VERSION=${PKG_VERSION} \
-  ${SCRIPT_PATH}/utils/update-dcos-repo
+  "${SCRIPT_PATH}/utils/update-dcos-repo"

--- a/scripts/ci/utils/update-dcos-repo
+++ b/scripts/ci/utils/update-dcos-repo
@@ -13,7 +13,7 @@ set -e
 SCRIPT_PATH="$(cd $(dirname "$0")/$(dirname "$(readlink "$0")") && pwd)"
 
 # project root for this file
-PROJECT_ROOT="$( cd "$( echo ${SCRIPT_PATH} | sed s+/scripts/ci/utils++)" && pwd )"
+PROJECT_ROOT="$( cd "$( echo "${SCRIPT_PATH}" | sed s+/scripts/ci/utils++)" && pwd )"
 
 # where to store dcos repo in
 DCOS_FOLDER=${DCOS_FOLDER:-"dcos-repo"}
@@ -39,7 +39,7 @@ fi
 ## Update DC/OS Repo
 #####################################################################
 
-[ -d "${PROJECT_ROOT}/${DCOS_FOLDER}" ] && rm -rf ${PROJECT_ROOT}/${DCOS_FOLDER}
+[ -d "${PROJECT_ROOT}/${DCOS_FOLDER}" ] && rm -rf "${PROJECT_ROOT:?}/${DCOS_FOLDER}"
 
 git clone "${GITHUB_URL}${DCOS_ORIGIN}" "${PROJECT_ROOT}/${DCOS_FOLDER}"
 
@@ -56,11 +56,11 @@ git -C "${PROJECT_ROOT}/${DCOS_FOLDER}" \
   reset --hard "upstream/${PKG_TARGET}"
 
 # this is an intermediate step we need until we actually bumped the new process to DC/OS
-echo -e '#!/bin/bash\n\ncp -r "/pkg/src/dcos-ui" "$PKG_PATH"/usr/' > ${PROJECT_ROOT}/${DCOS_FOLDER}/packages/dcos-ui/build
+echo -e '#!/bin/bash\n\ncp -r "/pkg/src/dcos-ui" "$PKG_PATH"/usr/' > "${PROJECT_ROOT}/${DCOS_FOLDER}/packages/dcos-ui/build"
 git -C "${PROJECT_ROOT}/${DCOS_FOLDER}" \
   add "${PROJECT_ROOT}/${DCOS_FOLDER}/packages/dcos-ui/build"
 
-cp -f ${PROJECT_ROOT}/buildinfo.json ${PROJECT_ROOT}/${DCOS_FOLDER}/packages/dcos-ui/buildinfo.json
+cp -f "${PROJECT_ROOT}/buildinfo.json" "${PROJECT_ROOT}/${DCOS_FOLDER}/packages/dcos-ui/buildinfo.json"
 git -C "${PROJECT_ROOT}/${DCOS_FOLDER}" \
   add "${PROJECT_ROOT}/${DCOS_FOLDER}/packages/dcos-ui/buildinfo.json"
 
@@ -68,6 +68,6 @@ git -C "${PROJECT_ROOT}/${DCOS_FOLDER}" \
   commit -m "chore(dcos-ui): bump DC/OS UI ${PKG_VERSION}"
 
 git -C "${PROJECT_ROOT}/${DCOS_FOLDER}" \
-  push --force --set-upstream origin $DCOS_BRANCH
+  push --force --set-upstream origin "$DCOS_BRANCH"
 
-rm -rf ${PROJECT_ROOT}/${DCOS_FOLDER}
+rm -rf "${PROJECT_ROOT:?}/${DCOS_FOLDER}"

--- a/scripts/ci/utils/upload-build
+++ b/scripts/ci/utils/upload-build
@@ -13,7 +13,7 @@ set -e
 SCRIPT_PATH="$(cd $(dirname "$0")/$(dirname "$(readlink "$0")") && pwd)"
 
 # project root for this file
-PROJECT_ROOT="$( cd "$( echo ${SCRIPT_PATH} | sed s+/scripts/ci/utils++)" && pwd )"
+PROJECT_ROOT="$( cd "$( echo "${SCRIPT_PATH}" | sed s+/scripts/ci/utils++)" && pwd )"
 
 # aws bucket to upload to
 AWS_BUCKET='downloads.mesosphere.io'
@@ -42,7 +42,7 @@ fi
 
 RELEASE_NAME="${RELEASE_NAME}.tar.gz"
 
-ENCODED_RELEASE_NAME=$(echo ${RELEASE_NAME} | sed "s/\+/\%2B/g")
+ENCODED_RELEASE_NAME=$(echo "${RELEASE_NAME}" | sed "s/\+/\%2B/g")
 
 ## Write buildinfo.json
 #####################################################################

--- a/scripts/post-checkout
+++ b/scripts/post-checkout
@@ -2,4 +2,4 @@
 
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
 
-${SCRIPT_PATH}/validate-engine-versions
+"${SCRIPT_PATH}/validate-engine-versions"

--- a/scripts/post-commit
+++ b/scripts/post-commit
@@ -3,7 +3,7 @@
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
 
 # Import utils
-source ${SCRIPT_PATH}/utils/message
+source "${SCRIPT_PATH}/utils/message"
 
 title "Lint commit message..."
 

--- a/scripts/post-rewrite
+++ b/scripts/post-rewrite
@@ -3,7 +3,7 @@
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
 
 # Import utils
-source ${SCRIPT_PATH}/utils/message
+source "${SCRIPT_PATH}/utils/message"
 
 title "Run post-rewrite hook..."
 

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -3,9 +3,9 @@
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
 
 # Import utils
-source ${SCRIPT_PATH}/utils/git
-source ${SCRIPT_PATH}/utils/message
-source ${SCRIPT_PATH}/utils/test
+source "${SCRIPT_PATH}/utils/git"
+source "${SCRIPT_PATH}/utils/message"
+source "${SCRIPT_PATH}/utils/test"
 
 title "Run pre-commit hook..."
 

--- a/scripts/pre-install
+++ b/scripts/pre-install
@@ -4,13 +4,13 @@ SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
 MARATHON_VERSION="1.7.49-f24b03af3"
 
 # Import utils
-source ${SCRIPT_PATH}/utils/git
-source ${SCRIPT_PATH}/utils/marathon
+source "${SCRIPT_PATH}/utils/git"
+source "${SCRIPT_PATH}/utils/marathon"
 
 # Validate node and npm version and install git hooks.
 # Install Marathon RAML before hooks so RAML isn't skipped in CI if
 # git hooks fail to install
-${SCRIPT_PATH}/validate-engine-versions && \
+"${SCRIPT_PATH}/validate-engine-versions" && \
   install_marathon_raml "$MARATHON_VERSION" && \
   install_hooks "pre-commit post-rewrite post-commit post-checkout"
 

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -3,9 +3,9 @@
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
 
 # Import utils
-source ${SCRIPT_PATH}/utils/git
-source ${SCRIPT_PATH}/utils/message
-source ${SCRIPT_PATH}/utils/test
+source "${SCRIPT_PATH}/utils/git"
+source "${SCRIPT_PATH}/utils/message"
+source "${SCRIPT_PATH}/utils/test"
 
 title "Run pre-push hook..."
 
@@ -13,7 +13,7 @@ fork_point=$(get_fork_point)
 
 header "Validate staged JavaScript tests..."
 debug_directives=$(
-  find_debug_directives $(git diff --name-only ${fork_point} HEAD  -- "*.js")
+  find_debug_directives $(git diff --name-only "${fork_point}" HEAD  -- "*.js")
 )
 
 if [ -n "${debug_directives}" ]
@@ -30,11 +30,11 @@ info "Staged JavaScript tests looks good"
 
 header "Lint commit messages..."
 linting_errors="$(
-  npm run commitlint --silent -- -f ${fork_point} -t HEAD;
+  npm run commitlint --silent -- -f "${fork_point}" -t HEAD;
   echo x$?
 )"
 
-if [  ${linting_errors##*x} -ne 0 ]
+if [  "${linting_errors##*x}" -ne 0 ]
 then
   warning "Wrong commit message format"
 

--- a/scripts/run-integration-tests
+++ b/scripts/run-integration-tests
@@ -99,7 +99,7 @@ function runTestFile {
 function setup_plugins {
   if [ -n "${PLUGINS_PATH}" ]; then
     echo "==> Setup external plugins…"
-    rsync -aH ${PROJECT_ROOT}/${PLUGINS_PATH}/${TESTS_FOLDER}/ ${PROJECT_ROOT}/${TESTS_FOLDER}/
+    rsync -aH "${PROJECT_ROOT}/${PLUGINS_PATH}/${TESTS_FOLDER}/" "${PROJECT_ROOT}/${TESTS_FOLDER}/"
     echo "===> done."
   else
     echo "==> No Plugins configured."
@@ -109,7 +109,7 @@ function setup_plugins {
 # removes copied plugins files…
 function teardown_plugins {
   if [ -n "${PLUGINS_PATH}" ]; then
-    if [ ${CLEANUP_TESTS} -eq 0 ]; then
+    if [ "${CLEANUP_TESTS}" -eq 0 ]; then
       echo ""
       echo "==> !!! PLUGINS TESTS ARE STILL IN YOUR ./${TESTS_FOLDER} FOLDER, MAKE SURE TO CLEAN UP !!!"
       echo "==> You can use 'rm -r ./${TESTS_FOLDER} && git checkout ./${TESTS_FOLDER}' to easily clean up."
@@ -117,8 +117,8 @@ function teardown_plugins {
       echo ""
     else
       echo "==> Cleaning up ./${TESTS_FOLDER} folder"
-      rm -r ${PROJECT_ROOT}/${TESTS_FOLDER}
-      git checkout ${PROJECT_ROOT}/${TESTS_FOLDER}
+      rm -r "${PROJECT_ROOT:?}/${TESTS_FOLDER}"
+      git checkout "${PROJECT_ROOT}/${TESTS_FOLDER}"
       echo "==> done."
     fi
   fi
@@ -126,9 +126,9 @@ function teardown_plugins {
 
 # merges results from cypress runs into one file
 function teardown_merge {
-  if [ "$(find ${PROJECT_ROOT}/${CYPRESS_FOLDER}/ -type f -name result.xml | wc -l)" -ne 0 ]; then
+  if [ "$(find "${PROJECT_ROOT}/${CYPRESS_FOLDER}/" -type f -name result.xml | wc -l)" -ne 0 ]; then
     echo "==> Merging results from ./${CYPRESS_FOLDER}/*/result.xml into ./${CYPRESS_FOLDER}/results.xml…"
-    junit-merge --out ${PROJECT_ROOT}/${CYPRESS_FOLDER}/results.xml $(find ${PROJECT_ROOT}/${CYPRESS_FOLDER}/ -type f -name result.xml)
+    junit-merge --out "${PROJECT_ROOT}/${CYPRESS_FOLDER}/results.xml" $(find "${PROJECT_ROOT}/${CYPRESS_FOLDER}/" -type f -name result.xml)
     echo "===> done."
   else
     echo "==> Nothing to merge."
@@ -147,16 +147,16 @@ function setup {
   echo "=> Setup"
 
   ## Setup proxy
-  if [ -n "$(lsof -i :${PROXY_PORT})" ]; then
+  if [ -n "$(lsof -i :"${PROXY_PORT}")" ]; then
     echo "==> ERROR: Port ${PROXY_PORT} is already in use"
     exit 1
   fi
-  if [ ! -d ${PROJECT_ROOT}/dist ]; then
+  if [ ! -d "${PROJECT_ROOT}/dist" ]; then
     echo "==> ERROR: no dist folder! forgot npm run build?"
     exit 1
   fi
   echo "==> Starting http-server, serving files from ./dist…"
-  http-server -sp ${PROXY_PORT} ${PROJECT_ROOT}/dist&
+  http-server -sp "${PROXY_PORT}" "${PROJECT_ROOT}/dist"&
   PROXY_PID=$!
   echo "===> done (PID: ${PROXY_PID})."
 
@@ -168,7 +168,7 @@ function setup {
   ## Remove old results
   if [ -d "${PROJECT_ROOT}/${CYPRESS_FOLDER}" ]; then
     echo "==> Directory ./${CYPRESS_FOLDER} already exists…"
-    rm -r "${PROJECT_ROOT}/${CYPRESS_FOLDER}"
+    rm -r "${PROJECT_ROOT:?}/${CYPRESS_FOLDER}"
     echo "===> removed."
   fi
 }
@@ -190,7 +190,7 @@ function run_tests {
   find "$PROJECT_ROOT/${TESTS_FOLDER}" -type f -name "${SEARCH}-cy.js" -print | \
     while read FOUND_FILE
     do
-      RELATIVE_PATH="$(echo ${FOUND_FILE} | sed s+${PROJECT_ROOT}/${TESTS_FOLDER}/++)" runTestFile || exit 1
+      RELATIVE_PATH="$(echo "${FOUND_FILE}" | sed s+${PROJECT_ROOT}/${TESTS_FOLDER}/++)" runTestFile || exit 1
     done
 }
 

--- a/scripts/utils/git
+++ b/scripts/utils/git
@@ -3,7 +3,7 @@
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
 
 # Import utils
-source ${SCRIPT_PATH}/utils/message
+source "${SCRIPT_PATH}/utils/message"
 
 # Install/link GIT hooks
 # Example: install_hooks "pre-commit post-rewrite"

--- a/scripts/utils/marathon
+++ b/scripts/utils/marathon
@@ -4,7 +4,7 @@ PROJECT_ROOT=$(git rev-parse --show-toplevel)
 SCRIPT_PATH="${PROJECT_ROOT}/scripts"
 
 # Import utils
-source ${SCRIPT_PATH}/utils/message
+source "${SCRIPT_PATH}/utils/message"
 
 # Make sure that we have the RAML files for the specified marathon version
 function install_marathon_raml() {
@@ -21,7 +21,7 @@ function install_marathon_raml() {
   title "Install RAML Marathon ${VERSION} specs..."
 
   # Check if the installer version matches the requested
-  local INSTALLED_VERSION=$(cat ${TARGET_DIR}/.marathon-version 2>/dev/null)
+  local INSTALLED_VERSION=$(cat "${TARGET_DIR}/.marathon-version" 2>/dev/null)
   if [ "$INSTALLED_VERSION" == "$VERSION" ]; then
     info "Local files are up to date"
     return
@@ -31,19 +31,19 @@ function install_marathon_raml() {
   header "Downloading marathon ${VERSION} archive"
   local URL="https://downloads.mesosphere.com/marathon/builds/${VERSION}/marathon-docs-${VERSION}.tgz"
   local TMP_DIR=`mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'`
-  curl -L ${URL} | tar -zx -C $TMP_DIR
+  curl -L "${URL}" | tar -zx -C "${TMP_DIR}"
 
   # Empty the target raml directory
-  [ -d $TARGET_DIR ] && rm -rf $TARGET_DIR
-  mkdir -p $TARGET_DIR
+  [ -d "${TARGET_DIR}" ] && rm -rf "${TARGET_DIR}"
+  mkdir -p "${TARGET_DIR}"
 
   # Copy only relevant parts in the RAML directory
   header "Installing raml files"
-  cp -r $TMP_DIR/marathon-docs-${VERSION}/docs/rest-api/public/api/v2/{schema,types,*.raml} $TARGET_DIR \
-    && echo $VERSION > "${TARGET_DIR}/.marathon-version"
+  cp -r "${TMP_DIR}/marathon-docs-${VERSION}/docs/rest-api/public/api/v2/"{schema,types,*.raml} "${TARGET_DIR}" \
+    && echo "$VERSION" > "${TARGET_DIR}/.marathon-version"
 
   # Cleanup
-  rm -rf $TMP_DIR
+  rm -rf "${TMP_DIR:?}"
 
   info "Updated RAML in ${TARGET_DIR}"
 }

--- a/scripts/validate-engine-versions
+++ b/scripts/validate-engine-versions
@@ -3,7 +3,7 @@
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
 
 # Import utils
-source ${SCRIPT_PATH}/utils/message
+source "${SCRIPT_PATH}/utils/message"
 
 # uncomment for debugging
 # set -x

--- a/scripts/validate-tests
+++ b/scripts/validate-tests
@@ -3,8 +3,8 @@
 SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
 
 # Import utils
-source ${SCRIPT_PATH}/utils/message
-source ${SCRIPT_PATH}/utils/test
+source "${SCRIPT_PATH}/utils/message"
+source "${SCRIPT_PATH}/utils/test"
 
 title "Validating tests..."
 


### PR DESCRIPTION
I've messed up my new laptop setup and now I have a space in my home directory name 😩 
Because of that I realized that our scripts don't support that. So I double quoted everything that `shellcheck` asked me to double quote and what made sense to me.

On top of that I followed its advice and added `:?` to `rm -rf ${VAR}` so it become `rm -rf ${VAR:?}` so that if `$VAR` for whatever reason empty we don't kill `/`

## Testing

Try running those scripts from a path that has a space in it.

## Trade-offs

There are some more stuff `shellcheck` complains about. I decided keeping the scope rather small.