### PR TITLE
[1.11] DCOS-41282: remove text truncation for load balanced address

### DIFF
--- a/plugins/services/src/js/components/DeclinedOffersTable.js
+++ b/plugins/services/src/js/components/DeclinedOffersTable.js
@@ -323,7 +323,7 @@ class DeclinedOffersTable extends React.Component {
     return (
       <MountService.Mount type="DeclinedOffersTable">
         <Table
-          className="table table-flush table-borderless-outer table-borderless-inner-columns table-header-nowrap table-break-word table-hover flush-bottom"
+          className="table table-flush table-borderless-outer table-borderless-inner-columns table-break-word table-hover flush-bottom"
           colGroup={this.getColGroup()}
           columns={this.getColumns()}
           data={offers}

--- a/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
+++ b/plugins/services/src/js/service-configuration/ServiceNetworkingConfigSection.js
@@ -128,7 +128,7 @@ class ServiceNetworkingConfigSection extends ServiceConfigBaseSectionDisplay {
               {
                 heading: getColumnHeadingFn("Load Balanced Address"),
                 prop: "",
-                className: getColumnClassNameFn(),
+                className: getColumnClassNameFn("wrap-content"),
                 render(prop, row) {
                   const { port, labels } = row;
                   const vipLabel = ServiceConfigUtil.findVIPLabel(labels);

--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -2,13 +2,6 @@
 
   .table {
 
-    &.table-header-nowrap {
-
-      th {
-        white-space: nowrap;
-      }
-    }
-
     &.table-hide-header {
 
       thead {

--- a/src/styles/content/tables/styles.less
+++ b/src/styles/content/tables/styles.less
@@ -101,6 +101,10 @@
       }
     }
 
+    td.wrap-content {
+      white-space: normal;
+    }
+
     th,
     td {
       display: table-cell;


### PR DESCRIPTION
Backport of DCOS-40685

https://github.com/dcos/dcos-ui/pull/3222

## Testing
* Open Create Service Form and paste the following in JSON Editor:
```
{
  "id": "/truncation-test",
  "instances": 1,
  "container": {
    "portMappings": [
      {
        "containerPort": 80,
        "hostPort": 0,
        "labels": {
          "VIP_0": "/truncation-test:10101"
        },
        "protocol": "tcp",
        "name": "test"
      }
    ],
    "type": "DOCKER",
    "volumes": [],
    "docker": {
      "image": "nginx"
    }
  },
  "cpus": 0.1,
  "mem": 128,
  "requirePorts": false,
  "networks": [
    {
      "mode": "container/bridge"
    }
  ],
  "healthChecks": [],
  "fetch": [],
  "constraints": []
}
```
* Click "Review & Run"
* "Load Balanced Address" column content is not truncated

## Screenshots

### Before
![screen shot 2018-08-30 at 5 19 02 pm](https://user-images.githubusercontent.com/4956107/44886004-d5557280-ac78-11e8-9ff1-4c3f545ff08a.png)

### After
![screen shot 2018-08-30 at 5 17 52 pm](https://user-images.githubusercontent.com/4956107/44886009-d9819000-ac78-11e8-9e70-6555735d43ce.png)