### PR TITLE
DCOS-42395: Fix error message for labels

### DIFF
--- a/plugins/services/src/js/components/forms/EnvironmentFormSection.js
+++ b/plugins/services/src/js/components/forms/EnvironmentFormSection.js
@@ -137,7 +137,7 @@ class EnvironmentFormSection extends Component {
                 value={label.key || ""}
               />
             </FieldAutofocus>
-            <FieldError>A label needs to contain at least a key.</FieldError>
+            <FieldError>The key cannot be empty.</FieldError>
             <span className="emphasis form-colon">:</span>
           </FormGroup>
           <FormGroup

--- a/tests/pages/services/ServiceFormModal-cy.js
+++ b/tests/pages/services/ServiceFormModal-cy.js
@@ -1508,9 +1508,7 @@ describe("Service Form Modal", function() {
           cy.get("@tabView")
             .find('.form-control[name="labels.0.value"]')
             .type("value");
-          cy.get("@tabView").contains(
-            "A label needs to contain at least a key."
-          );
+          cy.get("@tabView").contains("The key cannot be empty.");
         });
       });
     });


### PR DESCRIPTION
Update error message when a environment label has a value but no key

Closes https://jira.mesosphere.com/browse/DCOS-42395

Relevant discussion: https://github.com/dcos/dcos-ui/pull/3298#issuecomment-422834336

## Testing
Click on Services Tab
Click `+` or `Run a Service` to add a new service
Click on Single Container
Click on Environment
Click on `Add Label`
Enter a `Value` without entering `Key`
Verify that there is an error message and it says "The key cannot be empty."
Test the same thing for a Multi-Container

## Trade-offs
None

## Dependencies
None

## Screenshots

### Before
![screenshot from 2018-09-25 15-10-30](https://user-images.githubusercontent.com/40791275/46013909-418b9080-c0d6-11e8-8662-1719e006b8e7.png)

### After
![screenshot from 2018-09-25 15-07-44](https://user-images.githubusercontent.com/40791275/46013918-46504480-c0d6-11e8-9628-aef062cc4dc2.png)
