### PR TITLE
DCOS-8601: Ensure package detail links open in new tab

### DIFF
--- a/src/js/pages/catalog/__tests__/__snapshots__/PackageDetailTab-test.js.snap
+++ b/src/js/pages/catalog/__tests__/__snapshots__/PackageDetailTab-test.js.snap
@@ -500,7 +500,7 @@ To create a nested path, please specify a group.",
               ],
               "type": "object",
             },
-            "description": "A container orchestration platform for Mesos and DCOS.",
+            "description": "A container orchestration platform for Mesos and DCOS. Documentation: https://docs.mesosphere.com/1.11/deploying-services/marathon-api/",
             "framework": true,
             "licenses": Array [
               Object {
@@ -522,7 +522,7 @@ To create a nested path, please specify a group.",
 ",
             "postUninstallNotes": "The Marathon DCOS Service has been uninstalled and will no longer run.
 Please follow the instructions at http://docs.mesosphere.com/services/marathon/#uninstall to clean up any persisted state",
-            "preInstallNotes": "We recommend a minimum of one node with at least 2 CPU shares and 1GB of RAM available for the Marathon DCOS Service.",
+            "preInstallNotes": "We recommend a minimum of one node with at least 2 CPU shares and 1GB of RAM available for the Marathon DCOS Service. More information: https://mesosphere.github.io/marathon/",
             "releaseVersion": 10,
             "resource": Object {
               "assets": Object {

--- a/src/js/utils/StringUtil.js
+++ b/src/js/utils/StringUtil.js
@@ -3,6 +3,20 @@ import marked from "marked";
 import React from "react";
 /* eslint-enable no-unused-vars */
 
+const markdownRenderer = {
+  rendererReady: false,
+  prepareMarkdownRenderer() {
+    const renderer = new marked.Renderer();
+    renderer.link = function() {
+      const out = marked.Renderer.prototype.link.apply(this, arguments);
+
+      return out.replace(/^<a/, '<a target="_blank"');
+    };
+    marked.setOptions({ renderer });
+    this.rendererReady = true;
+  }
+};
+
 const StringUtil = {
   arrayToJoinedString(array = [], separator = ", ") {
     if (Array.isArray(array)) {
@@ -189,6 +203,10 @@ const StringUtil = {
   parseMarkdown(text) {
     if (!text) {
       return null;
+    }
+
+    if (!markdownRenderer.rendererReady) {
+      markdownRenderer.prepareMarkdownRenderer();
     }
 
     const __html = marked(

--- a/src/js/utils/__tests__/StringUtil-test.js
+++ b/src/js/utils/__tests__/StringUtil-test.js
@@ -297,4 +297,44 @@ describe("StringUtil", function() {
       ).toEqual("one, two and three");
     });
   });
+
+  describe("#parseMarkdown", function() {
+    it("adds _blank target to plain links in text", function() {
+      expect(
+        StringUtil.parseMarkdown("Hello this is a link http://somelink.com")
+          .__html
+      ).toEqual(
+        `<p>Hello this is a link <a target="_blank" href="http://somelink.com">http://somelink.com</a></p>\n`
+      );
+    });
+
+    it("adds _blank target to formatted links in text", function() {
+      expect(
+        StringUtil.parseMarkdown("Hello this is a [link](http://somelink.com)")
+          .__html
+      ).toEqual(
+        `<p>Hello this is a <a target="_blank" href="http://somelink.com">link</a></p>\n`
+      );
+    });
+
+    it("does not add target _blank to non-uri segments attached to plain links containing '<a'", function() {
+      expect(
+        StringUtil.parseMarkdown(
+          "Hello this is a bad link http://a.com/<a-mean-uri"
+        ).__html
+      ).toEqual(
+        `<p>Hello this is a bad link <a target="_blank" href="http://a.com/">http://a.com/</a>&lt;a-mean-uri</p>\n`
+      );
+    });
+
+    it("does not add additional target _blank to uri segments in formatted links containing '<a'", function() {
+      expect(
+        StringUtil.parseMarkdown(
+          "Hello this is a bad [link](http://a.com/<a-mean-uri)"
+        ).__html
+      ).toEqual(
+        `<p>Hello this is a bad <a target="_blank" href="http://a.com/&lt;a-mean-uri">link</a></p>\n`
+      );
+    });
+  });
 });

--- a/tests/_fixtures/cosmos/package-describe.json
+++ b/tests/_fixtures/cosmos/package-describe.json
@@ -5,7 +5,7 @@
     "version": "1.4.6",
     "releaseVersion": 10,
     "maintainer": "support@mesosphere.io",
-    "description": "A container orchestration platform for Mesos and DCOS.",
+    "description": "A container orchestration platform for Mesos and DCOS. Documentation: https://docs.mesosphere.com/1.11/deploying-services/marathon-api/",
     "tags": [
       "init",
       "long-running"
@@ -13,7 +13,7 @@
     "selected": true,
     "scm": "https://github.com/mesosphere/marathon.git",
     "framework": true,
-    "preInstallNotes": "We recommend a minimum of one node with at least 2 CPU shares and 1GB of RAM available for the Marathon DCOS Service.",
+    "preInstallNotes": "We recommend a minimum of one node with at least 2 CPU shares and 1GB of RAM available for the Marathon DCOS Service. More information: https://mesosphere.github.io/marathon/",
     "postInstallNotes": "Marathon DCOS Service has been successfully installed!\n\n\tDocumentation: https://mesosphere.github.io/marathon\n\tIssues: https://github.com/mesosphere/marathon/issues\n",
     "postUninstallNotes": "The Marathon DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at http://docs.mesosphere.com/services/marathon/#uninstall to clean up any persisted state",
     "licenses": [

--- a/tests/pages/catalog/packages/package/PackageTab-cy.js
+++ b/tests/pages/catalog/packages/package/PackageTab-cy.js
@@ -1,11 +1,9 @@
 describe("Package Detail Tab", function() {
   beforeEach(function() {
-    cy
-      .configureCluster({
-        mesos: "1-task-healthy",
-        universePackages: true
-      })
-      .visitUrl({ url: "/catalog/packages/marathon?version=1.4.6" });
+    cy.configureCluster({
+      mesos: "1-task-healthy",
+      universePackages: true
+    }).visitUrl({ url: "/catalog/packages/marathon?version=1.4.6" });
   });
 
   context("Package Details", function() {
@@ -17,8 +15,7 @@ describe("Package Detail Tab", function() {
     it("displays marathon package details", function() {
       cy.get(".page-body-content .pod p").as("information");
 
-      cy
-        .get("@information")
+      cy.get("@information")
         .eq(0)
         .should(
           "contain",
@@ -44,53 +41,58 @@ describe("Package Detail Tab", function() {
         );
     });
 
+    it("contains _blank target for links in description", function() {
+      cy.get("h2")
+        .contains("Description")
+        .parent()
+        .find("a")
+        .should("have.attr", "target", "_blank");
+    });
+
+    it("contains _blank target for links in preinstall notes", function() {
+      cy.get(".pre-install-notes")
+        .find("a")
+        .should("have.attr", "target", "_blank");
+    });
+
     it("displays image in the image viewer", function() {
-      cy
-        .get(".media-object-item-fill-image.image-rounded-corners.clickable")
+      cy.get(".media-object-item-fill-image.image-rounded-corners.clickable")
         .eq(4)
         .click();
 
-      cy
-        .get(".modal.modal-image-viewer img")
-        .should(
-          "have.attr",
-          "src",
-          "http://www.clker.com/cliparts/0/f/d/b/12917289761851255679earth-map-huge.jpg"
-        );
+      cy.get(".modal.modal-image-viewer img").should(
+        "have.attr",
+        "src",
+        "http://www.clker.com/cliparts/0/f/d/b/12917289761851255679earth-map-huge.jpg"
+      );
     });
 
     it("changes image in the image viewer by clicking left arrow", function() {
-      cy
-        .get(".media-object-item-fill-image.image-rounded-corners.clickable")
+      cy.get(".media-object-item-fill-image.image-rounded-corners.clickable")
         .eq(4)
         .click();
 
       cy.get(".modal-image-viewer-arrow-container.clickable.backward").click();
 
-      cy
-        .get(".modal.modal-image-viewer img")
-        .should(
-          "have.attr",
-          "src",
-          "https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/marathon-0.6.0/mesosphere-marathon-app-list.png"
-        );
+      cy.get(".modal.modal-image-viewer img").should(
+        "have.attr",
+        "src",
+        "https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/marathon-0.6.0/mesosphere-marathon-app-list.png"
+      );
     });
 
     it("changes image in the image viewer by clicking right arrow", function() {
-      cy
-        .get(".media-object-item-fill-image.image-rounded-corners.clickable")
+      cy.get(".media-object-item-fill-image.image-rounded-corners.clickable")
         .eq(4)
         .click();
 
       cy.get(".modal-image-viewer-arrow-container.clickable.forward").click();
 
-      cy
-        .get(".modal.modal-image-viewer img")
-        .should(
-          "have.attr",
-          "src",
-          "https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/marathon-0.6.0/mesosphere-marathon-app-list.png"
-        );
+      cy.get(".modal.modal-image-viewer img").should(
+        "have.attr",
+        "src",
+        "https://mesosphere.com/wp-content/themes/mesosphere/library/images/assets/marathon-0.6.0/mesosphere-marathon-app-list.png"
+      );
     });
 
     it("dropdown display all versions available", function() {
@@ -100,7 +102,9 @@ describe("Package Detail Tab", function() {
 
     it("select available version on dropdown", function() {
       cy.get(".dropdown-toggle").click();
-      cy.get(".is-selectable").eq(3).click();
+      cy.get(".is-selectable")
+        .eq(3)
+        .click();
       cy.window().then(function(window) {
         const result = window.location.hash.includes("0.2.1");
         expect(result).to.equal(true);
@@ -110,24 +114,23 @@ describe("Package Detail Tab", function() {
 
   context("Package Configuration", function() {
     beforeEach(function() {
-      cy
-        .get(".page-body-content .package-action-buttons button")
+      cy.get(".page-body-content .package-action-buttons button")
         .contains("Review & Run")
         .click();
 
-      cy.get(".modal .modal-header button").contains("Review & Run").click();
+      cy.get(".modal .modal-header button")
+        .contains("Review & Run")
+        .click();
     });
 
     it("opens framework configuration when Review & Run clicked", function() {
-      cy
-        .get(".modal .configuration-map-label")
+      cy.get(".modal .configuration-map-label")
         .contains("Name")
         .should("to.have.length", 1);
     });
 
     it("shows preinstall notes on review screen", function() {
-      cy
-        .get(".modal .message.message-warning")
+      cy.get(".modal .message.message-warning")
         .contains(
           "We recommend a minimum of one node with at least 2 CPU shares and 1GB of RAM available for the Marathon DCOS Service."
         )
@@ -135,70 +138,71 @@ describe("Package Detail Tab", function() {
     });
 
     it("goes to form when back button is clicked", function() {
-      cy.get(".modal .modal-header button").contains("Back").click();
+      cy.get(".modal .modal-header button")
+        .contains("Back")
+        .click();
 
-      cy
-        .get('.modal .menu-tabbed-container input[name="group"]')
-        .type(`{selectall}group-1`);
+      cy.get('.modal .menu-tabbed-container input[name="group"]').type(
+        `{selectall}group-1`
+      );
     });
 
     it("changes cancel button to back when on review screen", function() {
-      cy.get(".modal button").contains("Edit Config").click();
+      cy.get(".modal button")
+        .contains("Edit Config")
+        .click();
 
-      cy
-        .get('.modal .menu-tabbed-container input[name="group"]')
-        .type(`{selectall}group-1`);
+      cy.get('.modal .menu-tabbed-container input[name="group"]').type(
+        `{selectall}group-1`
+      );
 
-      cy.get(".modal .modal-header button").contains("Review & Run").click();
+      cy.get(".modal .modal-header button")
+        .contains("Review & Run")
+        .click();
 
-      cy
-        .get(".modal .modal-header button")
+      cy.get(".modal .modal-header button")
         .contains("Back")
         .should("to.have.length", 1);
     });
 
     it("shows success dialog on successfully package install", function() {
-      cy
-        .get(".modal .modal-header button.button-primary")
+      cy.get(".modal .modal-header button.button-primary")
         .contains("Run Service")
         .click();
 
-      cy
-        .get(".modal.modal-small .modal-body")
+      cy.get(".modal.modal-small .modal-body")
         .contains("Success")
         .should("to.have.length", 1);
     });
 
     context("Framework: Placement", function() {
       beforeEach(function() {
-        cy.get(".modal button").contains("Edit Config").click();
+        cy.get(".modal button")
+          .contains("Edit Config")
+          .click();
       });
 
       context("Add Placement Constraint", function() {
         beforeEach(function() {
           cy.get(".menu-tabbed-view-container").as("tabView");
-          cy
-            .get(".button-primary-link")
+          cy.get(".button-primary-link")
             .contains("Add Placement Constraint")
             .click();
         });
 
         it('Should add rows when "Add Placement Constraint" link clicked', function() {
           // Field
-          cy
-            .get("@tabView")
+          cy.get("@tabView")
             .find('.form-control[name="constraints.0.fieldName"]')
             .should("exist");
 
           // operator
-          cy
-            .get("@tabView")
+          cy.get("@tabView")
             .find('[name="constraints.0.operator"]')
             .should("exist");
 
           // value
-          cy
-            .get("@tabView")
+          cy.get("@tabView")
             .find('.form-control[name="constraints.0.value"]')
             .should("exist");
         });
@@ -210,32 +214,30 @@ describe("Package Detail Tab", function() {
           });
 
           // Field
-          cy
-            .get("@tabView")
+          cy.get("@tabView")
             .find('.form-control[name="constraints.0.fieldName"]')
             .should("not.exist");
 
           // operator
-          cy
-            .get("@tabView")
+          cy.get("@tabView")
             .find('[name="constraints.0.operator"]')
             .should("not.exist");
 
           // value
-          cy
-            .get("@tabView")
+          cy.get("@tabView")
             .find('.form-control[name="constraints.0.value"]')
             .should("not.exist");
         });
 
         it("Should disable the field value when Unique is selected in operator dropdown", function() {
-          cy.get("@tabView").find(".button.dropdown-toggle").click();
+          cy.get("@tabView")
+            .find(".button.dropdown-toggle")
+            .click();
 
           cy.contains(".dropdown-select-item-title", "Unique").click();
 
           // value
-          cy
-            .get("@tabView")
+          cy.get("@tabView")
             .find('[name="constraints.0.value"]')
             .should("be.disabled");
         });


### PR DESCRIPTION
Ensure links on package detail page rendered from markdown open in new tab.

Closes DCOS-8601.

## Testing

- Go to catalog page
- Click on spark
- Ensure link in Description section opens in new tab
- Back to catalog page
- Click on kubernetes
- Ensure link in pre install section opens in new tab

## Trade-offs

Some links were opening in new tabs already and some were not - the ones that were not were being rendered from markdown. This makes wrapping the individual links in a component difficult since they are not separated from other text. We are currently using a package called `marked` to parse the markdown in the StringUtil `parseMarkdown` method. I've modified the `marked` renderer to add target="_blank" to links. This affects links in the Description, Pre Install notes, and Post Install notes sections.

For a discussion about modifying `marked` links, see [this PR](https://github.com/markedjs/marked/pull/659) from the `marked` project.

The StringUtil method is also used in FrameworkConfiguration. I've made the assumption that we want the behaviour to be consistent in both locations.
