### PR TITLE
DCOS_OSS-1961: don't swallow container fields added in JSON editor

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
@@ -392,7 +392,9 @@ module.exports = {
             newState
           );
 
-          newState.push(Object.assign({}, DEFAULT_POD_CONTAINER, { name }));
+          newState.push(
+            Object.assign({}, DEFAULT_POD_CONTAINER, { name }, value)
+          );
           this.cache.push({});
           this.endpoints.push([]);
           break;

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
@@ -239,6 +239,24 @@ describe("Containers", function() {
       });
     });
 
+    describe("container with arbitrary value", function() {
+      it("contains a container with arbitrary field", function() {
+        let batch = new Batch();
+
+        batch = batch.add(
+          new Transaction(["containers"], { someKey: "value" }, ADD_ITEM)
+        );
+
+        expect(batch.reduce(Containers.JSONReducer.bind({}))).toEqual([
+          {
+            name: "container-1",
+            resources: { cpus: 0.1, mem: 128 },
+            someKey: "value"
+          }
+        ]);
+      });
+    });
+
     describe("endpoints", function() {
       describe("Host Mode", function() {
         it("has one endpoint", function() {


### PR DESCRIPTION
Before, 'name' was the only part of the updated value being pushed into newState

Closes DCOS_OSS-1961

## Testing
1. Go to "Services"
2. Add a new service by clicking "+" icon or "Run a Service"
3. Click "Multi/container (Pod)"
4. Toggle the JSON editor open
5. Replace the first object in the `containers` array with:
```
    {
      "name": "container-1",
      "resources": {
        "cpus": 0.1,
        "mem": 128
      },
      "lifecycle": {
        "killGracePeriodSeconds": 600
      },
      "image": {
        "id": "nginx",
        "kind": "DOCKER"
      }
    }
```
6. Focus any field in the form
7. Add a Service ID
8. Tap "Review & Run"
9. Tap "Review & Run" on the confirmation screen
10. When you land back on the services screen, click the service you just added
11. Click the "Edit" button
12. Toggle the JSON editor open

The JSON editor should still contain `"lifecycle": { "killGracePeriodSeconds": 600 }`

## Trade-offs
Not that I know of

## Dependencies
None

## Screenshots
Before:
https://cl.ly/706236dc4395

After:
https://cl.ly/2f569868456c
