### PR TITLE
DCOS-21202: MS Edge sidebar glitch

### DIFF
--- a/src/js/components/FrameworkConfigurationForm.js
+++ b/src/js/components/FrameworkConfigurationForm.js
@@ -357,31 +357,35 @@ export default class FrameworkConfigurationForm extends Component {
             items={this.getDropdownNavigationList()}
           />
           <FluidGeminiScrollbar>
-            <div className="modal-body-padding-surrogate create-service-modal-form-container">
-              <div className="framework-configuration-form create-service-modal-form container">
+            <div className="create-service-modal-form-container">
+              <div className="framework-configuration-form create-service-modal-form">
                 <Tabs
                   activeTab={activeTab}
                   handleTabChange={this.handleTabChange}
                   vertical={true}
                   className={"menu-tabbed-container-fixed"}
                 >
-                  <TabButtonList>{this.getFormTabList()}</TabButtonList>
-                  <div className="menu-tabbed-view-container">
-                    {errorsAlert}
-                    {defaultConfigWarningMessage}
-                    <SchemaForm
-                      schema={schema}
-                      formData={formData}
-                      onChange={this.handleFormChange}
-                      uiSchema={this.getUiSchema()}
-                      fields={{ SchemaField, TitleField }}
-                      liveValidate={true}
-                      validate={this.validate}
-                      ErrorList={this.jsonSchemaErrorList}
-                      transformErrors={this.transformErrors}
-                    >
-                      <div />
-                    </SchemaForm>
+                  <TabButtonList className="create-service-modal-tabButtonList">
+                    {this.getFormTabList()}
+                  </TabButtonList>
+                  <div className="menu-tabbed-view-container-fixed-scrollWrapper modal-body-padding-surrogate">
+                    <div className="menu-tabbed-view-container-fixed-scrollWrapper-content menu-tabbed-view-container">
+                      {errorsAlert}
+                      {defaultConfigWarningMessage}
+                      <SchemaForm
+                        schema={schema}
+                        formData={formData}
+                        onChange={this.handleFormChange}
+                        uiSchema={this.getUiSchema()}
+                        fields={{ SchemaField, TitleField }}
+                        liveValidate={true}
+                        validate={this.validate}
+                        ErrorList={this.jsonSchemaErrorList}
+                        transformErrors={this.transformErrors}
+                      >
+                        <div />
+                      </SchemaForm>
+                    </div>
                   </div>
                 </Tabs>
               </div>

--- a/src/styles/components/menu-tabbed/styles.less
+++ b/src/styles/components/menu-tabbed/styles.less
@@ -11,12 +11,33 @@
   }
 
   .menu-tabbed-container-fixed {
+    display: grid;
+    grid-auto-rows: 100%;
+
+    /* Reason: fr actually _is_ a unit */
+    /* stylelint-disable unit-no-unknown */
+    grid-template-columns: repeat(7, 1fr);
+    /* stylelint-enable unit-no-unknown*/
+    height: 100%;
+    width: 100%;
 
     .menu-tabbed-vertical {
+      grid-column-end: 3;
       height: 100%;
-      position: fixed;
-      top: 135px;
+      justify-self: right;
     }
+  }
+
+  .menu-tabbed-view-container-fixed-scrollWrapper {
+    grid-column-end: 8;
+    grid-column-start: 1;
+    overflow: scroll;
+    width: 100%;
+  }
+
+  .menu-tabbed-view-container-fixed-scrollWrapper-content {
+    height: 100%;
+    max-width: @container-width-screen-jumbo - @menu-tabbed-vertical-width;
   }
 
   .menu-tabbed {
@@ -237,6 +258,10 @@
 
   @media (min-width: @layout-screen-medium-min-width) {
 
+    .menu-tabbed-view-container-fixed-scrollWrapper {
+      grid-column-start: 3;
+    }
+
     .menu-tabbed {
       margin-bottom: @menu-tabbed-margin-bottom-screen-medium;
 
@@ -269,13 +294,6 @@
       .menu-tabbed-item-label {
         padding-bottom: @menu-tabbed-vertical-item-link-padding-bottom-screen-medium;
         padding-top: @menu-tabbed-vertical-item-link-padding-top-screen-medium;
-      }
-    }
-
-    .menu-tabbed-container-fixed {
-
-      .menu-tabbed-view-container {
-        padding-left: @menu-tabbed-vertical-width-screen-medium + @menu-tabbed-vertical-margin-right-screen-medium;
       }
     }
 
@@ -332,13 +350,6 @@
       }
     }
 
-    .menu-tabbed-container-fixed {
-
-      .menu-tabbed-view-container {
-        padding-left: @menu-tabbed-vertical-width-screen-large + @menu-tabbed-vertical-margin-right-screen-large;
-      }
-    }
-
     .menu-tabbed-item {
       margin-right: @menu-tabbed-horizontal-item-margin-right-screen-large;
     }
@@ -389,13 +400,6 @@
       .menu-tabbed-item-label {
         padding-bottom: @menu-tabbed-vertical-item-link-padding-bottom-screen-jumbo;
         padding-top: @menu-tabbed-vertical-item-link-padding-top-screen-jumbo;
-      }
-    }
-
-    .menu-tabbed-container-fixed {
-
-      .menu-tabbed-view-container {
-        padding-left: @menu-tabbed-vertical-width-screen-jumbo + @menu-tabbed-vertical-margin-right-screen-jumbo;
       }
     }
 

--- a/src/styles/views/create-service-modal/styles.less
+++ b/src/styles/views/create-service-modal/styles.less
@@ -17,6 +17,11 @@
       }
     }
 
+    &-tabButtonList {
+      margin-right: 0;
+      padding-top: @modal-full-screen-body-padding-vertical;
+    }
+
     &-form {
       display: flex;
       flex: 1 1 auto;
@@ -25,6 +30,11 @@
         display: flex;
         flex: 1 0 auto;
         flex-direction: row;
+        height: 100%;
+      }
+
+      &__scrollbar-container .gm-scroll-view {
+        overflow: hidden;
       }
 
       &__scrollbar-container {
@@ -53,9 +63,9 @@
         display: none;
 
         &:after {
-          bottom: -@modal-full-screen-body-padding-vertical;
+          bottom: 0;
           height: auto;
-          top: -@modal-full-screen-body-padding-vertical;
+          top: 0;
         }
       }
     }
@@ -104,20 +114,6 @@
 
     .create-service-modal {
 
-      &-form {
-
-        &-container {
-
-          .menu-tabbed-vertical {
-
-            &:after {
-              bottom: -@modal-full-screen-body-padding-vertical-screen-small;
-              top: -@modal-full-screen-body-padding-vertical-screen-small;
-            }
-          }
-        }
-      }
-
       &-json-only {
 
         &-introduction {
@@ -139,17 +135,6 @@
     .create-service-modal {
 
       &-form {
-
-        &-container {
-
-          .menu-tabbed-vertical {
-
-            &:after {
-              bottom: -@modal-full-screen-body-padding-vertical-screen-medium;
-              top: -@modal-full-screen-body-padding-vertical-screen-medium;
-            }
-          }
-        }
 
         .menu-tabbed-vertical {
           display: block;
@@ -176,20 +161,6 @@
 
     .create-service-modal {
 
-      &-form {
-
-        &-container {
-
-          .menu-tabbed-vertical {
-
-            &:after {
-              bottom: -@modal-full-screen-body-padding-vertical-screen-large;
-              top: -@modal-full-screen-body-padding-vertical-screen-large;
-            }
-          }
-        }
-      }
-
       &-json-only {
 
         &-introduction {
@@ -210,20 +181,6 @@
 
     .create-service-modal {
 
-      &-form {
-
-        &-container {
-
-          .menu-tabbed-vertical {
-
-            &:after {
-              bottom: -@modal-full-screen-body-padding-vertical-screen-jumbo;
-              top: -@modal-full-screen-body-padding-vertical-screen-jumbo;
-            }
-          }
-        }
-      }
-
       &-json-only {
 
         &-introduction {
@@ -234,6 +191,10 @@
 
     .artifacts-section {
       margin-top: @base-spacing-unit-screen-jumbo * 3/4;
+    }
+
+    .create-service-modal-tabButtonList {
+      padding-top: @modal-full-screen-body-padding-vertical-screen-jumbo;
     }
   }
 }


### PR DESCRIPTION
In Microsoft Edge, the sidebar of Framework Configuration screens would flash, "glitch-out", or disappear entirely when the user opened the JSON editor and clicked inside with their cursor.
Edge was having rendering performance issues with the `position: fixed` style of the sidebar

Closes DCOS-21202

## Testing
Ping me for an invite to Browserstack
Open any Edge browser
Add a new framework from the "Catalog" section
After you hit "Review and Run" and you're landed on the "Edit Configuration" modal, toggle open the JSON editor
Click inside of the JSON editor

You can also get to the "Edit Configuration" screen by editing an existing framework running in the "Services" tab

After you click into the JSON editor, there should be no content flashing on the screen

## Trade-offs
TL;DR: This fix required some "clever" workarounds with CSS layout that feel a little hack-y

This bug was originally caused by Edge's poor handling of `position: fixed`. To achieve the same effect without `position: fixed` I had to make the right side of the screen a scrolling div. In order for the form content to scroll no matter where on the right half of the screen your cursor was, I had to use CSS grid layout for centering the content instead of relying on the `auto` margins. When the content is centered using `auto` left and right margins, if the cursor was in the margin or too far to the right of the screen, the form content would not scroll.
This layout technique feels a little hack-y, especially since it's to support a very specific use case in a browser with so few users.

## Dependencies
None

## Screenshots
Before:
![screen recording 2018-09-06 at 11 06 am](https://user-images.githubusercontent.com/2313998/45168528-7d16f700-b1c9-11e8-8efb-87ab826a077d.gif)

After:
![screen recording 2018-09-06 at 11 10 am](https://user-images.githubusercontent.com/2313998/45168544-83a56e80-b1c9-11e8-8b21-b211b365768e.gif)
