### PR TITLE
DCOS-40649: Health column header truncated in FF

### DIFF
--- a/src/styles/components/task-table/styles.less
+++ b/src/styles/components/task-table/styles.less
@@ -42,7 +42,7 @@
     }
 
     &-health {
-      width: 70px;
+      width: 80px;
     }
 
     &-logs {


### PR DESCRIPTION
Even at fullscreen, the Health column header was being truncated in Firefox

Closes: DCOS-40649

## Testing
Use Firefox to test this change
Add a framework from the Catalog (I used Kafka)
Navigate to the "Services" page
Click on the new service

The health column header should not be truncated

## Trade-offs
A better way to fix this would be to rendered this table with the components from ui-kit. However, that would take a little more time in order to support the checkbox selection of table rows ([ticket created here](https://jira.mesosphere.com/browse/DCOS-41571))

## Dependencies
None

## Screenshots
Before:
![screen shot 2018-09-10 at 3 11 39 pm](https://user-images.githubusercontent.com/2313998/45318776-ea00f880-b50b-11e8-84fa-584f0767b121.png)

After:
![screen shot 2018-09-10 at 3 10 51 pm](https://user-images.githubusercontent.com/2313998/45318787-eff6d980-b50b-11e8-8452-11bcf21b0722.png)
