### PR TITLE
DCOS-41769: Clipboard icon background fix / React warning

### DIFF
--- a/plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js
+++ b/plugins/services/src/js/containers/service-connection/ServiceConnectionEndpointList.js
@@ -61,7 +61,9 @@ class ServiceConnectionEndpointList extends React.Component {
 
     if (hostPortValue) {
       return (
-        <EndpointClipboardTrigger command={getDisplayValue(hostPortValue)} />
+        <EndpointClipboardTrigger
+          command={getDisplayValue(hostPortValue.toString())}
+        />
       );
     }
 
@@ -88,7 +90,11 @@ class ServiceConnectionEndpointList extends React.Component {
     const portValue = portDefinition.containerPort;
 
     if (portValue) {
-      return <EndpointClipboardTrigger command={getDisplayValue(portValue)} />;
+      return (
+        <EndpointClipboardTrigger
+          command={getDisplayValue(portValue.toString())}
+        />
+      );
     }
 
     return getDisplayValue(portValue);
@@ -98,7 +104,7 @@ class ServiceConnectionEndpointList extends React.Component {
     if (portDefinition.servicePort) {
       return (
         <EndpointClipboardTrigger
-          command={getDisplayValue(portDefinition.servicePort)}
+          command={getDisplayValue(portDefinition.servicePort.toString())}
         />
       );
     }

--- a/plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.js
+++ b/plugins/services/src/js/containers/service-connection/ServicePodConnectionEndpointList.js
@@ -55,7 +55,9 @@ class ServicePodConnectionEndpointList extends React.Component {
     const hostPortValue = portDefinition.hostPort;
 
     if (hostPortValue) {
-      return this.getClipboardTrigger(getDisplayValue(hostPortValue));
+      return this.getClipboardTrigger(
+        getDisplayValue(hostPortValue.toString())
+      );
     }
 
     return getDisplayValue(hostPortValue);

--- a/src/styles/components/code/styles.less
+++ b/src/styles/components/code/styles.less
@@ -24,8 +24,6 @@
     &:hover {
 
       .code-copy-icon {
-        background: @code-block-background-color;
-        box-shadow: 4px 0 6px @code-block-padding-top @code-block-background-color;
         display: block;
         position: absolute;
         right: @code-block-padding-right;


### PR DESCRIPTION
1. We were often passing in port values as numbers, which were triggering PropType warnings
2. I added a style fix for something that may or may be intentional. @lilysamimi can you confirm that this was an unintentional background color or perhaps a padding issue?

## Testing

1. Add nginx service
2. Visit service detail, Endpoints tab
3. No warning, no floating background

## Trade-offs

I could have alternatively loosened the proptype requirements for EndpointClipboardTrigger to accept numbers/strings.

## Screenshots

Warnings visible here

![screen shot 2018-09-12 at 5 19 34 pm](https://user-images.githubusercontent.com/174332/45458263-13f32000-b6b0-11e8-9b5a-1820d7f27430.png)

Look closely and you can see the floating shadow/background

1.12
<img width="218" alt="screen shot 2018-09-12 at 4 37 22 pm" src="https://user-images.githubusercontent.com/174332/45458460-1144fa80-b6b1-11e8-9af5-ebdef38deaec.png">

1.11
<img width="292" alt="screen shot 2018-09-12 at 5 02 24 pm" src="https://user-images.githubusercontent.com/174332/45458469-1a35cc00-b6b1-11e8-853e-d824ab8bcd5f.png">

And here is the after: (tooltip not changed)

<img width="184" alt="screen shot 2018-09-12 at 4 35 28 pm" src="https://user-images.githubusercontent.com/174332/45458487-2588f780-b6b1-11e8-9609-4a4bbdf94090.png">

