### PR TITLE
[1.10] BACKPORT: Ph/backport/dcos 41280 1.10

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
@@ -421,6 +421,10 @@ module.exports = {
           });
       }
 
+      if (this.volumeMounts.length === 0 && container.volumeMounts != null) {
+        container.volumeMounts = [];
+      }
+
       return container;
     });
 

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
@@ -968,7 +968,6 @@ describe("Containers", function() {
           new Transaction(["containers"], null, ADD_ITEM),
           new Transaction(["volumeMounts"], null, ADD_ITEM),
           new Transaction(["volumeMounts", 0, "name"], "extvol", SET),
-          new Transaction(["volumeMounts", 0, "mountPath"], null, ADD_ITEM),
           new Transaction(["volumeMounts", 0, "mountPath", 0], "mount", SET),
           new Transaction(["volumeMounts"], 0, REMOVE_ITEM)
         ]);


### PR DESCRIPTION
This fixes an issue which happens when you create a multi container service with a volume mount and
you later in the process remove the last volume mount. The volume will get removed from the json but
the volumemount stays in the json.

Close DCOS-15289

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
