### PR TITLE
DCOS-41914: add a 'recommended' label to UCR containerization option

### DIFF
--- a/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
+++ b/plugins/services/src/js/components/forms/GeneralServiceFormSection.js
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { Confirm, Tooltip } from "reactjs-components";
+import { Badge } from "@dcos/ui-kit";
 
 import { findNestedPropertyInObject } from "#SRC/js/utils/Util";
 import { isEmpty } from "#SRC/js/utils/ValidatorUtil";
@@ -258,7 +259,14 @@ class GeneralServiceFormSection extends Component {
             type="radio"
             value={runtimeName}
           />
-          {label}
+          <div className="flex flex-align-items-center">
+            {label}
+            {runtimeName === "MESOS" && (
+              <span className="runtimeLabel-badge">
+                <Badge>Recommended</Badge>
+              </span>
+            )}
+          </div>
           <FieldHelp>{helpText}</FieldHelp>
         </FieldLabel>
       );

--- a/src/styles/components/advanced-section/styles.less
+++ b/src/styles/components/advanced-section/styles.less
@@ -15,6 +15,10 @@
       }
     }
   }
+
+  .runtimeLabel-badge {
+    margin-left: 7px;
+  }
 }
 
 & when (@advanced-section-enabled) and (@layout-screen-small-enabled) {


### PR DESCRIPTION
We're going to change default containerizer from Docker to UCR soon, to prepare our customers, we're recommending UCR

Closes DCOS-41914

## Testing
1. Go to "Services"
2. Add a new service by clicking "+" icon or "Run a Service"
3. Click "Single container"
4. Click the "More Settings" dropdown
5. Scroll to the "Container Runtime" section

The radio label for "Universal Container Runtime (UCR)" should have a badge 

## Trade-offs
Very minor: had to add some markup to vertically center the Badge

## Dependencies
None

## Screenshots
Before:
<img width="727" alt="screen shot 2018-09-20 at 4 13 04 pm" src="https://user-images.githubusercontent.com/2313998/45845144-4d500f00-bcf2-11e8-87fe-7dfd36fbfd67.png">

After:
<img width="737" alt="screen shot 2018-09-20 at 4 12 24 pm" src="https://user-images.githubusercontent.com/2313998/45845631-a3718200-bcf3-11e8-84bd-3f0f9888c319.png">

