### PR TITLE
DCOS-42349: Show error page when the log file won't load

### DIFF
--- a/plugins/services/src/js/components/MesosLogContainer.js
+++ b/plugins/services/src/js/components/MesosLogContainer.js
@@ -15,7 +15,9 @@ const METHODS_TO_BIND = [
   "handleGoToWorkingDirectory",
   "handleFetchPreviousLog",
   "onMesosLogStoreError",
-  "onMesosLogStoreSuccess"
+  "onMesosLogStoreSuccess",
+  "onMesosLogStoreOffsetError",
+  "onMesosLogStoreOffsetSuccess"
 ];
 
 class MesosLogContainer extends mixin(StoreMixin) {
@@ -27,12 +29,13 @@ class MesosLogContainer extends mixin(StoreMixin) {
       fullLog: null,
       isFetchingPrevious: false,
       isLoading: true,
-      hasLoadingError: 0
+      hasLoadingError: 0,
+      hasOffsetLoadingError: false
     };
 
     this.store_listeners = [
       {
-        events: ["success", "error"],
+        events: ["success", "error", "offsetSuccess", "offsetError"],
         name: "mesosLog",
         suppressUpdate: true
       }
@@ -97,6 +100,7 @@ class MesosLogContainer extends mixin(StoreMixin) {
     const stateToCheck = [
       "direction",
       "hasLoadingError",
+      "hasOffsetLoadingError",
       "isFetchingPrevious",
       "isLoading",
       "fullLog" // Check fullLog at the end, as this could be a long string
@@ -127,6 +131,18 @@ class MesosLogContainer extends mixin(StoreMixin) {
     this.setState({
       hasLoadingError: this.state.hasLoadingError + 1,
       isFetchingPrevious: false
+    });
+  }
+
+  onMesosLogStoreOffsetError() {
+    this.setState({
+      hasOffsetLoadingError: true
+    });
+  }
+
+  onMesosLogStoreOffsetSuccess() {
+    this.setState({
+      hasOffsetLoadingError: false
     });
   }
 
@@ -213,9 +229,9 @@ class MesosLogContainer extends mixin(StoreMixin) {
   }
 
   render() {
-    const { hasLoadingError, isLoading } = this.state;
+    const { hasLoadingError, isLoading, hasOffsetLoadingError } = this.state;
 
-    if (hasLoadingError >= 3) {
+    if (hasLoadingError >= 3 || hasOffsetLoadingError) {
       return this.getErrorScreen();
     }
 

--- a/plugins/services/src/js/stores/MesosLogStore.js
+++ b/plugins/services/src/js/stores/MesosLogStore.js
@@ -37,7 +37,9 @@ class MesosLogStore extends BaseStore {
       storeID: this.storeID,
       events: {
         success: MESOS_LOG_CHANGE,
-        error: MESOS_LOG_REQUEST_ERROR
+        error: MESOS_LOG_REQUEST_ERROR,
+        offsetSuccess: MESOS_INITIALIZE_LOG_CHANGE,
+        offsetError: MESOS_INITIALIZE_LOG_REQUEST_ERROR
       },
       unmountWhen() {
         return true;

--- a/tests/_fixtures/1-service-with-executor-task/files-read.json
+++ b/tests/_fixtures/1-service-with-executor-task/files-read.json
@@ -1,0 +1,5 @@
+{
+  "data":
+    "Preparing rootfs at /var/lib/mesos/slave/provisioner/containers/677d3da3-e4cf-4c56-9013-4247589dd2a1/containers/e01a6998-93cd-4474-b9a9-baa57088f621/backends/overlay/rootfses/88e448d1-3d9d-4f64-9451-e0aec4b043ae\nMarked '/' as rslave\nhello world error log\n",
+  "offset": 0
+}

--- a/tests/_support/index.js
+++ b/tests/_support/index.js
@@ -203,8 +203,15 @@ Cypress.Commands.add("configureCluster", function(configuration) {
         "fx:1-service-with-executor-task/browse"
       )
       .route(
-        /agent\/.*\/files\/read/,
+        /agent\/.*\/files\/read.*\/stderr/,
         "fx:1-service-with-executor-task/files-read"
+      )
+      .route(
+        /agent\/.*\/files\/read.*\/stdout/,
+        {},
+        {
+          status: 404
+        }
       )
       .route(/dcos-version/, "fx:dcos/dcos-version")
       .route(

--- a/tests/_support/index.js
+++ b/tests/_support/index.js
@@ -202,6 +202,10 @@ Cypress.Commands.add("configureCluster", function(configuration) {
         /agent\/(.*)?\/files\/browse/,
         "fx:1-service-with-executor-task/browse"
       )
+      .route(
+        /agent\/.*\/files\/read/,
+        "fx:1-service-with-executor-task/files-read"
+      )
       .route(/dcos-version/, "fx:dcos/dcos-version")
       .route(
         /history\/minute/,

--- a/tests/pages/services/TasksTable-cy.js
+++ b/tests/pages/services/TasksTable-cy.js
@@ -37,6 +37,31 @@ describe("Tasks Table", function() {
     });
   });
 
+  context("displays logs", function() {
+    beforeEach(function() {
+      cy.configureCluster({
+        mesos: "1-service-with-executor-task",
+        nodeHealth: true
+      });
+
+      cy.visitUrl({
+        url: "/services/detail/%2Fcassandra/tasks/server-0_10a"
+      });
+      cy.get(".page-header-navigation .menu-tabbed-item")
+        .contains("Logs")
+        .click();
+    });
+
+    it("lets you switch between Error and Output", function() {
+      cy.contains("Error").should("be.visible");
+      cy.contains("Output").should("be.visible");
+    });
+
+    it("shows an error log", function() {
+      cy.contains("hello world error log").should("be.visible");
+    });
+  });
+
   context("For a Service", function() {
     beforeEach(function() {
       cy.configureCluster({

--- a/tests/pages/services/TasksTable-cy.js
+++ b/tests/pages/services/TasksTable-cy.js
@@ -18,8 +18,7 @@ describe("Tasks Table", function() {
         cy.visitUrl({
           url: "/services/detail/%2Fcassandra/tasks/server-0_10a"
         });
-        cy
-          .get(".page-header-navigation .menu-tabbed-item")
+        cy.get(".page-header-navigation .menu-tabbed-item")
           .contains("Files")
           .click();
       });
@@ -31,9 +30,9 @@ describe("Tasks Table", function() {
       });
 
       it("shows directories as well as files", function() {
-        cy
-          .get(".page-body-content  .table-virtual-list")
-          .contains("jre1.7.0_76");
+        cy.get(".page-body-content  .table-virtual-list").contains(
+          "jre1.7.0_76"
+        );
       });
     });
   });
@@ -49,8 +48,7 @@ describe("Tasks Table", function() {
 
     context("Running task without healthcheck", function() {
       beforeEach(function() {
-        cy
-          .get("table tr")
+        cy.get("table tr")
           .contains("broker-0__3c7ab984-a9b9-41fb-bb73-0569f88c657e")
           .closest("tr")
           .find("td")
@@ -58,19 +56,23 @@ describe("Tasks Table", function() {
       });
 
       it("correctly shows status", function() {
-        cy.get("@tds").eq(6).contains("Running");
+        cy.get("@tds")
+          .eq(6)
+          .contains("Running");
       });
 
       it("correctly shows health", function() {
-        cy.get("@tds").eq(7).find(".dot").trigger("mouseover");
+        cy.get("@tds")
+          .eq(7)
+          .find(".dot")
+          .trigger("mouseover");
         cy.get(".tooltip").contains("No health checks available");
       });
     });
 
     context("Running task with healthcheck", function() {
       beforeEach(function() {
-        cy
-          .get("table tr")
+        cy.get("table tr")
           .contains("confluent-kafka.825e1e2e-d6a6-11e6-a564-8605ecf0a9df")
           .closest("tr")
           .find("td")
@@ -78,11 +80,16 @@ describe("Tasks Table", function() {
       });
 
       it("correctly shows status", function() {
-        cy.get("@tds").eq(6).contains("Running");
+        cy.get("@tds")
+          .eq(6)
+          .contains("Running");
       });
 
       it("correctly shows health", function() {
-        cy.get("@tds").eq(7).find(".dot").trigger("mouseover");
+        cy.get("@tds")
+          .eq(7)
+          .find(".dot")
+          .trigger("mouseover");
         cy.get(".tooltip").contains("Healthy");
       });
     });
@@ -94,7 +101,9 @@ describe("Tasks Table", function() {
         mesos: "1-service-with-executor-task"
       });
       cy.visitUrl({ url: "/services/detail/%2Fcassandra/tasks?_k=rh67gf" });
-      cy.get("table tr").find(".form-element-checkbox").as("checkboxes");
+      cy.get("table tr")
+        .find(".form-element-checkbox")
+        .as("checkboxes");
     });
 
     function assertCheckboxLength() {
@@ -102,44 +111,58 @@ describe("Tasks Table", function() {
     }
 
     function assertActionButtons() {
-      cy
-        .get(".filter-bar .button-collection .button-primary-link > span")
+      cy.get(".filter-bar .button-collection .button-primary-link > span")
         .eq(0)
         .contains("Restart");
-      cy
-        .get(".button-collection .button-primary-link > span")
+      cy.get(".button-collection .button-primary-link > span")
         .eq(1)
         .contains("Stop");
     }
 
     it("Select all tasks available and confirm action buttons exist", function() {
       assertCheckboxLength();
-      cy.get("@checkboxes").eq(0).click();
-      cy.get("@checkboxes").eq(0).find("input").should(function($checkbox) {
-        expect($checkbox[0].name).to.equal("headingCheckbox");
-        expect($checkbox[0].checked).to.equal(true);
-      });
-      cy.get("@checkboxes").eq(1).find("input").should(function($checkbox) {
-        expect($checkbox[0].name).to.equal(
-          "cassandra.f3c25eea-da3d-11e5-af84-0242fa37187c"
-        );
-        expect($checkbox[0].checked).to.equal(true);
-      });
+      cy.get("@checkboxes")
+        .eq(0)
+        .click();
+      cy.get("@checkboxes")
+        .eq(0)
+        .find("input")
+        .should(function($checkbox) {
+          expect($checkbox[0].name).to.equal("headingCheckbox");
+          expect($checkbox[0].checked).to.equal(true);
+        });
+      cy.get("@checkboxes")
+        .eq(1)
+        .find("input")
+        .should(function($checkbox) {
+          expect($checkbox[0].name).to.equal(
+            "cassandra.f3c25eea-da3d-11e5-af84-0242fa37187c"
+          );
+          expect($checkbox[0].checked).to.equal(true);
+        });
       assertActionButtons();
     });
 
     it("Select first task available and confirm action buttons exist", function() {
       assertCheckboxLength();
-      cy.get("@checkboxes").eq(1).find("input").should(function($checkbox) {
-        expect($checkbox[0].name).to.equal(
-          "cassandra.f3c25eea-da3d-11e5-af84-0242fa37187c"
-        );
-        expect($checkbox[0].checked).to.equal(false);
-      });
-      cy.get("@checkboxes").eq(1).click();
-      cy.get("@checkboxes").eq(1).find("input").should(function($checkbox) {
-        expect($checkbox[0].checked).to.equal(true);
-      });
+      cy.get("@checkboxes")
+        .eq(1)
+        .find("input")
+        .should(function($checkbox) {
+          expect($checkbox[0].name).to.equal(
+            "cassandra.f3c25eea-da3d-11e5-af84-0242fa37187c"
+          );
+          expect($checkbox[0].checked).to.equal(false);
+        });
+      cy.get("@checkboxes")
+        .eq(1)
+        .click();
+      cy.get("@checkboxes")
+        .eq(1)
+        .find("input")
+        .should(function($checkbox) {
+          expect($checkbox[0].checked).to.equal(true);
+        });
       assertActionButtons();
     });
   });
@@ -194,7 +217,9 @@ describe("Tasks Table", function() {
 
     it("Shows the correct region", function() {
       cy.visitUrl({ url: "/services/detail/%2Fcassandra/tasks?_k=rh67gf" });
-      cy.get("td.task-table-column-zone-address").eq(1).contains("N/A");
+      cy.get("td.task-table-column-zone-address")
+        .eq(1)
+        .contains("N/A");
     });
   });
 
@@ -209,15 +234,15 @@ describe("Tasks Table", function() {
       cy.visitUrl({ url: "/services/detail/%2Fsleep/tasks" });
       cy.get("th.task-table-column-host-address").click();
 
-      cy
-        .get(":nth-child(2) > .task-table-column-host-address")
-        .contains("dcos-01");
-      cy
-        .get(":nth-child(3) > .task-table-column-host-address")
-        .contains("dcos-02");
-      cy
-        .get(":nth-child(4) > .task-table-column-host-address")
-        .contains("dcos-03");
+      cy.get(":nth-child(2) > .task-table-column-host-address").contains(
+        "dcos-01"
+      );
+      cy.get(":nth-child(3) > .task-table-column-host-address").contains(
+        "dcos-02"
+      );
+      cy.get(":nth-child(4) > .task-table-column-host-address").contains(
+        "dcos-03"
+      );
     });
 
     it("sorts ASC by hostname", function() {
@@ -225,15 +250,15 @@ describe("Tasks Table", function() {
       cy.get("th.task-table-column-host-address").click();
       cy.get("th.task-table-column-host-address").click();
 
-      cy
-        .get(":nth-child(2) > .task-table-column-host-address")
-        .contains("dcos-03");
-      cy
-        .get(":nth-child(3) > .task-table-column-host-address")
-        .contains("dcos-02");
-      cy
-        .get(":nth-child(4) > .task-table-column-host-address")
-        .contains("dcos-01");
+      cy.get(":nth-child(2) > .task-table-column-host-address").contains(
+        "dcos-03"
+      );
+      cy.get(":nth-child(3) > .task-table-column-host-address").contains(
+        "dcos-02"
+      );
+      cy.get(":nth-child(4) > .task-table-column-host-address").contains(
+        "dcos-01"
+      );
     });
 
     it("sorts DESC by region", function() {
@@ -241,15 +266,15 @@ describe("Tasks Table", function() {
 
       cy.get("th.task-table-column-region-address").click();
 
-      cy
-        .get(":nth-child(2) > .task-table-column-region-address")
-        .contains("ap-northeast-1");
-      cy
-        .get(":nth-child(3) > .task-table-column-region-address")
-        .contains("eu-central-1");
-      cy
-        .get(":nth-child(4) > .task-table-column-region-address")
-        .contains("eu-central-1");
+      cy.get(":nth-child(2) > .task-table-column-region-address").contains(
+        "ap-northeast-1"
+      );
+      cy.get(":nth-child(3) > .task-table-column-region-address").contains(
+        "eu-central-1"
+      );
+      cy.get(":nth-child(4) > .task-table-column-region-address").contains(
+        "eu-central-1"
+      );
     });
 
     it("sorts ASC by region", function() {
@@ -258,15 +283,15 @@ describe("Tasks Table", function() {
       cy.get("th.task-table-column-region-address").click();
       cy.get("th.task-table-column-region-address").click();
 
-      cy
-        .get(":nth-child(2) > .task-table-column-region-address")
-        .contains("eu-central-1");
-      cy
-        .get(":nth-child(3) > .task-table-column-region-address")
-        .contains("eu-central-1");
-      cy
-        .get(":nth-child(4) > .task-table-column-region-address")
-        .contains("ap-northeast-1");
+      cy.get(":nth-child(2) > .task-table-column-region-address").contains(
+        "eu-central-1"
+      );
+      cy.get(":nth-child(3) > .task-table-column-region-address").contains(
+        "eu-central-1"
+      );
+      cy.get(":nth-child(4) > .task-table-column-region-address").contains(
+        "ap-northeast-1"
+      );
     });
 
     it("sorts DESC by zone", function() {
@@ -274,15 +299,15 @@ describe("Tasks Table", function() {
 
       cy.get("th.task-table-column-zone-address").click();
 
-      cy
-        .get(":nth-child(2) > .task-table-column-zone-address")
-        .contains("ap-northeast-1a");
-      cy
-        .get(":nth-child(3) > .task-table-column-zone-address")
-        .contains("eu-central-1b");
-      cy
-        .get(":nth-child(4) > .task-table-column-zone-address")
-        .contains("eu-central-1c");
+      cy.get(":nth-child(2) > .task-table-column-zone-address").contains(
+        "ap-northeast-1a"
+      );
+      cy.get(":nth-child(3) > .task-table-column-zone-address").contains(
+        "eu-central-1b"
+      );
+      cy.get(":nth-child(4) > .task-table-column-zone-address").contains(
+        "eu-central-1c"
+      );
     });
 
     it("sorts ASC by zone", function() {
@@ -290,15 +315,15 @@ describe("Tasks Table", function() {
 
       cy.get("th.task-table-column-zone-address").click();
       cy.get("th.task-table-column-zone-address").click();
-      cy
-        .get(":nth-child(2) > .task-table-column-zone-address")
-        .contains("eu-central-1c");
-      cy
-        .get(":nth-child(3) > .task-table-column-zone-address")
-        .contains("eu-central-1b");
-      cy
-        .get(":nth-child(4) > .task-table-column-zone-address")
-        .contains("ap-northeast-1a");
+      cy.get(":nth-child(2) > .task-table-column-zone-address").contains(
+        "eu-central-1c"
+      );
+      cy.get(":nth-child(3) > .task-table-column-zone-address").contains(
+        "eu-central-1b"
+      );
+      cy.get(":nth-child(4) > .task-table-column-zone-address").contains(
+        "ap-northeast-1a"
+      );
     });
   });
 });

--- a/tests/pages/services/TasksTable-cy.js
+++ b/tests/pages/services/TasksTable-cy.js
@@ -60,6 +60,15 @@ describe("Tasks Table", function() {
     it("shows an error log", function() {
       cy.contains("hello world error log").should("be.visible");
     });
+
+    it("shows an error for the missing stdout log", function() {
+      cy.contains("Output").click();
+      cy.wait(500);
+
+      cy.contains("cannot retrieve the requested information").should(
+        "be.visible"
+      );
+    });
   });
 
   context("For a Service", function() {


### PR DESCRIPTION
## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

Look at a task and go to Log. Now open the network tab and search for "files/read". Block that URL. Reload. See an error message instead of infinite loading.


## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- Decided to use the very same error page for both errors as the origin of this issue is unclear in both occasions.
- Decided to directly show the error, might lead to blinking if it's first not there and then there, but this is really an upstream bug (if it even exists) and I am willing to do this tradeoff

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

None

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

Not so interesting here 🤷‍♂️ 
