### PR TITLE
DCOS-42035: Invalid Environment variables have no error and are simply ignored (1.11 backport)

### DIFF
--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -55,17 +55,26 @@ class EnvironmentFormSection extends Component {
           );
         }
 
+        const isValueWithoutKey = Boolean(!env.key && env.value);
+
         return (
           <FormRow key={key}>
-            <FormGroup className="column-6" required={false}>
+            <FormGroup
+              className="column-6"
+              required={false}
+              showError={isValueWithoutKey}
+            >
               {keyLabel}
               <FieldAutofocus>
                 <FieldInput
                   name={`env.${key}.key`}
                   type="text"
-                  value={env.key}
+                  value={env.key || ""}
                 />
               </FieldAutofocus>
+              <FieldError>
+                An environment variable needs to contain at least a key.
+              </FieldError>
               <span className="emphasis form-colon">:</span>
             </FormGroup>
             <FormGroup
@@ -77,7 +86,7 @@ class EnvironmentFormSection extends Component {
               <FieldInput
                 name={`env.${key}.value`}
                 type="text"
-                value={env.value}
+                value={env.value || ""}
               />
               <FieldError>{errors[env.key]}</FieldError>
             </FormGroup>

--- a/src/styles/components/form-elements/styles.less
+++ b/src/styles/components/form-elements/styles.less
@@ -59,9 +59,9 @@
   }
 
   .form-colon {
-    bottom: 0.8rem;
     left: 100%;
     position: absolute;
+    top: 2.2rem;
   }
 
   .form-group-container-action-button-group {

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1465,6 +1465,18 @@ describe("Service Form Modal", function() {
 
           cy.get('.form-control[name="env.0.key"]').should("not.exist");
         });
+
+        it("shows an error if only the value is filled out", function() {
+          cy
+            .get("@tabView")
+            .find('.form-control[name="env.0.value"]')
+            .type("value");
+          cy
+            .get("@tabView")
+            .contains(
+              "An environment variable needs to contain at least a key."
+            );
+        });
       });
 
       context("Labels", function() {


### PR DESCRIPTION
backport for https://github.com/dcos/dcos-ui/pull/3234 with some minor fixes

Half of https://jira.mesosphere.com/browse/DCOS-42035

## Testing
1. Switch to branch 1.11 and set up node to use version 8.9.4 and npm to use version 5.6.0
I recommend using a new copy of the dcos-ui repository.
Setting up node is easy: just use a node version manager (I used https://github.com/creationix/nvm) and run (if you are using nvm) `nvm install 8.9.4` in the directory. Setting up npm should happen automatically in this case, but if it doesn't, it is a bit trickier - navigate to the nvm directory, for example `cd ~/.nvm/versions/node/v8.9.4/lib` and run `npm install npm@5.6.0`.
Then run `npm install`.
2. Test the changes
Click on Services Tab
Click `+` or `Run a Service` to add a new service
Click on Single Container
Click on Environment
Click on `Add Environment Variable`
Enter a `Value` without entering `Key`
Verify that an error message is shown
Test the same thing for a Multi-Container

## Trade-offs
None

## Dependencies
None

## Screenshots

### Before
![peek 2018-09-18 16-02](https://user-images.githubusercontent.com/40791275/45743184-2e734f00-bc04-11e8-8173-c607282940cd.gif)

### After
![peek 2018-09-18 16-03](https://user-images.githubusercontent.com/40791275/45743196-33d09980-bc04-11e8-82cd-e5c3ce8e13de.gif)

### After with css change
![peek 2018-09-19 12-12](https://user-images.githubusercontent.com/40791275/45744149-7e531580-bc06-11e8-9bed-f65702ee324a.gif)


