### PR TITLE
DCOS-41699: [1.10] Changing custom VIP port from the form doesn't work

### DIFF
--- a/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/MultiContainerNetworkingFormSection.js
@@ -273,24 +273,29 @@ class MultiContainerNetworkingFormSection extends mixin(StoreMixin) {
 
     let address = vip;
 
-    if (address == null) {
-      let port = "";
-      if (!portsAutoAssign && !ValidatorUtil.isEmpty(hostPort)) {
-        port = hostPort;
-      }
-      if (!ValidatorUtil.isEmpty(containerPort)) {
-        port = containerPort;
-      }
-      if (!ValidatorUtil.isEmpty(vipPort)) {
-        port = vipPort;
-      }
+    let port = "";
+    if (!portsAutoAssign && !ValidatorUtil.isEmpty(hostPort)) {
+      port = hostPort;
+    }
+    if (!ValidatorUtil.isEmpty(containerPort)) {
+      port = containerPort;
+    }
+    if (!ValidatorUtil.isEmpty(vipPort)) {
+      port = vipPort;
+    }
 
+    if (address == null) {
       address = `${id}:${port}`;
+    }
+
+    const vipMatch = address.match(/(.+):\d+/);
+    if (vipMatch) {
+      address = `${vipMatch[1]}:${port}`;
     }
 
     let hostName = null;
     if (!vipPortError) {
-      hostName = ServiceConfigUtil.buildHostNameFromVipLabel(address);
+      hostName = ServiceConfigUtil.buildHostNameFromVipLabel(address, port);
     }
 
     const helpText = (

--- a/plugins/services/src/js/components/forms/NetworkingFormSection.js
+++ b/plugins/services/src/js/components/forms/NetworkingFormSection.js
@@ -228,24 +228,29 @@ class NetworkingFormSection extends mixin(StoreMixin) {
 
     let address = vip;
 
-    if (address == null) {
-      let port = "";
-      if (!portsAutoAssign && !ValidatorUtil.isEmpty(hostPort)) {
-        port = hostPort;
-      }
-      if (!ValidatorUtil.isEmpty(containerPort)) {
-        port = containerPort;
-      }
-      if (!ValidatorUtil.isEmpty(vipPort)) {
-        port = vipPort;
-      }
+    let port = "";
+    if (!portsAutoAssign && !ValidatorUtil.isEmpty(hostPort)) {
+      port = hostPort;
+    }
+    if (!ValidatorUtil.isEmpty(containerPort)) {
+      port = containerPort;
+    }
+    if (!ValidatorUtil.isEmpty(vipPort)) {
+      port = vipPort;
+    }
 
+    if (address == null) {
       address = `${id}:${port}`;
+    }
+
+    const vipMatch = address.match(/(.+):\d+/);
+    if (vipMatch) {
+      address = `${vipMatch[1]}:${port}`;
     }
 
     let hostName = null;
     if (!vipPortError) {
-      hostName = ServiceConfigUtil.buildHostNameFromVipLabel(address);
+      hostName = ServiceConfigUtil.buildHostNameFromVipLabel(address, port);
     }
 
     const helpText = (

--- a/plugins/services/src/js/utils/VipLabelUtil.js
+++ b/plugins/services/src/js/utils/VipLabelUtil.js
@@ -10,6 +10,11 @@ const VipLabelUtil = {
         vipValue = `${appId}:${vipPort}`;
       }
 
+      const vipMatch = vipValue.match(/(.+):\d+/);
+      if (vipMatch) {
+        vipValue = `${vipMatch[1]}:${vipPort}`;
+      }
+
       return Object.assign({}, labels, { [vipLabel]: vipValue });
     }
 

--- a/plugins/services/src/js/utils/__tests__/VipLabelUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/VipLabelUtil-test.js
@@ -65,7 +65,7 @@ describe("VipLabelUtil", function() {
       });
 
       describe("when vip has been given", function() {
-        it("generates VIP", function() {
+        it("generates VIP with new port value", function() {
           var portDefinition = {
             loadBalanced: true,
             vip: "service-address:9091"
@@ -77,7 +77,7 @@ describe("VipLabelUtil", function() {
             vipPort
           );
 
-          expect(result).toEqual({ VIP_0: "service-address:9091" });
+          expect(result).toEqual({ VIP_0: "service-address:7070" });
         });
       });
     });

--- a/tests/_fixtures/marathon-1-pod-group/groups.json
+++ b/tests/_fixtures/marathon-1-pod-group/groups.json
@@ -204,6 +204,81 @@
       ],
       "lastUpdated": "2017-04-21T00:53:27.51Z",
       "lastChanged": "2017-04-20T22:06:33.371Z"
+    },
+    {
+      "id": "/customvip",
+      "spec": {
+        "id": "/customvip",
+        "version": "2018-09-13T05:11:09.298Z",
+        "containers": [
+          {
+            "name": "container-1",
+            "exec": { "command": { "shell": "sleep 100" } },
+            "resources": { "cpus": 0.1, "mem": 128, "disk": 0, "gpus": 0 },
+            "endpoints": [
+              {
+                "name": "foo",
+                "containerPort": 200,
+                "hostPort": 0,
+                "protocol": ["tcp"],
+                "labels": { "VIP_0": "/bar:500" }
+              }
+            ],
+            "image": { "kind": "DOCKER", "id": "nginx" }
+          }
+        ],
+        "networks": [{ "name": "dcos", "mode": "container" }],
+        "scaling": { "kind": "fixed", "instances": 1 },
+        "scheduling": {
+          "backoff": {
+            "backoff": 1,
+            "backoffFactor": 1.15,
+            "maxLaunchDelay": 3600
+          },
+          "upgrade": { "minimumHealthCapacity": 1, "maximumOverCapacity": 1 },
+          "killSelection": "YOUNGEST_FIRST",
+          "unreachableStrategy": {
+            "inactiveAfterSeconds": 0,
+            "expungeAfterSeconds": 0
+          }
+        },
+        "executorResources": { "cpus": 0.1, "mem": 32, "disk": 10 }
+      },
+      "status": "STABLE",
+      "statusSince": "2018-09-13T05:13:23.075Z",
+      "instances": [
+        {
+          "id": "customvip.instance-6d1cdda0-b713-11e8-9616-62da7168ca86",
+          "status": "STABLE",
+          "statusSince": "2018-09-13T05:13:23.075Z",
+          "conditions": [],
+          "agentHostname": "10.0.3.185",
+          "agentId": "56f4d2c0-d31d-40b6-ad4d-ffdd97964448-S1",
+          "resources": { "cpus": 0.2, "mem": 160, "disk": 10, "gpus": 0 },
+          "networks": [{ "name": "dcos", "addresses": ["9.0.2.2"] }],
+          "containers": [
+            {
+              "name": "container-1",
+              "status": "TASK_RUNNING",
+              "statusSince": "2018-09-13T05:13:23.075Z",
+              "conditions": [],
+              "containerId":
+                "customvip.instance-6d1cdda0-b713-11e8-9616-62da7168ca86.container-1",
+              "endpoints": [{ "name": "foo", "allocatedHostPort": 10968 }],
+              "resources": { "cpus": 0.1, "mem": 128, "disk": 0, "gpus": 0 },
+              "lastUpdated": "2018-09-13T05:13:23.075Z",
+              "lastChanged": "2018-09-13T05:13:23.075Z"
+            }
+          ],
+          "specReference": "/v2/pods/customvip::versions/2018-09-13T05:11:09.298Z",
+          "localVolumes": [],
+          "lastUpdated": "2018-09-13T05:13:23.075Z",
+          "lastChanged": "2018-09-13T05:13:23.075Z"
+        }
+      ],
+      "terminationHistory": [],
+      "lastUpdated": "2018-09-13T05:14:59.991Z",
+      "lastChanged": "2018-09-13T05:13:23.075Z"
     }
   ]
 }

--- a/tests/_fixtures/marathon-1-task/groups.json
+++ b/tests/_fixtures/marathon-1-task/groups.json
@@ -1,6 +1,134 @@
 {
   "apps": [
     {
+      "id": "/net",
+      "backoffFactor": 1.15,
+      "backoffSeconds": 1,
+      "container": {
+        "type": "DOCKER",
+        "docker": {
+          "forcePullImage": false,
+          "image": "nginx",
+          "parameters": [],
+          "privileged": false
+        },
+        "volumes": [],
+        "portMappings": [
+          {
+            "containerPort": 10,
+            "labels": {
+              "VIP_0": "notnet:1234"
+            },
+            "name": "ping",
+            "protocol": "tcp",
+            "servicePort": 10000
+          }
+        ]
+      },
+      "cpus": 0.1,
+      "disk": 0,
+      "executor": "",
+      "instances": 1,
+      "labels": {},
+      "maxLaunchDelaySeconds": 3600,
+      "mem": 128,
+      "gpus": 0,
+      "networks": [
+        {
+          "name": "dcos",
+          "mode": "container"
+        }
+      ],
+      "requirePorts": false,
+      "upgradeStrategy": {
+        "maximumOverCapacity": 1,
+        "minimumHealthCapacity": 1
+      },
+      "version": "2018-09-07T11:54:17.842Z",
+      "versionInfo": {
+        "lastScalingAt": "2018-09-07T11:54:17.842Z",
+        "lastConfigChangeAt": "2018-09-07T11:54:17.842Z"
+      },
+      "killSelection": "YOUNGEST_FIRST",
+      "unreachableStrategy": {
+        "inactiveAfterSeconds": 0,
+        "expungeAfterSeconds": 0
+      },
+      "tasksStaged": 0,
+      "tasksRunning": 1,
+      "tasksHealthy": 0,
+      "tasksUnhealthy": 0,
+      "deployments": [],
+      "tasks": [
+        {
+          "appId": "/net",
+          "healthCheckResults": [],
+          "host": "10.0.0.206",
+          "id": "net.c0a40ad4-b294-11e8-a6fa-e2d3821ae5ef",
+          "ipAddresses": [
+            {
+              "ipAddress": "9.0.2.130",
+              "protocol": "IPv4"
+            }
+          ],
+          "ports": [],
+          "servicePorts": [],
+          "slaveId": "2fe1bab0-d44b-4665-8ac0-29196e6980c5-S1",
+          "state": "TASK_RUNNING",
+          "stagedAt": "2018-09-07T11:54:19.182Z",
+          "startedAt": "2018-09-07T11:54:20.195Z",
+          "version": "2018-09-07T11:54:17.842Z",
+          "localVolumes": [],
+          "region": "aws/eu-central-1",
+          "zone": "aws/eu-central-1a"
+        }
+      ],
+      "taskStats": {
+        "startedAfterLastScaling": {
+          "stats": {
+            "counts": {
+              "staged": 0,
+              "running": 1,
+              "healthy": 0,
+              "unhealthy": 0
+            },
+            "lifeTime": {
+              "averageSeconds": 3974.008,
+              "medianSeconds": 3974.008
+            }
+          }
+        },
+        "withLatestConfig": {
+          "stats": {
+            "counts": {
+              "staged": 0,
+              "running": 1,
+              "healthy": 0,
+              "unhealthy": 0
+            },
+            "lifeTime": {
+              "averageSeconds": 3974.008,
+              "medianSeconds": 3974.008
+            }
+          }
+        },
+        "totalSummary": {
+          "stats": {
+            "counts": {
+              "staged": 0,
+              "running": 1,
+              "healthy": 0,
+              "unhealthy": 0
+            },
+            "lifeTime": {
+              "averageSeconds": 3974.008,
+              "medianSeconds": 3974.008
+            }
+          }
+        }
+      }
+    },
+    {
       "id": "/sleep",
       "cmd": "sleep 3000",
       "args": null,

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1219,6 +1219,20 @@ describe("Service Form Modal", function() {
           });
         });
       });
+
+      context("Edit Service Endpoint", function() {
+        it("sets vip port when host does not match app id", function() {
+          cy.configureCluster({
+            mesos: "1-task-healthy"
+          });
+          cy.visitUrl({ url: "/services/detail/%2Fnet" });
+          cy.get(".page-header-actions .dropdown").click();
+          cy.get(".dropdown-menu-items").contains("Edit").click();
+          cy.get(".menu-tabbed-item-label").contains("Networking").click();
+          cy.get(".form-control[name='portDefinitions.0.vipPort']").type(5);
+          cy.contains(".marathon.l4lb.thisdcos.directory:12345");
+        });
+      });
     });
 
     context("Service: Volumes", function() {
@@ -1678,13 +1692,15 @@ describe("Service Form Modal", function() {
         });
 
         function addServiceEndpoint() {
-          cy.get(".button.button-primary-link")
+          cy
+            .get(".button.button-primary-link")
             .contains("Add Service Endpoint")
             .click();
         }
 
         function enableLoadBalancedAddress() {
-          cy.get(".form-group-heading-content")
+          cy
+            .get(".form-group-heading-content")
             .contains("Enable Load Balanced Service Address")
             .click();
         }
@@ -1700,9 +1716,9 @@ describe("Service Form Modal", function() {
             });
 
             it("sets vip port", function() {
-              cy.get(
-                '.form-control[name="containers.0.endpoints.0.vipPort"]'
-              ).type(9007);
+              cy
+                .get('.form-control[name="containers.0.endpoints.0.vipPort"]')
+                .type(9007);
 
               cy.contains(".marathon.l4lb.thisdcos.directory:9007");
             });
@@ -1711,9 +1727,9 @@ describe("Service Form Modal", function() {
 
         context("Virtual Network: dcos-1", function() {
           beforeEach(function() {
-            cy.get('select[name="networks.0"]').select(
-              "Virtual Network: dcos-1"
-            );
+            cy
+              .get('select[name="networks.0"]')
+              .select("Virtual Network: dcos-1");
           });
 
           context("Load balanced ports", function() {
@@ -1722,9 +1738,9 @@ describe("Service Form Modal", function() {
             });
 
             it("sets vip port", function() {
-              cy.get(
-                '.form-control[name="containers.0.endpoints.0.vipPort"]'
-              ).type(9007);
+              cy
+                .get('.form-control[name="containers.0.endpoints.0.vipPort"]')
+                .type(9007);
 
               cy.contains(".marathon.l4lb.thisdcos.directory:9007");
             });
@@ -1850,6 +1866,20 @@ describe("Service Form Modal", function() {
       // Click edit to view form
       cy.get("a.button.button-link").eq(-1).click({ force: true });
       cy.get(".menu-tabbed-view").contains("Networking");
+    });
+  });
+
+  context("Multi-container - Edit", function() {
+    it("sets vip port when host does not match app id", function() {
+      cy.configureCluster({
+        mesos: "1-pod"
+      });
+      cy.visitUrl({ url: "/services/detail/%2Fcustomvip" });
+      cy.get(".page-header-actions .dropdown").click();
+      cy.get(".dropdown-menu-items").contains("Edit").click();
+      cy.get(".menu-tabbed-item-label").contains("Networking").click();
+      cy.get(".form-control[name='containers.0.endpoints.0.vipPort']").type(5);
+      cy.contains(".marathon.l4lb.thisdcos.directory:5005");
     });
   });
 });


### PR DESCRIPTION
Allows the VIP port to be edited in the UI even when the VIP host name is not the same as the app-id.

1.10 backport for https://github.com/dcos/dcos-ui/pull/3256

Closes https://jira.mesosphere.com/browse/DCOS-41699

## Testing
- Deploy an app with a VIP label [0]
- Go to edit the app definition
- Go to Networking
- Find the field Load Balanced Port, and test it.

## Dependencies
none