### PR TITLE
DCOS-41015: Nodes Health missing link

### DIFF
--- a/src/js/pages/system/units-health-node-detail/NodeInfoPanel.js
+++ b/src/js/pages/system/units-health-node-detail/NodeInfoPanel.js
@@ -7,8 +7,6 @@ import ConfigurationMapHeading from "../../../components/ConfigurationMapHeading
 import ConfigurationMapRow from "../../../components/ConfigurationMapRow";
 import ConfigurationMapSection from "../../../components/ConfigurationMapSection";
 
-import { documentationURI } from "../../../config/Config";
-
 class NodeInfoPanel extends React.Component {
   constructor() {
     super(...arguments);
@@ -24,9 +22,11 @@ class NodeInfoPanel extends React.Component {
           <ConfigurationMapSection>
             <ConfigurationMapHeading>Summary</ConfigurationMapHeading>
             <p>{summary}</p>
-            <a href={docsURL} target="_blank">
-              View Documentation
-            </a>
+            {docsURL && (
+              <a href={docsURL} target="_blank">
+                View Documentation
+              </a>
+            )}
           </ConfigurationMapSection>
           <ConfigurationMapSection>
             <ConfigurationMapHeading>Output</ConfigurationMapHeading>
@@ -44,10 +44,6 @@ NodeInfoPanel.propTypes = {
   docsURL: PropTypes.string,
   output: PropTypes.string,
   summary: PropTypes.string
-};
-
-NodeInfoPanel.defaultProps = {
-  docsURL: documentationURI
 };
 
 module.exports = NodeInfoPanel;


### PR DESCRIPTION
Check if link is empty and if yes, do not show it.

Closes https://jira.mesosphere.com/browse/DCOS-41015

It turns out that the id that should show the link here (see `/src/js/components/UnitsHealthNodeDetail.js`) doesn't exist in `/src/js/constants/UnitSummaries.js`. Until now, this meant that the default documentation page was shown, however this is broken in 1.12. @juliangieseke and I decided to hide the link if no page is given and fix the id and the links in another issue.

## Testing
Go to `Nodes`
Click a Node
Click Health
Click any of the links in the `Health Check` column
Verify that the page doesn't contain an unclickable link

## Trade-offs
Althouth I considered deleting it, I decided to keep `documentationURI` in `Config.ts`, because I think we will need it later.

## Dependencies
None

## Screenshots

### Before
![screenshot from 2018-09-11 12-44-06](https://user-images.githubusercontent.com/40791275/45354404-301a9280-b5c6-11e8-8f4d-1c10701aab4c.png)

### After
![screenshot from 2018-09-11 12-59-42](https://user-images.githubusercontent.com/40791275/45354410-3446b000-b5c6-11e8-9398-60130961c4bf.png)
