### PR TITLE
[1.10] Backport: fix(VirtualNetworksTabContent): fix filter on networks table

### DIFF
--- a/src/js/pages/network/VirtualNetworksTab.js
+++ b/src/js/pages/network/VirtualNetworksTab.js
@@ -103,8 +103,8 @@ class VirtualNetworksTabContent extends mixin(StoreMixin) {
 
     return overlayList.filterItems(function(overlay) {
       return (
-        overlay.getName().includes(searchString) ||
-        overlay.getSubnet().includes(searchString)
+        (overlay.getName() && overlay.getName().includes(searchString)) ||
+        (overlay.getSubnet() && overlay.getSubnet().includes(searchString))
       );
     });
   }


### PR DESCRIPTION
Backport changes to fix filter function to allow filtering of networks table.

Do not close DCOS-41514 until #3251 is merged as well.

## Testing

See #3221 
