### PR TITLE
DCOS-40507: style selected state for ResourceSwitchDropdown items

### DIFF
--- a/src/js/components/ResourceSwitchDropdown.js
+++ b/src/js/components/ResourceSwitchDropdown.js
@@ -29,7 +29,7 @@ export default class ResourceSwitchDropdown extends React.Component {
       if (this.props.selectedResource === resource) {
         html = (
           <span className="selected">
-            <Icon color="black" id="check" size="mini" />
+            <Icon color="purple" id="check" size="mini" />
             {label}
           </span>
         );
@@ -64,7 +64,7 @@ export default class ResourceSwitchDropdown extends React.Component {
         dropdownMenuListClassName="dropdown-menu-list resource-switch-dropdown-menu-list"
         items={this.getMenuItems()}
         onItemSelection={this.handleItemSelection}
-        persistentID="dropdown-trigger"
+        initialID={this.props.selectedResource}
         transition={true}
         trigger={this.getTrigger()}
       />

--- a/src/styles/components/dropdown-menus/styles.less
+++ b/src/styles/components/dropdown-menus/styles.less
@@ -110,6 +110,10 @@
         cursor: pointer;
       }
 
+      &.is-selected {
+        color: @purple;
+      }
+
       &:first-child {
 
         &.hidden {


### PR DESCRIPTION
The style to highlight a selected item was not applied on the ResourceSwitchDropdown of the Nodes chart view

Closes: DCOS-40507

## Testing
Navigate to the "Nodes" page
Toggle the chart view by clicking the donut icon on the right side of the view
Change the selected item in the dropdown to the left of the list icon (initial state is "CPU")

The text and icon of the selected item in the dropdown should be purple (see screenshots below)

## Trade-offs
The styling change in this PR could have also been made in [reactjs-components](https://github.com/mesosphere/reactjs-components/), but I saw other style overrides happening directly in dcos-ui. **Please let me know if we'd prefer the `.is-selected` style update to be made in reactjs-components instead**

## Dependencies
None

## Screenshots
Before:
![screen shot 2018-09-10 at 10 53 18 am](https://user-images.githubusercontent.com/2313998/45305226-d2177d80-b4e7-11e8-8d54-96bb93130ede.png)

After:
![screen shot 2018-09-10 at 10 48 39 am](https://user-images.githubusercontent.com/2313998/45305213-ccba3300-b4e7-11e8-8b7d-7f87471205a1.png)