### PR TITLE
DCOS-41283: Add zbase to user_id in Intercom

### DIFF
--- a/plugins/intercom/hooks.js
+++ b/plugins/intercom/hooks.js
@@ -80,8 +80,7 @@ module.exports = {
     global.Intercom("boot", {
       app_id: this.configuration.appId,
       email: user.email,
-      name: user.name,
-      user_id: user.uid
+      name: AuthStore.getUserLabel()
     });
 
     IntercomStore.addChangeListener(

--- a/plugins/intercom/stores/IntercomStore.js
+++ b/plugins/intercom/stores/IntercomStore.js
@@ -7,6 +7,7 @@ import {
   HEALTH_NODES_CHANGE,
   CLUSTER_CCID_SUCCESS
 } from "#SRC/js/constants/EventTypes";
+import AuthStore from "#SRC/js/stores/AuthStore";
 import ConfigStore from "#SRC/js/stores/ConfigStore";
 import MetadataStore from "#SRC/js/stores/MetadataStore";
 import NodeHealthStore from "../../nodes/src/js/stores/NodeHealthStore";
@@ -123,8 +124,13 @@ class IntercomStore extends GetSetBaseStore {
   }
 
   onClusterCCIDSuccess() {
+    const user = AuthStore.getUser();
     const ccid = ConfigStore.get("ccid");
-    this.set({ crypto_cluster_uuid: ccid.zbase32_public_key });
+
+    this.set({
+      crypto_cluster_uuid: ccid.zbase32_public_key,
+      user_id: `${user.uid}+${ccid.zbase32_public_key}`
+    });
 
     this.emit(INTERCOM_CHANGE);
   }

--- a/plugins/intercom/stores/__tests__/IntercomStore-test.js
+++ b/plugins/intercom/stores/__tests__/IntercomStore-test.js
@@ -1,11 +1,14 @@
 const MetadataStore = require("#SRC/js/stores/MetadataStore");
 const ConfigStore = require("#SRC/js/stores/ConfigStore");
+const AuthStore = require("#SRC/js/stores/AuthStore");
 const EventTypes = require("#SRC/js/constants/EventTypes");
 
 const NodeHealthStore = require("../../../nodes/src/js/stores/NodeHealthStore");
 
 const { INTERCOM_CHANGE } = require("../../constants/EventTypes");
 const IntercomStore = require("../IntercomStore");
+
+jest.mock("#SRC/js/stores/AuthStore");
 
 describe("IntercomStore", function() {
   it("adds attribute", function() {
@@ -58,6 +61,8 @@ describe("IntercomStore", function() {
     it("triggers an action upon ccid success", function() {
       const mockedFn = jest.genMockFunction();
       IntercomStore.onClusterCCIDSuccess = mockedFn;
+
+      AuthStore.getUser.mockResolvedValue({ uid: "user_uid" });
 
       addIntercomChangeListener();
 


### PR DESCRIPTION
This PR adds a UUID part to intercom user ID so intercom could tell between different users.

Closes DCOS-41283

## Testing

1. Read the thread https://mesosphere.slack.com/archives/C03UXUVH7/p1535963672000100
2. Verify that all the history is available on the daily cluster
3. Checkout the PR
4. Verify that _all_ the history is not available anymore, but only messages sent from your user and that very cluster.
5. Create a new user under `Organization -> Users`
6. Verify that the history of the default user in not available for the new user

## Trade-offs

1. Listed in the above mentioned Slack thread
2. I decided to add `user_id` post intercom boot so that we don't need to wait for all metadata before we boot