### PR TITLE
DCOS-42326: don't swallow container fields added in JSON editor

### DIFF
--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/Containers.js
@@ -396,7 +396,9 @@ module.exports = {
             newState
           );
 
-          newState.push(Object.assign({}, DEFAULT_POD_CONTAINER, { name }));
+          newState.push(
+            Object.assign({}, DEFAULT_POD_CONTAINER, { name }, value)
+          );
           this.cache.push({});
           this.endpoints.push([]);
           break;

--- a/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
+++ b/plugins/services/src/js/reducers/serviceForm/JSONReducers/__tests__/Containers-test.js
@@ -239,6 +239,24 @@ describe("Containers", function() {
       });
     });
 
+    describe("container with arbitrary value", function() {
+      it("contains a container with arbitrary field", function() {
+        let batch = new Batch();
+
+        batch = batch.add(
+          new Transaction(["containers"], { someKey: "value" }, ADD_ITEM)
+        );
+
+        expect(batch.reduce(Containers.JSONReducer.bind({}))).toEqual([
+          {
+            name: "container-1",
+            resources: { cpus: 0.1, mem: 128 },
+            someKey: "value"
+          }
+        ]);
+      });
+    });
+
     describe("endpoints", function() {
       describe("Host Mode", function() {
         it("has one endpoint", function() {


### PR DESCRIPTION
## Testing
1. Go to "Services"
2. Add a new service by clicking "+" icon or "Run a Service"
3. Click "Multi/container (Pod)"
4. Toggle the JSON editor open
5. Replace the first object in the `containers` array with:
```
    {
      "name": "container-1",
      "resources": {
        "cpus": 0.1,
        "mem": 128
      },
      "lifecycle": {
        "killGracePeriodSeconds": 600
      },
      "image": {
        "id": "nginx",
        "kind": "DOCKER"
      }
    }
```
6. Focus any field in the form
7. Add a Service ID

The JSON editor should still contain `"lifecycle": { "killGracePeriodSeconds": 600 }` after you focus on the service ID input

## Trade-offs
None

## Dependencies
None

## Screenshots
Before:
https://cl.ly/3c8722d63b9a

After:
https://cl.ly/99add280d670

