### PR TITLE
DCOS_OSS-1551: show VIP fields in host mode

### DIFF
--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -174,11 +174,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
     ];
   }
 
-  getLoadBalancedServiceAddressField(endpoint, network, index, containerIndex) {
-    if (network !== CONTAINER) {
-      return null;
-    }
-
+  getLoadBalancedServiceAddressField(endpoint, index, containerIndex) {
     const { containerPort, hostPort, loadBalanced, vip } = endpoint;
     const { errors } = this.props;
     let loadBalancedError = findNestedPropertyInObject(
@@ -474,7 +470,6 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
           </FormRow>
           {this.getLoadBalancedServiceAddressField(
             endpoint,
-            network,
             index,
             containerIndex
           )}

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
@@ -46,14 +46,14 @@ function mapEndpoints(endpoints = [], networkType, appState) {
       hostPort = 0;
     }
 
-    if (networkType === CONTAINER) {
-      labels = VipLabelUtil.generateVipLabel(
-        appState.id,
-        endpoint,
-        vipLabel || VipLabelUtil.defaultVip(index),
-        vipPort || containerPort || hostPort
-      );
+    labels = VipLabelUtil.generateVipLabel(
+      appState.id,
+      endpoint,
+      vipLabel || VipLabelUtil.defaultVip(index),
+      vipPort || containerPort || hostPort
+    );
 
+    if (networkType === CONTAINER) {
       return {
         name,
         containerPort,

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1509,27 +1509,62 @@ describe("Service Form Modal", function() {
           .click();
       });
 
-      context("Virtual Network: dcos-1", function() {
+      context("Service Endpoints", function() {
         beforeEach(function() {
-          cy.get('select[name="networks.0"]').select("Virtual Network: dcos-1");
+          addServiceEndpoint();
         });
 
-        context("Load balanced ports", function() {
+        function addServiceEndpoint() {
+          cy.get(".button.button-primary-link")
+            .contains("Add Service Endpoint")
+            .click();
+        }
+
+        function enableLoadBalancedAddress() {
+          cy.get(".form-group-heading-content")
+            .contains("Enable Load Balanced Service Address")
+            .click();
+        }
+
+        context("Host", function() {
           beforeEach(function() {
-            cy.get(".button.button-primary-link")
-              .contains("Add Service Endpoint")
-              .click();
-            cy.get(".form-group-heading-content")
-              .contains("Enable Load Balanced Service Address")
-              .click();
+            cy.get('select[name="networks.0"]').select("Host");
           });
 
-          it("sets vip port", function() {
-            cy.get(
-              '.form-control[name="containers.0.endpoints.0.vipPort"]'
-            ).type(9007);
+          context("Load balanced ports", function() {
+            beforeEach(function() {
+              enableLoadBalancedAddress();
+            });
 
-            cy.contains(".marathon.l4lb.thisdcos.directory:9007");
+            it("sets vip port", function() {
+              cy.get(
+                '.form-control[name="containers.0.endpoints.0.vipPort"]'
+              ).type(9007);
+
+              cy.contains(".marathon.l4lb.thisdcos.directory:9007");
+            });
+          });
+        });
+
+        context("Virtual Network: dcos-1", function() {
+          beforeEach(function() {
+            cy.get('select[name="networks.0"]').select(
+              "Virtual Network: dcos-1"
+            );
+          });
+
+          context("Load balanced ports", function() {
+            beforeEach(function() {
+              enableLoadBalancedAddress();
+            });
+
+            it("sets vip port", function() {
+              cy.get(
+                '.form-control[name="containers.0.endpoints.0.vipPort"]'
+              ).type(9007);
+
+              cy.contains(".marathon.l4lb.thisdcos.directory:9007");
+            });
           });
         });
       });


### PR DESCRIPTION
For pods, fixes the issue where when adding a service endpoint in host mode, there was no fields shown to enable VIP (load balanced address).

Closes DCOS_OSS-1551

## Testing
* Go to pod create service form
* Click Networking tab
* Click Add Service Endpoint _("Enable Load Balanced Address" checkbox shows)_
* Click the checkbox _(Open JSON editor and labels:VIP_0 shows)_
* Enter a load balanced port _(labels:VIP_0 is updated with the port)_

## Trade-offs
* Decided to remove the checks for network type based on the assumption that any network type can have VIP properties set.

## Dependencies
None

## Screenshots
![screen shot 2018-08-31 at 5 31 05 pm](https://user-images.githubusercontent.com/4956107/44940467-ae17a780-ad43-11e8-9338-ddae19ebd7d5.png)
