### PR TITLE
DCOS-42157: truncate FrameworkConfigurationForm labels instead of overflowing

### DIFF
--- a/src/styles/components/framework-configuration/styles.less
+++ b/src/styles/components/framework-configuration/styles.less
@@ -1,6 +1,7 @@
 .framework-configuration-form fieldset {
   border: 0;
   margin: 0;
+  min-width: 0;
   padding: 0;
 
   .error-detail {


### PR DESCRIPTION
Long labels were allowed to flow outside of <fieldset>s because most browsers set a useragent style on <fieldset> like  min-width: [min-content](https://developer.mozilla.org/en-US/docs/Web/CSS/width#min-content)

Closes DCOS-42157

## Testing
1. Go to "Catalog"
2. Add the Elastics services
3. Go to the "Elasticsearch" tab
4. Toggle the JSON editor open
5. Resize your viewport width to somewhere between 991px and 1050px

Any labels in the form should be truncated with an ellipsis, not overflowing out of the width

## Trade-offs
It doesn't feel quite right to truncate a form label, but we at least provide a `title` attribute, and labels long enough to be truncated are an edge case

## Dependencies
This issue will be more easier to reproduce once #3293 merges and makes the JSON editor wider

## Screenshots
Before:
<img width="990" alt="screen shot 2018-09-18 at 3 12 26 pm" src="https://user-images.githubusercontent.com/2313998/45710688-59529a00-bb55-11e8-85cd-fe319d1399f7.png">

After:
<img width="989" alt="screen shot 2018-09-18 at 3 11 58 pm" src="https://user-images.githubusercontent.com/2313998/45710697-5f487b00-bb55-11e8-94dd-ac643828c44c.png">

