### PR TITLE
DCOS-41502: show JSON parsing errors as top level errors

### DIFF
--- a/plugins/services/src/js/components/modals/CreateServiceModalForm.js
+++ b/plugins/services/src/js/components/modals/CreateServiceModalForm.js
@@ -56,6 +56,7 @@ const METHODS_TO_BIND = [
   "handleFormChange",
   "handleJSONChange",
   "handleJSONPropertyChange",
+  "handleJSONErrorStateChange",
   "handleRemoveItem",
   "handleClickItem"
 ];
@@ -256,6 +257,14 @@ class CreateServiceModalForm extends Component {
       this.setState({
         editedFieldPaths: editedFieldPaths.concat([pathStr])
       });
+    }
+  }
+
+  handleJSONErrorStateChange(errorMessage) {
+    if (errorMessage !== null) {
+      this.props.onErrorsChange([{ message: errorMessage, path: [] }]);
+    } else {
+      this.props.onErrorsChange([]);
     }
   }
 
@@ -752,6 +761,7 @@ class CreateServiceModalForm extends Component {
             errors={errors}
             onChange={this.handleJSONChange}
             onPropertyChange={this.handleJSONPropertyChange}
+            onErrorStateChange={this.handleJSONErrorStateChange}
             showGutter={true}
             showPrintMargin={false}
             theme="monokai"

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -103,6 +103,59 @@ describe("Service Form Modal", function() {
           .first()
           .should("to.have.text", "Networking");
       });
+
+      describe("JSON errors", function() {
+        it("displays an error with invalid JSON", function() {
+          openServiceModal();
+          openServiceForm();
+
+          // Switch to JSON
+          cy
+            .get(".modal-full-screen-actions label")
+            .contains("JSON Editor")
+            .click();
+
+          cy
+            .get(".ace_text-input")
+            .focus()
+            .type("{selectall}{backspace}", { force: true });
+
+          cy
+            .get(".alert")
+            .contains("Unexpected end of JSON input")
+            .should("be.visible");
+        });
+
+        it("clears the JSON error once it is fixed", function() {
+          openServiceModal();
+          openServiceForm();
+
+          // Switch to JSON
+          cy
+            .get(".modal-full-screen-actions label")
+            .contains("JSON Editor")
+            .click();
+
+          cy
+            .get(".ace_text-input")
+            .focus()
+            .type("{selectall}{backspace}", { force: true });
+
+          cy
+            .get(".alert")
+            .contains("Unexpected end of JSON input")
+            .should("be.visible");
+
+          // The closing } is auto inserted
+          cy
+            .get(".ace_text-input")
+            .focus()
+            .type('{{}\n\t"id": "/foo"\n', { force: true });
+
+          cy.get(".alert").should("not.be.visible");
+          cy.get("input[name=id]").should("have.value", "/foo");
+        });
+      });
     });
 
     context("Group level", function() {


### PR DESCRIPTION
## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

Go to the Service form and open the JSON editor. Create invalid JSON. Admire the error message being shown on the left side and the review button not doing anything on click

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- Decided against system tests, as this is a UI only issue IMHO

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

None

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

From 1.12:

![bildschirmfoto 2018-09-07 um 15 03 02](https://user-images.githubusercontent.com/1337046/45225248-61d8e400-b2bc-11e8-8ed6-de4105ca9634.png)

