### PR TITLE
DCOS-21464: fix(serviceform): fix 0 gpu runtime block

### DIFF
--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -241,7 +241,7 @@ class GeneralServiceFormSection extends Component {
       type = container.type;
     }
 
-    if (!isEmpty(gpus) && gpus !== 0) {
+    if (!isEmpty(gpus) && parseFloat(gpus) !== 0) {
       isDisabled[DOCKER] = true;
       disabledTooltipContent =
         "Docker Engine does not support GPU resources, please select Universal Container Runtime (UCR) if you want to use GPU resources.";


### PR DESCRIPTION
This fixes an issue which blocked the user from switching from Mesos runtime to docker runtime if
they provided a 0 gpu setting.

Close DCOS-21464


## Testing

To test this:
- go to: `/#/services/overview/create`
- Select `Single Container`
- In the General Section click `More Settings`
- Select `Universal Contianer Runtime (UCR)`
- Go to GPUs and enter a value bigger as `0`
- The Docker Runtime should get disabled here
- Change the value of GPUs to `0`
- Select Docker Runtime 

## Trade-offs

This solution will have the trade of that in the case of a 0 gpu value the `gpus` in the JSON will be `0` which is mostly a cosmetic drawback as Marathon will accept it anyways.


<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->


## Screenshots

![gpu-fix mov](https://user-images.githubusercontent.com/156010/44912719-713fb680-ad2b-11e8-8f91-30b1746e0837.gif)