### PR TITLE
DCOS-41121: version cell tooltip alignment

### DIFF
--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -429,7 +429,15 @@ class ServicesTable extends React.Component {
         ? FrameworkUtil.extractBaseTechVersion(rawVersion)
         : "";
 
-    return <Tooltip content={rawVersion}>{displayVersion}</Tooltip>;
+    return (
+      <Tooltip
+        content={rawVersion}
+        wrapperClassName="tooltip-wrapper tooltip-block-wrapper text-overflow"
+        wrapText={true}
+      >
+        {displayVersion}
+      </Tooltip>
+    );
   }
 
   renderInstances(prop, service) {


### PR DESCRIPTION
Overflowing text was causing the tooltip to misalign

Closes DCOS-41121

## Testing
Add filler text in the `Tooltip` returned by the `renderVersion()` method to cause an ellipsis
Go to Services tab
Hover the version cell

## Trade-offs
No

## Dependencies
No

## Screenshots
Before:
![versioncellalign-before](https://user-images.githubusercontent.com/2313998/45177238-60d28480-b1e0-11e8-9aa3-13e9c01ea3a7.gif)

After:
![versioncellalign-after](https://user-images.githubusercontent.com/2313998/45177243-63cd7500-b1e0-11e8-999d-6910088e1479.gif)
