### PR TITLE
DCOS-40780: Fix filter on networks table

### DIFF
--- a/src/js/pages/network/VirtualNetworksTab.js
+++ b/src/js/pages/network/VirtualNetworksTab.js
@@ -104,8 +104,9 @@ class VirtualNetworksTabContent extends mixin(StoreMixin) {
 
     return overlayList.filterItems(function(overlay) {
       return (
-        overlay.getName().includes(searchString) ||
-        overlay.getSubnet().includes(searchString)
+        (overlay.getName() && overlay.getName().includes(searchString)) ||
+        (overlay.getSubnet() && overlay.getSubnet().includes(searchString)) ||
+        (overlay.getSubnet6() && overlay.getSubnet6().includes(searchString))
       );
     });
   }


### PR DESCRIPTION
Fix filter function to allow filtering of networks table. Previously, you could only type one character into the filter and the rest wouldn't appear, and the table contents weren't filtering as expected.

Closes DCOS-40780

## Testing

Go to networks table and try filtering based on Name and IP Subnet. Ensure that you try a search string that matches the subnet in both entries (if you're testing with the regular shared cluster).

## Trade-offs

None that are obvious to me.
