### PR TITLE
chore(ServiceBreadcrumbs): Remove unused prop

### DIFF
--- a/plugins/services/src/js/components/ServiceBreadcrumbs.js
+++ b/plugins/services/src/js/components/ServiceBreadcrumbs.js
@@ -246,7 +246,6 @@ class ServiceBreadcrumbs extends React.Component {
           <BreadcrumbTextContent>
             <Link
               to={`/services/detail/${aggregateIDs}/tasks/${encodedTaskID}`}
-              index={taskID}
             >
               {taskName}
             </Link>


### PR DESCRIPTION
Unused prop on this react-router component was triggering a React proptype warning

## Testing

1. Add hello-world service from catalog
2. Visit service details, container-1 logs tab
3. Observe no warnings

## Screenshots

Warnings here:

<img width="1792" alt="screen shot 2018-09-12 at 6 00 18 pm" src="https://user-images.githubusercontent.com/174332/45459574-207a7700-b6b6-11e8-97e3-76e363a22f3d.png">
