### PR TITLE
chore(FrameworkConfigurationContainer): fix react warning

### DIFF
--- a/plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.js
+++ b/plugins/services/src/js/containers/framework-configuration/FrameworkConfigurationContainer.js
@@ -4,6 +4,8 @@ import React from "react";
 import UniversePackage from "#SRC/js/structs/UniversePackage";
 
 import Framework from "#PLUGINS/services/src/js/structs/Framework";
+import Application from "#PLUGINS/services/src/js/structs/Application";
+
 import { routerShape } from "react-router";
 import FrameworkConfigurationReviewScreen from "#SRC/js/components/FrameworkConfigurationReviewScreen";
 import Loader from "#SRC/js/components/Loader";
@@ -95,7 +97,10 @@ class FrameworkConfigurationContainer extends React.Component {
 }
 
 FrameworkConfigurationContainer.propTypes = {
-  service: PropTypes.instanceOf(Framework).isRequired
+  service: PropTypes.oneOfType([
+    PropTypes.instanceOf(Framework),
+    PropTypes.instanceOf(Application)
+  ]).isRequired
 };
 
 FrameworkConfigurationContainer.contextTypes = {


### PR DESCRIPTION
Fixes React proptype warning

It is possible for this component to receive an Application instance from `js/components/HighOrderServiceConfiguration`

## Testing

1. Add nginx service
2. Navigate to nginx service details, Configuration tab

No React warning

## Trade-offs

Should there be an ApplicationConfigurationContainer added to the various containers delegated to by  `js/components/HighOrderServiceConfiguration` ?

## Dependencies

None

## Screenshots

Warning seen here:

![screen shot 2018-09-12 at 3 54 16 pm](https://user-images.githubusercontent.com/174332/45455698-3895ca80-b6a5-11e8-8e04-1cfd5bb9f14c.png)

