### PR TITLE
DCOS-41973: Fix sorting on services table (versions column)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "classnames": "2.2.3",
     "clipboard": "1.5.10",
     "cnvs": "1.1.14",
+    "compare-versions": "3.4.0",
     "cookie": "0.2.3",
     "d3": "3.5.16",
     "dcos-dygraphs": "1.1.0-beta.3",

--- a/plugins/services/src/js/containers/services/ServicesTable.js
+++ b/plugins/services/src/js/containers/services/ServicesTable.js
@@ -34,8 +34,6 @@ import ServiceStatus from "../../constants/ServiceStatus";
 import ServiceActionLabels from "../../constants/ServiceActionLabels";
 import ServiceTableHeaderLabels from "../../constants/ServiceTableHeaderLabels";
 import ServiceTableUtil from "../../utils/ServiceTableUtil";
-import FrameworkUtil from "../../utils/FrameworkUtil";
-import Framework from "../../structs/Framework";
 import ServiceTree from "../../structs/ServiceTree";
 import ServiceStatusIcon from "../../components/ServiceStatusIcon";
 
@@ -420,22 +418,18 @@ class ServicesTable extends React.Component {
   }
 
   renderVersion(prop, service) {
-    if (!service.getVersion || service.getVersion === "") {
+    const version = ServiceTableUtil.getFormattedVersion(service);
+    if (!version) {
       return null;
     }
-    const rawVersion = service.getVersion();
-    const displayVersion =
-      service && service instanceof Framework
-        ? FrameworkUtil.extractBaseTechVersion(rawVersion)
-        : "";
 
     return (
       <Tooltip
-        content={rawVersion}
+        content={version.rawVersion}
         wrapperClassName="tooltip-wrapper tooltip-block-wrapper text-overflow"
         wrapText={true}
       >
-        {displayVersion}
+        {version.displayVersion}
       </Tooltip>
     );
   }
@@ -516,7 +510,7 @@ class ServicesTable extends React.Component {
         headerClassName: this.getCellClasses,
         prop: "version",
         render: this.renderVersion,
-        sortable: false,
+        sortable: true,
         sortFunction: ServiceTableUtil.propCompareFunctionFactory,
         heading
       },


### PR DESCRIPTION
Fix sorting on versions column in Services table.

Closes DCOS-21233.

## Testing

Run some services that have displayed versions (ex: kafka, cassandra) and some that don't (nginx). Go to services page and sort table on versions column.

## Trade-offs

- Added the [compare-versions](https://github.com/omichelsen/compare-versions) npm package (MIT license) to handle determining sort order of dot separated version numbers
- Extracted the logic involved in getting displayed version numbers out from the `ServicesTable` component to the `ServiceTableUtil` so it could be reused in the version sort function as well

## Dependencies

None

## Screenshots

Before video in [Jira ticket](https://jira.mesosphere.com/browse/DCOS-21233). 
After:
![version-sorting](https://user-images.githubusercontent.com/19582796/45530719-ec2fb500-b7a0-11e8-9df9-26021658885e.gif)

