### PR TITLE
DCOS-40899: make the graph in the Nodes chart green

### DIFF
--- a/src/js/components/charts/HostTimeSeriesChart.js
+++ b/src/js/components/charts/HostTimeSeriesChart.js
@@ -13,13 +13,15 @@ var HostTimeSeriesChart = React.createClass({
     data: PropTypes.array.isRequired,
     refreshRate: PropTypes.number.isRequired,
     roundUpValue: PropTypes.number,
-    minMaxY: PropTypes.number
+    minMaxY: PropTypes.number,
+    colorIndex: PropTypes.number
   },
 
   getDefaultProps() {
     return {
       roundUpValue: 5,
-      minMaxY: 10
+      minMaxY: 10,
+      colorIndex: 0
     };
   },
 
@@ -45,7 +47,7 @@ var HostTimeSeriesChart = React.createClass({
     return [
       {
         name: "Nodes",
-        colorIndex: 0,
+        colorIndex: props.colorIndex,
         values: props.data
       }
     ];
@@ -71,7 +73,7 @@ var HostTimeSeriesChart = React.createClass({
     return (
       <div className="chart">
         <TimeSeriesLabel
-          colorIndex={0}
+          colorIndex={props.colorIndex}
           currentValue={props.currentValue}
           subHeading={"Connected Nodes"}
           y="slavesCount"

--- a/src/js/pages/DashboardPage.js
+++ b/src/js/pages/DashboardPage.js
@@ -248,6 +248,7 @@ var DashboardPage = React.createClass({
                 data={data.activeNodes}
                 currentValue={data.hostCount}
                 refreshRate={Config.getRefreshRate()}
+                colorIndex={4}
               />
             </Panel>
           </div>


### PR DESCRIPTION
Match the design team's mocks with the nodes chart green

Closes DCOS-40899

## Testing
Go to the dashboard
The Nodes chart should be green

## Trade-offs
Probably not

## Dependencies
None

## Screenshots
Before:
![screen shot 2018-08-31 at 3 44 51 pm](https://user-images.githubusercontent.com/2313998/44932814-dd72e800-ad34-11e8-81e5-85be3eca58d1.png)

After:
![screen shot 2018-08-31 at 3 44 15 pm](https://user-images.githubusercontent.com/2313998/44932825-e2d03280-ad34-11e8-972d-8ed14d1fea2f.png)

