### PR TITLE
DCOS-41016: Nodes Health missing link (backport 1.11)

### DIFF
--- a/src/js/pages/system/units-health-node-detail/NodeInfoPanel.js
+++ b/src/js/pages/system/units-health-node-detail/NodeInfoPanel.js
@@ -9,8 +9,6 @@ import ConfigurationMapRow from "../../../components/ConfigurationMapRow";
 import ConfigurationMapSection
   from "../../../components/ConfigurationMapSection";
 
-import { documentationURI } from "../../../config/Config";
-
 class NodeInfoPanel extends React.Component {
   constructor() {
     super(...arguments);
@@ -30,9 +28,10 @@ class NodeInfoPanel extends React.Component {
             <p>
               {summary}
             </p>
-            <a href={docsURL} target="_blank">
-              View Documentation
-            </a>
+            {docsURL &&
+              <a href={docsURL} target="_blank">
+                View Documentation
+              </a>}
           </ConfigurationMapSection>
           <ConfigurationMapSection>
             <ConfigurationMapHeading>
@@ -54,10 +53,6 @@ NodeInfoPanel.propTypes = {
   docsURL: PropTypes.string,
   output: PropTypes.string,
   summary: PropTypes.string
-};
-
-NodeInfoPanel.defaultProps = {
-  docsURL: documentationURI
 };
 
 module.exports = NodeInfoPanel;


### PR DESCRIPTION
1.11 backport for https://github.com/dcos/dcos-ui/pull/3264

Half of https://jira.mesosphere.com/browse/DCOS-41016

## Testing
1. Set up node to use version 4.4.7 and npm to use version 3.9.6
I recommend using a new copy of the dcos-ui repository.
Setting up node is easy: just use a node version manager (I used https://github.com/creationix/nvm) and run (if you are using nvm) `nvm install 4.4.7` in the directory. Setting up npm is a bit trickier - navigate to the nvm directory, for example `cd ~/.nvm/versions/node/v4.4.7/lib` and run `npm install npm@3.9.6`. Then run `npm install`.

2.Go to `Nodes`
Click a Node
Click Health
Click any of the links in the `Health Check` column
Verify that the page doesn't contain an unclickable link
