### PR TITLE
DCOS_OSS-526: fix(package repository settings): remove url validation on add

### DIFF
--- a/plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.js
+++ b/plugins/catalog/src/js/repositories/components/AddRepositoryFormModal.js
@@ -44,10 +44,12 @@ class AddRepositoryFormModal extends React.Component {
         name: "uri",
         placeholder: "URL",
         required: true,
-        validationErrorText: "Must be a valid url with http:// or https://",
+        showError: false,
         showLabel: false,
         writeType: "input",
-        validation: /^https?:\/\/.+\..+$/,
+        validation() {
+          return true;
+        },
         value: ""
       },
       {

--- a/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
+++ b/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
@@ -1,10 +1,9 @@
 describe("Add Repository Form Modal", function() {
   beforeEach(function() {
-    cy
-      .configureCluster({
-        mesos: "1-task-healthy",
-        universePackages: true
-      })
+    cy.configureCluster({
+      mesos: "1-task-healthy",
+      universePackages: true
+    })
       .visitUrl({ url: "/settings/repositories" })
       .get(".page-header-actions button")
       .click();
@@ -19,36 +18,32 @@ describe("Add Repository Form Modal", function() {
   });
 
   it("displays error if both fields aren't filled out", function() {
-    cy
-      .get(".modal .modal-footer .button.button-primary")
+    cy.get(".modal .modal-footer .button.button-primary")
       .contains("Add")
       .click();
 
-    cy
-      .get(".modal .form-control-feedback")
+    cy.get(".modal .form-control-feedback")
       .eq(0)
       .should("contain", "Field cannot be empty.");
 
-    cy
-      .get(".modal .form-control-feedback")
+    cy.get(".modal .form-control-feedback")
       .eq(1)
       .should("contain", "Must be a valid url with http:// or https://");
   });
 
   it("displays error if not a valid url", function() {
-    cy
-      .get(".modal .modal-footer .button.button-primary")
+    cy.get(".modal .modal-footer .button.button-primary")
       .contains("Add")
       .click();
 
-    cy
-      .get(".modal .form-control-feedback")
-      .should("contain", "Must be a valid url with http:// or https://");
+    cy.get(".modal .form-control-feedback").should(
+      "contain",
+      "Must be a valid url with http:// or https://"
+    );
   });
 
   it("closes modal after add is successful", function() {
-    cy
-      .get(".modal input")
+    cy.get(".modal input")
       .eq(0)
       .type("Here we go!")
       .get(".modal input")
@@ -65,14 +60,12 @@ describe("Add Repository Form Modal", function() {
 
     // Clean up
     cy.clusterCleanup(function() {
-      cy
-        .get(".page-body-content")
+      cy.get(".page-body-content")
         .contains("tr", "Here we go!")
         .find(".button.button-primary-link.button-danger")
         .invoke("show")
         .click({ force: true });
-      cy
-        .get(".modal .modal-footer .button.button-danger")
+      cy.get(".modal .modal-footer .button.button-danger")
         .contains("Delete Repository")
         .click();
     });
@@ -81,15 +74,14 @@ describe("Add Repository Form Modal", function() {
   it("displays error in modal after add causes an error", function() {
     // We need to add a fixture for this test to pass.
     var url = "http://there-is-no-stopping.us";
-    cy
-      .route({
-        method: "POST",
-        url: /repository\/add/,
-        status: 409,
-        response: {
-          message: "Conflict with " + url
-        }
-      })
+    cy.route({
+      method: "POST",
+      url: /repository\/add/,
+      status: 409,
+      response: {
+        message: "Conflict with " + url
+      }
+    })
       .get(".modal input")
       .eq(0)
       .type("Here we go!")
@@ -99,8 +91,7 @@ describe("Add Repository Form Modal", function() {
       .get(".modal input")
       .eq(2)
       .type("0");
-    cy
-      .get(".modal .modal-footer .button.button-primary")
+    cy.get(".modal .modal-footer .button.button-primary")
       .contains("Add")
       .click();
 
@@ -109,25 +100,22 @@ describe("Add Repository Form Modal", function() {
 
   // TODO: Turn into unit test
   it("displays generic error in modal if no message is provided", function() {
-    cy
-      .route({
-        method: "POST",
-        url: /repository\/add/,
-        status: 400,
-        response: {}
-      })
+    cy.route({
+      method: "POST",
+      url: /repository\/add/,
+      status: 400,
+      response: {}
+    })
       .get(".modal input")
       .eq(0)
       .type("Here we go!");
-    cy
-      .get(".modal input")
+    cy.get(".modal input")
       .eq(1)
       .type("http://there-is-no-stopping.us")
       .get(".modal input")
       .eq(2)
       .type("0");
-    cy
-      .get(".modal .modal-footer .button.button-primary")
+    cy.get(".modal .modal-footer .button.button-primary")
       .contains("Add")
       .click();
 

--- a/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
+++ b/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
@@ -28,18 +28,7 @@ describe("Add Repository Form Modal", function() {
 
     cy.get(".modal .form-control-feedback")
       .eq(1)
-      .should("contain", "Must be a valid url with http:// or https://");
-  });
-
-  it("displays error if not a valid url", function() {
-    cy.get(".modal .modal-footer .button.button-primary")
-      .contains("Add")
-      .click();
-
-    cy.get(".modal .form-control-feedback").should(
-      "contain",
-      "Must be a valid url with http:// or https://"
-    );
+      .should("contain", "Field cannot be empty.");
   });
 
   it("closes modal after add is successful", function() {


### PR DESCRIPTION
This removes the regex validation of the url field and lets rather the backend decide if a url is
valid or not.

Close DCOS_OSS-526


For Review, you may look at 65a30cfa341e771d216a1a1037504455df8c5be1 this is the commit which if filtered of the code style changes.

 ## Testing

To Test this:
- go to `Settings > Package Repository`
- Click the `+`
- Add a random Repository Name
- Add a url like `http://0.0.0.1:8080`
- Add a priority `1`
- Click `Add`

Now you should be presented with the error from the server instead of the error on the input field.

 ## Trade-offs

A Trade off is that we are showing the error from the Server which can be unexpected long for example with the url `http://0.0.0.0:8080` it will show some long message which is not really helpful.
<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

 ## Screenshots

*Before*:
![image](https://user-images.githubusercontent.com/156010/44915800-3c842d00-ad34-11e8-9005-1bbf09296170.png)

*After*: 
![image](https://user-images.githubusercontent.com/156010/44915837-63426380-ad34-11e8-9a06-30a67043ddca.png)



<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->