### PR TITLE
DCOS-42054: [1.10] Invalid labels have no error and are simply ignored

### DIFF
--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -120,17 +120,20 @@ class EnvironmentFormSection extends Component {
         );
       }
 
+      const isValueWithoutKey = Boolean(!label.key && label.value);
+
       return (
         <FormRow key={key}>
-          <FormGroup className="column-6">
+          <FormGroup className="column-6" showError={isValueWithoutKey}>
             {keyLabel}
             <FieldAutofocus>
               <FieldInput
                 name={`labels.${key}.key`}
                 type="text"
-                value={label.key}
+                value={label.key || ""}
               />
             </FieldAutofocus>
+            <FieldError>A label needs to contain at least a key.</FieldError>
             <span className="emphasis form-colon">:</span>
           </FormGroup>
           <FormGroup
@@ -142,7 +145,7 @@ class EnvironmentFormSection extends Component {
             <FieldInput
               name={`labels.${key}.value`}
               type="text"
-              value={label.value}
+              value={label.value || ""}
             />
             <FieldError>{errors[label.key]}</FieldError>
           </FormGroup>

--- a/src/styles/components/form-elements/styles.less
+++ b/src/styles/components/form-elements/styles.less
@@ -59,9 +59,9 @@
   }
 
   .form-colon {
-    bottom: 0.8rem;
     left: 100%;
     position: absolute;
+    top: 2.2rem;
   }
 
   .form-group-container-action-button-group {

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1580,6 +1580,16 @@ describe("Service Form Modal", function() {
 
           cy.should("not.contain", '.form-control[name="labels.0.key"]');
         });
+
+        it("shows an error if only the value is filled out", function() {
+          cy
+            .get("@tabView")
+            .find('.form-control[name="labels.0.value"]')
+            .type("value");
+          cy
+            .get("@tabView")
+            .contains("A label needs to contain at least a key.");
+        });
       });
     });
 


### PR DESCRIPTION
Show error when a label has a value but no key

Closes https://jira.mesosphere.com/browse/DCOS-42054

## Testing
1. Switch to branch 1.10 and set up node to use version 4.4.7 and npm to use version 3.9.6
I recommend using a new copy of the dcos-ui repository.
Setting up node is easy: just use a node version manager (I used https://github.com/creationix/nvm) and run (if you are using nvm) `nvm install 4.4.7` in the directory. Setting up npm is a bit trickier - navigate to the nvm directory, for example `cd ~/.nvm/versions/node/v4.4.7/lib` and run `npm install npm@3.9.6`.
Then run `npm install`.
2. Test the changes
Click on Services Tab
Click `+` or `Run a Service` to add a new service
Click on Single Container
Click on Environment
Click on `Add Label`
Enter a `Value` without entering `Key`
Verify that an error message is shown
Test the same thing for a Multi-Container

## Trade-offs
None

## Dependencies
None

## Screenshots

### Before
![peek 2018-09-19 17-08](https://user-images.githubusercontent.com/40791275/45759054-b91d7380-bc2f-11e8-89c6-54da930d74e5.gif)

### After
![peek 2018-09-19 17-09](https://user-images.githubusercontent.com/40791275/45759060-bcb0fa80-bc2f-11e8-8fdb-ef5673c0c3eb.gif)
