### PR TITLE
[1.11] BACKPORT: fix(packagerepository): remove url validation on add

### DIFF
--- a/src/js/components/modals/AddRepositoryFormModal.js
+++ b/src/js/components/modals/AddRepositoryFormModal.js
@@ -82,10 +82,12 @@ class AddRepositoryFormModal extends mixin(StoreMixin) {
         name: "uri",
         placeholder: "URL",
         required: true,
-        validationErrorText: "Must be a valid url with http:// or https://",
+        showError: false,
         showLabel: false,
         writeType: "input",
-        validation: /^https?:\/\/.+\..+$/,
+        validation() {
+          return true;
+        },
         value: ""
       },
       {

--- a/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
+++ b/tests/pages/system/overview/repositories/AddRepositoryFormModal-cy.js
@@ -32,18 +32,7 @@ describe("Add Repository Form Modal", function() {
     cy
       .get(".modal .form-control-feedback")
       .eq(1)
-      .should("contain", "Must be a valid url with http:// or https://");
-  });
-
-  it("should display error if not a valid url", function() {
-    cy
-      .get(".modal .modal-footer .button.button-primary")
-      .contains("Add")
-      .click();
-
-    cy
-      .get(".modal .form-control-feedback")
-      .should("contain", "Must be a valid url with http:// or https://");
+      .should("contain", "Field cannot be empty.");
   });
 
   it("closes modal after add is successful", function() {


### PR DESCRIPTION
This removes the regex validation of the url field and lets rather the backend decide if a url is
valid or not.

Close DCOS_OSS-526


<!--- Thank you for your contribution! Please provide enough information for others to best review your code. -->

<!-- Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it. -->

<!-- Description of motivation for making this change, what does it solve and steps needed to see change. -->

![gif/image]()

```
<!-- Suplemental codeblock -->
```

**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?

<!-- More info can be found by clicking the "guidelines for contributing" link above. -->