### PR TITLE
[1.11] Backport: fix(VirtualNetworksTabContent): fix filter on networks table

### DIFF
--- a/src/js/pages/network/VirtualNetworksTab.js
+++ b/src/js/pages/network/VirtualNetworksTab.js
@@ -103,8 +103,9 @@ class VirtualNetworksTabContent extends mixin(StoreMixin) {
 
     return overlayList.filterItems(function(overlay) {
       return (
-        overlay.getName().includes(searchString) ||
-        overlay.getSubnet().includes(searchString)
+        (overlay.getName() && overlay.getName().includes(searchString)) ||
+        (overlay.getSubnet() && overlay.getSubnet().includes(searchString)) ||
+        (overlay.getSubnet6() && overlay.getSubnet6().includes(searchString))
       );
     });
   }


### PR DESCRIPTION
Backport changes to fix filter function to allow filtering of networks table.

DCOS-41514 should not be closed until #3252 is merged as well.

## Testing

See #3221 

