### PR TITLE
DCOS-20222: add error for environment values without keys

### DIFF
--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -49,10 +49,15 @@ class EnvironmentFormSection extends Component {
             </FieldLabel>
           );
         }
+        const isValueWithoutKey = !env.key && env.value;
 
         return (
           <FormRow key={key}>
-            <FormGroup className="column-6" required={false}>
+            <FormGroup
+              className="column-6"
+              required={false}
+              showError={isValueWithoutKey}
+            >
               {keyLabel}
               <FieldAutofocus>
                 <FieldInput
@@ -61,6 +66,9 @@ class EnvironmentFormSection extends Component {
                   value={env.key}
                 />
               </FieldAutofocus>
+              <FieldError>
+                An environment variable needs to contain at least a key.
+              </FieldError>
               <span className="emphasis form-colon">:</span>
             </FormGroup>
             <FormGroup

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1362,6 +1362,16 @@ describe("Service Form Modal", function() {
 
           cy.get('.form-control[name="env.0.key"]').should("not.exist");
         });
+
+        it("shows an error if only the value is filled out", function() {
+          cy.get("@tabView")
+            .find('.form-control[name="env.0.value"]')
+            .type("value");
+
+          cy.get("@tabView").contains(
+            "An environment variable needs to contain at least a key."
+          );
+        });
       });
 
       context("Labels", function() {


### PR DESCRIPTION
## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

- Go to the pods / service form
- Go to the environment section
- Create a label without a key
- See that it is shown as an error

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

None that I am aware of

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

None

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

![bildschirmfoto 2018-09-03 um 12 03 57](https://user-images.githubusercontent.com/1337046/44980922-7b52f680-af71-11e8-9384-04eacde0636a.png)
