### PR TITLE
 DCOS-40640: reuse Cypress cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,6 @@ pipeline {
     stage("Build") {
       steps {
         sh "npm --unsafe-perm install"
-        sh "npx cypress install"
         sh "npm run build"
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,7 @@ pipeline {
     stage("Build") {
       steps {
         sh "npm --unsafe-perm install"
+        sh "npx cypress install"
         sh "npm run build"
       }
     }

--- a/system-tests/_scripts/sandbox-setup.sh
+++ b/system-tests/_scripts/sandbox-setup.sh
@@ -4,4 +4,6 @@ SCRIPT=`realpath $0`
 SCRIPT_PATH=`dirname $SCRIPT`
 CYPRESS=`realpath "${SCRIPT_PATH}/../../node_modules/cypress/bin/cypress"`
 
-ln -s $CYPRESS "$TMPDIR/cypress"
+cp -R "/root/.cache" "$TMPDIR/../"
+mkdir "$TMPDIR/bin"
+ln -s $CYPRESS "$TMPDIR/bin/cypress"

--- a/system-tests/_scripts/setup.sh
+++ b/system-tests/_scripts/setup.sh
@@ -12,9 +12,7 @@ fi
 chmod +x .env/bin/dcos
 
 # Symlink cypress in isolation so we don't need to install it every time
-mv "$TMPDIR/cypress" .env/bin/cypress
-
-cypress install
+mv "$TMPDIR/bin/cypress" .env/bin/cypress
 
 # Configure DC/OS CLI
 CONFIG_DIR=~/.dcos


### PR DESCRIPTION
With this PR we will be re-using cached Cypress installation that should reduce the build time.

Closes DCOS-40640

## Testing

CI should pass. 
Go inside the build and make sure we're not installing cypress for every set of tests.

This is what should not be present in the logs
<img width="866" alt="screenshot 2018-10-01 at 18 17 48" src="https://user-images.githubusercontent.com/186223/46301335-5371a580-c5a6-11e8-91fc-89a145e36cdb.png">

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->
