### PR TITLE
DCOS-40650: upload source maps to sentry.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,6 +81,7 @@ pipeline {
       steps {
         withCredentials([
           string(credentialsId: "d146870f-03b0-4f6a-ab70-1d09757a51fc", variable: "GH_TOKEN"), // semantic-release
+          string(credentialsId: "sentry_io_token", variable: "SENTRY_AUTH_TOKEN"), // upload-build
           string(credentialsId: "3f0dbb48-de33-431f-b91c-2366d2f0e1cf",variable: "AWS_ACCESS_KEY_ID"), // upload-build
           string(credentialsId: "f585ec9a-3c38-4f67-8bdb-79e5d4761937",variable: "AWS_SECRET_ACCESS_KEY"), // upload-build
           usernamePassword(credentialsId: "a7ac7f84-64ea-4483-8e66-bb204484e58f", passwordVariable: "GIT_PASSWORD", usernameVariable: "GIT_USER"), // update-dcos-repo

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5463,6 +5463,32 @@
         }
       }
     },
+    "@sentry/cli": {
+      "version": "1.35.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.35.6.tgz",
+      "integrity": "sha512-gsMJOlgmM55QDl789Rc/UV8OjHFwBhj4R76F3WakgIzqDdFJn9GsWZhSHLI3Ltp8b6yq8UwDyvbfoz3PgHyabw==",
+      "dev": true,
+      "requires": {
+        "https-proxy-agent": "2.2.1",
+        "node-fetch": "2.2.0",
+        "progress": "2.0.0",
+        "proxy-from-env": "1.0.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
+          "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==",
+          "dev": true
+        },
+        "progress": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+          "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+          "dev": true
+        }
+      }
+    },
     "@types/blob-util": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@types/blob-util/-/blob-util-1.3.3.tgz",
@@ -28149,6 +28175,12 @@
         "forwarded": "0.1.2",
         "ipaddr.js": "1.6.0"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "dev": true
     },
     "prr": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@commitlint/config-conventional": "6.1.3",
     "@dcos/eslint-config": "0.3.0",
     "@semantic-release/exec": "3.1.0",
+    "@sentry/cli": "1.35.6",
     "@types/events": "1.2.0",
     "@types/jest": "22.2.3",
     "@types/prop-types": "15.5.3",

--- a/scripts/ci/upload-release
+++ b/scripts/ci/upload-release
@@ -10,6 +10,7 @@ set -x
 # BRANCH_NAME: Branch Name to work on
 # GIT_USER: git user for curl command
 # GIT_PASSWORD: git password for curl command
+# SENTRY_AUTH_TOKEN: auth token for sentry.io
 # aws login credentials
 #
 # run these commands from project root:
@@ -63,6 +64,11 @@ tar czf release.tar.gz dist
 # if this fails, there is already a release with this SHA -> stop.
 RELEASE_NAME="${RELEASE_NAME}" \
   "${SCRIPT_PATH}/utils/upload-build" || exit 0
+
+# Upload source maps to sentry.io
+SENTRY_AUTH_TOKEN="${SENTRY_AUTH_TOKEN}" \
+  RELEASE_NAME="${RELEASE_NAME}" \
+  "${SCRIPT_PATH}/utils/upload-sourcemaps" || exit 0
 
 ## Update Latest DC/OS PR
 #####################################################################

--- a/scripts/ci/utils/upload-sourcemaps
+++ b/scripts/ci/utils/upload-sourcemaps
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# This file is intended to run on Jenkins, if you need to run it
+# locally, you need to provide some environment variables:
+#
+# SENTRY_AUTH_TOKEN
+# RELEASE_NAME
+
+## Configuration
+#####################################################################
+
+SENTRY_AUTH_TOKEN=${SENTRY_AUTH_TOKEN:-''}
+RELEASE_NAME=${RELEASE_NAME:-''}
+SENTRY_ORG="mesosphere"
+SENTRY_PROJECT="dcos-ui"
+
+# Create release on Sentry
+SENTRY_AUTH_TOKEN="${SENTRY_AUTH_TOKEN}" \
+  npx sentry-cli releases -o "${SENTRY_ORG}" -p "${SENTRY_PROJECT}" \
+  new "${RELEASE_NAME}"
+
+# Upload sourcemaps
+SENTRY_AUTH_TOKEN="${SENTRY_AUTH_TOKEN}" \
+  npx sentry-cli releases -o "${SENTRY_ORG}" -p "${SENTRY_PROJECT}" \
+  files "${RELEASE_NAME}" upload-sourcemaps ./dist


### PR DESCRIPTION
This PR adds a script to our release pipeline that uploads source maps to sentry.io to improve dev experience.

## Testing

1. Get Sentry token in Onelogin secure notes
2. Make a build `npm run build-assets`
3. Run the script 
```
SENTRY_AUTH_TOKEN="<token>" \
  RELEASE_NAME="test-<any salt>" \
  ./scripts/ci/utils/upload-sourcemaps
```

## Trade-offs

1. It's a shell script, sorry
2. Decided to go with a CLI lib instead of cURL https://docs.sentry.io/clients/javascript/sourcemaps/#uploading-source-maps-to-sentry to spare some time debugging
3. This very PR won't trigger a release since we don't release `chore` commits