### PR TITLE
DCOS-42317: skip non-string fields in Universe response

### DIFF
--- a/plugins/services/src/js/utils/FrameworkUtil.js
+++ b/plugins/services/src/js/utils/FrameworkUtil.js
@@ -51,6 +51,10 @@ const FrameworkUtil = {
     const images = Object.assign({}, packageImages);
 
     Object.keys(images).forEach(image => {
+      if (typeof images[image] !== "string") {
+        return;
+      }
+
       const queryString = images[image].substring(
         images[image].lastIndexOf("?")
       );

--- a/plugins/services/src/js/utils/__tests__/FrameworkUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/FrameworkUtil-test.js
@@ -122,4 +122,52 @@ describe("FrameworkUtil", function() {
       expect(FrameworkUtil.extractBaseTechVersion()).toEqual("N/A");
     });
   });
+
+  describe("#extractImageUrls", () => {
+    it("extracts icon urls", () => {
+      const input = {
+        "icon-large":
+          "http://localhost/package/resource?url=https://downloads.mesosphere.com/assets/universe/000/grafana-icon-large.png",
+        "icon-medium":
+          "http://localhost/package/resource?url=https://downloads.mesosphere.com/assets/universe/000/grafana-icon-medium.png",
+        "icon-small":
+          "http://localhost/package/resource?url=https://downloads.mesosphere.com/assets/universe/000/grafana-icon-small.png"
+      };
+
+      expect(FrameworkUtil.extractImageUrls(input)).toEqual({
+        "icon-large":
+          "https://downloads.mesosphere.com/assets/universe/000/grafana-icon-large.png",
+        "icon-medium":
+          "https://downloads.mesosphere.com/assets/universe/000/grafana-icon-medium.png",
+        "icon-small":
+          "https://downloads.mesosphere.com/assets/universe/000/grafana-icon-small.png"
+      });
+    });
+
+    it("supports partial response", () => {
+      const input = {
+        "icon-small":
+          "http://localhost/package/resource?url=https://downloads.mesosphere.com/assets/universe/000/grafana-icon-small.png"
+      };
+
+      expect(FrameworkUtil.extractImageUrls(input)).toEqual({
+        "icon-small":
+          "https://downloads.mesosphere.com/assets/universe/000/grafana-icon-small.png"
+      });
+    });
+
+    it("skips non string fields", () => {
+      const input = {
+        screenshots: [
+          "http://localhost/package/resource?url=https://downloads.mesosphere.com/assets/universe/000/grafana-screenshot.png"
+        ]
+      };
+
+      expect(FrameworkUtil.extractImageUrls(input)).toEqual({
+        screenshots: [
+          "http://localhost/package/resource?url=https://downloads.mesosphere.com/assets/universe/000/grafana-screenshot.png"
+        ]
+      });
+    });
+  });
 });


### PR DESCRIPTION
The PR adds a type check for the fields skipping all non-string fields.

Relevant slack discussion linked in the ticket: https://jira.mesosphere.com/browse/DCOS-42317

Closes DCOS-42317

## Testing

1. Try installing `grafana` from the Catalog without the patch.
2. See UI went broken
3. With the patch you should be able using the UI normally

## Trade-offs

We do extraction in prod even though we don't need it there.