### PR TITLE
[1.11] Clarify resource totals on pod instances table

### DIFF
--- a/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
+++ b/plugins/services/src/js/containers/pod-instances/PodInstancesTable.js
@@ -234,12 +234,13 @@ class PodInstancesTable extends React.Component {
 
   getContainersWithResources(podSpec, containers, agentAddress) {
     const children = containers.map(function(container) {
-      let containerResources = container.getResources();
+      const containerResources = container.getResources();
 
       // TODO: Remove the following 4 lines when DCOS-10098 is addressed
+      let containerSpecResources = containerResources;
       const containerSpec = podSpec.getContainerSpec(container.name);
       if (containerSpec) {
-        containerResources = containerSpec.resources;
+        containerSpecResources = containerSpec.resources;
       }
 
       const addressComponents = container
@@ -266,7 +267,9 @@ class PodInstancesTable extends React.Component {
         cpus: containerResources.cpus,
         mem: containerResources.mem,
         updated: container.getLastUpdated(),
-        version: ""
+        version: "",
+        containerSpecResources,
+        isHistoricalInstance: container.isHistoricalInstance
       };
     });
 
@@ -307,7 +310,8 @@ class PodInstancesTable extends React.Component {
         updated: instance.getLastUpdated(),
         status: instance.getInstanceStatus(),
         version: podSpec.getVersion(),
-        children
+        children,
+        podSpec
       };
     });
   }
@@ -449,9 +453,33 @@ class PodInstancesTable extends React.Component {
   }
 
   renderColumnResource(prop, row, rowOptions = {}) {
+    let tooltipContent;
+    if (rowOptions.hasChildren) {
+      const executorResource = row.podSpec && row.podSpec.executorResources
+        ? row.podSpec.executorResources[prop] || 0
+        : 0;
+      const childResources = row.children
+        .filter(child => !child.isHistoricalInstance)
+        .reduce((sum, current) => sum + (current[prop] || 0), 0);
+      tooltipContent = `Containers: ${Units.formatResource(prop, childResources)}, Executor: ${Units.formatResource(prop, executorResource)}`;
+    } else {
+      const activeResource = row.isHistoricalInstance ? 0 : row[prop] || 0;
+      const totalResource = row.containerSpecResources[prop] || 0;
+      tooltipContent = `Using ${activeResource}/${Units.formatResource(prop, totalResource)}`;
+    }
+
     return this.renderWithClickHandler(
       rowOptions,
-      <span>{Units.formatResource(prop, row[prop])}</span>
+      <Tooltip anchor="center" content={tooltipContent}>
+        <span>
+          {Units.formatResource(
+            prop,
+            row.containerSpecResources
+              ? row.containerSpecResources[prop] || 0
+              : row[prop]
+          )}
+        </span>
+      </Tooltip>
     );
   }
 

--- a/plugins/services/src/js/utils/PodUtil.js
+++ b/plugins/services/src/js/utils/PodUtil.js
@@ -84,7 +84,9 @@ var PodUtil = {
 
       let combinedContainers = [].concat(
         podInstance.containers,
-        historicalInstance.containers
+        historicalInstance.containers.map(container =>
+          Object.assign({}, container, { isHistoricalInstance: true })
+        )
       );
 
       // Filter combined container list to remove potential duplicates

--- a/plugins/services/src/js/utils/__tests__/PodUtil-test.js
+++ b/plugins/services/src/js/utils/__tests__/PodUtil-test.js
@@ -110,7 +110,9 @@ describe("PodUtil", function() {
       expect(instances.getItems().length).toEqual(1);
       expect(instances.getItems()[0].getContainers().length).toEqual(3);
       expect(instances.getItems()[0].getContainers()[2].get()).toEqual(
-        historicalInstances[0].containers[0]
+        Object.assign(historicalInstances[0].containers[0], {
+          isHistoricalInstance: true
+        })
       );
     });
 


### PR DESCRIPTION
Backport changes that clarify to users what the breakdown of the resources is on the pod instances table.

Closes DCOS-42365.

## Testing

- Run a service from JSON config.
```
{
"id": "/podtest",
"version": "2018-09-06T16:24:51.764Z",
"containers": [
{
"name": "container-1",
"resources": {
"cpus": 0.1,
"mem": 64,
"disk": 0
},
"image": {
"kind": "DOCKER",
"id": "alpine"
},
"exec": {
"command": {
"shell": "sleep 100;"
}
}
},
{
"name": "container-2",
"resources": {
"cpus": 0.1,
"mem": 64,
"disk": 0
},
"image": {
"kind": "DOCKER",
"id": "alpine"
},
"exec": {
"command": {
"shell": "sleep 10000;"
}
}
}
],
"networks": [
{
"mode": "host"
}
],
"scaling": {
"instances": 1,
"kind": "fixed"
},
"scheduling": {
"placement": {
"constraints": []
}
},
"executorResources": {
"cpus": 0.1,
"mem": 32,
"disk": 10
},
"volumes": [],
"fetch": []
}
```
- Go to services, click on the service you just started, hover over the resource cells on the parent (expandable) row. They should give breakdown of resources being used by containers and executor resources.
- Expand the instance row. Hover again over the resource cells in the rows. They should indicate what the container is using compared to what's allocated. (Using this config, when the task is complete, the used resources should be 0).

## Trade-offs

See #3305 

