### PR TITLE
[1.10] Backport: fix(PackagesTab): provide empty message for catalog search

### DIFF
--- a/src/js/pages/catalog/PackagesTab.js
+++ b/src/js/pages/catalog/PackagesTab.js
@@ -37,7 +37,7 @@ const PackagesBreadcrumbs = () => {
   return <Page.Header.Breadcrumbs iconID="packages" breadcrumbs={crumbs} />;
 };
 
-const METHODS_TO_BIND = ["handleSearchStringChange"];
+const METHODS_TO_BIND = ["handleSearchStringChange", "clearInput"];
 
 const shouldRenderCatalogOption = Hooks.applyFilter(
   "hasCapability",
@@ -104,6 +104,10 @@ class PackagesTab extends mixin(StoreMixin) {
     this.setState({ searchString });
   }
 
+  clearInput() {
+    this.handleSearchStringChange("");
+  }
+
   getErrorScreen() {
     const { errorMessage } = this.state;
 
@@ -139,12 +143,8 @@ class PackagesTab extends mixin(StoreMixin) {
           label={this.getPackageOptionBadge(cosmosPackage)}
           onOptionSelect={this.handleDetailOpen.bind(this, cosmosPackage)}
         >
-          <div className="h6 flush-top short">
-            {cosmosPackage.getName()}
-          </div>
-          <small className="flush">
-            {cosmosPackage.getVersion()}
-          </small>
+          <div className="h6 flush-top short">{cosmosPackage.getName()}</div>
+          <small className="flush">{cosmosPackage.getVersion()}</small>
         </CatalogPackageOption>
       );
     });
@@ -169,27 +169,27 @@ class PackagesTab extends mixin(StoreMixin) {
       <div className="pod flush-top flush-horizontal clearfix">
         <h4 className="short flush-top">Certified</h4>
         <p className="tall flush-top">
-          Certified packages are verified by Mesosphere for interoperability with DC/OS.
+          Certified packages are verified by Mesosphere for interoperability
+          with DC/OS.
         </p>
-        <div className="panel-grid row">
-          {this.getPackageGrid(packages)}
-        </div>
+        <div className="panel-grid row">{this.getPackageGrid(packages)}</div>
       </div>
     );
   }
 
   getCommunityPackagesGrid(packages) {
-    if (packages.getItems().length === 0) {
+    const isSearchActive = this.state.searchString !== "";
+    if (!isSearchActive && packages.getItems().length === 0) {
       return null;
     }
 
     let subtitle = (
       <p className="tall flush-top">
-        Community packages are unverified and unreviewed content from the community.
+        Community packages are unverified and unreviewed content from the
+        community.
       </p>
     );
     let title = "Community";
-    const isSearchActive = this.state.searchString !== "";
     const titleClasses = classNames("flush-top", {
       short: !isSearchActive,
       tall: isSearchActive
@@ -197,19 +197,29 @@ class PackagesTab extends mixin(StoreMixin) {
 
     if (isSearchActive) {
       const foundPackagesLength = packages.getItems().length;
-      const packagesWord = StringUtil.pluralize("service", foundPackagesLength);
+      if (foundPackagesLength < 1) {
+        const noResults = `No results were found for your search: "${this.state.searchString}" `;
 
+        return (
+          <div className="clearfix">
+            {noResults}
+            (<a className="clickable" onClick={this.clearInput}>
+              view all
+            </a>)
+          </div>
+        );
+      }
+
+      const packagesWord = StringUtil.pluralize("service", foundPackagesLength);
       subtitle = null;
       title = `${packages.getItems().length} ${packagesWord} found`;
     }
 
     return (
       <div className="clearfix">
-        <h4 className={titleClasses}>{title}</h4>
+        <h1 className={titleClasses}>{title}</h1>
         {subtitle}
-        <div className="panel-grid row">
-          {this.getPackageGrid(packages)}
-        </div>
+        <div className="panel-grid row">{this.getPackageGrid(packages)}</div>
       </div>
     );
   }

--- a/tests/pages/catalog/packages/PackagesTab-cy.js
+++ b/tests/pages/catalog/packages/PackagesTab-cy.js
@@ -113,7 +113,7 @@ describe("Packages Tab", function() {
     });
 
     it("should hide certified panels", function() {
-      cy.get("h4").contains("Certified").should(function($certifiedHeading) {
+      cy.get("h1").contains("Certified").should(function($certifiedHeading) {
         expect($certifiedHeading.length).to.equal(0);
       });
     });
@@ -122,6 +122,11 @@ describe("Packages Tab", function() {
       cy.get(".panel").should(function($panels) {
         expect($panels.length).to.equal(1);
       });
+    });
+
+    it("shows message when no matching packages found", function() {
+      cy.get("input").type("notfound");
+      cy.contains("No results were found for your search");
     });
   });
 


### PR DESCRIPTION
Backport changes from #3231 that provide a message indicating when no results were found when searching Catalog page.

Closes DCOS-41396

## Testing

Go to Catalog page and try searching using strings that will match as well as strings that won't. Ensure regular filtering happens as expected and ensure non-matching strings show the empty message. Ensure 'view all' clears the filter as expected.
