### PR TITLE
DCOS-42035: Invalid Environment variables have no error and are simply ignored (1.10 backport)

### DIFF
--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -54,17 +54,26 @@ class EnvironmentFormSection extends Component {
           );
         }
 
+        const isValueWithoutKey = Boolean(!env.key && env.value);
+
         return (
           <FormRow key={key}>
-            <FormGroup className="column-6" required={false}>
+            <FormGroup
+              className="column-6"
+              required={false}
+              showError={isValueWithoutKey}
+            >
               {keyLabel}
               <FieldAutofocus>
                 <FieldInput
                   name={`env.${key}.key`}
                   type="text"
-                  value={env.key}
+                  value={env.key || ""}
                 />
               </FieldAutofocus>
+              <FieldError>
+                An environment variable needs to contain at least a key.
+              </FieldError>
               <span className="emphasis form-colon">:</span>
             </FormGroup>
             <FormGroup
@@ -76,7 +85,7 @@ class EnvironmentFormSection extends Component {
               <FieldInput
                 name={`env.${key}.value`}
                 type="text"
-                value={env.value}
+                value={env.value || ""}
               />
               <FieldError>{errors[env.key]}</FieldError>
             </FormGroup>

--- a/src/styles/components/form-elements/styles.less
+++ b/src/styles/components/form-elements/styles.less
@@ -59,9 +59,9 @@
   }
 
   .form-colon {
-    bottom: 0.8rem;
     left: 100%;
     position: absolute;
+    top: 2.2rem;
   }
 
   .form-group-container-action-button-group {

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1546,6 +1546,18 @@ describe("Service Form Modal", function() {
 
           cy.should("not.contain", '.form-control[name="env.0.key"]');
         });
+
+        it("shows an error if only the value is filled out", function() {
+          cy
+            .get("@tabView")
+            .find('.form-control[name="env.0.value"]')
+            .type("value");
+          cy
+            .get("@tabView")
+            .contains(
+              "An environment variable needs to contain at least a key."
+            );
+        });
       });
 
       context("Labels", function() {


### PR DESCRIPTION
backport for https://github.com/dcos/dcos-ui/pull/3234 with some minor fixes

Half of https://jira.mesosphere.com/browse/DCOS-42035

This branch was created using @DanielMSchmidt 's tool https://github.com/DanielMSchmidt/backporter which works great.

## Testing
1. Switch to branch 1.10 and set up node to use version 4.4.7 and npm to use version 3.9.6
I recommend using a new copy of the dcos-ui repository.
Setting up node is easy: just use a node version manager (I used https://github.com/creationix/nvm) and run (if you are using nvm) `nvm install 4.4.7` in the directory. Setting up npm is a bit trickier - navigate to the nvm directory, for example `cd ~/.nvm/versions/node/v4.4.7/lib` and run `npm install npm@3.9.6`.
Then run `npm install`.
2. Test the changes
Click on Services Tab
Click `+` or `Run a Service` to add a new service
Click on Single Container
Click on Environment
Click on `Add Environment Variable`
Enter a `Value` without entering `Key`
Verify that an error message is shown
Test the same thing for a Multi-Container

## Trade-offs
None

## Dependencies
None

## Screenshots

### Before
![peek 2018-09-19 13-13](https://user-images.githubusercontent.com/40791275/45747623-181ec080-bc0f-11e8-95da-e863b23620de.gif)

### After
![peek 2018-09-19 13-15](https://user-images.githubusercontent.com/40791275/45747627-1bb24780-bc0f-11e8-8986-718867f4b9b7.gif)

### After with css change
![peek 2018-09-19 13-17](https://user-images.githubusercontent.com/40791275/45747634-210f9200-bc0f-11e8-8a2d-a84648cedd96.gif)

