### PR TITLE
DCOS_OSS-4082: add vip transactions for all network types

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
@@ -224,49 +224,43 @@ function containersParser(state) {
               endpoint.containerPort
             )
           );
+        }
 
-          const vip = VipLabelUtil.findVip(endpoint.labels);
+        const vip = VipLabelUtil.findVip(endpoint.labels);
 
-          if (vip != null) {
-            const [vipLabel, vipValue] = vip;
+        if (vip != null) {
+          const [vipLabel, vipValue] = vip;
+          memo.push(
+            new Transaction(
+              ["containers", index, "endpoints", endpointIndex, "loadBalanced"],
+              true
+            )
+          );
+
+          memo.push(
+            new Transaction(
+              ["containers", index, "endpoints", endpointIndex, "vipLabel"],
+              vipLabel
+            )
+          );
+
+          if (!vipValue.startsWith(`${state.id}:`)) {
             memo.push(
               new Transaction(
-                [
-                  "containers",
-                  index,
-                  "endpoints",
-                  endpointIndex,
-                  "loadBalanced"
-                ],
-                true
+                ["containers", index, "endpoints", endpointIndex, "vip"],
+                vipValue
               )
             );
+          }
 
+          const vipPortMatch = vipValue.match(/.+:(\d+)/);
+          if (vipPortMatch) {
             memo.push(
               new Transaction(
-                ["containers", index, "endpoints", endpointIndex, "vipLabel"],
-                vipLabel
+                ["containers", index, "endpoints", endpointIndex, "vipPort"],
+                vipPortMatch[1]
               )
             );
-
-            if (!vipValue.startsWith(`${state.id}:`)) {
-              memo.push(
-                new Transaction(
-                  ["containers", index, "endpoints", endpointIndex, "vip"],
-                  vipValue
-                )
-              );
-            }
-
-            const vipPortMatch = vipValue.match(/.+:(\d+)/);
-            if (vipPortMatch) {
-              memo.push(
-                new Transaction(
-                  ["containers", index, "endpoints", endpointIndex, "vipPort"],
-                  vipPortMatch[1]
-                )
-              );
-            }
           }
         }
 

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
@@ -1008,15 +1008,30 @@ describe("Containers", function() {
     });
 
     describe("endpoints", function() {
-      it("parses VIP ports", function() {
-        expect(
-          Containers.JSONParser({
-            networks: [
-              {
-                mode: "container"
-              }
-            ],
-            containers: [
+      describe("Container Mode", function() {
+        it("parses VIP ports", function() {
+          expect(
+            Containers.JSONParser({
+              networks: [
+                {
+                  mode: "container"
+                }
+              ],
+              containers: [
+                {
+                  endpoints: [
+                    {
+                      labels: {
+                        VIP_0: "/:900"
+                      }
+                    }
+                  ]
+                }
+              ]
+            })
+          ).toEqual([
+            new Transaction(
+              ["containers"],
               {
                 endpoints: [
                   {
@@ -1025,92 +1040,180 @@ describe("Containers", function() {
                     }
                   }
                 ]
-              }
-            ]
-          })
-        ).toEqual([
-          new Transaction(
-            ["containers"],
-            {
-              endpoints: [
-                {
-                  labels: {
-                    VIP_0: "/:900"
-                  }
-                }
-              ]
-            },
-            ADD_ITEM
-          ),
-          new Transaction(
-            ["containers", 0, "endpoints"],
-            {
-              labels: { VIP_0: "/:900" }
-            },
-            ADD_ITEM
-          ),
-          new Transaction(
-            ["containers", 0, "endpoints", 0, "hostPort"],
-            undefined,
-            SET
-          ),
-          new Transaction(
-            ["containers", 0, "endpoints", 0, "automaticPort"],
-            false,
-            SET
-          ),
-          new Transaction(
-            ["containers", 0, "endpoints", 0, "servicePort"],
-            false,
-            SET
-          ),
-          new Transaction(
-            ["containers", 0, "endpoints", 0, "name"],
-            undefined,
-            SET
-          ),
-          new Transaction(
-            ["containers", 0, "endpoints", 0, "labels"],
-            { VIP_0: "/:900" },
-            SET
-          ),
-          new Transaction(
-            ["containers", 0, "endpoints", 0, "containerPort"],
-            undefined,
-            SET
-          ),
-          new Transaction(
-            ["containers", 0, "endpoints", 0, "loadBalanced"],
-            true,
-            SET
-          ),
-          new Transaction(
-            ["containers", 0, "endpoints", 0, "vipLabel"],
-            "VIP_0",
-            SET
-          ),
-          new Transaction(
-            ["containers", 0, "endpoints", 0, "vip"],
-            "/:900",
-            SET
-          ),
-          new Transaction(
-            ["containers", 0, "endpoints", 0, "vipPort"],
-            "900",
-            SET
-          ),
+              },
+              ADD_ITEM
+            ),
+            new Transaction(
+              ["containers", 0, "endpoints"],
+              {
+                labels: { VIP_0: "/:900" }
+              },
+              ADD_ITEM
+            ),
+            new Transaction(
+              ["containers", 0, "endpoints", 0, "hostPort"],
+              undefined,
+              SET
+            ),
+            new Transaction(
+              ["containers", 0, "endpoints", 0, "automaticPort"],
+              false,
+              SET
+            ),
+            new Transaction(
+              ["containers", 0, "endpoints", 0, "servicePort"],
+              false,
+              SET
+            ),
+            new Transaction(
+              ["containers", 0, "endpoints", 0, "name"],
+              undefined,
+              SET
+            ),
+            new Transaction(
+              ["containers", 0, "endpoints", 0, "labels"],
+              { VIP_0: "/:900" },
+              SET
+            ),
+            new Transaction(
+              ["containers", 0, "endpoints", 0, "containerPort"],
+              undefined,
+              SET
+            ),
+            new Transaction(
+              ["containers", 0, "endpoints", 0, "loadBalanced"],
+              true,
+              SET
+            ),
+            new Transaction(
+              ["containers", 0, "endpoints", 0, "vipLabel"],
+              "VIP_0",
+              SET
+            ),
+            new Transaction(
+              ["containers", 0, "endpoints", 0, "vip"],
+              "/:900",
+              SET
+            ),
+            new Transaction(
+              ["containers", 0, "endpoints", 0, "vipPort"],
+              "900",
+              SET
+            ),
 
-          new Transaction(
-            ["containers", 0, "endpoints", 0, "protocol", "udp"],
-            false,
-            SET
-          ),
-          new Transaction(
-            ["containers", 0, "endpoints", 0, "protocol", "tcp"],
-            false,
-            SET
-          )
-        ]);
+            new Transaction(
+              ["containers", 0, "endpoints", 0, "protocol", "udp"],
+              false,
+              SET
+            ),
+            new Transaction(
+              ["containers", 0, "endpoints", 0, "protocol", "tcp"],
+              false,
+              SET
+            )
+          ]);
+        });
+
+        describe("Host Mode", function() {
+          it("parses VIP ports", function() {
+            expect(
+              Containers.JSONParser({
+                networks: [
+                  {
+                    mode: "host"
+                  }
+                ],
+                containers: [
+                  {
+                    endpoints: [
+                      {
+                        labels: {
+                          VIP_0: "/:900"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              })
+            ).toEqual([
+              new Transaction(
+                ["containers"],
+                {
+                  endpoints: [
+                    {
+                      labels: {
+                        VIP_0: "/:900"
+                      }
+                    }
+                  ]
+                },
+                ADD_ITEM
+              ),
+              new Transaction(
+                ["containers", 0, "endpoints"],
+                {
+                  labels: { VIP_0: "/:900" }
+                },
+                ADD_ITEM
+              ),
+              new Transaction(
+                ["containers", 0, "endpoints", 0, "hostPort"],
+                undefined,
+                SET
+              ),
+              new Transaction(
+                ["containers", 0, "endpoints", 0, "automaticPort"],
+                false,
+                SET
+              ),
+              new Transaction(
+                ["containers", 0, "endpoints", 0, "servicePort"],
+                false,
+                SET
+              ),
+              new Transaction(
+                ["containers", 0, "endpoints", 0, "name"],
+                undefined,
+                SET
+              ),
+              new Transaction(
+                ["containers", 0, "endpoints", 0, "labels"],
+                { VIP_0: "/:900" },
+                SET
+              ),
+              new Transaction(
+                ["containers", 0, "endpoints", 0, "loadBalanced"],
+                true,
+                SET
+              ),
+              new Transaction(
+                ["containers", 0, "endpoints", 0, "vipLabel"],
+                "VIP_0",
+                SET
+              ),
+              new Transaction(
+                ["containers", 0, "endpoints", 0, "vip"],
+                "/:900",
+                SET
+              ),
+              new Transaction(
+                ["containers", 0, "endpoints", 0, "vipPort"],
+                "900",
+                SET
+              ),
+              new Transaction(
+                ["containers", 0, "endpoints", 0, "protocol", "udp"],
+                false,
+                SET
+              ),
+              new Transaction(
+                ["containers", 0, "endpoints", 0, "protocol", "tcp"],
+                false,
+                SET
+              )
+            ]);
+          });
+        });
       });
     });
 


### PR DESCRIPTION
* This (https://github.com/dcos/dcos-ui/pull/3233) was merged, however it was only working partially
* This PR adds the remaining bits to fix the bug
* Adds VIP transactions as long as it exists in the endpoint labels, rather than doing so only if the network mode was container (as done previously)

Closes DCOS_OSS-4082

## Testing

See https://github.com/dcos/dcos-ui/pull/3233 for instructions.
