### PR TITLE
DCOS-37789: Fix gpu NaN in Jobs details

### DIFF
--- a/src/js/utils/Units.js
+++ b/src/js/utils/Units.js
@@ -8,7 +8,7 @@ const Units = {
       value = Units.filesize(value * 1024 * 1024, 1);
     }
 
-    return value;
+    return value || 0;
   },
 
   filesize(size, decimals, threshold, multiplier, units) {

--- a/src/js/utils/__tests__/Units-test.js
+++ b/src/js/utils/__tests__/Units-test.js
@@ -33,6 +33,16 @@ describe("Units", function() {
       const value = Units.formatResource("gpus", 3.405);
       expect(value).toEqual(3.41);
     });
+
+    it("returns default for undefined mem", function() {
+      const value = Units.formatResource("mem", undefined);
+      expect(value).toEqual("0 B");
+    });
+
+    it("returns default for undefined gpu", function() {
+      const value = Units.formatResource("gpus", undefined);
+      expect(value).toEqual(0);
+    });
   });
 
   describe("#filesize", function() {


### PR DESCRIPTION
Jobs details was showing NaN value for the gpu resource if it wasn't provided (ie if job did not use gpu resources). Ensure Units `formatResource` utility handles undefined input by returning 0 as default for undefined cpu, gpu.

Closes DCOS-37789

## Testing

Start a job that doesn't use gpu resources (ie a basic command like `sleep 60`). Check the Configuration details for that run and ensure that the gpu resource does not appear as NaN.

## Trade-offs

The Units utility (specifically the `formatResource` method) is used in many other components in the Services plugin. None of them currently handle undefined values (from what I could tell) except for the DeclinedOffersTable, which defaults to "N/A". This change would affect everywhere that uses this method, which means the "N/A" default will be overridden. 

I have set the default to 0 for cpu and gpu as the default value for mem and disk are "0 B" (from the Units utility `filesize` method). Do we want the default to be:
- 0
- Blank cell
- "N/A"
And do we want this to be consistent wherever resources are displayed, or should it vary between components?


