### PR TITLE
DCOS-21232: Better text filtering

### DIFF
--- a/src/js/structs/UniversePackagesList.js
+++ b/src/js/structs/UniversePackagesList.js
@@ -20,6 +20,31 @@ class UniversePackagesList extends List {
     super(options, ...Array.prototype.slice(arguments, 1));
   }
 
+  reRankCertified(items) {
+    // Can't use array sort here since sorting on a boolean value will
+    // reorder nearly everything and we want to preserve the previous ordering
+    let certIndex = 0;
+
+    return items.reduce((acc, item) => {
+      if (item.isCertified()) {
+        acc.splice(certIndex, 0, item);
+        certIndex++;
+      } else {
+        acc.push(item);
+      }
+
+      return acc;
+    }, []);
+  }
+
+  filterItemsByText(filterText) {
+    const items = List.prototype.filterItemsByText
+      .call(this, filterText)
+      .getItems();
+
+    return new this.constructor({ items: this.reRankCertified(items) });
+  }
+
   getSelectedAndNonSelectedPackages() {
     const selectedPackages = [];
     const nonSelectedPackages = [];

--- a/src/js/structs/UniversePackagesList.js
+++ b/src/js/structs/UniversePackagesList.js
@@ -6,8 +6,8 @@ class UniversePackagesList extends List {
     // Specify filter properties if not specified
     if (!options.filterProperties) {
       options.filterProperties = {
-        description: null, // use default getter
         name: null, // use default getter
+        description: null, // use default getter
         tags(item) {
           const tags = item.get("tags") || [];
 

--- a/src/js/structs/__tests__/HealthUnitsList-test.js
+++ b/src/js/structs/__tests__/HealthUnitsList-test.js
@@ -19,12 +19,12 @@ describe("HealthUnitsList", function() {
     });
 
     it("filters by title", function() {
-      const items = [{ id: "foo" }, { id: "bar" }, { id: "baz" }];
+      const items = [{ id: "foo" }, { id: "foobar" }, { id: "baz" }];
       const list = new HealthUnitsList({ items });
       const filteredList = list.filter({ title: "ba" }).getItems();
       expect(filteredList.length).toEqual(2);
-      expect(filteredList[0].get("id")).toEqual("bar");
-      expect(filteredList[1].get("id")).toEqual("baz");
+      expect(filteredList[0].get("id")).toEqual("baz");
+      expect(filteredList[1].get("id")).toEqual("foobar");
     });
 
     it("filters by unit health title", function() {

--- a/src/js/structs/__tests__/List-test.js
+++ b/src/js/structs/__tests__/List-test.js
@@ -233,8 +233,8 @@ describe("List", function() {
     it("filters by subItems", function() {
       var filteredItems = thisInstance.filterItemsByText("two").getItems();
       expect(filteredItems.length).toEqual(2);
-      expect(filteredItems[0].subItems).toEqual(["one", "two"]);
-      expect(filteredItems[1].subItems).toEqual(["two", "three"]);
+      expect(filteredItems[0].subItems).toEqual(["two", "three"]);
+      expect(filteredItems[1].subItems).toEqual(["one", "two"]);
     });
 
     it("handles filter by with null elements", function() {

--- a/src/js/structs/__tests__/UniversePackagesList-test.js
+++ b/src/js/structs/__tests__/UniversePackagesList-test.js
@@ -31,12 +31,17 @@ describe("UniversePackagesList", function() {
     });
 
     it("filters by tags", function() {
-      var items = [{ tags: ["foo", "bar"] }, { tags: ["foo"] }, { tags: [] }];
+      var items = [
+        { tags: ["word", "foo", "bar"] },
+        { tags: ["foo"] },
+        { tags: [] }
+      ];
+
       var list = new UniversePackagesList({ items });
       items = list.filterItemsByText("foo").getItems();
       expect(items.length).toEqual(2);
-      expect(items[0].get("tags")).toEqual(["foo", "bar"]);
-      expect(items[1].get("tags")).toEqual(["foo"]);
+      expect(items[0].get("tags")).toEqual(["foo"]);
+      expect(items[1].get("tags")).toEqual(["word", "foo", "bar"]);
     });
 
     it("handles filter by tags with null elements", function() {

--- a/src/js/structs/__tests__/UniversePackagesList-test.js
+++ b/src/js/structs/__tests__/UniversePackagesList-test.js
@@ -22,6 +22,25 @@ describe("UniversePackagesList", function() {
       expect(items[0].get("name")).toEqual("bar");
     });
 
+    it("sorts exact matches first", function() {
+      var items = [{ name: "kafka-beta" }, { name: "kafka" }];
+      var list = new UniversePackagesList({ items });
+      items = list.filterItemsByText("kafka").getItems();
+      expect(items.length).toEqual(2);
+      expect(items[0].get("name")).toEqual("kafka");
+    });
+
+    it("sorts certified packages first", function() {
+      var items = [
+        { name: "certified kafka", selected: true }, // without certification, this package would be ordered first.
+        { name: "a kafka", selected: false }
+      ];
+      var list = new UniversePackagesList({ items });
+      items = list.filterItemsByText("kafka").getItems();
+      expect(items.length).toEqual(2);
+      expect(items[0].isCertified()).toBeTruthy();
+    });
+
     it("filters by description", function() {
       var items = [{ description: "foo" }, { description: "bar" }];
       var list = new UniversePackagesList({ items });

--- a/src/js/utils/StringUtil.js
+++ b/src/js/utils/StringUtil.js
@@ -40,22 +40,15 @@ const StringUtil = {
     );
   },
 
-  filterByString(objects, getter, searchString) {
+  filterByString(objects, property, searchString) {
     const searchItems = this.getSearchTokens(searchString);
 
-    if (typeof getter === "function") {
-      return objects.filter(obj => {
-        return searchItems.some(item => {
-          return this.getSearchTokens(getter(obj)).some(token => {
-            return token.startsWith(item);
-          });
-        });
-      });
-    }
+    const getter =
+      typeof property === "function" ? property : obj => obj[property];
 
     return objects.filter(obj => {
       return searchItems.some(item => {
-        return this.getSearchTokens(obj[getter]).some(token => {
+        return this.getSearchTokens(getter(obj)).some(token => {
           return token.startsWith(item);
         });
       });

--- a/src/js/utils/__tests__/StringUtil-test.js
+++ b/src/js/utils/__tests__/StringUtil-test.js
@@ -45,44 +45,6 @@ describe("StringUtil", function() {
     });
   });
 
-  describe("#getSearchTokens", function() {
-    it("splits on non-word characters, but not slashes", function() {
-      expect(
-        StringUtil.getSearchTokens(
-          "foo/bar\\.baz.quis,qux quux[quuz]corge grault,garply\twaldo\bfred"
-        )
-      ).toEqual([
-        "foo/bar",
-        "baz",
-        "quis",
-        "qux",
-        "quux",
-        "quuz",
-        "corge",
-        "grault",
-        "garply",
-        "waldo",
-        "fred"
-      ]);
-    });
-
-    it("returns converts input to string if not a string", function() {
-      expect(StringUtil.getSearchTokens(10)).toEqual(["10"]);
-    });
-
-    it("removes empty strings", function() {
-      expect(StringUtil.getSearchTokens("bar\\.baz")).toEqual(["bar", "baz"]);
-    });
-
-    it("lowercases strings", function() {
-      expect(StringUtil.getSearchTokens("QuUx[qUuz]coRge")).toEqual([
-        "quux",
-        "quuz",
-        "corge"
-      ]);
-    });
-  });
-
   describe("#filterByString", function() {
     it("filters using a key as getter", function() {
       var _return = StringUtil.filterByString(
@@ -103,41 +65,6 @@ describe("StringUtil", function() {
         "baz"
       );
       expect(_return).toEqual([{ id: 1, foo: "baz" }]);
-    });
-
-    it("sorts by relevance, word distance from beginning of string", function() {
-      const _return = StringUtil.filterByString(
-        [
-          { id: 0, foo: "beta-baz" },
-          { id: 1, foo: "community-baz" },
-          { id: 2, foo: "baz" }
-        ],
-        "foo",
-        "baz"
-      );
-
-      expect(_return.length).toEqual(3);
-      expect(_return[0].foo).toEqual("baz");
-      expect(_return[1].foo).toEqual("beta-baz");
-      expect(_return[2].foo).toEqual("community-baz");
-    });
-
-    it("sorts by relevance, combining relevance of multiple search tokens", function() {
-      const _return = StringUtil.filterByString(
-        [
-          { id: 0, foo: "footballs" },
-          { id: 1, foo: "strange bazookas" },
-          { id: 2, foo: "bar" },
-          { id: 3, foo: "foo bar baz" }
-        ],
-        "foo",
-        "foo baz"
-      );
-
-      expect(_return.length).toEqual(3);
-      expect(_return[0].foo).toEqual("foo bar baz");
-      expect(_return[1].foo).toEqual("footballs");
-      expect(_return[2].foo).toEqual("strange bazookas");
     });
   });
 

--- a/src/js/utils/__tests__/StringUtil-test.js
+++ b/src/js/utils/__tests__/StringUtil-test.js
@@ -104,6 +104,41 @@ describe("StringUtil", function() {
       );
       expect(_return).toEqual([{ id: 1, foo: "baz" }]);
     });
+
+    it("sorts by relevance, word distance from beginning of string", function() {
+      const _return = StringUtil.filterByString(
+        [
+          { id: 0, foo: "beta-baz" },
+          { id: 1, foo: "community-baz" },
+          { id: 2, foo: "baz" }
+        ],
+        "foo",
+        "baz"
+      );
+
+      expect(_return.length).toEqual(3);
+      expect(_return[0].foo).toEqual("baz");
+      expect(_return[1].foo).toEqual("beta-baz");
+      expect(_return[2].foo).toEqual("community-baz");
+    });
+
+    it("sorts by relevance, combining relevance of multiple search tokens", function() {
+      const _return = StringUtil.filterByString(
+        [
+          { id: 0, foo: "footballs" },
+          { id: 1, foo: "strange bazookas" },
+          { id: 2, foo: "bar" },
+          { id: 3, foo: "foo bar baz" }
+        ],
+        "foo",
+        "foo baz"
+      );
+
+      expect(_return.length).toEqual(3);
+      expect(_return[0].foo).toEqual("foo bar baz");
+      expect(_return[1].foo).toEqual("footballs");
+      expect(_return[2].foo).toEqual("strange bazookas");
+    });
   });
 
   describe("#escapeForRegExp", function() {

--- a/src/js/utils/__tests__/search-test.js
+++ b/src/js/utils/__tests__/search-test.js
@@ -1,0 +1,90 @@
+import search, { tokenize } from "../search";
+
+describe("search util", function() {
+  describe("search", function() {
+    const fooExtractor = thing => thing.foo;
+
+    it("sorts by relevance, word distance from beginning of string", function() {
+      const _return = search(
+        "baz",
+        [
+          { id: 0, foo: "beta-baz" },
+          { id: 1, foo: "community-baz" },
+          { id: 2, foo: "baz" }
+        ],
+        fooExtractor
+      );
+
+      expect(_return.length).toEqual(3);
+      expect(_return[0].obj.foo).toEqual("baz");
+      expect(_return[1].obj.foo).toEqual("beta-baz");
+      expect(_return[2].obj.foo).toEqual("community-baz");
+    });
+
+    it("sorts by relevance, combining relevance of multiple search tokens", function() {
+      const _return = search(
+        "foo baz",
+        [
+          { id: 0, foo: "footballs" },
+          { id: 1, foo: "strange bazookas" },
+          { id: 2, foo: "bar" },
+          { id: 3, foo: "foo bar baz" }
+        ],
+        fooExtractor
+      );
+
+      expect(_return.length).toEqual(3);
+      expect(_return[0].obj.foo).toEqual("foo bar baz");
+      expect(_return[1].obj.foo).toEqual("footballs");
+      expect(_return[2].obj.foo).toEqual("strange bazookas");
+    });
+  });
+
+  describe("tokenize", function() {
+    it("return a lowercase array", function() {
+      expect(tokenize("Hello, World")).toEqual(["hello", "world"]);
+    });
+
+    it("does not break on dash", function() {
+      expect(tokenize("Hello-World")).toEqual(["hello-world"]);
+    });
+
+    it("does not break on slash", function() {
+      expect(tokenize("Hello/World")).toEqual(["hello/world"]);
+    });
+
+    describe("null input", function() {
+      it("returns empty array", function() {
+        expect(tokenize(null)).toEqual([]);
+      });
+    });
+
+    it("splits on non-word characters, but not slashes", function() {
+      expect(
+        tokenize(
+          "foo/bar\\.baz.quis,qux quux[quuz]corge grault,garply\twaldo\bfred"
+        )
+      ).toEqual([
+        "foo/bar",
+        "baz",
+        "quis",
+        "qux",
+        "quux",
+        "quuz",
+        "corge",
+        "grault",
+        "garply",
+        "waldo",
+        "fred"
+      ]);
+    });
+
+    it("returns converts input to string if not a string", function() {
+      expect(tokenize(10)).toEqual(["10"]);
+    });
+
+    it("removes empty strings", function() {
+      expect(tokenize("bar\\.baz")).toEqual(["bar", "baz"]);
+    });
+  });
+});

--- a/src/js/utils/search.ts
+++ b/src/js/utils/search.ts
@@ -1,0 +1,73 @@
+export interface ScoredObject {
+  obj: any;
+  score: number;
+}
+
+export type ScoringFunction = (
+  extractedText: string,
+  searchTerm: string
+) => number;
+
+function favorBeginningOfTextScoring(
+  extractedText: string,
+  searchTerm: string
+): number {
+  if (!extractedText) {
+    return 0;
+  }
+
+  extractedText = String(extractedText || "").toLowerCase();
+  const pos = extractedText.indexOf(searchTerm.toLowerCase());
+  if (pos === -1) {
+    return 0;
+  }
+
+  // Exact matches are scored very high but otherwise
+  // Longer searchTerms near the beginning of a value score highest.
+  return searchTerm === extractedText
+    ? 100 // ding
+    : searchTerm.length / extractedText.length +
+        (1 - pos / extractedText.length);
+}
+
+function scoreText(text: string, terms: string[], f: ScoringFunction): number {
+  return terms.reduce((termScore, term) => {
+    return termScore + f(text, term);
+  }, 0);
+}
+
+export function tokenize(phrase: string): string[] {
+  if (!phrase) {
+    return [];
+  }
+
+  return String(phrase)
+    .trim()
+    .toLowerCase()
+    .split(/[^\w/-]/)
+    .filter(Boolean);
+}
+
+// Filters and sorts an array according to search terms. Uses a simple relevance
+// algorithm that scores longer tokens near the beginning of a value higher.
+export default function search<T>(
+  searchString: string,
+  objects: T[],
+  extractor: (obj: T) => string,
+  scoringFunction: ScoringFunction = favorBeginningOfTextScoring
+): ScoredObject[] {
+  return objects
+    .map(obj => {
+      // Wrap each object in an object that includes a score
+      return {
+        obj,
+        score: scoreText(
+          extractor(obj),
+          tokenize(searchString),
+          scoringFunction
+        )
+      };
+    })
+    .filter(obj => obj.score > 0) // Objects with a 0 score are not relevant
+    .sort((a, b) => b.score - a.score); // Sort by score, descending
+}


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-21232

StringUtil#filterByString now sorts matches by relevance score. This change affects node health checks and universe packages. Here's how scoring is calculated:

- Search phrase are tokenized and each term is evaluated individually, with multiple scores summed together. So if you type "foo bar baz" a package named "foo baz" would appear before "foo" or "bar"
- Exact term matches are scored very very high
- Otherwise, longer terms appearing closer to the beginning of the string are scored higher than shorter terms closer to the end
- Additionally, universe packages are re-ranked to show certified packages first.

The "string" being searched is the concatenated values of "filterProperties"... For universe packages, that would be the name, description, and tags.

I got some ideas from fuse.js and Sifterjs, but ultimately chose an algorithm that felt best.

## Testing

1. Visit catalog
2. Observe exact matches like "beta-kubernetes" rank before more proximate packages like "kubernetes"
3. Observe search phrase "kaf" has more relevant ranking

1. Visit node details health tab
2. Observe that text filtering still works and ranks according to the rules outlined above

## Trade-offs

It is plausible that future callers of StringUtil#filterByString may not want reordering to take place.

## Screenshots

Before:

<img width="939" alt="screen shot 2018-09-20 at 4 36 54 pm" src="https://user-images.githubusercontent.com/174332/45850462-7f15a580-bcf3-11e8-8f25-f6a2e86e6b98.png">


After:

<img width="948" alt="screen shot 2018-09-20 at 4 34 25 pm" src="https://user-images.githubusercontent.com/174332/45850466-8472f000-bcf3-11e8-85e6-345f5ac46f4a.png">


