### PR TITLE
DCOS-42158: truncate labels instead of overflowing (1.11 backport)

### DIFF
--- a/src/styles/components/framework-configuration/styles.less
+++ b/src/styles/components/framework-configuration/styles.less
@@ -1,6 +1,7 @@
 .framework-configuration-form fieldset {
   border: 0;
   margin: 0;
+  min-width: 0;
   padding: 0;
 }
 


### PR DESCRIPTION
## Testing
Before starting dcos-ui:
Make sure you're using Node 8.9.4 and NPM 5.6.0
Check out `release/1.11` in `dcos-ui-plugins-private`
`rm -rf node_modules/ && npm install` to reinstall dependencies

Then proceed with actual testing:
1. Go to "Catalog"
2. Add the Elastics services
3. Go to the "Elasticsearch" tab
4. Toggle the JSON editor open
5. Resize your viewport width to somewhere between 991px and 1050px

Any labels in the form should be truncated with an ellipsis, not overflowing out of the width

## Trade-offs
None

## Dependencies
None

## Screenshots
Before:
<img width="992" alt="screen shot 2018-09-19 at 4 16 00 pm" src="https://user-images.githubusercontent.com/2313998/45778763-78b9f780-bc27-11e8-9482-fec24dca94aa.png">

After:
<img width="992" alt="screen shot 2018-09-19 at 4 15 02 pm" src="https://user-images.githubusercontent.com/2313998/45778777-80799c00-bc27-11e8-8d52-efe673856fea.png">
