### PR TITLE
DCOS-21986: remove undefined fetchData method call

### DIFF
--- a/plugins/services/src/js/containers/pod-instances/PodInstancesContainer.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesContainer.js
@@ -204,9 +204,6 @@ class PodInstancesContainer extends React.Component {
     this.setState({ modal: {} });
   }
 
-  fetchData() {
-    // Re-fetch data - this will end up being a single Relay request
-  }
   /**
    * Sets the actionType to pending in state which will in turn be pushed
    * to children components as a prop. Also clears any existing error for
@@ -251,11 +248,6 @@ class PodInstancesContainer extends React.Component {
         false
       )
     });
-
-    // Fetch new data if action was successful
-    if (!error) {
-      this.fetchData();
-    }
   }
 
   clearActionError(actionType) {

--- a/plugins/services/src/js/containers/services/ServicesContainer.js
+++ b/plugins/services/src/js/containers/services/ServicesContainer.js
@@ -323,9 +323,6 @@ class ServicesContainer extends React.Component {
     this.setState({ filterExpression });
   }
 
-  fetchData() {
-    // Re-fetch data - this will end up being a single Relay request
-  }
   /**
    * Sets the actionType to pending in state which will in turn be pushed
    * to children components as a prop. Also clears any existing error for
@@ -370,11 +367,6 @@ class ServicesContainer extends React.Component {
         false
       )
     });
-
-    // Fetch new data if action was successful
-    if (!error) {
-      this.fetchData();
-    }
   }
 
   clearActionError(actionType) {

--- a/plugins/services/src/js/containers/tasks/TasksContainer.js
+++ b/plugins/services/src/js/containers/tasks/TasksContainer.js
@@ -228,11 +228,6 @@ class TasksContainer extends React.Component {
         false
       )
     });
-
-    // Fetch new data if action was successful
-    if (!error) {
-      this.fetchData();
-    }
   }
 
   clearActionError(actionType) {


### PR DESCRIPTION
## Testing

### Short Version
* There is no `fetchData` method defined in `TasksContainer.js`, so it makes sense to remove the method call 😏 

### Long Version
* Deploy a service with command `sleep 100`
* Go to its service detail page
* Check the task and click delete to delete it
* Check there are no errors in the console

## Trade-offs

* I went ahead and removed other calls for fetchData in other files.
