### PR TITLE
[1.10] Backport: fix(PackageDetailTab): package detail links open in new tab

### DIFF
--- a/src/js/utils/StringUtil.js
+++ b/src/js/utils/StringUtil.js
@@ -3,6 +3,20 @@ import marked from "marked";
 import React from "react";
 /* eslint-enable no-unused-vars */
 
+const markdownRenderer = {
+  rendererReady: false,
+  prepareMarkdownRenderer() {
+    const renderer = new marked.Renderer();
+    renderer.link = function() {
+      const out = marked.Renderer.prototype.link.apply(this, arguments);
+
+      return out.replace(/^<a/, '<a target="_blank"');
+    };
+    marked.setOptions({ renderer });
+    this.rendererReady = true;
+  }
+};
+
 const StringUtil = {
   arrayToJoinedString(array = [], separator = ", ") {
     if (Array.isArray(array)) {
@@ -165,6 +179,10 @@ const StringUtil = {
   parseMarkdown(text) {
     if (!text) {
       return null;
+    }
+
+    if (!markdownRenderer.rendererReady) {
+      markdownRenderer.prepareMarkdownRenderer();
     }
 
     const __html = marked(

--- a/src/js/utils/__tests__/StringUtil-test.js
+++ b/src/js/utils/__tests__/StringUtil-test.js
@@ -257,6 +257,44 @@ describe("StringUtil", function() {
       );
     });
 
+    describe("#parseMarkdown", function() {
+      it("adds _blank target to plain links in text", function() {
+        expect(
+          StringUtil.parseMarkdown("Hello this is a link http://somelink.com")
+            .__html
+        ).toEqual(
+          `<p>Hello this is a link <a target="_blank" href="http://somelink.com">http://somelink.com</a></p>\n`
+        );
+      });
+      it("adds _blank target to formatted links in text", function() {
+        expect(
+          StringUtil.parseMarkdown(
+            "Hello this is a [link](http://somelink.com)"
+          ).__html
+        ).toEqual(
+          `<p>Hello this is a <a target="_blank" href="http://somelink.com">link</a></p>\n`
+        );
+      });
+      it("does not add target _blank to non-uri segments attached to plain links containing '<a'", function() {
+        expect(
+          StringUtil.parseMarkdown(
+            "Hello this is a bad link http://a.com/<a-mean-uri"
+          ).__html
+        ).toEqual(
+          `<p>Hello this is a bad link <a target="_blank" href="http://a.com/">http://a.com/</a>&lt;a-mean-uri</p>\n`
+        );
+      });
+      it("does not add additional target _blank to uri segments in formatted links containing '<a'", function() {
+        expect(
+          StringUtil.parseMarkdown(
+            "Hello this is a bad [link](http://a.com/<a-mean-uri)"
+          ).__html
+        ).toEqual(
+          `<p>Hello this is a bad <a target="_blank" href="http://a.com/&lt;a-mean-uri">link</a></p>\n`
+        );
+      });
+    });
+
     it("allows the user to disable the serial comma", function() {
       expect(
         StringUtil.humanizeArray(["one", "two", "three"], {

--- a/tests/_fixtures/cosmos/package-describe.json
+++ b/tests/_fixtures/cosmos/package-describe.json
@@ -4,7 +4,7 @@
     "name": "marathon",
     "version": "0.11.1",
     "maintainer": "help@dcos.io",
-    "description": "A cluster-wide init and control system for services in cgroups or Docker containers.",
+    "description": "A cluster-wide init and control system for services in cgroups or Docker containers. Documentation: https://docs.mesosphere.com/1.11/deploying-services/marathon-api/",
     "tags": [
       "init",
       "long-running"
@@ -12,7 +12,7 @@
     "scm": "https://github.com/mesosphere/marathon.git",
     "website": null,
     "framework": true,
-    "preInstallNotes": "We recommend a minimum of one node with at least 2 CPU's and 1GB of RAM available for the Marathon Service.",
+    "preInstallNotes": "We recommend a minimum of one node with at least 2 CPU's and 1GB of RAM available for the Marathon Service. More information: https://mesosphere.github.io/marathon/",
     "postInstallNotes": "Marathon DCOS Service has been successfully installed!\n\n\tDocumentation: https://mesosphere.github.io/marathon\n\tIssues: https://github.com/mesosphere/marathon/issues\n",
     "postUninstallNotes": "The Marathon DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at http://docs.mesosphere.com/services/marathon/#uninstall to clean up any persisted state",
     "licenses": [
@@ -284,7 +284,7 @@
             },
             "uris": {
               "default": [
-
+                
               ],
               "description": "List of URIs that will be download and made available in the current working directory of Marathon. For example this can be used to download a Java keystore file for SSL configuration.",
               "items": {

--- a/tests/pages/catalog/packages/package/PackageTab-cy.js
+++ b/tests/pages/catalog/packages/package/PackageTab-cy.js
@@ -43,6 +43,21 @@ describe("Package Detail Tab", function() {
       );
   });
 
+  it("contains _blank target for links in description", function() {
+    cy
+      .contains("Description")
+      .parent()
+      .find("a")
+      .should("have.attr", "target", "_blank");
+  });
+  it("contains _blank target for links in preinstall notes", function() {
+    cy
+      .contains("Pre-Install Notes")
+      .parent()
+      .find("a")
+      .should("have.attr", "target", "_blank");
+  });
+
   it("displays image in the image viewer", function() {
     cy
       .get(".media-object-item-fill-image.image-rounded-corners.clickable")


### PR DESCRIPTION
Backport changes that ensure links on package detail page rendered from markdown open in new tab.

Closes DCOS-41668.

## Testing

- Go to catalog page
- Click on spark
- Ensure link in Description section opens in new tab
- Back to catalog page
- Click on kubernetes
- Ensure link in pre install section opens in new tab

## Trade-offs

See #3263 

