### PR TITLE
DCOS-43077: Wrap text resources in the app (src/js/components)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ src/resources/raml
 .env
 locale/_build/
 locale/*/messages.js
+.dcos-ui-plugins-private

--- a/.linguirc
+++ b/.linguirc
@@ -6,7 +6,8 @@
   "localeDir": "./locale",
   "srcPathDirs": [
       "./src",
-      "./plugins"
+      "./plugins",
+      "./.dcos-ui-plugins-private"
   ],
   "srcPathIgnorePatterns": [
       "node_modules/",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -449,6 +449,15 @@
       ]
     ]
   },
+  "Looks Like Something is Wrong": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/modals/ErrorModal.js",
+        24
+      ]
+    ]
+  },
   "Media": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -333,6 +333,15 @@
       ]
     ]
   },
+  "Media": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/ImageViewer.js",
+        71
+      ]
+    ]
+  },
   "Overview": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -418,6 +418,15 @@
       ]
     ]
   },
+  "Services": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/NestedServiceLinks.js",
+        111
+      ]
+    ]
+  },
   "Showing {currentLength} of {totalLength} {name}": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -111,6 +111,15 @@
       ]
     ]
   },
+  "An error has occurred": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/ServerErrorModal.js",
+        107
+      ]
+    ]
+  },
   "An error has occurred.": {
     "translation": "",
     "origin": [
@@ -144,6 +153,10 @@
       [
         "src/js/components/Modals.js",
         129
+      ],
+      [
+        "src/js/components/ServerErrorModal.js",
+        75
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -66,6 +66,15 @@
       ]
     ]
   },
+  "Cluster": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/ClusterHeader.js",
+        59
+      ]
+    ]
+  },
   "Community packages are unverified and unreviewed content from the community.": {
     "translation": "",
     "origin": [
@@ -119,6 +128,15 @@
       ]
     ]
   },
+  "Documentation": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/ClusterHeader.js",
+        136
+      ]
+    ]
+  },
   "Download Snapshot": {
     "translation": "",
     "origin": [
@@ -134,6 +152,15 @@
       [
         "src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js",
         28
+      ]
+    ]
+  },
+  "Install CLI": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/ClusterHeader.js",
+        143
       ]
     ]
   },
@@ -211,6 +238,10 @@
     "translation": "",
     "origin": [
       [
+        "src/js/components/ClusterHeader.js",
+        114
+      ],
+      [
         "src/js/pages/system/OverviewDetailTab.js",
         43
       ]
@@ -267,6 +298,15 @@
       [
         "src/js/pages/system/units-health-node-detail/NodeInfoPanel.js",
         25
+      ]
+    ]
+  },
+  "Support": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/ClusterHeader.js",
+        131
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -26,12 +26,30 @@
       ]
     ]
   },
+  "<0>See documentation</0>.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        292
+      ]
+    ]
+  },
   "Access denied": {
     "translation": "",
     "origin": [
       [
         "src/js/components/AccessDeniedPage.js",
         45
+      ]
+    ]
+  },
+  "Actions (<0>Allow All</0>)": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        248
       ]
     ]
   },
@@ -44,12 +62,65 @@
       ]
     ]
   },
+  "Add Constraint": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementFormPartial.js",
+        108
+      ]
+    ]
+  },
+  "Add Directory": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryFormModal.js",
+        102
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryFormModal.js",
+        127
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        345
+      ]
+    ]
+  },
+  "Add External Load Balancer": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        295
+      ]
+    ]
+  },
+  "Add Identity Provider": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProvidersModal.js",
+        139
+      ]
+    ]
+  },
   "Add Package Repository": {
     "translation": "",
     "origin": [
       [
         "src/js/pages/catalog/PackagesTab.js",
         63
+      ]
+    ]
+  },
+  "Add Permission": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AdvancedACLsTab.js",
+        329
       ]
     ]
   },
@@ -62,12 +133,70 @@
       ]
     ]
   },
+  "Add Provider": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProvidersModal.js",
+        78
+      ]
+    ]
+  },
+  "Add Secret": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/ServiceCreate.js",
+        224
+      ]
+    ]
+  },
+  "Add Service": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        300
+      ]
+    ]
+  },
+  "Add Service to External Load Balancer": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerAddServiceFormModal.js",
+        137
+      ]
+    ]
+  },
+  "Add Service to Load Balancer": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        220
+      ]
+    ]
+  },
   "Add User to Cluster": {
     "translation": "",
     "origin": [
       [
         "src/js/components/modals/UserFormModal.js",
         113
+      ]
+    ]
+  },
+  "Advanced Constraints": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PodPlacementConfigSection.js",
+        81
+      ],
+      [
+        ".dcos-ui-plugins-private/placement/components/ServicePlacementConfigSection.js",
+        72
       ]
     ]
   },
@@ -81,6 +210,15 @@
       [
         "src/js/components/UnitHealthDropdown.js",
         13
+      ]
+    ]
+  },
+  "All stats are for the past minute": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.js",
+        153
       ]
     ]
   },
@@ -111,6 +249,24 @@
       ]
     ]
   },
+  "App Reach": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPsTable.js",
+        52
+      ]
+    ]
+  },
+  "Application Reachability": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendsTable.js",
+        79
+      ]
+    ]
+  },
   "Apply": {
     "translation": "",
     "origin": [
@@ -125,7 +281,71 @@
     "origin": [
       [
         "src/js/components/FrameworkConfiguration.js",
-        357
+        356
+      ]
+    ]
+  },
+  "Are you sure?": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/pages/AuthProviderDetailPage.js",
+        285
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        385
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostDetail.js",
+        293
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountDetailPage.js",
+        272
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountGroupTable.js",
+        173
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupDetailPage.js",
+        267
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupMemberTable.js",
+        207
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretActionsModal.js",
+        58
+      ]
+    ]
+  },
+  "Available Agents": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/LoadBalancersTable.js",
+        42
+      ]
+    ]
+  },
+  "Back": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProvidersModal.js",
+        103
+      ]
+    ]
+  },
+  "Bootstrap Config": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/bootstrap-config/components/BootstrapConfigHashMap.js",
+        78
       ]
     ]
   },
@@ -138,12 +358,33 @@
       ]
     ]
   },
+  "Callback URL": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProviderDetailTab.js",
+        73
+      ]
+    ]
+  },
   "Cancel": {
     "translation": "",
     "origin": [
       [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProvidersModal.js",
+        92
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryFormModal.js",
+        114
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretFormModal.js",
+        167
+      ],
+      [
         "src/js/components/FrameworkConfiguration.js",
-        350
+        349
       ]
     ]
   },
@@ -156,6 +397,15 @@
       ],
       [
         "src/js/pages/catalog/PackagesTab.js",
+        35
+      ]
+    ]
+  },
+  "Certificates": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/pages/CertificatesPage.js",
         35
       ]
     ]
@@ -191,6 +441,18 @@
     "translation": "",
     "origin": [
       [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProvidersModal.js",
+        115
+      ],
+      [
+        ".dcos-ui-plugins-private/cluster-linking/components/ClusterLinkingModal.js",
+        22
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        532
+      ],
+      [
         "src/js/components/Modals.js",
         129
       ],
@@ -203,6 +465,10 @@
   "Cluster": {
     "translation": "",
     "origin": [
+      [
+        ".dcos-ui-plugins-private/auth/components/AuthenticatedClusterDropdown.js",
+        61
+      ],
       [
         "src/js/components/ClusterHeader.js",
         59
@@ -244,12 +510,88 @@
       ]
     ]
   },
+  "Container Path": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSInput.js",
+        41
+      ],
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSVolumeConfig.js",
+        78
+      ]
+    ]
+  },
+  "Containers": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSInput.js",
+        32
+      ]
+    ]
+  },
+  "Control where your app runs with advanced rules and constraint attributes": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementFormPartial.js",
+        90
+      ]
+    ]
+  },
   "Copy and paste the code snippet into the terminal:": {
     "translation": "",
     "origin": [
       [
         "src/js/components/modals/CliInstallModal.js",
         94
+      ]
+    ]
+  },
+  "Create External Load Balancer": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        134
+      ]
+    ]
+  },
+  "Create New Group": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupFormModal.js",
+        84
+      ]
+    ]
+  },
+  "Create New User": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/hooks.js",
+        134
+      ]
+    ]
+  },
+  "Create an external load balancer for your services.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        147
+      ]
+    ]
+  },
+  "Created": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
+        229
       ]
     ]
   },
@@ -262,12 +604,21 @@
       ]
     ]
   },
+  "Currently Deploying Package": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        162
+      ]
+    ]
+  },
   "DC/OS UI cannot retrieve the requested information at this moment.": {
     "translation": "",
     "origin": [
       [
         "src/js/components/RequestErrorMsg.js",
-        53
+        50
       ]
     ]
   },
@@ -280,12 +631,56 @@
       ]
     ]
   },
+  "Define the permission in a string format. If the permission also includes an action, specify the action that should be allowed. Refer to <0>the documentation</0> for more details.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        435
+      ]
+    ]
+  },
+  "Delete": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        186
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostDetail.js",
+        137
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryActionButtons.js",
+        136
+      ]
+    ]
+  },
+  "Delete Action": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AdvancedACLsTab.js",
+        236
+      ]
+    ]
+  },
+  "Description": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
+        207
+      ]
+    ]
+  },
   "Discard": {
     "translation": "",
     "origin": [
       [
         "src/js/components/FrameworkConfiguration.js",
-        352
+        351
       ]
     ]
   },
@@ -294,7 +689,7 @@
     "origin": [
       [
         "src/js/components/FrameworkConfiguration.js",
-        345
+        344
       ]
     ]
   },
@@ -304,6 +699,15 @@
       [
         "src/js/components/ClusterHeader.js",
         136
+      ]
+    ]
+  },
+  "Download": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProviderDetailTab.js",
+        85
       ]
     ]
   },
@@ -325,12 +729,143 @@
       ]
     ]
   },
+  "Edit": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        179
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryActionButtons.js",
+        130
+      ],
+      [
+        ".dcos-ui-plugins-private/placement/components/RegionConstraintsSection.js",
+        17
+      ],
+      [
+        ".dcos-ui-plugins-private/placement/components/ZoneConstraintsSection.js",
+        17
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/components/ServiceConfigSecretsSectionDisplay.js",
+        87
+      ]
+    ]
+  },
+  "Edit Directory": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryFormModal.js",
+        130
+      ]
+    ]
+  },
+  "Edit User": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/components/modals/UserEditFormModal.js",
+        123
+      ]
+    ]
+  },
   "Enter": {
     "translation": "",
     "origin": [
       [
         "src/js/components/modals/CliInstallModal.js",
         119
+      ]
+    ]
+  },
+  "EntityID": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProviderDetailTab.js",
+        91
+      ]
+    ]
+  },
+  "External": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/OrganizationTab.js",
+        162
+      ]
+    ]
+  },
+  "External LDAP Configuration": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        321
+      ]
+    ]
+  },
+  "Failure %": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/LoadBalancersTable.js",
+        45
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPsTable.js",
+        51
+      ]
+    ]
+  },
+  "Failures": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/LoadBalancersTable.js",
+        44
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendsTable.js",
+        77
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPsTable.js",
+        50
+      ]
+    ]
+  },
+  "For information and instructions on how to create virtual IPs see <0>networking documentation</0>.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.js",
+        89
+      ]
+    ]
+  },
+  "Group Search": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        178
+      ]
+    ]
+  },
+  "Groups": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupDetailPage.js",
+        34
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/pages/GroupsPage.js",
+        39
       ]
     ]
   },
@@ -343,6 +878,51 @@
       ]
     ]
   },
+  "Host Name": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostDetail.js",
+        247
+      ]
+    ]
+  },
+  "ID": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretFormModal.js",
+        197
+      ]
+    ]
+  },
+  "IP": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostDetail.js",
+        255
+      ]
+    ]
+  },
+  "IP Reach": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPsTable.js",
+        53
+      ]
+    ]
+  },
+  "IP Reachability": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendsTable.js",
+        80
+      ]
+    ]
+  },
   "IP Subnet": {
     "translation": "",
     "origin": [
@@ -352,12 +932,79 @@
       ]
     ]
   },
+  "IPs": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        355
+      ]
+    ]
+  },
+  "Identity Providers": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/pages/AuthProviderDetailPage.js",
+        41
+      ],
+      [
+        ".dcos-ui-plugins-private/auth-providers/pages/AuthProvidersTab.js",
+        35
+      ]
+    ]
+  },
+  "If left undefined this will run in your local region.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/RegionSelection.js",
+        97
+      ]
+    ]
+  },
+  "If you": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretActionsModal.js",
+        83
+      ]
+    ]
+  },
+  "Import LDAP Groups": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/modals/LDAPGroupFormModal.js",
+        174
+      ]
+    ]
+  },
+  "Import LDAP Users": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/components/modals/LDAPUserFormModal.js",
+        149
+      ]
+    ]
+  },
   "In Command Prompt, enter": {
     "translation": "",
     "origin": [
       [
         "src/js/components/modals/CliInstallModal.js",
         118
+      ]
+    ]
+  },
+  "Insert Permission String": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        555
       ]
     ]
   },
@@ -379,12 +1026,70 @@
       ]
     ]
   },
+  "Install {dcosLBPackageName}": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        175
+      ]
+    ]
+  },
+  "Install {dcosLBPackageName} to enable this capability.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        190
+      ]
+    ]
+  },
   "JSON Editor": {
     "translation": "",
     "origin": [
       [
         "src/js/components/FrameworkConfiguration.js",
-        171
+        170
+      ]
+    ]
+  },
+  "LDAP Directory": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        38
+      ]
+    ]
+  },
+  "License Expiration": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingExpirationRow.js",
+        66
+      ]
+    ]
+  },
+  "Link a cluster to switch between clusters.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
+        55
+      ]
+    ]
+  },
+  "Linked Clusters": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/cluster-linking/components/ClusterLinkingModal.js",
+        12
+      ],
+      [
+        ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
+        25
       ]
     ]
   },
@@ -394,6 +1099,15 @@
       [
         "src/js/components/AccessDeniedPage.js",
         32
+      ]
+    ]
+  },
+  "Login to your account": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth/components/LoginModal.js",
+        153
       ]
     ]
   },
@@ -428,6 +1142,26 @@
     "translation": "",
     "origin": [
       [
+        ".dcos-ui-plugins-private/dss/components/DSSInput.js",
+        109
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        337
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/LoadBalancersTable.js",
+        41
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendsTable.js",
+        75
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPsTable.js",
+        48
+      ],
+      [
         "src/js/constants/RepositoriesTableHeaderLabels.js",
         4
       ],
@@ -458,6 +1192,42 @@
       ]
     ]
   },
+  "No External Load Balancers": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        145
+      ]
+    ]
+  },
+  "No directory configured": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        335
+      ]
+    ]
+  },
+  "No linked clusters": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
+        53
+      ]
+    ]
+  },
+  "No networks detected": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.js",
+        87
+      ]
+    ]
+  },
   "No package repositories": {
     "translation": "",
     "origin": [
@@ -467,12 +1237,74 @@
       ]
     ]
   },
+  "No services found": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        230
+      ]
+    ]
+  },
   "No virtual networks detected": {
     "translation": "",
     "origin": [
       [
         "src/js/pages/network/VirtualNetworksTab.js",
         91
+      ]
+    ]
+  },
+  "Node Capacity": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingNodeCapacityRow.js",
+        93
+      ]
+    ]
+  },
+  "Not Applicable": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PodPlacementConfigSection.js",
+        51
+      ],
+      [
+        ".dcos-ui-plugins-private/placement/components/ServicePlacementConfigSection.js",
+        28
+      ]
+    ]
+  },
+  "Number of Agents": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        345
+      ]
+    ]
+  },
+  "Number of Zones": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/ZoneConstraintsSection.js",
+        32
+      ],
+      [
+        ".dcos-ui-plugins-private/placement/components/ZoneSelection.js",
+        23
+      ]
+    ]
+  },
+  "Number of zones to evenly distribute instances across.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/ZoneSelection.js",
+        35
       ]
     ]
   },
@@ -507,12 +1339,65 @@
       ]
     ]
   },
+  "P99 Latency": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/LoadBalancersTable.js",
+        47
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendsTable.js",
+        78
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPsTable.js",
+        54
+      ]
+    ]
+  },
+  "Package not installed": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        188
+      ]
+    ]
+  },
   "Page not found": {
     "translation": "",
     "origin": [
       [
         "src/js/pages/NotFoundPage.js",
         28
+      ]
+    ]
+  },
+  "Permission inherited from the <0>{0}</0> group.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AdvancedACLsTab.js",
+        218
+      ]
+    ]
+  },
+  "Placement": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementSection.js",
+        20
+      ]
+    ]
+  },
+  "Placement constraints control where apps run to allow optimization for either fault tolerance or locality.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementSection.js",
+        32
       ]
     ]
   },
@@ -525,12 +1410,73 @@
       ]
     ]
   },
+  "Profile Name": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSInput.js",
+        126
+      ],
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSVolumeConfig.js",
+        61
+      ]
+    ]
+  },
   "Public IP": {
     "translation": "",
     "origin": [
       [
         "src/js/pages/system/OverviewDetailTab.js",
         178
+      ]
+    ]
+  },
+  "Recommended": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/dss/components/VolumeMountTypesSelect.js",
+        17
+      ],
+      [
+        ".dcos-ui-plugins-private/dss/components/VolumeTypeSelect.js",
+        17
+      ]
+    ]
+  },
+  "Region": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/RegionConstraintsSection.js",
+        32
+      ],
+      [
+        ".dcos-ui-plugins-private/placement/components/RegionSelection.js",
+        84
+      ]
+    ]
+  },
+  "Remove": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountGroupTable.js",
+        159
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/groups/components/GroupMemberTable.js",
+        187
+      ]
+    ]
+  },
+  "Resource": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        481
       ]
     ]
   },
@@ -543,12 +1489,171 @@
       ]
     ]
   },
+  "SP Metadata": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProviderDetailTab.js",
+        81
+      ]
+    ]
+  },
+  "SSL/TLS Setting": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        249
+      ]
+    ]
+  },
+  "Save Configuration": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryFormModal.js",
+        105
+      ]
+    ]
+  },
+  "Secret": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/ServiceCreate.js",
+        90
+      ]
+    ]
+  },
+  "Secret Stores": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretStorePage.js",
+        23
+      ]
+    ]
+  },
+  "Secret store sealed": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SealedStoreAlert.js",
+        17
+      ]
+    ]
+  },
+  "Secrets": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/ServiceCreate.js",
+        197
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
+        34
+      ],
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretsPage.js",
+        55
+      ]
+    ]
+  },
+  "Security Mode": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/bootstrap-config/components/BootstrapConfigHashMap.js",
+        82
+      ]
+    ]
+  },
+  "Select a number of agents to allocate": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerFormModal.js",
+        116
+      ]
+    ]
+  },
+  "Select an identity provider to easily allow access to users.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/AuthProvidersModalButtonContents.js",
+        35
+      ]
+    ]
+  },
+  "Service": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostDetail.js",
+        263
+      ]
+    ]
+  },
+  "Service Accounts": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/components/ServiceAccountDetailPage.js",
+        116
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/pages/ServiceAccountsPage.js",
+        32
+      ]
+    ]
+  },
+  "Service Addresses": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendDetailPage.js",
+        41
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/LoadBalancingTabContent.js",
+        32
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPDetailPage.js",
+        33
+      ]
+    ]
+  },
   "Services": {
     "translation": "",
     "origin": [
       [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/LoadBalancersTable.js",
+        46
+      ],
+      [
         "src/js/components/NestedServiceLinks.js",
         111
+      ]
+    ]
+  },
+  "Set up an LDAP connection to avoid having to recreate your user accounts within DC/OS.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        337
+      ]
+    ]
+  },
+  "Set variables for each task your service launches. You can also use variables to expose Secrets. <0>Manage secrets here</0>. <1>Learn more about variables</1>.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/hooks.js",
+        363
       ]
     ]
   },
@@ -561,12 +1666,51 @@
       ]
     ]
   },
+  "Size (MiB)": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSInput.js",
+        142
+      ],
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSVolumeConfig.js",
+        93
+      ]
+    ]
+  },
+  "Store": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
+        218
+      ]
+    ]
+  },
   "Success!": {
     "translation": "",
     "origin": [
       [
         "src/js/pages/catalog/PackageDetailTab.js",
         398
+      ]
+    ]
+  },
+  "Successes": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/LoadBalancersTable.js",
+        43
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/BackendsTable.js",
+        76
+      ],
+      [
+        ".dcos-ui-plugins-private/networking/submodules/internal-load-balancing/components/VIPsTable.js",
+        49
       ]
     ]
   },
@@ -588,12 +1732,66 @@
       ]
     ]
   },
+  "Switch": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/cluster-linking/components/LinkedClustersTable.js",
+        82
+      ]
+    ]
+  },
+  "Switch Cluster": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/cluster-linking/components/ClusterLinkingModalTrigger.js",
+        45
+      ]
+    ]
+  },
+  "Test Connection": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryActionButtons.js",
+        142
+      ]
+    ]
+  },
+  "Test External Directory": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/components/DirectoryActionButtons.js",
+        152
+      ]
+    ]
+  },
+  "The contents of this secret store cannot be accessed until it is unsealed. See <0>instructions</0> on how to access sealed secret stores.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SealedStoreAlert.js",
+        19
+      ]
+    ]
+  },
   "The page you requested cannot be found. Check the address you provided, or head back to the <0>Dashboard</0>.": {
     "translation": "",
     "origin": [
       [
         "src/js/pages/NotFoundPage.js",
         30
+      ]
+    ]
+  },
+  "The secret cannot be empty.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/ServiceCreate.js",
+        100
       ]
     ]
   },
@@ -606,6 +1804,15 @@
       ]
     ]
   },
+  "There are no services associated with this load balancer.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        232
+      ]
+    ]
+  },
   "There is an error with your configuration": {
     "translation": "",
     "origin": [
@@ -615,12 +1822,48 @@
       ]
     ]
   },
+  "This action is irreversible and may break your cluster.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/service-accounts/components/ServiceAccountsActionsModal.js",
+        64
+      ]
+    ]
+  },
+  "This feature will be available once {dcosLBPackageName} finishes deploying.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        164
+      ]
+    ]
+  },
   "This package can only be installed using the CLI. See the <0>documentation</0>.": {
     "translation": "",
     "origin": [
       [
         "src/js/pages/catalog/PackageDetailTab.js",
         270
+      ]
+    ]
+  },
+  "To enable this feature please contact support via {slackLink} or send us an email at {supportLink}.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancersTab.js",
+        235
+      ]
+    ]
+  },
+  "To use a secret in an application, a user needs appropriate permissions.<0>More information</0>.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/ServiceCreate.js",
+        181
       ]
     ]
   },
@@ -642,9 +1885,22 @@
       ]
     ]
   },
+  "Unable to edit this Volume": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSInput.js",
+        74
+      ]
+    ]
+  },
   "Unable to edit {0}": {
     "translation": "",
     "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/PlacementSchemaField.js",
+        52
+      ],
       [
         "src/js/components/PlacementConstraintsSchemaField.js",
         31
@@ -660,9 +1916,71 @@
       ]
     ]
   },
+  "Upgrade": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingExpirationRow.js",
+        75
+      ]
+    ]
+  },
+  "Usage Logs": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/licensing/components/LicensingNodeCapacityRow.js",
+        78
+      ]
+    ]
+  },
+  "Use the form below to build your permission. For more information see the <0>documentation</0>. To bulk add permissions, <1>switch to advanced mode</1>.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        574
+      ]
+    ]
+  },
+  "Use the form below to manually enter or paste permissions. <0>Switch to permission builder</0> to add a single permission.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        564
+      ]
+    ]
+  },
+  "Use the<0>DC/OS Secret Store</0> to secure important values like private keys, API tokens, and database passwords.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/ServiceCreate.js",
+        207
+      ]
+    ]
+  },
+  "User Search": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/submodules/directories/pages/DirectoriesPage.js",
+        149
+      ]
+    ]
+  },
   "Users": {
     "translation": "",
     "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/AccountDetailPage.js",
+        162
+      ],
+      [
+        ".dcos-ui-plugins-private/organization/submodules/users/pages/UsersPage.js",
+        38
+      ],
       [
         "src/js/pages/system/OrganizationTab.js",
         54
@@ -673,12 +1991,43 @@
       ]
     ]
   },
+  "Value": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretFormModal.js",
+        225
+      ]
+    ]
+  },
+  "Variable name": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/ServiceCreate.js",
+        26
+      ]
+    ]
+  },
   "View Documentation": {
     "translation": "",
     "origin": [
       [
         "src/js/pages/system/units-health-node-detail/NodeInfoPanel.js",
         30
+      ]
+    ]
+  },
+  "Volume Type": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSInput.js",
+        95
+      ],
+      [
+        ".dcos-ui-plugins-private/dss/components/DSSVolumeConfig.js",
+        45
       ]
     ]
   },
@@ -718,12 +2067,30 @@
       ]
     ]
   },
-  "You can also join us on our <0>Slack channel</0> or send us an email at {supportLink}.": {
+  "You can also join us on our <0>Slack channel</0> or send us an email at <1>{0}</1>.": {
     "translation": "",
     "origin": [
       [
         "src/js/components/RequestErrorMsg.js",
-        16
+        12
+      ]
+    ]
+  },
+  "You can link a cluster via the DC/OS CLI. See {documentation} for complete instructions.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
+        44
+      ]
+    ]
+  },
+  "You do not have access to this resource. Please contact your {0} administrator or see <0>security documentation</0> for more information.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth/hooks.js",
+        181
       ]
     ]
   },
@@ -736,12 +2103,93 @@
       ]
     ]
   },
+  "You do not have permission to list this cluster's secrets.<0/>Please contact your super admin to learn more.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretsPage.js",
+        66
+      ]
+    ]
+  },
+  "You do not have permission to see this secret.<0/>Please contact your super admin to learn more.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/pages/SecretDetail.js",
+        64
+      ]
+    ]
+  },
   "You need at least one package repository with some packages to be able to install packages. For more <0>information on repositories</0>.": {
     "translation": "",
     "origin": [
       [
         "src/js/pages/catalog/PackagesTab.js",
         50
+      ]
+    ]
+  },
+  "any services that are making use of it will no longer be able to do so, and all history will be lost.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretActionsModal.js",
+        74
+      ]
+    ]
+  },
+  "any services that are making use of it will no longer be able to do so.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretActionsModal.js",
+        76
+      ]
+    ]
+  },
+  "documentation": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/cluster-linking/pages/LinkedClustersPage.js",
+        40
+      ]
+    ]
+  },
+  "or": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/auth-providers/components/LoginModalProviders.js",
+        113
+      ]
+    ]
+  },
+  "services will be able to access them.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretActionsModal.js",
+        78
+      ]
+    ]
+  },
+  "these secrets": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/secrets/components/SecretActionsModal.js",
+        70
+      ]
+    ]
+  },
+  "{0} ({1} available)": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/ExternalLoadBalancerDetail.js",
+        348
       ]
     ]
   },
@@ -760,6 +2208,33 @@
       [
         "src/js/pages/system/OverviewDetailTab.js",
         166
+      ]
+    ]
+  },
+  "{0} will be deleted.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/networking/submodules/external-load-balancing/components/VHostDetail.js",
+        187
+      ]
+    ]
+  },
+  "{content} <0>Learn more</0>.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/placement/components/LearnMoreTooltip.js",
+        10
+      ]
+    ]
+  },
+  "{errorMsg} Go to <0>insert permission string</0> to enter a permission manually.": {
+    "translation": "",
+    "origin": [
+      [
+        ".dcos-ui-plugins-private/organization/components/PermissionBuilderModal.js",
+        506
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -35,79 +35,21 @@
       ]
     ]
   },
-  "Add Package Repository": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/pages/catalog/PackagesTab.js",
-        63
-      ]
-    ]
-  },
-  "An Error Occurred": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/pages/catalog/PackagesTab.js",
-        147
-      ]
-    ]
-  },
-  "CLI Only Package": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/pages/catalog/PackageDetailTab.js",
-        269
-      ]
-    ]
-  },
-  "Cancel": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/components/FrameworkConfiguration.js",
-        345
-      ]
-    ]
-  },
-  "Catalog": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/pages/catalog/PackageDetailTab.js",
-        35
-      ],
-      [
-        "src/js/pages/catalog/PackagesTab.js",
-        35
-      ]
-    ]
-  },
-  "Certified": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/pages/catalog/PackagesTab.js",
-        200
-      ]
-    ]
-  },
-  "Certified packages are verified by Mesosphere for interoperability with DC/OS.": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/pages/catalog/PackagesTab.js",
-        203
-      ]
-    ]
-  },
   "Active": {
     "translation": "",
     "origin": [
       [
         "src/js/components/FrameworkConfigurationReviewScreen.js",
         67
+      ]
+    ]
+  },
+  "Add Package Repository": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        63
       ]
     ]
   },
@@ -139,6 +81,15 @@
       [
         "src/js/components/UnitHealthDropdown.js",
         13
+      ]
+    ]
+  },
+  "An Error Occurred": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        147
       ]
     ]
   },
@@ -174,7 +125,56 @@
     "origin": [
       [
         "src/js/components/FrameworkConfiguration.js",
-        354
+        357
+      ]
+    ]
+  },
+  "CLI Only Package": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        269
+      ]
+    ]
+  },
+  "Cancel": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        350
+      ]
+    ]
+  },
+  "Catalog": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        35
+      ],
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        35
+      ]
+    ]
+  },
+  "Certified": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        200
+      ]
+    ]
+  },
+  "Certified packages are verified by Mesosphere for interoperability with DC/OS.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackagesTab.js",
+        203
       ]
     ]
   },
@@ -235,33 +235,6 @@
       ]
     ]
   },
-  "Cryptographic Cluster ID": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/pages/system/OverviewDetailTab.js",
-        172
-      ]
-    ]
-  },
-  "Dashboard": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/pages/DashboardPage.js",
-        47
-      ]
-    ]
-  },
-  "Discard": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/components/FrameworkConfiguration.js",
-        347
-      ]
-    ]
-  },
   "Components Not Found": {
     "translation": "",
     "origin": [
@@ -280,6 +253,15 @@
       ]
     ]
   },
+  "Cryptographic Cluster ID": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/system/OverviewDetailTab.js",
+        172
+      ]
+    ]
+  },
   "DC/OS UI cannot retrieve the requested information at this moment.": {
     "translation": "",
     "origin": [
@@ -289,12 +271,30 @@
       ]
     ]
   },
+  "Dashboard": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/DashboardPage.js",
+        47
+      ]
+    ]
+  },
+  "Discard": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        352
+      ]
+    ]
+  },
   "Discard Changes?": {
     "translation": "",
     "origin": [
       [
         "src/js/components/FrameworkConfiguration.js",
-        342
+        345
       ]
     ]
   },
@@ -313,15 +313,6 @@
       [
         "src/js/pages/system/UnitsHealthTab.js",
         214
-      ]
-    ]
-  },
-  "IP Subnet": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js",
-        28
       ]
     ]
   },
@@ -349,6 +340,15 @@
       [
         "src/js/constants/UnitHealthStatus.js",
         18
+      ]
+    ]
+  },
+  "IP Subnet": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/network/virtual-network-detail/VirtualNetworkDetailsTab.js",
+        28
       ]
     ]
   },
@@ -384,7 +384,7 @@
     "origin": [
       [
         "src/js/components/FrameworkConfiguration.js",
-        169
+        171
       ]
     ]
   },
@@ -394,6 +394,33 @@
       [
         "src/js/components/AccessDeniedPage.js",
         32
+      ]
+    ]
+  },
+  "Looks Like Something is Wrong": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/modals/ErrorModal.js",
+        24
+      ]
+    ]
+  },
+  "Media": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/ImageViewer.js",
+        71
+      ]
+    ]
+  },
+  "N/A": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/constants/UnitHealthStatus.js",
+        39
       ]
     ]
   },
@@ -467,33 +494,6 @@
       ]
     ]
   },
-  "Looks Like Something is Wrong": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/components/modals/ErrorModal.js",
-        24
-      ]
-    ]
-  },
-  "Media": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/components/ImageViewer.js",
-        71
-      ]
-    ]
-  },
-  "N/A": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/constants/UnitHealthStatus.js",
-        39
-      ]
-    ]
-  },
   "Overview": {
     "translation": "",
     "origin": [
@@ -543,24 +543,6 @@
       ]
     ]
   },
-  "Success!": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/pages/catalog/PackageDetailTab.js",
-        398
-      ]
-    ]
-  },
-  "Summary": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/pages/system/units-health-node-detail/NodeInfoPanel.js",
-        25
-      ]
-    ]
-  },
   "Services": {
     "translation": "",
     "origin": [
@@ -576,6 +558,24 @@
       [
         "src/js/components/FilterHeadline.js",
         65
+      ]
+    ]
+  },
+  "Success!": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        398
+      ]
+    ]
+  },
+  "Summary": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/system/units-health-node-detail/NodeInfoPanel.js",
+        25
       ]
     ]
   },
@@ -606,21 +606,21 @@
       ]
     ]
   },
-  "This package can only be installed using the CLI. See the <0>documentation</0>.": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/pages/catalog/PackageDetailTab.js",
-        270
-      ]
-    ]
-  },
   "There is an error with your configuration": {
     "translation": "",
     "origin": [
       [
         "src/js/components/ErrorsAlert.js",
         49
+      ]
+    ]
+  },
+  "This package can only be installed using the CLI. See the <0>documentation</0>.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/pages/catalog/PackageDetailTab.js",
+        270
       ]
     ]
   },
@@ -639,6 +639,24 @@
       [
         "src/js/constants/RepositoriesTableHeaderLabels.js",
         6
+      ]
+    ]
+  },
+  "Unable to edit {0}": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/PlacementConstraintsSchemaField.js",
+        31
+      ]
+    ]
+  },
+  "Unhealthy": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/constants/UnitHealthStatus.js",
+        25
       ]
     ]
   },
@@ -661,24 +679,6 @@
       [
         "src/js/pages/system/units-health-node-detail/NodeInfoPanel.js",
         30
-      ]
-    ]
-  },
-  "Unable to edit {0}": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/components/PlacementConstraintsSchemaField.js",
-        31
-      ]
-    ]
-  },
-  "Unhealthy": {
-    "translation": "",
-    "origin": [
-      [
-        "src/js/constants/UnitHealthStatus.js",
-        25
       ]
     ]
   },
@@ -742,6 +742,15 @@
       [
         "src/js/pages/catalog/PackagesTab.js",
         50
+      ]
+    ]
+  },
+  "{0} Info": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/modals/VersionsModal.js",
+        31
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -209,6 +209,15 @@
       ]
     ]
   },
+  "DC/OS UI cannot retrieve the requested information at this moment.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/RequestErrorMsg.js",
+        53
+      ]
+    ]
+  },
   "Discard Changes?": {
     "translation": "",
     "origin": [
@@ -545,6 +554,15 @@
       [
         "src/js/components/Modals.js",
         100
+      ]
+    ]
+  },
+  "You can also join us on our <0>Slack channel</0> or send us an email at {supportLink}.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/RequestErrorMsg.js",
+        16
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1,4 +1,13 @@
 {
+  "Access denied": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/AccessDeniedPage.js",
+        45
+      ]
+    ]
+  },
   "Add Package Repository": {
     "translation": "",
     "origin": [
@@ -161,6 +170,15 @@
       [
         "src/js/components/ClusterHeader.js",
         143
+      ]
+    ]
+  },
+  "Log out": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/AccessDeniedPage.js",
+        32
       ]
     ]
   },
@@ -374,6 +392,15 @@
       [
         "src/js/pages/system/units-health-node-detail/NodeInfoPanel.js",
         30
+      ]
+    ]
+  },
+  "You do not have access to this service. Please contact your {0} administrator or see <0>security documentation</0> for more information.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/AccessDeniedPage.js",
+        47
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -391,6 +391,15 @@
       ]
     ]
   },
+  "There is an error with your configuration": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/ErrorsAlert.js",
+        49
+      ]
+    ]
+  },
   "Total Tasks": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -75,6 +75,15 @@
       ]
     ]
   },
+  "An error has occurred.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/ComponentList.js",
+        102
+      ]
+    ]
+  },
   "Cluster": {
     "translation": "",
     "origin": [
@@ -134,6 +143,15 @@
       [
         "src/js/components/FrameworkConfiguration.js",
         347
+      ]
+    ]
+  },
+  "Components Not Found": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/ComponentList.js",
+        99
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -17,6 +17,15 @@
       ]
     ]
   },
+  "<0>Important:</0> Because telemetry is disabled you must manually notify users of ACL changes.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/modals/UserFormModal.js",
+        124
+      ]
+    ]
+  },
   "Access denied": {
     "translation": "",
     "origin": [
@@ -108,6 +117,15 @@
       [
         "src/js/components/PlacementConstraintsPartial.js",
         224
+      ]
+    ]
+  },
+  "Add User to Cluster": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/modals/UserFormModal.js",
+        113
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -682,6 +682,24 @@
       ]
     ]
   },
+  "You are about to stop the job run with id": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/modals/JobStopRunModal.js",
+        71
+      ]
+    ]
+  },
+  "You are about to stop the selected job runs.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/modals/JobStopRunModal.js",
+        73
+      ]
+    ]
+  },
   "You can also join us on our <0>Slack channel</0> or send us an email at {supportLink}.": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1,4 +1,13 @@
 {
+  "(Clear)": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/FilterHeadline.js",
+        69
+      ]
+    ]
+  },
   "Access denied": {
     "translation": "",
     "origin": [
@@ -352,6 +361,15 @@
       [
         "src/js/pages/system/units-health-node-detail/NodeInfoPanel.js",
         25
+      ]
+    ]
+  },
+  "Showing {currentLength} of {totalLength} {name}": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/FilterHeadline.js",
+        65
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -84,6 +84,15 @@
       ]
     ]
   },
+  "Apply": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/DSLFormDropdownPanel.js",
+        91
+      ]
+    ]
+  },
   "Cluster": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -84,6 +84,15 @@
       ]
     ]
   },
+  "Active": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/FrameworkConfigurationReviewScreen.js",
+        67
+      ]
+    ]
+  },
   "An error has occurred.": {
     "translation": "",
     "origin": [
@@ -99,6 +108,15 @@
       [
         "src/js/components/DSLFormDropdownPanel.js",
         91
+      ]
+    ]
+  },
+  "Are you sure you want to leave this page? Any data you entered will be lost.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        354
       ]
     ]
   },
@@ -173,6 +191,15 @@
       ]
     ]
   },
+  "Discard Changes?": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        342
+      ]
+    ]
+  },
   "Documentation": {
     "translation": "",
     "origin": [
@@ -215,6 +242,15 @@
       [
         "src/js/components/CreateServiceModalCatalogPanelOption.js",
         24
+      ]
+    ]
+  },
+  "JSON Editor": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/FrameworkConfiguration.js",
+        169
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -93,6 +93,15 @@
       ]
     ]
   },
+  "Add Placement Constraint": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/PlacementConstraintsPartial.js",
+        224
+      ]
+    ]
+  },
   "An error has occurred.": {
     "translation": "",
     "origin": [
@@ -518,6 +527,15 @@
       [
         "src/js/pages/system/units-health-node-detail/NodeInfoPanel.js",
         30
+      ]
+    ]
+  },
+  "Unable to edit {0}": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/PlacementConstraintsSchemaField.js",
+        31
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -111,6 +111,19 @@
       ]
     ]
   },
+  "All Health Checks": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/UnitHealthDropdown.js",
+        12
+      ],
+      [
+        "src/js/components/UnitHealthDropdown.js",
+        13
+      ]
+    ]
+  },
   "An error has occurred": {
     "translation": "",
     "origin": [
@@ -276,6 +289,15 @@
       ]
     ]
   },
+  "Healthy": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/constants/UnitHealthStatus.js",
+        18
+      ]
+    ]
+  },
   "Install CLI": {
     "translation": "",
     "origin": [
@@ -388,6 +410,15 @@
       [
         "src/js/components/ImageViewer.js",
         71
+      ]
+    ]
+  },
+  "N/A": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/constants/UnitHealthStatus.js",
+        39
       ]
     ]
   },
@@ -567,6 +598,24 @@
       [
         "src/js/components/PlacementConstraintsSchemaField.js",
         31
+      ]
+    ]
+  },
+  "Unhealthy": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/constants/UnitHealthStatus.js",
+        25
+      ]
+    ]
+  },
+  "Warning": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/constants/UnitHealthStatus.js",
+        32
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -8,6 +8,15 @@
       ]
     ]
   },
+  "<0><1/> Download config.json</0>": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/ReviewConfig.js",
+        57
+      ]
+    ]
+  },
   "Access denied": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -191,6 +191,15 @@
       ]
     ]
   },
+  "Install a Package": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/CreateServiceModalCatalogPanelOption.js",
+        24
+      ]
+    ]
+  },
   "Log out": {
     "translation": "",
     "origin": [

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -160,6 +160,15 @@
       ]
     ]
   },
+  "Choose your operating system and follow the instructions. For any issues or questions, please refer to our <0>documentation</0>.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/modals/CliInstallModal.js",
+        172
+      ]
+    ]
+  },
   "Close": {
     "translation": "",
     "origin": [
@@ -244,6 +253,15 @@
       ]
     ]
   },
+  "Copy and paste the code snippet into the terminal:": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/modals/CliInstallModal.js",
+        94
+      ]
+    ]
+  },
   "DC/OS UI cannot retrieve the requested information at this moment.": {
     "translation": "",
     "origin": [
@@ -289,12 +307,39 @@
       ]
     ]
   },
+  "Download and install: <0><1/> Download dcos.exe</0>.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/modals/CliInstallModal.js",
+        137
+      ]
+    ]
+  },
+  "Enter": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/modals/CliInstallModal.js",
+        119
+      ]
+    ]
+  },
   "Healthy": {
     "translation": "",
     "origin": [
       [
         "src/js/constants/UnitHealthStatus.js",
         18
+      ]
+    ]
+  },
+  "In Command Prompt, enter": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/modals/CliInstallModal.js",
+        118
       ]
     ]
   },

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -120,6 +120,15 @@
       ]
     ]
   },
+  "Close": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/Modals.js",
+        129
+      ]
+    ]
+  },
   "Cluster": {
     "translation": "",
     "origin": [
@@ -500,6 +509,15 @@
       [
         "src/js/pages/system/units-health-node-detail/NodeInfoPanel.js",
         30
+      ]
+    ]
+  },
+  "We are unable to retrieve the version {0} versions. Please try again.": {
+    "translation": "",
+    "origin": [
+      [
+        "src/js/components/Modals.js",
+        100
       ]
     ]
   },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1947,7 +1947,7 @@
       "dev": true,
       "requires": {
         "@lingui/babel-plugin-transform-react": "2.7.0",
-        "babel-plugin-macros": "2.4.2"
+        "babel-plugin-macros": "2.4.1"
       }
     },
     "@lingui/react": {
@@ -6103,6 +6103,195 @@
         "@types/sinon": "4.0.0"
       }
     },
+    "@webassemblyjs/ast": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.6.tgz",
+      "integrity": "sha512-8nkZS48EVsMUU0v6F1LCIOw4RYWLm2plMtbhFTjNgeXmsTNLuU3xTRtnljt9BFQB+iPbLRobkNrCWftWnNC7wQ==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/helper-module-context": "1.7.6",
+        "@webassemblyjs/helper-wasm-bytecode": "1.7.6",
+        "@webassemblyjs/wast-parser": "1.7.6",
+        "mamacro": "0.0.3"
+      }
+    },
+    "@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.6.tgz",
+      "integrity": "sha512-VBOZvaOyBSkPZdIt5VBMg3vPWxouuM13dPXGWI1cBh3oFLNcFJ8s9YA7S9l4mPI7+Q950QqOmqj06oa83hNWBA==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-api-error": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.6.tgz",
+      "integrity": "sha512-SCzhcQWHXfrfMSKcj8zHg1/kL9kb3aa5TN4plc/EREOs5Xop0ci5bdVBApbk2yfVi8aL+Ly4Qpp3/TRAUInjrg==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-buffer": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.6.tgz",
+      "integrity": "sha512-1/gW5NaGsEOZ02fjnFiU8/OEEXU1uVbv2um0pQ9YVL3IHSkyk6xOwokzyqqO1qDZQUAllb+V8irtClPWntbVqw==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-code-frame": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.6.tgz",
+      "integrity": "sha512-+suMJOkSn9+vEvDvgyWyrJo5vJsWSDXZmJAjtoUq4zS4eqHyXImpktvHOZwXp1XQjO5H+YQwsBgqTQEc0J/5zg==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/wast-printer": "1.7.6"
+      }
+    },
+    "@webassemblyjs/helper-fsm": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.6.tgz",
+      "integrity": "sha512-HCS6KN3wgxUihGBW7WFzEC/o8Eyvk0d56uazusnxXthDPnkWiMv+kGi9xXswL2cvfYfeK5yiM17z2K5BVlwypw==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-module-context": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.6.tgz",
+      "integrity": "sha512-e8/6GbY7OjLM+6OsN7f2krC2qYVNaSr0B0oe4lWdmq5sL++8dYDD1TFbD1TdAdWMRTYNr/Qq7ovXWzia2EbSjw==",
+      "dev": true,
+      "requires": {
+        "mamacro": "0.0.3"
+      }
+    },
+    "@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.6.tgz",
+      "integrity": "sha512-PzYFCb7RjjSdAOljyvLWVqd6adAOabJW+8yRT+NWhXuf1nNZWH+igFZCUK9k7Cx7CsBbzIfXjJc7u56zZgFj9Q==",
+      "dev": true
+    },
+    "@webassemblyjs/helper-wasm-section": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.6.tgz",
+      "integrity": "sha512-3GS628ppDPSuwcYlQ7cDCGr4W2n9c4hLzvnRKeuz+lGsJSmc/ADVoYpm1ts2vlB1tGHkjtQMni+yu8mHoMlKlA==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.7.6",
+        "@webassemblyjs/helper-buffer": "1.7.6",
+        "@webassemblyjs/helper-wasm-bytecode": "1.7.6",
+        "@webassemblyjs/wasm-gen": "1.7.6"
+      }
+    },
+    "@webassemblyjs/ieee754": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.6.tgz",
+      "integrity": "sha512-V4cIp0ruyw+hawUHwQLn6o2mFEw4t50tk530oKsYXQhEzKR+xNGDxs/SFFuyTO7X3NzEu4usA3w5jzhl2RYyzQ==",
+      "dev": true,
+      "requires": {
+        "@xtuc/ieee754": "1.2.0"
+      }
+    },
+    "@webassemblyjs/leb128": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.6.tgz",
+      "integrity": "sha512-ojdlG8WpM394lBow4ncTGJoIVZ4aAtNOWHhfAM7m7zprmkVcKK+2kK5YJ9Bmj6/ketTtOn7wGSHCtMt+LzqgYQ==",
+      "dev": true,
+      "requires": {
+        "@xtuc/long": "4.2.1"
+      }
+    },
+    "@webassemblyjs/utf8": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.6.tgz",
+      "integrity": "sha512-oId+tLxQ+AeDC34ELRYNSqJRaScB0TClUU6KQfpB8rNT6oelYlz8axsPhf6yPTg7PBJ/Z5WcXmUYiHEWgbbHJw==",
+      "dev": true
+    },
+    "@webassemblyjs/wasm-edit": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.6.tgz",
+      "integrity": "sha512-pTNjLO3o41v/Vz9VFLl+I3YLImpCSpodFW77pNoH4agn5I6GgSxXHXtvWDTvYJFty0jSeXZWLEmbaSIRUDlekg==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.7.6",
+        "@webassemblyjs/helper-buffer": "1.7.6",
+        "@webassemblyjs/helper-wasm-bytecode": "1.7.6",
+        "@webassemblyjs/helper-wasm-section": "1.7.6",
+        "@webassemblyjs/wasm-gen": "1.7.6",
+        "@webassemblyjs/wasm-opt": "1.7.6",
+        "@webassemblyjs/wasm-parser": "1.7.6",
+        "@webassemblyjs/wast-printer": "1.7.6"
+      }
+    },
+    "@webassemblyjs/wasm-gen": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.6.tgz",
+      "integrity": "sha512-mQvFJVumtmRKEUXMohwn8nSrtjJJl6oXwF3FotC5t6e2hlKMh8sIaW03Sck2MDzw9xPogZD7tdP5kjPlbH9EcQ==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.7.6",
+        "@webassemblyjs/helper-wasm-bytecode": "1.7.6",
+        "@webassemblyjs/ieee754": "1.7.6",
+        "@webassemblyjs/leb128": "1.7.6",
+        "@webassemblyjs/utf8": "1.7.6"
+      }
+    },
+    "@webassemblyjs/wasm-opt": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.6.tgz",
+      "integrity": "sha512-go44K90fSIsDwRgtHhX14VtbdDPdK2sZQtZqUcMRvTojdozj5tLI0VVJAzLCfz51NOkFXezPeVTAYFqrZ6rI8Q==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.7.6",
+        "@webassemblyjs/helper-buffer": "1.7.6",
+        "@webassemblyjs/wasm-gen": "1.7.6",
+        "@webassemblyjs/wasm-parser": "1.7.6"
+      }
+    },
+    "@webassemblyjs/wasm-parser": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.6.tgz",
+      "integrity": "sha512-t1T6TfwNY85pDA/HWPA8kB9xA4sp9ajlRg5W7EKikqrynTyFo+/qDzIpvdkOkOGjlS6d4n4SX59SPuIayR22Yg==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.7.6",
+        "@webassemblyjs/helper-api-error": "1.7.6",
+        "@webassemblyjs/helper-wasm-bytecode": "1.7.6",
+        "@webassemblyjs/ieee754": "1.7.6",
+        "@webassemblyjs/leb128": "1.7.6",
+        "@webassemblyjs/utf8": "1.7.6"
+      }
+    },
+    "@webassemblyjs/wast-parser": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.6.tgz",
+      "integrity": "sha512-1MaWTErN0ziOsNUlLdvwS+NS1QWuI/kgJaAGAMHX8+fMJFgOJDmN/xsG4h/A1Gtf/tz5VyXQciaqHZqp2q0vfg==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.7.6",
+        "@webassemblyjs/floating-point-hex-parser": "1.7.6",
+        "@webassemblyjs/helper-api-error": "1.7.6",
+        "@webassemblyjs/helper-code-frame": "1.7.6",
+        "@webassemblyjs/helper-fsm": "1.7.6",
+        "@xtuc/long": "4.2.1",
+        "mamacro": "0.0.3"
+      }
+    },
+    "@webassemblyjs/wast-printer": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.6.tgz",
+      "integrity": "sha512-vHdHSK1tOetvDcl1IV1OdDeGNe/NDDQ+KzuZHMtqTVP1xO/tZ/IKNpj5BaGk1OYFdsDWQqb31PIwdEyPntOWRQ==",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.7.6",
+        "@webassemblyjs/wast-parser": "1.7.6",
+        "@xtuc/long": "4.2.1"
+      }
+    },
+    "@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "dev": true
+    },
+    "@xtuc/long": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.1.tgz",
+      "integrity": "sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==",
+      "dev": true
+    },
     "JSONSelect": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz",
@@ -6150,23 +6339,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
       "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
       "dev": true
-    },
-    "acorn-dynamic-import": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
-      "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
-      "dev": true,
-      "requires": {
-        "acorn": "4.0.13"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-          "dev": true
-        }
-      }
     },
     "acorn-globals": {
       "version": "4.1.0",
@@ -6227,6 +6399,12 @@
         "json-stable-stringify": "1.0.1"
       }
     },
+    "ajv-errors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.0.tgz",
+      "integrity": "sha1-7PAh+hCP0X37Xms4Py3SM+Mf/Fk=",
+      "dev": true
+    },
     "ajv-keywords": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
@@ -6253,6 +6431,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
+    "ansi-colors": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.1.0.tgz",
+      "integrity": "sha512-hTv1qPdi+sVEk3jYsdjox5nQI0C9HTbjKShbCdYLKb1LOfNbb7wsF4d7OEKIZoxIHx02tSp3m94jcPW2EfMjmA==",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "1.4.0",
@@ -6433,16 +6617,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
       "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
-    },
-    "array-includes": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0"
-      }
     },
     "array-map": {
       "version": "0.0.0",
@@ -7093,7 +7267,7 @@
         "@emotion/memoize": "0.6.5",
         "@emotion/stylis": "0.7.0",
         "babel-core": "6.26.3",
-        "babel-plugin-macros": "2.4.2",
+        "babel-plugin-macros": "2.4.1",
         "babel-plugin-syntax-jsx": "6.18.0",
         "convert-source-map": "1.5.1",
         "find-root": "1.1.0",
@@ -7200,12 +7374,11 @@
       "dev": true
     },
     "babel-plugin-macros": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.2.tgz",
-      "integrity": "sha512-NBVpEWN4OQ/bHnu1fyDaAaTPAjnhXCEPqr1RwqxrU7b6tZ2hypp+zX4hlNfmVGfClD5c3Sl6Hfj5TJNF5VG5aA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.1.tgz",
+      "integrity": "sha512-pUdm8I6LAcKIzh6H2JZ1QUJByg7Im5/llcUHD/T9mTtlaBl/4YkHzvd6oUpT0cjIFgkCadVSHuJNVoNkLqvM1w==",
       "requires": {
-        "cosmiconfig": "5.0.6",
-        "resolve": "1.8.1"
+        "cosmiconfig": "5.0.6"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -7239,14 +7412,6 @@
           "requires": {
             "error-ex": "1.3.1",
             "json-parse-better-errors": "1.0.1"
-          }
-        },
-        "resolve": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-          "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-          "requires": {
-            "path-parse": "1.0.5"
           }
         }
       }
@@ -8629,7 +8794,7 @@
         },
         "uuid": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
           "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
           "dev": true
         }
@@ -8902,6 +9067,12 @@
       "integrity": "sha1-DiGPoTPQ0HHIhqoEG0NSWMx0aJE=",
       "dev": true
     },
+    "caniuse-lite": {
+      "version": "1.0.30000890",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000890.tgz",
+      "integrity": "sha512-4NI3s4Y6ROm+SgZN5sLUG4k7nVWQnedis3c/RWkynV5G6cHSY7+a8fwFyn2yoBDE3E6VswhTNNwR3PvzGqlTkg==",
+      "dev": true
+    },
     "capture-stack-trace": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
@@ -9112,6 +9283,15 @@
       "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
       "dev": true
     },
+    "chrome-trace-event": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
+      "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
+      "dev": true,
+      "requires": {
+        "tslib": "1.9.0"
+      }
+    },
     "ci-info": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
@@ -9233,6 +9413,23 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.3.tgz",
       "integrity": "sha1-VRt3S2dioMCplxh/e6Tx1gOWGsU="
+    },
+    "clean-css": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+      "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "clean-stack": {
       "version": "1.3.0",
@@ -9523,7 +9720,7 @@
     "compare-versions": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
-      "integrity": "sha1-4HR99cnLfwVNbT3D4dvERPnpKyY="
+      "integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg=="
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -9776,6 +9973,12 @@
           "dev": true
         }
       }
+    },
+    "connect-history-api-fallback": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
+      "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
+      "dev": true
     },
     "connect-livereload": {
       "version": "0.5.4",
@@ -10277,6 +10480,12 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
+      "dev": true
+    },
     "cosmiconfig": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
@@ -10580,6 +10789,70 @@
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
+    "css-declaration-sorter": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
+      "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
+      "dev": true,
+      "requires": {
+        "postcss": "7.0.5",
+        "timsort": "0.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
+          "integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
     "css-loader": {
       "version": "0.28.10",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.10.tgz",
@@ -10795,6 +11068,12 @@
         "source-map": "0.5.7"
       }
     },
+    "css-unit-converter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
+      "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
+      "dev": true
+    },
     "css-url-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
@@ -10887,6 +11166,632 @@
           }
         }
       }
+    },
+    "cssnano-preset-default": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.2.tgz",
+      "integrity": "sha512-zO9PeP84l1E4kbrdyF7NSLtA/JrJY1paX5FHy5+w/ziIXO2kDqDMfJ/mosXkaHHSa3RPiIY3eB6aEgwx3IiGqA==",
+      "dev": true,
+      "requires": {
+        "css-declaration-sorter": "4.0.1",
+        "cssnano-util-raw-cache": "4.0.1",
+        "postcss": "7.0.5",
+        "postcss-calc": "6.0.2",
+        "postcss-colormin": "4.0.2",
+        "postcss-convert-values": "4.0.1",
+        "postcss-discard-comments": "4.0.1",
+        "postcss-discard-duplicates": "4.0.2",
+        "postcss-discard-empty": "4.0.1",
+        "postcss-discard-overridden": "4.0.1",
+        "postcss-merge-longhand": "4.0.6",
+        "postcss-merge-rules": "4.0.2",
+        "postcss-minify-font-values": "4.0.2",
+        "postcss-minify-gradients": "4.0.1",
+        "postcss-minify-params": "4.0.1",
+        "postcss-minify-selectors": "4.0.1",
+        "postcss-normalize-charset": "4.0.1",
+        "postcss-normalize-display-values": "4.0.1",
+        "postcss-normalize-positions": "4.0.1",
+        "postcss-normalize-repeat-style": "4.0.1",
+        "postcss-normalize-string": "4.0.1",
+        "postcss-normalize-timing-functions": "4.0.1",
+        "postcss-normalize-unicode": "4.0.1",
+        "postcss-normalize-url": "4.0.1",
+        "postcss-normalize-whitespace": "4.0.1",
+        "postcss-ordered-values": "4.1.1",
+        "postcss-reduce-initial": "4.0.2",
+        "postcss-reduce-transforms": "4.0.1",
+        "postcss-svgo": "4.0.1",
+        "postcss-unique-selectors": "4.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "browserslist": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.2.0.tgz",
+          "integrity": "sha512-Berls1CHL7qfQz8Lct6QxYA5d2Tvt4doDWHcjvAISybpd+EKZVppNtXgXhaN6SdrPKo7YLTSZuYBs5cYrSWN8w==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "1.0.30000890",
+            "electron-to-chromium": "1.3.75",
+            "node-releases": "1.0.0-alpha.12"
+          }
+        },
+        "caniuse-api": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+          "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+          "dev": true,
+          "requires": {
+            "browserslist": "4.2.0",
+            "caniuse-lite": "1.0.30000890",
+            "lodash.memoize": "4.1.2",
+            "lodash.uniq": "4.5.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "coa": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.1.tgz",
+          "integrity": "sha512-5wfTTO8E2/ja4jFSxePXlG5nRu5bBtL/r1HCIpJW/lzT6yDtKl0u0Z4o/Vpz32IpKmBn7HerheEZQgA9N2DarQ==",
+          "dev": true,
+          "requires": {
+            "q": "1.5.1"
+          }
+        },
+        "color": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/color/-/color-3.1.0.tgz",
+          "integrity": "sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1",
+            "color-string": "1.5.3"
+          }
+        },
+        "color-string": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+          "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3",
+            "simple-swizzle": "0.2.2"
+          }
+        },
+        "css-select": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.0.tgz",
+          "integrity": "sha512-MGhoq1S9EyPgZIGnts8Yz5WwUOyHmPMdlqeifsYs/xFX7AAm3hY0RJe1dqVlXtYPI66Nsk39R/sa5/ree6L2qg==",
+          "dev": true,
+          "requires": {
+            "boolbase": "1.0.0",
+            "css-what": "2.1.0",
+            "domutils": "1.7.0",
+            "nth-check": "1.0.1"
+          }
+        },
+        "csso": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
+          "integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
+          "dev": true,
+          "requires": {
+            "css-tree": "1.0.0-alpha.29"
+          },
+          "dependencies": {
+            "css-tree": {
+              "version": "1.0.0-alpha.29",
+              "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
+              "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
+              "dev": true,
+              "requires": {
+                "mdn-data": "1.1.4",
+                "source-map": "0.5.7"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
+          }
+        },
+        "domutils": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+          "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "0.1.0",
+            "domelementtype": "1.3.0"
+          }
+        },
+        "dot-prop": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+          "dev": true,
+          "requires": {
+            "is-obj": "1.0.1"
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.75",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.75.tgz",
+          "integrity": "sha512-nLo03Qpw++8R6BxDZL/B1c8SQvUe/htdgc5LWYHe5YotV2jVvRUMP5AlOmxOsyeOzgMiXrNln2mC05Ixz6vuUQ==",
+          "dev": true
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "is-svg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
+          "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
+          "dev": true,
+          "requires": {
+            "html-comment-regex": "1.1.1"
+          }
+        },
+        "js-yaml": {
+          "version": "3.12.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.10",
+            "esprima": "4.0.1"
+          }
+        },
+        "normalize-url": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+          "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
+          "integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.5.0"
+          }
+        },
+        "postcss-calc": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-6.0.2.tgz",
+          "integrity": "sha512-fiznXjEN5T42Qm7qqMCVJXS3roaj9r4xsSi+meaBVe7CJBl8t/QLOXu02Z2E6oWAMWIvCuF6JrvzFekmVEbOKA==",
+          "dev": true,
+          "requires": {
+            "css-unit-converter": "1.1.1",
+            "postcss": "7.0.5",
+            "postcss-selector-parser": "2.2.3",
+            "reduce-css-calc": "2.1.5"
+          }
+        },
+        "postcss-colormin": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.2.tgz",
+          "integrity": "sha512-1QJc2coIehnVFsz0otges8kQLsryi4lo19WD+U5xCWvXd0uw/Z+KKYnbiNDCnO9GP+PvErPHCG0jNvWTngk9Rw==",
+          "dev": true,
+          "requires": {
+            "browserslist": "4.2.0",
+            "color": "3.1.0",
+            "has": "1.0.1",
+            "postcss": "7.0.5",
+            "postcss-value-parser": "3.3.0"
+          }
+        },
+        "postcss-convert-values": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
+          "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
+          "dev": true,
+          "requires": {
+            "postcss": "7.0.5",
+            "postcss-value-parser": "3.3.0"
+          }
+        },
+        "postcss-discard-comments": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.1.tgz",
+          "integrity": "sha512-Ay+rZu1Sz6g8IdzRjUgG2NafSNpp2MSMOQUb+9kkzzzP+kh07fP0yNbhtFejURnyVXSX3FYy2nVNW1QTnNjgBQ==",
+          "dev": true,
+          "requires": {
+            "postcss": "7.0.5"
+          }
+        },
+        "postcss-discard-duplicates": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
+          "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
+          "dev": true,
+          "requires": {
+            "postcss": "7.0.5"
+          }
+        },
+        "postcss-discard-empty": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
+          "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
+          "dev": true,
+          "requires": {
+            "postcss": "7.0.5"
+          }
+        },
+        "postcss-discard-overridden": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
+          "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
+          "dev": true,
+          "requires": {
+            "postcss": "7.0.5"
+          }
+        },
+        "postcss-merge-longhand": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.6.tgz",
+          "integrity": "sha512-JavnI+V4IHWsaUAfOoKeMEiJQGXTraEy1nHM0ILlE6NIQPEZrJDAnPh3lNGZ5HAk2mSSrwp66JoGhvjp6SqShA==",
+          "dev": true,
+          "requires": {
+            "css-color-names": "0.0.4",
+            "postcss": "7.0.5",
+            "postcss-value-parser": "3.3.0",
+            "stylehacks": "4.0.1"
+          }
+        },
+        "postcss-merge-rules": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.2.tgz",
+          "integrity": "sha512-UiuXwCCJtQy9tAIxsnurfF0mrNHKc4NnNx6NxqmzNNjXpQwLSukUxELHTRF0Rg1pAmcoKLih8PwvZbiordchag==",
+          "dev": true,
+          "requires": {
+            "browserslist": "4.2.0",
+            "caniuse-api": "3.0.0",
+            "cssnano-util-same-parent": "4.0.1",
+            "postcss": "7.0.5",
+            "postcss-selector-parser": "3.1.1",
+            "vendors": "1.0.1"
+          },
+          "dependencies": {
+            "postcss-selector-parser": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+              "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+              "dev": true,
+              "requires": {
+                "dot-prop": "4.2.0",
+                "indexes-of": "1.0.1",
+                "uniq": "1.0.1"
+              }
+            }
+          }
+        },
+        "postcss-minify-font-values": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
+          "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
+          "dev": true,
+          "requires": {
+            "postcss": "7.0.5",
+            "postcss-value-parser": "3.3.0"
+          }
+        },
+        "postcss-minify-gradients": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.1.tgz",
+          "integrity": "sha512-pySEW3E6Ly5mHm18rekbWiAjVi/Wj8KKt2vwSfVFAWdW6wOIekgqxKxLU7vJfb107o3FDNPkaYFCxGAJBFyogA==",
+          "dev": true,
+          "requires": {
+            "cssnano-util-get-arguments": "4.0.0",
+            "is-color-stop": "1.1.0",
+            "postcss": "7.0.5",
+            "postcss-value-parser": "3.3.0"
+          }
+        },
+        "postcss-minify-params": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.1.tgz",
+          "integrity": "sha512-h4W0FEMEzBLxpxIVelRtMheskOKKp52ND6rJv+nBS33G1twu2tCyurYj/YtgU76+UDCvWeNs0hs8HFAWE2OUFg==",
+          "dev": true,
+          "requires": {
+            "alphanum-sort": "1.0.2",
+            "browserslist": "4.2.0",
+            "cssnano-util-get-arguments": "4.0.0",
+            "postcss": "7.0.5",
+            "postcss-value-parser": "3.3.0",
+            "uniqs": "2.0.0"
+          }
+        },
+        "postcss-minify-selectors": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.1.tgz",
+          "integrity": "sha512-8+plQkomve3G+CodLCgbhAKrb5lekAnLYuL1d7Nz+/7RANpBEVdgBkPNwljfSKvZ9xkkZTZITd04KP+zeJTJqg==",
+          "dev": true,
+          "requires": {
+            "alphanum-sort": "1.0.2",
+            "has": "1.0.1",
+            "postcss": "7.0.5",
+            "postcss-selector-parser": "3.1.1"
+          },
+          "dependencies": {
+            "postcss-selector-parser": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+              "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+              "dev": true,
+              "requires": {
+                "dot-prop": "4.2.0",
+                "indexes-of": "1.0.1",
+                "uniq": "1.0.1"
+              }
+            }
+          }
+        },
+        "postcss-normalize-charset": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
+          "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
+          "dev": true,
+          "requires": {
+            "postcss": "7.0.5"
+          }
+        },
+        "postcss-normalize-url": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
+          "integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
+          "dev": true,
+          "requires": {
+            "is-absolute-url": "2.1.0",
+            "normalize-url": "3.3.0",
+            "postcss": "7.0.5",
+            "postcss-value-parser": "3.3.0"
+          }
+        },
+        "postcss-ordered-values": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.1.tgz",
+          "integrity": "sha512-PeJiLgJWPzkVF8JuKSBcylaU+hDJ/TX3zqAMIjlghgn1JBi6QwQaDZoDIlqWRcCAI8SxKrt3FCPSRmOgKRB97Q==",
+          "dev": true,
+          "requires": {
+            "cssnano-util-get-arguments": "4.0.0",
+            "postcss": "7.0.5",
+            "postcss-value-parser": "3.3.0"
+          }
+        },
+        "postcss-reduce-initial": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.2.tgz",
+          "integrity": "sha512-epUiC39NonKUKG+P3eAOKKZtm5OtAtQJL7Ye0CBN1f+UQTHzqotudp+hki7zxXm7tT0ZAKDMBj1uihpPjP25ug==",
+          "dev": true,
+          "requires": {
+            "browserslist": "4.2.0",
+            "caniuse-api": "3.0.0",
+            "has": "1.0.1",
+            "postcss": "7.0.5"
+          }
+        },
+        "postcss-reduce-transforms": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.1.tgz",
+          "integrity": "sha512-sZVr3QlGs0pjh6JAIe6DzWvBaqYw05V1t3d9Tp+VnFRT5j+rsqoWsysh/iSD7YNsULjq9IAylCznIwVd5oU/zA==",
+          "dev": true,
+          "requires": {
+            "cssnano-util-get-match": "4.0.0",
+            "has": "1.0.1",
+            "postcss": "7.0.5",
+            "postcss-value-parser": "3.3.0"
+          }
+        },
+        "postcss-svgo": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.1.tgz",
+          "integrity": "sha512-YD5uIk5NDRySy0hcI+ZJHwqemv2WiqqzDgtvgMzO8EGSkK5aONyX8HMVFRFJSdO8wUWTuisUFn/d7yRRbBr5Qw==",
+          "dev": true,
+          "requires": {
+            "is-svg": "3.0.0",
+            "postcss": "7.0.5",
+            "postcss-value-parser": "3.3.0",
+            "svgo": "1.1.1"
+          }
+        },
+        "postcss-unique-selectors": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
+          "integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
+          "dev": true,
+          "requires": {
+            "alphanum-sort": "1.0.2",
+            "postcss": "7.0.5",
+            "uniqs": "2.0.0"
+          }
+        },
+        "reduce-css-calc": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.5.tgz",
+          "integrity": "sha512-AybiBU03FKbjYzyvJvwkJZY6NLN+80Ufc2EqEs+41yQH+8wqBEslD6eGiS0oIeq5TNLA5PrhBeYHXWdn8gtW7A==",
+          "dev": true,
+          "requires": {
+            "css-unit-converter": "1.1.1",
+            "postcss-value-parser": "3.3.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "stylehacks": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.1.tgz",
+          "integrity": "sha512-TK5zEPeD9NyC1uPIdjikzsgWxdQQN/ry1X3d1iOz1UkYDCmcr928gWD1KHgyC27F50UnE0xCTrBOO1l6KR8M4w==",
+          "dev": true,
+          "requires": {
+            "browserslist": "4.2.0",
+            "postcss": "7.0.5",
+            "postcss-selector-parser": "3.1.1"
+          },
+          "dependencies": {
+            "postcss-selector-parser": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+              "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+              "dev": true,
+              "requires": {
+                "dot-prop": "4.2.0",
+                "indexes-of": "1.0.1",
+                "uniq": "1.0.1"
+              }
+            }
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        },
+        "svgo": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.1.1.tgz",
+          "integrity": "sha512-GBkJbnTuFpM4jFbiERHDWhZc/S/kpHToqmZag3aEBjPYK44JAN2QBjvrGIxLOoCyMZjuFQIfTO2eJd8uwLY/9g==",
+          "dev": true,
+          "requires": {
+            "coa": "2.0.1",
+            "colors": "1.1.2",
+            "css-select": "2.0.0",
+            "css-select-base-adapter": "0.1.0",
+            "css-tree": "1.0.0-alpha.28",
+            "css-url-regex": "1.1.0",
+            "csso": "3.5.1",
+            "js-yaml": "3.12.0",
+            "mkdirp": "0.5.1",
+            "object.values": "1.0.4",
+            "sax": "1.2.4",
+            "stable": "0.1.8",
+            "unquote": "1.1.1",
+            "util.promisify": "1.0.0"
+          }
+        }
+      }
+    },
+    "cssnano-util-get-arguments": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
+      "integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8=",
+      "dev": true
+    },
+    "cssnano-util-get-match": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
+      "integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0=",
+      "dev": true
+    },
+    "cssnano-util-raw-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
+      "integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
+      "dev": true,
+      "requires": {
+        "postcss": "7.0.5"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
+          "integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "cssnano-util-same-parent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
+      "integrity": "sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q==",
+      "dev": true
     },
     "csso": {
       "version": "2.3.2",
@@ -11465,7 +12370,7 @@
             },
             "readable-stream": {
               "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
@@ -11828,6 +12733,52 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+        }
+      }
+    },
+    "default-gateway": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.2.tgz",
+      "integrity": "sha512-lAc4i9QJR0YHSDFdzeBQKfZ1SRDG3hsJNEkrpcZa8QhBfidLAilT60BDEIVUUGqosFp425KOgB3uYqcnQrWafQ==",
+      "dev": true,
+      "requires": {
+        "execa": "0.10.0",
+        "ip-regex": "2.1.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "1.0.4",
+            "path-key": "2.0.1",
+            "semver": "5.5.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "6.0.5",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "ip-regex": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+          "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+          "dev": true
         }
       }
     },
@@ -12322,7 +13273,7 @@
             },
             "readable-stream": {
               "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
@@ -12572,6 +13523,18 @@
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
+      }
+    },
+    "ecstatic": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-2.2.1.tgz",
+      "integrity": "sha512-ztE4WqheoWLh3wv+HQwy7dACnvNY620coWpa+XqY6R2cVWgaAT2lUISU1Uf7JpdLLJCURktJOaA9av2AOzsyYQ==",
+      "dev": true,
+      "requires": {
+        "he": "1.1.1",
+        "mime": "1.3.4",
+        "minimist": "1.2.0",
+        "url-join": "2.0.5"
       }
     },
     "ee-first": {
@@ -13279,6 +14242,16 @@
         }
       }
     },
+    "eslint-scope": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
+      }
+    },
     "espree": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
@@ -13674,7 +14647,7 @@
         "qs": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg=",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
           "dev": true
         },
         "range-parser": {
@@ -13874,68 +14847,6 @@
         "is-extglob": "1.0.0"
       }
     },
-    "extract-text-webpack-plugin": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.2.tgz",
-      "integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
-      "dev": true,
-      "requires": {
-        "async": "2.6.0",
-        "loader-utils": "1.1.0",
-        "schema-utils": "0.3.0",
-        "webpack-sources": "1.1.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.5"
-          }
-        },
-        "loader-utils": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true,
-          "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1"
-          }
-        },
-        "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-          "dev": true
-        },
-        "source-list-map": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-          "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "webpack-sources": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
-          "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
-          "dev": true,
-          "requires": {
-            "source-list-map": "2.0.0",
-            "source-map": "0.6.1"
-          }
-        }
-      }
-    },
     "extract-zip": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
@@ -13967,13 +14878,13 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
           "dev": true,
           "requires": {
@@ -14624,6 +15535,37 @@
         }
       }
     },
+    "find-cache-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+      "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+      "dev": true,
+      "requires": {
+        "commondir": "1.0.1",
+        "make-dir": "1.2.0",
+        "pkg-dir": "2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0"
+          }
+        }
+      }
+    },
     "find-index": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
@@ -15194,7 +16136,7 @@
     "fsevents": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha1-9B3LGvJYKvNpLaNvxVy9jhBBxCY=",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -16158,6 +17100,12 @@
         "resolve-dir": "1.0.1"
       }
     },
+    "global-modules-path": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/global-modules-path/-/global-modules-path-2.3.0.tgz",
+      "integrity": "sha512-HchvMJNYh9dGSCy8pOQ2O8u/hoXaL+0XhnrwH0RyLiSXMMTl9W3N6KUU73+JFOg5PGjtzl6VZzUQsnrpm7Szag==",
+      "dev": true
+    },
     "global-prefix": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
@@ -16254,7 +17202,7 @@
     },
     "got": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+      "resolved": "http://registry.npmjs.org/got/-/got-5.7.1.tgz",
       "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
       "dev": true,
       "requires": {
@@ -16908,6 +17856,18 @@
         "sntp": "1.0.9"
       }
     },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "hex-color-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
+      "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
+      "dev": true
+    },
     "history": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/history/-/history-2.1.2.tgz",
@@ -17030,6 +17990,18 @@
         }
       }
     },
+    "hsl-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
+      "integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
+      "dev": true
+    },
+    "hsla-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
+      "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
+      "dev": true
+    },
     "html-comment-regex": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
@@ -17151,24 +18123,19 @@
         }
       }
     },
-    "html-tags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-1.2.0.tgz",
-      "integrity": "sha1-x43mW1Zjqll5id0rerSSANfk25g=",
-      "dev": true
-    },
-    "html-webpack-plugin": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.30.1.tgz",
-      "integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
+    "html-minifier": {
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.20.tgz",
+      "integrity": "sha512-ZmgNLaTp54+HFKkONyLFEfs5dd/ZOtlquKaTnqIWFmx3Av5zG6ZPcV2d0o9XM2fXOTxxIf6eDcwzFFotke/5zA==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
-        "html-minifier": "3.5.12",
-        "loader-utils": "0.2.17",
-        "lodash": "4.17.5",
-        "pretty-error": "2.1.1",
-        "toposort": "1.0.6"
+        "camel-case": "3.0.0",
+        "clean-css": "4.2.1",
+        "commander": "2.17.1",
+        "he": "1.1.1",
+        "param-case": "2.1.1",
+        "relateurl": "0.2.7",
+        "uglify-js": "3.4.9"
       },
       "dependencies": {
         "camel-case": {
@@ -17181,41 +18148,10 @@
             "upper-case": "1.1.3"
           }
         },
-        "clean-css": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
-          "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.7"
-          }
-        },
-        "he": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-          "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-          "dev": true
-        },
-        "html-minifier": {
-          "version": "3.5.12",
-          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.12.tgz",
-          "integrity": "sha512-+N778qLf0RWBscD0TPGoYdeGNDZ0s76/0pQhY1/409EOudcENkm9IbSkk37RDyPdg/09GVHTKotU4ya93RF1Gg==",
-          "dev": true,
-          "requires": {
-            "camel-case": "3.0.0",
-            "clean-css": "4.1.11",
-            "commander": "2.15.1",
-            "he": "1.1.1",
-            "ncname": "1.0.0",
-            "param-case": "2.1.1",
-            "relateurl": "0.2.7",
-            "uglify-js": "3.3.16"
-          }
-        },
-        "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
           "dev": true
         },
         "param-case": {
@@ -17227,29 +18163,56 @@
             "no-case": "2.3.2"
           }
         },
-        "toposort": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.6.tgz",
-          "integrity": "sha1-wxdI5V0hDv/AD9zcfW5o19e7nOw=",
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "uglify-js": {
-          "version": "3.3.16",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.16.tgz",
-          "integrity": "sha512-FMh5SRqJRGhv9BbaTffENIpDDQIoPDR8DBraunGORGhySArsXlw9++CN+BWzPBLpoI4RcSnpfGPnilTxWL3Vvg==",
+          "version": "3.4.9",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+          "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
           "dev": true,
           "requires": {
-            "commander": "2.15.1",
+            "commander": "2.17.1",
             "source-map": "0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-              "dev": true
-            }
           }
+        }
+      }
+    },
+    "html-tags": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-1.2.0.tgz",
+      "integrity": "sha1-x43mW1Zjqll5id0rerSSANfk25g=",
+      "dev": true
+    },
+    "html-webpack-plugin": {
+      "version": "3.2.0",
+      "resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
+      "dev": true,
+      "requires": {
+        "html-minifier": "3.5.20",
+        "loader-utils": "0.2.17",
+        "lodash": "4.17.11",
+        "pretty-error": "2.1.1",
+        "tapable": "1.1.0",
+        "toposort": "1.0.7",
+        "util.promisify": "1.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "tapable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.0.tgz",
+          "integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA==",
+          "dev": true
         }
       }
     },
@@ -17358,46 +18321,33 @@
         }
       }
     },
-    "http-proxy-middleware": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
-      "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
-      "dev": true,
-      "requires": {
-        "http-proxy": "1.16.2",
-        "is-glob": "3.1.0",
-        "lodash": "4.17.5",
-        "micromatch": "2.3.11"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "2.1.1"
-          }
-        },
-        "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-          "dev": true
-        }
-      }
-    },
     "http-response-object": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
       "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM=",
       "dev": true
+    },
+    "http-server": {
+      "version": "github:johntron/http-server#2af9dee8ed4471d9bfc3b675ac5ae3cc420e711a",
+      "dev": true,
+      "requires": {
+        "colors": "1.0.3",
+        "corser": "2.0.1",
+        "ecstatic": "2.2.1",
+        "http-proxy": "1.16.2",
+        "opener": "1.4.3",
+        "optimist": "0.6.1",
+        "portfinder": "1.0.13",
+        "union": "0.4.6"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        }
+      }
     },
     "http-signature": {
       "version": "1.1.1",
@@ -17899,15 +18849,6 @@
         }
       }
     },
-    "internal-ip": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
-      "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
-      "dev": true,
-      "requires": {
-        "meow": "3.7.0"
-      }
-    },
     "interpret": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
@@ -18101,6 +19042,20 @@
       "dev": true,
       "requires": {
         "ci-info": "1.1.3"
+      }
+    },
+    "is-color-stop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
+      "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
+      "dev": true,
+      "requires": {
+        "css-color-names": "0.0.4",
+        "hex-color-regex": "1.1.0",
+        "hsl-regex": "1.0.0",
+        "hsla-regex": "1.0.0",
+        "rgb-regex": "1.0.1",
+        "rgba-regex": "1.0.0"
       }
     },
     "is-cwebp-readable": {
@@ -19846,7 +20801,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -20399,6 +21354,24 @@
       "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.0.4.tgz",
       "integrity": "sha1-eFCzihGobZ9Jx2Qh4evpxdNWLC8=",
       "dev": true
+    },
+    "last-call-webpack-plugin": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
+      "integrity": "sha512-7KI2l2GIZa9p2spzPIVZBYyNKkN+e/SQPpnjlTiPhdbDW3F86tdKKELxKpzJ5sgU19wQWsACULZmpTPYHeWO5w==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.11",
+        "webpack-sources": "1.1.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
     },
     "later": {
       "version": "1.2.0",
@@ -20969,6 +21942,12 @@
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
     "lodash.defaults": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
@@ -21409,6 +22388,12 @@
         "tmpl": "1.0.4"
       }
     },
+    "mamacro": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
+      "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
+      "dev": true
+    },
     "map-age-cleaner": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.2.tgz",
@@ -21762,6 +22747,86 @@
       "dev": true,
       "requires": {
         "dom-walk": "0.1.1"
+      }
+    },
+    "mini-css-extract-plugin": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.3.tgz",
+      "integrity": "sha512-Mxs0nxzF1kxPv4TRi2NimewgXlJqh0rGE30vviCU2WHrpbta6wklnUV9dr9FUtoAHmB3p3LeXEC+ZjgHvB0Dzg==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "schema-utils": "1.0.0",
+        "webpack-sources": "1.1.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
+          "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+          "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
+          "requires": {
+            "ajv": "6.5.4",
+            "ajv-errors": "1.0.0",
+            "ajv-keywords": "3.2.0"
+          }
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+          "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+          "dev": true,
+          "requires": {
+            "punycode": "2.1.1"
+          }
+        }
       }
     },
     "minimalistic-assert": {
@@ -22325,6 +23390,15 @@
             "safe-buffer": "5.1.1"
           }
         }
+      }
+    },
+    "node-releases": {
+      "version": "1.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.12.tgz",
+      "integrity": "sha512-VPB4rTPqpVyWKBHbSa4YPFme3+8WHsOSpvbp0Mfj0bWsC8TEjt4HQrLl1hsBDELlp1nB4lflSgSuGTYiuyaP7Q==",
+      "dev": true,
+      "requires": {
+        "semver": "5.5.0"
       }
     },
     "node-status-codes": {
@@ -27001,6 +28075,12 @@
         }
       }
     },
+    "opener": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+      "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
+      "dev": true
+    },
     "opn": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
@@ -27028,6 +28108,119 @@
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+        }
+      }
+    },
+    "optimize-css-assets-webpack-plugin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.1.tgz",
+      "integrity": "sha512-Rqm6sSjWtx9FchdP0uzTQDc7GXDKnwVEGoSxjezPkzMewx7gEWE9IMUYKmigTRC4U3RaNSwYVnUDLuIdtTpm0A==",
+      "dev": true,
+      "requires": {
+        "cssnano": "4.1.4",
+        "last-call-webpack-plugin": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "cosmiconfig": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
+          "integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
+          "dev": true,
+          "requires": {
+            "is-directory": "0.3.1",
+            "js-yaml": "3.12.0",
+            "parse-json": "4.0.0"
+          }
+        },
+        "cssnano": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.4.tgz",
+          "integrity": "sha512-wP0wbOM9oqsek14CiNRYrK9N3w3jgadtGZKHXysgC/OMVpy0KZgWVPdNqODSZbz7txO9Gekr9taOfcCgL0pOOw==",
+          "dev": true,
+          "requires": {
+            "cosmiconfig": "5.0.6",
+            "cssnano-preset-default": "4.0.2",
+            "is-resolvable": "1.1.0",
+            "postcss": "7.0.5"
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.12.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.10",
+            "esprima": "4.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
+          }
+        },
+        "postcss": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
+          "integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
         }
       }
     },
@@ -27517,7 +28710,8 @@
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
     },
     "path-root": {
       "version": "0.1.1",
@@ -29204,6 +30398,415 @@
         }
       }
     },
+    "postcss-normalize-display-values": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.1.tgz",
+      "integrity": "sha512-R5mC4vaDdvsrku96yXP7zak+O3Mm9Y8IslUobk7IMP+u/g+lXvcN4jngmHY5zeJnrQvE13dfAg5ViU05ZFDwdg==",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-match": "4.0.0",
+        "postcss": "7.0.5",
+        "postcss-value-parser": "3.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
+          "integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-normalize-positions": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.1.tgz",
+      "integrity": "sha512-GNoOaLRBM0gvH+ZRb2vKCIujzz4aclli64MBwDuYGU2EY53LwiP7MxOZGE46UGtotrSnmarPPZ69l2S/uxdaWA==",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-arguments": "4.0.0",
+        "has": "1.0.1",
+        "postcss": "7.0.5",
+        "postcss-value-parser": "3.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
+          "integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-normalize-repeat-style": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.1.tgz",
+      "integrity": "sha512-fFHPGIjBUyUiswY2rd9rsFcC0t3oRta4wxE1h3lpwfQZwFeFjXFSiDtdJ7APCmHQOnUZnqYBADNRPKPwFAONgA==",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-arguments": "4.0.0",
+        "cssnano-util-get-match": "4.0.0",
+        "postcss": "7.0.5",
+        "postcss-value-parser": "3.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
+          "integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-normalize-string": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.1.tgz",
+      "integrity": "sha512-IJoexFTkAvAq5UZVxWXAGE0yLoNN/012v7TQh5nDo6imZJl2Fwgbhy3J2qnIoaDBrtUP0H7JrXlX1jjn2YcvCQ==",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "7.0.5",
+        "postcss-value-parser": "3.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
+          "integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-normalize-timing-functions": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.1.tgz",
+      "integrity": "sha512-1nOtk7ze36+63ONWD8RCaRDYsnzorrj+Q6fxkQV+mlY5+471Qx9kspqv0O/qQNMeApg8KNrRf496zHwJ3tBZ7w==",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-match": "4.0.0",
+        "postcss": "7.0.5",
+        "postcss-value-parser": "3.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
+          "integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-normalize-unicode": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
+      "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
+      "dev": true,
+      "requires": {
+        "browserslist": "4.2.0",
+        "postcss": "7.0.5",
+        "postcss-value-parser": "3.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "browserslist": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.2.0.tgz",
+          "integrity": "sha512-Berls1CHL7qfQz8Lct6QxYA5d2Tvt4doDWHcjvAISybpd+EKZVppNtXgXhaN6SdrPKo7YLTSZuYBs5cYrSWN8w==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "1.0.30000890",
+            "electron-to-chromium": "1.3.75",
+            "node-releases": "1.0.0-alpha.12"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.75",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.75.tgz",
+          "integrity": "sha512-nLo03Qpw++8R6BxDZL/B1c8SQvUe/htdgc5LWYHe5YotV2jVvRUMP5AlOmxOsyeOzgMiXrNln2mC05Ixz6vuUQ==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
+          "integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
     "postcss-normalize-url": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
@@ -29235,6 +30838,70 @@
           "dev": true,
           "requires": {
             "has-flag": "1.0.0"
+          }
+        }
+      }
+    },
+    "postcss-normalize-whitespace": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.1.tgz",
+      "integrity": "sha512-U8MBODMB2L+nStzOk6VvWWjZgi5kQNShCyjRhMT3s+W9Jw93yIjOnrEkKYD3Ul7ChWbEcjDWmXq0qOL9MIAnAw==",
+      "dev": true,
+      "requires": {
+        "postcss": "7.0.5",
+        "postcss-value-parser": "3.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
+          "integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -31486,6 +33153,18 @@
         }
       }
     },
+    "rgb-regex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
+      "integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
+      "dev": true
+    },
+    "rgba-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
+      "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
+      "dev": true
+    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -31935,7 +33614,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
@@ -32703,6 +34382,23 @@
         }
       }
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.3.2"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+          "dev": true
+        }
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -32862,31 +34558,6 @@
       "requires": {
         "faye-websocket": "0.10.0",
         "uuid": "3.2.1"
-      }
-    },
-    "sockjs-client": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
-      "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "eventsource": "0.1.6",
-        "faye-websocket": "0.11.1",
-        "inherits": "2.0.3",
-        "json3": "3.3.2",
-        "url-parse": "1.2.0"
-      },
-      "dependencies": {
-        "faye-websocket": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
-          "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
-          "dev": true,
-          "requires": {
-            "websocket-driver": "0.7.0"
-          }
-        }
       }
     },
     "sort-keys": {
@@ -33445,7 +35116,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "1.0.2",
@@ -33716,7 +35387,7 @@
     },
     "strip-dirs": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
       "integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
       "dev": true,
       "requires": {
@@ -34898,6 +36569,12 @@
         "setimmediate": "1.0.5"
       }
     },
+    "timsort": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
+      "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+      "dev": true
+    },
     "tiny-emitter": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-1.2.0.tgz",
@@ -35083,6 +36760,12 @@
           }
         }
       }
+    },
+    "toposort": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
+      "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
+      "dev": true
     },
     "touch": {
       "version": "1.0.0",
@@ -36364,7 +38047,7 @@
         },
         "buffer": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
           "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
           "dev": true,
           "requires": {
@@ -36392,6 +38075,23 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
       "integrity": "sha1-QLq4S60Z0jAJbo1u9ii/8FXYPbA=",
       "dev": true
+    },
+    "union": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.4.6.tgz",
+      "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
+      "dev": true,
+      "requires": {
+        "qs": "2.3.3"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+          "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
+          "dev": true
+        }
+      }
     },
     "union-value": {
       "version": "1.0.0",
@@ -36606,6 +38306,12 @@
         }
       }
     },
+    "url-join": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
+      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
+      "dev": true
+    },
     "url-parse": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
@@ -36728,6 +38434,12 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+    },
+    "v8-compile-cache": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz",
+      "integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw==",
+      "dev": true
     },
     "v8flags": {
       "version": "2.1.1",
@@ -37347,426 +39059,69 @@
       "dev": true
     },
     "webpack": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
-      "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.19.1.tgz",
+      "integrity": "sha512-j7Q/5QqZRqIFXJvC0E59ipLV5Hf6lAnS3ezC3I4HMUybwEDikQBVad5d+IpPtmaQPQArvgUZLXIN6lWijHBn4g==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3",
-        "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "async": "2.6.0",
-        "enhanced-resolve": "3.4.1",
-        "escope": "3.6.0",
-        "interpret": "1.1.0",
-        "json-loader": "0.5.4",
-        "json5": "0.5.1",
+        "@webassemblyjs/ast": "1.7.6",
+        "@webassemblyjs/helper-module-context": "1.7.6",
+        "@webassemblyjs/wasm-edit": "1.7.6",
+        "@webassemblyjs/wasm-parser": "1.7.6",
+        "acorn": "5.7.3",
+        "acorn-dynamic-import": "3.0.0",
+        "ajv": "6.5.4",
+        "ajv-keywords": "3.2.0",
+        "chrome-trace-event": "1.0.0",
+        "enhanced-resolve": "4.1.0",
+        "eslint-scope": "4.0.0",
+        "json-parse-better-errors": "1.0.2",
         "loader-runner": "2.3.0",
         "loader-utils": "1.1.0",
         "memory-fs": "0.4.1",
+        "micromatch": "3.1.10",
         "mkdirp": "0.5.1",
+        "neo-async": "2.5.1",
         "node-libs-browser": "2.1.0",
-        "source-map": "0.5.7",
-        "supports-color": "4.5.0",
-        "tapable": "0.2.8",
-        "uglifyjs-webpack-plugin": "0.4.6",
+        "schema-utils": "0.4.7",
+        "tapable": "1.1.0",
+        "uglifyjs-webpack-plugin": "1.3.0",
         "watchpack": "1.5.0",
-        "webpack-sources": "1.1.0",
-        "yargs": "8.0.2"
+        "webpack-sources": "1.3.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        },
+        "acorn-dynamic-import": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+          "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
+            "acorn": "5.7.3"
+          }
+        },
+        "ajv": {
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
+          "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "2.0.1",
             "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
           }
         },
         "ajv-keywords": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+          "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
           "dev": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.5"
-          }
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "loader-utils": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true,
-          "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1"
-          }
-        },
-        "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-          "dev": true
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
-          "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
-          }
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "2.3.0"
-          }
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          },
-          "dependencies": {
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
-            }
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
-          "dependencies": {
-            "yargs": {
-              "version": "3.10.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-              "dev": true,
-              "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
-                "window-size": "0.1.0"
-              }
-            }
-          }
-        },
-        "uglifyjs-webpack-plugin": {
-          "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
-          "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-js": "2.8.29",
-            "webpack-sources": "1.1.0"
-          }
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-              "dev": true
-            },
-            "cliui": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-              "dev": true,
-              "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.1.0"
-              },
-              "dependencies": {
-                "string-width": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "dev": true,
-                  "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-              "dev": true
-            }
-          }
-        }
-      }
-    },
-    "webpack-dev-middleware": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz",
-      "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
-      "dev": true,
-      "requires": {
-        "memory-fs": "0.4.1",
-        "mime": "1.6.0",
-        "path-is-absolute": "1.0.1",
-        "range-parser": "1.0.3",
-        "time-stamp": "2.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "memory-fs": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-          "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-          "dev": true,
-          "requires": {
-            "errno": "0.1.7",
-            "readable-stream": "2.3.5"
-          }
-        },
-        "mime": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "time-stamp": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
-          "integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=",
-          "dev": true
-        }
-      }
-    },
-    "webpack-dev-server": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.1.tgz",
-      "integrity": "sha512-ombhu5KsO/85sVshIDTyQ5HF3xjZR3N0sf5Ao6h3vFwpNyzInEzA1GV3QPVjTMLTNckp8PjfG1PFGznzBwS5lg==",
-      "dev": true,
-      "requires": {
-        "ansi-html": "0.0.7",
-        "array-includes": "3.0.3",
-        "bonjour": "3.5.0",
-        "chokidar": "2.0.3",
-        "compression": "1.5.2",
-        "connect-history-api-fallback": "1.5.0",
-        "debug": "3.1.0",
-        "del": "3.0.0",
-        "express": "4.16.3",
-        "html-entities": "1.2.1",
-        "http-proxy-middleware": "0.17.4",
-        "import-local": "1.0.0",
-        "internal-ip": "1.2.0",
-        "ip": "1.1.5",
-        "killable": "1.0.0",
-        "loglevel": "1.6.1",
-        "opn": "5.3.0",
-        "portfinder": "1.0.13",
-        "selfsigned": "1.10.2",
-        "serve-index": "1.7.3",
-        "sockjs": "0.3.19",
-        "sockjs-client": "1.1.4",
-        "spdy": "3.4.7",
-        "strip-ansi": "3.0.1",
-        "supports-color": "5.3.0",
-        "webpack-dev-middleware": "1.12.2",
-        "yargs": "6.6.0"
-      },
-      "dependencies": {
-        "anymatch": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-          "dev": true,
-          "requires": {
-            "micromatch": "3.1.10",
-            "normalize-path": "2.1.1"
-          }
         },
         "arr-diff": {
           "version": "4.0.0",
@@ -37781,22 +39136,110 @@
           "dev": true
         },
         "braces": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.1.tgz",
-          "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
             "arr-flatten": "1.1.0",
             "array-unique": "0.3.2",
-            "define-property": "1.0.0",
             "extend-shallow": "2.0.1",
             "fill-range": "4.0.0",
             "isobject": "3.0.1",
-            "kind-of": "6.0.2",
             "repeat-element": "1.1.2",
             "snapdragon": "0.8.2",
             "snapdragon-node": "2.1.1",
             "split-string": "3.1.0",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "enhanced-resolve": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
+          "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "memory-fs": "0.4.1",
+            "tapable": "1.1.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
             "to-regex": "3.0.2"
           },
           "dependencies": {
@@ -37820,56 +39263,797 @@
             }
           }
         },
-        "camelcase": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "is-number": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+          "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "0.4.7",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "6.5.4",
+            "ajv-keywords": "3.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "tapable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.0.tgz",
+          "integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA==",
+          "dev": true
+        },
+        "uglifyjs-webpack-plugin": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
+          "integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
+          "dev": true,
+          "requires": {
+            "cacache": "10.0.4",
+            "find-cache-dir": "1.0.0",
+            "schema-utils": "0.4.7",
+            "serialize-javascript": "1.4.0",
+            "source-map": "0.6.1",
+            "uglify-es": "3.3.9",
+            "webpack-sources": "1.3.0",
+            "worker-farm": "1.6.0"
+          }
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+          "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+          "dev": true,
+          "requires": {
+            "punycode": "2.1.1"
+          }
+        },
+        "webpack-sources": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
+          "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+          "dev": true,
+          "requires": {
+            "source-list-map": "2.0.0",
+            "source-map": "0.6.1"
+          }
+        }
+      }
+    },
+    "webpack-cli": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.1.0.tgz",
+      "integrity": "sha512-p5NeKDtYwjZozUWq6kGNs9w+Gtw/CPvyuXjXn2HMdz8Tie+krjEg8oAtonvIyITZdvpF7XG9xDHwscLr2c+ugQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.1",
+        "cross-spawn": "6.0.5",
+        "enhanced-resolve": "4.1.0",
+        "global-modules-path": "2.3.0",
+        "import-local": "1.0.0",
+        "inquirer": "6.2.0",
+        "interpret": "1.1.0",
+        "loader-utils": "1.1.0",
+        "supports-color": "5.5.0",
+        "v8-compile-cache": "2.0.2",
+        "yargs": "12.0.2"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "2.0.0"
+          }
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "1.0.4",
+            "path-key": "2.0.1",
+            "semver": "5.5.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "decamelize": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+          "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+          "dev": true,
+          "requires": {
+            "xregexp": "4.0.0"
+          }
+        },
+        "enhanced-resolve": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
+          "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "memory-fs": "0.4.1",
+            "tapable": "1.1.0"
+          }
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "6.0.5",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "3.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
+          "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "3.1.0",
+            "chalk": "2.4.1",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "3.0.3",
+            "figures": "2.0.0",
+            "lodash": "4.17.11",
+            "mute-stream": "0.0.7",
+            "run-async": "2.3.0",
+            "rxjs": "6.3.3",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
+          }
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "dev": true,
+          "requires": {
+            "invert-kv": "2.0.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "mem": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
+          "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+          "dev": true,
+          "requires": {
+            "map-age-cleaner": "0.1.2",
+            "mimic-fn": "1.2.0",
+            "p-is-promise": "1.1.0"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.2.0"
+          }
+        },
+        "os-locale": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
+          "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+          "dev": true,
+          "requires": {
+            "execa": "0.10.0",
+            "lcid": "2.0.0",
+            "mem": "4.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "dev": true,
+          "requires": {
+            "p-try": "2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "2.0.1",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+          "dev": true,
+          "requires": {
+            "is-promise": "2.1.0"
+          }
+        },
+        "rxjs": {
+          "version": "6.3.3",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+          "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.9.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        },
+        "tapable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.0.tgz",
+          "integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA==",
+          "dev": true
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "12.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
+          "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
+          "dev": true,
+          "requires": {
+            "cliui": "4.1.0",
+            "decamelize": "2.0.0",
+            "find-up": "3.0.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "3.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "10.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          }
+        }
+      }
+    },
+    "webpack-dev-server": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.8.tgz",
+      "integrity": "sha512-c+tcJtDqnPdxCAzEEZKdIPmg3i5i7cAHe+B+0xFNK0BlCc2HF/unYccbU7xTgfGc5xxhCztCQzFmsqim+KhI+A==",
+      "dev": true,
+      "requires": {
+        "ansi-html": "0.0.7",
+        "bonjour": "3.5.0",
+        "chokidar": "2.0.4",
+        "compression": "1.5.2",
+        "connect-history-api-fallback": "1.5.0",
+        "debug": "3.2.5",
+        "del": "3.0.0",
+        "express": "4.16.3",
+        "html-entities": "1.2.1",
+        "http-proxy-middleware": "0.18.0",
+        "import-local": "2.0.0",
+        "internal-ip": "3.0.1",
+        "ip": "1.1.5",
+        "killable": "1.0.0",
+        "loglevel": "1.6.1",
+        "opn": "5.3.0",
+        "portfinder": "1.0.13",
+        "schema-utils": "1.0.0",
+        "selfsigned": "1.10.2",
+        "serve-index": "1.7.3",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.5",
+        "spdy": "3.4.7",
+        "strip-ansi": "3.0.1",
+        "supports-color": "5.5.0",
+        "webpack-dev-middleware": "3.2.0",
+        "webpack-log": "2.0.0",
+        "yargs": "12.0.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
+          "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+          "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
+          "requires": {
+            "micromatch": "3.1.10",
+            "normalize-path": "2.1.1"
+          }
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "chokidar": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
-          "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+          "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
           "dev": true,
           "requires": {
             "anymatch": "2.0.0",
             "async-each": "1.0.1",
-            "braces": "2.3.1",
+            "braces": "2.3.2",
             "fsevents": "1.2.4",
             "glob-parent": "3.1.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
             "is-glob": "4.0.0",
+            "lodash.debounce": "4.0.8",
             "normalize-path": "2.1.1",
             "path-is-absolute": "1.0.1",
             "readdirp": "2.1.0",
-            "upath": "1.0.4"
+            "upath": "1.1.0"
           }
         },
         "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
             "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
           }
         },
-        "connect-history-api-fallback": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-          "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "nice-try": "1.0.4",
+            "path-key": "2.0.1",
+            "semver": "5.5.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.1"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+              "dev": true
+            }
+          }
+        },
+        "decamelize": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+          "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+          "dev": true,
+          "requires": {
+            "xregexp": "4.0.0"
           }
         },
         "del": {
@@ -37884,6 +40068,21 @@
             "p-map": "1.2.0",
             "pify": "3.0.0",
             "rimraf": "2.6.2"
+          }
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "6.0.5",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "expand-brackets": {
@@ -37983,6 +40182,21 @@
             }
           }
         },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "faye-websocket": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+          "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+          "dev": true,
+          "requires": {
+            "websocket-driver": "0.7.0"
+          }
+        },
         "fill-range": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -38004,6 +40218,15 @@
                 "is-extendable": "0.1.1"
               }
             }
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "3.0.0"
           }
         },
         "glob-parent": {
@@ -38054,6 +40277,44 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
+        "http-proxy-middleware": {
+          "version": "0.18.0",
+          "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+          "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
+          "dev": true,
+          "requires": {
+            "http-proxy": "1.16.2",
+            "is-glob": "4.0.0",
+            "lodash": "4.17.11",
+            "micromatch": "3.1.10"
+          }
+        },
+        "import-local": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+          "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+          "dev": true,
+          "requires": {
+            "pkg-dir": "3.0.0",
+            "resolve-cwd": "2.0.0"
+          }
+        },
+        "internal-ip": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.1.tgz",
+          "integrity": "sha512-NXXgESC2nNVtU+pqmC9e6R8B1GpKxzsAQhffvh5AL79qKnodd+L7tnEQmTiUAVngqLalPbSqRA7XGIEL5nCd0Q==",
+          "dev": true,
+          "requires": {
+            "default-gateway": "2.7.2",
+            "ipaddr.js": "1.6.0"
+          }
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+          "dev": true
+        },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -38100,6 +40361,12 @@
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
           "dev": true
         },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
         "is-glob": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
@@ -38135,11 +40402,53 @@
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "dev": true,
+          "requires": {
+            "invert-kv": "2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "mem": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
+          "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+          "dev": true,
+          "requires": {
+            "map-age-cleaner": "0.1.2",
+            "mimic-fn": "1.2.0",
+            "p-is-promise": "1.1.0"
+          }
         },
         "micromatch": {
           "version": "3.1.10",
@@ -38149,7 +40458,7 @@
           "requires": {
             "arr-diff": "4.0.0",
             "array-unique": "0.3.2",
-            "braces": "2.3.1",
+            "braces": "2.3.2",
             "define-property": "2.0.2",
             "extend-shallow": "3.0.2",
             "extglob": "2.0.4",
@@ -38162,10 +40471,57 @@
             "to-regex": "3.0.2"
           }
         },
+        "mime": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
+          "dev": true
+        },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
+          "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+          "dev": true,
+          "requires": {
+            "execa": "0.10.0",
+            "lcid": "2.0.0",
+            "mem": "4.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "dev": true,
+          "requires": {
+            "p-try": "2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "pify": {
@@ -38174,44 +40530,175 @@
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "dev": true,
+          "requires": {
+            "find-up": "3.0.0"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
+          "requires": {
+            "ajv": "6.5.4",
+            "ajv-errors": "1.0.0",
+            "ajv-keywords": "3.2.0"
+          }
+        },
+        "sockjs-client": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
+          "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "eventsource": "0.1.6",
+            "faye-websocket": "0.11.1",
+            "inherits": "2.0.3",
+            "json3": "3.3.2",
+            "url-parse": "1.2.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
         "supports-color": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
           }
         },
-        "yargs": {
-          "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+        "upath": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+          "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+          "dev": true
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+          "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
+            "punycode": "2.1.1"
+          }
+        },
+        "url-join": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
+          "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=",
+          "dev": true
+        },
+        "webpack-dev-middleware": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.2.0.tgz",
+          "integrity": "sha512-YJLMF/96TpKXaEQwaLEo+Z4NDK8aV133ROF6xp9pe3gQoS7sxfpXh4Rv9eC+8vCvWfmDjRQaMSlRPbO+9G6jgA==",
+          "dev": true,
+          "requires": {
+            "loud-rejection": "1.6.0",
+            "memory-fs": "0.4.1",
+            "mime": "2.3.1",
+            "path-is-absolute": "1.0.1",
+            "range-parser": "1.0.3",
+            "url-join": "4.0.0",
+            "webpack-log": "2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "12.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
+          "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
+          "dev": true,
+          "requires": {
+            "cliui": "4.1.0",
+            "decamelize": "2.0.0",
+            "find-up": "3.0.0",
             "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
+            "os-locale": "3.0.1",
             "require-directory": "2.1.1",
             "require-main-filename": "1.0.1",
             "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
             "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
+            "yargs-parser": "10.1.0"
           }
         },
         "yargs-parser": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "4.1.0"
           }
+        }
+      }
+    },
+    "webpack-log": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+      "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "3.1.0",
+        "uuid": "3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -216,7 +216,8 @@
     "validate-build": "scripts/validate-build dist/*.js",
     "versions": "echo npm: $(npm --version) && echo node: $(node --version)",
     "tslint": "tslint -c tslint.json --project tsconfig.json",
-    "release": "standard-version --tag-prefix \"$(python -c \"import sys, json; dcosrc = json.load(open('.dcosrc')); sys.stdout.write(str(dcosrc['base']));\")+v\""
+    "release": "standard-version --tag-prefix \"$(python -c \"import sys, json; dcosrc = json.load(open('.dcosrc')); sys.stdout.write(str(dcosrc['base']));\")+v\"",
+    "lingui-extract-with-plugins": "./scripts/lingui-extract-with-plugins"
   },
   "jest-webpack-alias": {
     "configFile": "./webpack/webpack.dev.js"

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "babel-cli": "6.24.1",
     "babel-core": "6.24.1",
     "babel-loader": "7.1.3",
-    "babel-plugin-macros": "2.4.2",
+    "babel-plugin-macros": "2.4.1",
     "babel-plugin-transform-runtime": "6.23.0",
     "babel-preset-es2015": "6.24.1",
     "babel-preset-jest": "22.2.0",

--- a/scripts/lingui-extract-with-plugins
+++ b/scripts/lingui-extract-with-plugins
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+SCRIPT_PATH="$(dirname "$0")/$(dirname "$(readlink "$0")")"
+
+# Import utils
+source "${SCRIPT_PATH}/utils/message"
+
+function sanityCheck {
+  if [ ! -d ../dcos-ui-plugins-private ]; then
+    warning "../dcos-ui-plugins-private directory not found."
+    return 1
+  elif [ ! -f ../dcos-ui-plugins-private/.babelrc ]; then
+    warning "../dcos-ui-plugins-private/.babelrc file not found. Did this script fail previously? Try running with --unpatch to fix"
+    return 1
+  elif [ -f ./.dcos-ui-plugins-private ]; then
+    warning "Temporary symlink already exists. Did this script fail previously? Try running with --unpatch to fix"
+    return 1
+  else
+    return 0
+  fi
+}
+
+# lingui extract cannot extract messages from macros that are outside of the package
+# due to the way packages are resolved from each source file. This script creates a temporary symlink
+# to the conventional dcos-ui-plugins-private directory and also temporarily hides the .babelrc file
+# which is not useful when followed through the symlink
+function patch {
+  info "Symlinking .dcos-ui-plugins-private for lingui extract tooling"
+  ln -s ../dcos-ui-plugins-private ./.dcos-ui-plugins-private
+  mv ../dcos-ui-plugins-private/.babelrc ../dcos-ui-plugins-private/.tmp.babelrc
+}
+
+function unpatch {
+  unlink ./.dcos-ui-plugins-private
+  mv ../dcos-ui-plugins-private/.tmp.babelrc ../dcos-ui-plugins-private/.babelrc
+  info "Unlinked .dcos-ui-plugins-private"
+}
+
+title "Running lingui extract for dcos-ui and dcos-ui-plugins-private"
+
+VERBOSE=""
+if [[ $* == *--verbose* ]]; then
+  VERBOSE="--verbose "
+fi
+
+sanityCheck
+if [[ $? == 0 ]]; then
+  patch
+  info "This may take a minute..."
+  eval "lingui extract $VERBOSE--clean"
+  unpatch
+elif [[ $* == *--unpatch ]]; then
+  unpatch
+fi

--- a/src/js/components/AccessDeniedPage.js
+++ b/src/js/components/AccessDeniedPage.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import React from "react";
 
 import AuthStore from "../stores/AuthStore";
@@ -28,7 +29,7 @@ module.exports = class AccessDeniedPage extends React.Component {
           className="button button-primary"
           onClick={this.handleUserLogout}
         >
-          Log out
+          <Trans>Log out</Trans>
         </button>
       </div>
     );
@@ -40,8 +41,10 @@ module.exports = class AccessDeniedPage extends React.Component {
         <div className="page">
           <div className="page-body-content vertical-center flex-item-grow-1">
             <AlertPanel>
-              <AlertPanelHeader>Access denied</AlertPanelHeader>
-              <p className="tall">
+              <AlertPanelHeader>
+                <Trans>Access denied</Trans>
+              </AlertPanelHeader>
+              <Trans render="p" className="tall">
                 {"You do not have access to this service. Please contact your "}
                 {Config.productName}
                 {" administrator or see "}
@@ -52,7 +55,7 @@ module.exports = class AccessDeniedPage extends React.Component {
                   security documentation
                 </a>{" "}
                 for more information.
-              </p>
+              </Trans>
               {this.getFooter()}
             </AlertPanel>
           </div>

--- a/src/js/components/ClusterHeader.js
+++ b/src/js/components/ClusterHeader.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import * as React from "react";
 import mixin from "reactjs-mixin";
 import { StoreMixin } from "mesosphere-shared-reactjs";
@@ -55,7 +56,7 @@ export default class ClusterHeader extends mixin(StoreMixin) {
     const states = MesosSummaryStore.get("states");
     const clusterName = states.getClusterName();
 
-    return clusterName || "Cluster";
+    return clusterName || <Trans render="span">Cluster</Trans>;
   }
 
   getPublicIP() {
@@ -110,7 +111,7 @@ export default class ClusterHeader extends mixin(StoreMixin) {
         onClick: this.handleItemSelect
       },
       {
-        html: "Overview",
+        html: <Trans render="span">Overview</Trans>,
         id: "overview",
         onClick: () => {
           this.context.router.push("/cluster/overview");
@@ -127,19 +128,19 @@ export default class ClusterHeader extends mixin(StoreMixin) {
       },
       {
         className: "dropdown-menu-section-header",
-        html: <label>Support</label>,
+        html: <Trans render="label">Support</Trans>,
         id: "header-support",
         selectable: false
       },
       {
-        html: "Documentation",
+        html: <Trans render="span">Documentation</Trans>,
         id: "documentation",
         onClick() {
           global.open(MetadataStore.buildDocsURI("/"), "_blank");
         }
       },
       {
-        html: "Install CLI",
+        html: <Trans render="span">Install CLI</Trans>,
         id: "install-cli",
         onClick() {
           SidebarActions.openCliInstructions();

--- a/src/js/components/ComponentList.js
+++ b/src/js/components/ComponentList.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import classNames from "classnames";
 import { Link } from "react-router";
 import { List } from "reactjs-components";
@@ -95,8 +96,12 @@ class ComponentList extends React.Component {
   getErrorMessage() {
     return (
       <div>
-        <h3 className="flush-top text-align-center">Components Not Found</h3>
-        <p className="flush text-align-center">An error has occurred.</p>
+        <Trans render="h3" className="flush-top text-align-center">
+          Components Not Found
+        </Trans>
+        <Trans render="p" className="flush text-align-center">
+          An error has occurred.
+        </Trans>
       </div>
     );
   }

--- a/src/js/components/CreateServiceModalCatalogPanelOption.js
+++ b/src/js/components/CreateServiceModalCatalogPanelOption.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -20,7 +21,7 @@ class CreateServicePickerCatalogOption extends React.Component {
       >
         <CreateServiceModalServicePickerOptionImage src={packageServiceImage} />
         <CreateServiceModalServicePickerOptionContent>
-          Install a Package
+          <Trans render="span">Install a Package</Trans>
         </CreateServiceModalServicePickerOptionContent>
       </CreateServiceModalServicePickerOption>
     );

--- a/src/js/components/DSLFormDropdownPanel.js
+++ b/src/js/components/DSLFormDropdownPanel.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
@@ -87,7 +88,7 @@ class DSLFormDropdownPanel extends React.Component {
             className="button button-small button-primary-link flush-right"
             onClick={this.handleApply}
           >
-            Apply
+            <Trans render="span">Apply</Trans>
           </a>
         </div>
       </div>

--- a/src/js/components/ErrorsAlert.js
+++ b/src/js/components/ErrorsAlert.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -45,7 +46,7 @@ const ErrorsAlert = function(props) {
 
   return (
     <Alert>
-      <h4>There is an error with your configuration</h4>
+      <Trans render="h4">There is an error with your configuration</Trans>
       <ul>{errorItems}</ul>
     </Alert>
   );

--- a/src/js/components/FilterHeadline.js
+++ b/src/js/components/FilterHeadline.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import classNames from "classnames";
 import PureRender from "react-addons-pure-render-mixin";
 import PropTypes from "prop-types";
@@ -61,11 +62,13 @@ class FilterHeadline extends React.Component {
 
     return (
       <ul className={listClassSet}>
-        <li className={filteredClassSet}>
+        <Trans render="li" className={filteredClassSet}>
           Showing {currentLength} of {totalLength} {name}
-        </li>
+        </Trans>
         <li className={anchorClassSet} onClick={this.handleReset}>
-          <a className="small flush">(Clear)</a>
+          <Trans render="a" className="small flush">
+            (Clear)
+          </Trans>
         </li>
         <li className={unfilteredClassSet}>
           {totalLength} {name}

--- a/src/js/components/FrameworkConfiguration.js
+++ b/src/js/components/FrameworkConfiguration.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { Confirm } from "reactjs-components";
@@ -167,7 +168,7 @@ class FrameworkConfiguration extends Component {
             onChange={this.handleJSONToggle}
             key="json-editor"
           >
-            JSON Editor
+            <Trans render="span">JSON Editor</Trans>
           </ToggleButton>
         )
       });
@@ -339,7 +340,11 @@ class FrameworkConfiguration extends Component {
         {pageContents}
         <Confirm
           closeByBackdropClick={true}
-          header={<ModalHeading>Discard Changes?</ModalHeading>}
+          header={
+            <ModalHeading>
+              <Trans render="span">Discard Changes?</Trans>
+            </ModalHeading>
+          }
           open={isConfirmOpen}
           onClose={this.handleCloseConfirmModal}
           leftButtonText={i18n._(t`Cancel`)}
@@ -349,10 +354,10 @@ class FrameworkConfiguration extends Component {
           rightButtonCallback={this.handleConfirmGoBack}
           showHeader={true}
         >
-          <p>
+          <Trans render="p">
             Are you sure you want to leave this page? Any data you entered will
             be lost.
-          </p>
+          </Trans>
         </Confirm>
       </FullScreenModal>
     );

--- a/src/js/components/FrameworkConfiguration.js
+++ b/src/js/components/FrameworkConfiguration.js
@@ -1,9 +1,8 @@
-import { Trans } from "@lingui/macro";
+import { Trans, t } from "@lingui/macro";
+import { withI18n } from "@lingui/react";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { Confirm } from "reactjs-components";
-import { withI18n } from "@lingui/react";
-import { t } from "@lingui/macro";
 
 import FullScreenModal from "#SRC/js/components/modals/FullScreenModal";
 import FullScreenModalHeader from "#SRC/js/components/modals/FullScreenModalHeader";

--- a/src/js/components/FrameworkConfigurationReviewScreen.js
+++ b/src/js/components/FrameworkConfigurationReviewScreen.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import PropTypes from "prop-types";
 import React from "react";
 import { Dropdown, Tooltip } from "reactjs-components";
@@ -63,7 +64,9 @@ class FrameworkConfigurationReviewScreen extends React.Component {
             >
               <span className="badge-container">
                 <span className="badge-container-text">{frameworkMeta}</span>
-                <span className="badge">Active</span>
+                <Trans render="span" className="badge">
+                  Active
+                </Trans>
               </span>
             </span>
           </div>

--- a/src/js/components/ImageViewer.js
+++ b/src/js/components/ImageViewer.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import PropTypes from "prop-types";
 import React from "react";
 import ImageViewerModal from "./modals/ImageViewerModal";
@@ -67,7 +68,7 @@ class ImageViewer extends React.Component {
 
     return (
       <div className="pod pod-short flush-top flush-right flush-left">
-        <h2>Media</h2>
+        <Trans render="h2">Media</Trans>
         <div className="media-object-spacing-wrapper media-object-offset">
           <div className="media-object media-object-wrap">
             {this.getImages(images)}

--- a/src/js/components/Modals.js
+++ b/src/js/components/Modals.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import PropTypes from "prop-types";
 import React from "react";
 import { Hooks } from "PluginSDK";
@@ -96,10 +97,10 @@ var Modals = React.createClass({
     this.setState({
       showErrorModal: true,
       modalErrorMsg: (
-        <p className="text-align-center flush-bottom">
+        <Trans render="p" className="text-align-center flush-bottom">
           We are unable to retrieve the version {Config.productName} versions.
           Please try again.
-        </p>
+        </Trans>
       )
     });
   },
@@ -125,7 +126,7 @@ var Modals = React.createClass({
         <div>
           <div className="text-align-center">
             <button className="button button-primary-link" onClick={onClose}>
-              Close
+              <Trans render="span">Close</Trans>
             </button>
           </div>
         </div>

--- a/src/js/components/NestedServiceLinks.js
+++ b/src/js/components/NestedServiceLinks.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import classNames from "classnames/dedupe";
 import { Link } from "react-router";
 import PropTypes from "prop-types";
@@ -107,7 +108,7 @@ class NestedServiceLinks extends React.Component {
             to="/services"
             title="services"
           >
-            Services
+            <Trans render="span">Services</Trans>
           </Link>
         </div>
       </div>

--- a/src/js/components/PlacementConstraintsPartial.js
+++ b/src/js/components/PlacementConstraintsPartial.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import React, { Component } from "react";
 import { Tooltip, Select, SelectOption } from "reactjs-components";
 
@@ -220,7 +221,7 @@ export default class PlacementConstraintsPartial extends Component {
                 value: { type: "default" }
               })}
             >
-              Add Placement Constraint
+              <Trans render="span">Add Placement Constraint</Trans>
             </AddButton>
           </FormGroup>
         </FormRow>

--- a/src/js/components/PlacementConstraintsSchemaField.js
+++ b/src/js/components/PlacementConstraintsSchemaField.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import Batch from "#SRC/js/structs/Batch";
@@ -26,7 +27,9 @@ const JsonField = props => (
   <div>
     <FieldLabel>{props.label}</FieldLabel>
     <pre>{JSON.stringify(props.json, props.replacer, props.space)}</pre>
-    <FieldError>Unable to edit {props.fieldName}</FieldError>
+    <FieldError>
+      <Trans render="span">Unable to edit {props.fieldName}</Trans>
+    </FieldError>
   </div>
 );
 

--- a/src/js/components/RequestErrorMsg.js
+++ b/src/js/components/RequestErrorMsg.js
@@ -1,3 +1,6 @@
+import { Trans } from "@lingui/macro";
+import { i18nMark } from "@lingui/react";
+
 import classNames from "classnames/dedupe";
 import PropTypes from "prop-types";
 import React from "react";
@@ -5,21 +8,15 @@ import React from "react";
 import Config from "../config/Config";
 
 function getDefaultMessage() {
-  const slackLink = (
-    <a href={Config.slackChannel} target="_blank">
-      Slack channel
-    </a>
-  );
-  const supportLink = (
-    <a href={`mailto:${Config.supportEmail}`}>{Config.supportEmail}</a>
-  );
-
   return (
-    <p className="text-align-center flush-bottom">
-      You can also join us on our {slackLink} or send us an email at{" "}
-      {supportLink}
-      .
-    </p>
+    <Trans render="p" className="text-align-center flush-bottom">
+      You can also join us on our{" "}
+      <a href={Config.slackChannel} target="_blank">
+        Slack channel
+      </a>{" "}
+      or send us an email at{" "}
+      <a href={`mailto:${Config.supportEmail}`}>{Config.supportEmail}</a>.
+    </Trans>
   );
 }
 
@@ -36,7 +33,11 @@ class RequestErrorMsg extends React.Component {
     return (
       <div className="row">
         <div className={columnClasses}>
-          <h3 className="text-align-center flush-top">{header}</h3>
+          <Trans
+            render="h3"
+            className="text-align-center flush-top"
+            id={header}
+          />
           {message}
         </div>
       </div>
@@ -46,7 +47,9 @@ class RequestErrorMsg extends React.Component {
 
 RequestErrorMsg.defaultProps = {
   columnClasses: {},
-  header: "DC/OS UI cannot retrieve the requested information at this moment.",
+  header: i18nMark(
+    "DC/OS UI cannot retrieve the requested information at this moment."
+  ),
   message: getDefaultMessage()
 };
 

--- a/src/js/components/ReviewConfig.js
+++ b/src/js/components/ReviewConfig.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import GeminiScrollbar from "react-gemini-scrollbar";
 import PropTypes from "prop-types";
 import React from "react";
@@ -53,7 +54,7 @@ class ReviewConfig extends React.Component {
               </div>
             </div>
           </div>
-          <div className="column-8 text-align-right">
+          <Trans render="div" className="column-8 text-align-right">
             <a
               className="button button-primary-link"
               onClick={RouterUtil.triggerIEDownload.bind(
@@ -70,7 +71,7 @@ class ReviewConfig extends React.Component {
             >
               <Icon id="download" size="mini" /> Download config.json
             </a>
-          </div>
+          </Trans>
         </div>
       </div>
     );

--- a/src/js/components/ServerErrorModal.js
+++ b/src/js/components/ServerErrorModal.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import classNames from "classnames";
 import mixin from "reactjs-mixin";
 import { Modal } from "reactjs-components";
@@ -71,7 +72,7 @@ module.exports = class ServerErrorModal extends mixin(StoreMixin) {
     return (
       <div className="button-collection text-align-center flush-bottom">
         <div className="button" onClick={this.handleModalClose}>
-          Close
+          <Trans render="span">Close</Trans>
         </div>
       </div>
     );
@@ -101,7 +102,11 @@ module.exports = class ServerErrorModal extends mixin(StoreMixin) {
   }
 
   render() {
-    const header = <ModalHeading level={5}>An error has occurred</ModalHeading>;
+    const header = (
+      <ModalHeading level={5}>
+        <Trans render="span">An error has occurred</Trans>
+      </ModalHeading>
+    );
 
     return (
       <Modal

--- a/src/js/components/UnitHealthDropdown.js
+++ b/src/js/components/UnitHealthDropdown.js
@@ -1,3 +1,5 @@
+import { Trans } from "@lingui/macro";
+
 import { Dropdown } from "reactjs-components";
 import PureRender from "react-addons-pure-render-mixin";
 import PropTypes from "prop-types";
@@ -7,8 +9,8 @@ import UnitHealthStatus from "../constants/UnitHealthStatus";
 
 const DEFAULT_ITEM = {
   id: "all",
-  html: "All Health Checks",
-  selectedHtml: "All Health Checks"
+  html: <Trans render="span">All Health Checks</Trans>,
+  selectedHtml: <Trans render="span">All Health Checks</Trans>
 };
 
 class UnitHealthDropdown extends React.Component {
@@ -26,8 +28,8 @@ class UnitHealthDropdown extends React.Component {
     const items = keys.map(function(key) {
       return {
         id: key,
-        html: UnitHealthStatus[key].title,
-        selectedHtml: UnitHealthStatus[key].title
+        html: <Trans render="span" id={UnitHealthStatus[key].title} />,
+        selectedHtml: <Trans render="span" id={UnitHealthStatus[key].title} />
       };
     });
 

--- a/src/js/components/__tests__/__snapshots__/PlacementConstraintsSchemaFields-test.js.snap
+++ b/src/js/components/__tests__/__snapshots__/PlacementConstraintsSchemaFields-test.js.snap
@@ -15,8 +15,11 @@ exports[`PlacementConstraintsSchemaField with invalid content displays form to e
   <p
     className="form-control-feedback"
   >
-    Unable to edit 
-    placement_constraints
+    <span
+      className={undefined}
+    >
+      Unable to edit {0}
+    </span>
   </p>
 </div>
 `;
@@ -63,7 +66,11 @@ exports[`PlacementConstraintsSchemaField with valid content displays edit constr
               />
             </svg>
             <span>
-              Add Placement Constraint
+              <span
+                className={undefined}
+              >
+                Add Placement Constraint
+              </span>
             </span>
           </a>
         </div>

--- a/src/js/components/modals/CliInstallModal.js
+++ b/src/js/components/modals/CliInstallModal.js
@@ -1,3 +1,6 @@
+import { Trans } from "@lingui/macro";
+import { i18nMark } from "@lingui/react";
+
 import browserInfo from "browser-info";
 import classNames from "classnames";
 import { Modal } from "reactjs-components";
@@ -88,9 +91,9 @@ class CliInstallModal extends React.Component {
 
     return (
       <div>
-        <p className="short-bottom">
+        <Trans render="p" className="short-bottom">
           Copy and paste the code snippet into the terminal:
-        </p>
+        </Trans>
         <div className="flush-top snippet-wrapper">
           <ClickToSelect>
             <pre className="prettyprint flush-bottom">
@@ -110,15 +113,14 @@ class CliInstallModal extends React.Component {
     ]
       .filter(instruction => instruction !== undefined)
       .map((instruction, index) => {
-        let helpText = "Enter";
-
-        if (index === 0) {
-          helpText = "In Command Prompt, enter";
-        }
+        const helpText =
+          index === 0
+            ? i18nMark("In Command Prompt, enter")
+            : i18nMark("Enter");
 
         return (
           <li key={index}>
-            <p className="short-bottom">{helpText}</p>
+            <Trans render="p" className="short-bottom" id={helpText} />
             <div className="flush-top snippet-wrapper">
               <ClickToSelect>
                 <pre className="prettyprint flush-bottom prettyprinted">
@@ -132,12 +134,12 @@ class CliInstallModal extends React.Component {
 
     return (
       <ol>
-        <li>
+        <Trans render="li">
           Download and install:{" "}
           <a href={downloadUrl + ".exe"}>
             <Icon id="download" size="mini" /> Download dcos.exe
           </a>.
-        </li>
+        </Trans>
         {steps}
       </ol>
     );
@@ -167,14 +169,13 @@ class CliInstallModal extends React.Component {
   getContent() {
     return (
       <div className="install-cli-modal-content">
-        <p>
-          {
-            "Choose your operating system and follow the instructions. For any issues or questions, please refer to our "
-          }
+        <Trans render="p">
+          Choose your operating system and follow the instructions. For any
+          issues or questions, please refer to our{" "}
           <a href={MetadataStore.buildDocsURI("/cli/install")} target="_blank">
             documentation
           </a>.
-        </p>
+        </Trans>
         <div className="button-group">{this.getOSButtons()}</div>
         {this.getCliInstructions()}
       </div>

--- a/src/js/components/modals/ErrorModal.js
+++ b/src/js/components/modals/ErrorModal.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -18,7 +19,11 @@ var ErrorModal = React.createClass({
   },
 
   render() {
-    const header = <ModalHeading>Looks Like Something is Wrong</ModalHeading>;
+    const header = (
+      <ModalHeading>
+        <Trans render="span">Looks Like Something is Wrong</Trans>
+      </ModalHeading>
+    );
 
     return (
       <Modal

--- a/src/js/components/modals/JobStopRunModal.js
+++ b/src/js/components/modals/JobStopRunModal.js
@@ -1,3 +1,5 @@
+import { Trans } from "@lingui/macro";
+import { i18nMark } from "@lingui/react";
 import { Confirm } from "reactjs-components";
 import mixin from "reactjs-mixin";
 import PropTypes from "prop-types";
@@ -64,15 +66,13 @@ class JobStopRunModal extends mixin(StoreMixin) {
   }
 
   getConfirmTextBody(selectedItems, selectedItemsLength) {
-    let bodyText;
+    const bodyText =
+      selectedItemsLength === 1
+        ? i18nMark("You are about to stop the job run with id") +
+          ` ${selectedItems[0]}.`
+        : i18nMark("You are about to stop the selected job runs.");
 
-    if (selectedItemsLength === 1) {
-      bodyText = `the job run with id ${selectedItems[0]}`;
-    } else {
-      bodyText = "the selected job runs";
-    }
-
-    return <span key="confirmText">You are about to stop {bodyText}.</span>;
+    return <Trans render="span" id={bodyText} />;
   }
 
   getModalContents() {

--- a/src/js/components/modals/UserFormModal.js
+++ b/src/js/components/modals/UserFormModal.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import mixin from "reactjs-mixin";
 import { Hooks } from "PluginSDK";
 /* eslint-disable no-unused-vars */
@@ -9,9 +10,6 @@ import AuthStore from "../../stores/AuthStore";
 import FormModal from "../FormModal";
 import ModalHeading from "../modals/ModalHeading";
 import UserStore from "../../stores/UserStore";
-
-const TELEMETRY_NOTIFICATION =
-  "Because telemetry is disabled you must manually notify users of ACL changes.";
 
 const METHODS_TO_BIND = ["handleNewUserSubmit", "onUserStoreCreateSuccess"];
 
@@ -111,7 +109,9 @@ class UserFormModal extends mixin(StoreMixin) {
   getHeader() {
     return Hooks.applyFilter(
       "userFormModalHeader",
-      <ModalHeading>Add User to Cluster</ModalHeading>
+      <ModalHeading>
+        <Trans render="span">Add User to Cluster</Trans>
+      </ModalHeading>
     );
   }
 
@@ -121,9 +121,13 @@ class UserFormModal extends mixin(StoreMixin) {
         {Hooks.applyFilter("userAddPolicy", null)}
         {Hooks.applyFilter(
           "userFormModalFooter",
-          <p className="form-group-without-top-label flush-bottom text-align-center">
-            <strong>Important:</strong> {TELEMETRY_NOTIFICATION}
-          </p>
+          <Trans
+            render="p"
+            className="form-group-without-top-label flush-bottom text-align-center"
+          >
+            <strong>Important:</strong> Because telemetry is disabled you must
+            manually notify users of ACL changes.
+          </Trans>
         )}
       </div>
     );

--- a/src/js/components/modals/VersionsModal.js
+++ b/src/js/components/modals/VersionsModal.js
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import { Modal } from "reactjs-components";
 import PropTypes from "prop-types";
 import React from "react";
@@ -25,7 +26,11 @@ var VersionsModal = React.createClass({
   },
 
   render() {
-    const header = <ModalHeading>{Config.productName} Info</ModalHeading>;
+    const header = (
+      <ModalHeading>
+        <Trans render="span">{Config.productName} Info</Trans>
+      </ModalHeading>
+    );
 
     return (
       <Modal

--- a/src/js/constants/UnitHealthStatus.js
+++ b/src/js/constants/UnitHealthStatus.js
@@ -1,3 +1,5 @@
+import { i18nMark } from "@lingui/react";
+
 import {
   SERVER_HEALTHY,
   SERVER_NA,
@@ -13,28 +15,28 @@ import {
  */
 const UnitHealthStatus = {
   [SERVER_HEALTHY]: {
-    title: "Healthy",
+    title: i18nMark("Healthy"),
     key: "HEALTHY",
     classNames: "text-success",
     sortingValue: 3,
     value: SERVER_HEALTHY
   },
   [SERVER_UNHEALTHY]: {
-    title: "Unhealthy",
+    title: i18nMark("Unhealthy"),
     key: "UNHEALTHY",
     classNames: "text-danger",
     sortingValue: 0,
     value: SERVER_UNHEALTHY
   },
   [SERVER_WARN]: {
-    title: "Warning",
+    title: i18nMark("Warning"),
     key: "WAR",
     classNames: "text-warning",
     sortingValue: 2,
     value: SERVER_WARN
   },
   [SERVER_NA]: {
-    title: "N/A",
+    title: i18nMark("N/A"),
     key: "NA",
     classNames: "text-mute",
     sortingValue: 1,


### PR DESCRIPTION
## Testing

There should be no visible difference and minimal markup changes as a result of merging this PR. The point is to add all the macros to rendered JSX text and extract them into translatable json

## Testing `npm run lingui-extract-with-plugins`

Long story short, to be able to include "../dcos-ui-plugins-private" in the lingui config for messages extraction i had to work out a script to patch it in via symlink and I also had to submit a patch to lingui to allow symlinks to be followed for message extraction. The patch is merged but not released so here's a quick way to test the script:

0. Optionally remove messages.json
1. _Modify_ `node_modules/@lingui/cli/api/extract.js` Line 75. Change `lstatSync` to `statSync`
2. `npm run lingui-extract-with-plugins -- --verbose`
3. messages from src/ plugins/ and ../dcos-ui-plugins-private should be extracted into the same file.

## More background on plugins-private

I think we agree that we need to include messages extracted from ../dcos-ui-plugins-private into the app messages.json file.

babel macros is limited by how it can load npm modules at build time, so I couldn’t simply specify “../dcos-ui-plugins-private” in .linguirc because it would try to load modules from that directory, which has no node_modules or package.json. So I created a script for message extraction (`npm run lingui-extract-with-plugins`) that temporarily symlinks in ../dcos-ui-plugins-private, does the extraction, and then unlinks it.

I also had to submit a patch to lingui to follow the symlinks. It was merged yesterday but won’t be released until next week. If you run the script without the patch it won’t work. So until that is released, and after we merge https://github.com/mesosphere/dcos-ui-plugins-private/pull/854 we must do some extra steps to extract messages which I included above.
