### PR TITLE
[1.10] DCOS_OSS-4034: show VIP fields in host mode

### DIFF
--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -20,11 +20,12 @@ import Icon from "#SRC/js/components/Icon";
 import Networking from "#SRC/js/constants/Networking";
 import MetadataStore from "#SRC/js/stores/MetadataStore";
 import VirtualNetworksStore from "#SRC/js/stores/VirtualNetworksStore";
-
+import ValidatorUtil from "#SRC/js/utils/ValidatorUtil";
 import {
   FormReducer as networks
 } from "../../reducers/serviceForm/MultiContainerNetwork";
 import ServiceConfigUtil from "../../utils/ServiceConfigUtil";
+import VipLabelUtil from "../../utils/VipLabelUtil";
 
 const { CONTAINER, HOST } = Networking.type;
 const METHODS_TO_BIND = ["onVirtualNetworksStoreSuccess"];
@@ -44,6 +45,13 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
         suppressUpdate: true
       }
     ];
+  }
+
+  isHostNetwork() {
+    const networkType =
+      findNestedPropertyInObject(this.props.data, "networks.0.mode") || HOST;
+
+    return networkType === HOST;
   }
 
   onVirtualNetworksStoreSuccess() {
@@ -107,7 +115,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
 
     const tooltipContent = (
       <span>
-        {`This host port will be accessible as an environment variable called ${environmentVariableName}'. `}
+        {`This host port will be accessible as an environment variable called ${environmentVariableName}. `}
         <a
           href="https://mesosphere.github.io/marathon/docs/ports.html"
           target="_blank"
@@ -164,11 +172,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
     ];
   }
 
-  getLoadBalancedServiceAddressField(endpoint, network, index, containerIndex) {
-    if (network !== CONTAINER) {
-      return null;
-    }
-
+  getLoadBalancedServiceAddressField(endpoint, index, containerIndex) {
     const { containerPort, hostPort, loadBalanced, vip } = endpoint;
     const { errors } = this.props;
     let loadBalancedError = findNestedPropertyInObject(
@@ -208,7 +212,7 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
       </span>
     );
 
-    return (
+    return [
       <FormRow>
         <FormGroup className="column-12" showError={Boolean(loadBalancedError)}>
           <FieldLabel>
@@ -233,13 +237,107 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
                 </Tooltip>
               </FormGroupHeadingContent>
             </FormGroupHeading>
-            <FieldHelp>
-              Load balance this service internally at
-              {" "}
-              {ServiceConfigUtil.buildHostNameFromVipLabel(address)}
-            </FieldHelp>
           </FieldLabel>
           <FieldError>{loadBalancedError}</FieldError>
+        </FormGroup>
+      </FormRow>,
+      loadBalanced &&
+        this.getLoadBalancedPortField(endpoint, index, containerIndex)
+    ];
+  }
+
+  getLoadBalancedPortField(endpoint, index, containerIndex) {
+    const { errors, data: { id, portsAutoAssign } } = this.props;
+
+    const { hostPort, containerPort, vip, vipPort } = endpoint;
+
+    const defaultVipPort = this.isHostNetwork() ? hostPort : containerPort;
+
+    // clear placeholder when HOST network portsAutoAssign is true
+    const placeholder = this.isHostNetwork() && portsAutoAssign
+      ? ""
+      : defaultVipPort;
+
+    let vipPortError = null;
+    let loadBalancedError = findNestedPropertyInObject(
+      errors,
+      `containers.${containerIndex}.endpoints.${index}.labels`
+    );
+
+    const tooltipContent =
+      "This port will be used to load balance this service address internally";
+    if (isObject(loadBalancedError)) {
+      vipPortError = loadBalancedError[VipLabelUtil.defaultVip(index)];
+      loadBalancedError = null;
+    }
+
+    let address = vip;
+
+    if (address == null) {
+      let port = "";
+      if (!portsAutoAssign && !ValidatorUtil.isEmpty(hostPort)) {
+        port = hostPort;
+      }
+      if (!ValidatorUtil.isEmpty(containerPort)) {
+        port = containerPort;
+      }
+      if (!ValidatorUtil.isEmpty(vipPort)) {
+        port = vipPort;
+      }
+
+      address = `${id}:${port}`;
+    }
+
+    let hostName = null;
+    if (!vipPortError) {
+      hostName = ServiceConfigUtil.buildHostNameFromVipLabel(address);
+    }
+
+    const helpText = (
+      <FieldHelp>Load balance this service internally at {hostName}</FieldHelp>
+    );
+
+    return (
+      <FormRow key="lb-port">
+        <FormGroup className="column-12">
+          <FieldLabel>
+            <FormGroupHeading>
+              <FormGroupHeadingContent primary={true}>
+                Load Balanced Port
+              </FormGroupHeadingContent>
+              <FormGroupHeadingContent>
+                <Tooltip
+                  content={tooltipContent}
+                  interactive={true}
+                  maxWidth={300}
+                  wrapText={true}
+                >
+                  <Icon color="grey" id="circle-question" size="mini" />
+                </Tooltip>
+              </FormGroupHeadingContent>
+            </FormGroupHeading>
+          </FieldLabel>
+          <FormRow>
+            <FormGroup
+              className="column-3"
+              key="vip-port"
+              showError={Boolean(vipPortError)}
+            >
+              <FieldInput
+                min="1"
+                placeholder={placeholder}
+                name={`containers.${containerIndex}.endpoints.${index}.vipPort`}
+                type="number"
+                value={vipPort}
+              />
+            </FormGroup>
+          </FormRow>
+          <FormRow>
+            <FormGroup className="column-12" showError={Boolean(vipPortError)}>
+              <FieldError>{vipPortError}</FieldError>
+              {!vipPortError && helpText}
+            </FormGroup>
+          </FormRow>
         </FormGroup>
       </FormRow>
     );
@@ -363,7 +461,6 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
           </FormRow>
           {this.getLoadBalancedServiceAddressField(
             endpoint,
-            network,
             index,
             containerIndex
           )}

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/Endpoints.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/Endpoints.js
@@ -13,7 +13,8 @@ const defaultEndpointsFieldValues = {
     udp: false
   },
   servicePort: null,
-  vip: null
+  vip: null,
+  vipPort: null
 };
 
 module.exports = {
@@ -45,7 +46,13 @@ module.exports = {
         break;
     }
 
-    const fieldNames = ["name", "automaticPort", "loadBalanced", "vip"];
+    const fieldNames = [
+      "name",
+      "automaticPort",
+      "loadBalanced",
+      "vip",
+      "vipPort"
+    ];
     const numericalFiledNames = ["containerPort", "hostPort"];
 
     if (type === SET && name === "protocol") {

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Containers-test.js
@@ -31,6 +31,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -71,6 +72,7 @@ describe("Containers", function() {
                   name: "foo",
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -122,6 +124,7 @@ describe("Containers", function() {
                   name: "foo",
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -167,6 +170,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: true
@@ -212,6 +216,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false,
@@ -253,6 +258,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -295,6 +301,7 @@ describe("Containers", function() {
                   name: "foo",
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -348,6 +355,7 @@ describe("Containers", function() {
                   name: "foo",
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -393,6 +401,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: true
@@ -438,6 +447,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     foo: true,
                     tcp: true,
@@ -484,6 +494,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: false,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -537,6 +548,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: true,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -597,6 +609,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: true,
                   vip: "1.3.3.7:8080",
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -652,6 +665,7 @@ describe("Containers", function() {
                   name: null,
                   loadBalanced: true,
                   vip: null,
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false
@@ -715,6 +729,7 @@ describe("Containers", function() {
                   loadBalanced: true,
                   containerPort: 8080,
                   vip: "1.3.3.7:8080",
+                  vipPort: null,
                   protocol: {
                     tcp: true,
                     udp: false

--- a/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Endpoints-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/FormReducers/__tests__/Endpoints-test.js
@@ -23,6 +23,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -54,6 +55,7 @@ describe("Endpoints", function() {
             name: "foo",
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -96,6 +98,7 @@ describe("Endpoints", function() {
             name: "foo",
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -132,6 +135,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: true
@@ -168,6 +172,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false,
@@ -200,6 +205,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -233,6 +239,7 @@ describe("Endpoints", function() {
             name: "foo",
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -277,6 +284,7 @@ describe("Endpoints", function() {
             name: "foo",
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -313,6 +321,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: true
@@ -349,6 +358,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               foo: true,
               tcp: true,
@@ -386,6 +396,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: false,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -430,6 +441,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: true,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -481,6 +493,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: true,
             vip: "1.3.3.7:8080",
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -527,6 +540,7 @@ describe("Endpoints", function() {
             name: null,
             loadBalanced: true,
             vip: null,
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false
@@ -581,6 +595,7 @@ describe("Endpoints", function() {
             loadBalanced: true,
             containerPort: 8080,
             vip: "1.3.3.7:8080",
+            vipPort: null,
             protocol: {
               tcp: true,
               udp: false

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Endpoints.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Endpoints.js
@@ -13,7 +13,8 @@ const defaultEndpointsFieldValues = {
     udp: false
   },
   servicePort: null,
-  vip: null
+  vip: null,
+  vipPort: null
 };
 
 module.exports = {
@@ -53,7 +54,8 @@ module.exports = {
       "automaticPort",
       "loadBalanced",
       "labels",
-      "vip"
+      "vip",
+      "vipPort"
     ];
     const numericalFiledNames = ["containerPort", "hostPort"];
 

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Endpoints-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Endpoints-test.js
@@ -24,6 +24,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -57,6 +58,7 @@ describe("Endpoints", function() {
               name: "foo",
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -101,6 +103,7 @@ describe("Endpoints", function() {
               name: "foo",
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -139,6 +142,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: true
@@ -177,6 +181,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false,
@@ -211,6 +216,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -246,6 +252,7 @@ describe("Endpoints", function() {
               name: "foo",
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -292,6 +299,7 @@ describe("Endpoints", function() {
               name: "foo",
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -330,6 +338,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: true
@@ -368,6 +377,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 foo: true,
                 tcp: true,
@@ -407,6 +417,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: false,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -453,6 +464,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: true,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -506,6 +518,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: true,
               vip: "1.3.3.7:8080",
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -554,6 +567,7 @@ describe("Endpoints", function() {
               name: null,
               loadBalanced: true,
               vip: null,
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false
@@ -610,6 +624,7 @@ describe("Endpoints", function() {
               loadBalanced: true,
               containerPort: 8080,
               vip: "1.3.3.7:8080",
+              vipPort: null,
               protocol: {
                 tcp: true,
                 udp: false

--- a/plugins/services/src/js/utils/ValidatorUtil.js
+++ b/plugins/services/src/js/utils/ValidatorUtil.js
@@ -1,0 +1,69 @@
+var ValidatorUtil = {
+  isCallable(value) {
+    return Boolean(value && typeof value.call === "function");
+  },
+
+  isDefined(value) {
+    return (value != null && value !== "") || typeof value === "number";
+  },
+
+  isEmail(email) {
+    return (
+      email != null &&
+      email.length > 0 &&
+      !/\s/.test(email) &&
+      /.+@.+\..+/.test(email)
+    );
+  },
+
+  isEmpty(data) {
+    if (typeof data === "number" || typeof data === "boolean") {
+      return false;
+    }
+
+    if (typeof data === "undefined" || data === null) {
+      return true;
+    }
+
+    if (typeof data.length !== "undefined") {
+      return data.length === 0;
+    }
+
+    return (
+      Object.keys(data).reduce(function(memo, key) {
+        if (Object.prototype.hasOwnProperty.call(data, key)) {
+          memo++;
+        }
+
+        return memo;
+      }, 0) === 0
+    );
+  },
+
+  isInteger(value) {
+    return ValidatorUtil.isNumber(value) && Number.isInteger(parseFloat(value));
+  },
+
+  isNumber(value) {
+    const number = parseFloat(value);
+
+    return (
+      /^[0-9e+-.,]+$/.test(value) &&
+      !Number.isNaN(number) &&
+      Number.isFinite(number)
+    );
+  },
+
+  isNumberInRange(value, range = {}) {
+    const { min = 0, max = Number.POSITIVE_INFINITY } = range;
+    const number = parseFloat(value);
+
+    return ValidatorUtil.isNumber(value) && number >= min && number <= max;
+  },
+
+  isStringInteger(value) {
+    return typeof value === "string" && /^([0-9]+)$/.test(value);
+  }
+};
+
+module.exports = ValidatorUtil;

--- a/plugins/services/src/js/utils/VipLabelUtil.js
+++ b/plugins/services/src/js/utils/VipLabelUtil.js
@@ -21,6 +21,10 @@ const VipLabelUtil = {
     }
 
     return labels;
+  },
+
+  defaultVip(index) {
+    return `VIP_${index}`;
   }
 };
 

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1614,6 +1614,72 @@ describe("Service Form Modal", function() {
       });
     });
 
+    context("Networking", function() {
+      beforeEach(function() {
+        cy.get(".menu-tabbed-item-label").contains("Networking").click();
+      });
+
+      context("Service Endpoints", function() {
+        beforeEach(function() {
+          addServiceEndpoint();
+        });
+
+        function addServiceEndpoint() {
+          cy.get(".button.button-primary-link")
+            .contains("Add Service Endpoint")
+            .click();
+        }
+
+        function enableLoadBalancedAddress() {
+          cy.get(".form-group-heading-content")
+            .contains("Enable Load Balanced Service Address")
+            .click();
+        }
+
+        context("Host", function() {
+          beforeEach(function() {
+            cy.get('select[name="networks.0"]').select("Host");
+          });
+
+          context("Load balanced ports", function() {
+            beforeEach(function() {
+              enableLoadBalancedAddress();
+            });
+
+            it("sets vip port", function() {
+              cy.get(
+                '.form-control[name="containers.0.endpoints.0.vipPort"]'
+              ).type(9007);
+
+              cy.contains(".marathon.l4lb.thisdcos.directory:9007");
+            });
+          });
+        });
+
+        context("Virtual Network: dcos-1", function() {
+          beforeEach(function() {
+            cy.get('select[name="networks.0"]').select(
+              "Virtual Network: dcos-1"
+            );
+          });
+
+          context("Load balanced ports", function() {
+            beforeEach(function() {
+              enableLoadBalancedAddress();
+            });
+
+            it("sets vip port", function() {
+              cy.get(
+                '.form-control[name="containers.0.endpoints.0.vipPort"]'
+              ).type(9007);
+
+              cy.contains(".marathon.l4lb.thisdcos.directory:9007");
+            });
+          });
+        });
+      });
+    });
+
     context("Multi-container (pod)", function() {
       beforeEach(function() {
         cy


### PR DESCRIPTION
## Testing

Backport for 1.10. See: https://github.com/dcos/dcos-ui/pull/3233

## Trade-offs

* In 1.10, the load balanced port is the same as the container port when network type is set to container (Virtual Network: dcos in the UI)
* To add load balanced port for network type "Host", it did not make sense to me to set the load balanced port to be the same as host port, therefore I added the load balanced port field.