### PR TITLE
DCOS-15289: fix(serviceform): fix containers reducer

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
@@ -438,6 +438,10 @@ module.exports = {
           });
       }
 
+      if (this.volumeMounts.length === 0 && container.volumeMounts != null) {
+        container.volumeMounts = [];
+      }
+
       return container;
     });
 

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
@@ -968,7 +968,6 @@ describe("Containers", function() {
           new Transaction(["containers"], null, ADD_ITEM),
           new Transaction(["volumeMounts"], null, ADD_ITEM),
           new Transaction(["volumeMounts", 0, "name"], "extvol", SET),
-          new Transaction(["volumeMounts", 0, "mountPath"], null, ADD_ITEM),
           new Transaction(["volumeMounts", 0, "mountPath", 0], "mount", SET),
           new Transaction(["volumeMounts"], 0, REMOVE_ITEM)
         ]);


### PR DESCRIPTION
This fixes an issue which happens when you create a multi container service with a volume mount and
you later in the process remove the last volume mount. The volume will get removed from the json but
the volumemount stays in the json.

Close DCOS-15289


## TESTING
To test this 
- Go to `/#/services/overview/create`.
- Select `Multi-Container (Pod)`
- Go to `Volumes`
- Click `Add Volume`
- Open JSON editor 
Your container should look like this:
```JSON
{
  "name": "container-1",
  "resources": {
    "cpus": 0.1,
    "mem": 128
  },
  "volumeMounts": []
}
```
- Now click `Add Volume` 
- Add a name `volume`
- In the Container path section next to `container-1` add a container path: `containerPath`
- In the JSON editor you should see:
```JSON
{
  "name": "container-1",
  "resources": {
    "cpus": 0.1,
    "mem": 128
  },
  "volumeMounts": [
    {
      "name": "volume",
      "mountPath": "containerPath"
    }
  ]
}
```
- Now remove the volume via the `x` 
- JSON editor should now display again:
```JSON
{
  "name": "container-1",
  "resources": {
    "cpus": 0.1,
    "mem": 128
  },
  "volumeMounts": []
}
```
## Trade-offs

No known trade-offs


N/A