### PR TITLE
[1.10] fix(serviceform): fix 0 gpu runtime block

### DIFF
--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -484,7 +484,7 @@ class GeneralServiceFormSection extends Component {
       type = container.type;
     }
 
-    if (!isEmpty(gpus) && gpus !== 0) {
+    if (!isEmpty(gpus) && parseFloat(gpus) !== 0) {
       isDisabled[DOCKER] = true;
       disabledTooltipContent =
         "Docker Engine does not support GPU resources, please select Universal Container Runtime (UCR) if you want to use GPU resources.";


### PR DESCRIPTION
This fixes an issue which blocked the user from switching from Mesos runtime to docker runtime if
they provided a 0 gpu setting.

Close DCOS-21464


<!--- Thank you for your contribution! Please provide enough information for others to best review your code. -->

<!-- Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it. -->

<!-- Description of motivation for making this change, what does it solve and steps needed to see change. -->

![gif/image]()

```
<!-- Suplemental codeblock -->
```

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->