### PR TITLE
Discussion: Is this vendor.js bundle useful?

### DIFF
--- a/webpack/webpack.dev.js
+++ b/webpack/webpack.dev.js
@@ -1,12 +1,7 @@
 const merge = require("webpack-merge");
 
-const packageInfo = require("../package");
 const common = require("./webpack.config.js");
 const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
-
-const dependencies = Object.assign({}, packageInfo.dependencies);
-delete dependencies["canvas-ui"];
-delete dependencies["cnvs"];
 
 const maybeProfile = process.env.PROFILE_WEBPACK
   ? new SpeedMeasurePlugin().wrap
@@ -16,8 +11,7 @@ module.exports = maybeProfile(
   merge(common, {
     mode: "development",
     entry: {
-      index: "./src/js/index.js",
-      vendor: Object.keys(dependencies)
+      index: "./src/js/index.js"
     },
     devtool: "cheap-module-eval-source-map"
   })

--- a/webpack/webpack.production.js
+++ b/webpack/webpack.production.js
@@ -10,15 +10,10 @@ const SVGCompilerPlugin = require("./plugins/svg-compiler-plugin");
 const packageInfo = require("../package");
 const common = require("./webpack.config.js");
 
-const dependencies = Object.assign({}, packageInfo.dependencies);
-delete dependencies["canvas-ui"];
-delete dependencies["cnvs"];
-
 module.exports = merge(common, {
   mode: "production",
   entry: {
-    index: "./src/js/index.js",
-    vendor: Object.keys(dependencies)
+    index: "./src/js/index.js"
   },
   devtool: "source-map",
   plugins: [


### PR DESCRIPTION
Why are we bundling and loading all the package dependencies separately? It seems to me that we only need to load what we import through index.js. Our app size may be 2.5MB too large?

## Screenshots

Before (Production build)
![screen shot 2018-09-19 at 12 13 22 pm](https://user-images.githubusercontent.com/174332/45773040-87dc7d80-bc06-11e8-851b-8bc000f0378e.png)

Before (Bundle Analysis)
![screen shot 2018-09-19 at 12 18 00 pm](https://user-images.githubusercontent.com/174332/45773052-8f9c2200-bc06-11e8-93d2-001fca94b29d.png)

After
![screen shot 2018-09-19 at 12 09 00 pm](https://user-images.githubusercontent.com/174332/45773127-bbb7a300-bc06-11e8-9e9c-648643b2c7e0.png)

