### PR TITLE
DCOS-22126: Don't validate forms until submit

### DIFF
--- a/src/js/components/FrameworkConfiguration.js
+++ b/src/js/components/FrameworkConfiguration.js
@@ -27,7 +27,8 @@ const METHODS_TO_BIND = [
   "handleActiveTabChange",
   "handleFocusFieldChange",
   "handleCloseConfirmModal",
-  "handleConfirmGoBack"
+  "handleConfirmGoBack",
+  "handleFormSubmit"
 ];
 
 export default class FrameworkConfiguration extends Component {
@@ -43,7 +44,8 @@ export default class FrameworkConfiguration extends Component {
       focusField,
       jsonEditorActive: false,
       isConfirmOpen: false,
-      isOpen: true
+      isOpen: true,
+      liveValidate: false
     };
 
     METHODS_TO_BIND.forEach(method => {
@@ -116,7 +118,13 @@ export default class FrameworkConfiguration extends Component {
       return;
     }
 
-    this.setState({ reviewActive: true });
+    // Only live validate once the form is submitted.
+    this.setState({ liveValidate: true }, () => {
+      // This is the prescribed method for submitting a react-jsonschema-form
+      // using an external control.
+      // https://github.com/mozilla-services/react-jsonschema-form#tips-and-tricks
+      this.submitButton.click();
+    });
   }
 
   handleConfirmGoBack() {
@@ -127,6 +135,10 @@ export default class FrameworkConfiguration extends Component {
       // navigate away once the animation is over.
       setTimeout(handleGoBack, 300);
     });
+  }
+
+  handleFormSubmit() {
+    this.setState({ liveValidate: false, reviewActive: true });
   }
 
   getSecondaryActions() {
@@ -318,7 +330,10 @@ export default class FrameworkConfiguration extends Component {
           deployErrors={deployErrors}
           onFormDataChange={onFormDataChange}
           onFormErrorChange={onFormErrorChange}
+          onFormSubmit={this.handleFormSubmit}
           defaultConfigWarning={defaultConfigWarning}
+          submitRef={el => (this.submitButton = el)} // ref forwarding https://reactjs.org/docs/forwarding-refs.html
+          liveValidate={this.state.liveValidate}
         />
       );
     }

--- a/src/js/components/SchemaField.js
+++ b/src/js/components/SchemaField.js
@@ -315,17 +315,16 @@ class SchemaField extends Component {
     const autofocus = uiSchema && uiSchema["ui:autofocus"];
 
     let errorMessage;
+    let showError = false;
     if (errorSchema) {
       errorMessage = errorSchema.__errors.map(error => {
         return <div>{error}</div>;
       });
+      showError = errorMessage.length > 0;
     }
 
     return (
-      <FormGroup
-        showError={errorMessage.length > 0}
-        errorClassName="form-group-danger"
-      >
+      <FormGroup showError={showError} errorClassName="form-group-danger">
         {this.getFieldContent(errorMessage, autofocus)}
       </FormGroup>
     );

--- a/src/js/components/SchemaField.js
+++ b/src/js/components/SchemaField.js
@@ -19,7 +19,8 @@ class SchemaField extends Component {
   shouldComponentUpdate(nextProps) {
     return (
       !isEqual(nextProps.formData, this.props.formData) ||
-      !isEqual(nextProps.uiSchema, this.props.uiSchema)
+      !isEqual(nextProps.uiSchema, this.props.uiSchema) ||
+      !isEqual(nextProps.errorSchema, this.props.errorSchema)
     );
   }
 

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -3,7 +3,10 @@ import { SERVER_RESPONSE_DELAY } from "../../_support/constants/Timeouts";
 describe("Service Actions", function() {
   function clickHeaderAction(actionText) {
     cy.get(".page-header-actions .dropdown").click();
-    cy.get(".dropdown-menu-items").contains(actionText).click();
+
+    cy.get(".dropdown-menu-items")
+      .contains(actionText)
+      .click();
   }
 
   context("Open Service Action", function() {
@@ -15,8 +18,8 @@ describe("Service Actions", function() {
       cy.visitUrl({ url: "/services/detail/%2Fcassandra-healthy" });
 
       cy.get(".page-header-actions .dropdown").click();
-      cy
-        .get(".dropdown-menu-items")
+
+      cy.get(".dropdown-menu-items")
         .contains("Open Service")
         .should(function($menuItem) {
           expect($menuItem.length).to.equal(1);
@@ -31,8 +34,8 @@ describe("Service Actions", function() {
       cy.visitUrl({ url: "/services/detail/%2Fcassandra-unhealthy" });
 
       cy.get(".page-header-actions .dropdown").click();
-      cy
-        .get(".dropdown-menu-items")
+
+      cy.get(".dropdown-menu-items")
         .contains("Open Service")
         .should(function($menuItem) {
           expect($menuItem.length).to.equal(0);
@@ -47,8 +50,8 @@ describe("Service Actions", function() {
       cy.visitUrl({ url: "/services/detail/%2Fservices%2Fsdk-sleep" });
 
       cy.get(".page-header-actions .dropdown").click();
-      cy
-        .get(".dropdown-menu-items")
+
+      cy.get(".dropdown-menu-items")
         .contains("Open Service")
         .should(function($menuItem) {
           expect($menuItem.length).to.equal(0);
@@ -70,35 +73,49 @@ describe("Service Actions", function() {
     });
 
     it("navigates to the correct route", function() {
-      cy
-        .location()
+      cy.location()
         .its("hash")
         .should("include", "#/services/detail/%2Fcassandra-healthy/edit");
     });
 
     it("opens the correct service edit modal", function() {
-      cy
-        .get('.modal .menu-tabbed-container input[name="name"]')
-        .should("to.have.value", "elastic");
+      cy.get('.modal .menu-tabbed-container input[name="name"]').should(
+        "to.have.value",
+        "elastic"
+      );
     });
 
     it("closes modal on successful API request", function() {
-      cy.get(".modal .modal-header .button").contains("Review & Run").click();
-      cy.get(".modal .modal-header .button").contains("Run Service").click();
+      cy.get(".modal .modal-header .button")
+        .contains("Review & Run")
+        .click();
+
+      cy.get(".modal .modal-header .button")
+        .contains("Run Service")
+        .click();
+
       cy.get(".modal").should("to.have.length", 0);
     });
 
     it("opens confirm after edits", function() {
       cy.get('.modal .menu-tabbed-container input[name="name"]').type("elast");
-      cy.get(".modal .modal-header .button").contains("Cancel").click();
+
+      cy.get(".modal .modal-header .button")
+        .contains("Cancel")
+        .click();
 
       cy.get(".modal-small").should("to.have.length", 1);
     });
 
     it("closes both confirm and edit modal after confirmation", function() {
       cy.get('.modal .menu-tabbed-container input[name="name"]').type("elast");
-      cy.get(".modal .modal-header .button").contains("Cancel").click();
-      cy.get(".modal-small .button").contains("Discard").click();
+      cy.get(".modal .modal-header .button")
+        .contains("Cancel")
+        .click();
+
+      cy.get(".modal-small .button")
+        .contains("Discard")
+        .click();
 
       cy.get(".modal-small").should("to.have.length", 0);
       cy.get(".modal").should("to.have.length", 0);
@@ -106,25 +123,35 @@ describe("Service Actions", function() {
 
     it("it stays in the edit modal after cancelling confirmation", function() {
       cy.get('.modal .menu-tabbed-container input[name="name"]').type("elast");
-      cy.get(".modal .modal-header .button").contains("Cancel").click();
-      cy.get(".modal-small .button").contains("Cancel").click();
+      cy.get(".modal .modal-header .button")
+        .contains("Cancel")
+        .click();
+      cy.get(".modal-small .button")
+        .contains("Cancel")
+        .click();
 
       cy.get(".modal-small").should("to.have.length", 0);
       cy.get(".modal").should("to.have.length", 1);
     });
 
     it("opens and closes the JSON mode after clicking toggle", function() {
-      cy.get(".modal .modal-header span").contains("JSON Editor").click();
+      cy.get(".modal .modal-header span")
+        .contains("JSON Editor")
+        .click();
 
-      cy
-        .get(".modal .modal-full-screen-side-panel.is-visible")
-        .should("to.have.length", 1);
+      cy.get(".modal .modal-full-screen-side-panel.is-visible").should(
+        "to.have.length",
+        1
+      );
 
-      cy.get(".modal .modal-header span").contains("JSON Editor").click();
+      cy.get(".modal .modal-header span")
+        .contains("JSON Editor")
+        .click();
 
-      cy
-        .get(".modal .modal-full-screen-side-panel.is-visible")
-        .should("to.have.length", 0);
+      cy.get(".modal .modal-full-screen-side-panel.is-visible").should(
+        "to.have.length",
+        0
+      );
     });
 
     it("shows tab error badge when error in form section", function() {
@@ -167,7 +194,6 @@ describe("Service Actions", function() {
     it("disables Review & Run button when error", function() {
       cy.get('.modal .menu-tabbed-container input[name="name"]').clear();
 
-      cy
       cy.get(".modal .modal-header button")
         .contains("Review & Run")
         .click();
@@ -178,43 +204,53 @@ describe("Service Actions", function() {
     });
 
     it("change JSON editor contents when form content change", function() {
-      cy
-        .get('.modal .menu-tabbed-container input[name="name"]')
-        .type(`{selectall}elast`);
+      cy.get('.modal .menu-tabbed-container input[name="name"]').type(
+        `{selectall}elast`
+      );
 
-      cy
-        .get(".modal .modal-full-screen-side-panel .ace_line")
+      cy.get(".modal .modal-full-screen-side-panel .ace_line")
         .contains("elast")
         .should("to.have.length", 1);
     });
 
     it("shows review screen when Review & Run clicked", function() {
-      cy.get(".modal .modal-header button").contains("Review & Run").click();
+      cy.get(".modal .modal-header button")
+        .contains("Review & Run")
+        .click();
 
-      cy
-        .get(".modal .configuration-map-label")
+      cy.get(".modal .configuration-map-label")
         .contains("Name")
         .should("to.have.length", 1);
     });
 
     it("back button on review screen goes back to form", function() {
-      cy.get(".modal .modal-header button").contains("Review & Run").click();
+      cy.get(".modal .modal-header button")
+        .contains("Review & Run")
+        .click();
 
-      cy.get(".modal .modal-header button").contains("Back").click();
+      cy.get(".modal .modal-header button")
+        .contains("Back")
+        .click();
 
-      cy
-        .get('.modal .menu-tabbed-container input[name="name"]')
-        .should("have.length", 1);
+      cy.get('.modal .menu-tabbed-container input[name="name"]').should(
+        "have.length",
+        1
+      );
     });
 
     it("shows edit config button on review screen that opens form", function() {
-      cy.get(".modal .modal-header button").contains("Review & Run").click();
+      cy.get(".modal .modal-header button")
+        .contains("Review & Run")
+        .click();
 
-      cy.get(".modal button").contains("Edit Config").click();
+      cy.get(".modal button")
+        .contains("Edit Config")
+        .click();
 
-      cy
-        .get('.modal .menu-tabbed-container input[name="name"]')
-        .should("to.have.value", "elastic");
+      cy.get('.modal .menu-tabbed-container input[name="name"]').should(
+        "to.have.value",
+        "elastic"
+      );
     });
   });
 
@@ -229,10 +265,11 @@ describe("Service Actions", function() {
       cy.visitUrl({ url: "/services/detail/%2Fcassandra-healthy" });
     });
     it("shows a Edit button on top level", function() {
-      cy.get(".button").contains("Edit").click();
+      cy.get(".button")
+        .contains("Edit")
+        .click();
 
-      cy
-        .location()
+      cy.location()
         .its("hash")
         .should("include", "#/services/detail/%2Fcassandra-healthy/edit");
     });
@@ -251,8 +288,7 @@ describe("Service Actions", function() {
       });
 
       it("opens the correct service destroy dialog", function() {
-        cy
-          .get(".modal-body p strong")
+        cy.get(".modal-body p strong")
           .contains("sleep")
           .should("to.have.length", 1);
       });
@@ -281,9 +317,10 @@ describe("Service Actions", function() {
         });
         cy.get(".modal-body .filter-input-text").type("sleep");
         cy.get(".modal-small .button-danger").click();
-        cy
-          .get(".modal-body .text-danger")
-          .should("to.have.text", "App is locked by one or more deployments.");
+        cy.get(".modal-body .text-danger").should(
+          "to.have.text",
+          "App is locked by one or more deployments."
+        );
       });
 
       it("shows error message on not authorized", function() {
@@ -295,9 +332,10 @@ describe("Service Actions", function() {
         });
         cy.get(".modal-body .filter-input-text").type("sleep");
         cy.get(".modal-small .button-danger").click();
-        cy
-          .get(".modal-body .text-danger")
-          .should("to.have.text", "Not Authorized to perform this action!");
+        cy.get(".modal-body .text-danger").should(
+          "to.have.text",
+          "Not Authorized to perform this action!"
+        );
       });
 
       it("re-enables button after faulty request", function() {
@@ -316,7 +354,9 @@ describe("Service Actions", function() {
       });
 
       it("closes dialog on secondary button click", function() {
-        cy.get(".modal-small .button").contains("Cancel").click();
+        cy.get(".modal-small .button")
+          .contains("Cancel")
+          .click();
         cy.get(".modal-small").should("to.have.length", 0);
       });
     });
@@ -334,8 +374,7 @@ describe("Service Actions", function() {
     });
 
     it("opens the correct service scale dialog", function() {
-      cy
-        .get(".modal-header")
+      cy.get(".modal-header")
         .contains("Scale Service")
         .should("to.have.length", 1);
     });
@@ -346,8 +385,7 @@ describe("Service Actions", function() {
         url: /marathon\/v2\/apps\/\/cassandra-healthy/,
         response: []
       });
-      cy
-        .get(".modal-footer .button-primary")
+      cy.get(".modal-footer .button-primary")
         .click()
         .should("have.class", "disabled");
     });
@@ -372,9 +410,10 @@ describe("Service Actions", function() {
         }
       });
       cy.get(".modal-footer .button-primary").click();
-      cy
-        .get(".modal-body .text-danger")
-        .should("to.have.text", "App is locked by one or more deployments.");
+      cy.get(".modal-body .text-danger").should(
+        "to.have.text",
+        "App is locked by one or more deployments."
+      );
     });
 
     it("shows error message on not authorized", function() {
@@ -387,9 +426,10 @@ describe("Service Actions", function() {
         }
       });
       cy.get(".modal-footer .button-primary").click();
-      cy
-        .get(".modal-body .text-danger")
-        .should("to.have.text", "Not Authorized to perform this action!");
+      cy.get(".modal-body .text-danger").should(
+        "to.have.text",
+        "Not Authorized to perform this action!"
+      );
     });
 
     it("re-enables button after faulty request", function() {
@@ -399,13 +439,17 @@ describe("Service Actions", function() {
         response: [],
         delay: SERVER_RESPONSE_DELAY
       });
-      cy.get(".modal-footer .button-primary").as("primaryButton").click();
+      cy.get(".modal-footer .button-primary")
+        .as("primaryButton")
+        .click();
       cy.get("@primaryButton").should("have.class", "disabled");
       cy.get("@primaryButton").should("not.have.class", "disabled");
     });
 
     it("closes dialog on secondary button click", function() {
-      cy.get(".modal-footer .button").contains("Cancel").click();
+      cy.get(".modal-footer .button")
+        .contains("Cancel")
+        .click();
       cy.get(".modal-body").should("to.have.length", 0);
     });
   });
@@ -422,8 +466,7 @@ describe("Service Actions", function() {
     });
 
     it("opens the correct service stop dialog", function() {
-      cy
-        .get(".modal-small p strong")
+      cy.get(".modal-small p strong")
         .contains("cassandra-healthy")
         .should("to.have.length", 1);
     });
@@ -434,8 +477,7 @@ describe("Service Actions", function() {
         url: /marathon\/v2\/apps\/\/cassandra-healthy/,
         response: []
       });
-      cy
-        .get(".modal-small .button-danger")
+      cy.get(".modal-small .button-danger")
         .click()
         .should("have.class", "disabled");
     });
@@ -460,9 +502,10 @@ describe("Service Actions", function() {
         }
       });
       cy.get(".modal-small .button-danger").click();
-      cy
-        .get(".modal-small .text-danger")
-        .should("to.have.text", "App is locked by one or more deployments.");
+      cy.get(".modal-small .text-danger").should(
+        "to.have.text",
+        "App is locked by one or more deployments."
+      );
     });
 
     it("shows error message on not authorized", function() {
@@ -475,9 +518,10 @@ describe("Service Actions", function() {
         }
       });
       cy.get(".modal-small .button-danger").click();
-      cy
-        .get(".modal-small .text-danger")
-        .should("to.have.text", "Not Authorized to perform this action!");
+      cy.get(".modal-small .text-danger").should(
+        "to.have.text",
+        "Not Authorized to perform this action!"
+      );
     });
 
     it("re-enables button after faulty request", function() {
@@ -487,13 +531,17 @@ describe("Service Actions", function() {
         response: [],
         delay: SERVER_RESPONSE_DELAY
       });
-      cy.get(".modal-small .button-danger").as("primaryButton").click();
+      cy.get(".modal-small .button-danger")
+        .as("primaryButton")
+        .click();
       cy.get("@primaryButton").should("have.class", "disabled");
       cy.get("@primaryButton").should("not.have.class", "disabled");
     });
 
     it("closes dialog on secondary button click", function() {
-      cy.get(".modal-small .button").contains("Cancel").click();
+      cy.get(".modal-small .button")
+        .contains("Cancel")
+        .click();
       cy.get(".modal-small").should("to.have.length", 0);
     });
   });
@@ -517,8 +565,7 @@ describe("Service Actions", function() {
     it("shows the resume option in the service action dropdown", function() {
       cy.get(".page-header-actions .dropdown").click();
 
-      cy
-        .get(".dropdown-menu-items li")
+      cy.get(".dropdown-menu-items li")
         .contains("Resume")
         .should("not.have.class", "hidden");
     });
@@ -526,8 +573,7 @@ describe("Service Actions", function() {
     it("opens the resume dialog", function() {
       clickHeaderAction("Resume");
 
-      cy
-        .get(".modal-header")
+      cy.get(".modal-header")
         .contains("Resume Service")
         .should("have.length", 1);
     });
@@ -558,8 +604,7 @@ describe("Service Actions", function() {
 
       clickHeaderAction("Resume");
 
-      cy
-        .get(".modal-footer .button-primary")
+      cy.get(".modal-footer .button-primary")
         .click()
         .should("have.class", "disabled");
     });
@@ -590,9 +635,10 @@ describe("Service Actions", function() {
       clickHeaderAction("Resume");
 
       cy.get(".modal-footer .button-primary").click();
-      cy
-        .get(".modal-body .text-danger")
-        .should("to.have.text", "App is locked by one or more deployments.");
+      cy.get(".modal-body .text-danger").should(
+        "to.have.text",
+        "App is locked by one or more deployments."
+      );
     });
 
     it("shows error message on not authorized", function() {
@@ -608,9 +654,10 @@ describe("Service Actions", function() {
       clickHeaderAction("Resume");
 
       cy.get(".modal-footer .button-primary").click();
-      cy
-        .get(".modal-body .text-danger")
-        .should("to.have.text", "Not Authorized to perform this action!");
+      cy.get(".modal-body .text-danger").should(
+        "to.have.text",
+        "Not Authorized to perform this action!"
+      );
     });
 
     it("re-enables button after faulty request", function() {
@@ -623,7 +670,9 @@ describe("Service Actions", function() {
 
       clickHeaderAction("Resume");
 
-      cy.get(".modal-footer .button-primary").as("primaryButton").click();
+      cy.get(".modal-footer .button-primary")
+        .as("primaryButton")
+        .click();
       cy.get("@primaryButton").should("have.class", "disabled");
       cy.get("@primaryButton").should("not.have.class", "disabled");
     });
@@ -631,7 +680,9 @@ describe("Service Actions", function() {
     it("closes dialog on secondary button click", function() {
       clickHeaderAction("Resume");
 
-      cy.get(".modal-footer .button").contains("Cancel").click();
+      cy.get(".modal-footer .button")
+        .contains("Cancel")
+        .click();
       cy.get(".modal-body").should("to.have.length", 0);
     });
   });
@@ -649,15 +700,16 @@ describe("Service Actions", function() {
     it("opens the destroy dialog", function() {
       clickHeaderAction("Delete");
 
-      cy
-        .get(".modal-header")
+      cy.get(".modal-header")
         .contains("Delete Service")
         .should("to.have.length", 1);
 
       cy.get(".modal-body p").contains("sdk-sleep");
       cy.get(".modal .filter-input-text").should("exist");
 
-      cy.get(".modal button").contains("Cancel").click();
+      cy.get(".modal button")
+        .contains("Cancel")
+        .click();
 
       cy.get(".modal").should("not.exist");
     });
@@ -665,8 +717,7 @@ describe("Service Actions", function() {
     it("submits destroy with enter", function() {
       clickHeaderAction("Delete");
 
-      cy
-        .get(".modal-header")
+      cy.get(".modal-header")
         .contains("Delete Service")
         .should("to.have.length", 1);
 
@@ -680,33 +731,30 @@ describe("Service Actions", function() {
     it("opens the scale dialog", function() {
       clickHeaderAction("Scale");
 
-      cy
-        .get(".modal-header")
+      cy.get(".modal-header")
         .contains("Scale Service")
         .should("to.have.length", 1);
 
-      cy
-        .get(".modal pre")
-        .contains(
-          "dcos test --name=/services/sdk-sleep update start --options=options.json"
-        );
+      cy.get(".modal pre").contains(
+        "dcos test --name=/services/sdk-sleep update start --options=options.json"
+      );
 
-      cy.get(".modal button").contains("Close").click();
+      cy.get(".modal button")
+        .contains("Close")
+        .click();
 
       cy.get(".modal").should("not.exist");
     });
 
     it("restart does not exist", function() {
-      cy
-        .get(".page-header-actions .dropdown")
+      cy.get(".page-header-actions .dropdown")
         .click()
         .contains("restart")
         .should("not.exist");
     });
 
     it("stop does not exist", function() {
-      cy
-        .get(".page-header-actions .dropdown")
+      cy.get(".page-header-actions .dropdown")
         .click()
         .contains("stop")
         .should("not.exist");

--- a/tests/pages/services/ServiceActions-cy.js
+++ b/tests/pages/services/ServiceActions-cy.js
@@ -130,16 +130,24 @@ describe("Service Actions", function() {
     it("shows tab error badge when error in form section", function() {
       cy.get('.modal .menu-tabbed-container input[name="name"]').clear();
 
-      cy
-        .get(".modal .menu-tabbed-container span[class*='css-']")
-        .should("to.have.length", 1);
+      cy.get(".modal .modal-header button")
+        .contains("Review & Run")
+        .click();
+
+      cy.get(".modal .menu-tabbed-container span[class*='css-']").should(
+        "to.have.length",
+        1
+      );
     });
 
     it("shows anchored error when error in form section", function() {
       cy.get('.modal .menu-tabbed-container input[name="name"]').clear();
 
-      cy
-        .get(".modal .menu-tabbed-container .form-control-feedback")
+      cy.get(".modal .modal-header button")
+        .contains("Review & Run")
+        .click();
+
+      cy.get(".modal .menu-tabbed-container .form-control-feedback")
         .contains("Expecting a string here")
         .should("to.have.length", 1);
     });
@@ -147,16 +155,24 @@ describe("Service Actions", function() {
     it("shows error message in JSON when form error", function() {
       cy.get('.modal .menu-tabbed-container input[name="name"]').clear();
 
-      cy
-        .get(".modal .modal-full-screen-side-panel .ace_gutter-cell.ace_error")
-        .should("to.have.length", 1);
+      cy.get(".modal .modal-header button")
+        .contains("Review & Run")
+        .click();
+
+      cy.get(
+        ".modal .modal-full-screen-side-panel .ace_gutter-cell.ace_error"
+      ).should("to.have.length", 1);
     });
 
     it("disables Review & Run button when error", function() {
       cy.get('.modal .menu-tabbed-container input[name="name"]').clear();
 
       cy
-        .get(".modal .modal-header button[disabled]")
+      cy.get(".modal .modal-header button")
+        .contains("Review & Run")
+        .click();
+
+      cy.get(".modal .modal-header button[disabled]")
         .contains("Review & Run")
         .should("to.have.length", 1);
     });

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -105,6 +105,37 @@ describe("Service Form Modal", function() {
           .should("to.have.text", "Networking");
       });
 
+      describe("Form errors", function() {
+        it("displays an error only after Review & Run is clicked", function() {
+          openServiceModal();
+          openServiceForm();
+
+          cy.get('.form-control[name="id"]')
+            .clear()
+            .blur();
+
+          cy.get(".message").should("not.be.visible");
+
+          // Click review and run
+          cy.get(".modal-full-screen-actions")
+            .contains("button", "Review & Run")
+            .click();
+
+          cy.get(".message")
+            .contains("Service ID must be defined")
+            .should("be.visible");
+
+          cy.get('.form-control[name="id"]')
+            .type("/hello-world")
+            .blur();
+
+          // Now automatic revalidation happens without clicking Review & Run again
+          cy.get(".message")
+            .contains("Service ID must be defined")
+            .should("not.be.visible");
+        });
+      });
+
       describe("JSON errors", function() {
         it("displays an error with invalid JSON", function() {
           openServiceModal();

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -142,18 +142,15 @@ describe("Service Form Modal", function() {
           openServiceForm();
 
           // Switch to JSON
-          cy
-            .get(".modal-full-screen-actions label")
+          cy.get(".modal-full-screen-actions label")
             .contains("JSON Editor")
             .click();
 
-          cy
-            .get(".ace_text-input")
+          cy.get(".ace_text-input")
             .focus()
             .type("{selectall}{backspace}", { force: true });
 
-          cy
-            .get(".message")
+          cy.get(".message")
             .contains("Unexpected end of JSON input")
             .should("be.visible");
         });
@@ -163,24 +160,20 @@ describe("Service Form Modal", function() {
           openServiceForm();
 
           // Switch to JSON
-          cy
-            .get(".modal-full-screen-actions label")
+          cy.get(".modal-full-screen-actions label")
             .contains("JSON Editor")
             .click();
 
-          cy
-            .get(".ace_text-input")
+          cy.get(".ace_text-input")
             .focus()
             .type("{selectall}{backspace}", { force: true });
 
-          cy
-            .get(".message")
+          cy.get(".message")
             .contains("Unexpected end of JSON input")
             .should("be.visible");
 
           // The closing } is auto inserted
-          cy
-            .get(".ace_text-input")
+          cy.get(".ace_text-input")
             .focus()
             .type('{{}\n\t"id": "/foo"\n', { force: true });
 


### PR DESCRIPTION
## Background

Form controllers that are affected by this change are FramworkConfiguration and CreateServiceModal. They now need to trigger validation after submitting and not at all times.

Unfortunately, these two forms have different lifecycles with respect to real time validation:

- [x] CreateServiceModal performs validation during the render phase with calls to `getAllErrors` that validate the serviceSpec state. This same method is used to short-circuit the button handler.

- [x] FrameworkConfiguration uses a standard `react-jsonschema-form` and depends on `liveValidation={true}`. The existence of form errors that are derived whenever the form changes (when live validation is on) determines whether the Review & Run button is enabled.  This form is not wired up for submission and therefore react-jsonschema-form does not ever validate when liveValidation is turned off. The approach allows the modal's owned Review & Run button to trigger the form submit externally, as illustrated here https://jsfiddle.net/spacebaboon/g5a1re63/

## Testing

CreateServiceModal:

1. Create a single container service
2. clear Service ID
3. observe no validation errors
4. click Review & Run
5. observe validation errors

FrameworkConfiguration:

1. Create a cassandra service
2. clear name
3. observe no validation errors
4. click Review & Run
5. observe validation errors

## Trade-offs

This change introduces some damage and workarounds in FrameworkConfigurationForm due to the limitations of react-jsonschema-form

## Observations

1. On FrameworkConfiguration, the JSONEditor does not display errors until Review & Run is clicked. This is probably not desirable.

2. On CreateServiceModal, we don't currently display the number of form validation issues as a badge next to each tab.

## Dependencies

None
