### PR TITLE
DCOS-21187: fix preinstall styling and markdown usage

### DIFF
--- a/src/styles/components/framework-configuration/styles.less
+++ b/src/styles/components/framework-configuration/styles.less
@@ -10,10 +10,6 @@
 
 .pre-install-notes.message.message-warning {
 
-  p {
-    display: inline;
-  }
-
   a {
     color: inherit;
   }


### PR DESCRIPTION
## Testing
navigate to package detail and package config review screens for multiple packages and verify that package description and orange-ish box is displayed correctly.

(remember to `npm install` after you checked out the branch)
<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs
~I decided to refactor the way we inject markdown because the old one used `dangerouslySetInnerHTML` which - by its name - should be replaced ASAP and it was an easy win. 
If it causes any trouble in this PR, I'm happy to remove or extract it.~ tests failed, data isnt in shape, removed it from this PR.
<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots
**Before:**
![screen shot 2018-08-31 at 14 24 51](https://user-images.githubusercontent.com/530632/44912185-a814cd00-ad29-11e8-9c0d-52b1fab4e407.png)
**After:**
![screen shot 2018-08-31 at 14 24 18](https://user-images.githubusercontent.com/530632/44912186-a8ad6380-ad29-11e8-97a0-b9872c02a61e.png)



