### PR TITLE
[1.11] Backport: fix(PackagesTab): provide empty message for catalog search

### DIFF
--- a/src/js/pages/catalog/PackagesTab.js
+++ b/src/js/pages/catalog/PackagesTab.js
@@ -38,7 +38,7 @@ const PackagesBreadcrumbs = () => {
   return <Page.Header.Breadcrumbs iconID="catalog" breadcrumbs={crumbs} />;
 };
 
-const METHODS_TO_BIND = ["handleSearchStringChange"];
+const METHODS_TO_BIND = ["handleSearchStringChange", "clearInput"];
 
 const shouldRenderCatalogOption = Hooks.applyFilter(
   "hasCapability",
@@ -105,6 +105,10 @@ class PackagesTab extends mixin(StoreMixin) {
     this.setState({ searchString });
   }
 
+  clearInput() {
+    this.handleSearchStringChange("");
+  }
+
   getErrorScreen() {
     const { errorMessage } = this.state;
 
@@ -140,12 +144,8 @@ class PackagesTab extends mixin(StoreMixin) {
           label={this.getPackageOptionBadge(cosmosPackage)}
           onOptionSelect={this.handleDetailOpen.bind(this, cosmosPackage)}
         >
-          <div className="h3 flush">
-            {cosmosPackage.getName()}
-          </div>
-          <small className="flush">
-            {cosmosPackage.getVersion()}
-          </small>
+          <div className="h3 flush">{cosmosPackage.getName()}</div>
+          <small className="flush">{cosmosPackage.getVersion()}</small>
         </CatalogPackageOption>
       );
     });
@@ -170,27 +170,27 @@ class PackagesTab extends mixin(StoreMixin) {
       <div className="pod flush-top flush-horizontal clearfix">
         <h1 className="short flush-top">Certified</h1>
         <p className="tall flush-top">
-          Certified packages are verified by Mesosphere for interoperability with DC/OS.
+          Certified packages are verified by Mesosphere for interoperability
+          with DC/OS.
         </p>
-        <div className="panel-grid row">
-          {this.getPackageGrid(packages)}
-        </div>
+        <div className="panel-grid row">{this.getPackageGrid(packages)}</div>
       </div>
     );
   }
 
   getCommunityPackagesGrid(packages) {
-    if (packages.getItems().length === 0) {
+    const isSearchActive = this.state.searchString !== "";
+    if (!isSearchActive && packages.getItems().length === 0) {
       return null;
     }
 
     let subtitle = (
       <p className="tall flush-top">
-        Community packages are unverified and unreviewed content from the community.
+        Community packages are unverified and unreviewed content from the
+        community.
       </p>
     );
     let title = "Community";
-    const isSearchActive = this.state.searchString !== "";
     const titleClasses = classNames("flush-top", {
       short: !isSearchActive,
       tall: isSearchActive
@@ -198,8 +198,20 @@ class PackagesTab extends mixin(StoreMixin) {
 
     if (isSearchActive) {
       const foundPackagesLength = packages.getItems().length;
-      const packagesWord = StringUtil.pluralize("service", foundPackagesLength);
+      if (foundPackagesLength < 1) {
+        const noResults = `No results were found for your search: "${this.state.searchString}" `;
 
+        return (
+          <div className="clearfix">
+            {noResults}
+            (<a className="clickable" onClick={this.clearInput}>
+              view all
+            </a>)
+          </div>
+        );
+      }
+
+      const packagesWord = StringUtil.pluralize("service", foundPackagesLength);
       subtitle = null;
       title = `${packages.getItems().length} ${packagesWord} found`;
     }
@@ -208,9 +220,7 @@ class PackagesTab extends mixin(StoreMixin) {
       <div className="clearfix">
         <h1 className={titleClasses}>{title}</h1>
         {subtitle}
-        <div className="panel-grid row">
-          {this.getPackageGrid(packages)}
-        </div>
+        <div className="panel-grid row">{this.getPackageGrid(packages)}</div>
       </div>
     );
   }

--- a/tests/pages/catalog/packages/PackagesTab-cy.js
+++ b/tests/pages/catalog/packages/PackagesTab-cy.js
@@ -123,6 +123,11 @@ describe("Packages Tab", function() {
         expect($panels.length).to.equal(1);
       });
     });
+
+    it("shows message when no matching packages found", function() {
+      cy.get("input").type("notfound");
+      cy.contains("No results were found for your search");
+    });
   });
 
   context("selected packages", function() {


### PR DESCRIPTION
Backport changes from #3231 that provide a message indicating when no results were found when searching Catalog page.

Closes DCOS-41391

## Testing

Go to Catalog page and try searching using strings that will match as well as strings that won't. Ensure regular filtering happens as expected and ensure non-matching strings show the empty message. Ensure 'view all' clears the filter as expected.

