### PR TITLE
DCOS-42394: Fix error message for environment variables

### DIFF
--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -66,9 +66,7 @@ class EnvironmentFormSection extends Component {
                   value={env.key || ""}
                 />
               </FieldAutofocus>
-              <FieldError>
-                An environment variable needs to contain at least a key.
-              </FieldError>
+              <FieldError>The key cannot be empty.</FieldError>
               <span className="emphasis form-colon">:</span>
             </FormGroup>
             <FormGroup

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1467,9 +1467,7 @@ describe("Service Form Modal", function() {
             .find('.form-control[name="env.0.value"]')
             .type("value");
 
-          cy.get("@tabView").contains(
-            "An environment variable needs to contain at least a key."
-          );
+          cy.get("@tabView").contains("The key cannot be empty.");
         });
       });
 


### PR DESCRIPTION
Update error message when a environment variable has a value but no key

Closes https://jira.mesosphere.com/browse/DCOS-42394

Relevant discussion: https://github.com/dcos/dcos-ui/pull/3298#issuecomment-422834336

## Testing
Click on Services Tab
Click `+` or `Run a Service` to add a new service
Click on Single Container
Click on Environment
Click on `Add Environment Variable`
Enter a `Value` without entering `Key`
Verify that there is an error message and it says "The key cannot be empty."
Test the same thing for a Multi-Container

## Trade-offs
None

## Dependencies
None

## Screenshots

### Before
![screenshot from 2018-09-25 14-46-17](https://user-images.githubusercontent.com/40791275/46013061-bc06e100-c0d3-11e8-90d8-2790f99a9d7f.png)

### After
![screenshot from 2018-09-25 14-44-56](https://user-images.githubusercontent.com/40791275/46013056-b4dfd300-c0d3-11e8-8ae5-c0e7e9579def.png)
