### PR TITLE
DCOS-35756: Fix Headings levels in Config Screens

### DIFF
--- a/src/js/components/FrameworkConfigurationReviewScreen.js
+++ b/src/js/components/FrameworkConfigurationReviewScreen.js
@@ -9,7 +9,7 @@ import Icon from "#SRC/js/components/Icon";
 import EmptyStates from "#SRC/js/constants/EmptyStates";
 import RouterUtil from "#SRC/js/utils/RouterUtil";
 
-const METHODS_TO_BIND = ["getHashMapRenderKeys"];
+const METHODS_TO_BIND = ["getHashMapRenderKeys", "getFrameworkSections"];
 
 class FrameworkConfigurationReviewScreen extends React.Component {
   constructor(props) {
@@ -102,6 +102,24 @@ class FrameworkConfigurationReviewScreen extends React.Component {
     );
   }
 
+  getFrameworkSections() {
+    const { frameworkData } = this.props;
+    const renderKeys = this.getHashMapRenderKeys(frameworkData);
+
+    return Object.keys(renderKeys).map((key, index) => {
+      return (
+        <HashMapDisplay
+          hash={frameworkData[key]}
+          headline={renderKeys[key]}
+          renderKeys={renderKeys}
+          headlineClassName={"text-capitalize"}
+          emptyValue={EmptyStates.CONFIG_VALUE}
+          key={`framework-config-review-section-${index}`}
+        />
+      );
+    });
+  }
+
   render() {
     const { frameworkData, title, onEditClick, frameworkMeta } = this.props;
 
@@ -142,13 +160,7 @@ class FrameworkConfigurationReviewScreen extends React.Component {
             </a>
           </div>
         </div>
-        <HashMapDisplay
-          hash={frameworkData}
-          headingLevel={0} // this is invalid usage of HasMapDisplay, related issue: https://jira.mesosphere.com/browse/DCOS-35756
-          renderKeys={this.getHashMapRenderKeys(frameworkData)}
-          headlineClassName={"text-capitalize"}
-          emptyValue={EmptyStates.CONFIG_VALUE}
-        />
+        {this.getFrameworkSections()}
       </div>
     );
   }

--- a/src/js/components/HashMapDisplay.js
+++ b/src/js/components/HashMapDisplay.js
@@ -45,8 +45,8 @@ class HashMapDisplay extends React.Component {
         value !== null &&
         !React.isValidElement(value)
       ) {
-        // Increase the heading level for each nested description list, making
-        // ensuring we don't surpass heading level 6.
+        // Increase the heading level for each nested description list,
+        // ensuring we don't surpass heading level <h6/>.
         const nextHeadingLevel = Math.min(headingLevel + 1, 6);
 
         return (

--- a/src/js/components/HashMapDisplay.js
+++ b/src/js/components/HashMapDisplay.js
@@ -97,7 +97,7 @@ class HashMapDisplay extends React.Component {
     }
 
     return (
-      <ConfigurationMapSection key={this.props.key}>
+      <ConfigurationMapSection>
         {this.getHeadline()}
         {this.getItems()}
       </ConfigurationMapSection>
@@ -107,7 +107,6 @@ class HashMapDisplay extends React.Component {
 
 HashMapDisplay.defaultProps = {
   headingLevel: 1,
-  key: "",
   renderKeys: {}
 };
 
@@ -116,7 +115,6 @@ HashMapDisplay.propTypes = {
   headlineClassName: PropTypes.string,
   headline: PropTypes.node,
   hash: PropTypes.object,
-  key: PropTypes.string,
   // Optional object with keys consisting of keys in `props.hash` to be
   // replaced, and with corresponding values of the replacement to be rendered.
   renderKeys: PropTypes.object,

--- a/src/js/components/HashMapDisplay.js
+++ b/src/js/components/HashMapDisplay.js
@@ -8,10 +8,16 @@ import ConfigurationMapRow from "./ConfigurationMapRow";
 import ConfigurationMapSection from "./ConfigurationMapSection";
 import ConfigurationMapValue from "./ConfigurationMapValue";
 
+const METHODS_TO_BIND = ["formatValue", "isHashMap"];
+
 class HashMapDisplay extends React.Component {
   constructor() {
     super(...arguments);
     this.shouldComponentUpdate = PureRender.shouldComponentUpdate.bind(this);
+
+    METHODS_TO_BIND.forEach(method => {
+      this[method] = this[method].bind(this);
+    });
   }
 
   getHeadline() {
@@ -31,45 +37,43 @@ class HashMapDisplay extends React.Component {
     );
   }
 
+  getHashMapDisplay(headline, hashMap) {
+    // Increase the heading level for each nested description list,
+    // ensuring we don't surpass heading level <h6/>.
+    const nextHeadingLevel = Math.min(this.props.headingLevel + 1, 6);
+
+    return (
+      <HashMapDisplay
+        {...this.props}
+        hash={hashMap}
+        headingLevel={nextHeadingLevel}
+        key={`hash-map-${headline}`}
+        headline={headline}
+      />
+    );
+  }
+
+  getItemRow(headline, value) {
+    const isAttribute = this.props.headline === "Attributes";
+
+    return (
+      <ConfigurationMapRow key={`hash-map-value-${headline}`}>
+        <ConfigurationMapLabel keepTextCase={isAttribute}>
+          {headline}
+        </ConfigurationMapLabel>
+        <ConfigurationMapValue>{this.formatValue(value)}</ConfigurationMapValue>
+      </ConfigurationMapRow>
+    );
+  }
+
   getItems() {
-    const { hash, headingLevel, renderKeys, emptyValue } = this.props;
+    const { hash, renderKeys } = this.props;
 
-    return Object.keys(hash).map((key, index) => {
-      let value = hash[key];
+    return Object.keys(hash).map(key => {
+      const value = hash[key];
 
-      // Check whether we are trying to render an object that is not a
-      // React component
-      if (
-        typeof value === "object" &&
-        !Array.isArray(value) &&
-        value !== null &&
-        !React.isValidElement(value)
-      ) {
-        // Increase the heading level for each nested description list,
-        // ensuring we don't surpass heading level <h6/>.
-        const nextHeadingLevel = Math.min(headingLevel + 1, 6);
-
-        return (
-          <HashMapDisplay
-            {...this.props}
-            hash={value}
-            headingLevel={nextHeadingLevel}
-            key={index}
-            headline={key}
-          />
-        );
-      }
-
-      if (typeof value === "boolean") {
-        value = value.toString();
-      }
-
-      if (Array.isArray(value)) {
-        value = value.join(", ");
-      }
-
-      if (!value && emptyValue) {
-        value = emptyValue;
+      if (this.isHashMap(value)) {
+        return this.getHashMapDisplay(key, value);
       }
 
       // Check if we need to render a component in the dt
@@ -77,21 +81,13 @@ class HashMapDisplay extends React.Component {
         key = renderKeys[key];
       }
 
-      const isAttribute = this.props.headline === "Attributes";
-
-      return (
-        <ConfigurationMapRow key={index}>
-          <ConfigurationMapLabel keepTextCase={isAttribute}>
-            {key}
-          </ConfigurationMapLabel>
-          <ConfigurationMapValue>{value}</ConfigurationMapValue>
-        </ConfigurationMapRow>
-      );
+      return this.getItemRow(key, value);
     });
   }
 
   render() {
     const { hash } = this.props;
+
     if (!hash || Object.keys(hash).length === 0) {
       return null;
     }
@@ -101,6 +97,34 @@ class HashMapDisplay extends React.Component {
         {this.getHeadline()}
         {this.getItems()}
       </ConfigurationMapSection>
+    );
+  }
+
+  formatValue(value) {
+    if (typeof value === "boolean") {
+      value = value.toString();
+    }
+
+    if (Array.isArray(value)) {
+      value = value.join(", ");
+    }
+
+    if (!value && this.props.emptyValue) {
+      value = this.props.emptyValue;
+    }
+
+    return value;
+  }
+
+  isHashMap(value) {
+    // Check whether we are trying to render an object that is not a
+    // React component
+
+    return (
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      value !== null &&
+      !React.isValidElement(value)
     );
   }
 }


### PR DESCRIPTION
I was resolving some React warnings in the Services section and ran across https://jira.mesosphere.com/browse/DCOS-35756 (which was not prioritized) and decided to implement @juliangieseke proposed fix from the discussion here https://github.com/dcos/dcos-ui/pull/2913#discussion_r184711525

While I was in there, I refactored HashMapDisplay a little for complexity and fixed another warning related to using a prop named "key"

## Testing

1. Add kafka service
2. Visit  kafka service detail
3. Click configuration tab
4. It should look the exact same

## Trade-offs

One drawback of the HashMapDisplay component is that it begins with &lt;h2&gt; if there is no top level headline defined. An alternative implementation could deduct 1 from the headlineLevel prop if no headline is given.

## Dependencies
None

## Screenshots

Warnings seen here

![screen shot 2018-09-12 at 9 37 58 am](https://user-images.githubusercontent.com/174332/45453022-cb7e3700-b69c-11e8-817b-92aaa23467e5.png)

