### PR TITLE
DCOS-14757: Fix Volumes reducer [1.10]

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Volumes.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Volumes.js
@@ -9,7 +9,7 @@ const { type: { MESOS, DOCKER } } = ContainerConstants;
 const mapLocalVolumes = function(volume) {
   if (volume.type === "PERSISTENT") {
     return {
-      persistent: volume.persistent,
+      persistent: volume.persistent || {},
       mode: volume.mode,
       containerPath: volume.containerPath
     };
@@ -151,7 +151,7 @@ function reduceVolumes(state, { type, path, value }) {
           this.localVolumes.push(
             value || {
               containerPath: null,
-              persistent: { size: null },
+              persistent: { size: 0 },
               mode: "RW"
             }
           );

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Volumes-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Volumes-test.js
@@ -27,7 +27,7 @@ describe("Volumes", function() {
         {
           containerPath: null,
           persistent: {
-            size: null
+            size: 0
           },
           mode: "RW"
         }
@@ -152,7 +152,7 @@ describe("Volumes", function() {
         {
           containerPath: null,
           persistent: {
-            size: null
+            size: 0
           },
           mode: "RW"
         },

--- a/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/__tests__/Container-test.js
@@ -1182,7 +1182,7 @@ describe("Container", function() {
           {
             containerPath: null,
             persistent: {
-              size: null
+              size: 0
             },
             mode: "RW"
           }
@@ -1230,7 +1230,7 @@ describe("Container", function() {
           {
             containerPath: null,
             persistent: {
-              size: null
+              size: 0
             },
             mode: "RW"
           },


### PR DESCRIPTION
This ensures that persistent volumes do contain a field with a non null value. This is needed so
that the rendered JSON does contain a persistent attribute in the volume.

Close DCOS-14757