### PR TITLE
DCOS-40781: Provide empty message for catalog search

### DIFF
--- a/src/js/pages/catalog/PackagesTab.js
+++ b/src/js/pages/catalog/PackagesTab.js
@@ -228,7 +228,9 @@ class PackagesTab extends mixin(StoreMixin) {
         return (
           <div className="clearfix">
             {noResults}
-            (<a onClick={this.clearInput}>view all</a>)
+            (<a className="clickable" onClick={this.clearInput}>
+              view all
+            </a>)
           </div>
         );
       }

--- a/src/js/pages/catalog/PackagesTab.js
+++ b/src/js/pages/catalog/PackagesTab.js
@@ -62,7 +62,7 @@ const PackagesEmptyState = () => {
   );
 };
 
-const METHODS_TO_BIND = ["handleSearchStringChange"];
+const METHODS_TO_BIND = ["handleSearchStringChange", "clearInput"];
 
 const shouldRenderCatalogOption = Hooks.applyFilter(
   "hasCapability",
@@ -127,6 +127,10 @@ class PackagesTab extends mixin(StoreMixin) {
 
   handleSearchStringChange(searchString = "") {
     this.setState({ searchString });
+  }
+
+  clearInput() {
+    this.handleSearchStringChange("");
   }
 
   getErrorScreen() {
@@ -197,7 +201,8 @@ class PackagesTab extends mixin(StoreMixin) {
   }
 
   getCommunityPackagesGrid(packages) {
-    if (packages.getItems().length === 0) {
+    const isSearchActive = this.state.searchString !== "";
+    if (!isSearchActive && packages.getItems().length === 0) {
       return null;
     }
 
@@ -208,7 +213,6 @@ class PackagesTab extends mixin(StoreMixin) {
       </p>
     );
     let title = "Community";
-    const isSearchActive = this.state.searchString !== "";
     const titleClasses = classNames("flush-top", {
       short: !isSearchActive,
       tall: isSearchActive
@@ -216,8 +220,20 @@ class PackagesTab extends mixin(StoreMixin) {
 
     if (isSearchActive) {
       const foundPackagesLength = packages.getItems().length;
-      const packagesWord = StringUtil.pluralize("service", foundPackagesLength);
+      if (foundPackagesLength < 1) {
+        const noResults = `No results were found for your search: "${
+          this.state.searchString
+        }" `;
 
+        return (
+          <div className="clearfix">
+            {noResults}
+            (<a onClick={this.clearInput}>view all</a>)
+          </div>
+        );
+      }
+
+      const packagesWord = StringUtil.pluralize("service", foundPackagesLength);
       subtitle = null;
       title = `${packages.getItems().length} ${packagesWord} found`;
     }

--- a/tests/pages/catalog/packages/PackagesTab-cy.js
+++ b/tests/pages/catalog/packages/PackagesTab-cy.js
@@ -107,6 +107,11 @@ describe("Packages Tab", function() {
         expect($panels.length).to.equal(1);
       });
     });
+
+    it("shows message when no matching packages found", function() {
+      cy.get("input").type("notfound");
+      cy.contains("No results were found for your search");
+    });
   });
 
   context("selected packages", function() {

--- a/tests/pages/catalog/packages/PackagesTab-cy.js
+++ b/tests/pages/catalog/packages/PackagesTab-cy.js
@@ -7,101 +7,83 @@ describe("Packages Tab", function() {
   });
 
   it("displays correct error message for invalid repo uri", function() {
-    cy
-      .route({
-        method: "POST",
-        url: /package\/search/,
-        status: 400,
-        response: {
-          type: "RepositoryUriSyntax",
-          name: "Invalid",
-          message: "The url for Invalid does not have correct syntax"
-        }
-      })
-      .visitUrl({ url: "/catalog/packages", logIn: true });
+    cy.route({
+      method: "POST",
+      url: /package\/search/,
+      status: 400,
+      response: {
+        type: "RepositoryUriSyntax",
+        name: "Invalid",
+        message: "The url for Invalid does not have correct syntax"
+      }
+    }).visitUrl({ url: "/catalog/packages", logIn: true });
 
-    cy
-      .get(".page-body-content .message")
-      .should(
-        "contain",
-        "The url for Invalid does not have correct syntax. You can go to the Repositories Settings page to change installed repositories."
-      );
+    cy.get(".page-body-content .message").should(
+      "contain",
+      "The url for Invalid does not have correct syntax. You can go to the Repositories Settings page to change installed repositories."
+    );
   });
 
   it("displays correct message for 'no index' error", function() {
-    cy
-      .route({
-        method: "POST",
-        url: /package\/search/,
-        status: 400,
-        response: {
-          type: "IndexNotFound",
-          name: "Invalid",
-          message: "The index file is missing in Invalid"
-        }
-      })
-      .visitUrl({ url: "/catalog", logIn: true });
+    cy.route({
+      method: "POST",
+      url: /package\/search/,
+      status: 400,
+      response: {
+        type: "IndexNotFound",
+        name: "Invalid",
+        message: "The index file is missing in Invalid"
+      }
+    }).visitUrl({ url: "/catalog", logIn: true });
 
-    cy
-      .get(".page-body-content .message")
-      .should(
-        "contain",
-        "The index file is missing in Invalid. You can go to the Repositories Settings page to change installed repositories."
-      );
+    cy.get(".page-body-content .message").should(
+      "contain",
+      "The index file is missing in Invalid. You can go to the Repositories Settings page to change installed repositories."
+    );
   });
 
   it("displays correct message for missing package file", function() {
-    cy
-      .route({
-        method: "POST",
-        url: /package\/search/,
-        status: 400,
-        response: {
-          type: "PackageFileMissing",
-          name: "Invalid",
-          message: "The package file is missing in Invalid"
-        }
-      })
-      .visitUrl({ url: "/catalog", logIn: true });
+    cy.route({
+      method: "POST",
+      url: /package\/search/,
+      status: 400,
+      response: {
+        type: "PackageFileMissing",
+        name: "Invalid",
+        message: "The package file is missing in Invalid"
+      }
+    }).visitUrl({ url: "/catalog", logIn: true });
 
-    cy
-      .get(".page-body-content .message")
-      .should(
-        "contain",
-        "The package file is missing in Invalid. You can go to the Repositories Settings page to change installed repositories."
-      );
+    cy.get(".page-body-content .message").should(
+      "contain",
+      "The package file is missing in Invalid. You can go to the Repositories Settings page to change installed repositories."
+    );
   });
 
   it("uses default repository name if not provided", function() {
-    cy
-      .route({
-        method: "POST",
-        url: /package\/search/,
-        status: 400,
-        response: {
-          type: "PackageFileMissing",
-          message: "The package file is missing in a repository"
-        }
-      })
-      .visitUrl({ url: "/catalog", logIn: true });
+    cy.route({
+      method: "POST",
+      url: /package\/search/,
+      status: 400,
+      response: {
+        type: "PackageFileMissing",
+        message: "The package file is missing in a repository"
+      }
+    }).visitUrl({ url: "/catalog", logIn: true });
 
-    cy
-      .get(".page-body-content .message")
-      .should(
-        "contain",
-        "The package file is missing in a repository. You can go to the Repositories Settings page to change installed repositories."
-      );
+    cy.get(".page-body-content .message").should(
+      "contain",
+      "The package file is missing in a repository. You can go to the Repositories Settings page to change installed repositories."
+    );
   });
 
   it("shows default error message for missing package file", function() {
-    cy
-      .route({
-        method: "POST",
-        url: /package\/search/,
-        status: 400,
-        response: { message: "Some other error" }
-      })
-      .visitUrl({ url: "/catalog", logIn: true });
+    cy.route({
+      method: "POST",
+      url: /package\/search/,
+      status: 400,
+      response: { message: "Some other error" }
+    }).visitUrl({ url: "/catalog", logIn: true });
 
     cy.get(".panel-content h2").should("contain", "An Error Occurred");
   });
@@ -113,9 +95,11 @@ describe("Packages Tab", function() {
     });
 
     it("hides certified panels", function() {
-      cy.get("h1").contains("Certified").should(function($certifiedHeading) {
-        expect($certifiedHeading.length).to.equal(0);
-      });
+      cy.get("h1")
+        .contains("Certified")
+        .should(function($certifiedHeading) {
+          expect($certifiedHeading.length).to.equal(0);
+        });
     });
 
     it("shows only cassandra in panels", function() {
@@ -128,8 +112,7 @@ describe("Packages Tab", function() {
   context("selected packages", function() {
     beforeEach(function() {
       cy.visitUrl({ url: "/catalog", logIn: true });
-      cy
-        .get("h1")
+      cy.get("h1")
         .contains("Certified")
         .closest(".pod")
         .find(".panel")
@@ -149,8 +132,12 @@ describe("Packages Tab", function() {
     });
 
     it("opens the modal when the panel button is clicked", function() {
-      cy.get(".panel").contains("arangodb").click();
-      cy.get(".button.button-primary").contains("Review & Run").click();
+      cy.get(".panel")
+        .contains("arangodb")
+        .click();
+      cy.get(".button.button-primary")
+        .contains("Review & Run")
+        .click();
 
       cy.get(".modal").should(function($modal) {
         expect($modal.length).to.equal(1);
@@ -158,7 +145,9 @@ describe("Packages Tab", function() {
     });
 
     it("doesn't open the modal when the panel is clicked", function() {
-      cy.get(".panel").contains("arangodb").click();
+      cy.get(".panel")
+        .contains("arangodb")
+        .click();
 
       cy.get(".modal").should(function($modal) {
         expect($modal.length).to.equal(0);
@@ -168,19 +157,18 @@ describe("Packages Tab", function() {
 
   context("respect DCOS version", function() {
     beforeEach(function() {
-      cy
-        .route(/dcos-version/, {
-          version: "1.6",
-          "dcos-image-commit": "null",
-          "bootstrap-id": "null"
-        })
-        .visitUrl({ url: "/catalog", logIn: true });
+      cy.route(/dcos-version/, {
+        version: "1.6",
+        "dcos-image-commit": "null",
+        "bootstrap-id": "null"
+      }).visitUrl({ url: "/catalog", logIn: true });
     });
 
     it("cant install package because of DCOS version", function() {
-      cy.get(".panel").contains("arangodb").click();
-      cy
-        .get(".button.button-primary")
+      cy.get(".panel")
+        .contains("arangodb")
+        .click();
+      cy.get(".button.button-primary")
         .contains("Review & Run")
         .should("be.disabled");
     });


### PR DESCRIPTION
Provide a message indicating when no results were found when searching Catalog page.

Closes DCOS-40781

## Testing

Go to Catalog page and try searching using strings that will match as well as strings that won't. Ensure regular filtering happens as expected and ensure non-matching strings show the empty message. Ensure 'view all' clears the filter as expected.

## Trade-offs

Seems a little convoluted to handle the search results from within `getCommunityPackagesGrid`. Maybe this could eventually be refactored into its own function.

## Screenshots

Before: 
<img width="999" alt="before" src="https://user-images.githubusercontent.com/19582796/44933477-181d5600-ad1e-11e8-8a57-211e41ae551e.png">

After:
<img width="1102" alt="after" src="https://user-images.githubusercontent.com/19582796/44933491-1d7aa080-ad1e-11e8-890d-0d602ad9c0b7.png">

