### PR TITLE
DCOS-42230: Clarify resource totals on pod instances table

### DIFF
--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
@@ -263,9 +263,9 @@ class PodInstancesTable extends React.Component {
         address: addressComponents,
         cpus: containerResources.cpus,
         mem: containerResources.mem,
-        activeResources: container.activeResources,
         updated: container.getLastUpdated(),
-        version: ""
+        version: "",
+        isHistoricalInstance: container.isHistoricalInstance
       };
     });
 
@@ -437,19 +437,14 @@ class PodInstancesTable extends React.Component {
           ? row.podSpec.executorResources[prop] || 0
           : 0;
       const childResources = row.children
-        .filter(child => child.activeResources)
-        .reduce(
-          (sum, current) => sum + (current.activeResources[prop] || 0),
-          0
-        );
+        .filter(child => !child.isHistoricalInstance)
+        .reduce((sum, current) => sum + (current[prop] || 0), 0);
       tooltipContent = `Containers: ${Units.formatResource(
         prop,
         childResources
       )}, Executor: ${Units.formatResource(prop, executorResource)}`;
     } else {
-      const activeResource = row.activeResources
-        ? row.activeResources[prop] || 0
-        : 0;
+      const activeResource = row.isHistoricalInstance ? 0 : row[prop] || 0;
       const totalResource = row[prop];
       tooltipContent = `Using ${activeResource}/${Units.formatResource(
         prop,

--- a/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.js
+++ b/plugins/services/src/js/containers/pod-instances/__tests__/PodInstancesTable-test.js
@@ -335,7 +335,7 @@ describe("PodInstancesTable", function() {
 
       it("renders the cpu column", function() {
         const names = thisInstance
-          .find("td.task-table-column-cpus div > div > span")
+          .find("td.task-table-column-cpus div.tooltip-wrapper > span")
           .map(function(el) {
             return el.text();
           });
@@ -355,7 +355,7 @@ describe("PodInstancesTable", function() {
 
       it("renders the mem column", function() {
         const names = thisInstance
-          .find("td.task-table-column-mem div > div > span")
+          .find("td.task-table-column-mem div.tooltip-wrapper > span")
           .map(function(el) {
             return el.text();
           });

--- a/plugins/services/src/js/utils/__tests__/PodUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/PodUtil-test.js
@@ -145,7 +145,11 @@ describe("PodUtil", function() {
           .getItems()[0]
           .getContainers()[1]
           .get()
-      ).toEqual(historicalInstances[0].containers[0]);
+      ).toEqual(
+        Object.assign(historicalInstances[0].containers[0], {
+          activeResources: {}
+        })
+      );
     });
   });
 

--- a/plugins/services/src/js/utils/__tests__/PodUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/PodUtil-test.js
@@ -116,7 +116,11 @@ describe("PodUtil", function() {
           .getItems()[0]
           .getContainers()[2]
           .get()
-      ).toEqual(historicalInstances[0].containers[0]);
+      ).toEqual(
+        Object.assign(historicalInstances[0].containers[0], {
+          isHistoricalInstance: true
+        })
+      );
     });
 
     it("does not duplicate containers", function() {
@@ -145,11 +149,7 @@ describe("PodUtil", function() {
           .getItems()[0]
           .getContainers()[1]
           .get()
-      ).toEqual(
-        Object.assign(historicalInstances[0].containers[0], {
-          activeResources: {}
-        })
-      );
+      ).toMatchObject(historicalInstances[0].containers[0]);
     });
   });
 


### PR DESCRIPTION
Clarify to users what the breakdown of the resources is on the pod instances table.

Added tooltips to the resource cells in the PodInstancesTable. If it is an expandable row (has child containers), it gives a breakdown of the resource summary as "Containers: X, Executor: Y". If is a non-expandable row (child container), it indicates how much of the allocated resource is being used as "Using X/Y".

Closes DCOS-42230.

## Testing

- Run a service from JSON config which can be found in [JIRA ticket comment](https://jira.mesosphere.com/browse/DCOS-17436?focusedCommentId=174971&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-174971). 
- Go to services, click on the service you just started, hover over the resource cells on the parent (expandable) row. They should give breakdown of resources being used by containers and executor resources. 
- Expand the instance row. Hover again over the resource cells in the rows. They should indicate what the container is using compared to what's allocated. (Using this config, when the task is complete, the used resources should be 0).

## Trade-offs

Many. Some background:

Historical instances and pod instances are merged together in the `PodInstancesContainer` (via the `PodUtil` `mergeHistoricalInstanceList`), and the `PodInstancesTable` receives this merged instance list eventually as a prop. If a task in a container has completed, it will be in both the pod instance list and historical instance list. When the containers are merged together, if there are two containers with the same containerId, only one is kept in the merged list. The container from the pod instance list has NO resources listed since it is not using resources. The matching container from the historical instance list HAS resources listed to represent the available (not used) resources for that container. So when we keep only one (the match from the historical instance list), there is a resources property on that container.

This is inconsistent with how non-completed tasks are represented, since the resources property on these objects represents the resources in use (not resources available). This discrepancy makes it difficult to determine when the resources property is indicating resources that are available or resources that are in use by a container.

**1st Approach:**

To alleviate the problem, I added an `activeResources` property to the containers to indicate which resources are in use. If there are NO historical instances (no completed tasks), the `activeResources` will simply be a copy of the regular resources property. If there ARE historical instances, when they are merged, we look at the pod instance match and if there is no resources property on this object, we add an empty `activeResources` object to the container to indicate that there are no resources being used.

**2nd Approach:**

Added `isHistoricalInstance` property to historical resources in the `mergeHistoricalInstanceList` method of `PodUtil`. Then do not use resources from these historical instances in calculations for currently active resources.

**Summary:** having access to the `activeResources` or `isHistoricalInstance` property depends currently on calling `mergeHistoricalInstanceList` (which always happens now in `PodInstancesContainer` but is not enforced at the `PodInstancesTable` component). Adding `activeResources` or `isHistoricalInstance` changes the "shape" of the pod instances list.

~~Also, as of right now a bunch of unit tests are broken~~ 

