### PR TITLE
DCOS-38653: fix ts file linting in githooks

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -12,6 +12,7 @@ title "Run pre-commit hook..."
 # Get a list of staged JavaScript and Less files
 staged_javascript_files=$(get_staged_files_with_name '*.js');
 staged_less_files=$(get_staged_files_with_name '*.less');
+staged_typescript_files=$(get_staged_files_with_name '*.ts*');
 
 # Validate staged tests
 if [ -n "${staged_javascript_files}" ]
@@ -46,6 +47,13 @@ then
   header "Lint staged Less files..."
   npm run stylelint --silent -- ${staged_less_files} || exit $?
   info "Staged Less looks good"
+fi
+
+if [ -n "${staged_typescript_files}" ]
+then
+  header "Lint staged TypeScript files..."
+  npm run tslint --silent -- ${staged_typescript_files} || exit $?
+  info "Staged TypeScript looks good"
 fi
 
 # Test staged JavaScript files


### PR DESCRIPTION
Update pre-commit script to lint typescript files

Closes https://jira.mesosphere.com/browse/DCOS-38653

## Testing
Open a test branch
Open a `.ts` file, a `.tsx` file and a `.d.ts` file from the project
Make some linting errors like adding a whitespace at the end of a line
Try to commit
Verify that you can't and the linter is working

## Trade-offs
1. The script test for `.ts*` files to test both `.ts` and `.tsx` which means that if we have `.tsj` file or something like that it will also test them.
2. This will test the `d.ts` files which are otherwise not test when we run `npm run lint`, I think we should decide if we want to lint them everywhere or nowhere (I would vote for everywhere).

## Dependencies
None.

## Screenshots
![screenshot from 2018-09-28 18-23-29](https://user-images.githubusercontent.com/40791275/46220148-f4b3ee00-c351-11e8-87e2-876203e1c6bd.png)

