### PR TITLE
DCOS-42348: Show error page when the log file won't load

### DIFF
--- a/plugins/services/src/js/components/MesosLogContainer.js
+++ b/plugins/services/src/js/components/MesosLogContainer.js
@@ -15,7 +15,9 @@ const METHODS_TO_BIND = [
   "handleGoToWorkingDirectory",
   "handleFetchPreviousLog",
   "onMesosLogStoreError",
-  "onMesosLogStoreSuccess"
+  "onMesosLogStoreSuccess",
+  "onMesosLogStoreOffsetError",
+  "onMesosLogStoreOffsetSuccess"
 ];
 
 class MesosLogContainer extends mixin(StoreMixin) {
@@ -27,12 +29,13 @@ class MesosLogContainer extends mixin(StoreMixin) {
       fullLog: null,
       isFetchingPrevious: false,
       isLoading: true,
-      hasLoadingError: 0
+      hasLoadingError: 0,
+      hasOffsetLoadingError: false
     };
 
     this.store_listeners = [
       {
-        events: ["success", "error"],
+        events: ["success", "error", "offsetSuccess", "offsetError"],
         name: "mesosLog",
         suppressUpdate: true
       }
@@ -97,6 +100,7 @@ class MesosLogContainer extends mixin(StoreMixin) {
     const stateToCheck = [
       "direction",
       "hasLoadingError",
+      "hasOffsetLoadingError",
       "isFetchingPrevious",
       "isLoading",
       "fullLog" // Check fullLog at the end, as this could be a long string
@@ -127,6 +131,18 @@ class MesosLogContainer extends mixin(StoreMixin) {
     this.setState({
       hasLoadingError: this.state.hasLoadingError + 1,
       isFetchingPrevious: false
+    });
+  }
+
+  onMesosLogStoreOffsetError() {
+    this.setState({
+      hasOffsetLoadingError: true
+    });
+  }
+
+  onMesosLogStoreOffsetSuccess() {
+    this.setState({
+      hasOffsetLoadingError: false
     });
   }
 
@@ -213,9 +229,9 @@ class MesosLogContainer extends mixin(StoreMixin) {
   }
 
   render() {
-    const { hasLoadingError, isLoading } = this.state;
+    const { hasLoadingError, isLoading, hasOffsetLoadingError } = this.state;
 
-    if (hasLoadingError >= 3) {
+    if (hasLoadingError >= 3 || hasOffsetLoadingError) {
       return this.getErrorScreen();
     }
 

--- a/plugins/services/src/js/stores/MesosLogStore.js
+++ b/plugins/services/src/js/stores/MesosLogStore.js
@@ -37,7 +37,9 @@ class MesosLogStore extends BaseStore {
       storeID: this.storeID,
       events: {
         success: MESOS_LOG_CHANGE,
-        error: MESOS_LOG_REQUEST_ERROR
+        error: MESOS_LOG_REQUEST_ERROR,
+        offsetSuccess: MESOS_INITIALIZE_LOG_CHANGE,
+        offsetError: MESOS_INITIALIZE_LOG_REQUEST_ERROR
       },
       unmountWhen() {
         return true;

--- a/tests/_fixtures/1-service-with-executor-task/files-read.json
+++ b/tests/_fixtures/1-service-with-executor-task/files-read.json
@@ -1,0 +1,5 @@
+{
+  "data":
+    "Preparing rootfs at /var/lib/mesos/slave/provisioner/containers/677d3da3-e4cf-4c56-9013-4247589dd2a1/containers/e01a6998-93cd-4474-b9a9-baa57088f621/backends/overlay/rootfses/88e448d1-3d9d-4f64-9451-e0aec4b043ae\nMarked '/' as rslave\nhello world error log\n",
+  "offset": 0
+}

--- a/tests/_support/index.js
+++ b/tests/_support/index.js
@@ -196,6 +196,17 @@ Cypress.Commands.add("configureCluster", function(configuration) {
         /agent\/(.*)?\/files\/browse/,
         "fx:1-service-with-executor-task/browse"
       )
+      .route(
+        /agent\/.*\/files\/read.*\/stderr/,
+        "fx:1-service-with-executor-task/files-read"
+      )
+      .route(
+        /agent\/.*\/files\/read.*\/stdout/,
+        {},
+        {
+          status: 404
+        }
+      )
       .route(/dcos-version/, "fx:dcos/dcos-version")
       .route(
         /history\/minute/,

--- a/tests/pages/services/TasksTable-cy.js
+++ b/tests/pages/services/TasksTable-cy.js
@@ -36,15 +36,6 @@ describe("Tasks Table", function() {
           .contains("jre1.7.0_76");
       });
     });
-
-    it("shows an error for the missing stdout log", function() {
-      cy.contains("Output").click();
-      cy.wait(500);
-
-      cy.contains("cannot retrieve the requested information").should(
-        "be.visible"
-      );
-    });
   });
 
   context("displays logs", function() {
@@ -69,6 +60,15 @@ describe("Tasks Table", function() {
 
     it("shows an error log", function() {
       cy.contains("hello world error log").should("be.visible");
+    });
+
+    it("shows an error for the missing stdout log", function() {
+      cy.contains("Output").click();
+      cy.wait(500);
+
+      cy.contains("Cannot Connect With The Server").should(
+        "be.visible"
+      );
     });
   });
 

--- a/tests/pages/services/TasksTable-cy.js
+++ b/tests/pages/services/TasksTable-cy.js
@@ -36,6 +36,15 @@ describe("Tasks Table", function() {
           .contains("jre1.7.0_76");
       });
     });
+
+    it("shows an error for the missing stdout log", function() {
+      cy.contains("Output").click();
+      cy.wait(500);
+
+      cy.contains("cannot retrieve the requested information").should(
+        "be.visible"
+      );
+    });
   });
 
   context("For a Service", function() {

--- a/tests/pages/services/TasksTable-cy.js
+++ b/tests/pages/services/TasksTable-cy.js
@@ -47,6 +47,31 @@ describe("Tasks Table", function() {
     });
   });
 
+  context("displays logs", function() {
+    beforeEach(function() {
+      cy.configureCluster({
+        mesos: "1-service-with-executor-task",
+        nodeHealth: true
+      });
+
+      cy.visitUrl({
+        url: "/services/detail/%2Fcassandra/tasks/server-0_10a"
+      });
+      cy.get(".page-header-navigation .menu-tabbed-item")
+        .contains("Logs")
+        .click();
+    });
+
+    it("lets you switch between Error and Output", function() {
+      cy.contains("Error").should("be.visible");
+      cy.contains("Output").should("be.visible");
+    });
+
+    it("shows an error log", function() {
+      cy.contains("hello world error log").should("be.visible");
+    });
+  });
+
   context("For a Service", function() {
     beforeEach(function() {
       cy.configureCluster({


### PR DESCRIPTION
## Testing

<!--
What is needed to test the changes? e.g. specific cluster, service definitions
How can one see the result of your work? e.g. configurations, URLs
-->

Look at a task and go to Log. Now open the network tab and search for "files/read". Block that URL. Reload. See an error message instead of infinite loading.


## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

- Decided to use the very same error page for both errors as the origin of this issue is unclear in both occasions.
- Decided to directly show the error, might lead to blinking if it's first not there and then there, but this is really an upstream bug (if it even exists) and I am willing to do this tradeoff

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

None

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

Not so interesting here 🤷‍♂️ 
