### PR TITLE
Improved error handling when downloading CLI.

### DIFF
--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -65,9 +65,14 @@ class CliInstallModal extends React.Component {
     }
     const clusterUrl = `${protocol}://${hostname}${port}`;
     const { selectedOS } = this.state;
+    let version = MetadataStore.parsedVersion;
+    // Prepend 'dcos-' to any version other than latest
+    if (version !== "latest") {
+      version = `dcos-${version}`;
+    }
     const downloadUrl = `https://downloads.dcos.io/binaries/cli/${
       osTypes[selectedOS]
-    }/x86-64/latest/dcos`;
+    }/x86-64/${version}/dcos`;
     if (selectedOS === "Windows") {
       return this.getWindowsInstallInstruction(clusterUrl, downloadUrl);
     }


### PR DESCRIPTION
To close https://jira.mesosphere.com/browse/DCOS-21077 we have added an extra step checking for an existing `dcos` file when downloading the CLI through the DC/OS UI. With the change of path of curl's download, we now check that there is no existing `dcos` file or directory in `/usr/local/bin/` before downloading the new CLI.

## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
