### PR TITLE
DCOS-19300: make the JSON editor wider

### DIFF
--- a/src/styles/components/modal/full-screen/styles.less
+++ b/src/styles/components/modal/full-screen/styles.less
@@ -241,17 +241,5 @@
     .modal-full-screen-actions-secondary {
       left: @pod-margin-left-screen-jumbo;
     }
-
-    .modal-full-screen-side-panel {
-      right: @modal-full-screen-side-panel-width-screen-jumbo * -1;
-      width: @modal-full-screen-side-panel-width-screen-jumbo;
-    }
-
-    .modal-full-screen-side-panel-placeholder {
-
-      &.is-visible {
-        width: @modal-full-screen-side-panel-width-screen-jumbo;
-      }
-    }
   }
 }

--- a/src/styles/components/modal/full-screen/variables.less
+++ b/src/styles/components/modal/full-screen/variables.less
@@ -20,5 +20,4 @@
 @modal-full-screen-body-padding-horizontal-screen-jumbo: @pod-margin-left-screen-jumbo;
 
 @modal-full-screen-side-panel-width: 100%;
-@modal-full-screen-side-panel-width-screen-large: 400px;
-@modal-full-screen-side-panel-width-screen-jumbo: 500px;
+@modal-full-screen-side-panel-width-screen-large: 50vw;

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -111,18 +111,15 @@ describe("Service Form Modal", function() {
           openServiceForm();
 
           // Switch to JSON
-          cy
-            .get(".modal-full-screen-actions label")
+          cy.get(".modal-full-screen-actions label")
             .contains("JSON Editor")
             .click();
 
-          cy
-            .get(".ace_text-input")
+          cy.get(".ace_text-input")
             .focus()
             .type("{selectall}{backspace}", { force: true });
 
-          cy
-            .get(".message")
+          cy.get(".message")
             .contains("Unexpected end of JSON input")
             .should("be.visible");
         });
@@ -132,24 +129,20 @@ describe("Service Form Modal", function() {
           openServiceForm();
 
           // Switch to JSON
-          cy
-            .get(".modal-full-screen-actions label")
+          cy.get(".modal-full-screen-actions label")
             .contains("JSON Editor")
             .click();
 
-          cy
-            .get(".ace_text-input")
+          cy.get(".ace_text-input")
             .focus()
             .type("{selectall}{backspace}", { force: true });
 
-          cy
-            .get(".message")
+          cy.get(".message")
             .contains("Unexpected end of JSON input")
             .should("be.visible");
 
           // The closing } is auto inserted
-          cy
-            .get(".ace_text-input")
+          cy.get(".ace_text-input")
             .focus()
             .type('{{}\n\t"id": "/foo"\n', { force: true });
 
@@ -538,7 +531,9 @@ describe("Service Form Modal", function() {
         cy.get(".modal-full-screen-side-panel.is-visible").then(function(
           $jsonEditor
         ) {
-          expect($jsonEditor.width()).to.equal(500);
+          expect($jsonEditor.width()).to.equal(
+            $jsonEditor.parents(".modal-full-screen").width() / 2
+          );
 
           expect($jsonEditor.parents(".modal-full-screen").width()).to.be.above(
             $jsonEditor.width()


### PR DESCRIPTION
We get complaints that the width of the JSON editor makes it hard to use, especially for catalog packages

Closes DCOS-19300

This is a good start, but I've filed a [follow-up issue](https://jira.mesosphere.com/browse/DCOS-42072) to make the editor resizable, per @leemunroe's suggestion

## Testing
1. Go to Catalog and select a framework
2. Tap "Review & Run"
3. Toggle the JSON editor using the toggle switch in the modal header

The JSON editor should be a comfortable width to work with, and the form on the left should still be scannable

Note: The JSON editor also appears when adding a new service (go to Services tab and tap the "+" icon in the upper right). I checked it in both places before submitting this PR

## Trade-offs
None

## Dependencies
None

## Screenshots
Before:
![screen shot 2018-09-17 at 1 19 22 pm](https://user-images.githubusercontent.com/2313998/45638835-58016e80-ba7c-11e8-809c-3073959ee834.png)

After:
![screen shot 2018-09-17 at 1 18 44 pm](https://user-images.githubusercontent.com/2313998/45638846-6059a980-ba7c-11e8-8361-c42f4b501a85.png)