### PR TITLE
DCOS-42132: Fix scrolling on the UI

### DIFF
--- a/src/styles/components/scrollbar/styles.less
+++ b/src/styles/components/scrollbar/styles.less
@@ -34,7 +34,8 @@
     }
   }
 
-  .gm-prevented {
+  .gm-prevented,
+  .gm-scrollbar-container-fluid-view-width.gm-prevented {
     overflow: auto;
   }
 


### PR DESCRIPTION
Looks like new node/npm version has something to do with the way we bundle our build. We've fixed the issue for 1.12 in https://github.com/dcos/dcos-ui/pull/3018 and after upgrading node/npm on 1.11 it popped up.

Closes DCOS-42132

## Testing

0. Connect to the VPN if not in the office 😅 
1. check out release/1.11
2. make sure you are running node@8.9.4 npm@5.6.0
3. npm run build-assets
4. ./node_modules/.bin/http-server ./dist --proxy-secure=false -P https://soak111.testing.mesosphe.re
5. http://0.0.0.0:8080 - verify that UI doesn't scroll on any pages. I.e. Nodes page

6. Checkout the branch
7. Repeat the steps verifying that the change fixes the issue.

